### PR TITLE
Update package.json homepage & issue URLs from Big Rig

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/googlechrome/big-rig/issues"
+    "url": "https://github.com/googlechrome/lighthouse/issues"
   },
-  "homepage": "https://github.com/googlechrome/big-rig#readme",
+  "homepage": "https://github.com/googlechrome/lighthouse#readme",
   "dependencies": {
     "axe-core": "^1.1.1",
     "chrome-devtools-frontend": "1.0.381789",


### PR DESCRIPTION
Was poking about on [npm](https://www.npmjs.com/package/lighthouse) and noticed these references hadn't been changed  :wave: