### PR TITLE
Launch Chromium without an abort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - export LIGHTHOUSE_CHROMIUM_PATH="$(pwd)/chrome-linux/chrome"
   - sh -e /etc/init.d/xvfb start
   - ./scripts/download-chrome.sh
-  - start-stop-daemon --start --background --exec $(pwd)/scripts/launch-chrome.sh -- --disable-setuid-sandbox
+  - start-stop-daemon --start --background --exec $(pwd)/scripts/launch-chrome.sh
   - sleep 5
 script:
   - npm run lint

--- a/scripts/launch-chrome.sh
+++ b/scripts/launch-chrome.sh
@@ -32,6 +32,7 @@ launch_linux() {
   TMP_PROFILE_DIR=$(mktemp -d -t lighthouse.XXXXXXXXXX)
   echo "Launching Google Chrome from $LIGHTHOUSE_CHROMIUM_PATH"
   "$LIGHTHOUSE_CHROMIUM_PATH" \
+    --disable-setuid-sandbox \
     --remote-debugging-port=9222 \
     --no-first-run \
     --user-data-dir=$TMP_PROFILE_DIR \


### PR DESCRIPTION
Fixes #378 

Unzip the folder, then check if the sandbox is named `chrome_sandbox` still, if so move it to `chrome-sandbox`. This way if things are fixed upstream then the script shouldn't cause an error later.