### PR TITLE
Fixes Speedline for extension

### DIFF
--- a/extension/dtm-transform.js
+++ b/extension/dtm-transform.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const through = require('through2');
+const path = require('path');
+
+module.exports = function() {
+  const fileContents = [];
+  return through(function(part, enc, next) {
+    fileContents.push(part);
+    next();
+  }, function(done) {
+    let fileContentsString = fileContents.join('');
+    const dtmRegExp = /require\(['"]devtools-timeline-model['"]\)/gim;
+    const newPath = path.join(__dirname, '../', 'src/lib/traces/devtools-timeline-model');
+
+    if (dtmRegExp.test(fileContentsString)) {
+      fileContentsString = fileContentsString.replace(dtmRegExp, `require("${newPath}")`);
+    }
+
+    this.push(fileContentsString);
+    done();
+  });
+};

--- a/extension/dtm-transform.js
+++ b/extension/dtm-transform.js
@@ -20,6 +20,11 @@
 const through = require('through2');
 const path = require('path');
 
+/**
+ * This is a browserify transform that looks for requires to devtools-timeline-model
+ * and replaces them for the local version in Lighthouse. This is just for the extension
+ * since by default it doesn't browserify properly.
+ */
 module.exports = function() {
   const fileContents = [];
   return through(function(part, enc, next) {

--- a/extension/gulpfile.js
+++ b/extension/gulpfile.js
@@ -80,6 +80,9 @@ gulp.task('browserify', () => {
       file.contents = browserify(file.path, {
         transform: ['brfs']
       })
+      .transform('./dtm-transform.js', {
+        global: true
+      })
       .ignore('npmlog')
       .ignore('chrome-remote-interface')
       .bundle();

--- a/extension/gulpfile.js
+++ b/extension/gulpfile.js
@@ -80,6 +80,8 @@ gulp.task('browserify', () => {
       file.contents = browserify(file.path, {
         transform: ['brfs']
       })
+      // Do the additional transform to convert references to devtools-timeline-model
+      // to the modified version internal to Lighthouse.
       .transform('./dtm-transform.js', {
         global: true
       })

--- a/extension/package.json
+++ b/extension/package.json
@@ -20,6 +20,7 @@
     "gulp-livereload": "^3.8.1",
     "gulp-tap": "^0.1.3",
     "gulp-zip": "^3.2.0",
-    "run-sequence": "^1.1.5"
+    "run-sequence": "^1.1.5",
+    "through2": "^2.0.1"
   }
 }


### PR DESCRIPTION
Fixes #269 by adding a browserify transform that intercepts the require for devtools-timeline-model and sets it to use the local version. Means we don't have to maintain a fork of Speedline, and when dtm has upstreamed its changes that make it friendlier to Lighthouse we can drop this transform altogether.

/cc @paulirish 