### PR TITLE
Use launch-chrome.sh in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "5.0"
   - "node"
 sudo: false
 cache:
@@ -8,7 +9,8 @@ cache:
      - chrome-linux
 before_script:
   - export DISPLAY=:99.0
+  - export LIGHTHOUSE_CHROMIUM_PATH="$(pwd)/chrome-linux/chrome"
   - sh -e /etc/init.d/xvfb start
   - ./test/download-chrome.sh
-  - start-stop-daemon --start --background --exec $(pwd)/chrome-linux/chrome -- --remote-debugging-port=9222 --no-first-run --enable-gpu-benchmarking --user-data-dir="/tmp/lighthouse-profile" --disable-setuid-sandbox "about:blank"
+  - start-stop-daemon --start --background --exec $(pwd)/launch-chrome.sh -- --disable-setuid-sandbox
   - sleep 5

--- a/launch-chrome.sh
+++ b/launch-chrome.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+CHROME_ARGS=$@
+
 launch_osx() {
   CHROME_CANARY_PATH="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
   if [ ! -f "$CHROME_CANARY_PATH" ]; then
@@ -12,6 +14,7 @@ launch_osx() {
     --no-first-run \
     --enable-gpu-benchmarking \
     --user-data-dir="/tmp/lighthouse-profile" \
+    $CHROME_ARGS \ 
     "about:blank"
 }
 
@@ -28,6 +31,7 @@ launch_linux() {
     --no-first-run \
     --enable-gpu-benchmarking \
     --user-data-dir="/tmp/lighthouse-profile" \
+    $CHROME_ARGS \
     "about:blank"
 }
 

--- a/test/download-chrome.sh
+++ b/test/download-chrome.sh
@@ -2,8 +2,13 @@
 
 # Download chrome inside of our CI env.
 
-chromepath=chrome-linux/chrome
-if [ -e "$chromepath" ]
+if [ x"$LIGHTHOUSE_CHROMIUM_PATH" == x ]
+then
+    echo "Error: Environment variable LIGHTHOUSE_CHROMIUM_PATH not set"
+    exit 1
+fi
+
+if [ -e "$LIGHTHOUSE_CHROMIUM_PATH" ]
 then
   echo "cached chrome found"
 else


### PR DESCRIPTION
Follow-up to #119. Also added node version 5.0 to .travis.yml. 

I kept the `--disable-setuid-sandbox` flag because the command fails without the flag on my linux workstation. Curiously enough, travis tests [still pass if I leave out the flag](https://travis-ci.org/deepanjanroy/lighthouse/builds/120651147#L750). I'm not sure why that is the case. 