### PR TITLE
added short-name-length check

### DIFF
--- a/aggregators/will-get-add-to-homescreen-prompt/index.js
+++ b/aggregators/will-get-add-to-homescreen-prompt/index.js
@@ -34,6 +34,9 @@ const manifestIconsMin144 = require('../../audits/manifest/icons-min-144').name;
 /** @type {string} */
 const manifestShortName = require('../../audits/manifest/short-name').name;
 
+/** @type {string} */
+const manifestShortNameLength = require('../../audits/manifest/short-name-length').name;
+
 class AddToHomescreen extends Aggregate {
 
   /**
@@ -52,6 +55,7 @@ class AddToHomescreen extends Aggregate {
    *   - valid start_url
    *   - valid name
    *   - valid short_name
+   *   - short_name of reasonable length
    *   - icon of size >= 144x144 and png (either type `image/png` or filename ending in `.png`
    * @see https://github.com/GoogleChrome/lighthouse/issues/23
    *
@@ -82,6 +86,11 @@ class AddToHomescreen extends Aggregate {
     };
 
     criteria[manifestShortName] = {
+      value: true,
+      weight: 0
+    };
+
+    criteria[manifestShortNameLength] = {
       value: true,
       weight: 0
     };

--- a/audits/manifest/short-name-length.js
+++ b/audits/manifest/short-name-length.js
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Audit = require('../audit');
+
+class ManifestShortNameLength extends Audit {
+  /**
+   * @override
+   */
+  static get tags() {
+    return ['Manifest'];
+  }
+
+  /**
+   * @override
+   */
+  static get name() {
+    return 'manifest-short-name-length';
+  }
+
+  /**
+   * @override
+   */
+  static get description() {
+    return 'App short_name won\'t be truncated on the homescreen';
+  }
+
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    let isShortNameShortEnough = false;
+    let debugString;
+    const manifest = artifacts.manifest.value;
+    const suggestedLength = 12;
+
+    if (manifest && manifest.short_name && manifest.short_name.value) {
+      // Historically, Chrome recommended 12 chars as the maximum length to prevent truncation.
+      // See #69 for more discussion.
+      isShortNameShortEnough = (manifest.short_name.value.length <= suggestedLength);
+      if (!isShortNameShortEnough) {
+        debugString = `${suggestedLength} chars is the suggested maximum length`;
+      }
+    }
+
+    return ManifestShortNameLength.generateAuditResult(
+      isShortNameShortEnough,
+      undefined,
+      debugString
+    );
+  }
+}
+
+module.exports = ManifestShortNameLength;

--- a/extension/app/scripts.babel/pwa-check.js
+++ b/extension/app/scripts.babel/pwa-check.js
@@ -43,6 +43,7 @@ const audits = [
   require('../../../audits/manifest/icons-min-144'),
   require('../../../audits/manifest/name'),
   require('../../../audits/manifest/short-name'),
+  require('../../../audits/manifest/short-name-length'),
   require('../../../audits/manifest/start-url'),
   require('../../../audits/html/meta-theme-color')
 ];

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ const audits = [
   require('./audits/manifest/icons-min-144'),
   require('./audits/manifest/name'),
   require('./audits/manifest/short-name'),
+  require('./audits/manifest/short-name-length'),
   require('./audits/manifest/start-url'),
   require('./audits/html/meta-theme-color')
 ];

--- a/test/audits/manifest/short-name-length.js
+++ b/test/audits/manifest/short-name-length.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const Audit = require('../../../audits/manifest/short-name-length.js');
+const assert = require('assert');
+const manifestParser = require('../../../helpers/manifest-parser');
+
+/* global describe, it*/
+
+describe('Manifest: short_name_length audit', () => {
+  it('fails when an empty manifest is present', () => {
+    const manifest = manifestParser('{}');
+    console.info('got empty manifest', manifest);
+    return assert.equal(Audit.audit({manifest}).value, false);
+  });
+
+  // Need to disable camelcase check for dealing with short_name.
+  /* eslint-disable camelcase */
+  it('fails when a manifest contains no short_name', () => {
+    const manifestSrc = JSON.stringify({
+      short_name: undefined
+    });
+    const manifest = manifestParser(manifestSrc);
+    return assert.equal(Audit.audit({manifest}).value, false);
+  });
+
+  it('fails when a manifest contains a long short_name', () => {
+    const manifestSrc = JSON.stringify({
+      short_name: 'i\'m much longer than the recommended size'
+    });
+    const manifest = manifestParser(manifestSrc);
+    const out = Audit.audit({manifest});
+    assert.equal(out.value, false);
+    assert.notEqual(out.debugString, undefined);
+  });
+
+  it('succeeds when a manifest contains a short_name', () => {
+    const manifestSrc = JSON.stringify({
+      short_name: 'Lighthouse'
+    });
+    const manifest = manifestParser(manifestSrc);
+    return assert.equal(Audit.audit({manifest}).value, true);
+  });
+  /* eslint-enable camelcase */
+});


### PR DESCRIPTION
Starts to solve #69 with a basic assumption of 12 chars max, taken from the [old Chrome extension manifest docs](https://developer.chrome.com/extensions/manifest/name#short_name) (which presumably evolved into the format we have today).

(Also partially just learning how to write an audit).