### PR TITLE
add istanbul test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ third_party/src
 extension/pages/scripts/lighthouse-report.js
 npm-debug.log
 artifacts.log
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ script:
   - npm run closure
   - npm run smoke
   - (cd extension && gulp build)
+  - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "watch": "find . -name '*.js' -not -path '*/node_modules/*' -not -path '*/extension/*' | entr npm run unit",
     "unit": "mocha $(find ./test -name '*.js') --timeout 60000",
     "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find ./test -name '*.js') --timeout 60000",
+    "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "chrome": "./scripts/launch-chrome.sh",
     "smoke": "./scripts/run-smoke-tests.sh",
     "start": "node ./cli/index.js"
@@ -45,6 +46,7 @@
     "speedline": "^0.1.2"
   },
   "devDependencies": {
+    "coveralls": "^2.11.9",
     "eslint": "^2.4.0",
     "eslint-config-google": "^0.4.0",
     "google-closure-compiler": "^20160315.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "npm run lint --silent && npm run unit && npm run closure",
     "watch": "find . -name '*.js' -not -path '*/node_modules/*' -not -path '*/extension/*' | entr npm run unit",
     "unit": "mocha $(find ./test -name '*.js') --timeout 60000",
+    "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find ./test -name '*.js') --timeout 60000",
     "chrome": "./scripts/launch-chrome.sh",
     "smoke": "./scripts/run-smoke-tests.sh",
     "start": "node ./cli/index.js"
@@ -50,6 +51,7 @@
     "gulp": "^3.9.1",
     "gulp-replace": "^0.5.4",
     "gulp-util": "^3.0.7",
+    "istanbul": "^0.4.3",
     "jsdom": "^9.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.3",

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@
 
 
 [![Build Status](https://travis-ci.org/GoogleChrome/lighthouse.svg?branch=master)](https://travis-ci.org/GoogleChrome/lighthouse)
+[![Coverage Status](https://coveralls.io/repos/github/GoogleChrome/lighthouse/badge.svg?branch=master)](https://coveralls.io/github/GoogleChrome/lighthouse?branch=master)
 
 _status: prototype extension and CLI available for testing_
 


### PR DESCRIPTION
also removes smoke tests from what are (ostensibly) unit tests

one issue: anything using driver.evaluateAsync is totally broken under istanbul, since it instruments the code we then send over to the page to run, which is obviously is broken in that context. Some initial efforts to fix didn't work, but not a problem with this PR since we have no test coverage on those gatherers yet :)