### PR TITLE
eslintignore istanbul coverage report

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@
 **/dist/
 
 **/closure/*/*
+coverage/**


### PR DESCRIPTION
`npm run lint` fails if you've run `npm run coverage` before :)