### PR TITLE
add closure type checking (to audits/ only for now)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@ node_modules/
 extension/
 
 dist
+
+closure/*/*

--- a/audits/audit.js
+++ b/audits/audit.js
@@ -14,22 +14,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
 
 class Audit {
+  /**
+   * @return {!Array<string>}
+   */
   static get tags() {
     throw new Error('Audit tags must be overridden');
   }
 
+  /**
+   * @return {string}
+   */
   static get name() {
     throw new Error('Audit name must be overridden');
   }
 
+  /**
+   * @return {string}
+   */
   static get description() {
     throw new Error('Audit description must be overridden');
   }
 
+  /**
+   * @param {(boolean|number|string)} value
+   * @param {?(boolean|number|string)=} rawValue
+   * @return {!AuditResult}
+   */
   static generateAuditResult(value, rawValue) {
     return {
       value: value,

--- a/audits/html/theme-color.js
+++ b/audits/html/theme-color.js
@@ -1,5 +1,5 @@
 /**
- * @licence
+ * @license
  * Copyright 2016 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,21 +19,33 @@
 const Audit = require('../audit');
 
 class ThemeColor extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['HTML'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'theme-color-meta';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Site has a theme-color meta tag';
   }
 
-  static audit(inputs) {
-    const themeColorMeta = inputs.themeColorMeta;
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    const themeColorMeta = artifacts.themeColorMeta;
     // TODO: Verify this is a valid CSS color. Issue #92
     return ThemeColor.generateAuditResult(!!themeColorMeta, themeColorMeta);
   }

--- a/audits/manifest/background-color.js
+++ b/audits/manifest/background-color.js
@@ -20,27 +20,43 @@
 const Audit = require('../audit');
 
 class ManifestBackgroundColor extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Manifest'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'manifest-background-color';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Contains background_color';
   }
 
+  /**
+   * @param {!Manifest} manifest
+   * @return {boolean}
+   */
   static hasBackgroundColorValue(manifest) {
     return manifest !== undefined &&
       manifest.background_color !== undefined &&
       manifest.background_color.value !== undefined;
   }
 
-  static audit(inputs) {
-    const hasBackgroundColor = ManifestBackgroundColor.hasBackgroundColorValue(inputs.manifest);
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    const hasBackgroundColor = ManifestBackgroundColor.hasBackgroundColorValue(artifacts.manifest);
 
     return ManifestBackgroundColor.generateAuditResult(hasBackgroundColor);
   }

--- a/audits/manifest/icons-192.js
+++ b/audits/manifest/icons-192.js
@@ -20,27 +20,39 @@
 const Audit = require('../audit');
 
 class ManifestIcons192 extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Manifest'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'manifest-icons-192';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Contains 192px icons';
   }
 
-  static audit(inputs) {
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
     let hasIcons = false;
-    const manifest = inputs.manifest;
+    const manifest = artifacts.manifest;
 
-    if (manifest && manifest.icons && manifest.icons.value) {
+    if (manifest && manifest.icons.value) {
       const icons192 = manifest.icons.value.find(icon => {
         const sizesArray = icon.value.sizes.value;
-        return sizesArray && sizesArray.indexOf('192x192') !== -1;
+        return !!sizesArray && sizesArray.indexOf('192x192') !== -1;
       });
       hasIcons = (!!icons192);
     }

--- a/audits/manifest/icons.js
+++ b/audits/manifest/icons.js
@@ -20,22 +20,34 @@
 const Audit = require('../audit');
 
 class ManifestIcons extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Manifest'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'manifest-icons';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Contains icons';
   }
 
-  static audit(inputs) {
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
     let hasIcons = false;
-    const manifest = inputs.manifest;
+    const manifest = artifacts.manifest;
 
     if (manifest && manifest.icons && manifest.icons.value) {
       hasIcons = (manifest.icons.value.length > 0);

--- a/audits/manifest/name.js
+++ b/audits/manifest/name.js
@@ -20,22 +20,34 @@
 const Audit = require('../audit');
 
 class ManifestName extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Manifest'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'manifest-name';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Contains name';
   }
 
-  static audit(inputs) {
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
     let hasName = false;
-    const manifest = inputs.manifest;
+    const manifest = artifacts.manifest;
 
     if (manifest && manifest.name) {
       hasName = (!!manifest.name.value);

--- a/audits/manifest/short-name.js
+++ b/audits/manifest/short-name.js
@@ -20,22 +20,34 @@
 const Audit = require('../audit');
 
 class ManifestShortName extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Manifest'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'manifest-short-name';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Contains short_name';
   }
 
-  static audit(inputs) {
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
     let hasShortName = false;
-    const manifest = inputs.manifest;
+    const manifest = artifacts.manifest;
 
     if (manifest && manifest.short_name) {
       hasShortName = (!!manifest.short_name.value);

--- a/audits/manifest/start-url.js
+++ b/audits/manifest/start-url.js
@@ -20,22 +20,34 @@
 const Audit = require('../audit');
 
 class ManifestStartUrl extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Manifest'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'manifest-start-url';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Contains start_url';
   }
 
-  static audit(inputs) {
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
     let hasStartUrl = false;
-    const manifest = inputs.manifest;
+    const manifest = artifacts.manifest;
 
     if (manifest && manifest.start_url) {
       hasStartUrl = (!!manifest.start_url.value);

--- a/audits/manifest/theme-color.js
+++ b/audits/manifest/theme-color.js
@@ -20,22 +20,34 @@
 const Audit = require('../audit');
 
 class ManifestThemeColor extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Manifest'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'manifest-theme-color';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Contains theme_color';
   }
 
-  static audit(inputs) {
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
     let hasThemeColor = false;
-    const manifest = inputs.manifest;
+    const manifest = artifacts.manifest;
 
     if (manifest && manifest.theme_color) {
       hasThemeColor = (!!manifest.theme_color.value);

--- a/audits/mobile-friendly/viewport.js
+++ b/audits/mobile-friendly/viewport.js
@@ -19,22 +19,34 @@
 const Audit = require('../audit');
 
 class Viewport extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Mobile Friendly'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'viewport';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Site has a viewport meta tag';
   }
 
-  static audit(inputs) {
-    const hasMobileViewport = typeof inputs.viewport === 'string' &&
-        inputs.viewport.includes('width=');
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    const hasMobileViewport = typeof artifacts.viewport === 'string' &&
+        artifacts.viewport.includes('width=');
     return Viewport.generateAuditResult(!!hasMobileViewport);
   }
 }

--- a/audits/offline/service-worker.js
+++ b/audits/offline/service-worker.js
@@ -20,24 +20,36 @@
 const Audit = require('../audit');
 
 class ServiceWorker extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Offline'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'service-worker';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Has a Service Worker registration';
   }
 
-  static audit(inputs) {
-    const registrations = inputs.serviceWorkers.versions;
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    const registrations = artifacts.serviceWorkers.versions;
     const activatedRegistrations = registrations.filter(reg => {
       return reg.status === 'activated' &&
-          reg.scriptURL.startsWith(inputs.url);
+          reg.scriptURL.startsWith(artifacts.url);
     });
 
     return ServiceWorker.generateAuditResult(activatedRegistrations.length > 0);

--- a/audits/performance/first-meaningful-paint.js
+++ b/audits/performance/first-meaningful-paint.js
@@ -21,15 +21,23 @@ const FMPMetric = require('../../metrics/performance/first-meaningful-paint');
 const Audit = require('../audit');
 
 class FirstMeaningfulPaint extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Performance'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'first-meaningful-paint';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Has a good first meaningful paint';
   }
@@ -37,12 +45,12 @@ class FirstMeaningfulPaint extends Audit {
   /**
    * Audits the page to give a score for First Meaningful Paint.
    * @see  https://github.com/GoogleChrome/lighthouse/issues/26
-   * @param  {Object} inputs The inputs from the gather phase.
-   * @return {Object} The score from the audit, ranging from 0-100.
+   * @param {!Artifacts} artifacts The artifacts from the gather phase.
+   * @return {!AuditResult} The score from the audit, ranging from 0-100.
    */
-  static audit(inputs) {
+  static audit(artifacts) {
     return FMPMetric
-        .parse(inputs.traceContents)
+        .parse(artifacts.traceContents)
         .then(fmp => {
           if (fmp.err) {
             return {

--- a/audits/security/is-on-https.js
+++ b/audits/security/is-on-https.js
@@ -19,21 +19,33 @@
 const Audit = require('../audit');
 
 class HTTPS extends Audit {
-
+  /**
+   * @override
+   */
   static get tags() {
     return ['Security'];
   }
 
+  /**
+   * @override
+   */
   static get name() {
     return 'is-on-https';
   }
 
+  /**
+   * @override
+   */
   static get description() {
     return 'Site is on HTTPS';
   }
 
-  static audit(inputs) {
-    return HTTPS.generateAuditResult(!!inputs.https);
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    return HTTPS.generateAuditResult(!!artifacts.https);
   }
 }
 

--- a/closure/closure-type-checking.js
+++ b/closure/closure-type-checking.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const closureCompiler = require('google-closure-compiler').gulp();
+const gulp = require('gulp');
+const gutil = require('gulp-util');
+const replace = require('gulp-replace');
+
+/* eslint-disable camelcase */
+gulp.task('js-compile', function() {
+  return gulp.src([
+    'closure/typedefs/*.js',
+    'closure/third_party/*.js',
+    'audits/**/*.js',
+    'metrics/performance/first-meaningful-paint.js'
+  ])
+    // TODO: hack to remove `require`s that Closure currently can't resolve.
+    .pipe(replace(
+        'const DevtoolsTimelineModel = require(\'devtools-timeline-model\');',
+        ''))
+
+    .pipe(closureCompiler({
+      compilation_level: 'SIMPLE',
+      process_common_js_modules: true,
+      new_type_inf: true,
+      checks_only: true,
+      language_in: 'ECMASCRIPT6_STRICT',
+      language_out: 'ECMASCRIPT5_STRICT',
+      warning_level: 'VERBOSE',
+      jscomp_warning: [
+        // https://github.com/google/closure-compiler/wiki/Warnings
+        'accessControls',
+        'const',
+        'visibility'
+        // 'reportUnknownTypes'
+      ]
+    }))
+    .on('end', () => {
+      gutil.log('Closure compilation successful.');
+    });
+});
+/* eslint-enable */
+
+gulp.start('js-compile');

--- a/closure/third_party/DevtoolsTimelineModel.js
+++ b/closure/third_party/DevtoolsTimelineModel.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typing externs file for the `devtools-timeline-model` module.
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @struct
+ * @param {!Array<!Object>} traceData
+ */
+function DevtoolsTimelineModel(traceData) {};
+
+/**
+ * @return {!DevtoolsTimelineModel.Model}
+ */
+DevtoolsTimelineModel.prototype.timelineModel = function() {};
+
+/**
+ * @struct
+ * @record
+ */
+DevtoolsTimelineModel.Model = function() {};
+
+/**
+ * @return {!Array<!DevtoolsTimelineModel.MainThreadEvent>}
+ */
+DevtoolsTimelineModel.Model.prototype.mainThreadEvents = function() {};
+
+/**
+ * @struct
+ * @record
+ */
+DevtoolsTimelineModel.MainThreadEvent = function() {};
+
+/** @type {string} */
+DevtoolsTimelineModel.MainThreadEvent.prototype.categoriesString;
+
+/** @type {string} */
+DevtoolsTimelineModel.MainThreadEvent.prototype.name;
+
+/** @type {number} */
+DevtoolsTimelineModel.MainThreadEvent.prototype.startTime;

--- a/closure/typedefs/Artifacts.js
+++ b/closure/typedefs/Artifacts.js
@@ -15,41 +15,37 @@
  * limitations under the License.
  */
 
-'use strict';
+/**
+ * Typing externs file for collected output of the artifact gatherers stage.
+ * @externs
+ */
 
-const Audit = require('../audit');
+/**
+ * @struct
+ * @record
+ */
+function Artifacts() {}
 
-class ManifestExists extends Audit {
-  /**
-   * @override
-   */
-  static get tags() {
-    return ['Manifest'];
-  }
+/** @type {string} */
+Artifacts.prototype.html;
 
-  /**
-   * @override
-   */
-  static get name() {
-    return 'manifest-exists';
-  }
+/** @type {boolean} */
+Artifacts.prototype.https;
 
-  /**
-   * @override
-   */
-  static get description() {
-    return 'Manifest exists';
-  }
+/** @type {!Array<!Object>} */
+Artifacts.prototype.networkRecords;
 
-  /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
-   */
-  static audit(artifacts) {
-    return ManifestExists.generateAuditResult(
-      typeof artifacts.manifest !== 'undefined'
-    );
-  }
-}
+/** @type {?} */
+Artifacts.prototype.traceContents;
 
-module.exports = ManifestExists;
+/** @type {!Manifest} */
+Artifacts.prototype.manifest;
+
+/** @type {!ServiceWorkerVersions} */
+Artifacts.prototype.serviceWorkers;
+
+/** @type {?string} */
+Artifacts.prototype.themeColorMeta;
+
+/** @type {string} */
+Artifacts.prototype.url;

--- a/closure/typedefs/AuditResult.js
+++ b/closure/typedefs/AuditResult.js
@@ -15,41 +15,28 @@
  * limitations under the License.
  */
 
-'use strict';
+/**
+ * Typing externs file for the result of an audit.
+ * @externs
+ */
 
-const Audit = require('../audit');
+/**
+ * @struct
+ * @record
+ */
+function AuditResult() {}
 
-class ManifestExists extends Audit {
-  /**
-   * @override
-   */
-  static get tags() {
-    return ['Manifest'];
-  }
+/** @type {(boolean|number|string)} */
+AuditResult.prototype.value;
 
-  /**
-   * @override
-   */
-  static get name() {
-    return 'manifest-exists';
-  }
+/** @type {(boolean|number|string|undefined|null)} */
+AuditResult.prototype.rawValue;
 
-  /**
-   * @override
-   */
-  static get description() {
-    return 'Manifest exists';
-  }
+/** @type {string} */
+AuditResult.prototype.name;
 
-  /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
-   */
-  static audit(artifacts) {
-    return ManifestExists.generateAuditResult(
-      typeof artifacts.manifest !== 'undefined'
-    );
-  }
-}
+/** @type {!Array<string>} */
+AuditResult.prototype.tags;
 
-module.exports = ManifestExists;
+/** @type {string} */
+AuditResult.prototype.description;

--- a/closure/typedefs/Manifest.js
+++ b/closure/typedefs/Manifest.js
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typing externs file for parsed Manifest.
+ * @externs
+ */
+
+/**
+ * @struct
+ * @template T
+ * @record
+ */
+function ManifestNode() {}
+
+/** @type {!*} */
+ManifestNode.prototype.raw;
+
+/** @type {T} */
+ManifestNode.prototype.value;
+
+/** @type {string} */
+ManifestNode.prototype.warning;
+
+/**
+ * @struct
+ * @record
+ */
+function ManifestImageValue() {}
+
+/** @type {!ManifestNode<(string|undefined)>} */
+ManifestImageValue.prototype.src;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+ManifestImageValue.prototype.type;
+
+/** @type {!ManifestNode<number>} */
+ManifestImageValue.prototype.density;
+
+/** @type {!ManifestNode<(!Array<string>|undefined)>} */
+ManifestImageValue.prototype.sizes;
+
+/**
+ * @typedef {!ManifestNode<!ManifestImageValue>}
+ */
+var ManifestImageNode;
+
+/**
+ * @struct
+ * @record
+ */
+function ManifestApplicationValue() {}
+
+/** @type {!ManifestNode<(string|undefined)>} */
+ManifestApplicationValue.prototype.platform;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+ManifestApplicationValue.prototype.id;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+ManifestApplicationValue.prototype.url;
+
+/**
+ * @typedef {!ManifestNode<!ManifestApplicationValue>}
+ */
+var ManifestApplicationNode;
+
+/**
+ * @struct
+ * @record
+ */
+function Manifest() {}
+
+/** @type {!ManifestNode<(string|undefined)>} */
+Manifest.prototype.name;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+Manifest.prototype.short_name;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+Manifest.prototype.start_url;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+Manifest.prototype.display;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+Manifest.prototype.orientation;
+
+/** @type {!ManifestNode<(!Array<!ManifestImageNode>|undefined)>} */
+Manifest.prototype.icons;
+
+/** @type {!ManifestNode<(!Array<!ManifestApplicationNode>|undefined)>} */
+Manifest.prototype.related_applications;
+
+/** @type {!ManifestNode<(boolean|undefined)>} */
+Manifest.prototype.prefer_related_applications;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+Manifest.prototype.theme_color;
+
+/** @type {!ManifestNode<(string|undefined)>} */
+Manifest.prototype.background_color;

--- a/closure/typedefs/ServiceWorkerVersions.js
+++ b/closure/typedefs/ServiceWorkerVersions.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typing externs file for Chrome protocol ServiceWorker.workerVersionUpdated request, used as an
+ * artifact.
+ * @see https://chromedevtools.github.io/debugger-protocol-viewer/ServiceWorker/#event-workerVersionUpdated
+ * @externs
+ */
+
+/**
+ * @struct
+ * @record
+ */
+function ServiceWorkerVersions() {}
+
+/** @type {!Array<!ServiceWorkerVersion>} */
+ServiceWorkerVersions.prototype.versions;
+
+/**
+ * @struct
+ * @record
+ */
+function ServiceWorkerVersion() {}
+
+/** @type {string} */
+ServiceWorkerVersion.prototype.versionId;
+
+/** @type {string} */
+ServiceWorkerVersion.prototype.registrationId;
+
+/** @type {string} */
+ServiceWorkerVersion.prototype.scriptURL;
+
+/** @type {string} */
+ServiceWorkerVersion.prototype.runningStatus;
+
+/** @type {string} */
+ServiceWorkerVersion.prototype.status;
+
+/** @type {number} */
+ServiceWorkerVersion.prototype.scriptLastModified;
+
+/** @type {number} */
+ServiceWorkerVersion.prototype.scriptResponseTime;
+
+/** @type {!Array<string>} */
+ServiceWorkerVersion.prototype.controlledClients;

--- a/metrics/performance/first-meaningful-paint.js
+++ b/metrics/performance/first-meaningful-paint.js
@@ -19,6 +19,9 @@
 const DevtoolsTimelineModel = require('devtools-timeline-model');
 
 class FirstMeaningfulPaint {
+  /**
+   * @param {!Array<!Object>} traceData
+   */
   static parse(traceData) {
     return new Promise((resolve, reject) => {
       const model = new DevtoolsTimelineModel(traceData);
@@ -40,11 +43,21 @@ class FirstMeaningfulPaint {
     });
   }
 
+  /**
+   * @param {!DevtoolsTimelineModel.MainThreadEvent} e
+   * @return {boolean}
+   * @private
+   */
   static _filterEventsForNavStart(e) {
     return e.categoriesString.includes('blink.user_timing') &&
         e.name === 'navigationStart';
   }
 
+  /**
+   * @param {!DevtoolsTimelineModel.MainThreadEvent} e
+   * @return {boolean}
+   * @private
+   */
   static _filterEventsForFirstTextPaint(e) {
     return e.categoriesString.includes('blink.user_timing') &&
         e.name === 'firstTextPaint';

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "node": ">=5"
   },
   "scripts": {
+    "closure": "closure/closure-type-checking.js",
     "lint": "eslint .",
-    "test": "npm run lint --silent && npm run unit",
+    "test": "npm run lint --silent && npm run unit && npm run closure",
     "unit": "mocha $(find ./test -name '*.js') --timeout 60000",
     "start": "node ."
   },
@@ -35,6 +36,10 @@
   "devDependencies": {
     "eslint": "^2.4.0",
     "eslint-config-google": "^0.4.0",
+    "google-closure-compiler": "^20160315.0.0",
+    "gulp": "^3.9.1",
+    "gulp-replace": "^0.5.4",
+    "gulp-util": "^3.0.7",
     "mocha": "^2.3.3",
     "request": "^2.69.0",
     "walk": "^2.3.9"

--- a/test/audits/manifest/icons-192.js
+++ b/test/audits/manifest/icons-192.js
@@ -24,14 +24,10 @@ describe('Manifest: icons-192 audit', () => {
     return assert.equal(Audit.audit({}).value, false);
   });
 
-  it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({manifest: {}}).value, false);
-  });
-
   it('fails when a manifest contains no icons', () => {
     const inputs = {
       manifest: {
-        icons: null
+        icons: {}
       }
     };
 


### PR DESCRIPTION
Just on `audits/` before this PR gets unreviewable, and to check in before I keep going.

- `closure/typedefs/` - type declarations for our own types, e.g. the set of all artifacts from the gatherer stage, audit outputs, etc
- `closure/third_party` - type declarations for code from third party modules. In this PR, only a subset of `devtools-timeline-model` was required

uses gulp because we need some transformation pipeline to alter the files so we can hide node_modules from Closure, and Closure doesn't take input off of stdin, so reusing their gulp plugin.