### PR TITLE
add a few more icon-192 tests

### DIFF
--- a/audits/manifest/icons-192.js
+++ b/audits/manifest/icons-192.js
@@ -32,7 +32,8 @@ class ManifestIcons192 {
 
     if (manifest && manifest.icons && manifest.icons.value) {
       const icons192 = manifest.icons.value.find(icon => {
-        return icon.value.sizes.value.indexOf('192x192') !== -1;
+        const sizesArray = icon.value.sizes.value;
+        return sizesArray && sizesArray.indexOf('192x192') !== -1;
       });
       hasIcons = (!!icons192);
     }

--- a/test/audits/manifest/icons-192.js
+++ b/test/audits/manifest/icons-192.js
@@ -15,9 +15,7 @@
  */
 const Audit = require('../../../audits/manifest/icons-192.js');
 const assert = require('assert');
-const manifestSrc = JSON.stringify(require('./manifest.json'));
 const manifestParser = require('../../../helpers/manifest-parser');
-const manifest = manifestParser(manifestSrc).value;
 
 /* global describe, it*/
 
@@ -40,7 +38,45 @@ describe('manifest: icons-192 audit', () => {
     return assert.equal(Audit.audit(inputs).value, false);
   });
 
+  it('fails when a manifest contains an icon with no size', () => {
+    const manifestSrc = JSON.stringify({
+      icons: [{
+        src: 'icon.png'
+      }]
+    });
+    const manifest = manifestParser(manifestSrc).value;
+
+    return assert.equal(Audit.audit({manifest}).value, false);
+  });
+
+  it('fails when a manifest contains an icon with no 192x192 within its sizes', () => {
+    const manifestSrc = JSON.stringify({
+      icons: [{
+        src: 'icon.png',
+        sizes: '72x72 96x96 128x128 256x256'
+      }]
+    });
+    const manifest = manifestParser(manifestSrc).value;
+
+    return assert.equal(Audit.audit({manifest}).value, false);
+  });
+
   it('succeeds when a manifest contains a 192x192 icon', () => {
-    return assert.equal(Audit.audit({manifest: manifest}).value, true);
+    const manifestSrc = JSON.stringify(require('./manifest.json'));
+    const manifest = manifestParser(manifestSrc).value;
+
+    return assert.equal(Audit.audit({manifest}).value, true);
+  });
+
+  it('succeeds when a manifest contains an icon with 192x192 within its sizes', () => {
+    const manifestSrc = JSON.stringify({
+      icons: [{
+        src: 'icon.png',
+        sizes: '96x96 128x128 192x192 256x256'
+      }]
+    });
+    const manifest = manifestParser(manifestSrc).value;
+
+    return assert.equal(Audit.audit({manifest}).value, true);
   });
 });


### PR DESCRIPTION
also fixes a TypeError in the icon-192 audit when a manifest has an icon with no list of sizes