### PR TITLE
relax constraint to be greater than 4.3.3.

### DIFF
--- a/lighthouse-core/package.json
+++ b/lighthouse-core/package.json
@@ -41,7 +41,7 @@
     "json-stringify-safe": "^5.0.1",
     "jszip": "2.6.0",
     "npmlog": "^2.0.3",
-    "semver": "^5.1.0",
+    "semver": ">=4.3.3",
     "speedline": "^0.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Since lighthouse only uses a simple less than test we can pull the semver version back. I'm specifically picking 4.3.3 because of other packages that I care about being locked to this, this can be technically be pulled back further.

Let me know if this is an ok thing to do.