### PR TITLE
linting fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,22 @@
 {
-  "extends": "google"
+  "extends": "google",
+  "env": {
+    "node": true
+  },
+  "rules": {
+    "no-implicit-coercion": [2, {
+      "boolean": false,
+      "number": true,
+      "string": true
+    }],
+    "no-unused-expressions": [2, {
+      "allowShortCircuit": true,
+      "allowTernary": false
+    }],
+    "no-unused-vars": [2, {
+      "vars": "all",
+      "args": "after-used",
+      "argsIgnorePattern": "(^reject$|^_$)"
+    }],
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 dist
 init.sh
+npm-debug.log

--- a/audits/minify-html/index.js
+++ b/audits/minify-html/index.js
@@ -23,8 +23,7 @@ class MinifyHTMLTest {
    * @param  {*} inputs The test inputs.
    * @return {Number} A score. 1 = 100% minified; 0 = 0% minified.
    */
-  run (inputs) {
-
+  run(inputs) {
     if (typeof inputs === 'undefined') {
       return Promise.reject('No data provided.');
     }

--- a/audits/service-worker/index.js
+++ b/audits/service-worker/index.js
@@ -18,8 +18,7 @@
 
 class ServiceWorkerTest {
 
-  run (inputs) {
-
+  run(inputs) {
     if (inputs.length < 1) {
       return Promise.reject('No data provided.');
     }
@@ -34,7 +33,7 @@ class ServiceWorkerTest {
 
     this.url = inputs.url;
 
-    return new Promise(((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       let driver = inputs.driver;
 
       // hacky settimeout to delay SW work from page loading
@@ -42,22 +41,18 @@ class ServiceWorkerTest {
         driver
           .requestTab(this.url)
           .then(_ => {
-            driver.subscribeToServiceWorkerDetails(this.swVersionUpdated.bind(this), resolve)
-          })
-
+            driver.subscribeToServiceWorkerDetails(this.swVersionUpdated.bind(this), resolve);
+          });
       }, 5 * 1000);
-
-    }).bind(this));
-
+    });
   }
 
-  swVersionUpdated (data, resolve) {
-    var swObj = data.versions.filter( sw => sw.scriptURL.includes(this.url) ).pop();
+  swVersionUpdated(data, resolve) {
+    var swObj = data.versions.filter(sw => sw.scriptURL.includes(this.url)).pop();
     resolve(swObj);
   }
 
-  hasFetchRegistered (fileContents) {
-
+  hasFetchRegistered(fileContents) {
       // Get the Service Worker JS. We need a nicer way to do this!
           // return inputs.loader.load(serviceWorkerPath)
           //     .then(fileContents => {

--- a/audits/time-in-javascript/index.js
+++ b/audits/time-in-javascript/index.js
@@ -20,8 +20,7 @@ let traceProcessor = require('../../lib/processor');
 
 class TimeInJavaScriptTest {
 
-  run (inputs) {
-
+  run(inputs) {
     if (inputs.length < 1) {
       return Promise.reject('No data provided.');
     }
@@ -44,7 +43,7 @@ class TimeInJavaScriptTest {
         .then(results => {
           resolve(results[0].extendedInfo.javaScript);
         }).catch(err => {
-          console.error(err)
+          console.error(err);
         });
     });
   }

--- a/audits/viewport-meta-tag/index.js
+++ b/audits/viewport-meta-tag/index.js
@@ -23,8 +23,7 @@ class ViewportMetaTagTest {
    * @param  {*} inputs The test inputs.
    * @return {Number} A score. 1 = viewport meta tag present; 0 = not found.
    */
-  run (inputs) {
-
+  run(inputs) {
     if (typeof inputs === 'undefined') {
       return Promise.reject('No data provided.');
     }
@@ -44,7 +43,6 @@ class ViewportMetaTagTest {
 
     // Else zero.
     return Promise.resolve(false);
-
   }
 }
 

--- a/helpers/dom-parser.js
+++ b/helpers/dom-parser.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* global window */
+
 'use strict';
 
 class DOMParser {
@@ -24,10 +26,10 @@ class DOMParser {
    * @param  {String} input The HTML to parse.
    * @return {Object} A selector engine.
    */
-  static parse (input) {
+  static parse(input) {
     let output;
     if (typeof window === 'undefined') {
-      // TODO(paullewis: change this to load dynamically to avoid
+      // TODO(paullewis): change this to load dynamically to avoid
       // being transpiled in every time.
       let cheerio = require('cheerio');
       output = cheerio.load(input);

--- a/helpers/remote-file-loader.js
+++ b/helpers/remote-file-loader.js
@@ -14,27 +14,29 @@
  * limitations under the License.
  */
 
+/* global window, fetch */
+
 'use strict';
 
 class RemoteFileLoader {
 
-  load (url) {
-
+  load(url) {
     if (typeof window === 'undefined') {
-      // TODO(paullewis: change this to load dynamically to avoid
+      // TODO(paullewis): change this to load dynamically to avoid
       // being transpiled in every time.
       return new Promise((resolve, reject) => {
         let https = require('https');
-        https.get(url, (res) => {
+        https.get(url, res => {
           let body = '';
-          res.on('data', data => body += data);
+          res.on('data', data => {
+            body += data;
+          });
           res.on('end', () => resolve(body));
         });
       });
     }
 
     return fetch(url).then(response => response.text());
-
   }
 }
 

--- a/helpers/test-loader.js
+++ b/helpers/test-loader.js
@@ -23,7 +23,7 @@ let fs = require('fs');
 let tests = {};
 
 module.exports = {
-  getTests: function (filePath) {
+  getTests: function(filePath) {
     if (typeof tests[filePath] !== 'undefined') {
       return tests[filePath];
     }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-/* global tr */
-
 var traceviewer = require('traceviewer');
 
 var URL = require('url');
@@ -24,8 +22,7 @@ var RESPONSE = 'Response';
 var ANIMATION = 'Animation';
 var LOAD = 'Load';
 
-function analyzeTrace (contents, opts) {
-
+function analyzeTrace(contents, opts) {
   var contentsJSON = null;
 
   try {
@@ -37,9 +34,8 @@ function analyzeTrace (contents, opts) {
       typeof contentsJSON.traceEvents !== 'undefined') {
       contentsJSON = contentsJSON.traceEvents;
     }
-
   } catch (e) {
-    throw 'Invalid trace contents; not JSON';
+    throw new Error('Invalid trace contents; not JSON');
   }
 
   var events = [JSON.stringify({
@@ -62,7 +58,6 @@ function analyzeTrace (contents, opts) {
 
     if (typeof candidate.labels !== 'undefined' &&
         candidate.labels[0] === 'BackgroundPage') {
-
       var error = 'Extensions running during capture; ' +
                   'see http://bit.ly/bigrig-extensions';
       if (typeof opts !== 'undefined' && opts.strict) {
@@ -72,7 +67,7 @@ function analyzeTrace (contents, opts) {
   });
 
   if (summarizable.length === 0) {
-    throw 'Zero processes (tabs) found.';
+    throw new Error('Zero processes (tabs) found.');
   }
 
   if (summarizable.length > 1) {
@@ -84,37 +79,35 @@ function analyzeTrace (contents, opts) {
         .filter(pr => !!pr.labels[0])
         .slice(-1);
 
-
-    console.groupCollapsed && console.groupCollapsed('trace processor: multiple tabs')
+    console.groupCollapsed && console.groupCollapsed('trace processor: multiple tabs');
     console.warn('Multiple processes (tabs) found:' + bullet, tabs);
     console.log('\nProceeding using the last named tab:' + bullet,
         summarizable[0].labels[0]);
-    console.groupEnd && console.groupEnd('trace processor: multiple tabs')
+    console.groupEnd && console.groupEnd('trace processor: multiple tabs');
   }
 
   traceProcess = summarizable.pop();
   return processTrace(model, traceProcess, opts);
 }
 
-function convertEventsToModel (events) {
-  var io = new tr.importer.ImportOptions();
+function convertEventsToModel(events) {
+  var io = new traceviewer.importer.ImportOptions();
   io.showImportWarnings = false;
   io.pruneEmptyContainers = false;
 
-  var model = new tr.Model();
-  var importer = new tr.importer.Import(model, io);
+  var model = new traceviewer.Model();
+  var importer = new traceviewer.importer.Import(model, io);
   importer.importTraces(events);
 
   return model;
 }
 
-function processTrace (model, traceProcess, opts) {
-
+function processTrace(model, traceProcess, opts) {
   var threads = getThreads(traceProcess);
   var rendererThread = getThreadByName(traceProcess, 'CrRendererMain');
 
   if (!rendererThread) {
-    throw 'Can\'t find renderer thread';
+    throw new Error('Can\'t find renderer thread');
   }
 
   var timeRanges = getTimeRanges(rendererThread);
@@ -130,12 +123,10 @@ function processTrace (model, traceProcess, opts) {
   return createRangesForTrace(timeRanges, threads, opts);
 }
 
-function createRangesForTrace (timeRanges, threads, opts) {
-
-
+function createRangesForTrace(timeRanges, threads, opts) {
   var results = [];
   var baseTypes = {
-    'Load': LOAD
+    Load: LOAD
   };
 
   if (typeof opts === 'undefined') {
@@ -153,7 +144,6 @@ function createRangesForTrace (timeRanges, threads, opts) {
   // @see https://github.com/eslint/eslint/issues/3484
 
   timeRanges.forEach(function(timeRange) {
-
     var frames = 0;
     var timeRangeEnd = timeRange.start + timeRange.duration;
     var result = {
@@ -183,26 +173,23 @@ function createRangesForTrace (timeRanges, threads, opts) {
 
     /* eslint-enable */
 
-    threads.forEach(function (thread) {
-
+    threads.forEach(function(thread) {
       var slices = thread.sliceGroup.topLevelSlices;
       var slice = null;
 
-      for (var s = 0 ; s < slices.length; s++) {
+      for (var s = 0; s < slices.length; s++) {
         slice = slices[s];
 
         if (slice.start < timeRange.start || slice.end > timeRangeEnd) {
           continue;
         }
 
-        slice.iterateAllDescendents(function (subslice) {
+        slice.iterateAllDescendents(function(subslice) {
           addDurationToResult(subslice, result);
         });
       }
 
-
-      thread.iterateAllEvents(function (evt) {
-
+      thread.iterateAllEvents(function(evt) {
         if (evt.start < timeRange.start || evt.end > timeRangeEnd) {
           return;
         }
@@ -230,7 +217,6 @@ function createRangesForTrace (timeRanges, threads, opts) {
             break;
         }
       });
-
     });
 
     if (typeof result.type === 'undefined') {
@@ -255,14 +241,14 @@ function createRangesForTrace (timeRanges, threads, opts) {
   return results;
 }
 
-function hasStackInfo (slice) {
+function hasStackInfo(slice) {
   return slice.args &&
       slice.args.beginData &&
       slice.args.beginData.stackTrace &&
       slice.args.beginData.stackTrace.length;
 }
 
-function getJavascriptUrlFromStackInfo (slice) {
+function getJavascriptUrlFromStackInfo(slice) {
   var url = null;
 
   if (typeof slice.args.data === 'undefined') {
@@ -274,20 +260,17 @@ function getJavascriptUrlFromStackInfo (slice) {
   if (typeof slice.args.data.url !== 'undefined' &&
       slice.args.data.url !== '' &&
       /^http/.test(slice.args.data.url)) {
-
     url = slice.args.data.url;
   } else if (typeof slice.args.data.scriptName !== 'undefined' &&
       slice.args.data.scriptName !== '' &&
       /^http/.test(slice.args.data.scriptName)) {
-
     url = slice.args.data.scriptName;
   }
 
   return url;
 }
 
-function addDurationToResult (slice, result) {
-
+function addDurationToResult(slice, result) {
   var duration = getBestDurationForSlice(slice);
   var hasStack;
 
@@ -333,7 +316,6 @@ function addDurationToResult (slice, result) {
       hasStack = hasStackInfo(slice);
 
       if (hasStack) {
-
         if (typeof result.extendedInfo.forcedRecalcs === 'undefined') {
           result.extendedInfo.forcedRecalcs = 0;
         }
@@ -353,7 +335,6 @@ function addDurationToResult (slice, result) {
       hasStack = hasStackInfo(slice);
 
       if (hasStack) {
-
         if (typeof result.extendedInfo.forcedLayouts === 'undefined') {
           result.extendedInfo.forcedLayouts = 0;
         }
@@ -381,8 +362,7 @@ function addDurationToResult (slice, result) {
   }
 }
 
-function getBestDurationForSlice (slice) {
-
+function getBestDurationForSlice(slice) {
   var duration = 0;
 
   if (typeof slice.cpuSelfTime !== 'undefined') {
@@ -396,8 +376,7 @@ function getBestDurationForSlice (slice) {
   return duration;
 }
 
-function getThreads (traceProcess) {
-
+function getThreads(traceProcess) {
   var threadKeys = Object.keys(traceProcess.threads);
   var threads = [];
 
@@ -418,8 +397,7 @@ function getThreads (traceProcess) {
   return threads;
 }
 
-function getThreadByName (traceProcess, name) {
-
+function getThreadByName(traceProcess, name) {
   var threadKeys = Object.keys(traceProcess.threads);
   var threadKey = null;
   var thread = null;
@@ -436,11 +414,10 @@ function getThreadByName (traceProcess, name) {
   return null;
 }
 
-function getTimeRanges (thread) {
-
+function getTimeRanges(thread) {
   var timeRanges = [];
 
-  thread.iterateAllEvents(function (evt) {
+  thread.iterateAllEvents(function(evt) {
     if (evt.category === 'blink.console' && typeof evt.start === 'number') {
       timeRanges.push(evt);
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "npm run lint && npm run unit",
+    "test": "npm run lint --silent && npm run unit",
     "unit": "mocha test/*.js --timeout 60000"
   },
   "repository": {

--- a/test/bigrig_tests.js
+++ b/test/bigrig_tests.js
@@ -6,31 +6,24 @@ var fs = require('fs');
 var expect = require('chai').expect;
 var bigrig = require('../');
 
-describe('Lighthouse', function () {
-
-  it ('throws if no processes are found', function () {
-
-    expect(function () {
+describe('Lighthouse', function() {
+  it('throws if no processes are found', function() {
+    expect(function() {
       bigrig.analyze(null);
     }).to.throw('Zero processes (tabs) found.');
-
   });
 
-  it ('throws if given invalid input data is given', function () {
-
-    expect(function () {
+  it('throws if given invalid input data is given', function() {
+    expect(function() {
       bigrig.analyze('wobble');
     }).to.throw('Invalid trace contents; not JSON');
-
   });
 
-  it ('throws if given a trace with extensions and strict mode is enabled',
-    function (done) {
-
+  it('throws if given a trace with extensions and strict mode is enabled',
+    function(done) {
       fs.readFile('./test/data/load-extensions.json', 'utf8',
 
-        function (err, data) {
-
+        function(err, data) {
           if (err) {
             throw err;
           }
@@ -38,7 +31,7 @@ describe('Lighthouse', function () {
           var error = 'Extensions running during capture; ' +
               'see http://bit.ly/bigrig-extensions';
 
-          expect(function () {
+          expect(function() {
             bigrig.analyze(data, {
               strict: true
             });
@@ -46,16 +39,13 @@ describe('Lighthouse', function () {
 
           done();
         });
-
     });
 
   // TODO(paullewis) Add multiprocess test.
 
-  it ('returns JSON for a file with a single process', function (done) {
-
+  it('returns JSON for a file with a single process', function(done) {
     fs.readFile('./test/data/load.json', 'utf8',
-      function (err, data) {
-
+      function(err, data) {
         if (err) {
           throw err;
         }
@@ -65,15 +55,12 @@ describe('Lighthouse', function () {
         expect(jsonData).to.be.an('array');
         expect(jsonData[0]).to.be.an('object');
         done();
-
       });
   });
 
-  it ('generates valid JSON', function (done) {
-
+  it('generates valid JSON', function(done) {
     fs.readFile('./test/data/load.json', 'utf8',
-      function (err, data) {
-
+      function(err, data) {
         if (err) {
           throw err;
         }
@@ -83,15 +70,12 @@ describe('Lighthouse', function () {
 
         expect(jsonData).to.be.an('array');
         done();
-
       });
   });
 
-  it ('supports timed ranges', function (done) {
-
+  it('supports timed ranges', function(done) {
     fs.readFile('./test/data/animation.json', 'utf8',
-      function (err, data) {
-
+      function(err, data) {
         if (err) {
           throw err;
         }
@@ -103,39 +87,33 @@ describe('Lighthouse', function () {
         expect(jsonData[0].start).to.be.above(0);
         expect(jsonData[0].end).to.be.within(1179, 1180);
         done();
-
       });
   });
 
-  it ('correctly applies RAIL type when time range is specified',
+  it('correctly applies RAIL type when time range is specified',
 
-    function (done) {
-
+    function(done) {
       fs.readFile('./test/data/animation.json', 'utf8',
-        function (err, data) {
-
+        function(err, data) {
           if (err) {
             throw err;
           }
 
           var jsonData = bigrig.analyze(data, {
             types: {
-              'sideNavAnimation': bigrig.ANIMATION
+              sideNavAnimation: bigrig.ANIMATION
             }
           });
 
           expect(jsonData[0].type).to.equal(bigrig.ANIMATION);
           done();
-
         });
     });
 
-  it ('correctly infers RAIL Load when time range not specified',
-    function (done) {
-
+  it('correctly infers RAIL Load when time range not specified',
+    function(done) {
       fs.readFile('./test/data/load.json', 'utf8',
-        function (err, data) {
-
+        function(err, data) {
           if (err) {
             throw err;
           }
@@ -144,16 +122,13 @@ describe('Lighthouse', function () {
           expect(jsonData[0].type).to.equal(bigrig.LOAD);
           expect(jsonData[0].title).to.equal('Load');
           done();
-
         });
     });
 
-  it ('correctly infers RAIL Response when time range not specified',
-    function (done) {
-
+  it('correctly infers RAIL Response when time range not specified',
+    function(done) {
       fs.readFile('./test/data/response.json', 'utf8',
-        function (err, data) {
-
+        function(err, data) {
           if (err) {
             throw err;
           }
@@ -162,16 +137,13 @@ describe('Lighthouse', function () {
           expect(jsonData[0].type).to.equal(bigrig.RESPONSE);
           expect(jsonData[0].title).to.equal('sideNavResponse');
           done();
-
         });
     });
 
-  it ('correctly infers RAIL Animation when time range not specified',
-    function (done) {
-
+  it('correctly infers RAIL Animation when time range not specified',
+    function(done) {
       fs.readFile('./test/data/animation.json', 'utf8',
-        function (err, data) {
-
+        function(err, data) {
           if (err) {
             throw err;
           }
@@ -180,15 +152,12 @@ describe('Lighthouse', function () {
           expect(jsonData[0].type).to.equal(bigrig.ANIMATION);
           expect(jsonData[0].title).to.equal('sideNavAnimation');
           done();
-
         });
     });
 
-  it ('correctly infers multiple RAIL regions', function (done) {
-
+  it('correctly infers multiple RAIL regions', function(done) {
     fs.readFile('./test/data/response-animation.json', 'utf8',
-      function (err, data) {
-
+      function(err, data) {
         if (err) {
           throw err;
         }
@@ -204,15 +173,12 @@ describe('Lighthouse', function () {
         expect(jsonData[1].title).to.equal('sideNavAnimation');
 
         done();
-
       });
   });
 
-  it ('returns the correct fps for animations', function (done) {
-
+  it('returns the correct fps for animations', function(done) {
     fs.readFile('./test/data/animation.json', 'utf8',
-      function (err, data) {
-
+      function(err, data) {
         if (err) {
           throw err;
         }
@@ -220,15 +186,12 @@ describe('Lighthouse', function () {
         var jsonData = bigrig.analyze(data);
         expect(jsonData[0].fps).to.be.within(59, 61);
         done();
-
       });
   });
 
-  it ('returns the correct JS breakdown', function (done) {
-
+  it('returns the correct JS breakdown', function(done) {
     fs.readFile('./test/data/load.json', 'utf8',
-      function (err, data) {
-
+      function(err, data) {
         if (err) {
           throw err;
         }
@@ -241,15 +204,12 @@ describe('Lighthouse', function () {
           jsonData[0].extendedInfo.javaScript['www.google-analytics.com']
         ).to.be.within(59, 60);
         done();
-
       });
   });
 
-  it ('correctly captures forced layouts and recalcs', function (done) {
-
+  it('correctly captures forced layouts and recalcs', function(done) {
     fs.readFile('./test/data/forced-recalc-layout.json', 'utf8',
-      function (err, data) {
-
+      function(err, data) {
         if (err) {
           throw err;
         }
@@ -262,7 +222,6 @@ describe('Lighthouse', function () {
           jsonData[0].extendedInfo.forcedLayouts
         ).to.equal(1);
         done();
-
       });
   });
 });


### PR DESCRIPTION
Another update for #4 

This gets `npm run lint` (and `npm test`) running without error. 90% whitespace changes, with a few tweaks to the eslint rules.

Added two TODOs for @paulirish since I'm not entirely sure what's going on there and git blame blames him :)

There are remaining eslint warnings. I'll follow up in #4 