### PR TITLE
add driver.once for single-time event listening

### DIFF
--- a/src/lib/drivers/cri.js
+++ b/src/lib/drivers/cri.js
@@ -102,6 +102,21 @@ class CriDriver extends Driver {
   }
 
   /**
+   * Bind a one-time listener for protocol events. Listener is removed once it
+   * has been called.
+   * @param {!string} eventName
+   * @param {function(...)} cb
+   */
+  once(eventName, cb) {
+    if (this._chrome === null) {
+      throw new Error('connect() must be called before attempting to listen to events.');
+    }
+    // log event listeners being bound
+    _log('info', 'listen once for event =>', {method: eventName});
+    this._chrome.once(eventName, cb);
+  }
+
+  /**
    * Unbind event listeners
    * @param {!string} eventName
    * @param {function(...)} cb

--- a/src/lib/drivers/driver.js
+++ b/src/lib/drivers/driver.js
@@ -43,8 +43,6 @@ class DriverBase {
       'java',
       'v8'
     ];
-
-    this._asyncTimeout = undefined;
   }
 
   get url() {
@@ -106,6 +104,8 @@ class DriverBase {
 
   evaluateAsync(asyncExpression) {
     return new Promise((resolve, reject) => {
+      let asyncTimeout;
+
       // Inject the call to capture inspection.
       const expression = `(function() {
         const __inspect = inspect;
@@ -115,16 +115,16 @@ class DriverBase {
         ${asyncExpression}
       })()`;
 
-      this.on('Runtime.inspectRequested', value => {
-        if (this._asyncTimeout !== undefined) {
-          clearTimeout(this._asyncTimeout);
+      this.once('Runtime.inspectRequested', value => {
+        if (asyncTimeout !== undefined) {
+          clearTimeout(asyncTimeout);
         }
 
-        // If the returned object doesn't meet the expected pattern bail with an undefined.
-        if (typeof value === 'undefined' ||
-            typeof value.object === 'undefined' ||
-            typeof value.object.value === 'undefined') {
-          return resolve(undefined);
+        // If the returned object doesn't meet the expected pattern, bail with an undefined.
+        if (value === undefined ||
+            value.object === undefined ||
+            value.object.value === undefined) {
+          return resolve();
         }
 
         return resolve(JSON.parse(value.object.value));
@@ -136,7 +136,7 @@ class DriverBase {
       });
 
       // If this gets to 15s and it hasn't been resolved, reject the Promise.
-      this._asyncTimeout = setTimeout(reject, 15000);
+      asyncTimeout = setTimeout(reject, 15000);
     });
   }
 

--- a/src/lib/drivers/driver.js
+++ b/src/lib/drivers/driver.js
@@ -82,6 +82,14 @@ class DriverBase {
   }
 
   /**
+   * Bind a one-time listener for protocol events. Listener is removed once it
+   * has been called.
+   */
+  once() {
+    return Promise.reject(new Error('Not implemented'));
+  }
+
+  /**
    * Unbind event listeners
    */
   off() {

--- a/src/lib/drivers/extension.js
+++ b/src/lib/drivers/extension.js
@@ -108,9 +108,6 @@ class ExtensionDriver extends Driver {
     listenersCopy.forEach(cb => {
       cb(params);
     });
-
-    // Reset the listeners;
-    this._listeners[method].length = 0;
   }
 
   /**

--- a/src/lib/drivers/extension.js
+++ b/src/lib/drivers/extension.js
@@ -80,12 +80,32 @@ class ExtensionDriver extends Driver {
     this._listeners[eventName].push(cb);
   }
 
+  /**
+   * Bind a one-time listener for protocol events. Listener is removed once it
+   * has been called.
+   * @param {!string} eventName
+   * @param {function(...)} cb
+   */
+  once(eventName, cb) {
+    // Create a replacement listener that will immediately remove itself after calling cb once.
+    const cbGuard = function() {
+      cb(...arguments);
+      this.off(eventName, cbGuard);
+    }.bind(this);
+
+    this.on(eventName, cbGuard);
+  }
+
   _onEvent(source, method, params) {
-    if (typeof this._listeners[method] === 'undefined') {
+    if (this._listeners[method] === undefined) {
       return;
     }
 
-    this._listeners[method].forEach(cb => {
+    // Copy array of listeners so all listeners are called, even if some removed
+    // during loop over listeners. Consistent with node's removeListener behavior:
+    // https://nodejs.org/api/events.html#events_emitter_removelistener_eventname_listener
+    const listenersCopy = Array.from(this._listeners[method]);
+    listenersCopy.forEach(cb => {
       cb(params);
     });
 


### PR DESCRIPTION
also moves `evaluateAsync` to use `driver.once` instead of `driver.on` to automatically remove its event listener