### PR TITLE
Only protocol layer should be accessing the cri API.

### DIFF
--- a/helpers/browser/driver.js
+++ b/helpers/browser/driver.js
@@ -57,18 +57,18 @@ class ChromeProtocol {
   }
 
   /**
-   * @return {Promise<null>}
+   * @return {!Promise<null>}
    */
   connect() {
     return new Promise((resolve, reject) => {
       if (this._chrome) {
-        return resolve(null);
+        return resolve();
       }
 
       chromeRemoteInterface({port: port}, chrome => {
         this._chrome = chrome;
         this.beginLogging();
-        resolve(null);
+        resolve();
       }).on('error', e => reject(e));
     });
   }
@@ -96,7 +96,7 @@ class ChromeProtocol {
   /**
    * Bind listeners for protocol events
    * @param {!string} eventName
-   * @param {!Function} cb
+   * @param {function(...)} cb
    */
   on(eventName, cb) {
     if (this._chrome === null) {
@@ -110,7 +110,7 @@ class ChromeProtocol {
   /**
    * Unbind event listeners
    * @param {!string} eventName
-   * @param {!Function} cb
+   * @param {function(...)} cb
    */
   off(eventName, cb) {
     this._chrome.removeListener(eventName, cb);
@@ -119,7 +119,7 @@ class ChromeProtocol {
   /**
    * Call protocol methods
    * @param {!string} command
-   * @param {!object} params
+   * @param {!Object} params
    * @return {!Promise}
    */
   sendCommand(command, params) {

--- a/helpers/browser/driver.js
+++ b/helpers/browser/driver.js
@@ -93,7 +93,11 @@ class ChromeProtocol {
     this._chrome.on('event', req => _log('verbose', '<=', req));
   }
 
-  // bind listeners for protocol events
+  /**
+   * Bind listeners for protocol events
+   * @param {!string} eventName
+   * @param {!Function} cb
+   */
   on(eventName, cb) {
     if (this._chrome === null) {
       throw new Error('Trying to call on() but no cri instance available yet');
@@ -103,11 +107,21 @@ class ChromeProtocol {
     this._chrome.on(eventName, cb);
   }
 
+  /**
+   * Unbind event listeners
+   * @param {!string} eventName
+   * @param {!Function} cb
+   */
   off(eventName, cb) {
     this._chrome.removeListener(eventName, cb);
   }
 
-  // call protocol methods
+  /**
+   * Call protocol methods
+   * @param {!string} command
+   * @param {!object} params
+   * @return {!Promise}
+   */
   sendCommand(command, params) {
     return new Promise((resolve, reject) => {
       _log('info', 'method => browser', {method: command, params: params});
@@ -121,6 +135,10 @@ class ChromeProtocol {
     });
   }
 
+  /**
+   * Resolves when all outstanding protocol methods have returned.
+   * @return {!Promise}
+   */
   pendingCommandsComplete() {
     return new Promise((resolve, reject) => {
       this._chrome.once('ready', _ => resolve());


### PR DESCRIPTION
The big change here is that driver.connect() doesn't provide access to the cri object. 
That means all protocol work must go through driver.sendCommand, etc. This allows us to branch more elegantly between our node and extension setups.

A subsequent patch will split `browser/driver.js` into two classes, one for protocol, the other for driver. This will enable solid encapsulation such that all driving APIs don't need to differentiate between chrome.debugger and cri. 