### PR TITLE
add declarations for what gatherers produce and what audits consume

### DIFF
--- a/src/audits/accessibility/aria-allowed-attr.js
+++ b/src/audits/accessibility/aria-allowed-attr.js
@@ -43,6 +43,13 @@ class ARIAAllowedAttr extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['accessibility'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/accessibility/aria-valid-attr.js
+++ b/src/audits/accessibility/aria-valid-attr.js
@@ -43,6 +43,13 @@ class ARIAValidAttr extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['accessibility'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/accessibility/color-contrast.js
+++ b/src/audits/accessibility/color-contrast.js
@@ -43,6 +43,13 @@ class ColorContrast extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['accessibility'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/accessibility/image-alt.js
+++ b/src/audits/accessibility/image-alt.js
@@ -43,6 +43,13 @@ class ImageAlt extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['accessibility'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/accessibility/label.js
+++ b/src/audits/accessibility/label.js
@@ -43,6 +43,13 @@ class Label extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['accessibility'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/accessibility/tabindex.js
+++ b/src/audits/accessibility/tabindex.js
@@ -43,6 +43,13 @@ class TabIndex extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['accessibility'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/audit.js
+++ b/src/audits/audit.js
@@ -46,6 +46,13 @@ class Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    throw new Error('Audit requiredArtifacts must be overriden.');
+  }
+
+  /**
    * @param {!AuditResultInput} result
    * @return {!AuditResult}
    */

--- a/src/audits/html/meta-theme-color.js
+++ b/src/audits/html/meta-theme-color.js
@@ -42,6 +42,13 @@ class ThemeColor extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['themeColorMeta'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/manifest/background-color.js
+++ b/src/audits/manifest/background-color.js
@@ -42,6 +42,13 @@ class ManifestBackgroundColor extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Manifest=} manifest
    * @return {boolean}
    */

--- a/src/audits/manifest/exists.js
+++ b/src/audits/manifest/exists.js
@@ -42,6 +42,13 @@ class ManifestExists extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/manifest/icons-min-144.js
+++ b/src/audits/manifest/icons-min-144.js
@@ -43,6 +43,13 @@ class ManifestIconsMin144 extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/manifest/icons-min-192.js
+++ b/src/audits/manifest/icons-min-192.js
@@ -43,6 +43,13 @@ class ManifestIconsMin192 extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/manifest/name.js
+++ b/src/audits/manifest/name.js
@@ -42,6 +42,13 @@ class ManifestName extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/manifest/short-name-length.js
+++ b/src/audits/manifest/short-name-length.js
@@ -42,6 +42,13 @@ class ManifestShortNameLength extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/manifest/short-name.js
+++ b/src/audits/manifest/short-name.js
@@ -42,6 +42,13 @@ class ManifestShortName extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/manifest/start-url.js
+++ b/src/audits/manifest/start-url.js
@@ -42,6 +42,13 @@ class ManifestStartUrl extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/manifest/theme-color.js
+++ b/src/audits/manifest/theme-color.js
@@ -42,6 +42,13 @@ class ManifestThemeColor extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/mobile-friendly/display.js
+++ b/src/audits/mobile-friendly/display.js
@@ -43,6 +43,13 @@ class ManifestDisplay extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['manifest'];
+  }
+
+  /**
    * @param {string|null} val
    * @return {boolean}
    */

--- a/src/audits/mobile-friendly/viewport.js
+++ b/src/audits/mobile-friendly/viewport.js
@@ -41,6 +41,13 @@ class Viewport extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['viewport'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/offline/service-worker.js
+++ b/src/audits/offline/service-worker.js
@@ -42,6 +42,13 @@ class ServiceWorker extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['serviceWorkers'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/offline/works-offline.js
+++ b/src/audits/offline/works-offline.js
@@ -41,6 +41,13 @@ class WorksOffline extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['offlineResponseCode'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/performance/first-meaningful-paint.js
+++ b/src/audits/performance/first-meaningful-paint.js
@@ -57,6 +57,13 @@ class FirstMeaningfulPaint extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['traceContents'];
+  }
+
+  /**
    * Audits the page to give a score for First Meaningful Paint.
    * @see https://github.com/GoogleChrome/lighthouse/issues/26
    * @see https://docs.google.com/document/d/1BR94tJdZLsin5poeet0XoTW60M0SjvOJQttKT-JK8HI/view

--- a/src/audits/performance/input-readiness-metric.js
+++ b/src/audits/performance/input-readiness-metric.js
@@ -50,6 +50,13 @@ class InputReadinessMetric extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['traceContents'];
+  }
+
+  /**
    * Audits the page to give a score for Input Readiness.
    * @see https://github.com/GoogleChrome/lighthouse/issues/26
    * @param {!Artifacts} artifacts The artifacts from the gather phase.

--- a/src/audits/performance/speed-index-metric.js
+++ b/src/audits/performance/speed-index-metric.js
@@ -58,6 +58,13 @@ class SpeedIndexMetric extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['traceContents'];
+  }
+
+  /**
    * Audits the page to give a score for the Speed Index.
    * @see  https://github.com/GoogleChrome/lighthouse/issues/197
    * @param {!Artifacts} artifacts The artifacts from the gather phase.

--- a/src/audits/security/is-on-https.js
+++ b/src/audits/security/is-on-https.js
@@ -41,6 +41,13 @@ class HTTPS extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['https'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/audits/security/redirects-http.js
+++ b/src/audits/security/redirects-http.js
@@ -41,6 +41,13 @@ class RedirectsHTTP extends Audit {
   }
 
   /**
+   * @return {!Array<string>}
+   */
+  static requiredArtifacts() {
+    return ['redirectsHTTP'];
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */

--- a/src/gatherers/accessibility.js
+++ b/src/gatherers/accessibility.js
@@ -32,14 +32,15 @@ function runA11yChecks() {
 }
 
 class Accessibility extends Gather {
+  get name() {
+    return 'accessibility';
+  }
 
   static _errorAccessibility(errorString) {
     return {
-      accessibility: {
-        raw: undefined,
-        value: undefined,
-        debugString: errorString
-      }
+      raw: undefined,
+      value: undefined,
+      debugString: errorString
     };
   }
 
@@ -57,9 +58,7 @@ class Accessibility extends Gather {
           if (returnedValue.error) {
             this.artifact = Accessibility._errorAccessibility(returnedValue.error);
           } else {
-            this.artifact = {
-              accessibility: returnedValue
-            };
+            this.artifact = returnedValue;
           }
         });
   }

--- a/src/gatherers/critical-network-chains.js
+++ b/src/gatherers/critical-network-chains.js
@@ -67,6 +67,10 @@ class RequestNode {
 }
 
 class CriticalNetworkChains extends Gather {
+  get name() {
+    return 'criticalNetworkChains';
+  }
+
   /**
    * A sequential chain of RequestNodes
    * @typedef {!Array<RequestNode>} RequestNodeChain
@@ -169,7 +173,7 @@ class CriticalNetworkChains extends Gather {
       log.log('info', 'lengths of critical chains', debuggingData.map(d => d.totalRequests));
     }
 
-    this.artifacts = {CriticalNetworkChains: chains};
+    this.artifact = chains;
   }
 
   /**

--- a/src/gatherers/gather.js
+++ b/src/gatherers/gather.js
@@ -22,6 +22,13 @@ class Gather {
     this.artifact = {};
   }
 
+  /**
+   * @return {string}
+   */
+  get name() {
+    throw new Error('Gather name must be overridden.');
+  }
+
   /* eslint-disable no-unused-vars */
 
   setup(options) { }

--- a/src/gatherers/html.js
+++ b/src/gatherers/html.js
@@ -19,6 +19,9 @@
 const Gather = require('./gather');
 
 class HTML extends Gather {
+  get name() {
+    return 'html';
+  }
 
   postProfiling(options) {
     const driver = options.driver;
@@ -29,7 +32,7 @@ class HTML extends Gather {
           nodeId: nodeId
         }))
         .then(nodeHTML => {
-          this.artifact = {html: nodeHTML.outerHTML};
+          this.artifact = nodeHTML.outerHTML;
         });
   }
 }

--- a/src/gatherers/http-redirect.js
+++ b/src/gatherers/http-redirect.js
@@ -19,6 +19,9 @@
 const Gather = require('./gather');
 
 class HTTPRedirect extends Gather {
+  get name() {
+    return 'redirectsHTTP';
+  }
 
   constructor() {
     super();
@@ -33,10 +36,8 @@ class HTTPRedirect extends Gather {
       // security events at all. If that happens, bail.
       this._noSecurityChangesTimeout = setTimeout(_ => {
         this.artifact = {
-          redirectsHTTP: {
-            value: false,
-            debugString: 'Timed out waiting for HTTP redirection.'
-          }
+          value: false,
+          debugString: 'Timed out waiting for HTTP redirection.'
         };
 
         resolve();
@@ -51,9 +52,7 @@ class HTTPRedirect extends Gather {
           }
 
           this.artifact = {
-            redirectsHTTP: {
-              value: state.schemeIsCryptographic
-            }
+            value: state.schemeIsCryptographic
           };
 
           resolve();

--- a/src/gatherers/https.js
+++ b/src/gatherers/https.js
@@ -19,6 +19,10 @@
 const Gather = require('./gather');
 
 class HTTPS extends Gather {
+  get name() {
+    return 'https';
+  }
+
   constructor() {
     super();
     this._noSecurityChangesTimeout = undefined;
@@ -32,10 +36,8 @@ class HTTPS extends Gather {
       // security events at all. If that happens, bail.
       this._noSecurityChangesTimeout = setTimeout(_ => {
         this.artifact = {
-          https: {
-            value: false,
-            debugString: 'Timed out waiting for security event.'
-          }
+          value: false,
+          debugString: 'Timed out waiting for security event.'
         };
 
         resolve();
@@ -50,9 +52,7 @@ class HTTPS extends Gather {
           }
 
           this.artifact = {
-            https: {
-              value: state.schemeIsCryptographic
-            }
+            value: state.schemeIsCryptographic
           };
 
           resolve();

--- a/src/gatherers/manifest.js
+++ b/src/gatherers/manifest.js
@@ -53,14 +53,15 @@ function getManifestContent() {
 }
 
 class Manifest extends Gather {
+  get name() {
+    return 'manifest';
+  }
 
   static _errorManifest(errorString) {
     return {
-      manifest: {
-        raw: undefined,
-        value: undefined,
-        debugString: errorString
-      }
+      raw: undefined,
+      value: undefined,
+      debugString: errorString
     };
   }
 
@@ -82,9 +83,7 @@ class Manifest extends Gather {
       if (returnedValue.error) {
         this.artifact = Manifest._errorManifest(returnedValue.error);
       } else {
-        this.artifact = {
-          manifest: manifestParser(returnedValue.manifestContent)
-        };
+        this.artifact = manifestParser(returnedValue.manifestContent);
       }
     });
   }

--- a/src/gatherers/offline.js
+++ b/src/gatherers/offline.js
@@ -35,6 +35,9 @@ const requestPage = function() {
 };
 
 class Offline extends Gather {
+  get name() {
+    return 'offlineResponseCode';
+  }
 
   static goOffline(driver) {
     return driver.sendCommand('Network.emulateNetworkConditions', {
@@ -64,7 +67,7 @@ class Offline extends Gather {
         .goOffline(driver)
         .then(_ => driver.evaluateAsync(`(${requestPage.toString()}())`))
         .then(offlineResponseCode => {
-          this.artifact = {offlineResponseCode};
+          this.artifact = offlineResponseCode;
         })
         .then(_ => Offline.goOnline(driver));
   }

--- a/src/gatherers/service-worker.js
+++ b/src/gatherers/service-worker.js
@@ -19,6 +19,10 @@
 const Gather = require('./gather');
 
 class ServiceWorker extends Gather {
+  get name() {
+    return 'serviceWorkers';
+  }
+
   reloadSetup(options) {
     const driver = options.driver;
     this.resolved = false;
@@ -30,11 +34,9 @@ class ServiceWorker extends Gather {
               ServiceWorker.getActivatedServiceWorker(data.versions, options.url);
 
           this.artifact = {
-            serviceWorkers: {
-              versions: controlledClients ? [controlledClients] : []
-            }
+            versions: controlledClients ? [controlledClients] : []
           };
-          this.resolved = (typeof this.artifact.serviceWorkers.versions !== 'undefined');
+          this.resolved = (typeof this.artifact.versions !== 'undefined');
           res();
         }
       });

--- a/src/gatherers/theme-color.js
+++ b/src/gatherers/theme-color.js
@@ -19,6 +19,9 @@
 const Gather = require('./gather');
 
 class ThemeColor extends Gather {
+  get name() {
+    return 'themeColorMeta';
+  }
 
   postProfiling(options) {
     const driver = options.driver;
@@ -26,7 +29,7 @@ class ThemeColor extends Gather {
     return driver.querySelector('head meta[name="theme-color"]')
       .then(node => node && node.getAttribute('content'))
       .then(themeColorMeta => {
-        this.artifact = {themeColorMeta};
+        this.artifact = themeColorMeta;
       });
   }
 }

--- a/src/gatherers/url.js
+++ b/src/gatherers/url.js
@@ -19,8 +19,12 @@
 const Gather = require('./gather');
 
 class URL extends Gather {
+  get name() {
+    return 'url';
+  }
+
   setup(options) {
-    this.artifact = {url: options.url || options.driver.url};
+    this.artifact = options.url || options.driver.url;
   }
 }
 

--- a/src/gatherers/viewport.js
+++ b/src/gatherers/viewport.js
@@ -19,10 +19,13 @@
 const Gather = require('./gather');
 
 class Viewport extends Gather {
+  get name() {
+    return 'viewport';
+  }
 
   /**
    * @param {!{driver: !Object}} options Run options
-   * @return {!Promise<{viewport: !string}>} The value of the viewport meta's content attribute, or null
+   * @return {!Promise<?string>} The value of the viewport meta's content attribute, or null
    */
   postProfiling(options) {
     const driver = options.driver;
@@ -30,7 +33,7 @@ class Viewport extends Gather {
     return driver.querySelector('head meta[name="viewport"]')
       .then(node => node && node.getAttribute('content'))
       .then(viewport => {
-        this.artifact = {viewport};
+        this.artifact = viewport;
       });
   }
 }

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -89,12 +89,6 @@ function phaseRunner(gatherers) {
   };
 }
 
-function flattenArtifacts(artifacts) {
-  return artifacts.reduce(function(prev, curr) {
-    return Object.assign(prev, curr);
-  }, {});
-}
-
 function saveArtifacts(artifacts) {
   const artifactsFilename = 'artifacts.log';
   // The _target property of NetworkRequest is circular.
@@ -154,13 +148,15 @@ function run(gatherers, options) {
     .then(_ => runPhase(gatherer => gatherer.tearDown(options)))
     .then(_ => {
       // Collate all the gatherer results.
-      const unflattenedArtifacts = gatherers.map(g => g.artifact).concat(
-          {networkRecords: tracingData.networkRecords},
-          {rawNetworkEvents: tracingData.rawNetworkEvents},
-          {traceContents: tracingData.traceContents},
-          {frameLoadEvents: tracingData.frameLoadEvents});
-
-      const artifacts = flattenArtifacts(unflattenedArtifacts);
+      const artifacts = gatherers.reduce((artifacts, gatherer) => {
+        artifacts[gatherer.name] = gatherer.artifact;
+        return artifacts;
+      }, {
+        networkRecords: tracingData.networkRecords,
+        rawNetworkEvents: tracingData.rawNetworkEvents,
+        traceContents: tracingData.traceContents,
+        frameLoadEvents: tracingData.frameLoadEvents
+      });
 
       if (options.flags.saveArtifacts) {
         saveArtifacts(artifacts);


### PR DESCRIPTION
step 1 to fixing #293 and being able to selectively run gathers/audits.

Commits are much simpler separately: [first commit](https://github.com/GoogleChrome/lighthouse/pull/353/commits/df66ca5f98f8f3d7be2ef72e028c4892b3de9dee) is modifying gatherers to declare the name of the artifact they produce, [second](https://github.com/GoogleChrome/lighthouse/pull/353/commits/8c22218b4cdf6296a9a8d8887052c1d9071e0b9e) is audits declaring what they consume.