### PR TITLE
Adds extended info for report.

### DIFF
--- a/cli/printer.js
+++ b/cli/printer.js
@@ -91,14 +91,18 @@ function createOutput(results, outputMode) {
     let score = (item.score.overall * 100).toFixed(0);
     output += `${item.name}: ${score}%\n`;
 
-    item.score.subItems.forEach(subitem => {
-      let lineItem = ` -- ${subitem.description}: ${subitem.value}`;
-      if (subitem.rawValue) {
-        lineItem += ` (${subitem.rawValue})`;
+    item.score.subItems.forEach(subItem => {
+      let lineItem = ` -- ${subItem.description}: ${subItem.value}`;
+      if (subItem.rawValue) {
+        lineItem += ` (${subItem.rawValue})`;
       }
       output += `${lineItem}\n`;
-      if (subitem.debugString) {
-        output += `    ${subitem.debugString}\n`;
+      if (subItem.extendedInfo) {
+        const extendedInfoType = typeof subItem.extendedInfo;
+        if (extendedInfoType === 'string') {
+          output += `    ${subItem.extendedInfo}\n`;
+        }
+        // TODO: pretty print more complex extended info.
       }
     });
 

--- a/closure/typedefs/AuditResult.js
+++ b/closure/typedefs/AuditResult.js
@@ -32,8 +32,8 @@ AuditResult.prototype.value;
 /** @type {(boolean|number|string|undefined|null)} */
 AuditResult.prototype.rawValue;
 
-/** @type {(string|undefined)} */
-AuditResult.prototype.debugString;
+/** @type {(string|Object|undefined)} */
+AuditResult.prototype.extendedInfo;
 
 /** @type {string} */
 AuditResult.prototype.name;

--- a/closure/typedefs/Manifest.js
+++ b/closure/typedefs/Manifest.js
@@ -34,7 +34,7 @@ ManifestNode.prototype.raw;
 ManifestNode.prototype.value;
 
 /** @type {string} */
-ManifestNode.prototype.debugString;
+ManifestNode.prototype.extendedInfo;
 
 /**
  * @struct

--- a/report/styles/report.css
+++ b/report/styles/report.css
@@ -299,10 +299,20 @@ a {
 }
 
 .report-section__item {
-  display: flex;
   padding-left: 32px;
-  background: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNXB4IiBoZWlnaHQ9IjVweCIgdmlld0JveD0iMCAwIDUgNSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxjaXJjbGUgaWQ9Ik92YWwtNzAiIHN0cm9rZT0ibm9uZSIgZmlsbD0iIzY0NjQ2NCIgZmlsbC1ydWxlPSJldmVub2RkIiBjeD0iMi41IiBjeT0iMi41IiByPSIyLjUiPjwvY2lyY2xlPgo8L3N2Zz4K') 14px center no-repeat;
+  background: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNXB4IiBoZWlnaHQ9IjVweCIgdmlld0JveD0iMCAwIDUgNSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxjaXJjbGUgaWQ9Ik92YWwtNzAiIHN0cm9rZT0ibm9uZSIgZmlsbD0iIzY0NjQ2NCIgZmlsbC1ydWxlPSJldmVub2RkIiBjeD0iMi41IiBjeT0iMi41IiByPSIyLjUiPjwvY2lyY2xlPgo8L3N2Zz4K') 14px 8px no-repeat;
   line-height: 24px;
+}
+
+.report-section__item-details {
+  display: flex;
+}
+
+.report-section__item-extended-info {
+  font-size: 15px;
+  color: #555;
+  font-style: italic;
+  padding: 6px 6px 20px 6px;
 }
 
 .report-section__item-raw-value {

--- a/report/templates/extended-info/axe.html
+++ b/report/templates/extended-info/axe.html
@@ -1,0 +1,28 @@
+<style>
+.axe-violation {
+  color: #D0021B;
+}
+
+.axe-violation__help {
+  color: #76B530;
+}
+
+.axe-violation__help-minor,
+.axe-violation__help-moderate {
+  color: #F5A623;
+}
+
+.axe-violation__help-serious,
+.axe-violation__help--critical {
+  color: #D0021B;
+}
+</style>
+<div class="axe-violation">
+  <a class="axe-violation__help--{{ this.impact }}" href="{{ this.helpUrl }}" target="_blank">{{ this.help }}</a>
+
+  <ul>
+  {{#each this.nodes}}
+    <li><code>{{ this.target }}</code></li>
+  {{/each}}
+  </ul>
+</div>

--- a/report/templates/report.html
+++ b/report/templates/report.html
@@ -73,9 +73,18 @@ limitations under the License.
             <ul class="report-section__individual-results">
               {{#each this.score.subItems }}
                 <li class="report-section__item">
-                  <span class="report-section__item-description">{{ this.description }}</span>
-                  <span class="report-section__item-value report-section__item-value--{{ getItemRating this.value }}">{{ getItemValue this.value }}</span>
-                  <span class="report-section__item-raw-value">{{{ getItemRawValue this }}}</span>
+                  <div class="report-section__item-details">
+                    <span class="report-section__item-description">{{ this.description }}</span>
+                    <span class="report-section__item-value report-section__item-value--{{ getItemRating this.value }}">{{ getItemValue this.value }}</span>
+                    <span class="report-section__item-raw-value">{{{ getItemRawValue this }}}</span>
+                  </div>
+                  {{#if this.extendedInfo}}
+                    {{#hasExtendedInfoPartial this.name }}
+                      <div class="report-section__item-extended-info">
+                      {{> (lookup . 'name') ../extendedInfo }}
+                      </div>
+                    {{/hasExtendedInfoPartial}}
+                  {{/if}}
                 </li>
               {{/each}}
             </ul>

--- a/src/audits/accessibility/aria-valid-attr.js
+++ b/src/audits/accessibility/aria-valid-attr.js
@@ -38,7 +38,7 @@ class ARIAValidAttr extends Audit {
    * @override
    */
   static get description() {
-    return 'Ensures attributes that begin with aria- are valid ARIA attributes';
+    return 'Attributes that begin with aria- are valid ARIA attributes';
   }
 
   /**
@@ -52,19 +52,8 @@ class ARIAValidAttr extends Audit {
     return ARIAValidAttr.generateAuditResult(
       typeof rule === 'undefined',
       undefined,
-      this.createDebugString(rule)
+      rule
     );
-  }
-
-  static createDebugString(rule) {
-    if (typeof rule === 'undefined') {
-      return '';
-    }
-
-    return rule.help + ' (Failed on ' +
-      rule.nodes.reduce((prev, node) => {
-        return prev + `"${node.target.join(', ')}"`;
-      }, '') + ')';
   }
 }
 

--- a/src/audits/audit.js
+++ b/src/audits/audit.js
@@ -48,15 +48,15 @@ class Audit {
   /**
    * @param {(boolean|number|string)} value
    * @param {?(boolean|number|string)=} rawValue
-   * @param {string=} debugString Optional string to describe any error condition encountered.
+   * @param {(string|Object)=} extendedInfo Additional information to help developer diagnosis & insight.
    * @param {?(boolean|number|string)=} optimalValue
    * @return {!AuditResult}
    */
-  static generateAuditResult(value, rawValue, debugString, optimalValue) {
+  static generateAuditResult(value, rawValue, extendedInfo, optimalValue) {
     return {
       value,
       rawValue,
-      debugString,
+      extendedInfo,
       optimalValue,
       name: this.name,
       tags: this.tags,

--- a/src/audits/manifest/exists.js
+++ b/src/audits/manifest/exists.js
@@ -49,7 +49,7 @@ class ManifestExists extends Audit {
     return ManifestExists.generateAuditResult(
       typeof artifacts.manifest.value !== 'undefined',
       undefined,
-      artifacts.manifest.debugString
+      artifacts.manifest.extendedInfo
     );
   }
 }

--- a/test/src/audits/html/theme-colors.js
+++ b/test/src/audits/html/theme-colors.js
@@ -24,7 +24,7 @@ describe('HTML: theme-color audit', () => {
     const emptyAudit = Audit.audit({});
 
     assert.equal(emptyAudit.value, false);
-    assert(emptyAudit.debugString);
+    assert(emptyAudit.extendedInfo);
   });
 
   it('fails and warns when no value given', () => {
@@ -33,7 +33,7 @@ describe('HTML: theme-color audit', () => {
     });
 
     assert.equal(nullColorAudit.value, false);
-    assert(nullColorAudit.debugString);
+    assert(nullColorAudit.extendedInfo);
   });
 
   it('fails and warns when theme-color has an invalid CSS color', () => {
@@ -42,7 +42,7 @@ describe('HTML: theme-color audit', () => {
     });
 
     assert.equal(invalidColorAudit.value, false);
-    assert(invalidColorAudit.debugString);
+    assert(invalidColorAudit.extendedInfo);
   });
 
   it('succeeds when theme-color present in the html', () => {

--- a/test/src/audits/manifest/exists.js
+++ b/test/src/audits/manifest/exists.js
@@ -32,13 +32,13 @@ describe('Manifest: exists audit', () => {
   });
 
   it('correctly passes through debug strings', () => {
-    const debugString = 'No href found on <link rel="manifest">.';
+    const extendedInfo = 'No href found on <link rel="manifest">.';
 
     assert.equal(Audit.audit({
       manifest: {
         value: {},
-        debugString
+        extendedInfo
       }
-    }).debugString, debugString);
+    }).extendedInfo, extendedInfo);
   });
 });

--- a/test/src/audits/manifest/short-name-length.js
+++ b/test/src/audits/manifest/short-name-length.js
@@ -42,7 +42,7 @@ describe('Manifest: short_name_length audit', () => {
     const manifest = manifestParser(manifestSrc);
     const out = Audit.audit({manifest});
     assert.equal(out.value, false);
-    assert.notEqual(out.debugString, undefined);
+    assert.notEqual(out.extendedInfo, undefined);
   });
 
   it('succeeds when a manifest contains a short_name', () => {


### PR DESCRIPTION
This opens up the functionality for an audit to write out more detailed information to the reports.

![screen shot 2016-04-25 at 6 00 41 pm](https://cloud.githubusercontent.com/assets/617438/14791868/a701c1a2-0b0f-11e6-891b-5cdb30ca39da.png)

Each partial is self-contained so, for example, an audit could have a custom set of controls for diving into CRP or something like that.

Currently done our sole a11y / aria- audit as it has a decent amount of extended data. Existing `debugString` messages are supported; if the extendedInfo is a string, it's output as-is.