### PR TITLE
simplify meow usage in the CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,18 +21,15 @@ const meow = require('meow');
 const lighthouse = require('./');
 const log = require('npmlog');
 
-const cli = meow({
-  pkg: './package.json',
-  help: [
-    'Options',
-    '  --help          Show this help',
-    '  --version       Current version of package',
-    '  --verbose       Displays verbose logging',
-    '',
-    'Usage',
-    '  lighthouse [url]'
-  ]
-});
+const cli = meow(`
+  Usage
+    lighthouse [url]
+
+  Options
+    --help         Show this help
+    --version      Current version of package
+    --verbose      Displays verbose logging
+`);
 
 lighthouse({
   url: cli.input[0],


### PR DESCRIPTION
Also moved `Usage` to the top per common CLI convention

The `pkg` is inferred by `meow`, so no need to explicitly specify it.