### PR TITLE
fMP metric includes new blank webfont signal

### DIFF
--- a/cli/printer.js
+++ b/cli/printer.js
@@ -101,6 +101,10 @@ function createOutput(results, outputMode) {
         output += `    ${subitem.debugString}\n`;
       }
 
+      if (subitem.extendedInfo && !subitem.extendedInfo.formatter) {
+        log.log('warn', 'CLI formatter not provided', JSON.stringify(subitem.extendedInfo));
+      }
+
       if (subitem.extendedInfo && subitem.extendedInfo.value) {
         const formatter =
             Formatter.getByName(subitem.extendedInfo.formatter).getFormatter('pretty');

--- a/report/report-generator.js
+++ b/report/report-generator.js
@@ -21,6 +21,7 @@
 const Aggregate = require('../src/aggregators/aggregate');
 const Formatter = require('../formatters/formatter');
 const Handlebars = require('handlebars');
+const log = require('../src/lib/log.js');
 const fs = require('fs');
 const path = require('path');
 
@@ -176,6 +177,10 @@ class ReportGenerator {
     results.aggregations.forEach(aggregation => {
       aggregation.score.subItems.forEach(subItem => {
         if (!subItem.extendedInfo) {
+          return;
+        }
+        if (!subItem.extendedInfo.formatter) {
+          log.log('warn', 'HTML formatter not provided', JSON.stringify(subItem.extendedInfo));
           return;
         }
 


### PR DESCRIPTION
This matches up with the impl in traceviewer: https://codereview.chromium.org/1998063002
We require layouts that have fewer than 200 invisible text characters, via `approximateBlankCharacterCount`

Also we report all fMP candidate paints in the extendedInfo.


![image](https://cloud.githubusercontent.com/assets/39191/15525391/cd0c0110-21de-11e6-8ec8-983aa52e14af.png)
Here's a run with https://acrobat.adobe.com/us/en/sign.html?promoid=HM85XGHT which has some nice FOIT