### PR TITLE
add audit whitelisting, eliminating page reloads if not required

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -24,6 +24,7 @@ const semver = require('semver');
 const Printer = require('./printer');
 
 const lighthouseModule = require('../');
+const lighthouse = require('../src/lighthouse');
 
 // node 5.x required due to use of ES2015 features
 if (semver.lt(process.version, '5.0.0')) {
@@ -51,6 +52,7 @@ Run Configuration:
     --save-trace       Save the trace contents to disk
     --save-artifacts   Save all gathered artifacts to disk
     --audit-whitelist  Comma separated list of audits to run (default=all)
+    --list-all-audits  Prints a list of all available audits and exits
 
 Output:
     --output           Reporter for the results
@@ -58,6 +60,11 @@ Output:
     --output-path      The file path to output the results (default=stdout)
                        Example: --output-path=./lighthouse-results.html
 `);
+
+if (cli.flags.listAllAudits) {
+  log.info('All lighthouse audits:', lighthouse.getAuditList().join(', '));
+  process.exit(0);
+}
 
 const url = cli.input[0] || 'https://platform-status.mozilla.org/';
 const outputMode = cli.flags.output || Printer.OUTPUT_MODE.pretty;

--- a/cli/index.js
+++ b/cli/index.js
@@ -23,7 +23,7 @@ const log = require('../src/lib/log.js');
 const semver = require('semver');
 const Printer = require('./printer');
 
-const lighthouse = require('../');
+const lighthouseModule = require('../');
 
 // node 5.x required due to use of ES2015 features
 if (semver.lt(process.version, '5.0.0')) {
@@ -50,6 +50,7 @@ Run Configuration:
     --load-page        Loads the page (default=true)
     --save-trace       Save the trace contents to disk
     --save-artifacts   Save all gathered artifacts to disk
+    --audit-whitelist  Comma separated list of audits to run (default=all)
 
 Output:
     --output           Reporter for the results
@@ -77,8 +78,15 @@ if (cli.flags.verbose) {
   flags.logLevel = 'error';
 }
 
+// Normalize audit whitelist.
+if (!flags.auditWhitelist || flags.auditWhitelist === 'all') {
+  flags.auditWhitelist = null;
+} else {
+  flags.auditWhitelist = new Set(flags.auditWhitelist.split(','));
+}
+
 // kick off a lighthouse run
-lighthouse(url, flags)
+lighthouseModule(url, flags)
   .then(results => {
     return Printer.write(results, outputMode, outputPath);
   })

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -114,3 +114,11 @@ module.exports = function(driver, opts) {
         };
       });
 };
+
+/**
+ * Returns list of audit names for external querying.
+ * @return {!Array<string>}
+ */
+module.exports.getAuditList = function() {
+  return AUDITS.map(audit => audit.name);
+};

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -87,7 +87,14 @@ module.exports = function(driver, opts) {
     opts.flags.loadPage = true;
   }
 
-  const gatherers = gathererClasses.map(G => new G());
+  // Collate all artifacts required by audits to be run.
+  const auditArtifacts = audits.map(audit => audit.requiredArtifacts);
+  const requiredArtifacts = new Set([].concat(...auditArtifacts));
+
+  // Instantiate gatherers and discard any not needed by requested audits.
+  // For now, the trace and network records are assumed to be required.
+  const gatherers = gathererClasses.map(G => new G())
+    .filter(gatherer => requiredArtifacts.has(gatherer.name));
 
   return Scheduler
       .run(gatherers, Object.assign({}, opts, {driver}))

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -17,7 +17,9 @@
 'use strict';
 
 const fs = require('fs');
+
 const log = require('./lib/log.js');
+const Gather = require('./gatherers/gather.js');
 
 function loadPage(driver, gatherers, options) {
   const loadPage = options.flags.loadPage;
@@ -101,6 +103,54 @@ function saveAssets(tracingData, url) {
   log.log('info', 'trace file saved to disk', filename);
 }
 
+function shouldRunPass(gatherers, phases) {
+  return phases.reduce((shouldRun, phase) => {
+    return shouldRun || gatherers.some(gatherer => gatherer[phase] !== Gather.prototype[phase]);
+  }, false);
+}
+
+function firstPass(driver, gatherers, options, tracingData) {
+  const runPhase = phaseRunner(gatherers);
+
+  return runPhase(gatherer => gatherer.setup(options))
+    .then(_ => beginPassiveCollection(driver))
+    .then(_ => runPhase(gatherer => gatherer.beforePageLoad(options)))
+
+    // Load page, gather from browser, stop profilers.
+    .then(_ => loadPage(driver, gatherers, options))
+    .then(_ => runPhase(gatherer => gatherer.profiledPostPageLoad(options)))
+    .then(_ => endPassiveCollection(options, tracingData))
+    .then(_ => runPhase(gatherer => gatherer.postProfiling(options, tracingData)));
+}
+
+function secondPass(driver, gatherers, options) {
+  const phases = ['reloadSetup', 'beforeReloadPageLoad', 'afterReloadPageLoad'];
+  if (!shouldRunPass(gatherers, phases)) {
+    return Promise.resolve();
+  }
+
+  const runPhase = phaseRunner(gatherers);
+
+  // Reload page for SW, etc.
+  return runPhase(gatherer => gatherer.reloadSetup(options))
+    .then(_ => runPhase(gatherer => gatherer.beforeReloadPageLoad(options)))
+    .then(_ => reloadPage(driver, options))
+    .then(_ => runPhase(gatherer => gatherer.afterReloadPageLoad(options)));
+}
+
+function thirdPass(driver, gatherers, options) {
+  if (!shouldRunPass(gatherers, ['afterSecondReloadPageLoad'])) {
+    return Promise.resolve();
+  }
+
+  const runPhase = phaseRunner(gatherers);
+
+  // Reload page again for HTTPS redirect
+  options.url = options.url.replace(/^https/, 'http');
+  return reloadPage(driver, options)
+    .then(_ => runPhase(gatherer => gatherer.afterSecondReloadPageLoad(options)));
+}
+
 function run(gatherers, options) {
   const driver = options.driver;
   const tracingData = {};
@@ -112,30 +162,11 @@ function run(gatherers, options) {
   const runPhase = phaseRunner(gatherers);
 
   return driver.connect()
-    // Initial prep before the page load.
     .then(_ => setupDriver(driver, gatherers, options))
-    .then(_ => runPhase(gatherer => gatherer.setup(options)))
-    .then(_ => beginPassiveCollection(driver))
-    .then(_ => runPhase(gatherer => gatherer.beforePageLoad(options)))
 
-    // Load page, gather from browser, stop profilers.
-    .then(_ => loadPage(driver, gatherers, options))
-    .then(_ => runPhase(gatherer => gatherer.profiledPostPageLoad(options)))
-    .then(_ => endPassiveCollection(options, tracingData))
-    .then(_ => runPhase(gatherer => gatherer.postProfiling(options, tracingData)))
-
-    // Reload page for SW, etc.
-    .then(_ => runPhase(gatherer => gatherer.reloadSetup(options)))
-    .then(_ => runPhase(gatherer => gatherer.beforeReloadPageLoad(options)))
-    .then(_ => reloadPage(driver, options))
-    .then(_ => runPhase(gatherer => gatherer.afterReloadPageLoad(options)))
-
-    // Reload page again for HTTPS redirect
-    .then(_ => {
-      options.url = options.url.replace(/^https/, 'http');
-    })
-    .then(_ => reloadPage(driver, options))
-    .then(_ => runPhase(gatherer => gatherer.afterSecondReloadPageLoad(options)))
+    .then(_ => firstPass(driver, gatherers, options, tracingData))
+    .then(_ => secondPass(driver, gatherers, options))
+    .then(_ => thirdPass(driver, gatherers, options))
 
     // Finish and teardown.
     .then(_ => driver.disconnect())
@@ -147,9 +178,7 @@ function run(gatherers, options) {
         return artifacts;
       }, {
         networkRecords: tracingData.networkRecords,
-        rawNetworkEvents: tracingData.rawNetworkEvents,
-        traceContents: tracingData.traceContents,
-        frameLoadEvents: tracingData.frameLoadEvents
+        traceContents: tracingData.traceContents
       });
 
       if (options.flags.saveArtifacts) {


### PR DESCRIPTION
Another step toward #293. Try it out! e.g.
```
lighthouse --audit-whitelist=first-meaningful-paint,speed-index-metric
```

To get the audit names without going into each audit individually, use the
```
lighthouse --list-all-audits
```
 cli flag to list all available audits.

Some issues:

- scoring is not what you'd expect from a whitelist right now—aggregators will have to renormalize to account for audits you didn't run—but @paulirish wants to move forward with this as-is since there are several other aggregator/formatter changes in motion requiring further changes already

- right now you can't opt out of tracing/network recording, even if no audits need them, so the first pass always runs. This could be fixed, but will need some special handling since those artifacts don't come from gatherers but from the scheduler itself.

