### PR TITLE
Fix requiring gatherers and fix gulp watch for extension

### DIFF
--- a/lighthouse-core/driver/index.js
+++ b/lighthouse-core/driver/index.js
@@ -199,7 +199,7 @@ class Driver {
           return gatherer;
         }
 
-        const GathererClass = require(`./gatherers/${gatherer}`);
+        const GathererClass = Driver.getGathererClass(gatherer);
         return new GathererClass();
       });
 

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -52,10 +52,13 @@ class Runner {
       // that have been listed in the config.
       const filteredPasses = config.passes.map(pass => {
         pass.gatherers = pass.gatherers.filter(gatherer => {
+          if (typeof gatherer !== 'string') {
+            return requiredGatherers.has(gatherer.name);
+          }
+
           try {
             const GathererClass = Driver.getGathererClass(gatherer);
-            const gathererNecessary = requiredGatherers.has(GathererClass.name);
-            return gathererNecessary;
+            return requiredGatherers.has(GathererClass.name);
           } catch (requireError) {
             throw new Error(`Unable to locate gatherer: ${gatherer}`);
           }

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -149,13 +149,14 @@ gulp.task('watch', ['lint', 'browserify', 'html', 'copyReportScripts'], () => {
     'app/scripts/**/*.js',
     'app/images/**/*',
     'app/styles/**/*',
-    'app/_locales/**/*.json'
+    'app/_locales/**/*.json',
+    'node_modules/lighthouse-core/**/*.js'
   ]).on('change', livereload.reload);
 
   gulp.watch([
     '*.js',
     'app/src/**/*.js',
-    '../src/**/*.js'
+    'node_modules/lighthouse-core/**/*.js'
   ], ['browserify', 'lint']);
 });
 


### PR DESCRIPTION
Original PR: #423 

+ When lighthouse is run for the first time, pass.gatherers is modified from string to require('gatherer')
+ From the second time, require(GathererClass) would become require('[object object]') and throws
+ This fix returns the original gatherer when it's already required and in memory

(Close #423) 