### PR TITLE
be more explicit to ensure we aren't accidentally eslintignoring directories

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,9 @@
 # Igore js files inside local chromium download on Travis.
-chrome-linux/
+/chrome-linux/
 
-node_modules/
-extension/
+/node_modules/
+/extension/
 
-dist
+/dist/
 
-closure/*/*
+/closure/*/*

--- a/helpers/extension/driver.js
+++ b/helpers/extension/driver.js
@@ -16,7 +16,7 @@
  */
 'use strict';
 
-const ChromeProtocol = require('../browser/driver.js')
+const ChromeProtocol = require('../browser/driver.js');
 
 /* globals chrome */
 


### PR DESCRIPTION
We were missing `helpers/extension/driver.js` from the eslint pass, so made the `.eslintignore` more specific.

single semicolon fix to pass tests