### PR TITLE
add JS conformance tests to Closure Compiler checking

### DIFF
--- a/closure/closure-type-checking.js
+++ b/closure/closure-type-checking.js
@@ -43,13 +43,25 @@ gulp.task('js-compile', function() {
       language_in: 'ECMASCRIPT6_STRICT',
       language_out: 'ECMASCRIPT5_STRICT',
       warning_level: 'VERBOSE',
+      jscomp_error: [
+        'checkTypes',
+        'conformanceViolations'
+      ],
       jscomp_warning: [
         // https://github.com/google/closure-compiler/wiki/Warnings
         'accessControls',
+        'checkRegExp',
         'const',
+        // 'reportUnknownTypes',
+        'missingProperties',
+        'missingReturn',
+        'newCheckTypes',
+        'strictModuleDepCheck',
+        'typeInvalidation',
+        'undefinedNames',
         'visibility'
-        // 'reportUnknownTypes'
-      ]
+      ],
+      conformance_configs: 'closure/conformance_config.textproto'
     }))
     .on('end', () => {
       gutil.log('Closure compilation successful.');

--- a/closure/conformance_config.textproto
+++ b/closure/conformance_config.textproto
@@ -1,0 +1,41 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file defines the additional JS conformance tests run over lighthouse code
+# when compiled with the Closure Compiler. For more, see https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework
+
+requirement: {
+  type: CUSTOM
+  java_class: 'com.google.javascript.jscomp.ConformanceRules$BanNullDeref'
+  error_message: 'Dereferencing `null` or `undefined` is usually an error. See https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework#bannullderef'
+}
+
+# TODO(bckenny): fix unknown this error(s)
+# requirement: {
+#  type: CUSTOM
+#  java_class: 'com.google.javascript.jscomp.ConformanceRules$BanUnknownThis'
+#  error_message: 'References to `this` that are typed as `unknown` are not allowed. See https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework#banunknownthis'
+# }
+
+requirement: {
+  type: CUSTOM
+  java_class: 'com.google.javascript.jscomp.ConformanceRules$BanUnknownTypedClassPropsReferences'
+  error_message: 'References to object props that are typed as `unknown` are discouraged. See https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework#banunknowntypedclasspropsreferences'
+}
+
+requirement: {
+  type: CUSTOM
+  java_class: 'com.google.javascript.jscomp.ConformanceRules$BanUnresolvedType'
+  error_message: 'Forward-declared types must be included in the compilation. See https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework#banunresolvedtype'
+}

--- a/closure/typedefs/Artifacts.js
+++ b/closure/typedefs/Artifacts.js
@@ -49,3 +49,9 @@ Artifacts.prototype.themeColorMeta;
 
 /** @type {string} */
 Artifacts.prototype.url;
+
+/** @type {?string} */
+Artifacts.prototype.viewport;
+
+/** @type {number} */
+Artifacts.prototype.responseCode


### PR DESCRIPTION
adds the straightforward [JS conformance tests](https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework) that we probably want to follow to the closure check. Already caught one bug where I had missed one of the properties on `Artifacts`; fixed below.

Currently the conformance tests are warning only, they don't fail the compile, but we can step that up if we want. 

There is one warning generated here that I didn't fix. The checks don't like this use of [`this`](https://github.com/GoogleChrome/lighthouse/blob/843d145e0b13099bb3b34078a61930e6a37d01f9/audits/audit.js#L52) I think because of some combination of inheritance and the fact that they're static methods.

We could disable the 'unknown this' check or rearrange audit.js to be a bit simpler. I'm open to either.