### PR TITLE
pull out CSS color validator and validate <meta> theme-color

### DIFF
--- a/audits/html/meta-theme-color.js
+++ b/audits/html/meta-theme-color.js
@@ -16,6 +16,7 @@
  */
 'use strict';
 
+const validColor = require('../../helpers/web-inspector').Color.parse;
 const Audit = require('../audit');
 
 class ThemeColor extends Audit {
@@ -46,8 +47,17 @@ class ThemeColor extends Audit {
    */
   static audit(artifacts) {
     const themeColorMeta = artifacts.themeColorMeta;
-    // TODO: Verify this is a valid CSS color. Issue #92
-    return ThemeColor.generateAuditResult(!!themeColorMeta, themeColorMeta);
+    if (!themeColorMeta) {
+      return ThemeColor.generateAuditResult(false, undefined,
+          'No valid theme-color meta tag found.');
+    }
+
+    if (!validColor(themeColorMeta)) {
+      return ThemeColor.generateAuditResult(false, themeColorMeta,
+          'The theme-color meta tag did not contain a valid CSS color.');
+    }
+
+    return ThemeColor.generateAuditResult(true, themeColorMeta);
   }
 }
 

--- a/closure/closure-type-checking.js
+++ b/closure/closure-type-checking.js
@@ -31,9 +31,9 @@ gulp.task('js-compile', function() {
     'metrics/performance/first-meaningful-paint.js'
   ])
     // TODO: hack to remove `require`s that Closure currently can't resolve.
-    .pipe(replace(
-        'const DevtoolsTimelineModel = require(\'devtools-timeline-model\');',
-        ''))
+    .pipe(replace('const DevtoolsTimelineModel = require(\'devtools-timeline-model\');', ''))
+    .pipe(replace('require(\'../../helpers/web-inspector\').Color.parse;',
+        'WebInspector.Color.parse;'))
 
     .pipe(closureCompiler({
       compilation_level: 'SIMPLE',

--- a/closure/third_party/WebInspector.js
+++ b/closure/third_party/WebInspector.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Typing externs file for the `chrome-devtools-frontend` module.
+ * @externs
+ */
+
+/**
+ * @const
+ */
+var WebInspector = {};
+
+/**
+ * @constructor
+ * @struct
+ */
+WebInspector.Color = function() {};
+
+/**
+ * @param {string} text
+ * @return {?WebInspector.Color}
+ */
+WebInspector.Color.parse = function(text) {};

--- a/helpers/element.js
+++ b/helpers/element.js
@@ -28,7 +28,7 @@ class Element {
 
   /**
    * @param {!string} name Attribute name
-   * @return {!Promise<string>} The attribute value or null if not found
+   * @return {!Promise<?string>} The attribute value or null if not found
    */
   getAttribute(name) {
     return this.driver

--- a/helpers/manifest-parser.js
+++ b/helpers/manifest-parser.js
@@ -16,9 +16,7 @@
  */
 'use strict';
 
-// Required to initialize WebInspector.Color.
-global.WebInspector = global.WebInspector || {};
-require('chrome-devtools-frontend/front_end/common/Color.js');
+const validateColor = require('./web-inspector').Color.parse;
 
 const ALLOWED_DISPLAY_VALUES = [
   'fullscreen',
@@ -74,8 +72,8 @@ function parseColor(raw) {
   }
 
   // Use DevTools's color parser to check CSS3 Color parsing.
-  const parsedColor = global.WebInspector.Color.parse(color.raw);
-  if (!parsedColor) {
+  const validatedColor = validateColor(color.raw);
+  if (!validatedColor) {
     color.value = undefined;
     color.debugString = 'ERROR: color parsing failed.';
   }

--- a/helpers/network-recorder.js
+++ b/helpers/network-recorder.js
@@ -16,98 +16,15 @@
  */
 'use strict';
 
-/* global WebInspector:false */
+const NetworkManager = require('./web-inspector').NetworkManager;
 
-// Required for a select portion DevTools frontend to work (in node)
-global.self = global;
-global.Protocol = {
-  Agents() {}
-};
-global.WebInspector = global.WebInspector || {};
-global.WebInspector._moduleSettings = {
-  cacheDisabled: {
-    addChangeListener() {},
-    get() {
-      return false;
-    }
-  },
-  monitoringXHREnabled: {
-    addChangeListener() {},
-    get() {
-      return false;
-    }
-  }
-};
-global.WebInspector.moduleSetting = function(settingName) {
-  return this._moduleSettings[settingName];
-};
-// Enum from chromium//src/third_party/WebKit/Source/core/loader/MixedContentChecker.h
-global.NetworkAgent = {
-  RequestMixedContentType: {
-    Blockable: 'blockable',
-    OptionallyBlockable: 'optionally-blockable',
-    None: 'none'
-  }
-};
-// Enum from SecurityState enum in protocol's Security domain
-global.SecurityAgent = {
-  SecurityState: {
-    Unknown: 'unknown',
-    Neutral: 'neutral',
-    Insecure: 'insecure',
-    Warning: 'warning',
-    Secure: 'secure',
-    Info: 'info'
-  }
-};
-
-// From https://chromium.googlesource.com/chromium/src/third_party/WebKit/Source/devtools/+/master/protocol.json#93
-global.PageAgent = {
-  ResourceType: {
-    Document: 'document',
-    Stylesheet: 'stylesheet',
-    Image: 'image',
-    Media: 'media',
-    Font: 'font',
-    Script: 'script',
-    TextTrack: 'texttrack',
-    XHR: 'xhr',
-    Fetch: 'fetch',
-    EventSource: 'eventsource',
-    WebSocket: 'websocket',
-    Manifest: 'manifest',
-    Other: 'other'
-  }
-};
-
-require('chrome-devtools-frontend/front_end/common/Object.js');
-require('chrome-devtools-frontend/front_end/common/ParsedURL.js');
-require('chrome-devtools-frontend/front_end/common/ResourceType.js');
-require('chrome-devtools-frontend/front_end/common/UIString.js');
-require('chrome-devtools-frontend/front_end/platform/utilities.js');
-require('chrome-devtools-frontend/front_end/sdk/Target.js');
-require('chrome-devtools-frontend/front_end/sdk/NetworkManager.js');
-require('chrome-devtools-frontend/front_end/sdk/NetworkRequest.js');
-
-// Mocked-up WebInspector Target for NetworkManager
-let fakeNetworkAgent = {
-  enable() {}
-};
-let fakeTarget = {
-  _modelByConstructor: new Map(),
-  networkAgent() {
-    return fakeNetworkAgent;
-  },
-  registerNetworkDispatcher() {}
-};
-
-const REQUEST_FINISHED = WebInspector.NetworkManager.EventTypes.RequestFinished;
+const REQUEST_FINISHED = NetworkManager.EventTypes.RequestFinished;
 
 class NetworkRecorder {
   constructor(recordArray) {
     this._records = recordArray;
 
-    this.networkManager = new WebInspector.NetworkManager(fakeTarget);
+    this.networkManager = NetworkManager.createWithFakeTarget();
 
     // TODO(bckenny): loadingFailed calls are not recorded in REQUEST_FINISHED.
     this.networkManager.addEventListener(REQUEST_FINISHED, request => {

--- a/helpers/web-inspector.js
+++ b/helpers/web-inspector.js
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Stubbery to allow portions of the DevTools frontend to be used in lighthouse. `WebInspector`
+ * technically lives on the global object but should be accessed through a normal `require` call.
+ */
+
+// Global pollution.
+global.self = global;
+global.WebInspector = {};
+
+// Initialize WebInspector.NetworkManager.
+global.Protocol = {
+  Agents() {}
+};
+global.WebInspector._moduleSettings = {
+  cacheDisabled: {
+    addChangeListener() {},
+    get() {
+      return false;
+    }
+  },
+  monitoringXHREnabled: {
+    addChangeListener() {},
+    get() {
+      return false;
+    }
+  }
+};
+global.WebInspector.moduleSetting = function(settingName) {
+  return this._moduleSettings[settingName];
+};
+// Enum from chromium//src/third_party/WebKit/Source/core/loader/MixedContentChecker.h
+global.NetworkAgent = {
+  RequestMixedContentType: {
+    Blockable: 'blockable',
+    OptionallyBlockable: 'optionally-blockable',
+    None: 'none'
+  }
+};
+// Enum from SecurityState enum in protocol's Security domain
+global.SecurityAgent = {
+  SecurityState: {
+    Unknown: 'unknown',
+    Neutral: 'neutral',
+    Insecure: 'insecure',
+    Warning: 'warning',
+    Secure: 'secure',
+    Info: 'info'
+  }
+};
+// From https://chromium.googlesource.com/chromium/src/third_party/WebKit/Source/devtools/+/master/protocol.json#93
+global.PageAgent = {
+  ResourceType: {
+    Document: 'document',
+    Stylesheet: 'stylesheet',
+    Image: 'image',
+    Media: 'media',
+    Font: 'font',
+    Script: 'script',
+    TextTrack: 'texttrack',
+    XHR: 'xhr',
+    Fetch: 'fetch',
+    EventSource: 'eventsource',
+    WebSocket: 'websocket',
+    Manifest: 'manifest',
+    Other: 'other'
+  }
+};
+
+require('chrome-devtools-frontend/front_end/common/Object.js');
+require('chrome-devtools-frontend/front_end/common/ParsedURL.js');
+require('chrome-devtools-frontend/front_end/common/ResourceType.js');
+require('chrome-devtools-frontend/front_end/common/UIString.js');
+require('chrome-devtools-frontend/front_end/platform/utilities.js');
+require('chrome-devtools-frontend/front_end/sdk/Target.js');
+require('chrome-devtools-frontend/front_end/sdk/NetworkManager.js');
+require('chrome-devtools-frontend/front_end/sdk/NetworkRequest.js');
+
+/**
+ * Creates a new WebInspector NetworkManager using a mocked Target.
+ * @return {!WebInspector.NetworkManager}
+ */
+global.WebInspector.NetworkManager.createWithFakeTarget = function() {
+  // Mocked-up WebInspector Target for NetworkManager
+  const fakeNetworkAgent = {
+    enable() {}
+  };
+  const fakeTarget = {
+    _modelByConstructor: new Map(),
+    networkAgent() {
+      return fakeNetworkAgent;
+    },
+    registerNetworkDispatcher() {}
+  };
+
+  return new global.WebInspector.NetworkManager(fakeTarget);
+};
+
+// Initialize WebInspector.Color.
+require('chrome-devtools-frontend/front_end/common/Color.js');
+
+module.exports = global.WebInspector;

--- a/test/audits/html/theme-colors.js
+++ b/test/audits/html/theme-colors.js
@@ -20,14 +20,29 @@ const assert = require('assert');
 /* global describe, it*/
 
 describe('HTML: theme-color audit', () => {
-  it('fails when no window or html present', () => {
-    assert.equal(Audit.audit({}).value, false);
+  it('fails and warns when no window or html present', () => {
+    const emptyAudit = Audit.audit({});
+
+    assert.equal(emptyAudit.value, false);
+    assert(emptyAudit.debugString);
   });
 
-  it('fails when no value given', () => {
-    assert.equal(Audit.audit({
+  it('fails and warns when no value given', () => {
+    const nullColorAudit = Audit.audit({
       themeColorMeta: null
-    }).value, false);
+    });
+
+    assert.equal(nullColorAudit.value, false);
+    assert(nullColorAudit.debugString);
+  });
+
+  it('fails and warns when theme-color has an invalid CSS color', () => {
+    const invalidColorAudit = Audit.audit({
+      themeColorMeta: '#1234567'
+    });
+
+    assert.equal(invalidColorAudit.value, false);
+    assert(invalidColorAudit.debugString);
   });
 
   it('succeeds when theme-color present in the html', () => {
@@ -36,7 +51,7 @@ describe('HTML: theme-color audit', () => {
     }).value, true);
   });
 
-  it('succeeds when theme-color has a CSS name content value', () => {
+  it('succeeds when theme-color has a CSS nickname content value', () => {
     assert.equal(Audit.audit({
       themeColorMeta: 'red'
     }).value, true);


### PR DESCRIPTION
also puts all of the current code to get `chrome-devtools-frontend` able to be imported into lighthouse (the other place was `network-recorder.js`) into one file for easier maintenance.

fixes #92