### PR TITLE
add web app manifest parsing gatherer

### DIFF
--- a/gatherers/js-in-context.js
+++ b/gatherers/js-in-context.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* global document, XMLHttpRequest */
+
+var manifestParser = require('../helpers/manifest-parser');
+
+/**
+ * Gather data by running JS in page's context.
+ */
+
+function fetchManifest() {
+  var link = document.querySelector('link[rel=manifest]');
+
+  if (!link) {
+    return 'Manifest link not found.';
+  }
+
+  var request = new XMLHttpRequest();
+  request.open('GET', link.href, false);  // `false` makes the request synchronous
+  request.send(null);
+
+  if (request.status === 200) {
+    return request.responseText;
+  }
+
+  return 'Unable to fetch manifest at ' + link;
+}
+
+var JSGatherer = {
+  run: function(driver, url) {
+    return driver.evaluateFunction(url, fetchManifest)
+      .then(result => manifestParser(result.value))
+      .then(parsedManifest => ({parsedManifest}));
+  }
+};
+
+module.exports = JSGatherer;

--- a/helpers/manifest-parser.js
+++ b/helpers/manifest-parser.js
@@ -150,7 +150,7 @@ function parseIcon(raw) {
     let set = new Set();
     sizes.value.split(/\s/).forEach(size => set.add(size.toLowerCase()));
 
-    sizes.value = set.size > 0 ? set : undefined;
+    sizes.value = set.size > 0 ? Array.from(set) : undefined;
   }
 
   return {

--- a/helpers/manifest-parser.js
+++ b/helpers/manifest-parser.js
@@ -15,8 +15,9 @@
  */
 'use strict';
 
-var ManifestParser = (function() {
+/* global document */
 
+var ManifestParser = (function() {
   var _jsonInput = {};
   var _manifest = {};
   var _logs = [];
@@ -44,7 +45,7 @@ var ManifestParser = (function() {
       return undefined;
     }
 
-    if (typeof object[property] != 'string') {
+    if (typeof object[property] !== 'string') {
       _logs.push('ERROR: \'' + property +
           '\' expected to be a string but is not.');
       return undefined;
@@ -64,7 +65,7 @@ var ManifestParser = (function() {
       return defaultValue;
     }
 
-    if (typeof object[property] != 'boolean') {
+    if (typeof object[property] !== 'boolean') {
       _logs.push('ERROR: \'' + property +
           '\' expected to be a boolean but is not.');
       return defaultValue;
@@ -76,7 +77,6 @@ var ManifestParser = (function() {
   function _parseURL(args) {
     var object = args.object;
     var property = args.property;
-    var baseURL = args.baseURL;
 
     var str = _parseString({object: object, property: property, trim: false});
     if (str === undefined) {
@@ -84,6 +84,7 @@ var ManifestParser = (function() {
     }
 
     // TODO: resolve url using baseURL
+    // var baseURL = args.baseURL;
     // new URL(object[property], baseURL);
     return object[property];
   }
@@ -95,7 +96,7 @@ var ManifestParser = (function() {
       return undefined;
     }
 
-    if (typeof object[property] != 'string') {
+    if (typeof object[property] !== 'string') {
       _logs.push('ERROR: \'' + property +
           '\' expected to be a string but is not.');
       return undefined;
@@ -106,12 +107,12 @@ var ManifestParser = (function() {
     var dummy = document.createElement('div');
     dummy.style.color = 'white';
     dummy.style.color = object[property];
-    if (dummy.style.color != 'white') {
+    if (dummy.style.color !== 'white') {
       return object[property];
     }
     dummy.style.color = 'black';
     dummy.style.color = object[property];
-    if (dummy.style.color != 'black') {
+    if (dummy.style.color !== 'black') {
       return object[property];
     }
     return undefined;
@@ -140,7 +141,7 @@ var ManifestParser = (function() {
       return display;
     }
 
-    if (ALLOWED_DISPLAY_VALUES.indexOf(display.toLowerCase()) == -1) {
+    if (ALLOWED_DISPLAY_VALUES.indexOf(display.toLowerCase()) === -1) {
       _logs.push('ERROR: \'display\' has an invalid value, will be ignored.');
       return undefined;
     }
@@ -156,7 +157,7 @@ var ManifestParser = (function() {
       return orientation;
     }
 
-    if (ALLOWED_ORIENTATION_VALUES.indexOf(orientation.toLowerCase()) == -1) {
+    if (ALLOWED_ORIENTATION_VALUES.indexOf(orientation.toLowerCase()) === -1) {
       _logs.push('ERROR: \'orientation\' has an invalid value' +
           ', will be ignored.');
       return undefined;
@@ -204,7 +205,7 @@ var ManifestParser = (function() {
           set.add(link.sizes.item(i).toLowerCase());
         }
 
-        if (set.size != 0) {
+        if (set.size !== 0) {
           icon.sizes = set;
         }
       }
@@ -319,10 +320,10 @@ var ManifestParser = (function() {
 
   return {
     parse: _parse,
-    manifest: function() { return _manifest; },
-    logs: function() { return _logs; },
-    tips: function() { return _tips; },
-    success: function() { return _success; }
+    manifest: _ => _manifest,
+    logs: _ => _logs,
+    tips: _ => _tips,
+    success: _ => _success
   };
 })();
 

--- a/helpers/manifest-parser.js
+++ b/helpers/manifest-parser.js
@@ -68,6 +68,7 @@ function parseColor(raw) {
   }
 
   // TODO(bckenny): validate color, but for reals
+  // possibly pull in devtools/front_end/common/Color.js
   // If style.color changes when set to the given color, it is valid. Testing
   // against 'white' and 'black' in case of the given color is one of them.
   // var dummy = document.createElement('div');
@@ -104,7 +105,7 @@ function parseStartUrl(jsonInput) {
 }
 
 function parseDisplay(jsonInput) {
-  var display = parseString(jsonInput.display, true);
+  let display = parseString(jsonInput.display, true);
 
   if (display.value && ALLOWED_DISPLAY_VALUES.indexOf(display.value.toLowerCase()) === -1) {
     display.value = undefined;
@@ -115,7 +116,7 @@ function parseDisplay(jsonInput) {
 }
 
 function parseOrientation(jsonInput) {
-  var orientation = parseString(jsonInput.orientation, true);
+  let orientation = parseString(jsonInput.orientation, true);
 
   if (orientation.value &&
       ALLOWED_ORIENTATION_VALUES.indexOf(orientation.value.toLowerCase()) === -1) {

--- a/helpers/manifest-parser.js
+++ b/helpers/manifest-parser.js
@@ -15,316 +15,310 @@
  */
 'use strict';
 
-/* global document */
+const ALLOWED_DISPLAY_VALUES = [
+  'fullscreen',
+  'standalone',
+  'minimal-ui',
+  'browser'
+];
 
-var ManifestParser = (function() {
-  var _jsonInput = {};
-  var _manifest = {};
-  var _logs = [];
-  var _tips = [];
-  var _success = true;
+const ALLOWED_ORIENTATION_VALUES = [
+  'any',
+  'natural',
+  'landscape',
+  'portrait',
+  'portrait-primary',
+  'portrait-secondary',
+  'landscape-primary',
+  'landscape-secondary'
+];
 
-  var ALLOWED_DISPLAY_VALUES = ['fullscreen',
-                                 'standalone',
-                                 'minimal-ui',
-                                 'browser'];
+function parseString(raw, trim) {
+  let value;
+  let warning;
 
-  var ALLOWED_ORIENTATION_VALUES = ['any',
-                                     'natural',
-                                     'landscape',
-                                     'portrait',
-                                     'portrait-primary',
-                                     'portrait-secondary',
-                                     'landscape-primary',
-                                     'landscape-secondary'];
-
-  function _parseString(args) {
-    var object = args.object;
-    var property = args.property;
-    if (!(property in object)) {
-      return undefined;
+  if (typeof raw === 'string') {
+    value = trim ? raw.trim() : raw;
+  } else {
+    if (raw !== undefined) {
+      warning = 'ERROR: expected a string.';
     }
-
-    if (typeof object[property] !== 'string') {
-      _logs.push('ERROR: \'' + property +
-          '\' expected to be a string but is not.');
-      return undefined;
-    }
-
-    if (args.trim) {
-      return object[property].trim();
-    }
-    return object[property];
-  }
-
-  function _parseBoolean(args) {
-    var object = args.object;
-    var property = args.property;
-    var defaultValue = args.defaultValue;
-    if (!(property in object)) {
-      return defaultValue;
-    }
-
-    if (typeof object[property] !== 'boolean') {
-      _logs.push('ERROR: \'' + property +
-          '\' expected to be a boolean but is not.');
-      return defaultValue;
-    }
-
-    return object[property];
-  }
-
-  function _parseURL(args) {
-    var object = args.object;
-    var property = args.property;
-
-    var str = _parseString({object: object, property: property, trim: false});
-    if (str === undefined) {
-      return undefined;
-    }
-
-    // TODO: resolve url using baseURL
-    // var baseURL = args.baseURL;
-    // new URL(object[property], baseURL);
-    return object[property];
-  }
-
-  function _parseColor(args) {
-    var object = args.object;
-    var property = args.property;
-    if (!(property in object)) {
-      return undefined;
-    }
-
-    if (typeof object[property] !== 'string') {
-      _logs.push('ERROR: \'' + property +
-          '\' expected to be a string but is not.');
-      return undefined;
-    }
-
-    // If style.color changes when set to the given color, it is valid. Testing
-    // against 'white' and 'black' in case of the given color is one of them.
-    var dummy = document.createElement('div');
-    dummy.style.color = 'white';
-    dummy.style.color = object[property];
-    if (dummy.style.color !== 'white') {
-      return object[property];
-    }
-    dummy.style.color = 'black';
-    dummy.style.color = object[property];
-    if (dummy.style.color !== 'black') {
-      return object[property];
-    }
-    return undefined;
-  }
-
-  function _parseName() {
-    return _parseString({object: _jsonInput, property: 'name', trim: true});
-  }
-
-  function _parseShortName() {
-    return _parseString({object: _jsonInput,
-                          property: 'short_name',
-                          trim: true});
-  }
-
-  function _parseStartUrl() {
-    // TODO: parse url using manifest_url as a base (missing).
-    return _parseURL({object: _jsonInput, property: 'start_url'});
-  }
-
-  function _parseDisplay() {
-    var display = _parseString({object: _jsonInput,
-                                 property: 'display',
-                                 trim: true});
-    if (display === undefined) {
-      return display;
-    }
-
-    if (ALLOWED_DISPLAY_VALUES.indexOf(display.toLowerCase()) === -1) {
-      _logs.push('ERROR: \'display\' has an invalid value, will be ignored.');
-      return undefined;
-    }
-
-    return display;
-  }
-
-  function _parseOrientation() {
-    var orientation = _parseString({object: _jsonInput,
-                                     property: 'orientation',
-                                     trim: true});
-    if (orientation === undefined) {
-      return orientation;
-    }
-
-    if (ALLOWED_ORIENTATION_VALUES.indexOf(orientation.toLowerCase()) === -1) {
-      _logs.push('ERROR: \'orientation\' has an invalid value' +
-          ', will be ignored.');
-      return undefined;
-    }
-
-    return orientation;
-  }
-
-  function _parseIcons() {
-    var property = 'icons';
-    var icons = [];
-
-    if (!(property in _jsonInput)) {
-      return icons;
-    }
-
-    if (!Array.isArray(_jsonInput[property])) {
-      _logs.push('ERROR: \'' + property +
-          '\' expected to be an array but is not.');
-      return icons;
-    }
-
-    _jsonInput[property].forEach(function(object) {
-      var icon = {};
-      if (!('src' in object)) {
-        return;
-      }
-      // TODO: pass manifest url as base.
-      icon.src = _parseURL({object: object, property: 'src'});
-      icon.type = _parseString({object: object,
-                                 property: 'type',
-                                 trim: true});
-
-      icon.density = parseFloat(object.density);
-      if (isNaN(icon.density) || !isFinite(icon.density) || icon.density <= 0) {
-        icon.density = 1.0;
-      }
-
-      if ('sizes' in object) {
-        var set = new Set();
-        var link = document.createElement('link');
-        link.sizes = object.sizes;
-
-        for (var i = 0; i < link.sizes.length; ++i) {
-          set.add(link.sizes.item(i).toLowerCase());
-        }
-
-        if (set.size !== 0) {
-          icon.sizes = set;
-        }
-      }
-
-      icons.push(icon);
-    });
-
-    return icons;
-  }
-
-  function _parseRelatedApplications() {
-    var property = 'related_applications';
-    var applications = [];
-
-    if (!(property in _jsonInput)) {
-      return applications;
-    }
-
-    if (!Array.isArray(_jsonInput[property])) {
-      _logs.push('ERROR: \'' + property +
-          '\' expected to be an array but is not.');
-      return applications;
-    }
-
-    _jsonInput[property].forEach(function(object) {
-      var application = {};
-      application.platform = _parseString({object: object,
-                                            property: 'platform',
-                                            trim: true});
-      application.id = _parseString({object: object,
-                                      property: 'id',
-                                      trim: true});
-      // TODO: pass manfiest url as base.
-      application.url = _parseURL({object: object, property: 'url'});
-      applications.push(application);
-    });
-
-    return applications;
-  }
-
-  function _parsePreferRelatedApplications() {
-    return _parseBoolean({object: _jsonInput,
-                           property: 'prefer_related_applications',
-                           defaultValue: false});
-  }
-
-  function _parseThemeColor() {
-    return _parseColor({object: _jsonInput, property: 'theme_color'});
-  }
-
-  function _parseBackgroundColor() {
-    return _parseColor({object: _jsonInput, property: 'background_color'});
-  }
-
-  function _parse(string) {
-    // TODO: temporary while ManifestParser is a collection of static methods.
-    _logs = [];
-    _tips = [];
-    _success = true;
-
-    try {
-      _jsonInput = JSON.parse(string);
-    } catch (e) {
-      _logs.push('File isn\'t valid JSON: ' + e);
-      _tips.push('Your JSON failed to parse, these are the main reasons why ' +
-        'JSON parsing usually fails:\n' +
-        '- Double quotes should be used around property names and for ' +
-        'strings. Single quotes are not valid.\n' +
-        '- JSON specification disallow trailing comma after the last ' +
-        'property even if some implementations allow it.');
-
-      _success = false;
-      return;
-    }
-
-    _logs.push('JSON parsed successfully.');
-
-    _manifest.name = _parseName();
-    /* eslint-disable camelcase */
-    _manifest.short_name = _parseShortName();
-    _manifest.start_url = _parseStartUrl();
-    _manifest.display = _parseDisplay();
-    _manifest.orientation = _parseOrientation();
-    _manifest.icons = _parseIcons();
-    _manifest.related_applications = _parseRelatedApplications();
-    _manifest.prefer_related_applications = _parsePreferRelatedApplications();
-    _manifest.theme_color = _parseThemeColor();
-    _manifest.background_color = _parseBackgroundColor();
-
-    _logs.push('Parsed `name` property is: ' +
-        _manifest.name);
-    _logs.push('Parsed `short_name` property is: ' +
-        _manifest.short_name);
-    _logs.push('Parsed `start_url` property is: ' +
-        _manifest.start_url);
-    _logs.push('Parsed `display` property is: ' +
-        _manifest.display);
-    _logs.push('Parsed `orientation` property is: ' +
-        _manifest.orientation);
-    _logs.push('Parsed `icons` property is: ' +
-        JSON.stringify(_manifest.icons, null, 4));
-    _logs.push('Parsed `related_applications` property is: ' +
-        JSON.stringify(_manifest.related_applications, null, 4));
-    _logs.push('Parsed `prefer_related_applications` property is: ' +
-        JSON.stringify(_manifest.prefer_related_applications, null, 4));
-    _logs.push('Parsed `theme_color` property is: ' +
-        _manifest.theme_color);
-    _logs.push('Parsed `background_color` property is: ' +
-        _manifest.background_color);
-    /* eslint-enable camelcase */
+    value = undefined;
   }
 
   return {
-    parse: _parse,
-    manifest: _ => _manifest,
-    logs: _ => _logs,
-    tips: _ => _tips,
-    success: _ => _success
+    raw,
+    value,
+    warning
   };
-})();
+}
 
-module.exports = ManifestParser;
+function parseURL(raw) {
+  // TODO: resolve url using baseURL
+  // var baseURL = args.baseURL;
+  // new URL(parseString(raw).value, baseURL);
+  return parseString(raw, true);
+}
+
+function parseColor(raw) {
+  let color = parseString(raw);
+
+  if (color.value === undefined) {
+    return color;
+  }
+
+  // TODO(bckenny): validate color, but for reals
+  // If style.color changes when set to the given color, it is valid. Testing
+  // against 'white' and 'black' in case of the given color is one of them.
+  // var dummy = document.createElement('div');
+  // dummy.style.color = 'white';
+  // dummy.style.color = color.value;
+  // if (dummy.style.color !== 'white') {
+  //   return color;
+  // }
+  // dummy.style.color = 'black';
+  // dummy.style.color = color.value;
+  // if (dummy.style.color !== 'black') {
+  //   return color;
+  // }
+  return color;
+
+  // color.value = undefined;
+  // color.warning = 'ERROR: color parsing failed';
+
+  // return color;
+}
+
+function parseName(jsonInput) {
+  return parseString(jsonInput.name, true);
+}
+
+function parseShortName(jsonInput) {
+  return parseString(jsonInput.short_name, true);
+}
+
+function parseStartUrl(jsonInput) {
+  // TODO: parse url using manifest_url as a base (missing).
+  // start_url must be same-origin as Document of the top-level browsing context.
+  return parseURL(jsonInput.start_url);
+}
+
+function parseDisplay(jsonInput) {
+  var display = parseString(jsonInput.display, true);
+
+  if (display.value && ALLOWED_DISPLAY_VALUES.indexOf(display.value.toLowerCase()) === -1) {
+    display.value = undefined;
+    display.warning = 'ERROR: \'display\' has an invalid value, will be ignored.';
+  }
+
+  return display;
+}
+
+function parseOrientation(jsonInput) {
+  var orientation = parseString(jsonInput.orientation, true);
+
+  if (orientation.value &&
+      ALLOWED_ORIENTATION_VALUES.indexOf(orientation.value.toLowerCase()) === -1) {
+    orientation.value = undefined;
+    orientation.warning = 'ERROR: \'orientation\' has an invalid value, will be ignored.';
+  }
+
+  return orientation;
+}
+
+function parseIcon(raw) {
+  // TODO: pass manifest url as base.
+  let src = parseURL(raw.src);
+  let type = parseString(raw.type, true);
+
+  let density = {
+    raw: raw.density,
+    value: 1,
+    warning: undefined
+  };
+  if (density.raw !== undefined) {
+    density.value = parseFloat(density.raw);
+    if (isNaN(density.value) || !isFinite(density.value) || density.value <= 0) {
+      density.value = 1;
+      density.warning = 'ERROR: icon density cannot be NaN, +∞, or less than or equal to +0.';
+    }
+  }
+
+  let sizes = parseString(raw.sizes);
+  if (sizes.value !== undefined) {
+    let set = new Set();
+    sizes.value.split(/\s/).forEach(size => set.add(size.toLowerCase()));
+
+    sizes.value = set.size > 0 ? set : undefined;
+  }
+
+  return {
+    raw,
+    value: {
+      src,
+      type,
+      density,
+      sizes
+    },
+    warning: undefined
+  };
+}
+
+function parseIcons(jsonInput) {
+  const raw = jsonInput.icons;
+  let value;
+
+  if (raw === undefined) {
+    return {
+      raw,
+      value,
+      warning: undefined
+    };
+  }
+
+  if (!Array.isArray(raw)) {
+    return {
+      raw,
+      value,
+      warning: 'ERROR: \'icons\' expected to be an array but is not.'
+    };
+  }
+
+  // TODO(bckenny): spec says to skip icons missing `src`. Warn instead?
+  value = raw.filter(icon => !!icon.src).map(parseIcon);
+
+  return {
+    raw,
+    value,
+    warning: undefined
+  };
+}
+
+function parseApplication(raw) {
+  let platform = parseString(raw.platform, true);
+  let id = parseString(raw.id, true);
+  // TODO: pass manfiest url as base.
+  let url = parseURL(raw.url);
+
+  return {
+    raw,
+    value: {
+      platform,
+      id,
+      url
+    },
+    warning: undefined
+  };
+}
+
+function parseRelatedApplications(jsonInput) {
+  const raw = jsonInput.related_applications;
+  let value;
+
+  if (raw === undefined) {
+    return {
+      raw,
+      value,
+      warning: undefined
+    };
+  }
+
+  if (!Array.isArray(raw)) {
+    return {
+      raw,
+      value,
+      warning: 'ERROR: \'related_applications\' expected to be an array but is not.'
+    };
+  }
+
+  // TODO(bckenny): spec says to skip apps missing `platform`. Warn instead?
+  value = raw.filter(application => !!application.platform).map(parseApplication);
+
+  return {
+    raw,
+    value,
+    warning: undefined
+  };
+}
+
+function parsePreferRelatedApplications(jsonInput) {
+  const raw = jsonInput.prefer_related_applications;
+  let value;
+  let warning;
+
+  if (typeof raw === 'boolean') {
+    value = raw;
+  } else {
+    if (raw !== undefined) {
+      warning = 'ERROR: \'prefer_related_applications\' expected to be a boolean.';
+    }
+    value = undefined;
+  }
+
+  return {
+    raw,
+    value,
+    warning
+  };
+}
+
+function parseThemeColor(jsonInput) {
+  return parseColor(jsonInput.theme_color);
+}
+
+function parseBackgroundColor(jsonInput) {
+  return parseColor(jsonInput.background_color);
+}
+
+function parse(string, logToConsole) {
+  let jsonInput;
+
+  try {
+    jsonInput = JSON.parse(string);
+  } catch (e) {
+    return {
+      raw: string,
+      value: undefined,
+      warning: 'ERROR: file isn\'t valid JSON: ' + e
+    };
+  }
+
+  /* eslint-disable camelcase */
+  let manifest = {
+    name: parseName(jsonInput),
+    short_name: parseShortName(jsonInput),
+    start_url: parseStartUrl(jsonInput),
+    display: parseDisplay(jsonInput),
+    orientation: parseOrientation(jsonInput),
+    icons: parseIcons(jsonInput),
+    related_applications: parseRelatedApplications(jsonInput),
+    prefer_related_applications: parsePreferRelatedApplications(jsonInput),
+    theme_color: parseThemeColor(jsonInput),
+    background_color: parseBackgroundColor(jsonInput)
+  };
+  /* eslint-enable camelcase */
+
+  if (logToConsole) {
+    console.log('JSON parsed successfully.');
+    console.log('Parsed `name` property is: ' + manifest.name);
+    console.log('Parsed `short_name` property is: ' + manifest.short_name);
+    console.log('Parsed `start_url` property is: ' + manifest.start_url);
+    console.log('Parsed `display` property is: ' + manifest.display);
+    console.log('Parsed `orientation` property is: ' + manifest.orientation);
+    console.log('Parsed `icons` property is: ' + JSON.stringify(manifest.icons, null, 4));
+    console.log('Parsed `related_applications` property is: ' +
+        JSON.stringify(manifest.related_applications, null, 4));
+    console.log('Parsed `prefer_related_applications` property is: ' +
+        JSON.stringify(manifest.prefer_related_applications, null, 4));
+    console.log('Parsed `theme_color` property is: ' + manifest.theme_color);
+    console.log('Parsed `background_color` property is: ' + manifest.background_color);
+  }
+
+  return {
+    raw: string,
+    value: manifest,
+    warning: undefined
+  };
+}
+
+module.exports = parse;

--- a/helpers/manifest-parser.js
+++ b/helpers/manifest-parser.js
@@ -1,0 +1,329 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var ManifestParser = (function() {
+
+  var _jsonInput = {};
+  var _manifest = {};
+  var _logs = [];
+  var _tips = [];
+  var _success = true;
+
+  var ALLOWED_DISPLAY_VALUES = ['fullscreen',
+                                 'standalone',
+                                 'minimal-ui',
+                                 'browser'];
+
+  var ALLOWED_ORIENTATION_VALUES = ['any',
+                                     'natural',
+                                     'landscape',
+                                     'portrait',
+                                     'portrait-primary',
+                                     'portrait-secondary',
+                                     'landscape-primary',
+                                     'landscape-secondary'];
+
+  function _parseString(args) {
+    var object = args.object;
+    var property = args.property;
+    if (!(property in object)) {
+      return undefined;
+    }
+
+    if (typeof object[property] != 'string') {
+      _logs.push('ERROR: \'' + property +
+          '\' expected to be a string but is not.');
+      return undefined;
+    }
+
+    if (args.trim) {
+      return object[property].trim();
+    }
+    return object[property];
+  }
+
+  function _parseBoolean(args) {
+    var object = args.object;
+    var property = args.property;
+    var defaultValue = args.defaultValue;
+    if (!(property in object)) {
+      return defaultValue;
+    }
+
+    if (typeof object[property] != 'boolean') {
+      _logs.push('ERROR: \'' + property +
+          '\' expected to be a boolean but is not.');
+      return defaultValue;
+    }
+
+    return object[property];
+  }
+
+  function _parseURL(args) {
+    var object = args.object;
+    var property = args.property;
+    var baseURL = args.baseURL;
+
+    var str = _parseString({object: object, property: property, trim: false});
+    if (str === undefined) {
+      return undefined;
+    }
+
+    // TODO: resolve url using baseURL
+    // new URL(object[property], baseURL);
+    return object[property];
+  }
+
+  function _parseColor(args) {
+    var object = args.object;
+    var property = args.property;
+    if (!(property in object)) {
+      return undefined;
+    }
+
+    if (typeof object[property] != 'string') {
+      _logs.push('ERROR: \'' + property +
+          '\' expected to be a string but is not.');
+      return undefined;
+    }
+
+    // If style.color changes when set to the given color, it is valid. Testing
+    // against 'white' and 'black' in case of the given color is one of them.
+    var dummy = document.createElement('div');
+    dummy.style.color = 'white';
+    dummy.style.color = object[property];
+    if (dummy.style.color != 'white') {
+      return object[property];
+    }
+    dummy.style.color = 'black';
+    dummy.style.color = object[property];
+    if (dummy.style.color != 'black') {
+      return object[property];
+    }
+    return undefined;
+  }
+
+  function _parseName() {
+    return _parseString({object: _jsonInput, property: 'name', trim: true});
+  }
+
+  function _parseShortName() {
+    return _parseString({object: _jsonInput,
+                          property: 'short_name',
+                          trim: true});
+  }
+
+  function _parseStartUrl() {
+    // TODO: parse url using manifest_url as a base (missing).
+    return _parseURL({object: _jsonInput, property: 'start_url'});
+  }
+
+  function _parseDisplay() {
+    var display = _parseString({object: _jsonInput,
+                                 property: 'display',
+                                 trim: true});
+    if (display === undefined) {
+      return display;
+    }
+
+    if (ALLOWED_DISPLAY_VALUES.indexOf(display.toLowerCase()) == -1) {
+      _logs.push('ERROR: \'display\' has an invalid value, will be ignored.');
+      return undefined;
+    }
+
+    return display;
+  }
+
+  function _parseOrientation() {
+    var orientation = _parseString({object: _jsonInput,
+                                     property: 'orientation',
+                                     trim: true});
+    if (orientation === undefined) {
+      return orientation;
+    }
+
+    if (ALLOWED_ORIENTATION_VALUES.indexOf(orientation.toLowerCase()) == -1) {
+      _logs.push('ERROR: \'orientation\' has an invalid value' +
+          ', will be ignored.');
+      return undefined;
+    }
+
+    return orientation;
+  }
+
+  function _parseIcons() {
+    var property = 'icons';
+    var icons = [];
+
+    if (!(property in _jsonInput)) {
+      return icons;
+    }
+
+    if (!Array.isArray(_jsonInput[property])) {
+      _logs.push('ERROR: \'' + property +
+          '\' expected to be an array but is not.');
+      return icons;
+    }
+
+    _jsonInput[property].forEach(function(object) {
+      var icon = {};
+      if (!('src' in object)) {
+        return;
+      }
+      // TODO: pass manifest url as base.
+      icon.src = _parseURL({object: object, property: 'src'});
+      icon.type = _parseString({object: object,
+                                 property: 'type',
+                                 trim: true});
+
+      icon.density = parseFloat(object.density);
+      if (isNaN(icon.density) || !isFinite(icon.density) || icon.density <= 0) {
+        icon.density = 1.0;
+      }
+
+      if ('sizes' in object) {
+        var set = new Set();
+        var link = document.createElement('link');
+        link.sizes = object.sizes;
+
+        for (var i = 0; i < link.sizes.length; ++i) {
+          set.add(link.sizes.item(i).toLowerCase());
+        }
+
+        if (set.size != 0) {
+          icon.sizes = set;
+        }
+      }
+
+      icons.push(icon);
+    });
+
+    return icons;
+  }
+
+  function _parseRelatedApplications() {
+    var property = 'related_applications';
+    var applications = [];
+
+    if (!(property in _jsonInput)) {
+      return applications;
+    }
+
+    if (!Array.isArray(_jsonInput[property])) {
+      _logs.push('ERROR: \'' + property +
+          '\' expected to be an array but is not.');
+      return applications;
+    }
+
+    _jsonInput[property].forEach(function(object) {
+      var application = {};
+      application.platform = _parseString({object: object,
+                                            property: 'platform',
+                                            trim: true});
+      application.id = _parseString({object: object,
+                                      property: 'id',
+                                      trim: true});
+      // TODO: pass manfiest url as base.
+      application.url = _parseURL({object: object, property: 'url'});
+      applications.push(application);
+    });
+
+    return applications;
+  }
+
+  function _parsePreferRelatedApplications() {
+    return _parseBoolean({object: _jsonInput,
+                           property: 'prefer_related_applications',
+                           defaultValue: false});
+  }
+
+  function _parseThemeColor() {
+    return _parseColor({object: _jsonInput, property: 'theme_color'});
+  }
+
+  function _parseBackgroundColor() {
+    return _parseColor({object: _jsonInput, property: 'background_color'});
+  }
+
+  function _parse(string) {
+    // TODO: temporary while ManifestParser is a collection of static methods.
+    _logs = [];
+    _tips = [];
+    _success = true;
+
+    try {
+      _jsonInput = JSON.parse(string);
+    } catch (e) {
+      _logs.push('File isn\'t valid JSON: ' + e);
+      _tips.push('Your JSON failed to parse, these are the main reasons why ' +
+        'JSON parsing usually fails:\n' +
+        '- Double quotes should be used around property names and for ' +
+        'strings. Single quotes are not valid.\n' +
+        '- JSON specification disallow trailing comma after the last ' +
+        'property even if some implementations allow it.');
+
+      _success = false;
+      return;
+    }
+
+    _logs.push('JSON parsed successfully.');
+
+    _manifest.name = _parseName();
+    /* eslint-disable camelcase */
+    _manifest.short_name = _parseShortName();
+    _manifest.start_url = _parseStartUrl();
+    _manifest.display = _parseDisplay();
+    _manifest.orientation = _parseOrientation();
+    _manifest.icons = _parseIcons();
+    _manifest.related_applications = _parseRelatedApplications();
+    _manifest.prefer_related_applications = _parsePreferRelatedApplications();
+    _manifest.theme_color = _parseThemeColor();
+    _manifest.background_color = _parseBackgroundColor();
+
+    _logs.push('Parsed `name` property is: ' +
+        _manifest.name);
+    _logs.push('Parsed `short_name` property is: ' +
+        _manifest.short_name);
+    _logs.push('Parsed `start_url` property is: ' +
+        _manifest.start_url);
+    _logs.push('Parsed `display` property is: ' +
+        _manifest.display);
+    _logs.push('Parsed `orientation` property is: ' +
+        _manifest.orientation);
+    _logs.push('Parsed `icons` property is: ' +
+        JSON.stringify(_manifest.icons, null, 4));
+    _logs.push('Parsed `related_applications` property is: ' +
+        JSON.stringify(_manifest.related_applications, null, 4));
+    _logs.push('Parsed `prefer_related_applications` property is: ' +
+        JSON.stringify(_manifest.prefer_related_applications, null, 4));
+    _logs.push('Parsed `theme_color` property is: ' +
+        _manifest.theme_color);
+    _logs.push('Parsed `background_color` property is: ' +
+        _manifest.background_color);
+    /* eslint-enable camelcase */
+  }
+
+  return {
+    parse: _parse,
+    manifest: function() { return _manifest; },
+    logs: function() { return _logs; },
+    tips: function() { return _tips; },
+    success: function() { return _success; }
+  };
+})();
+
+module.exports = ManifestParser;

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ Promise.resolve(driver).then(gatherer([
   require('./audits/viewport-meta-tag/gather'),
   require('./audits/minify-html/gather'),
   require('./audits/service-worker/gather'),
-  require('./gatherers/trace')
+  require('./gatherers/trace'),
+  require('./gatherers/js-in-context')
 ], URL)).then(auditor([
   require('./audits/minify-html/audit'),
   require('./audits/service-worker/audit'),

--- a/test/manifest-parser-tests.js
+++ b/test/manifest-parser-tests.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* global describe, it */
+
+var ManifestParser = require('../helpers/manifest-parser');
+var assert = require('assert');
+
+describe('Manifest Parser', function() {
+  it('should not parse empty string input', function() {
+    ManifestParser.parse('');
+    assert.equal(false, ManifestParser.success());
+  });
+
+  it('has empty values when parsing empty manifest', function() {
+    ManifestParser.parse('');
+    assert.equal(null, ManifestParser.manifest().name);
+    assert.equal(null, ManifestParser.manifest().short_name);
+    assert.equal(null, ManifestParser.manifest().start_url);
+    assert.equal(null, ManifestParser.manifest().display);
+    assert.equal(null, ManifestParser.manifest().orientation);
+    assert.equal(null, ManifestParser.manifest().theme_color);
+    assert.equal(null, ManifestParser.manifest().background_color);
+  });
+
+  it('accepts empty dictionary', function() {
+    ManifestParser.parse('{}');
+    assert.equal(true, ManifestParser.success());
+    assert.equal(null, ManifestParser.manifest().name);
+    assert.equal(null, ManifestParser.manifest().short_name);
+    assert.equal(null, ManifestParser.manifest().start_url);
+    assert.equal(null, ManifestParser.manifest().display);
+    assert.equal(null, ManifestParser.manifest().orientation);
+    assert.equal(null, ManifestParser.manifest().theme_color);
+    assert.equal(null, ManifestParser.manifest().background_color);
+    // TODO:
+    // icons
+    // related_applications
+    // prefer_related_applications
+  });
+
+  it('accepts unknown values', function() {
+    ManifestParser.parse('{}');
+    assert.equal(true, ManifestParser.success());
+    assert.equal(null, ManifestParser.manifest().name);
+    assert.equal(null, ManifestParser.manifest().short_name);
+    assert.equal(null, ManifestParser.manifest().start_url);
+    assert.equal(null, ManifestParser.manifest().display);
+    assert.equal(null, ManifestParser.manifest().orientation);
+    assert.equal(null, ManifestParser.manifest().theme_color);
+    assert.equal(null, ManifestParser.manifest().background_color);
+  });
+
+  describe('name parsing', function() {
+    it('it parses basic string', function() {
+      ManifestParser.parse('{"name":"foo"}');
+      assert.equal(true, ManifestParser.success());
+      assert.equal('foo', ManifestParser.manifest().name);
+    });
+
+    it('it trims whitespaces', function() {
+      ManifestParser.parse('{"name":" foo "}');
+      assert.equal(true, ManifestParser.success());
+      assert.equal('foo', ManifestParser.manifest().name);
+    });
+
+    it('doesn\'t parse non-string', function() {
+      ManifestParser.parse('{"name": {} }');
+      assert.equal(true, ManifestParser.success());
+      assert.equal(null, ManifestParser.manifest().name);
+
+      ManifestParser.parse('{"name": 42 }');
+      assert.equal(true, ManifestParser.success());
+      assert.equal(null, ManifestParser.manifest().name);
+    });
+  });
+
+  describe('short_name parsing', function() {
+    it('it parses basic string', function() {
+      ManifestParser.parse('{"short_name":"foo"}');
+      assert.equal(true, ManifestParser.success());
+      assert.equal('foo', ManifestParser.manifest().short_name);
+    });
+
+    it('it trims whitespaces', function() {
+      ManifestParser.parse('{"short_name":" foo "}');
+      assert.equal(true, ManifestParser.success());
+      assert.equal('foo', ManifestParser.manifest().short_name);
+    });
+
+    it('doesn\'t parse non-string', function() {
+      ManifestParser.parse('{"short_name": {} }');
+      assert.equal(true, ManifestParser.success());
+      assert.equal(null, ManifestParser.manifest().short_name);
+
+      ManifestParser.parse('{"short_name": 42 }');
+      assert.equal(true, ManifestParser.success());
+      assert.equal(null, ManifestParser.manifest().short_name);
+    });
+  });
+});

--- a/test/manifest-parser-tests.js
+++ b/test/manifest-parser-tests.js
@@ -18,35 +18,35 @@
 /* global describe, it */
 
 var ManifestParser = require('../helpers/manifest-parser');
-var assert = require('assert');
+var expect = require('chai').expect;
 
 describe('Manifest Parser', function() {
   it('should not parse empty string input', function() {
     ManifestParser.parse('');
-    assert.equal(false, ManifestParser.success());
+    expect(ManifestParser.success()).to.equal(false);
   });
 
   it('has empty values when parsing empty manifest', function() {
     ManifestParser.parse('');
-    assert.equal(null, ManifestParser.manifest().name);
-    assert.equal(null, ManifestParser.manifest().short_name);
-    assert.equal(null, ManifestParser.manifest().start_url);
-    assert.equal(null, ManifestParser.manifest().display);
-    assert.equal(null, ManifestParser.manifest().orientation);
-    assert.equal(null, ManifestParser.manifest().theme_color);
-    assert.equal(null, ManifestParser.manifest().background_color);
+    expect(ManifestParser.manifest().name).to.equal(undefined);
+    expect(ManifestParser.manifest().short_name).to.equal(undefined);
+    expect(ManifestParser.manifest().start_url).to.equal(undefined);
+    expect(ManifestParser.manifest().display).to.equal(undefined);
+    expect(ManifestParser.manifest().orientation).to.equal(undefined);
+    expect(ManifestParser.manifest().theme_color).to.equal(undefined);
+    expect(ManifestParser.manifest().background_color).to.equal(undefined);
   });
 
   it('accepts empty dictionary', function() {
     ManifestParser.parse('{}');
-    assert.equal(true, ManifestParser.success());
-    assert.equal(null, ManifestParser.manifest().name);
-    assert.equal(null, ManifestParser.manifest().short_name);
-    assert.equal(null, ManifestParser.manifest().start_url);
-    assert.equal(null, ManifestParser.manifest().display);
-    assert.equal(null, ManifestParser.manifest().orientation);
-    assert.equal(null, ManifestParser.manifest().theme_color);
-    assert.equal(null, ManifestParser.manifest().background_color);
+    expect(ManifestParser.success()).to.equal(true);
+    expect(ManifestParser.manifest().name).to.equal(undefined);
+    expect(ManifestParser.manifest().short_name).to.equal(undefined);
+    expect(ManifestParser.manifest().start_url).to.equal(undefined);
+    expect(ManifestParser.manifest().display).to.equal(undefined);
+    expect(ManifestParser.manifest().orientation).to.equal(undefined);
+    expect(ManifestParser.manifest().theme_color).to.equal(undefined);
+    expect(ManifestParser.manifest().background_color).to.equal(undefined);
     // TODO:
     // icons
     // related_applications
@@ -54,62 +54,63 @@ describe('Manifest Parser', function() {
   });
 
   it('accepts unknown values', function() {
+    // TODO(bckenny): this is the same exact test as above
     ManifestParser.parse('{}');
-    assert.equal(true, ManifestParser.success());
-    assert.equal(null, ManifestParser.manifest().name);
-    assert.equal(null, ManifestParser.manifest().short_name);
-    assert.equal(null, ManifestParser.manifest().start_url);
-    assert.equal(null, ManifestParser.manifest().display);
-    assert.equal(null, ManifestParser.manifest().orientation);
-    assert.equal(null, ManifestParser.manifest().theme_color);
-    assert.equal(null, ManifestParser.manifest().background_color);
+    expect(ManifestParser.success()).to.equal(true);
+    expect(ManifestParser.manifest().name).to.equal(undefined);
+    expect(ManifestParser.manifest().short_name).to.equal(undefined);
+    expect(ManifestParser.manifest().start_url).to.equal(undefined);
+    expect(ManifestParser.manifest().display).to.equal(undefined);
+    expect(ManifestParser.manifest().orientation).to.equal(undefined);
+    expect(ManifestParser.manifest().theme_color).to.equal(undefined);
+    expect(ManifestParser.manifest().background_color).to.equal(undefined);
   });
 
   describe('name parsing', function() {
     it('it parses basic string', function() {
       ManifestParser.parse('{"name":"foo"}');
-      assert.equal(true, ManifestParser.success());
-      assert.equal('foo', ManifestParser.manifest().name);
+      expect(ManifestParser.success()).to.equal(true);
+      expect(ManifestParser.manifest().name).to.equal('foo');
     });
 
     it('it trims whitespaces', function() {
       ManifestParser.parse('{"name":" foo "}');
-      assert.equal(true, ManifestParser.success());
-      assert.equal('foo', ManifestParser.manifest().name);
+      expect(ManifestParser.success()).to.equal(true);
+      expect(ManifestParser.manifest().name).to.equal('foo');
     });
 
     it('doesn\'t parse non-string', function() {
       ManifestParser.parse('{"name": {} }');
-      assert.equal(true, ManifestParser.success());
-      assert.equal(null, ManifestParser.manifest().name);
+      expect(ManifestParser.success()).to.equal(true);
+      expect(ManifestParser.manifest().name).to.equal(undefined);
 
       ManifestParser.parse('{"name": 42 }');
-      assert.equal(true, ManifestParser.success());
-      assert.equal(null, ManifestParser.manifest().name);
+      expect(ManifestParser.success()).to.equal(true);
+      expect(ManifestParser.manifest().name).to.equal(undefined);
     });
   });
 
   describe('short_name parsing', function() {
     it('it parses basic string', function() {
       ManifestParser.parse('{"short_name":"foo"}');
-      assert.equal(true, ManifestParser.success());
-      assert.equal('foo', ManifestParser.manifest().short_name);
+      expect(ManifestParser.success()).to.equal(true);
+      expect(ManifestParser.manifest().short_name).to.equal('foo');
     });
 
     it('it trims whitespaces', function() {
       ManifestParser.parse('{"short_name":" foo "}');
-      assert.equal(true, ManifestParser.success());
-      assert.equal('foo', ManifestParser.manifest().short_name);
+      expect(ManifestParser.success()).to.equal(true);
+      expect(ManifestParser.manifest().short_name).to.equal('foo');
     });
 
     it('doesn\'t parse non-string', function() {
       ManifestParser.parse('{"short_name": {} }');
-      assert.equal(true, ManifestParser.success());
-      assert.equal(null, ManifestParser.manifest().short_name);
+      expect(ManifestParser.success()).to.equal(true);
+      expect(ManifestParser.manifest().short_name).to.equal(undefined);
 
       ManifestParser.parse('{"short_name": 42 }');
-      assert.equal(true, ManifestParser.success());
-      assert.equal(null, ManifestParser.manifest().short_name);
+      expect(ManifestParser.success()).to.equal(true);
+      expect(ManifestParser.manifest().short_name).to.equal(undefined);
     });
   });
 });

--- a/test/manifest-parser-tests.js
+++ b/test/manifest-parser-tests.js
@@ -17,36 +17,25 @@
 
 /* global describe, it */
 
-var ManifestParser = require('../helpers/manifest-parser');
+var manifestParser = require('../helpers/manifest-parser');
 var expect = require('chai').expect;
 
 describe('Manifest Parser', function() {
   it('should not parse empty string input', function() {
-    ManifestParser.parse('');
-    expect(ManifestParser.success()).to.equal(false);
-  });
-
-  it('has empty values when parsing empty manifest', function() {
-    ManifestParser.parse('');
-    expect(ManifestParser.manifest().name).to.equal(undefined);
-    expect(ManifestParser.manifest().short_name).to.equal(undefined);
-    expect(ManifestParser.manifest().start_url).to.equal(undefined);
-    expect(ManifestParser.manifest().display).to.equal(undefined);
-    expect(ManifestParser.manifest().orientation).to.equal(undefined);
-    expect(ManifestParser.manifest().theme_color).to.equal(undefined);
-    expect(ManifestParser.manifest().background_color).to.equal(undefined);
+    let parsedManifest = manifestParser('');
+    expect(!parsedManifest.warning).to.equal(false);
   });
 
   it('accepts empty dictionary', function() {
-    ManifestParser.parse('{}');
-    expect(ManifestParser.success()).to.equal(true);
-    expect(ManifestParser.manifest().name).to.equal(undefined);
-    expect(ManifestParser.manifest().short_name).to.equal(undefined);
-    expect(ManifestParser.manifest().start_url).to.equal(undefined);
-    expect(ManifestParser.manifest().display).to.equal(undefined);
-    expect(ManifestParser.manifest().orientation).to.equal(undefined);
-    expect(ManifestParser.manifest().theme_color).to.equal(undefined);
-    expect(ManifestParser.manifest().background_color).to.equal(undefined);
+    let parsedManifest = manifestParser('{}');
+    expect(!parsedManifest.warning).to.equal(true);
+    expect(parsedManifest.value.name.value).to.equal(undefined);
+    expect(parsedManifest.value.short_name.value).to.equal(undefined);
+    expect(parsedManifest.value.start_url.value).to.equal(undefined);
+    expect(parsedManifest.value.display.value).to.equal(undefined);
+    expect(parsedManifest.value.orientation.value).to.equal(undefined);
+    expect(parsedManifest.value.theme_color.value).to.equal(undefined);
+    expect(parsedManifest.value.background_color.value).to.equal(undefined);
     // TODO:
     // icons
     // related_applications
@@ -55,62 +44,62 @@ describe('Manifest Parser', function() {
 
   it('accepts unknown values', function() {
     // TODO(bckenny): this is the same exact test as above
-    ManifestParser.parse('{}');
-    expect(ManifestParser.success()).to.equal(true);
-    expect(ManifestParser.manifest().name).to.equal(undefined);
-    expect(ManifestParser.manifest().short_name).to.equal(undefined);
-    expect(ManifestParser.manifest().start_url).to.equal(undefined);
-    expect(ManifestParser.manifest().display).to.equal(undefined);
-    expect(ManifestParser.manifest().orientation).to.equal(undefined);
-    expect(ManifestParser.manifest().theme_color).to.equal(undefined);
-    expect(ManifestParser.manifest().background_color).to.equal(undefined);
+    let parsedManifest = manifestParser('{}');
+    expect(!parsedManifest.warning).to.equal(true);
+    expect(parsedManifest.value.name.value).to.equal(undefined);
+    expect(parsedManifest.value.short_name.value).to.equal(undefined);
+    expect(parsedManifest.value.start_url.value).to.equal(undefined);
+    expect(parsedManifest.value.display.value).to.equal(undefined);
+    expect(parsedManifest.value.orientation.value).to.equal(undefined);
+    expect(parsedManifest.value.theme_color.value).to.equal(undefined);
+    expect(parsedManifest.value.background_color.value).to.equal(undefined);
   });
 
   describe('name parsing', function() {
     it('it parses basic string', function() {
-      ManifestParser.parse('{"name":"foo"}');
-      expect(ManifestParser.success()).to.equal(true);
-      expect(ManifestParser.manifest().name).to.equal('foo');
+      let parsedManifest = manifestParser('{"name":"foo"}');
+      expect(!parsedManifest.warning).to.equal(true);
+      expect(parsedManifest.value.name.value).to.equal('foo');
     });
 
     it('it trims whitespaces', function() {
-      ManifestParser.parse('{"name":" foo "}');
-      expect(ManifestParser.success()).to.equal(true);
-      expect(ManifestParser.manifest().name).to.equal('foo');
+      let parsedManifest = manifestParser('{"name":" foo "}');
+      expect(!parsedManifest.warning).to.equal(true);
+      expect(parsedManifest.value.name.value).to.equal('foo');
     });
 
     it('doesn\'t parse non-string', function() {
-      ManifestParser.parse('{"name": {} }');
-      expect(ManifestParser.success()).to.equal(true);
-      expect(ManifestParser.manifest().name).to.equal(undefined);
+      let parsedManifest = manifestParser('{"name": {} }');
+      expect(!parsedManifest.warning).to.equal(true);
+      expect(parsedManifest.value.name.value).to.equal(undefined);
 
-      ManifestParser.parse('{"name": 42 }');
-      expect(ManifestParser.success()).to.equal(true);
-      expect(ManifestParser.manifest().name).to.equal(undefined);
+      parsedManifest = manifestParser('{"name": 42 }');
+      expect(!parsedManifest.warning).to.equal(true);
+      expect(parsedManifest.value.name.value).to.equal(undefined);
     });
   });
 
   describe('short_name parsing', function() {
     it('it parses basic string', function() {
-      ManifestParser.parse('{"short_name":"foo"}');
-      expect(ManifestParser.success()).to.equal(true);
-      expect(ManifestParser.manifest().short_name).to.equal('foo');
+      let parsedManifest = manifestParser('{"short_name":"foo"}');
+      expect(!parsedManifest.warning).to.equal(true);
+      expect(parsedManifest.value.short_name.value).to.equal('foo');
     });
 
     it('it trims whitespaces', function() {
-      ManifestParser.parse('{"short_name":" foo "}');
-      expect(ManifestParser.success()).to.equal(true);
-      expect(ManifestParser.manifest().short_name).to.equal('foo');
+      let parsedManifest = manifestParser('{"short_name":" foo "}');
+      expect(!parsedManifest.warning).to.equal(true);
+      expect(parsedManifest.value.short_name.value).to.equal('foo');
     });
 
     it('doesn\'t parse non-string', function() {
-      ManifestParser.parse('{"short_name": {} }');
-      expect(ManifestParser.success()).to.equal(true);
-      expect(ManifestParser.manifest().short_name).to.equal(undefined);
+      let parsedManifest = manifestParser('{"short_name": {} }');
+      expect(!parsedManifest.warning).to.equal(true);
+      expect(parsedManifest.value.short_name.value).to.equal(undefined);
 
-      ManifestParser.parse('{"short_name": 42 }');
-      expect(ManifestParser.success()).to.equal(true);
-      expect(ManifestParser.manifest().short_name).to.equal(undefined);
+      parsedManifest = manifestParser('{"short_name": 42 }');
+      expect(!parsedManifest.warning).to.equal(true);
+      expect(parsedManifest.value.short_name.value).to.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
@paullewis 

- some changes were made to the parser to retain more information through the manifest parsing. Each node in the manifest tree retains its original raw value, the parsed value, and the "[developer warnings](https://www.w3.org/TR/appmanifest/#dfn-issue-a-developer-warning)" the spec specifies when you make a mistake, even when recovered. The spec is very forgiving, though, so I've tweaked some things to make sure they still work even while issuing a warning. The original linear `_logs` is dropped in favor of the warning being associated with the erroneous manifest entry.
- changes from above mean that at every item in the manifest you have to hit `.value` to get the parsed value of that node. Kind of annoying, open to ideas there. See changes to test for example.
- ported tests from https://github.com/mounirlamouri/manifest-validator/blob/master/test/manifest-parser-tests.js. They are very preliminary.
- added gatherer that executes js in the page context to have the page pull in the manifest itself while we figure out #22
- nothing is actually audited yet. Value of parsed manifest is on `data.parsedManifest` inside your friendly neighborhood auditor