### PR TITLE
reorganization of devtools frontend imports and mocking

### DIFF
--- a/helpers/traces/devtools-timeline-model.js
+++ b/helpers/traces/devtools-timeline-model.js
@@ -17,17 +17,15 @@
 
 'use strict';
 
-/* global WebInspector, TimelineModelTreeView */
+const WebInspector = require('../web-inspector');
 
-// minor configurations
-require('devtools-timeline-model/lib/devtools-monkeypatches.js');
-// polyfill the bottom-up and topdown tree sorting
-require('devtools-timeline-model/lib/timeline-model-treeview.js');
+// Polyfill the bottom-up and topdown tree sorting.
+const TimelineModelTreeView =
+    require('devtools-timeline-model/lib/timeline-model-treeview.js')(WebInspector);
 
 class TimelineModel {
 
   constructor(events) {
-    this.WI = WebInspector;
     this.init(events);
   }
 

--- a/helpers/web-inspector.js
+++ b/helpers/web-inspector.js
@@ -23,20 +23,32 @@
 
 // Global pollution.
 global.self = global;
-global.WebInspector = {};
 if (typeof global.window === 'undefined') {
-  global.window = global.self = global;
+  global.window = global;
 }
 
-// Initialize WebInspector.NetworkManager.
 global.Runtime = {};
+global.Runtime.experiments = {
+  isEnabled(experimentName) {
+    switch (experimentName) {
+      case 'timelineLatencyInfo':
+        return true;
+      default:
+        return false;
+    }
+  }
+};
+
 global.TreeElement = {};
 global.WorkerRuntime = {};
 
 global.Protocol = {
   Agents() {}
 };
-global.WebInspector._moduleSettings = {
+
+global.WebInspector = {};
+const WebInspector = global.WebInspector;
+WebInspector._moduleSettings = {
   cacheDisabled: {
     addChangeListener() {},
     get() {
@@ -48,11 +60,18 @@ global.WebInspector._moduleSettings = {
     get() {
       return false;
     }
+  },
+  showNativeFunctionsInJSProfile: {
+    addChangeListener() {},
+    get() {
+      return true;
+    }
   }
 };
-global.WebInspector.moduleSetting = function(settingName) {
+WebInspector.moduleSetting = function(settingName) {
   return this._moduleSettings[settingName];
 };
+
 global.insertionIndexForObjectInListSortedByFunction =
     function(object, list, comparator, insertionIndexAfter) {
       if (insertionIndexAfter) {
@@ -116,8 +135,22 @@ require('chrome-devtools-frontend/front_end/sdk/Target.js');
 require('chrome-devtools-frontend/front_end/sdk/NetworkManager.js');
 require('chrome-devtools-frontend/front_end/sdk/NetworkRequest.js');
 
-// deps for timeline-model
-require('devtools-timeline-model/lib/api-stubs.js');
+// Dependencies for timeline-model
+WebInspector.targetManager = {
+  observeTargets() {}
+};
+WebInspector.settings = {
+  createSetting() {}
+};
+WebInspector.console = {
+  error() {}
+};
+WebInspector.VBox = function() {};
+WebInspector.HBox = function() {};
+WebInspector.ViewportDataGrid = function() {};
+WebInspector.ViewportDataGridNode = function() {};
+global.WorkerRuntime.Worker = function() {};
+
 require('chrome-devtools-frontend/front_end/common/SegmentedRange.js');
 require('chrome-devtools-frontend/front_end/bindings/TempFile.js');
 require('chrome-devtools-frontend/front_end/sdk/TracingModel.js');
@@ -126,18 +159,28 @@ require('chrome-devtools-frontend/front_end/timeline/TimelineUIUtils.js');
 require('chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js');
 require('chrome-devtools-frontend/front_end/timeline/LayerTreeModel.js');
 require('chrome-devtools-frontend/front_end/timeline/TimelineModel.js');
-require('chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js');
 require('chrome-devtools-frontend/front_end/ui_lazy/SortableDataGrid.js');
+require('chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js');
 require('chrome-devtools-frontend/front_end/timeline/TimelineProfileTree.js');
 require('chrome-devtools-frontend/front_end/components_lazy/FilmStripModel.js');
 require('chrome-devtools-frontend/front_end/timeline/TimelineIRModel.js');
 require('chrome-devtools-frontend/front_end/timeline/TimelineFrameModel.js');
 
+// DevTools makes a few assumptions about using backing storage to hold traces.
+WebInspector.DeferredTempFile = function() {};
+WebInspector.DeferredTempFile.prototype = {
+  write: function() {},
+  finishWriting: function() {}
+};
+
+// Dependencies for color parsing.
+require('chrome-devtools-frontend/front_end/common/Color.js');
+
 /**
  * Creates a new WebInspector NetworkManager using a mocked Target.
  * @return {!WebInspector.NetworkManager}
  */
-global.WebInspector.NetworkManager.createWithFakeTarget = function() {
+WebInspector.NetworkManager.createWithFakeTarget = function() {
   // Mocked-up WebInspector Target for NetworkManager
   const fakeNetworkAgent = {
     enable() {}
@@ -150,14 +193,7 @@ global.WebInspector.NetworkManager.createWithFakeTarget = function() {
     registerNetworkDispatcher() {}
   };
 
-  global.WebInspector.moduleSetting = function(settingName) {
-    return this._moduleSettings[settingName];
-  };
-
-  return new global.WebInspector.NetworkManager(fakeTarget);
+  return new WebInspector.NetworkManager(fakeTarget);
 };
 
-// Initialize WebInspector.Color.
-require('chrome-devtools-frontend/front_end/common/Color.js');
-
-module.exports = global.WebInspector;
+module.exports = WebInspector;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "chrome-devtools-frontend": "1.0.381789",
     "chrome-remote-interface": "^0.11.0",
-    "devtools-timeline-model": "1.0.16",
+    "devtools-timeline-model": "1.0.19",
     "meow": "^3.7.0",
     "npmlog": "^2.0.3",
     "semver": "^5.1.0",


### PR DESCRIPTION
followup to #190 

- require `WebInspector` into `devtools-timeline-model.js`
- some rearranging within `web-inspector.js` to make imports and stubbing out more explicit. This involved pulling in contents of `devtools-monkeypatches.js` and `api-stubs.js` directly instead of requiring them from `devtools-timeline-model` to keep things a little more sane. Some of the mocked APIs were getting redefined up to four times by us (e.g. `WebInspector.moduleSetting`) and their final value depended on the order in which the mocking files were called over the entirety of lighthouse since `WebInspector` lives in the global scope. We also get some nice things out of this like a single spot to enable/disable `Runtime.experiments`.

Some changes we may want to upstream to `devtools-timeline-model`, but conflicts seem inevitable since lighthouse needs quite a few more things stubbed out than just the timeline-related stuff.