### PR TITLE
Fixes extension after #414

### DIFF
--- a/extension/app/src/lighthouse-background.js
+++ b/extension/app/src/lighthouse-background.js
@@ -19,6 +19,8 @@
 
 const ExtensionProtocol = require('../../../src/lib/drivers/extension.js');
 const lighthouse = require('../../../src/lighthouse');
+const config = require('../../../config/default.json');
+
 const NO_SCORE_PROVIDED = '-1';
 
 window.createPageAndPopulate = function(results) {
@@ -41,7 +43,7 @@ window.runAudits = function(options) {
   return driver.getCurrentTabURL()
       .then(url => {
         // Add in the URL to the options.
-        return lighthouse(driver, Object.assign({}, options, {url}));
+        return lighthouse(driver, Object.assign({}, options, {url, config}));
       });
 };
 

--- a/extension/gulpfile.js
+++ b/extension/gulpfile.js
@@ -111,13 +111,13 @@ gulp.task('browserify', () => {
       const srcPath = /\.\.\/src\//;
 
       // Expose the audits and gatherers so they can be dynamically loaded.
-      bundle = audits.reduce((bundle, audit) => {
-        return bundle.require(audit, {expose: audit.replace(srcPath, './')});
-      }, bundle);
+      audits.forEach(audit => {
+        bundle = bundle.require(audit, {expose: audit.replace(srcPath, './')});
+      });
 
-      bundle = gatherers.reduce((bundle, gatherer) => {
-        return bundle.require(gatherer, {expose: gatherer.replace(srcPath, './')});
-      }, bundle);
+      gatherers.forEach(gatherer => {
+        bundle = bundle.require(gatherer, {expose: gatherer.replace(srcPath, './')});
+      });
 
       file.contents = bundle.bundle();
     }))

--- a/extension/gulpfile.js
+++ b/extension/gulpfile.js
@@ -1,6 +1,8 @@
 // generated on 2016-03-19 using generator-chrome-extension 0.5.4
 
 'use strict';
+const fs = require('fs');
+const path = require('path');
 const del = require('del');
 const gutil = require('gulp-util');
 const runSequence = require('run-sequence');
@@ -13,6 +15,14 @@ const livereload = require('gulp-livereload');
 const tap = require('gulp-tap');
 const zip = require('gulp-zip');
 const rename = require('gulp-rename');
+
+const audits = fs.readdirSync(path.join(__dirname, '../', 'src/audits/'))
+    .filter(f => /\.js$/.test(f))
+    .map(f => `../src/audits/${f.replace(/\.js$/, '')}`);
+
+const gatherers = fs.readdirSync(path.join(__dirname, '../', 'src/gatherers/'))
+    .filter(f => /\.js$/.test(f))
+    .map(f => `../src/gatherers/${f.replace(/\.js$/, '')}`);
 
 gulp.task('extras', () => {
   return gulp.src([
@@ -87,8 +97,8 @@ gulp.task('browserify', () => {
     'app/src/report-loader.js'
   ], {read: false})
     .pipe(tap(file => {
-      file.contents = browserify(file.path, {
-        transform: ['brfs']
+      let bundle = browserify(file.path, {
+        transform: ['brfs'],
       })
       // Do the additional transform to convert references to devtools-timeline-model
       // to the modified version internal to Lighthouse.
@@ -96,8 +106,20 @@ gulp.task('browserify', () => {
         global: true
       })
       .ignore('npmlog')
-      .ignore('chrome-remote-interface')
-      .bundle();
+      .ignore('chrome-remote-interface');
+
+      const srcPath = /\.\.\/src\//;
+
+      // Expose the audits and gatherers so they can be dynamically loaded.
+      bundle = audits.reduce((bundle, audit) => {
+        return bundle.require(audit, {expose: audit.replace(srcPath, './')});
+      }, bundle);
+
+      bundle = gatherers.reduce((bundle, gatherer) => {
+        return bundle.require(gatherer, {expose: gatherer.replace(srcPath, './')});
+      }, bundle);
+
+      file.contents = bundle.bundle();
     }))
     .pipe(gulp.dest('app/scripts'))
     .pipe(gulp.dest('dist/scripts'));

--- a/scripts/traceviewer-module-index.html
+++ b/scripts/traceviewer-module-index.html
@@ -6,6 +6,7 @@ found in the LICENSE file.
 -->
 
 <link rel="import" href="/tracing/importer/import.html">
+tr.isHeadless = true;
 <link rel="import" href="/tracing/model/model.html">
 <link rel="import" href="/tracing/extras/full_config.html">
 

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -44,7 +44,7 @@ function filterAndExpandAudits(audits, whitelist) {
     try {
       return require(`./audits/${audit}`);
     } catch (requireError) {
-      throw new Error(`Unable to locate audit: ${audit}`);
+      throw new Error(`Unable to load audit: ${audit}`);
     }
   });
 }
@@ -69,7 +69,7 @@ function expandPasses(audits, passes) {
             const gathererNecessary = requiredGatherers.has(GathererClass.name);
             return gathererNecessary;
           } catch (requireError) {
-            throw new Error(`Unable to locate gatherer: ${gatherer}`);
+            throw new Error(`Unable to load gatherer: ${gatherer}`);
           }
         })
 

--- a/third_party/traceviewer-js/index.js
+++ b/third_party/traceviewer-js/index.js
@@ -5,6 +5,7 @@ found in the LICENSE file.
 **/
 
 require("./importer/import.js");
+tr.isHeadless = true;
 require("./model/model.js");
 require("./extras/full_config.js");
 require("./metrics/value_list.js");


### PR DESCRIPTION
Since #414 landed the extension tries to load audits and gatherers dynamically. This makes sure that it can.