### PR TITLE
Log the protocol ACKs/returns 

### DIFF
--- a/helpers/browser/driver.js
+++ b/helpers/browser/driver.js
@@ -138,12 +138,14 @@ class ChromeProtocol {
     }
 
     return new Promise((resolve, reject) => {
-      _log('info', 'method => browser', {method: command, params: params});
+      _log('http', 'method => browser', {method: command, params: params});
 
       this._chrome.send(command, params, (err, result) => {
         if (err) {
+          _log('error', 'method <= browser', {method: command, params: result});
           return reject(result);
         }
+        _log('http', 'method <= browser OK', {method: command, params: result});
         resolve(result);
       });
     });

--- a/helpers/extension/driver.js
+++ b/helpers/extension/driver.js
@@ -103,13 +103,16 @@ class ExtensionProtocol extends ChromeProtocol {
       log('method => browser', command, params);
       chrome.debugger.sendCommand({tabId: this._tabId}, command, params, result => {
         if (chrome.runtime.lastError) {
+          log('error', 'method <= browser', command, result);
           return reject(chrome.runtime.lastError);
         }
 
         if (result.wasThrown) {
+          log('error', 'method <= browser', command, result);
           return reject(result.exceptionDetails);
         }
 
+        log('method <= browser OK', command, result);
         resolve(result);
       });
     });


### PR DESCRIPTION
Here's a bunch of successful ACKs with empty return objects:

![image](https://cloud.githubusercontent.com/assets/39191/14687076/82a632f2-06f0-11e6-9579-f30a31296dbd.png)

And here's the data coming back from more interactive commands:
![image](https://cloud.githubusercontent.com/assets/39191/14687095/9d4296b4-06f0-11e6-9f22-76d64d43b1c7.png)


Formatting bikeshedding welcome. :)