### PR TITLE
Refactors to start a 'full report'

### DIFF
--- a/extension/app/manifest.json
+++ b/extension/app/manifest.json
@@ -17,7 +17,8 @@
   },
   "permissions": [
     "activeTab",
-    "debugger"
+    "debugger",
+    "tabs"
   ],
   "browser_action": {
     "default_icon": {

--- a/extension/app/pages/report.html
+++ b/extension/app/pages/report.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="author" content="Paul Lewis" />
+  <meta name="viewport" content="width=device-width">
+  <title>Full report</title>
+</head>
+<body>
+<div class="content">
+  I am the full report.
+
+  Generated on <span class="generated"></span>
+</div>
+<script src="report.js"></script>
+</body>
+</html>

--- a/extension/app/pages/report.js
+++ b/extension/app/pages/report.js
@@ -1,0 +1,54 @@
+var NO_SCORE_PROVIDED = '-1';
+
+function escapeHTML(str) {
+  return str.replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/>/g, '&gt;')
+    .replace(/</g, '&lt;')
+    .replace(/`/g, '&#96;');
+}
+
+function createResultsHTML(results) {
+  let resultsHTML = '';
+
+  results.forEach(item => {
+    const score = (item.score.overall * 100).toFixed(0);
+    const groupHasErrors = (score < 100);
+    const groupClass = 'group ' +
+        (groupHasErrors ? 'errors expanded' : 'no-errors collapsed');
+
+    // Skip any tests that didn't run.
+    if (score === NO_SCORE_PROVIDED) {
+      return;
+    }
+
+    let groupHTML = '';
+    item.score.subItems.forEach(subitem => {
+      const debugString = subitem.debugString ? ` title="${escapeHTML(subitem.debugString)}"` : '';
+
+      const status = subitem.value ?
+          `<span class="pass" ${debugString}>Pass</span>` :
+          `<span class="fail" ${debugString}>Fail</span>`;
+      const rawValue = subitem.rawValue ? `(${escapeHTML(subitem.rawValue)})` : '';
+      groupHTML += `<li>${escapeHTML(subitem.description)}: ${status} ${rawValue}</li>`;
+    });
+
+    resultsHTML +=
+      `<li class="${groupClass}">
+        <span class="group-name">${escapeHTML(item.name)}</span>
+        <span class="group-score">(${score}%)</span>
+        <ul>
+          ${groupHTML}
+        </ul>
+      </li>`;
+  });
+
+  return resultsHTML;
+}
+
+chrome.runtime.onMessage.addListener(
+function(msg, sender, _) {
+  document.querySelector('.content').innerHTML = createResultsHTML(msg);
+  console.log(msg);
+});

--- a/extension/app/pages/report.js
+++ b/extension/app/pages/report.js
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 var NO_SCORE_PROVIDED = '-1';
 
 function escapeHTML(str) {

--- a/extension/app/popup.html
+++ b/extension/app/popup.html
@@ -15,7 +15,7 @@
     <h1>Lighthouse</h1>
     <h2>...</h2>
     <a href="https://github.com/googlechrome/lighthouse" target="_blank">Beta</a>
-    <button class="reload-all">Get performance data.</button>
+    <button class="generate-full-report">Generate full report</button>
   </header>
   <div class="results"></div>
   <script src="scripts/app.js"></script>

--- a/extension/app/scripts.babel/app.js
+++ b/extension/app/scripts.babel/app.js
@@ -19,25 +19,28 @@ document.addEventListener('DOMContentLoaded', _ => {
   const background = chrome.extension.getBackgroundPage();
   const siteNameEl = window.document.querySelector('header h2');
   const resultsEl = document.body.querySelector('.results');
-  const reloadPage = document.body.querySelector('.reload-all');
+  const generateFullReportEl = document.body.querySelector('.generate-full-report');
 
   background.runAudits({
     flags: {
       mobile: false,
       loadPage: false
     }
-  }).then(ret => {
-    resultsEl.innerHTML = ret;
+  })
+  .then(results => background.createResultsHTML(results))
+  .then(resultsHTML => {
+    resultsEl.innerHTML = resultsHTML;
   });
 
-  reloadPage.addEventListener('click', () => {
+  generateFullReportEl.addEventListener('click', () => {
     background.runAudits({
       flags: {
         mobile: true,
         loadPage: true
       }
-    }).then(ret => {
-      resultsEl.innerHTML = ret;
+    })
+    .then(results => {
+      background.createPageAndPopulate(results);
     });
   });
 

--- a/extension/app/scripts.babel/background.js
+++ b/extension/app/scripts.babel/background.js
@@ -21,6 +21,15 @@ const ExtensionProtocol = require('../../../helpers/extension/driver.js');
 const runner = require('../../../runner');
 const NO_SCORE_PROVIDED = '-1';
 
+window.createPageAndPopulate = function(results) {
+  const tabURL = chrome.extension.getURL('/pages/report.html');
+  chrome.tabs.create({url: tabURL}, tab => {
+    setTimeout(_ => {
+      chrome.tabs.sendMessage(tab.id, results);
+    }, 1000);
+  });
+};
+
 window.runAudits = function(options) {
   const driver = new ExtensionProtocol();
 
@@ -29,7 +38,6 @@ window.runAudits = function(options) {
         // Add in the URL to the options.
         return runner(driver, Object.assign({}, options, {url}));
       })
-      .then(results => createResultsHTML(results))
       .catch(returnError);
 };
 
@@ -46,7 +54,7 @@ function escapeHTML(str) {
     .replace(/`/g, '&#96;');
 }
 
-function createResultsHTML(results) {
+window.createResultsHTML = function(results) {
   let resultsHTML = '';
 
   results.forEach(item => {
@@ -82,7 +90,7 @@ function createResultsHTML(results) {
   });
 
   return resultsHTML;
-}
+};
 
 chrome.runtime.onInstalled.addListener(details => {
   console.log('previousVersion', details.previousVersion);

--- a/extension/app/styles/lighthouse.css
+++ b/extension/app/styles/lighthouse.css
@@ -163,7 +163,7 @@ header a {
   color: #D0021B;
 }
 
-.reload-all {
+.generate-full-report {
   display: block;
   font-size: 14px;
   padding: 5px;


### PR DESCRIPTION
This makes the audit runner in the background page side-effect free, returning the results. The results are then either posted to the full report page, or converted for HTML in the popup.