### PR TITLE
don't bundle CRI with extension

### DIFF
--- a/extension/gulpfile.babel.js
+++ b/extension/gulpfile.babel.js
@@ -90,7 +90,10 @@ gulp.task('babel', () => {
       presets: ['es2015']
     }))
     .pipe(browserify({
-      ignore: ['npmlog']
+      ignore: [
+        'npmlog',
+        'chrome-remote-interface'
+      ]
     }))
     .pipe(gulp.dest('app/scripts'))
     .pipe(gulp.dest('dist/scripts'));


### PR DESCRIPTION
Broken extension build was due to chrome-remote-interface [updating their ws version](https://github.com/cyrus-and/chrome-remote-interface/commit/05319536f0ad83036da0e6b88fc41028dc6deadd). The newer version of ws [moved `bufferutil` and `utf-8-validate` to devDependencies](https://github.com/websockets/ws/commit/49b11093e9a009e5305dcde7003d3a896b2811dc), which apparently, when [combined with the conditional `require`](https://github.com/websockets/ws/blob/4263f26d4dbe27e781c41a1ddfe3dab87dd9e1dc/lib/BufferUtil.js) for them, breaks browserify. [ws issue](https://github.com/websockets/ws/issues/659) (closed as WAI)

Rather than doing fine grained ignoring, just ignoring CRI altogether, since the extension overrides any methods using it to use `chrome.debugger` anyways.