### PR TITLE
validate manifest colors with DevTools's color parsing code

### DIFF
--- a/audits/manifest/icons-192.js
+++ b/audits/manifest/icons-192.js
@@ -32,7 +32,7 @@ class ManifestIcons192 {
 
     if (manifest && manifest.icons.value) {
       const icons192 = manifest.icons.value.find(icon => {
-        return icon.value.sizes.value.includes('192x192');
+        return icon.value.sizes.value.indexOf('192x192') !== -1;
       });
       hasIcons = (!!icons192);
     }

--- a/helpers/manifest-parser.js
+++ b/helpers/manifest-parser.js
@@ -73,8 +73,8 @@ function parseColor(raw) {
   }
 
   // Use DevTools's color parser to check CSS3 Color parsing.
-  const parseColor = global.WebInspector.Color.parse(color.raw);
-  if (!parseColor) {
+  const parsedColor = global.WebInspector.Color.parse(color.raw);
+  if (!parsedColor) {
     color.value = undefined;
     color.warning = 'ERROR: color parsing failed.';
   }

--- a/helpers/manifest-parser.js
+++ b/helpers/manifest-parser.js
@@ -15,6 +15,10 @@
  */
 'use strict';
 
+// Required to initialize WebInspector.Color.
+global.WebInspector = global.WebInspector || {};
+require('chrome-devtools-frontend/front_end/common/Color.js');
+
 const ALLOWED_DISPLAY_VALUES = [
   'fullscreen',
   'standalone',
@@ -61,33 +65,21 @@ function parseURL(raw) {
 }
 
 function parseColor(raw) {
-  let color = parseString(raw);
+  const color = parseString(raw);
 
+  // Finished if color missing or not a string.
   if (color.value === undefined) {
     return color;
   }
 
-  // TODO(bckenny): validate color, but for reals
-  // possibly pull in devtools/front_end/common/Color.js
-  // If style.color changes when set to the given color, it is valid. Testing
-  // against 'white' and 'black' in case of the given color is one of them.
-  // var dummy = document.createElement('div');
-  // dummy.style.color = 'white';
-  // dummy.style.color = color.value;
-  // if (dummy.style.color !== 'white') {
-  //   return color;
-  // }
-  // dummy.style.color = 'black';
-  // dummy.style.color = color.value;
-  // if (dummy.style.color !== 'black') {
-  //   return color;
-  // }
+  // Use DevTools's color parser to check CSS3 Color parsing.
+  const parseColor = global.WebInspector.Color.parse(color.raw);
+  if (!parseColor) {
+    color.value = undefined;
+    color.warning = 'ERROR: color parsing failed.';
+  }
+
   return color;
-
-  // color.value = undefined;
-  // color.warning = 'ERROR: color parsing failed';
-
-  // return color;
 }
 
 function parseName(jsonInput) {

--- a/helpers/network-recorder.js
+++ b/helpers/network-recorder.js
@@ -22,25 +22,24 @@ global.self = global;
 global.Protocol = {
   Agents() {}
 };
-global.WebInspector = Object.assign(global.WebInspector || {}, {
-  _moduleSettings: {
-    cacheDisabled: {
-      addChangeListener() {},
-      get() {
-        return false;
-      }
-    },
-    monitoringXHREnabled: {
-      addChangeListener() {},
-      get() {
-        return false;
-      }
+global.WebInspector = global.WebInspector || {};
+global.WebInspector._moduleSettings = {
+  cacheDisabled: {
+    addChangeListener() {},
+    get() {
+      return false;
     }
   },
-  moduleSetting: function(settingName) {
-    return this._moduleSettings[settingName];
+  monitoringXHREnabled: {
+    addChangeListener() {},
+    get() {
+      return false;
+    }
   }
-});
+};
+global.WebInspector.moduleSetting = function(settingName) {
+  return this._moduleSettings[settingName];
+};
 // Enum from chromium//src/third_party/WebKit/Source/core/loader/MixedContentChecker.h
 global.NetworkAgent = {
   RequestMixedContentType: {

--- a/helpers/network-recorder.js
+++ b/helpers/network-recorder.js
@@ -22,7 +22,7 @@ global.self = global;
 global.Protocol = {
   Agents() {}
 };
-global.WebInspector = {
+global.WebInspector = Object.assign(global.WebInspector || {}, {
   _moduleSettings: {
     cacheDisabled: {
       addChangeListener() {},
@@ -40,7 +40,7 @@ global.WebInspector = {
   moduleSetting: function(settingName) {
     return this._moduleSettings[settingName];
   }
-};
+});
 // Enum from chromium//src/third_party/WebKit/Source/core/loader/MixedContentChecker.h
 global.NetworkAgent = {
   RequestMixedContentType: {


### PR DESCRIPTION
also fix a bug where `Array.include` was being called (not yet in Node stable) 