### PR TITLE
Improves SW gather

### DIFF
--- a/src/audits/offline/service-worker.js
+++ b/src/audits/offline/service-worker.js
@@ -46,11 +46,7 @@ class ServiceWorker extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const registrations = artifacts.serviceWorkers.versions;
-    const activatedRegistrations = registrations.filter(reg => {
-      return reg.status === 'activated' &&
-          reg.scriptURL.startsWith(artifacts.url);
-    });
+    const activatedRegistrations = artifacts.serviceWorkers.versions;
 
     return ServiceWorker.generateAuditResult({
       value: activatedRegistrations.length > 0

--- a/src/gatherers/service-worker.js
+++ b/src/gatherers/service-worker.js
@@ -44,10 +44,6 @@ class ServiceWorker extends Gather {
   }
 
   static getOrigin(url) {
-    if (typeof window.URL === 'function') {
-      return new window.URL(url).origin;
-    }
-
     const parsedURL = require('url').parse(url);
     return `${parsedURL.protocol}//${parsedURL.hostname}`;
   }

--- a/src/gatherers/service-worker.js
+++ b/src/gatherers/service-worker.js
@@ -16,8 +16,6 @@
  */
 'use strict';
 
-/* global window */
-
 const Gather = require('./gather');
 
 class ServiceWorker extends Gather {

--- a/src/gatherers/service-worker.js
+++ b/src/gatherers/service-worker.js
@@ -16,6 +16,8 @@
  */
 'use strict';
 
+/* global window */
+
 const Gather = require('./gather');
 
 class ServiceWorker extends Gather {
@@ -41,8 +43,18 @@ class ServiceWorker extends Gather {
     });
   }
 
+  static getOrigin(url) {
+    if (typeof window.URL === 'function') {
+      return new window.URL(url).origin;
+    }
+
+    const parsedURL = require('url').parse(url);
+    return `${parsedURL.protocol}//${parsedURL.hostname}`;
+  }
+
   static getActivatedServiceWorker(versions, url) {
-    return versions.find(v => v.status === 'activated' && v.scriptURL.startsWith(url));
+    const origin = this.getOrigin(url);
+    return versions.find(v => v.status === 'activated' && v.scriptURL.startsWith(origin));
   }
 
   beforeReloadPageLoad(options) {


### PR DESCRIPTION
The check of matching registrations was naïve, and doesn't work if the provided URL isn't the root of the origin. This fixes it by getting the origin for the tested URL and uses that to filter down the registrations. It also removes the duplicated logic from the audit, which doesn't need to do the filtering again!

Fixes #272