### PR TITLE
fix error catches in module tests

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -23,7 +23,7 @@ const log = require('../src/lib/log.js');
 const semver = require('semver');
 const Printer = require('./printer');
 
-const lighthouse = require('../module');
+const lighthouse = require('../');
 
 // node 5.x required due to use of ES2015 features
 if (semver.lt(process.version, '5.0.0')) {

--- a/module/index.js
+++ b/module/index.js
@@ -28,19 +28,21 @@ if (semver.lt(process.version, '5.0.0')) {
 }
 
 module.exports = function(url, flags) {
-  if (!url) {
-    return Promise.reject(new Error('Lighthouse requires a URL'));
-  }
-  flags = flags || {};
+  return new Promise((resolve, reject) => {
+    if (!url) {
+      return reject(new Error('Lighthouse requires a URL'));
+    }
+    flags = flags || {};
 
-  const driver = new ChromeProtocol();
+    const driver = new ChromeProtocol();
 
-  // set logging preferences, assume quiet
-  log.level = 'error';
-  if (flags.logLevel) {
-    log.level = flags.logLevel;
-  }
+    // set logging preferences, assume quiet
+    log.level = 'error';
+    if (flags.logLevel) {
+      log.level = flags.logLevel;
+    }
 
-  // kick off a lighthouse run
-  return lighthouse(driver, {url, flags});
+    // kick off a lighthouse run
+    resolve(lighthouse(driver, {url, flags}));
+  });
 };

--- a/test/module/index.js
+++ b/test/module/index.js
@@ -98,44 +98,40 @@ describe('Module Tests', function() {
   it('should throw an error when the first parameter is not defined', function() {
     const lighthouse = require('../..');
     return lighthouse()
-    .then(() => {
-      assert.error(new Error('Should not have resolved when first arg is not a string'));
-    })
-    .catch(err => {
-      assert.ok(err);
-    });
+      .then(() => {
+        throw new Error('Should not have resolved when first arg is not a string');
+      }, err => {
+        assert.ok(err);
+      });
   });
 
   it('should throw an error when the first parameter is an empty string', function() {
     const lighthouse = require('../..');
-    return lighthouse()
-    .then(() => {
-      assert.error(new Error('Should not have resolved when first arg is not a string'));
-    })
-    .catch(err => {
-      assert.ok(err);
-    });
+    return lighthouse('')
+      .then(() => {
+        throw new Error('Should not have resolved when first arg is an empty string');
+      }, err => {
+        assert.ok(err);
+      });
   });
 
   it('should throw an error when the first parameter is not a string', function() {
     const lighthouse = require('../..');
     return lighthouse({})
-    .then(() => {
-      assert.error(new Error('Should not have resolved when first arg is not a string'));
-    })
-    .catch(err => {
-      assert.ok(err);
-    });
+      .then(() => {
+        throw new Error('Should not have resolved when first arg is not a string');
+      }, err => {
+        assert.ok(err);
+      });
   });
 
   it('should throw an error when the second parameter is not an object', function() {
     const lighthouse = require('../..');
-    return lighthouse(VALID_TEST_URL, [])
-    .then(() => {
-      assert.error(new Error('Should not have resolved when first arg is not a string'));
-    })
-    .catch(err => {
-      assert.ok(err);
-    });
+    return lighthouse(VALID_TEST_URL, 'flags')
+      .then(() => {
+        throw new Error('Should not have resolved when second arg is not an object');
+      }, err => {
+        assert.ok(err);
+      });
   });
 });


### PR DESCRIPTION
some of the module tests meant to fail weren't testing what they were supposed to be testing: `assert.error` isn't a thing, but the exception thrown on that would be caught, and so the test would succeed. Those tests now successfully throw on success, pass on failure. Bonus: unit tests now run 10 seconds faster as the last module test doesn't run until timeout.

Also wraps the entire lighthouse module code in a Promise so any early failures (e.g. in last module test which throws a `TypeError` on attempting to set flags on a string) are actually caught in the lighthouse promise chain and not as a normal exception.