### PR TITLE
gather manifest by intercepting requestAppBanner load

### DIFF
--- a/helpers/browser/driver.js
+++ b/helpers/browser/driver.js
@@ -227,11 +227,14 @@ class ChromeProtocol {
     });
   }
 
-  beginNetworkCollect() {
+  /**
+   * @param {function(!Object)=} requestListener Optional callback for every finished request.
+   */
+  beginNetworkCollect(requestListener) {
     return this.connect().then(_ => {
       return new Promise((resolve, reject) => {
         this._networkRecords = [];
-        this._networkRecorder = new NetworkRecorder(this._networkRecords);
+        this._networkRecorder = new NetworkRecorder(this._networkRecords, requestListener);
 
         this.on('Network.requestWillBeSent', this._networkRecorder.onRequestWillBeSent);
         this.on('Network.requestServedFromCache', this._networkRecorder.onRequestServedFromCache);

--- a/helpers/network-recorder.js
+++ b/helpers/network-recorder.js
@@ -21,14 +21,20 @@ const NetworkManager = require('./web-inspector').NetworkManager;
 const REQUEST_FINISHED = NetworkManager.EventTypes.RequestFinished;
 
 class NetworkRecorder {
-  constructor(recordArray) {
+  constructor(recordArray, requestListener) {
     this._records = recordArray;
+
+    this._listener = requestListener;
 
     this.networkManager = NetworkManager.createWithFakeTarget();
 
     // TODO(bckenny): loadingFailed calls are not recorded in REQUEST_FINISHED.
     this.networkManager.addEventListener(REQUEST_FINISHED, request => {
       this._records.push(request);
+
+      if (this._listener) {
+        this._listener(request.data);
+      }
     });
 
     this.onRequestWillBeSent = this.onRequestWillBeSent.bind(this);


### PR DESCRIPTION
WIP stab at loading the manifest via the page itself. Works great for e.g. guitar-tuner and airhorner.

A few problems I'm running into. Advice would be appreciated:
- when this works, it only works the first time you open chrome and run lighthouse. If you leave Chrome open and re-run lighthouse, the manifest request always times out for me (even when testing a different site)
- Looks like UA-emulation isn’t working for this request, at least. The request is sent with a UA string for my desktop, not what’s in emulation.js. For flipkart, this means I’m still getting a 404 when the page requests `https://www.flipkart.com/manifest.json`
- for the Opera PWA list, even though `https://operasoftware.github.io/pwa-list/.webmanifest` finishes loading and status code is 200, I always get `No data found for resource with given identifier` from `Network.getResponseBody`