### PR TITLE
make the devtools-timeline-model version be the same as speedlines

### DIFF
--- a/lighthouse-core/package.json
+++ b/lighthouse-core/package.json
@@ -34,7 +34,7 @@
     "axe-core": "^1.1.1",
     "chrome-devtools-frontend": "1.0.381789",
     "chrome-remote-interface": "^0.11.0",
-    "devtools-timeline-model": "1.0.19",
+    "devtools-timeline-model": "1.1.4",
     "empty-module": "0.0.2",
     "gl-matrix": "2.3.2",
     "handlebars": "^4.0.5",


### PR DESCRIPTION
Speed line currently includes v1.1.4 but lighthouse requires 1.0.19, make them the same here.