### PR TITLE
clean up traceviewer hankypanky

### DIFF
--- a/src/audits/performance/input-readiness-metric.js
+++ b/src/audits/performance/input-readiness-metric.js
@@ -18,33 +18,7 @@
 'use strict';
 
 const Audit = require('../audit');
-
-/* global window */
-window.global = window;
-
-// we need gl-matrix and jszip for traceviewer
-// since it has internal forks for isNode and they get mixed up during
-// browserify, we require them locally here and global-ize them.
-// from catapult/tracing/tracing/base/math.html
-const glMatrixModule = require('gl-matrix');
-Object.keys(glMatrixModule).forEach(exportName => {
-  global[exportName] = glMatrixModule[exportName];
-});
-// from catapult/tracing/tracing/extras/importer/jszip.html
-global.JSZip = require('jszip/dist/jszip.min.js');
-
-global.HTMLImportsLoader = {};
-global.HTMLImportsLoader.hrefToAbsolutePath = function(path) {
-  if (path === '/gl-matrix-min.js') {
-    return 'empty-module';
-  }
-  if (path === '/jszip.min.js') {
-    return 'jszip/dist/jszip.min.js';
-  }
-};
-
-require('../../../third_party/traceviewer-js/');
-const traceviewer = global.tr;
+const tracingProcessor = require('../../lib/traces/tracing-processor');
 
 class InputReadinessMetric extends Audit {
   /**
@@ -83,33 +57,15 @@ class InputReadinessMetric extends Audit {
    */
   static audit(artifacts) {
     try {
-      // Create the importer and import the trace contents to a model.
-      const io = new traceviewer.importer.ImportOptions();
-      io.showImportWarnings = false;
-      io.shiftWorldToZero = true;
-      io.pruneEmptyContainers = false;
+      const model = tracingProcessor.init(artifacts.traceContents);
+      const hazardMetric = tracingProcessor.getInputReadiness(model);
 
-      const events = [JSON.stringify({
-        traceEvents: artifacts.traceContents
-      })];
-      const model = new traceviewer.Model();
-      const importer = new traceviewer.importer.Import(model, io);
-      importer.importTraces(events);
-
-      // Now set up the user expectations model.
-      // TODO(paullewis) confirm these values are meaningful.
-      const idle = new traceviewer.model.um.IdleExpectation(model, 'test', 0, 10000);
-      model.userModel.expectations.push(idle);
-
-      // Set up a value list for the hazard metric.
-      const valueList = new traceviewer.metrics.ValueList();
-      traceviewer.metrics.sh.hazardMetric(valueList, model);
-      const values = valueList.valueDicts[0];
-      const readinessScore = 100 - (values.numeric.value * 100);
+      const readinessScore = Math.round(100 - (hazardMetric.numeric.value * 100));
+      const rawValue = hazardMetric.numeric.value.toFixed(4);
 
       return InputReadinessMetric.generateAuditResult({
-        value: Math.round(readinessScore),
-        rawValue: values.numeric.value.toFixed(4),
+        value: readinessScore,
+        rawValue: rawValue,
         optimalValue: this.optimalValue
       });
     } catch (err) {


### PR DESCRIPTION
Followup from #309 

Moves the tracing-processor calls from input readiness metric into the existing trace-processor module