### PR TITLE
Straw man: Adds start_url gather + audit

### DIFF
--- a/src/aggregators/can-load-offline/index.js
+++ b/src/aggregators/can-load-offline/index.js
@@ -29,6 +29,11 @@ const serviceWorker = require('../../audits/offline/service-worker').name;
  */
 const worksOffline = require('../../audits/offline/works-offline').name;
 
+/**
+ * @type {string}
+ */
+const startURLWorksOffline = require('../../audits/offline/start-url-works-offline').name;
+
 class WorksOffline extends Aggregate {
 
   /**
@@ -59,6 +64,11 @@ class WorksOffline extends Aggregate {
     };
 
     criteria[worksOffline] = {
+      value: true,
+      weight: 1
+    };
+
+    criteria[startURLWorksOffline] = {
       value: true,
       weight: 1
     };

--- a/src/audits/offline/start-url-works-offline.js
+++ b/src/audits/offline/start-url-works-offline.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const Audit = require('../audit');
+
+class StartURLWorksOffline extends Audit {
+  /**
+   * @override
+   */
+  static get tags() {
+    return ['Offline'];
+  }
+
+  /**
+   * @override
+   */
+  static get name() {
+    return 'start-url-works-offline';
+  }
+
+  /**
+   * @override
+   */
+  static get description() {
+    return 'Start URL responds with a 200 when offline';
+  }
+
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    return StartURLWorksOffline.generateAuditResult(artifacts.startURLResponseCode === 200);
+  }
+}
+
+module.exports = StartURLWorksOffline;

--- a/src/gatherers/accessibility.js
+++ b/src/gatherers/accessibility.js
@@ -35,11 +35,9 @@ class Accessibility extends Gather {
 
   static _errorAccessibility(errorString) {
     return {
-      accessibility: {
-        raw: undefined,
-        value: undefined,
-        debugString: errorString
-      }
+      raw: undefined,
+      value: undefined,
+      debugString: errorString
     };
   }
 
@@ -50,16 +48,15 @@ class Accessibility extends Gather {
         .evaluateAsync(`${axe};(${runA11yChecks.toString()}())`)
         .then(returnedValue => {
           if (!returnedValue) {
-            this.artifact = Accessibility._errorAccessibility('Unable to parse axe results');
+            options.artifacts.accessibility =
+                Accessibility._errorAccessibility('Unable to parse axe results');
             return;
           }
 
           if (returnedValue.error) {
-            this.artifact = Accessibility._errorAccessibility(returnedValue.error);
+            options.artifacts = Accessibility._errorAccessibility(returnedValue.error);
           } else {
-            this.artifact = {
-              accessibility: returnedValue
-            };
+            options.artifacts.accessibility = returnedValue;
           }
         });
   }

--- a/src/gatherers/html.js
+++ b/src/gatherers/html.js
@@ -29,7 +29,7 @@ class HTML extends Gather {
           nodeId: nodeId
         }))
         .then(nodeHTML => {
-          this.artifact = {html: nodeHTML.outerHTML};
+          options.artifacts.html = nodeHTML.outerHTML;
         });
   }
 }

--- a/src/gatherers/https.js
+++ b/src/gatherers/https.js
@@ -22,10 +22,8 @@ class HTTPS extends Gather {
   beforePageLoad(options) {
     const driver = options.driver;
     driver.on('Security.securityStateChanged', data => {
-      this.artifact = {
-        https: (data.securityState === 'secure' &&
-            data.schemeIsCryptographic)
-      };
+      options.artifacts.https =
+          (data.securityState === 'secure' && data.schemeIsCryptographic);
     });
 
     driver.enableSecurityEvents();

--- a/src/gatherers/manifest.js
+++ b/src/gatherers/manifest.js
@@ -56,11 +56,9 @@ class Manifest extends Gather {
 
   static _errorManifest(errorString) {
     return {
-      manifest: {
-        raw: undefined,
-        value: undefined,
-        debugString: errorString
-      }
+      raw: undefined,
+      value: undefined,
+      debugString: errorString
     };
   }
 
@@ -75,16 +73,14 @@ class Manifest extends Gather {
 
     .then(returnedValue => {
       if (!returnedValue) {
-        this.artifact = Manifest._errorManifest('Unable to retrieve manifest');
+        options.artifacts.manifest = Manifest._errorManifest('Unable to retrieve manifest');
         return;
       }
 
       if (returnedValue.error) {
-        this.artifact = Manifest._errorManifest(returnedValue.error);
+        options.artifacts.manifest = Manifest._errorManifest(returnedValue.error);
       } else {
-        this.artifact = {
-          manifest: manifestParser(returnedValue.manifestContent)
-        };
+        options.artifacts.manifest = manifestParser(returnedValue.manifestContent);
       }
     });
   }

--- a/src/gatherers/offline.js
+++ b/src/gatherers/offline.js
@@ -64,7 +64,7 @@ class Offline extends Gather {
         .goOffline(driver)
         .then(_ => driver.evaluateAsync(`(${requestPage.toString()}())`))
         .then(offlineResponseCode => {
-          this.artifact = {offlineResponseCode};
+          options.artifacts.offlineResponseCode = offlineResponseCode;
         })
         .then(_ => Offline.goOnline(driver));
   }

--- a/src/gatherers/service-worker.js
+++ b/src/gatherers/service-worker.js
@@ -29,12 +29,10 @@ class ServiceWorker extends Gather {
           const controlledClients =
               ServiceWorker.getActivatedServiceWorker(data.versions, options.url);
 
-          this.artifact = {
-            serviceWorkers: {
-              versions: controlledClients ? [controlledClients] : []
-            }
+          options.artifacts.serviceWorkers = {
+            versions: controlledClients ? [controlledClients] : []
           };
-          this.resolved = (typeof this.artifact.serviceWorkers.versions !== 'undefined');
+          this.resolved = (typeof options.artifacts.serviceWorkers.versions !== 'undefined');
           res();
         }
       });

--- a/src/gatherers/start-url.js
+++ b/src/gatherers/start-url.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global XMLHttpRequest, __returnResults, __startURL */
+
+'use strict';
+
+const Offline = require('./offline');
+
+// *WARNING* do not use fetch.. due to it requiring window focus to fire.
+// Request the current page by issuing a XMLHttpRequest request to ''
+// and storing the status code on the window.
+const requestStartURLPage = function() {
+  const oReq = new XMLHttpRequest();
+  oReq.onload = oReq.onerror = e => {
+    // __returnResults is injected by driver.evaluateAsync
+    __returnResults(e.currentTarget.status);
+  };
+
+  // __startURL is injected during afterReloadPageLoad
+  oReq.open('GET', __startURL);
+  oReq.send();
+};
+
+class StartURLOffline extends Offline {
+
+  afterReloadPageLoad(options) {
+    const driver = options.driver;
+
+    if (typeof options.artifacts.manifest === 'undefined' ||
+        typeof options.artifacts.manifest.value === 'undefined' ||
+        typeof options.artifacts.manifest.value.start_url === 'undefined' ||
+        typeof options.artifacts.manifest.value.start_url.value === 'undefined') {
+      options.artifacts.startURLResponseCode = 0;
+      return;
+    }
+
+    const startURL = options.artifacts.manifest.value.start_url.value;
+    const cmd = `__startURL = "${startURL}";(${requestStartURLPage.toString()}())`;
+
+    // TODO eventually we will want to walk all network
+    // requests that the page initially made and retry them.
+    return StartURLOffline
+        .goOffline(driver)
+        .then(_ => driver.evaluateAsync(cmd))
+        .then(startURLResponseCode => {
+          options.artifacts.startURLResponseCode = startURLResponseCode;
+        })
+        .then(_ => Offline.goOnline(driver));
+  }
+}
+
+module.exports = StartURLOffline;

--- a/src/gatherers/theme-color.js
+++ b/src/gatherers/theme-color.js
@@ -26,7 +26,7 @@ class ThemeColor extends Gather {
     return driver.querySelector('head meta[name="theme-color"]')
       .then(node => node && node.getAttribute('content'))
       .then(themeColorMeta => {
-        this.artifact = {themeColorMeta};
+        options.artifacts.themeColorMeta = themeColorMeta;
       });
   }
 }

--- a/src/gatherers/url.js
+++ b/src/gatherers/url.js
@@ -20,7 +20,7 @@ const Gather = require('./gather');
 
 class URL extends Gather {
   setup(options) {
-    this.artifact = {url: options.url || options.driver.url};
+    options.artifacts.url = options.url || options.driver.url;
   }
 }
 

--- a/src/gatherers/viewport.js
+++ b/src/gatherers/viewport.js
@@ -30,7 +30,7 @@ class Viewport extends Gather {
     return driver.querySelector('head meta[name="viewport"]')
       .then(node => node && node.getAttribute('content'))
       .then(viewport => {
-        this.artifact = {viewport};
+        options.artifacts.viewport = viewport;
       });
   }
 }

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -28,6 +28,7 @@ const gathererClasses = [
   require('./gatherers/theme-color'),
   require('./gatherers/html'),
   require('./gatherers/manifest'),
+  require('./gatherers/start-url'),
   require('./gatherers/accessibility'),
   require('./gatherers/offline')
 ];
@@ -36,6 +37,7 @@ const audits = [
   require('./audits/security/is-on-https'),
   require('./audits/offline/service-worker'),
   require('./audits/offline/works-offline'),
+  require('./audits/offline/start-url-works-offline'),
   require('./audits/mobile-friendly/viewport'),
   require('./audits/mobile-friendly/display'),
   require('./audits/performance/first-meaningful-paint'),

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -90,12 +90,6 @@ function phaseRunner(gatherers) {
   };
 }
 
-function flattenArtifacts(artifacts) {
-  return artifacts.reduce(function(prev, curr) {
-    return Object.assign(prev, curr);
-  }, {});
-}
-
 function saveArtifacts(artifacts) {
   const artifactsFilename = 'artifacts.log';
   fs.writeFileSync(artifactsFilename, JSON.stringify(artifacts));
@@ -114,6 +108,7 @@ function saveAssets(tracingData, url) {
 function run(gatherers, options) {
   const driver = options.driver;
   const tracingData = {};
+  options.artifacts = {};
 
   if (options.url === undefined || options.url === null) {
     throw new Error('You must provide a url to scheduler');
@@ -144,20 +139,16 @@ function run(gatherers, options) {
     .then(_ => driver.disconnect())
     .then(_ => runPhase(gatherer => gatherer.tearDown(options)))
     .then(_ => {
-      // Collate all the gatherer results.
-      const unflattenedArtifacts = gatherers.map(g => g.artifact).concat(
-          {networkRecords: tracingData.networkRecords},
-          {rawNetworkEvents: tracingData.rawNetworkEvents},
-          {traceContents: tracingData.traceContents},
-          {frameLoadEvents: tracingData.frameLoadEvents});
-
-      const artifacts = flattenArtifacts(unflattenedArtifacts);
+      options.artifacts.networkRecords = tracingData.networkRecords;
+      options.artifacts.rawNetworkEvents = tracingData.rawNetworkEvents;
+      options.artifacts.traceContents = tracingData.traceContents;
+      options.artifacts.frameLoadEvents = tracingData.frameLoadEvents;
 
       if (options.flags.saveArtifacts) {
-        saveArtifacts(artifacts);
+        saveArtifacts(options.artifacts);
       }
 
-      return artifacts;
+      return options.artifacts;
     });
 }
 


### PR DESCRIPTION
Fixes #279 

Requires significant changes to architecture:

1. An artifacts object is injected to each gatherer in turn; this allows one gatherer to use the results of a previous gatherer. In this case we need the manifest's start_url to power the offline for the start url 👍 
2. There's now an ordering requirement that the manifest gather _must_ happen prior to the start url gatherer. I've put in a check that will throw should the manifest artifact not be there, but perhaps we want a more robust ordering approach.