### PR TITLE
Add pylint conf and clean up python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
      - extension/node_modules
 before_script:
   - npm --prefix ./extension install ./extension
+  - pip install --user pylint
   - export DISPLAY=:99.0
   - export LIGHTHOUSE_CHROMIUM_PATH="$(pwd)/chrome-linux/chrome"
   - sh -e /etc/init.d/xvfb start
@@ -22,5 +23,4 @@ script:
   - npm run closure
   - npm run smoke
   - (cd extension && gulp build)
-  - pip install --user pylint
   - pylint --rcfile=scripts/pylint.conf scripts/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ script:
   - npm run closure
   - npm run smoke
   - (cd extension && gulp build)
+  - pip install --user pylint
+  - pylint --rcfile=scripts/pylint.conf scripts/*.py

--- a/scripts/netdep_graph_json.py
+++ b/scripts/netdep_graph_json.py
@@ -31,21 +31,25 @@ import request_dependencies_lens
 import loading_graph_view
 
 def get_network_dependency_graph(json_dict):
-    trace = loading_trace.LoadingTrace.FromJsonDict(json_dict)
-    content_lens = (
-        content_classification_lens.ContentClassificationLens.WithRulesFiles(
-            trace, '', ''))
-    frame_lens = frame_load_lens.FrameLoadLens(trace)
-    activity = activity_lens.ActivityLens(trace)
-    deps_lens = request_dependencies_lens.RequestDependencyLens(trace)
-    graph_view = loading_graph_view.LoadingGraphView(
-        trace, deps_lens, content_lens, frame_lens, activity)
-    return graph_view
+  trace = loading_trace.LoadingTrace.FromJsonDict(json_dict)
+  content_lens = (
+      content_classification_lens.ContentClassificationLens.WithRulesFiles(
+          trace, '', ''))
+  frame_lens = frame_load_lens.FrameLoadLens(trace)
+  activity = activity_lens.ActivityLens(trace)
+  deps_lens = request_dependencies_lens.RequestDependencyLens(trace)
+  graph_view = loading_graph_view.LoadingGraphView(
+      trace, deps_lens, content_lens, frame_lens, activity)
+  return graph_view
 
-with open('clovis-trace.log') as f:
-	graph = get_network_dependency_graph(json.load(f))
+def main():
+  with open('clovis-trace.log') as f:
+    graph = get_network_dependency_graph(json.load(f))
 
-output_file = "dependency-graph.json"
-with open(output_file ,'w') as f: 
-	json.dump(graph.deps_graph.ToJsonDict(), f)
-	print 'Wrote dependency graph to {0}'.format(output_file)
+  output_file = "dependency-graph.json"
+  with open(output_file, 'w') as f:
+    json.dump(graph.deps_graph.ToJsonDict(), f)
+    print 'Wrote dependency graph to {0}'.format(output_file)
+
+if __name__ == '__main__':
+  main()

--- a/scripts/pylint.conf
+++ b/scripts/pylint.conf
@@ -1,0 +1,25 @@
+[MESSAGES CONTROL]
+
+# F0401: import-error - we sys.path.append before import
+# C0111: missing-docstring
+# C0330: bad-continuation - pylint indent rules too rigid
+# C0413: wrong-import-position - because of sys.path.append imports are not 
+#   at top of file
+disable=F0401,C0111,C0330,C0413
+
+[REPORTS]
+reports=no
+
+[FORMAT]
+indent-string='  '
+
+[BASIC]
+# Good variable names which should always be accepted, separated by a comma
+good-names=f,i,j,k,ex,Run,_
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+# Otherwise pylint treats the sys.path.append hack at the beginning of each
+# file as duplicate code
+min-similarity-lines=10


### PR DESCRIPTION
Fixes #261 

I disabled import related errors because of our sys.path.append hack before we import clovis modules. Also disabled missing-docstring because it's too much work do document every function and bad-continuation because pylint indent continuation rules make no sense to me.  