### PR TITLE
Introduce the splash screen audit

### DIFF
--- a/aggregators/launches-with-splash-screen/index.js
+++ b/aggregators/launches-with-splash-screen/index.js
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Aggregate = require('../aggregate');
+
+class SplashScreen extends Aggregate {
+
+  static get name() {
+    return 'Will Launch With A Splash Screen';
+  }
+
+  /**
+   * An app that was installed to homescreen can get a custom splash screen
+   * while launching.
+   * Chrome needs the following:
+   *   - has valid manifest
+   *   - manifest has valid name
+   *   - manifest has valid background_color
+   *   - manifest has valid theme_color
+   *   - icon of size >= 192x192
+   *     - while optional, icons at 256, 384 and 512 will be used when appropriate
+   * More details: https://github.com/GoogleChrome/lighthouse/issues/24
+   */
+  static get criteria() {
+    const manifestExists = require('../../audits/manifest/exists').name;
+    const manifestName = require('../../audits/manifest/name').name;
+    const manifestBackgroundColor = require('../../audits/manifest/background-color').name;
+    const manifestThemeColor = require('../../audits/manifest/theme-color').name;
+    const manifestIcons = require('../../audits/manifest/icons').name;
+    const manifestIcons192 = require('../../audits/manifest/icons-192').name;
+
+    const criteria = {};
+
+    criteria[manifestExists] = {
+      value: true,
+      weight: 1
+    };
+
+    criteria[manifestName] = {
+      value: true,
+      weight: 0
+    };
+
+    criteria[manifestBackgroundColor] = {
+      value: true,
+      weight: 1
+    };
+
+    criteria[manifestThemeColor] = {
+      value: true,
+      weight: 0
+    };
+
+    criteria[manifestIcons] = {
+      value: true,
+      weight: 1
+    };
+
+    criteria[manifestIcons192] = {
+      value: true,
+      weight: 1
+    };
+
+    return criteria;
+  }
+}
+
+module.exports = SplashScreen;

--- a/extension/app/scripts.babel/pwa-check.js
+++ b/extension/app/scripts.babel/pwa-check.js
@@ -48,6 +48,7 @@ const audits = [
 ];
 const aggregators = [
   require('../../../aggregators/will-get-add-to-homescreen-prompt'),
+  require('../../../aggregators/launches-with-splash-screen'),
   require('../../../aggregators/omnibox-is-themed'),
   require('../../../aggregators/can-load-offline'),
   require('../../../aggregators/is-secure'),

--- a/index.js
+++ b/index.js
@@ -50,12 +50,14 @@ const audits = [
 ];
 const aggregators = [
   require('./aggregators/will-get-add-to-homescreen-prompt'),
+  require('./aggregators/launches-with-splash-screen'),
   require('./aggregators/omnibox-is-themed'),
   require('./aggregators/can-load-offline'),
   require('./aggregators/is-secure'),
   require('./aggregators/is-performant'),
   require('./aggregators/is-sized-for-mobile-screen')
 ];
+
 module.exports = function(opts) {
   const url = opts.url;
   return Gatherer


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/39191/14191363/5cc23db4-f74c-11e5-9b51-a175fc2db5a3.png)

fixes #24 

FWIW, I updated #24 with a lot of details on icon sizes, confirming what's neccessary here, and helping translate android's `dp` unit into `px`.