### PR TITLE
[Straw man] Insight / Actions POC

### DIFF
--- a/auditor.js
+++ b/auditor.js
@@ -17,16 +17,8 @@
 'use strict';
 
 class Auditor {
-
-  static _flattenArtifacts(artifacts) {
-    return artifacts.reduce(function(prev, curr) {
-      return Object.assign(prev, curr);
-    }, {});
-  }
-
   static audit(artifacts, audits) {
-    const flattenedArtifacts = Auditor._flattenArtifacts(artifacts);
-    return Promise.all(audits.map(audit => audit.audit(flattenedArtifacts)));
+    return Promise.all(audits.map(audit => audit.audit(artifacts)));
   }
 }
 

--- a/audits/audit.js
+++ b/audits/audit.js
@@ -42,13 +42,16 @@ class Audit {
    * @param {(boolean|number|string)} value
    * @param {?(boolean|number|string)=} rawValue
    * @param {string=} debugString Optional string to describe any error condition encountered.
+   * @param {Array<!AuditRecommendedAction>=} recommendedActions The actions you should take to
+   *     improve your score.
    * @return {!AuditResult}
    */
-  static generateAuditResult(value, rawValue, debugString) {
+  static generateAuditResult(value, rawValue, debugString, recommendedActions) {
     return {
       value,
       rawValue,
       debugString,
+      recommendedActions,
       name: this.name,
       tags: this.tags,
       description: this.description

--- a/audits/performance/first-meaningful-paint.js
+++ b/audits/performance/first-meaningful-paint.js
@@ -92,7 +92,7 @@ class FirstMeaningfulPaint extends Audit {
    * Generates some recommended actions for FMP.
    * @param {number} score The score to determine if we need to bother.
    * @param {!Artifacts} artifacts The artifacts from the gather phase.
-   * @return {Array<!AuditRecommendedAction>}
+   * @return {Array<!AuditRecommendedAction>|undefined}
    */
   static generateRecommendedActions(score, artifacts) {
     // If there is a score of 100 no further action is required.

--- a/audits/performance/first-meaningful-paint.js
+++ b/audits/performance/first-meaningful-paint.js
@@ -100,6 +100,10 @@ class FirstMeaningfulPaint extends Audit {
       return undefined;
     }
 
+    if (!artifacts.blockingResources) {
+      return undefined;
+    }
+
     // Attempt to figure out what the blocking resources are in the page.
     const recommendedActions = artifacts.blockingResources
         .map(resource => {

--- a/cli/printer.js
+++ b/cli/printer.js
@@ -36,6 +36,15 @@ const Printer = {
         if (subitem.debugString) {
           output.log(`    ${subitem.debugString}`);
         }
+        if (subitem.recommendedActions) {
+          output.log('    Recommended actions:');
+          subitem.recommendedActions.forEach(recommendedAction => {
+            output.log(`    -- ${recommendedAction.title}`);
+            recommendedAction.details.forEach(recommendedActionDetail => {
+              output.log(`       ${recommendedActionDetail}`);
+            });
+          });
+        }
       });
 
       output.log('');

--- a/closure/typedefs/Artifacts.js
+++ b/closure/typedefs/Artifacts.js
@@ -24,6 +24,36 @@
  * @struct
  * @record
  */
+function NetworkRecordResourceType() {}
+
+/** @type {!Object} */
+NetworkRecordResourceType.prototype._resourceType;
+
+/** @type {string} */
+NetworkRecordResourceType.prototype._name;
+
+/** @type {string} */
+NetworkRecordResourceType.prototype.url;
+
+/** @type {number} */
+NetworkRecordResourceType.prototype.startTime;
+
+/** @type {number} */
+NetworkRecordResourceType.prototype.endTime;
+
+/**
+ * @struct
+ * @record
+ */
+function NetworkRecord() {}
+
+/** @type {!NetworkRecordResourceType} */
+NetworkRecord.prototype.data;
+
+/**
+ * @struct
+ * @record
+ */
 function Artifacts() {}
 
 /** @type {string} */
@@ -37,6 +67,9 @@ Artifacts.prototype.networkRecords;
 
 /** @type {?} */
 Artifacts.prototype.traceContents;
+
+/** @type {!Array<!NetworkRecord>} */
+Artifacts.prototype.blockingResources;
 
 /** @type {!ManifestNode<(!Manifest|undefined)>} */
 Artifacts.prototype.manifest;

--- a/closure/typedefs/AuditResult.js
+++ b/closure/typedefs/AuditResult.js
@@ -24,6 +24,18 @@
  * @struct
  * @record
  */
+function AuditRecommendedAction() {}
+
+/** @type {string} */
+AuditRecommendedAction.prototype.title;
+
+/** @type {!Array<!string>} */
+AuditRecommendedAction.prototype.details;
+
+/**
+ * @struct
+ * @record
+ */
 function AuditResult() {}
 
 /** @type {(boolean|number|string)} */
@@ -34,6 +46,9 @@ AuditResult.prototype.rawValue;
 
 /** @type {(string|undefined)} */
 AuditResult.prototype.debugString;
+
+/** @type {(Array<!AuditRecommendations>|undefined)} */
+AuditResult.prototype.recommendedActions;
 
 /** @type {string} */
 AuditResult.prototype.name;

--- a/closure/typedefs/AuditResult.js
+++ b/closure/typedefs/AuditResult.js
@@ -47,7 +47,7 @@ AuditResult.prototype.rawValue;
 /** @type {(string|undefined)} */
 AuditResult.prototype.debugString;
 
-/** @type {(Array<!AuditRecommendations>|undefined)} */
+/** @type {(Array<!AuditRecommendedAction>|undefined)} */
 AuditResult.prototype.recommendedActions;
 
 /** @type {string} */

--- a/gatherer.js
+++ b/gatherer.js
@@ -20,13 +20,16 @@ class Gatherer {
 
   static gather(gatherers, options) {
     const driver = options.driver;
-    const artifacts = [];
+    const artifacts = {};
+
+    // Add in the artifacts to the options. This creates a running order dependency.
+    Object.assign(options, {artifacts});
 
     // Execute gatherers sequentially and return results array when complete.
     return gatherers.reduce((chain, gatherer) => {
       return chain
         .then(_ => gatherer.gather(options))
-        .then(artifact => artifacts.push(artifact));
+        .then(artifact => Object.assign(artifacts, artifact));
     }, driver.connect())
       .then(_ => driver.disconnect())
       .then(_ => artifacts);

--- a/gatherers/blocking-resources.js
+++ b/gatherers/blocking-resources.js
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const Gather = require('./gather');
+
+class BlockingResources extends Gather {
+
+  static gather(options) {
+    const url = options.url;
+    const driver = options.driver;
+    const networkRecords = options.artifacts.networkRecords;
+    const javascriptRequests = networkRecords.filter(record => {
+      return record.data._initiator.type === 'parser' &&
+          record.data._resourceType._name === 'script';
+    });
+
+    // Locate any records that were initiated by the parser, and which are CSS, or a font.
+    const blockingResources = networkRecords.filter(record => {
+      return record.data._initiator.type === 'parser' &&
+          (record.data._resourceType._name === 'stylesheet' ||
+           record.data._resourceType._name === 'font');
+    });
+
+    // Make a chain of queries to the DOM to find the appropriate element for each JS file.
+    const DOMQueries = javascriptRequests.reduce((chain, request) => {
+      // Remove the Page URL from the requests, which should then match on relative and absolute
+      // URLs in the elements found in the DOM.
+      const javaScriptURL = request.data.url.replace(url, '');
+      return chain
+        .then(_ => driver.querySelector(`script[src*="${javaScriptURL}"]`))
+        .then(node => {
+          // If there's an async or defer attribute, this is non-blocking.
+          if (node.getAttribute('defer') !== null ||
+            node.getAttribute('async') !== null) {
+            return;
+          }
+          blockingResources.push(request);
+        });
+    }, Promise.resolve());
+
+    return DOMQueries
+      .then(_ => {
+        return {blockingResources};
+      });
+  }
+}
+
+module.exports = BlockingResources;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const driver = new ChromeProtocol();
 const gatherers = [
   require('./gatherers/url'),
   require('./gatherers/load'),
+  require('./gatherers/blocking-resources'),
   require('./gatherers/https'),
   require('./gatherers/service-worker'),
   require('./gatherers/viewport'),


### PR DESCRIPTION
Smartens the audit a little so it can make recommendations. What comes out of this is:

1. that the blocking resources gatherer needs to be run after the load, which implies that gatherers need a scheduler and one gatherer could build on another's results.
2. the aggregation layer may, as @samccone and @brendankenny suggested, not be needed. I'm still on the fence here, because it depends on whether we want to adjust the suggested actions based on the weighting in the aggregation, i.e. something that blocks first meaningful paint when viewing a perf report may be considered greater severity than a general 'overall Progressive Web App health check', and the question becomes if the audit needs to know the weighting ahead of time.
3. the audit is now not just a 'dumb layer', but doing this work at the aggregation layer would have meant propagating the gathered values and spreads the interrogation out. Which is weird.
4. building the colleciton of blocking resources isn't too bad, but this is far from a CRP dependency tree, which would be much nicer

Over to @paulirish @samccone @brendankenny @deepanjanroy for bikeshed shenanigans.