### PR TITLE
Rename scheduler phases and move tasks to after profiling

### DIFF
--- a/src/gatherers/accessibility.js
+++ b/src/gatherers/accessibility.js
@@ -76,7 +76,7 @@ class Accessibility extends Gather {
     });
   }
 
-  afterPageLoad(options) {
+  postProfiling(options) {
     const driver = options.driver;
 
     return driver.sendCommand('Runtime.evaluate', {

--- a/src/gatherers/gather.js
+++ b/src/gatherers/gather.js
@@ -28,9 +28,9 @@ class Gather {
 
   beforePageLoad(options) { }
 
-  afterPageLoad(options) { }
+  profiledPostPageLoad(options) { }
 
-  afterTraceCollected(options, tracingData) { }
+  postProfiling(options, tracingData) { }
 
   reloadSetup(options) { }
 

--- a/src/gatherers/html.js
+++ b/src/gatherers/html.js
@@ -20,7 +20,7 @@ const Gather = require('./gather');
 
 class HTML extends Gather {
 
-  afterPageLoad(options) {
+  postProfiling(options) {
     const driver = options.driver;
 
     return driver.sendCommand('DOM.getDocument')

--- a/src/gatherers/https.js
+++ b/src/gatherers/https.js
@@ -20,7 +20,7 @@ const Gather = require('./gather');
 
 class HTTPS extends Gather {
 
-  afterPageLoad(options) {
+  postProfiling(options) {
     const driver = options.driver;
     return driver
         .sendCommand('Runtime.evaluate', {

--- a/src/gatherers/manifest.js
+++ b/src/gatherers/manifest.js
@@ -57,7 +57,7 @@ class Manifest extends Gather {
     };
   }
 
-  afterPageLoad(options) {
+  postProfiling(options) {
     const driver = options.driver;
     /**
      * This re-fetches the manifest separately, which could

--- a/src/gatherers/theme-color.js
+++ b/src/gatherers/theme-color.js
@@ -20,7 +20,7 @@ const Gather = require('./gather');
 
 class ThemeColor extends Gather {
 
-  afterPageLoad(options) {
+  postProfiling(options) {
     const driver = options.driver;
 
     return driver.querySelector('head meta[name="theme-color"]')

--- a/src/gatherers/viewport.js
+++ b/src/gatherers/viewport.js
@@ -24,7 +24,7 @@ class Viewport extends Gather {
    * @param {!{driver: !Object}} options Run options
    * @return {!Promise<{viewport: !string}>} The value of the viewport meta's content attribute, or null
    */
-  afterPageLoad(options) {
+  postProfiling(options) {
     const driver = options.driver;
 
     return driver.querySelector('head meta[name="viewport"]')

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -132,9 +132,9 @@ function run(gatherers, options) {
 
     // Load page, gather from browser, stop profilers.
     .then(_ => loadPage(driver, gatherers, options))
-    .then(_ => runPhase(gatherer => gatherer.afterPageLoad(options)))
+    .then(_ => runPhase(gatherer => gatherer.profiledPostPageLoad(options)))
     .then(_ => endPassiveCollection(options, tracingData))
-    .then(_ => runPhase(gatherer => gatherer.afterTraceCollected(options, tracingData)))
+    .then(_ => runPhase(gatherer => gatherer.postProfiling(options, tracingData)))
 
     // Reload page for SW, etc.
     .then(_ => runPhase(gatherer => gatherer.reloadSetup(options)))


### PR DESCRIPTION
Fixing #227. 

Visually compared lighthouse results on pwa.rocks before and after this change. Everything seems to be working fine. 