### PR TITLE
Fixes repeat runs of the XHR

### DIFF
--- a/gatherers/offline.js
+++ b/gatherers/offline.js
@@ -22,10 +22,12 @@ const Gather = require('./gather');
 // Request the current page by issuing a XMLHttpRequest request to ''
 // and storing the status code on the window.
 const requestPage = `
-  const oReq = new XMLHttpRequest();
-  oReq.onload = e => window._offlineRequestStatus = e.currentTarget.status;
-  oReq.open('GET', '');
-  oReq.send();
+  (function () {
+    const oReq = new XMLHttpRequest();
+    oReq.onload = e => window._offlineRequestStatus = e.currentTarget.status;
+    oReq.open('GET', '');
+    oReq.send();
+  })();
 `;
 
 const unsetPageStatusVar = `
@@ -86,6 +88,15 @@ class Offline extends Gather {
       expression: requestPage
     }).then(_ => {
       return Offline.pollForOfflineResponseStatus(driver, 0);
+    }, _ => {
+      // Account for execution errors.
+      return {
+        result: {
+          description: '0',
+          type: 'number',
+          value: 0
+        }
+      };
     }).then(ret => {
       return Offline._unsetOfflineValue(driver).then(_ => ret);
     });

--- a/gatherers/offline.js
+++ b/gatherers/offline.js
@@ -92,9 +92,9 @@ class Offline extends Gather {
       // Account for execution errors.
       return {
         result: {
-          description: '0',
+          description: '-1',
           type: 'number',
-          value: 0
+          value: -1
         }
       };
     }).then(ret => {

--- a/gatherers/offline.js
+++ b/gatherers/offline.js
@@ -24,7 +24,7 @@ const Gather = require('./gather');
 const requestPage = `
   (function () {
     const oReq = new XMLHttpRequest();
-    oReq.onload = e => window._offlineRequestStatus = e.currentTarget.status;
+    oReq.onload = oReq.onerror = e => window._offlineRequestStatus = e.currentTarget.status;
     oReq.open('GET', '');
     oReq.send();
   })();

--- a/helpers/extension/driver.js
+++ b/helpers/extension/driver.js
@@ -94,6 +94,10 @@ class ExtensionProtocol extends ChromeProtocol {
           return reject(chrome.runtime.lastError);
         }
 
+        if (result.wasThrown) {
+          return reject(result.exceptionDetails);
+        }
+
         resolve(result);
       });
     });


### PR DESCRIPTION
The `const` is causing an issue because it's globally scoped, and that causes an error to be thrown. This now causes a rejection in the driver, and the offline gatherer also recovers more gracefully from such cases.

PTAL @samccone @brendankenny 