### PR TITLE
Adds Input Readiness metric [not ready for merge]

### DIFF
--- a/cli/printer.js
+++ b/cli/printer.js
@@ -92,7 +92,7 @@ function createOutput(results, outputMode) {
 
     item.score.subItems.forEach(subitem => {
       let lineItem = ` -- ${subitem.description}: ${subitem.value}`;
-      if (subitem.rawValue) {
+      if (typeof subitem.rawValue !== 'undefined') {
         lineItem += ` (${subitem.rawValue})`;
       }
       output += `${lineItem}\n`;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "npmlog": "^2.0.3",
     "semver": "^5.1.0",
     "speedline": "^0.1.2",
-    "traceviewer": "^1.0.8"
+    "traceviewer": "^1.0.9"
   },
   "devDependencies": {
     "eslint": "^2.4.0",

--- a/src/aggregators/is-performant/index.js
+++ b/src/aggregators/is-performant/index.js
@@ -25,6 +25,9 @@ const firstMeaningfulPaint = require('../../audits/performance/first-meaningful-
 /** @type {string} */
 const speedIndexMetric = require('../../audits/performance/speed-index-metric').name;
 
+/** @type {string} */
+const inputReadinessMetric = require('../../audits/performance/input-readiness-metric').name;
+
 class IsPerformant extends Aggregate {
 
   /**
@@ -54,6 +57,10 @@ class IsPerformant extends Aggregate {
       weight: 1
     };
     criteria[speedIndexMetric] = {
+      value: 100,
+      weight: 1
+    };
+    criteria[inputReadinessMetric] = {
       value: 100,
       weight: 1
     };

--- a/src/audits/performance/input-readiness-metric.js
+++ b/src/audits/performance/input-readiness-metric.js
@@ -82,7 +82,7 @@ class InputReadinessMetric extends Audit {
       const readinessScore = 100 - (values.numeric.value * 100);
 
       return InputReadinessMetric.generateAuditResult(readinessScore,
-          values.numeric.value, undefined, this.optimalValue);
+          values.numeric.value.toFixed(4), undefined, this.optimalValue);
     } catch (err) {
       return InputReadinessMetric.generateAuditResult(-1, undefined,
           'Unable to parse trace contents');

--- a/src/audits/performance/input-readiness-metric.js
+++ b/src/audits/performance/input-readiness-metric.js
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const traceviewer = require('traceviewer');
+const Audit = require('../audit');
+
+class InputReadinessMetric extends Audit {
+  /**
+   * @override
+   */
+  static get tags() {
+    return ['Performance'];
+  }
+
+  /**
+   * @override
+   */
+  static get name() {
+    return 'input-readiness';
+  }
+
+  /**
+   * @override
+   */
+  static get description() {
+    return 'Input Readiness';
+  }
+
+  /**
+   * @override
+   */
+  static get optimalValue() {
+    return '100';
+  }
+
+  /**
+   * Audits the page to give a score for First Meaningful Paint.
+   * @see  https://github.com/GoogleChrome/lighthouse/issues/26
+   * @param {!Artifacts} artifacts The artifacts from the gather phase.
+   * @return {!AuditResult} The score from the audit, ranging from 0-100.
+   */
+  static audit(artifacts) {
+    try {
+      // Create the importer and import the trace contents to a model.
+      const io = new traceviewer.importer.ImportOptions();
+      io.showImportWarnings = false;
+      io.shiftWorldToZero = true;
+      io.pruneEmptyContainers = false;
+
+      const events = [JSON.stringify({
+        traceEvents: artifacts.traceContents
+      })];
+      const model = new traceviewer.Model();
+      const importer = new traceviewer.importer.Import(model, io);
+      importer.importTraces(events);
+
+      // Now set up the user expectations model.
+      // TODO(paullewis) confirm these values are meaningful.
+      const idle = new traceviewer.model.um.IdleExpectation(model, 'test', 0, 10000);
+      model.userModel.expectations.push(idle);
+
+      // Set up a value list for the hazard metric.
+      const valueList = new traceviewer.metrics.ValueList();
+      traceviewer.metrics.sh.hazardMetric(valueList, model);
+      const values = valueList.valueDicts[0];
+      const readinessScore = 100 - (values.numeric.value * 100);
+
+      return InputReadinessMetric.generateAuditResult(readinessScore,
+          values.numeric.value, undefined, this.optimalValue);
+    } catch (err) {
+      return InputReadinessMetric.generateAuditResult(-1, undefined,
+          'Unable to parse trace contents');
+    }
+  }
+}
+
+module.exports = InputReadinessMetric;

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -40,6 +40,7 @@ const audits = [
   require('./audits/mobile-friendly/display'),
   require('./audits/performance/first-meaningful-paint'),
   require('./audits/performance/speed-index-metric'),
+  require('./audits/performance/input-readiness-metric'),
   require('./audits/manifest/exists'),
   require('./audits/manifest/background-color'),
   require('./audits/manifest/theme-color'),


### PR DESCRIPTION
Uses traceviewer and hazardMetric. Requires adding a couple of lines to traceviewer's index.js:

```javascript
HTMLImportsLoader.loadHTML('/tracing/metrics/value_list.html');
HTMLImportsLoader.loadHTML('/tracing/metrics/all_metrics.html');
```

⚠️ DON'T MERGE: This doesn't work with the extension; the traceviewer code doesn't browserify ⚠️ 

@benshayden, have I done the right thing with [user expectations](https://github.com/GoogleChrome/lighthouse/compare/master...paullewis:input-ready?expand=1#diff-47182999bb5e6e540ad4ec924864d68bR75)? Also am I right that the value should be between 0 and 1?