### PR TITLE
Refactor driver call to about:blank for SW reload.

### DIFF
--- a/src/lib/drivers/driver.js
+++ b/src/lib/drivers/driver.js
@@ -23,10 +23,6 @@ const Element = require('../element.js');
 
 class DriverBase {
 
-  get WAIT_FOR_LOAD() {
-    return true;
-  }
-
   constructor() {
     this._url = null;
     this.PAUSE_AFTER_LOAD = 3000;
@@ -90,7 +86,8 @@ class DriverBase {
     return Promise.reject(new Error('Not implemented'));
   }
 
-  gotoURL(url, waitForLoad) {
+  gotoURL(url, options) {
+    const waitForLoad = options.waitForLoad || false;
     return this.sendCommand('Page.enable')
     .then(_ => this.sendCommand('Page.getNavigationHistory'))
     .then(navHistory => {

--- a/src/lib/drivers/driver.js
+++ b/src/lib/drivers/driver.js
@@ -23,6 +23,10 @@ const Element = require('../element.js');
 
 class DriverBase {
 
+  get WAIT_FOR_LOAD() {
+    return true;
+  }
+
   constructor() {
     this._url = null;
     this.PAUSE_AFTER_LOAD = 3000;
@@ -86,7 +90,7 @@ class DriverBase {
     return Promise.reject(new Error('Not implemented'));
   }
 
-  gotoURL(url) {
+  gotoURL(url, waitForLoad) {
     return this.sendCommand('Page.enable')
     .then(_ => this.sendCommand('Page.getNavigationHistory'))
     .then(navHistory => {
@@ -107,6 +111,10 @@ class DriverBase {
     }).then(_ => {
       return new Promise((resolve, reject) => {
         this.url = url;
+
+        if (!waitForLoad) {
+          return resolve();
+        }
 
         this.on('Page.loadEventFired', response => {
           setTimeout(_ => {

--- a/src/lib/drivers/driver.js
+++ b/src/lib/drivers/driver.js
@@ -87,7 +87,7 @@ class DriverBase {
   }
 
   gotoURL(url, options) {
-    const waitForLoad = options.waitForLoad || false;
+    const waitForLoad = (options && options.waitForLoad) || false;
     return this.sendCommand('Page.enable')
     .then(_ => this.sendCommand('Page.getNavigationHistory'))
     .then(navHistory => {

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -26,7 +26,7 @@ function loadPage(driver, gatherers, options) {
   const url = options.url;
 
   if (loadPage) {
-    return driver.gotoURL(url);
+    return driver.gotoURL(url, driver.WAIT_FOR_LOAD);
   }
 
   return Promise.resolve();
@@ -36,9 +36,7 @@ function reloadPage(driver, options) {
   // Such a hack... since a Page.reload command does not let
   // a service worker take over we have to trick the browser into going away
   // and then coming back.
-  return driver.sendCommand('Page.navigate', {url: 'about:blank'}).then(_ => {
-    return driver.gotoURL(options.url);
-  });
+  return driver.gotoURL('about:blank').then(_ => driver.gotoURL(options.url, driver.WAIT_FOR_LOAD));
 }
 
 function setupDriver(driver, gatherers, options) {

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -26,7 +26,7 @@ function loadPage(driver, gatherers, options) {
   const url = options.url;
 
   if (loadPage) {
-    return driver.gotoURL(url, driver.WAIT_FOR_LOAD);
+    return driver.gotoURL(url, {waitForLoad: true});
   }
 
   return Promise.resolve();
@@ -36,7 +36,7 @@ function reloadPage(driver, options) {
   // Such a hack... since a Page.reload command does not let
   // a service worker take over we have to trick the browser into going away
   // and then coming back.
-  return driver.gotoURL('about:blank').then(_ => driver.gotoURL(options.url, driver.WAIT_FOR_LOAD));
+  return driver.gotoURL('about:blank').then(_ => driver.gotoURL(options.url, {waitForLoad: true}));
 }
 
 function setupDriver(driver, gatherers, options) {


### PR DESCRIPTION
Reintroduces `WAIT_FOR_LOAD` (I know) so that we can call a run to `about:blank` and the driver will choose `Page.navigate` or `Page.reload` as it does in other cases. This will mean that the extension shouldn't get into an uncanny valley as it was before.

Fixes #229