### PR TITLE
Checks for HTTPS redirect

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -53,6 +53,12 @@ const outputMode = cli.flags.output || 'pretty';
 const outputPath = cli.flags.outputPath || 'stdout';
 const flags = cli.flags;
 
+// If the URL isn't https or localhost complain to the user.
+if (url.indexOf('https') !== 0 && url.indexOf('localhost') === -1) {
+  log.warn('Lighthouse', 'The URL provided should be on HTTPS');
+  log.warn('Lighthouse', 'Performance stats will be skewed redirecting from HTTP to HTTPS.');
+}
+
 // set logging preferences
 flags.logLevel = 'info';
 if (cli.flags.verbose) {

--- a/cli/index.js
+++ b/cli/index.js
@@ -54,7 +54,7 @@ const outputPath = cli.flags.outputPath || 'stdout';
 const flags = cli.flags;
 
 // If the URL isn't https or localhost complain to the user.
-if (url.indexOf('https') !== 0 && url.indexOf('localhost') === -1) {
+if (url.indexOf('https') !== 0 && url.indexOf('http://localhost') !== 0) {
   log.warn('Lighthouse', 'The URL provided should be on HTTPS');
   log.warn('Lighthouse', 'Performance stats will be skewed redirecting from HTTP to HTTPS.');
 }

--- a/src/audits/security/redirects-http.js
+++ b/src/audits/security/redirects-http.js
@@ -45,9 +45,10 @@ class RedirectsHTTP extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    return RedirectsHTTP.generateAuditResult(artifacts.redirectsHTTP.value,
-        undefined,
-        artifacts.redirectsHTTP.debugString);
+    return RedirectsHTTP.generateAuditResult({
+      value: artifacts.redirectsHTTP.value,
+      debugString: artifacts.redirectsHTTP.debugString
+    });
   }
 }
 

--- a/src/audits/security/redirects-http.js
+++ b/src/audits/security/redirects-http.js
@@ -45,7 +45,9 @@ class RedirectsHTTP extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    return RedirectsHTTP.generateAuditResult(artifacts.redirectsHTTP);
+    return RedirectsHTTP.generateAuditResult(artifacts.redirectsHTTP.value,
+        artifacts.redirectsHTTP.value,
+        artifacts.redirectsHTTP.debugString);
   }
 }
 

--- a/src/audits/security/redirects-http.js
+++ b/src/audits/security/redirects-http.js
@@ -46,7 +46,7 @@ class RedirectsHTTP extends Audit {
    */
   static audit(artifacts) {
     return RedirectsHTTP.generateAuditResult(artifacts.redirectsHTTP.value,
-        artifacts.redirectsHTTP.value,
+        undefined,
         artifacts.redirectsHTTP.debugString);
   }
 }

--- a/src/audits/security/redirects-http.js
+++ b/src/audits/security/redirects-http.js
@@ -14,53 +14,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
 
-const Aggregate = require('../aggregate');
+const Audit = require('../audit');
 
-/** @type {string} */
-const isOnHTTPS = require('../../audits/security/is-on-https').name;
-
-/** @type {string} */
-const redirectsHTTP = require('../../audits/security/redirects-http').name;
-
-class IsSecure extends Aggregate {
+class RedirectsHTTP extends Audit {
+  /**
+   * @override
+   */
+  static get tags() {
+    return ['Security'];
+  }
 
   /**
    * @override
-   * @return {string}
    */
   static get name() {
-    return 'Is Secure';
+    return 'redirects-http';
   }
 
   /**
    * @override
-   * @return {string}
    */
-  static get shortName() {
-    return 'Secure';
+  static get description() {
+    return 'Site redirects HTTP traffic to HTTPS';
   }
 
   /**
-   * @override
-   * @return {!AggregationCriteria}
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
    */
-  static get criteria() {
-    const criteria = {};
-    criteria[isOnHTTPS] = {
-      value: true,
-      weight: 1
-    };
-
-    criteria[redirectsHTTP] = {
-      value: true,
-      weight: 1
-    };
-
-    return criteria;
+  static audit(artifacts) {
+    return RedirectsHTTP.generateAuditResult(artifacts.redirectsHTTP);
   }
 }
 
-module.exports = IsSecure;
+module.exports = RedirectsHTTP;

--- a/src/gatherers/gather.js
+++ b/src/gatherers/gather.js
@@ -38,6 +38,8 @@ class Gather {
 
   afterReloadPageLoad(options) { }
 
+  afterSecondReloadPageLoad(options) { }
+
   tearDown(options, tracingData) { }
 
   /* eslint-enable no-unused-vars */

--- a/src/gatherers/http-redirect.js
+++ b/src/gatherers/http-redirect.js
@@ -38,7 +38,9 @@ class HTTPRedirect extends Gather {
     // If the URL hasn't changed then the origin URL was HTTP.
     if (httpURL === url) {
       this.artifact = {
-        redirectsHTTP: false
+        redirectsHTTP: {
+          value: false
+        }
       };
 
       return Promise.resolve();

--- a/src/gatherers/http-redirect.js
+++ b/src/gatherers/http-redirect.js
@@ -20,20 +20,8 @@ const Gather = require('./gather');
 
 class HTTPRedirect extends Gather {
 
-  static _error(errorString) {
-    return {
-      redirectsHTTP: {
-        value: undefined,
-        debugString: errorString
-      }
-    };
-  }
-
   constructor() {
     super();
-    this._resolved = false;
-    this._artifactsResolved = undefined;
-    this._onSecurityStateChanged = undefined;
     this._noSecurityChangesTimeout = undefined;
   }
 
@@ -44,7 +32,6 @@ class HTTPRedirect extends Gather {
       // Set up a timeout for ten seconds in case we don't get any
       // security events at all. If that happens, bail.
       this._noSecurityChangesTimeout = setTimeout(_ => {
-        this._resolved = true;
         this.artifact = {
           redirectsHTTP: {
             value: false,

--- a/src/gatherers/http-redirect.js
+++ b/src/gatherers/http-redirect.js
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const Gather = require('./gather');
+
+class HTTPRedirect extends Gather {
+
+  static _error(errorString) {
+    return {
+      redirectsHTTP: {
+        raw: undefined,
+        value: undefined,
+        debugString: errorString
+      }
+    };
+  }
+
+  afterReloadPageLoad(options) {
+    const driver = options.driver;
+    const url = options.url;
+    const httpURL = options.url.replace(/^https/, 'http');
+
+    // If the URL hasn't changed then the origin URL was HTTP.
+    if (httpURL === url) {
+      this.artifact = {
+        redirectsHTTP: false
+      };
+
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+      let securityStateChangedTimeout;
+      driver.on('Security.securityStateChanged', data => {
+        // Clear out any previous results.
+        if (securityStateChangedTimeout !== undefined) {
+          clearTimeout(securityStateChangedTimeout);
+        }
+
+        // Wait up to 3 seconds for updated security events.
+        securityStateChangedTimeout = setTimeout(_ => {
+          this.artifact = {
+            redirectsHTTP: data.schemeIsCryptographic
+          };
+          resolve();
+        }, 3000);
+      });
+
+      // Redirect out to about:blank
+      driver.gotoURL('about:blank', {waitForLoad: false})
+          .then(_ => driver.gotoURL(httpURL, {waitForLoad: true}));
+    });
+  }
+}
+
+module.exports = HTTPRedirect;

--- a/src/lib/drivers/driver.js
+++ b/src/lib/drivers/driver.js
@@ -141,7 +141,7 @@ class DriverBase {
   }
 
   getSecurityState() {
-    return new Promise((resolve, _) => {
+    return new Promise((resolve, reject) => {
       this.once('Security.securityStateChanged', data => {
         this.sendCommand('Security.disable');
         resolve(data);

--- a/src/lib/drivers/driver.js
+++ b/src/lib/drivers/driver.js
@@ -140,6 +140,17 @@ class DriverBase {
     });
   }
 
+  getSecurityState() {
+    return new Promise((resolve, _) => {
+      this.on('Security.securityStateChanged', data => {
+        this.sendCommand('Security.disable');
+        resolve(data);
+      });
+
+      this.sendCommand('Security.enable');
+    });
+  }
+
   gotoURL(url, options) {
     const waitForLoad = (options && options.waitForLoad) || false;
     return this.sendCommand('Page.enable')

--- a/src/lib/drivers/driver.js
+++ b/src/lib/drivers/driver.js
@@ -142,7 +142,7 @@ class DriverBase {
 
   getSecurityState() {
     return new Promise((resolve, _) => {
-      this.on('Security.securityStateChanged', data => {
+      this.once('Security.securityStateChanged', data => {
         this.sendCommand('Security.disable');
         resolve(data);
       });

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -23,6 +23,7 @@ const Aggregator = require('./aggregator');
 const gathererClasses = [
   require('./gatherers/url'),
   require('./gatherers/https'),
+  require('./gatherers/http-redirect'),
   require('./gatherers/service-worker'),
   require('./gatherers/viewport'),
   require('./gatherers/theme-color'),
@@ -34,6 +35,7 @@ const gathererClasses = [
 
 const audits = [
   require('./audits/security/is-on-https'),
+  require('./audits/security/redirects-http'),
   require('./audits/offline/service-worker'),
   require('./audits/offline/works-offline'),
   require('./audits/mobile-friendly/viewport'),

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -140,6 +140,10 @@ function run(gatherers, options) {
     .then(_ => reloadPage(driver, options))
     .then(_ => runPhase(gatherer => gatherer.afterReloadPageLoad(options)))
 
+    // Reload page again for HTTPS redirect
+    .then(_ => reloadPage(driver, options))
+    .then(_ => runPhase(gatherer => gatherer.afterSecondReloadPageLoad(options)))
+
     // Finish and teardown.
     .then(_ => driver.disconnect())
     .then(_ => runPhase(gatherer => gatherer.tearDown(options)))


### PR DESCRIPTION
A bunch of things:

1. Requires that #267 lands first, because it needs the Security domain enabled.
2. It's a bit ick insofar as it has to clear the backlog of Security events, so there's a fairly bleh timeout that waits up to 3 seconds to make sure we've got all the security events back.
3. It's not clear about whether we want to just trust `schemeIsCryptographic` or if we want to push on the security level to be 'secure' (which it doesn't seem to be in a bunch of cases, though why is unclear!).
4. This also includes an additional round-trip to `about:blank` and then to the HTTP version of the URL. You can't XHR the HTTP version because it triggers the Mixed Content warnings and is blocked by Chrome. We have baked in the second round trip to the scheduler to test the SW, so either we need to do the same thing here, or maybe we don't and it's just fine... One for us to discuss, but we should be consistent.

Also, fixes #263.