### PR TITLE
Break circular ref in NetworkRequest

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -97,7 +97,7 @@ function flattenArtifacts(artifacts) {
 
 function saveArtifacts(artifacts) {
   const artifactsFilename = 'artifacts.log';
-  // The _target properly of NetworkRequest is circular.
+  // The _target property of NetworkRequest is circular.
   // We skip it when stringifying.
   const replacer = (key, value) => key === '_target' ? undefined : value;
   fs.writeFileSync(artifactsFilename, JSON.stringify(artifacts, replacer));

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -97,7 +97,10 @@ function flattenArtifacts(artifacts) {
 
 function saveArtifacts(artifacts) {
   const artifactsFilename = 'artifacts.log';
-  fs.writeFileSync(artifactsFilename, JSON.stringify(artifacts));
+  // The _target properly of NetworkRequest is circular.
+  // We skip it when stringifying.
+  const replacer = (key, value) => key === '_target' ? '[Circular]' : value;
+  fs.writeFileSync(artifactsFilename, JSON.stringify(artifacts, replacer));
   log.log('info', 'artifacts file saved to disk', artifactsFilename);
 }
 

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -99,7 +99,7 @@ function saveArtifacts(artifacts) {
   const artifactsFilename = 'artifacts.log';
   // The _target properly of NetworkRequest is circular.
   // We skip it when stringifying.
-  const replacer = (key, value) => key === '_target' ? '[Circular]' : value;
+  const replacer = (key, value) => key === '_target' ? undefined : value;
   fs.writeFileSync(artifactsFilename, JSON.stringify(artifacts, replacer));
   log.log('info', 'artifacts file saved to disk', artifactsFilename);
 }

--- a/test/module/index.js
+++ b/test/module/index.js
@@ -95,6 +95,17 @@ describe('Module Tests', function() {
     });
   });
 
+  it('should be able to save artifacts', function() {
+    // Prevent regression of github.com/GoogleChrome/lighthouse/issues/345
+    const lighthouse = require('../..');
+    return lighthouse(VALID_TEST_URL, {saveArtifacts: true})
+    .then(results => {
+      assert.ok(results);
+    }).then(_ => {
+      fs.unlinkSync('artifacts.log');
+    });
+  });
+
   it('should throw an error when the first parameter is not defined', function() {
     const lighthouse = require('../..');
     return lighthouse()

--- a/test/module/index.js
+++ b/test/module/index.js
@@ -89,16 +89,10 @@ describe('Module Tests', function() {
 
   it('should be able to run lighthouse with just a url and options', function() {
     const lighthouse = require('../..');
-    return lighthouse(VALID_TEST_URL, {})
-    .then(results => {
-      assert.ok(results);
-    });
-  });
-
-  it('should be able to save artifacts', function() {
-    // Prevent regression of github.com/GoogleChrome/lighthouse/issues/345
-    const lighthouse = require('../..');
-    return lighthouse(VALID_TEST_URL, {saveArtifacts: true})
+    return lighthouse(VALID_TEST_URL, {
+      // Prevent regression of github.com/GoogleChrome/lighthouse/issues/345
+      saveArtifacts: true
+    })
     .then(results => {
       assert.ok(results);
     }).then(_ => {


### PR DESCRIPTION
This fixes #345, at least for now.

A more future-proof solution would be to use something like this: https://www.npmjs.com/package/json-stringify-safe. Although I do wonder if we should remove the option of saving artifacts altogether. 