### PR TITLE
Wait for promises to resolve in device emulation

### DIFF
--- a/helpers/browser/driver.js
+++ b/helpers/browser/driver.js
@@ -269,12 +269,12 @@ class ChromeProtocol {
   }
 
   beginEmulation() {
-    return new Promise((resolve, reject) => {
-      emulation.enableNexus5X(this);
-      emulation.enableNetworkThrottling(this);
-      emulation.disableCache(this);
-      this.pendingCommandsComplete().then(_ => resolve());
-    });
+    return Promise.all([
+      emulation.enableNexus5X(this),
+      emulation.enableNetworkThrottling(this),
+      emulation.disableCache(this),
+      this.pendingCommandsComplete()
+    ]);
   }
 }
 

--- a/helpers/emulation.js
+++ b/helpers/emulation.js
@@ -49,13 +49,6 @@ const TYPICAL_MOBILE_THROTTLING_METRICS = {
 };
 
 function enableNexus5X(driver) {
-  driver.sendCommand('Emulation.setDeviceMetricsOverride', NEXUS5X_EMULATION_METRICS);
-  driver.sendCommand('Network.setUserAgentOverride', NEXUS5X_USERAGENT);
-  driver.sendCommand('Emulation.setTouchEmulationEnabled', {
-    enabled: true,
-    configuration: 'mobile'
-  });
-
   /**
    * Finalizes touch emulation by enabling `"ontouchstart" in window` feature detect
    * to work. Messy hack, though copied verbatim from DevTools' emulation/TouchModel.js
@@ -77,17 +70,26 @@ function enableNexus5X(driver) {
     }
   };
   /* eslint-enable */
-  driver.sendCommand('Page.addScriptToEvaluateOnLoad', {
-    scriptSource: '(' + injectedTouchEventsFunction.toString() + ')()'
-  });
+
+  return Promise.all([
+    driver.sendCommand('Emulation.setDeviceMetricsOverride', NEXUS5X_EMULATION_METRICS),
+    driver.sendCommand('Network.setUserAgentOverride', NEXUS5X_USERAGENT),
+    driver.sendCommand('Emulation.setTouchEmulationEnabled', {
+      enabled: true,
+      configuration: 'mobile'
+    }),
+    driver.sendCommand('Page.addScriptToEvaluateOnLoad', {
+      scriptSource: '(' + injectedTouchEventsFunction.toString() + ')()'
+    })
+  ]);
 }
 
 function disableCache(driver) {
-  driver.sendCommand('Network.setCacheDisabled', {cacheDisabled: true});
+  return driver.sendCommand('Network.setCacheDisabled', {cacheDisabled: true});
 }
 
 function enableNetworkThrottling(driver) {
-  driver.sendCommand('Network.emulateNetworkConditions', TYPICAL_MOBILE_THROTTLING_METRICS);
+  return driver.sendCommand('Network.emulateNetworkConditions', TYPICAL_MOBILE_THROTTLING_METRICS);
 }
 
 module.exports = {


### PR DESCRIPTION
Not waiting doesn't cause any issues though.

curious why is this treated as fire and forget ?

These create side-effects, shouldn't we wait for it to resolve ? (or) is it taken care by `chrome.once('ready')` ?