### PR TITLE
Allows for FMP in extension.

### DIFF
--- a/closure/closure-type-checking.js
+++ b/closure/closure-type-checking.js
@@ -21,6 +21,8 @@ const closureCompiler = require('google-closure-compiler').gulp();
 const gulp = require('gulp');
 const gutil = require('gulp-util');
 const replace = require('gulp-replace');
+const devtoolsRequire =
+    'const DevtoolsTimelineModel = require(\'../../helpers/traces/devtools-timeline-model\');';
 
 /* eslint-disable camelcase */
 gulp.task('js-compile', function() {
@@ -33,7 +35,7 @@ gulp.task('js-compile', function() {
     'metrics/performance/first-meaningful-paint.js'
   ])
     // TODO: hack to remove `require`s that Closure currently can't resolve.
-    .pipe(replace('const DevtoolsTimelineModel = require(\'devtools-timeline-model\');', ''))
+    .pipe(replace(devtoolsRequire, ''))
     .pipe(replace('require(\'../../helpers/web-inspector\').Color.parse;',
         'WebInspector.Color.parse;'))
 

--- a/extension/app/popup.html
+++ b/extension/app/popup.html
@@ -15,7 +15,7 @@
     <h1>Lighthouse</h1>
     <h2>...</h2>
     <a href="https://github.com/googlechrome/lighthouse" target="_blank">Beta</a>
-    <button style="display: none" class="reload-all">Get performance data.</button>
+    <button class="reload-all">Get performance data.</button>
   </header>
   <div class="results"></div>
   <script src="scripts/app.js"></script>

--- a/helpers/traces/devtools-timeline-model.js
+++ b/helpers/traces/devtools-timeline-model.js
@@ -19,56 +19,12 @@
 
 /* global WebInspector, TimelineModelTreeView */
 
-console.log('Booting dtm');
-
-// establish our sandboxed globals
-if (typeof global.window === 'undefined') {
-  global.window = global.self = global;
-}
-
-// global.WebInspector = global.WebInspector || {};
-global.Runtime = global.Runtime || {};
-// global.TimelineModelTreeView = global.TimelineModelTreeView || {};
-global.TreeElement = global.TreeElement || {};
-global.WorkerRuntime = global.WorkerRuntime || {};
-// global.Protocol = global.Protocol || {};
-global.insertionIndexForObjectInListSortedByFunction =
-    function(object, list, comparator, insertionIndexAfter) {
-      if (insertionIndexAfter) {
-        return list.upperBound(object, comparator);
-      }
-
-      return list.lowerBound(object, comparator);
-    };
-
-// polyfills
-require('devtools-timeline-model/lib/api-stubs.js');
-
-// chrome devtools frontend
-// require('chrome-devtools-frontend/front_end/common/Object.js');
-require('chrome-devtools-frontend/front_end/common/SegmentedRange.js');
-// require('chrome-devtools-frontend/front_end/platform/utilities.js');
-// require('chrome-devtools-frontend/front_end/sdk/Target.js');
-require('chrome-devtools-frontend/front_end/bindings/TempFile.js');
-require('chrome-devtools-frontend/front_end/sdk/TracingModel.js');
-require('chrome-devtools-frontend/front_end/timeline/TimelineJSProfile.js');
-require('chrome-devtools-frontend/front_end/timeline/TimelineUIUtils.js');
-require('chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js');
-require('chrome-devtools-frontend/front_end/timeline/LayerTreeModel.js');
-require('chrome-devtools-frontend/front_end/timeline/TimelineModel.js');
-require('chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js');
-require('chrome-devtools-frontend/front_end/ui_lazy/SortableDataGrid.js');
-require('chrome-devtools-frontend/front_end/timeline/TimelineProfileTree.js');
-require('chrome-devtools-frontend/front_end/components_lazy/FilmStripModel.js');
-require('chrome-devtools-frontend/front_end/timeline/TimelineIRModel.js');
-require('chrome-devtools-frontend/front_end/timeline/TimelineFrameModel.js');
-
 // minor configurations
 require('devtools-timeline-model/lib/devtools-monkeypatches.js');
 // polyfill the bottom-up and topdown tree sorting
 require('devtools-timeline-model/lib/timeline-model-treeview.js');
 
-class SandboxedModel {
+class TimelineModel {
 
   constructor(events) {
     this.WI = WebInspector;
@@ -161,4 +117,4 @@ class SandboxedModel {
 
 }
 
-module.exports = SandboxedModel;
+module.exports = TimelineModel;

--- a/helpers/traces/devtools-timeline-model.js
+++ b/helpers/traces/devtools-timeline-model.js
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/* global WebInspector, TimelineModelTreeView */
+
+console.log('Booting dtm');
+
+// establish our sandboxed globals
+if (typeof global.window === 'undefined') {
+  global.window = global.self = global;
+}
+
+// global.WebInspector = global.WebInspector || {};
+global.Runtime = global.Runtime || {};
+// global.TimelineModelTreeView = global.TimelineModelTreeView || {};
+global.TreeElement = global.TreeElement || {};
+global.WorkerRuntime = global.WorkerRuntime || {};
+// global.Protocol = global.Protocol || {};
+global.insertionIndexForObjectInListSortedByFunction =
+    function(object, list, comparator, insertionIndexAfter) {
+      if (insertionIndexAfter) {
+        return list.upperBound(object, comparator);
+      }
+
+      return list.lowerBound(object, comparator);
+    };
+
+// polyfills
+require('devtools-timeline-model/lib/api-stubs.js');
+
+// chrome devtools frontend
+// require('chrome-devtools-frontend/front_end/common/Object.js');
+require('chrome-devtools-frontend/front_end/common/SegmentedRange.js');
+// require('chrome-devtools-frontend/front_end/platform/utilities.js');
+// require('chrome-devtools-frontend/front_end/sdk/Target.js');
+require('chrome-devtools-frontend/front_end/bindings/TempFile.js');
+require('chrome-devtools-frontend/front_end/sdk/TracingModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineJSProfile.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineUIUtils.js');
+require('chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js');
+require('chrome-devtools-frontend/front_end/timeline/LayerTreeModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js');
+require('chrome-devtools-frontend/front_end/ui_lazy/SortableDataGrid.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineProfileTree.js');
+require('chrome-devtools-frontend/front_end/components_lazy/FilmStripModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineIRModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineFrameModel.js');
+
+// minor configurations
+require('devtools-timeline-model/lib/devtools-monkeypatches.js');
+// polyfill the bottom-up and topdown tree sorting
+require('devtools-timeline-model/lib/timeline-model-treeview.js');
+
+class SandboxedModel {
+
+  constructor(events) {
+    this.WI = WebInspector;
+    this.init(events);
+  }
+
+  init(events) {
+    // (devtools) tracing model
+    this._tracingModel =
+        new WebInspector.TracingModel(new WebInspector.TempFileBackingStorage('tracing'));
+    // timeline model
+    this._timelineModel =
+        new WebInspector.TimelineModel(WebInspector.TimelineUIUtils.visibleEventsFilter());
+
+    // populate with events
+    this._tracingModel.reset();
+    this._tracingModel.addEvents(typeof events === 'string' ? JSON.parse(events) : events);
+    this._tracingModel.tracingComplete();
+    this._timelineModel.setEvents(this._tracingModel);
+
+    this._aggregator = new WebInspector.TimelineAggregator(event => {
+      return WebInspector.TimelineUIUtils.eventStyle(event).category.name;
+    });
+
+    return this;
+  }
+
+  timelineModel() {
+    return this._timelineModel;
+  }
+
+  tracingModel() {
+    return this._tracingModel;
+  }
+
+  topDown() {
+    var filters = [];
+    filters.push(WebInspector.TimelineUIUtils.visibleEventsFilter());
+    filters.push(new WebInspector.ExcludeTopLevelFilter());
+    var nonessentialEvents = [
+      WebInspector.TimelineModel.RecordType.EventDispatch,
+      WebInspector.TimelineModel.RecordType.FunctionCall,
+      WebInspector.TimelineModel.RecordType.TimerFire
+    ];
+    filters.push(new WebInspector.ExclusiveNameFilter(nonessentialEvents));
+
+    return WebInspector.TimelineProfileTree.buildTopDown(this._timelineModel.mainThreadEvents(),
+        filters, /* startTime */ 0, /* endTime */ Infinity,
+        WebInspector.TimelineAggregator.eventId);
+  }
+
+  bottomUp() {
+    var topDown = this.topDown();
+    var noGrouping = WebInspector.TimelineAggregator.GroupBy.None;
+    var noGroupAggregator = this._aggregator.groupFunction(noGrouping);
+    return WebInspector.TimelineProfileTree.buildBottomUp(topDown, noGroupAggregator);
+  }
+
+  // @ returns a grouped and sorted tree
+  bottomUpGroupBy(grouping) {
+    var topDown = this.topDown();
+
+    // One of: None Category Subdomain Domain URL
+    var groupSetting = WebInspector.TimelineAggregator.GroupBy[grouping];
+    var groupingAggregator = this._aggregator.groupFunction(groupSetting);
+    var bottomUpGrouped =
+        WebInspector.TimelineProfileTree.buildBottomUp(topDown, groupingAggregator);
+
+    // sort the grouped tree, in-place
+    new TimelineModelTreeView(bottomUpGrouped).sortingChanged('self', 'desc');
+    return bottomUpGrouped;
+  }
+
+  frameModel() {
+    var frameModel = new WebInspector.TracingTimelineFrameModel();
+    frameModel.addTraceEvents({ /* target */ },
+      this._timelineModel.inspectedTargetEvents(), this._timelineModel.sessionId() || '');
+    return frameModel;
+  }
+
+  filmStripModel() {
+    return new WebInspector.FilmStripModel(this._tracingModel);
+  }
+
+  interactionModel() {
+    var irModel = new WebInspector.TimelineIRModel();
+    irModel.populate(this._timelineModel);
+    return irModel;
+  }
+
+}
+
+module.exports = SandboxedModel;

--- a/helpers/web-inspector.js
+++ b/helpers/web-inspector.js
@@ -24,8 +24,15 @@
 // Global pollution.
 global.self = global;
 global.WebInspector = {};
+if (typeof global.window === 'undefined') {
+  global.window = global.self = global;
+}
 
 // Initialize WebInspector.NetworkManager.
+global.Runtime = {};
+global.TreeElement = {};
+global.WorkerRuntime = {};
+
 global.Protocol = {
   Agents() {}
 };
@@ -46,12 +53,28 @@ global.WebInspector._moduleSettings = {
 global.WebInspector.moduleSetting = function(settingName) {
   return this._moduleSettings[settingName];
 };
+global.insertionIndexForObjectInListSortedByFunction =
+    function(object, list, comparator, insertionIndexAfter) {
+      if (insertionIndexAfter) {
+        return list.upperBound(object, comparator);
+      }
+
+      return list.lowerBound(object, comparator);
+    };
+
 // Enum from chromium//src/third_party/WebKit/Source/core/loader/MixedContentChecker.h
 global.NetworkAgent = {
   RequestMixedContentType: {
     Blockable: 'blockable',
     OptionallyBlockable: 'optionally-blockable',
     None: 'none'
+  },
+  BlockedReason: {
+    CSP: 'csp',
+    MixedContent: 'mixed-content',
+    Origin: 'origin',
+    Inspector: 'inspector',
+    Other: 'other'
   }
 };
 // Enum from SecurityState enum in protocol's Security domain
@@ -83,7 +106,7 @@ global.PageAgent = {
     Other: 'other'
   }
 };
-
+// Dependencies for network-recorder
 require('chrome-devtools-frontend/front_end/common/Object.js');
 require('chrome-devtools-frontend/front_end/common/ParsedURL.js');
 require('chrome-devtools-frontend/front_end/common/ResourceType.js');
@@ -92,6 +115,23 @@ require('chrome-devtools-frontend/front_end/platform/utilities.js');
 require('chrome-devtools-frontend/front_end/sdk/Target.js');
 require('chrome-devtools-frontend/front_end/sdk/NetworkManager.js');
 require('chrome-devtools-frontend/front_end/sdk/NetworkRequest.js');
+
+// deps for timeline-model
+require('devtools-timeline-model/lib/api-stubs.js');
+require('chrome-devtools-frontend/front_end/common/SegmentedRange.js');
+require('chrome-devtools-frontend/front_end/bindings/TempFile.js');
+require('chrome-devtools-frontend/front_end/sdk/TracingModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineJSProfile.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineUIUtils.js');
+require('chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js');
+require('chrome-devtools-frontend/front_end/timeline/LayerTreeModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js');
+require('chrome-devtools-frontend/front_end/ui_lazy/SortableDataGrid.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineProfileTree.js');
+require('chrome-devtools-frontend/front_end/components_lazy/FilmStripModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineIRModel.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineFrameModel.js');
 
 /**
  * Creates a new WebInspector NetworkManager using a mocked Target.

--- a/helpers/web-inspector.js
+++ b/helpers/web-inspector.js
@@ -110,6 +110,10 @@ global.WebInspector.NetworkManager.createWithFakeTarget = function() {
     registerNetworkDispatcher() {}
   };
 
+  global.WebInspector.moduleSetting = function(settingName) {
+    return this._moduleSettings[settingName];
+  };
+
   return new global.WebInspector.NetworkManager(fakeTarget);
 };
 

--- a/metrics/performance/first-meaningful-paint.js
+++ b/metrics/performance/first-meaningful-paint.js
@@ -16,7 +16,7 @@
  */
 'use strict';
 
-const DevtoolsTimelineModel = require('devtools-timeline-model');
+const DevtoolsTimelineModel = require('../../helpers/traces/devtools-timeline-model');
 
 const FAILURE_MESSAGE = 'Navigation and first paint timings not found.';
 


### PR DESCRIPTION
Stomps the global. I figure:

1. We already do that in the Network Manager.
2. It only stomps the background page for the extension, and the CLI we could clean?

Generally had to do this because @paulirish's existing version relies on `vm`, which doesn't translate well if the script itself contains `fs.readFileSync` or `require`, since the former isn't supported in browserify, except via brfs, and only for string paths known at build time, and the latter only works if the module is already resolved by browserify, which undermines the sandbox.

Upside:

<img width="573" alt="screen shot 2016-04-13 at 2 06 56 pm" src="https://cloud.githubusercontent.com/assets/617438/14494246/b8602368-0181-11e6-84dc-afb62b22c6f4.png">

:shipit: 