### PR TITLE
last eslint fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,11 @@
     "node": true
   },
   "rules": {
+    "max-len": [2, 80, {
+      "ignoreComments": true,
+      "ignoreUrls": true,
+      "tabWidth": 2
+    }],
     "no-implicit-coercion": [2, {
       "boolean": false,
       "number": true,
@@ -16,9 +21,10 @@
     "no-unused-vars": [2, {
       "vars": "all",
       "args": "after-used",
-      "argsIgnorePattern": "(^reject$|^_$|^rej$)"
+      "argsIgnorePattern": "(^reject$|^_$)"
     }],
-    "valid-jsdoc": "off",
+    "quotes": [2, "single"],
     "require-jsdoc": "off",
+    "valid-jsdoc": "off"
   }
 }

--- a/audits/service-worker/gather.js
+++ b/audits/service-worker/gather.js
@@ -27,9 +27,10 @@ var ServiceWorkerGatherer = {
     return new Promise((resolve, reject) => {
       // hacky settimeout to delay SW work from page loading
       setTimeout(_ => {
-        driver.subscribeToServiceWorkerDetails(swVersionUpdated.bind(null, url)).then(data => {
-          return resolve({serviceWorker: data});
-        });
+        driver.subscribeToServiceWorkerDetails(swVersionUpdated.bind(null, url))
+          .then(data => {
+            return resolve({serviceWorker: data});
+          });
       }, 5 * 1000);
     });
   }

--- a/audits/time-in-javascript/audit.js
+++ b/audits/time-in-javascript/audit.js
@@ -17,14 +17,14 @@
 var traceProcessor = require('../../lib/processor');
 
 function gatherTimeInJavascript(pageLoadProfile) {
-  return new Promise(function(res, rej) {
-    res(traceProcessor.analyzeTrace(pageLoadProfile));
+  return new Promise(function(resolve, reject) {
+    resolve(traceProcessor.analyzeTrace(pageLoadProfile));
   }).then(ret => ret[0].extendedInfo.javaScript);
 }
 
 module.exports = function(data) {
   if (data.pageLoadProfile === undefined) {
-    throw new Error('time in javascript auditor requires page load profile data');
+    throw new Error('time in javascript auditor requires page load profile.');
   }
 
   return gatherTimeInJavascript(data.pageLoadProfile).then(ret => {

--- a/audits/viewport-meta-tag/audit.js
+++ b/audits/viewport-meta-tag/audit.js
@@ -18,12 +18,12 @@
 function hasCorrectViewportMetaQuery(obj) {
   var ret;
 
-  if (obj.type === "object" && obj.subtype === "null") {
+  if (obj.type === 'object' && obj.subtype === 'null') {
     ret = {pass: false};
   } else if (obj.subtype === 'node' && obj.props.content.includes('width=')) {
     ret = {pass: true};
   } else {
-    throw new Error("Unexpected viewport elements.");
+    throw new Error('Unexpected viewport elements.');
   }
 
   return ret;

--- a/helpers/browser/driver.js
+++ b/helpers/browser/driver.js
@@ -25,15 +25,15 @@ class ChromeProtocol {
     opts = opts || {};
 
     this.categories = [
-      "-*", // exclude default
-      "toplevel",
-      "blink.console",
-      "devtools.timeline",
-      "disabled-by-default-devtools.timeline",
-      "disabled-by-default-devtools.timeline.frame",
-      "disabled-by-default-devtools.timeline.stack",
-      "disabled-by-default-devtools.screenshot",
-      "disabled-by-default-v8.cpu_profile"
+      '-*', // exclude default
+      'toplevel',
+      'blink.console',
+      'devtools.timeline',
+      'disabled-by-default-devtools.timeline',
+      'disabled-by-default-devtools.timeline.frame',
+      'disabled-by-default-devtools.timeline.stack',
+      'disabled-by-default-devtools.screenshot',
+      'disabled-by-default-v8.cpu_profile'
     ];
   }
 
@@ -43,7 +43,7 @@ class ChromeProtocol {
         return resolve(this._instance);
       }
 
-      chromeremoteinterface({ /* github.com/cyrus-and/chrome-remote-interface#moduleoptions-callback */ },
+      chromeremoteinterface({ /* https://github.com/cyrus-and/chrome-remote-interface#moduleoptions-callback */ },
         instance => {
           this._instance = instance;
           resolve(instance);
@@ -70,24 +70,25 @@ class ChromeProtocol {
   subscribeToServiceWorkerDetails(fn) {
     var chrome = this._instance;
 
-    return new Promise(function(res, rej) {
+    return new Promise(function(resolve, reject) {
       chrome.ServiceWorker.enable();
       // chrome.on("ServiceWorker.workerCreated", log)
       // chrome.on("ServiceWorker.workerRegistrationUpdated", log)
-      chrome.on("ServiceWorker.workerVersionUpdated", data => {
-        res(fn(data));
+      chrome.on('ServiceWorker.workerVersionUpdated', data => {
+        resolve(fn(data));
       });
     });
   }
 
   static getEvaluationContextFor(url, instance) {
-    return new Promise((res, rej) => {
-      var errorTimeout = setTimeout((_ => rej(new Error(`No Evaluation context found for ${url}`))), 4000);
+    return new Promise((resolve, reject) => {
+      var errorTimeout = setTimeout((_ =>
+          reject(new Error(`No Evaluation context found for ${url}`))), 4000);
 
       instance.on('Runtime.executionContextCreated', evalContext => {
         if (evalContext.context.origin.indexOf(url) !== -1) {
           clearTimeout(errorTimeout);
-          res(evalContext.context.id);
+          resolve(evalContext.context.id);
         }
       });
     });
@@ -128,7 +129,8 @@ class ChromeProtocol {
         obj.props = {};
         if (Array.isArray(propsResult.result)) {
           propsResult.result.forEach(prop => {
-            obj.props[prop.name] = prop.value ? prop.value.value : prop.get.description;
+            obj.props[prop.name] = prop.value ? prop.value.value :
+                prop.get.description;
           });
         }
         resolve(obj);
@@ -144,7 +146,7 @@ class ChromeProtocol {
       this._instance.Page.enable();
       this._instance.Tracing.start({
         categories: this.categories.join(','),
-        options: "sampling-frequency=10000"  // 1000 is default and too slow.
+        options: 'sampling-frequency=10000'  // 1000 is default and too slow.
       }, (err, data) => {
         if (err) {
           reject(data);

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -26,7 +26,8 @@ function analyzeTrace(contents, opts) {
   var contentsJSON = null;
 
   try {
-    contentsJSON = typeof contents === 'string' ? JSON.parse(contents) : contents;
+    contentsJSON = typeof contents === 'string' ? JSON.parse(contents) :
+        contents;
 
     // If the file already wrapped the trace events in a
     // traceEvents object, grab the contents of the object.
@@ -79,7 +80,8 @@ function analyzeTrace(contents, opts) {
         .filter(pr => !!pr.labels[0])
         .slice(-1);
 
-    console.groupCollapsed && console.groupCollapsed('trace processor: multiple tabs');
+    console.groupCollapsed &&
+        console.groupCollapsed('trace processor: multiple tabs');
     console.warn('Multiple processes (tabs) found:' + bullet, tabs);
     console.log('\nProceeding using the last named tab:' + bullet,
         summarizable[0].labels[0]);


### PR DESCRIPTION
should settle everything outstanding in #4 

- enforces line length of 80
- enforces single quotes (allows backticks as long as something is being interpolated (see https://github.com/eslint/eslint/issues/5234 for that whole debate))
- settles on `resolve`/`reject` (instead of `res`/`rej`) for Promise executor signature since that's winning the current popularity contest in the repo