### PR TITLE
100 char line length.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "node": true
   },
   "rules": {
-    "max-len": [2, 80, {
+    "max-len": [2, 100, {
       "ignoreComments": true,
       "ignoreUrls": true,
       "tabWidth": 2


### PR DESCRIPTION
I really wanted to make 80 work, but I was having a hard time keeping things look readable and still satisfying 80.

My example in particular is the highlighted line in this block:

![image](https://cloud.githubusercontent.com/assets/39191/13895748/33ced1e0-ed35-11e5-9041-e8ab82b0613b.png)

That line is 84 characters long, and there isn't really a proper way to shorten it. :/

So... I think the answer is yes.. but to confirm: ya'll ok with 100?