### PR TITLE
Fix Chrome canary path

### DIFF
--- a/scripts/launch-chrome.sh
+++ b/scripts/launch-chrome.sh
@@ -4,16 +4,16 @@ CHROME_ARGS=$@
 
 launch_osx() {
   LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister
-  CHROME_CANARY_APPDIR=$($LSREGISTER -dump | grep -i "/Applications/google chrome canary.app$" | awk '{$1=""; print $0}' | xargs)
-  CHROME_CANARY_PATH="${CHROME_CANARY_APPDIR}/Contents/MacOS/Google Chrome Canary"
-  echo "Starting: $CHROME_CANARY_PATH"
-  if [ ! -f "$CHROME_CANARY_PATH" ]; then
+  CHROME_CANARY_PATH=${CHROME_CANARY_PATH:-$($LSREGISTER -dump | grep -i "google chrome canary.app$" | awk '{$1=""; print $0}' | head -n1 | xargs)}
+  CHROME_CANARY_EXEC_PATH="${CHROME_CANARY_PATH}/Contents/MacOS/Google Chrome Canary"
+  echo "Using Chrome Canary from path ${CHROME_CANARY_PATH}"
+  if [ ! -f "$CHROME_CANARY_EXEC_PATH" ]; then
     echo "You must install Google Chrome Canary to use lighthouse"
     echo "You can download it from https://www.google.com/chrome/browser/canary.html"
     exit 1
   fi
   TMP_PROFILE_DIR=$(mktemp -d -t lighthouse)
-  "$CHROME_CANARY_PATH" \
+  "$CHROME_CANARY_EXEC_PATH" \
     --remote-debugging-port=9222 \
     --no-first-run \
     --user-data-dir=$TMP_PROFILE_DIR \


### PR DESCRIPTION
Just a quick fix for users with multiple Chrome Canary... I think this happened when they have Chrome Canary in `/Applications` and the not unmounted `/Volumes/Google Chrome Canary` which they used to install, like this for example - 

<img width="844" alt="screenshot 2016-05-20 00 59 58" src="https://cloud.githubusercontent.com/assets/294474/15412371/466f0720-1e27-11e6-87b5-67b810524c37.png">

+ When there are multiple paths, simply choose the first1
+ Previously, the bug was that it chose all the items concatinated and the assumption was that there was only 1 Google Chrome Canary
+ (close #311) (close #339)
