### PR TITLE
three fixes

### DIFF
--- a/cli/printer.js
+++ b/cli/printer.js
@@ -44,7 +44,7 @@ const OUTPUT_MODE = {
  */
 function checkOutputMode(mode) {
   if (!OUTPUT_MODE.hasOwnProperty(mode)) {
-    log('warn', `Unknown output mode ${mode}; using pretty`);
+    log.log('warn', `Unknown output mode ${mode}; using pretty`);
     return OUTPUT_MODE.pretty;
   }
 
@@ -57,7 +57,7 @@ function checkOutputMode(mode) {
  */
 function checkOutputPath(path) {
   if (!path) {
-    log('warn', 'No output path set; using stdout');
+    log.log('warn', 'No output path set; using stdout');
     return 'stdout';
   }
 

--- a/src/lib/drivers/cri.js
+++ b/src/lib/drivers/cri.js
@@ -123,7 +123,7 @@ function _log(level, prefix, data) {
   const columns = (typeof process === 'undefined') ? Infinity : process.stdout.columns;
   const maxLength = columns - data.method.length - prefix.length - 7;
   const snippet = data.params ? JSON.stringify(data.params).substr(0, maxLength) : '';
-  log(level, prefix, data.method, snippet);
+  log.log(level, prefix, data.method, snippet);
 }
 
 module.exports = CriDriver;

--- a/src/lib/drivers/extension.js
+++ b/src/lib/drivers/extension.js
@@ -61,7 +61,7 @@ class ExtensionDriver extends Driver {
   beginLogging() {
     // log events received
     chrome.debugger.onEvent.addListener((source, method, params) =>
-     log('<=', method, params)
+     log.log('<=', method, params)
     );
   }
 
@@ -75,7 +75,7 @@ class ExtensionDriver extends Driver {
       this._listeners[eventName] = [];
     }
     // log event listeners being bound
-    log('listen for event =>', eventName);
+    log.log('listen for event =>', eventName);
     this._listeners[eventName].push(cb);
   }
 
@@ -100,19 +100,19 @@ class ExtensionDriver extends Driver {
    */
   sendCommand(command, params) {
     return new Promise((resolve, reject) => {
-      log('method => browser', command, params);
+      log.log('method => browser', command, params);
       chrome.debugger.sendCommand({tabId: this._tabId}, command, params, result => {
         if (chrome.runtime.lastError) {
-          log('error', 'method <= browser', command, result);
+          log.log('error', 'method <= browser', command, result);
           return reject(chrome.runtime.lastError);
         }
 
         if (result.wasThrown) {
-          log('error', 'method <= browser', command, result);
+          log.log('error', 'method <= browser', command, result);
           return reject(result.exceptionDetails);
         }
 
-        log('method <= browser OK', command, result);
+        log.log('method <= browser OK', command, result);
         resolve(result);
       });
     });

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -18,7 +18,7 @@
 
 const npmlog = require('npmlog');
 
-// Use `npmlog` in node, `console.log` in browser and electron.
+// Use `npmlog` in node, `console` in browser and electron.
 const isNode = !!process && !process.browser && !process.versions.electron;
 
-module.exports = isNode ? npmlog.log : console.log.bind(console);
+module.exports = isNode ? npmlog : console;

--- a/src/lib/web-inspector.js
+++ b/src/lib/web-inspector.js
@@ -173,6 +173,18 @@ WebInspector.DeferredTempFile.prototype = {
   finishWriting: function() {}
 };
 
+// Mock for WebInspector code that writes to console.
+WebInspector.ConsoleMessage = function() {};
+WebInspector.ConsoleMessage.MessageSource = {
+  Network: 'network'
+};
+WebInspector.ConsoleMessage.MessageLevel = {
+  Log: 'log'
+};
+WebInspector.ConsoleMessage.MessageType = {
+  Log: 'log'
+};
+
 // Dependencies for color parsing.
 require('chrome-devtools-frontend/front_end/common/Color.js');
 
@@ -185,8 +197,15 @@ WebInspector.NetworkManager.createWithFakeTarget = function() {
   const fakeNetworkAgent = {
     enable() {}
   };
+  const fakeConsoleModel = {
+    addMessage() {},
+    target() {}
+  };
   const fakeTarget = {
     _modelByConstructor: new Map(),
+    get consoleModel() {
+      return fakeConsoleModel;
+    },
     networkAgent() {
       return fakeNetworkAgent;
     },

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -99,7 +99,7 @@ function flattenArtifacts(artifacts) {
 function saveArtifacts(artifacts) {
   const artifactsFilename = 'artifacts.log';
   fs.writeFileSync(artifactsFilename, JSON.stringify(artifacts));
-  log('info', 'artifacts file saved to disk', artifactsFilename);
+  log.log('info', 'artifacts file saved to disk', artifactsFilename);
 }
 
 function saveAssets(tracingData, url) {
@@ -108,7 +108,7 @@ function saveAssets(tracingData, url) {
   const filename = (hostname + '_' + date.toISOString() + '.trace.json')
       .replace(/[\/\?<>\\:\*\|":]/g, '-');
   fs.writeFileSync(filename, JSON.stringify(tracingData.traceContents, null, 2));
-  log('info', 'trace file saved to disk', filename);
+  log.log('info', 'trace file saved to disk', filename);
 }
 
 function run(gatherers, options) {


### PR DESCRIPTION
unrelated fixes (probably easier to look at individual commits, sorry) to things I ran into while integrating lighthouse with an existing CI:
  - ~~switch back to continuous builds now that Linux dev is on m52~~
  - mock out `WebInspector.ConsoleMessage` for a code path hit when resource type and mime type don't match and `WebInspector` wants to log about it
  - get log levels working again. `npmlog.log` is bound to `npmlog`, so can be called independently, but the log `level` can only be set on the parent `npmlog` object, so it has to be exposed.