### PR TITLE
Close tabs behind you

### DIFF
--- a/src/lib/drivers/cri.js
+++ b/src/lib/drivers/cri.js
@@ -42,6 +42,7 @@ class CriDriver extends Driver {
         }
 
         chromeRemoteInterface({port: port, chooseTab: tab}, chrome => {
+          this._tab = tab;
           this._chrome = chrome;
           this.beginLogging();
           this.enableRuntimeEvents().then(_ => {
@@ -54,13 +55,31 @@ class CriDriver extends Driver {
   }
 
   disconnect() {
-    if (this._chrome === null) {
-      return;
-    }
+    return new Promise((resolve, reject) => {
+      if (!this._tab) {
+        return resolve();
+      }
 
-    this._chrome.close();
-    this._chrome = null;
-    this.url = null;
+      /* eslint-disable new-cap */
+      chromeRemoteInterface.Close({
+        id: this._tab.id
+      }, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+      /* eslint-enable new-cap */
+    })
+    .then(() => {
+      if (this._chrome) {
+        this._chrome.close();
+      }
+      this._tab = null;
+      this._chrome = null;
+      this.url = null;
+    });
   }
 
   beginLogging() {

--- a/src/lib/drivers/extension.js
+++ b/src/lib/drivers/extension.js
@@ -48,10 +48,10 @@ class ExtensionDriver extends Driver {
 
   disconnect() {
     if (this._tabId === null) {
-      return;
+      return Promise.resolve();
     }
 
-    this.detachDebugger_(this._tabId)
+    return this.detachDebugger_(this._tabId)
         .then(_ => {
           this._tabId = null;
           this.url = null;


### PR DESCRIPTION
This closes the tab on the CLI when disconnected.

I've made the disconnect method always return a promise - it doesn't need to, but feels cleaner / safer in the long run.