### PR TITLE
Redesigns report

### DIFF
--- a/report/report-generator.js
+++ b/report/report-generator.js
@@ -56,13 +56,27 @@ class ReportGenerator {
       return value;
     });
 
+    // Converts the total score to a rating that can be used for styling.
+    Handlebars.registerHelper('getTotalScoreRating', totalScore => {
+      let rating = 'poor';
+      if (totalScore > 45) {
+        rating = 'average';
+      }
+      if (totalScore > 75) {
+        rating = 'good';
+      }
+
+      return rating;
+    });
+
     // Converts a value to a rating string, which can be used inside the report for color styling.
-    Handlebars.registerHelper('getItemRating', value => {
+    Handlebars.registerHelper('getItemRating', (value, aggregatorType) => {
       if (typeof value === 'boolean') {
         return value ? 'good' : 'poor';
       }
 
-      let rating = 'poor';
+      // Limit the rating to average if this is a rating for Best Practices.
+      let rating = aggregatorType === Aggregate.TYPES.BEST_PRACTICE ? 'average' : 'poor';
       if (value > 0.33) {
         rating = 'average';
       }

--- a/report/scripts/lighthouse-report.js
+++ b/report/scripts/lighthouse-report.js
@@ -21,55 +21,18 @@
 
 /* Using ES5 to broaden support */
 function LighthouseReport() {
-  // A Magic value for the menu top.
-  var MENU_PADDING_TOP = 29;
-
-  this.menu = document.querySelector('.js-menu');
-  this.menuContainer = document.querySelector('.js-menu-container');
   this.printButton = document.querySelector('.js-print');
   this.radioButtonToggleViewUser = document.querySelector('.js-toggle-user');
   this.radioButtonToggleViewTechnology = document.querySelector('.js-toggle-technology');
   this.viewUserFeature = document.querySelector('.js-report-by-user-feature');
   this.viewTechnology = document.querySelector('.js-report-by-technology');
 
-  this.menuBCR = this.menuContainer.getBoundingClientRect();
-  this.menuTopPosition = this.menuBCR.top + window.scrollY - MENU_PADDING_TOP;
-  this.onScroll = this.onScroll.bind(this);
-  this.onResize = this.onResize.bind(this);
   this.updateView = this.updateView.bind(this);
 
   this.addEventListeners();
-  this.onResize();
 }
 
 LighthouseReport.prototype = {
-  onScroll: function() {
-    this.handleMenuStickiness();
-  },
-
-  handleMenuStickiness(options) {
-    var forceUpdate = (options && options.forceUpdate) || false;
-    var menuIsSticky = this.menu.classList.contains('menu--fixed');
-    var menuShouldBeSticky = (window.scrollY > this.menuTopPosition);
-
-    // If no change early exit.
-    if (!forceUpdate && menuShouldBeSticky === menuIsSticky) {
-      return;
-    }
-
-    if (menuShouldBeSticky) {
-      this.menu.classList.add('menu--fixed');
-      this.menu.style.width = this.menuBCR.width + 'px';
-      this.menu.style.left = this.menuBCR.left + 'px';
-    } else {
-      this.menu.classList.remove('menu--fixed');
-    }
-  },
-
-  onResize: function() {
-    this.menuBCR = this.menuContainer.getBoundingClientRect();
-    this.handleMenuStickiness({forceUpdate: true});
-  },
 
   onPrint: function() {
     window.print();
@@ -86,8 +49,6 @@ LighthouseReport.prototype = {
   },
 
   addEventListeners: function() {
-    window.addEventListener('scroll', this.onScroll);
-    window.addEventListener('resize', this.onResize);
     this.printButton.addEventListener('click', this.onPrint);
     this.radioButtonToggleViewUser.addEventListener('change', this.updateView);
     this.radioButtonToggleViewTechnology.addEventListener('change', this.updateView);

--- a/report/styles/report.css
+++ b/report/styles/report.css
@@ -40,15 +40,14 @@
 html, body {
   padding: 0;
   margin: 0;
-  background: #FAFAFA;
+  background: #F0F0F0;
   color: #444;
   font-family: Arial, sans-serif;
   font-size: 15px;
 }
 
 body {
-  min-width: 640px;
-  padding: 0 16px;
+  min-width: 845px;
 }
 
 a {
@@ -57,88 +56,11 @@ a {
 
 .report {
   width: 100%;
-  margin: 16px auto 100px auto;
-  border-radius: 4px;
+  margin: 0 auto;
+  border-radius: 0 0 4px 4px;
   max-width: 1280px;
   background: #FFF;
-  box-shadow: 0 4px 6px 0 rgba(0,0,0,0.26);
-}
-
-.header {
-  height: 180px;
-  background: #2D3441;
-  display: flex;
-  flex-direction: row;
-  border-radius: 4px 4px 0 0;
-  font-family: 'Roboto', Arial, sans-serif;
-  position: relative;
-}
-
-.header::after {
-  content: '';
-  display: block;
-  width: 90px;
-  height: 90px;
-  position: absolute;
-  top: 0;
-  right: 0;
-  background: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODYiIGhlaWdodD0iODYiIHZpZXdCb3g9IjAgMCA4NiA4NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+PHRpdGxlPkJldGE8L3RpdGxlPjxkZWZzPjxwYXRoIGlkPSJiIiBkPSJNLTExLjcwNCAxMy4xNDRIMTI1LjU4djMwSC0xMS43MDN6Ii8+PGZpbHRlciB4PSItNTAlIiB5PSItNTAlIiB3aWR0aD0iMjAwJSIgaGVpZ2h0PSIyMDAlIiBmaWx0ZXJVbml0cz0ib2JqZWN0Qm91bmRpbmdCb3giIGlkPSJhIj48ZmVPZmZzZXQgZHk9IjEiIGluPSJTb3VyY2VBbHBoYSIgcmVzdWx0PSJzaGFkb3dPZmZzZXRPdXRlcjEiLz48ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSIxIiBpbj0ic2hhZG93T2Zmc2V0T3V0ZXIxIiByZXN1bHQ9InNoYWRvd0JsdXJPdXRlcjEiLz48ZmVDb2xvck1hdHJpeCB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAuNSAwIiBpbj0ic2hhZG93Qmx1ck91dGVyMSIvPjwvZmlsdGVyPjxwYXRoIGlkPSJkIiBkPSJNLjQgMTYuOTcyaDExOXYyOC40SC40eiIvPjxmaWx0ZXIgeD0iLTUwJSIgeT0iLTUwJSIgd2lkdGg9IjIwMCUiIGhlaWdodD0iMjAwJSIgZmlsdGVyVW5pdHM9Im9iamVjdEJvdW5kaW5nQm94IiBpZD0iYyI+PGZlR2F1c3NpYW5CbHVyIHN0ZERldmlhdGlvbj0iMy41IiBpbj0iU291cmNlQWxwaGEiIHJlc3VsdD0ic2hhZG93Qmx1cklubmVyMSIvPjxmZU9mZnNldCBpbj0ic2hhZG93Qmx1cklubmVyMSIgcmVzdWx0PSJzaGFkb3dPZmZzZXRJbm5lcjEiLz48ZmVDb21wb3NpdGUgaW49InNoYWRvd09mZnNldElubmVyMSIgaW4yPSJTb3VyY2VBbHBoYSIgb3BlcmF0b3I9ImFyaXRobWV0aWMiIGsyPSItMSIgazM9IjEiIHJlc3VsdD0ic2hhZG93SW5uZXJJbm5lcjEiLz48ZmVDb2xvck1hdHJpeCB2YWx1ZXM9IjAgMCAwIDAgMSAwIDAgMCAwIDEgMCAwIDAgMCAxIDAgMCAwIDAuNjg5NTA5NzM3IDAiIGluPSJzaGFkb3dJbm5lcklubmVyMSIvPjwvZmlsdGVyPjx0ZXh0IGlkPSJmIiBmb250LWZhbWlseT0iQXJpYWwtQm9sZE1ULCBBcmlhbCIgZm9udC1zaXplPSIxMyIgZm9udC13ZWlnaHQ9ImJvbGQiIGZpbGw9IiNGRkYiPjx0c3BhbiB4PSIzNy41NTYiIHk9IjM0LjU1NiI+QUxQSEE8L3RzcGFuPjwvdGV4dD48ZmlsdGVyIHg9Ii01MCUiIHk9Ii01MCUiIHdpZHRoPSIyMDAlIiBoZWlnaHQ9IjIwMCUiIGZpbHRlclVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgaWQ9ImUiPjxmZU9mZnNldCBkeT0iMSIgaW49IlNvdXJjZUFscGhhIiByZXN1bHQ9InNoYWRvd09mZnNldE91dGVyMSIvPjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249Ii41IiBpbj0ic2hhZG93T2Zmc2V0T3V0ZXIxIiByZXN1bHQ9InNoYWRvd0JsdXJPdXRlcjEiLz48ZmVDb2xvck1hdHJpeCB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAuMTQwOTY0Njc0IDAiIGluPSJzaGFkb3dCbHVyT3V0ZXIxIi8+PC9maWx0ZXI+PC9kZWZzPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgbWFzaz0idXJsKCNtYXNrLTIpIiB0cmFuc2Zvcm09InJvdGF0ZSg0NSA1NS40NCAyNC41MjMpIj48dXNlIGZpbGw9IiMwMDAiIGZpbHRlcj0idXJsKCNhKSIgeGxpbms6aHJlZj0iI2IiLz48dXNlIGZpbGw9IiNDRjNBM0MiIHhsaW5rOmhyZWY9IiNiIi8+PC9nPjx1c2UgZmlsdGVyPSJ1cmwoI2MpIiB4bGluazpocmVmPSIjZCIgbWFzaz0idXJsKCNtYXNrLTIpIiB0cmFuc2Zvcm09InJvdGF0ZSg0NSA1OC40IDI3LjU1KSIgZmlsbD0iIzAwMCIvPjxnIG1hc2s9InVybCgjbWFzay0yKSIgdHJhbnNmb3JtPSJyb3RhdGUoNDUgNTguNTU2IDI2LjQzNSkiIGZpbGw9IiNGRkYiPjx1c2UgZmlsdGVyPSJ1cmwoI2UpIiB4bGluazpocmVmPSIjZiIvPjx1c2UgeGxpbms6aHJlZj0iI2YiLz48L2c+PHBhdGggZD0iTTguNS0uNWw4OC4yMDQgODguMjA0TTguNS0zOS41bDg4LjIwNCA4OC4yMDQiIHN0cm9rZT0iI0ZGRiIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWRhc2hhcnJheT0iMSwyIiBvcGFjaXR5PSIuMzg2IiBtYXNrPSJ1cmwoI21hc2stMikiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0zKSIvPjwvZz48L3N2Zz4K') top right no-repeat;
-}
-
-.header-titles {
-  height: 100%;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: 0 0 0 5%;
-}
-
-.header-titles__main,
-.header-titles__url {
-  margin: 0;
-  -webkit-font-smoothing: antialiased;
-}
-
-.header-titles__main {
-  font-size: 36px;
-  color: #FFF;
-  font-weight: 400;
-}
-
-.header-titles__url {
-  color: #FFF;
-  opacity: 0.65;
-  font-size: 18px;
-  font-weight: 400;
-  overflow: hidden;
-  width: 74%;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.header__score {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  border-radius: 0 4px 0 0;
-  height: 100%;
-  padding-left: 120px;
-  position: relative;
-  padding: 0 5% 0 0;
-  background: #45535F;
-}
-
-.header__score::before {
-  content: '';
-  display: block;
-  width: 120px;
-  height: 100%;
-  background: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzY0IiBoZWlnaHQ9IjE4NCIgdmlld0JveD0iMCAwIDM2NCAxODQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHRpdGxlPlBhdGggNDY8L3RpdGxlPjxwYXRoIHN0cm9rZT0iI0ZGRiIgZmlsbD0iIzQ1NTM1RiIgZD0iTTEgMTgzLjMxTDEwNC41NiAxaDI1OC4yMnYxODIuMzF6IiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHN0cm9rZS1vcGFjaXR5PSIuMTUiLz48L3N2Zz4K');
-  background-position: 0 -1px;
-  position: absolute;
-  left: -120px;
-  top: 0;
+  box-shadow: 0 0 6px 0 rgba(0,0,0,0.26);
 }
 
 .print {
@@ -150,16 +72,12 @@ a {
 }
 
 .toggle {
-  height: 44px;
-  border-top: 1px solid #F3E9CF;
-  border-bottom: 1px solid #F3E9CF;
-  line-height: 44px;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: center;
   font-size: 13px;
-  background: #FFF9E8;
+  margin-right: 56px;
 }
 
 .toggle__label {
@@ -200,41 +118,91 @@ a {
   font-weight: 500;
 }
 
+.report-body {
+  position: relative;
+}
+
 .report-body__content {
-  padding: 0 5%;
+  padding: 0 4% 0 4%;
+  margin-left: 22%;
   display: flex;
   flex-direction: row;
   align-items: flex-start;
+  position: relative;
 }
 
 .report-body__menu-container {
-  width: 22%;
+  height: 100%;
+  width: 100%;
   min-width: 230px;
-  margin: -54px 3% 0 -20px;
-  background: #FFFFFF;
-  border-radius: 2px;
+  max-width: 1280px;
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 0;
+  pointer-events: none;
 }
 
 .menu {
-  background: #FFF;
-  box-shadow: 0px 2px 3px 0px rgba(0,0,0,0.20);
-}
-
-.menu--fixed {
-  position: fixed;
-  min-width: 230px;
-  top: 28px;
+  width: 22%;
+  background: #FFFFFF;
+  min-width: 185px;
+  height: 100%;
+  top: 0;
+  left: 0;
+  pointer-events: auto;
+  border-right: 1px solid #DFDFDF;
 }
 
 .menu__header {
-  border-radius: 2px 2px 0 0;
-  background: #3F545F;
+  background: #2F3441;
   padding: 0 20px;
-  height: 54px;
+  height: 115px;
   line-height: 54px;
   color: #FFF;
   font-family: 'Roboto', Arial, sans-serif;
   font-size: 18px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-self: center;
+  justify-content: center;
+}
+
+.menu__header::after {
+  content: '';
+  display: block;
+  width: 90px;
+  height: 90px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODYiIGhlaWdodD0iODYiIHZpZXdCb3g9IjAgMCA4NiA4NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+PHRpdGxlPkJldGE8L3RpdGxlPjxkZWZzPjxwYXRoIGlkPSJiIiBkPSJNLTExLjcwNCAxMy4xNDRIMTI1LjU4djMwSC0xMS43MDN6Ii8+PGZpbHRlciB4PSItNTAlIiB5PSItNTAlIiB3aWR0aD0iMjAwJSIgaGVpZ2h0PSIyMDAlIiBmaWx0ZXJVbml0cz0ib2JqZWN0Qm91bmRpbmdCb3giIGlkPSJhIj48ZmVPZmZzZXQgZHk9IjEiIGluPSJTb3VyY2VBbHBoYSIgcmVzdWx0PSJzaGFkb3dPZmZzZXRPdXRlcjEiLz48ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSIxIiBpbj0ic2hhZG93T2Zmc2V0T3V0ZXIxIiByZXN1bHQ9InNoYWRvd0JsdXJPdXRlcjEiLz48ZmVDb2xvck1hdHJpeCB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAuNSAwIiBpbj0ic2hhZG93Qmx1ck91dGVyMSIvPjwvZmlsdGVyPjxwYXRoIGlkPSJkIiBkPSJNLjQgMTYuOTcyaDExOXYyOC40SC40eiIvPjxmaWx0ZXIgeD0iLTUwJSIgeT0iLTUwJSIgd2lkdGg9IjIwMCUiIGhlaWdodD0iMjAwJSIgZmlsdGVyVW5pdHM9Im9iamVjdEJvdW5kaW5nQm94IiBpZD0iYyI+PGZlR2F1c3NpYW5CbHVyIHN0ZERldmlhdGlvbj0iMy41IiBpbj0iU291cmNlQWxwaGEiIHJlc3VsdD0ic2hhZG93Qmx1cklubmVyMSIvPjxmZU9mZnNldCBpbj0ic2hhZG93Qmx1cklubmVyMSIgcmVzdWx0PSJzaGFkb3dPZmZzZXRJbm5lcjEiLz48ZmVDb21wb3NpdGUgaW49InNoYWRvd09mZnNldElubmVyMSIgaW4yPSJTb3VyY2VBbHBoYSIgb3BlcmF0b3I9ImFyaXRobWV0aWMiIGsyPSItMSIgazM9IjEiIHJlc3VsdD0ic2hhZG93SW5uZXJJbm5lcjEiLz48ZmVDb2xvck1hdHJpeCB2YWx1ZXM9IjAgMCAwIDAgMSAwIDAgMCAwIDEgMCAwIDAgMCAxIDAgMCAwIDAuNjg5NTA5NzM3IDAiIGluPSJzaGFkb3dJbm5lcklubmVyMSIvPjwvZmlsdGVyPjx0ZXh0IGlkPSJmIiBmb250LWZhbWlseT0iQXJpYWwtQm9sZE1ULCBBcmlhbCIgZm9udC1zaXplPSIxMyIgZm9udC13ZWlnaHQ9ImJvbGQiIGZpbGw9IiNGRkYiPjx0c3BhbiB4PSIzNy41NTYiIHk9IjM0LjU1NiI+QUxQSEE8L3RzcGFuPjwvdGV4dD48ZmlsdGVyIHg9Ii01MCUiIHk9Ii01MCUiIHdpZHRoPSIyMDAlIiBoZWlnaHQ9IjIwMCUiIGZpbHRlclVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgaWQ9ImUiPjxmZU9mZnNldCBkeT0iMSIgaW49IlNvdXJjZUFscGhhIiByZXN1bHQ9InNoYWRvd09mZnNldE91dGVyMSIvPjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249Ii41IiBpbj0ic2hhZG93T2Zmc2V0T3V0ZXIxIiByZXN1bHQ9InNoYWRvd0JsdXJPdXRlcjEiLz48ZmVDb2xvck1hdHJpeCB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAuMTQwOTY0Njc0IDAiIGluPSJzaGFkb3dCbHVyT3V0ZXIxIi8+PC9maWx0ZXI+PC9kZWZzPjxnIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+PGcgbWFzaz0idXJsKCNtYXNrLTIpIiB0cmFuc2Zvcm09InJvdGF0ZSg0NSA1NS40NCAyNC41MjMpIj48dXNlIGZpbGw9IiMwMDAiIGZpbHRlcj0idXJsKCNhKSIgeGxpbms6aHJlZj0iI2IiLz48dXNlIGZpbGw9IiNDRjNBM0MiIHhsaW5rOmhyZWY9IiNiIi8+PC9nPjx1c2UgZmlsdGVyPSJ1cmwoI2MpIiB4bGluazpocmVmPSIjZCIgbWFzaz0idXJsKCNtYXNrLTIpIiB0cmFuc2Zvcm09InJvdGF0ZSg0NSA1OC40IDI3LjU1KSIgZmlsbD0iIzAwMCIvPjxnIG1hc2s9InVybCgjbWFzay0yKSIgdHJhbnNmb3JtPSJyb3RhdGUoNDUgNTguNTU2IDI2LjQzNSkiIGZpbGw9IiNGRkYiPjx1c2UgZmlsdGVyPSJ1cmwoI2UpIiB4bGluazpocmVmPSIjZiIvPjx1c2UgeGxpbms6aHJlZj0iI2YiLz48L2c+PHBhdGggZD0iTTguNS0uNWw4OC4yMDQgODguMjA0TTguNS0zOS41bDg4LjIwNCA4OC4yMDQiIHN0cm9rZT0iI0ZGRiIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWRhc2hhcnJheT0iMSwyIiBvcGFjaXR5PSIuMzg2IiBtYXNrPSJ1cmwoI21hc2stMikiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0zKSIvPjwvZz48L3N2Zz4K') top right no-repeat;
+}
+
+.menu__header-title {
+  font-family: 'Roboto', Arial, sans-serif;
+  font-size: 22px;
+  font-weight: 400;
+  color: #FFFFFF;
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+}
+
+.menu__header-url {
+  opacity: 0.74;
+  font-family: Roboto-Regular;
+  font-size: 14px;
+  color: #FFFFFF;
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+  font-weight: 400;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 92%;
 }
 
 .menu__nav {
@@ -276,19 +244,22 @@ a {
 
 .menu__link-score--good,
 .report-section__score--good,
-.report-section__item-value--good {
+.report-section__item-value--good,
+.report-section__title-score-total--good {
   color: #76B530;
 }
 
 .menu__link-score--average,
 .report-section__score--average,
-.report-section__item-value--average {
+.report-section__item-value--average,
+.report-section__title-score-total--average {
   color: #F5A623;
 }
 
 .menu__link-score--poor,
 .report-section__score--poor,
-.report-section__item-value--poor {
+.report-section__item-value--poor,
+.report-section__title-score-total--poor {
   color: #D0021B;
 }
 
@@ -303,7 +274,7 @@ a {
 }
 
 .report-body__breakdown-item {
-  padding-bottom: 20px;
+  padding-bottom: 6px;
 }
 
 .report-body__breakdown-item:last-of-type {
@@ -311,13 +282,14 @@ a {
 }
 
 .report-body__header {
-  height: 80px;
+  height: 58px;
   border-bottom: 1px solid #EBEBEB;
+  background: #FAFAFA;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-end;
-  padding: 0 5%;
+  padding: 0 4%;
 }
 
 .report-section__title {
@@ -328,6 +300,20 @@ a {
   color: #49525F;
   display: flex;
   margin: 1em 0 0.3em 0;
+}
+
+.report-section__title-main {
+  flex: 1;
+}
+
+.report-section__title-score-total {
+  font-weight: 500;
+}
+
+.report-section__title-score-max {
+  font-weight: 400;
+  font-size: 18px;
+  margin-left: -4px;
 }
 
 .report-section__subtitle {
@@ -352,7 +338,7 @@ a {
   font-style: italic;
   color: #777;
   font-size: 14px;
-  margin: 0.6em 0 1.5em 0;
+  margin: 0.6em 0 0.8em 0;
   line-height: 1.4;
   max-width: 750px;
 }
@@ -375,6 +361,10 @@ a {
 
 .report-section__item-details {
   display: flex;
+}
+
+.report-section__item-category {
+  font-weight: 700;
 }
 
 .report-section__item-extended-info {
@@ -400,15 +390,12 @@ a {
   font-size: 12px;
   border-top: 1px solid #EBEBEB;
   color: #999;
+  margin-left: 22%;
 }
 
 @media print {
   .report {
     box-shadow: none;
-  }
-
-  .header * {
-    color: #333;
   }
 
   .report-body__header,

--- a/report/templates/report.html
+++ b/report/templates/report.html
@@ -27,30 +27,27 @@ limitations under the License.
 </head>
 <body>
 <div class="js-report report">
-  <header class="header">
-    <div class="header-titles">
-      <h1 class="header-titles__main">Lighthouse</h1>
-      <h2 class="header-titles__url">{{ url }}</h2>
-    </div>
-
-    <aside class="header__score">
-      <div class="score-container">
-        <span class="score-container__overall-score">{{ totalScore }}</span>
-        <span class="score-container__max-score">/&nbsp;100</span>
-      </div>
-    </aside>
-
-  </header>
 
   <section class="report-body">
     <div class="report-body__header">
+      <div class="toggle">
+        <h1 class="toggle__title">Toggle view:</h1>
+
+        <label class="toggle__label" for="user-feature">User feature</label>
+        <input name="view-toggle" class="js-toggle-user" id="user-feature" type="radio" value="user" checked>
+
+        <label class="toggle__label" for="technology">Technology</label>
+        <input name="view-toggle" class="js-toggle-technology" id="technology" type="radio" value="technology">
+      </div>
+
       <button class="print js-print"></button>
     </div>
     <div class="report-body__content">
-      <div class="js-menu-container report-body__menu-container">
-        <div class="js-menu menu">
+      <div class="report-body__menu-container">
+        <div class="menu">
           <div class="menu__header">
-            In this report:
+            <h1 class="menu__header-title">Lighthouse</h1>
+            <h2 class="menu__header-url">{{ url }}</h2>
           </div>
           <ul class="menu__nav">
             <li class="menu__nav-item">
@@ -68,20 +65,16 @@ limitations under the License.
         </div>
       </div>
       <div class="js-breakdown report-body__breakdown">
-        <h1 class="report-section__title" id="progressive-web-app">Progressive Web App</h1>
+        <h1 class="report-section__title" id="progressive-web-app">
+          <span class="report-section__title-main">Progressive Web App</span>
+          <span class="report-section__title-score">
+            <span class="report-section__title-score-total report-section__title-score-total--{{ getTotalScoreRating totalScore }}">{{ totalScore }}</span>
+            <span class="report-section__title-score-max"> / 100</span>
+          </span>
+        </h1>
         <p class="report-section__description">
-          These audits check for various aspects of creating a Progressive Web App, and they affect your overall score.
+          These audits validate the aspects of a Progressive Web App.
         </p>
-
-        <div class="toggle">
-          <h1 class="toggle__title">Toggle view:</h1>
-
-          <label class="toggle__label" for="user-feature">User feature</label>
-          <input name="view-toggle" class="js-toggle-user" id="user-feature" type="radio" value="user" checked>
-
-          <label class="toggle__label" for="technology">Technology</label>
-          <input name="view-toggle" class="js-toggle-technology" id="technology" type="radio" value="technology">
-        </div>
 
         <div class="js-report-by-user-feature">
           {{#each aggregations as |aggregation|}}
@@ -98,7 +91,7 @@ limitations under the License.
                       <span class="report-section__item-description">
                         {{ subItem.description }}
                         {{#if subItem.optimalValue }}
-                        (target: {{ subItem.optimalValue }})
+                        (target value: {{ subItem.optimalValue }})
                         {{/if}}
                       </span>
                       <span class="report-section__item-value report-section__item-value--{{ getItemRating subItem.value }}">{{ getItemValue subItem.value }}</span>
@@ -165,12 +158,12 @@ limitations under the License.
                 <li class="report-section__item">
                   <div class="report-section__item-details">
                     <span class="report-section__item-description">
-                      {{ subItem.category }}: {{ subItem.description }}
+                      <span class="report-section__item-category">{{ subItem.category }}:</span> {{ subItem.description }}
                       {{#if subItem.optimalValue }}
                       (target: {{ subItem.optimalValue }})
                       {{/if}}
                     </span>
-                    <span class="report-section__item-value report-section__item-value--{{ getItemRating subItem.value }}">{{ getItemValue subItem.value }}</span>
+                    <span class="report-section__item-value report-section__item-value--{{ getItemRating subItem.value }}">{{ getItemValue subItem.value aggregation.type.name }}</span>
                     {{#if subItem.rawValue }}
                     <span class="report-section__item-raw-value">&nbsp;({{ subItem.rawValue }})</span>
                     {{/if }}

--- a/src/aggregators/address-bar-is-themed/index.js
+++ b/src/aggregators/address-bar-is-themed/index.js
@@ -28,14 +28,14 @@ const manifestThemeColor = require('../../audits/manifest/theme-color').name;
 /** @type {string} */
 const metaThemeColor = require('../../audits/html/meta-theme-color').name;
 
-class OmniboxThemeColor extends Aggregate {
+class AddressBarThemeColor extends Aggregate {
 
   /**
    * @override
    * @return {string}
    */
   static get name() {
-    return 'Omnibox matches brand colors';
+    return 'Address bar matches brand colors';
   }
 
   /**
@@ -43,7 +43,11 @@ class OmniboxThemeColor extends Aggregate {
    * @return {string}
    */
   static get description() {
-    return '';
+    return `The browser address bar can be themed to match your site. A theme-color
+            <a href="https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android">meta tag</a>
+            will upgrade the address bar when a user browses the site, and the
+            <a href="https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color">manifest theme-color</a>
+            will apply the same theme site-wide once it's been added to homescreen.`;
   }
 
   /**
@@ -55,7 +59,7 @@ class OmniboxThemeColor extends Aggregate {
   }
 
   /**
-   * For the omnibox to adopt a theme color, Chrome needs the following:
+   * For the address bar to adopt a theme color, Chrome needs the following:
    *   - has valid manifest
    *   - valid theme_color in manifest
    *   - valid theme-color <meta> element
@@ -89,4 +93,4 @@ class OmniboxThemeColor extends Aggregate {
   }
 }
 
-module.exports = OmniboxThemeColor;
+module.exports = AddressBarThemeColor;

--- a/src/aggregators/is-performant/index.js
+++ b/src/aggregators/is-performant/index.js
@@ -43,7 +43,8 @@ class IsPerformant extends Aggregate {
    * @return {string}
    */
   static get description() {
-    return '';
+    return `Users notice if sites and apps don't perform well. These top-level metrics capture
+            the most important perceived performance concerns.`;
   }
 
   /**

--- a/src/aggregators/is-secure/index.js
+++ b/src/aggregators/is-secure/index.js
@@ -40,7 +40,8 @@ class IsSecure extends Aggregate {
    * @return {string}
    */
   static get description() {
-    return '';
+    return `Security is an important part of the web for both developers and users. Moving forward,
+            Transport Layer Security (TLS) support will be required for many APIs.`;
   }
 
   /**

--- a/src/aggregators/is-sized-for-mobile-screen/index.js
+++ b/src/aggregators/is-sized-for-mobile-screen/index.js
@@ -37,7 +37,8 @@ class MobileFriendly extends Aggregate {
    * @return {string}
    */
   static get description() {
-    return '';
+    return `Users increasingly experience your app on mobile devices, so it's important to
+            ensure that the experience can adapt to smaller screens.`;
   }
 
   /**

--- a/src/aggregators/will-get-add-to-homescreen-prompt/index.js
+++ b/src/aggregators/will-get-add-to-homescreen-prompt/index.js
@@ -41,7 +41,7 @@ class AddToHomescreen extends Aggregate {
    * @return {string}
    */
   static get name() {
-    return 'Will Get Add to Homescreen Prompt';
+    return 'User can be prompted to Add to Homescreen';
   }
 
   /**

--- a/src/audits/accessibility/aria-valid-attr.js
+++ b/src/audits/accessibility/aria-valid-attr.js
@@ -39,7 +39,7 @@ class ARIAValidAttr extends Audit {
    * @override
    */
   static get description() {
-    return 'Ensures attributes that begin with aria- are valid ARIA attributes';
+    return 'Element aria-* attributes are valid ARIA attributes';
   }
 
   /**

--- a/src/audits/manifest/short-name-length.js
+++ b/src/audits/manifest/short-name-length.js
@@ -38,7 +38,7 @@ class ManifestShortNameLength extends Audit {
    * @override
    */
   static get description() {
-    return 'App short_name won\'t be truncated';
+    return 'App\'s short_name won\'t be truncated when displayed on homescreen';
   }
 
   /**

--- a/src/audits/mobile-friendly/display.js
+++ b/src/audits/mobile-friendly/display.js
@@ -38,7 +38,8 @@ class ManifestDisplay extends Audit {
    * @override
    */
   static get description() {
-    return 'Manifest has suggested display property';
+    return `Manifest's display property set to “standalone” or “fullscreen” to
+            allow launching without address bar.`;
   }
 
   /**

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -58,12 +58,12 @@ const audits = [
 ];
 
 const aggregators = [
+  require('./aggregators/can-load-offline'),
+  require('./aggregators/is-performant'),
+  require('./aggregators/is-secure'),
   require('./aggregators/will-get-add-to-homescreen-prompt'),
   require('./aggregators/launches-with-splash-screen'),
-  require('./aggregators/omnibox-is-themed'),
-  require('./aggregators/can-load-offline'),
-  require('./aggregators/is-secure'),
-  require('./aggregators/is-performant'),
+  require('./aggregators/address-bar-is-themed'),
   require('./aggregators/is-sized-for-mobile-screen'),
   require('./aggregators/best-practices')
 ];


### PR DESCRIPTION
Fixes #313 

> **PWA Section**

> Will Get Add to Homescreen Prompt => User can be prompted to Add to Homescreen
Done.

> Re-sort them to match order in doc -- basically: offline, perf, secure, homescreen, splashscreen, omnibox, mobilefriendly

Done by rearraging them in `./src/lighthouse.js`; I didn't want to bake in explicit ordering at this point.

> We need descriptions for a few other aggregators:
> omnibox: The browser address bar can be themed to match your site. A theme-color [meta tag](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android?hl=en) will upgrade the address bar when a user browses the site, and the [manifest theme-color](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color?hl=en) will apply the same theme site-wide once it's been added to homescreen.
> security: Security is an important part of the web for both developers and users. Moving forward, Transport Layer Security (TLS) support will be required for most APIs.
> perf: Users notice if sites and apps don't perform well. These top-level metrics capture the most important perceived performance concerns.
> mobile-friendy: .. shrug.
> PWA copy: revised: These audits validate the aspects of a Progressive Web App.
> globally: omnibox => address bar

Done.

> **Best Practices section**
> 
> Best Practices failures shouldn't be in red color. Maybe yellow and Not yet?

Done the color, leaving the message

> Manifest: Manifest has suggested display property => Manifest's display property set to “standalone” or “fullscreen” to allow launching without address bar.

Done.

> Manifest: App short_name won't be truncated => Manifest: App's short_name won't be truncated when displayed on homescreen

Done.

> Ensures attributes that begin with aria- are valid ARIA attributes => Element aria-* attributes are valid ARIA attributes

Done.

> Visual
> Conserve vertical space. On my macbook air machine I only see the results of 1 pwa section without scrolling. Ideally you can see >50% of the pwa results
> Relatedly, view toggle is a bit loud. Maybe we can move that and print into the left column?

**Before:**
![screen shot 2016-05-11 at 12 09 28 pm](https://cloud.githubusercontent.com/assets/617438/15179133/e42992f8-1771-11e6-9cc2-c74fe4c326cc.png)

**After:**
![screen shot 2016-05-11 at 12 09 42 pm](https://cloud.githubusercontent.com/assets/617438/15179140/ebf4d754-1771-11e6-9b0c-3125fc5ba9e1.png)

