### PR TITLE
Adds final reload

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -152,7 +152,10 @@ function run(gatherers, options) {
     .then(_ => secondPass(driver, gatherers, options))
     .then(_ => thirdPass(driver, gatherers, options))
 
-    // Finish and teardown.
+    // Reload the page to remove any side-effects of Lighthouse (like disabling JavaScript).
+    .then(_ => reloadPage(driver, options))
+
+     // Finish and teardown.
     .then(_ => driver.disconnect())
     .then(_ => runPhase(gatherer => gatherer.tearDown(options)))
     .then(_ => {


### PR DESCRIPTION
The new JS-disabled audit leaves the page inert, which is okay for the CLI as it closes the tab, but the extension does not. This PR adds a final reload to the end of the run to "reset" the page. An improvement to this would be to only do this in the extension context, or if the JS-disabled run has definitely happened.

PTAL @paulirish 