### PR TITLE
Add exception handling to exit

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -67,6 +67,8 @@ lighthouse({
   } else {
     prettyPrint(results);
   }
+}).catch(function () {
+  process.exit();
 });
 
 if (cli.flags.verbose) {


### PR DESCRIPTION
There is no handler for exception throwing from lighthouse. so the cli app can't exit properly