### PR TITLE
Adds transfer size to CRC

### DIFF
--- a/lighthouse-core/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/driver/gatherers/critical-request-chains.js
@@ -74,7 +74,8 @@ class CriticalRequestChains extends Gather {
         url: request._url,
         startTime: request.startTime,
         endTime: request.endTime,
-        responseReceivedTime: request.responseReceivedTime
+        responseReceivedTime: request.responseReceivedTime,
+        transferSize: request.transferSize
       };
     };
 

--- a/lighthouse-core/formatters/critical-request-chains.js
+++ b/lighthouse-core/formatters/critical-request-chains.js
@@ -285,7 +285,7 @@ class CriticalRequestChains extends Formatter {
         });
       },
 
-      createGlobalContext(tree, opts) {
+      createTreeRenderContext(tree, opts) {
         const transferSize = 0;
         let startTime = 0;
         const rootNodes = Object.keys(tree);

--- a/lighthouse-core/formatters/critical-request-chains.js
+++ b/lighthouse-core/formatters/critical-request-chains.js
@@ -38,11 +38,15 @@ class CriticalRequestChains extends Formatter {
           }
 
           const longestChain = CriticalRequestChains._getLongestChainLength(info);
-          const longestDuration = CriticalRequestChains._getLongestChainDuration(info);
+          const longestDuration =
+              CriticalRequestChains._getLongestChainDuration(info).toFixed(2);
+          const longestTransferSize = CriticalRequestChains.formatTransferSize(
+              CriticalRequestChains._getLongestChainTransferSize(info));
           const urlTree = CriticalRequestChains._createURLTreeOutput(info);
 
           const output = `    - Longest request chain (shorter is better): ${longestChain}\n` +
-          `    - Longest chain duration (shorter is better): ${longestDuration.toFixed(2)}ms\n` +
+          `    - Longest chain duration (shorter is better): ${longestDuration}ms\n` +
+          `    - Longest chain transfer size (smaller is better): ${longestTransferSize}KB\n` +
           '    - Initial navigation\n' +
               '      ' + urlTree.replace(/\n/g, '\n      ') + '\n';
           return output;
@@ -58,10 +62,14 @@ class CriticalRequestChains extends Formatter {
   }
 
   static _traverse(tree, cb) {
-    function walk(node, depth, startTime) {
+    function walk(node, depth, startTime, transferSize) {
       const children = Object.keys(node);
       if (children.length === 0) {
         return;
+      }
+
+      if (!transferSize) {
+        transferSize = 0;
       }
 
       children.forEach(id => {
@@ -75,7 +83,8 @@ class CriticalRequestChains extends Formatter {
           depth,
           id,
           node: child,
-          chainDuration: (child.request.endTime - startTime) * 1000
+          chainDuration: (child.request.endTime - startTime) * 1000,
+          chainTransferSize: (transferSize + child.request.transferSize)
         });
 
         // Carry on walking.
@@ -110,6 +119,17 @@ class CriticalRequestChains extends Formatter {
     return longestChainDuration;
   }
 
+  static _getLongestChainTransferSize(tree) {
+    let transferSize = 0;
+    this._traverse(tree, opts => {
+      const chainTransferSize = opts.chainTransferSize;
+      if (chainTransferSize > transferSize) {
+        transferSize = chainTransferSize;
+      }
+    });
+    return transferSize;
+  }
+
   /**
    * Converts the tree into an ASCII tree.
    */
@@ -119,6 +139,7 @@ class CriticalRequestChains extends Formatter {
       const depth = opts.depth;
       const treeMarkers = opts.treeMarkers;
       let startTime = opts.startTime;
+      let transferSize = opts.transferSize;
 
       return Object.keys(node).reduce((output, id, currentIndex, arr) => {
         // Test if this node has children, and if it's the last child.
@@ -149,16 +170,19 @@ class CriticalRequestChains extends Formatter {
         }
 
         const duration = ((node[id].request.endTime - startTime) * 1000).toFixed(2);
+        const chainTransferSize = transferSize + node[id].request.transferSize;
+        const formattedTransferSize = CriticalRequestChains.formatTransferSize(chainTransferSize);
 
         // Return the previous output plus this new node, and recursively write its children.
         return output + `${treeMarker} ${parsedURL.file} (${parsedURL.hostname})` +
             // If this node has children, write them out. Othewise write the chain time.
-            (hasChildren ? '' : ` - ${duration}ms`) + '\n' +
+            (hasChildren ? '' : ` - ${duration}ms, ${formattedTransferSize}KB`) + '\n' +
             write({
               node: node[id].children,
               depth: depth + 1,
               treeMarkers: newTreeMakers,
-              startTime
+              startTime,
+              transferSize: chainTransferSize
             });
       }, '');
     }
@@ -167,12 +191,17 @@ class CriticalRequestChains extends Formatter {
       node: tree,
       depth: 0,
       treeMarkers: [],
-      startTime: 0
+      startTime: 0,
+      transferSize: 0
     });
   }
 
   static formatTime(time) {
     return time.toFixed(2);
+  }
+
+  static formatTransferSize(size) {
+    return (size / 1024).toFixed(2);
   }
 
   static parseURL(resourceURL, opts) {
@@ -212,9 +241,15 @@ class CriticalRequestChains extends Formatter {
         return CriticalRequestChains._getLongestChainDuration(info);
       },
 
+      longestChainTransferSize(info) {
+        return CriticalRequestChains._getLongestChainTransferSize(info);
+      },
+
       chainDuration(startTime, endTime) {
         return ((endTime - startTime) * 1000).toFixed(2);
       },
+
+      formatTransferSize: CriticalRequestChains.formatTransferSize,
 
       parseURL: CriticalRequestChains.parseURL,
 
@@ -226,7 +261,7 @@ class CriticalRequestChains extends Formatter {
        * it has any children itself and what the tree looks like all the way back
        * up to the root, so the tree markers can be drawn correctly.
        */
-      createContextFor(parent, id, treeMarkers, parentIsLastChild, startTime, opts) {
+      createContextFor(parent, id, treeMarkers, parentIsLastChild, startTime, transferSize, opts) {
         const node = parent[id];
         const siblings = Object.keys(parent);
         const isLastChild = siblings.indexOf(id) === (siblings.length - 1);
@@ -240,16 +275,29 @@ class CriticalRequestChains extends Formatter {
           newTreeMarkers.push(!parentIsLastChild);
         }
 
-        if (!startTime) {
-          startTime = node.request.startTime;
-        }
-
         return opts.fn({
           node,
           isLastChild,
           hasChildren,
           startTime,
+          transferSize: (transferSize + node.request.transferSize),
           treeMarkers: newTreeMarkers
+        });
+      },
+
+      createGlobalContext(tree, opts) {
+        const transferSize = 0;
+        let startTime = 0;
+        const rootNodes = Object.keys(tree);
+
+        if (rootNodes.length > 0) {
+          startTime = tree[rootNodes[0]].request.startTime;
+        }
+
+        return opts.fn({
+          tree,
+          startTime,
+          transferSize
         });
       }
     };

--- a/lighthouse-core/formatters/partials/critical-request-chains.html
+++ b/lighthouse-core/formatters/partials/critical-request-chains.html
@@ -90,13 +90,13 @@
         <span class="cnc-node__tree-hostname">({{ this.hostname }})</span>
       {{/parseURL}}
       {{#unless hasChildren}}
-        - <span class="cnc-node__chain-duration">{{chainDuration startTime this.node.request.endTime }}ms</span>
+        - <span class="cnc-node__chain-duration">{{chainDuration startTime this.node.request.endTime }}ms, {{formatTransferSize this.transferSize}}KB</span>
       {{/unless}}
     </span>
   </div>
 
   {{#each this.node.children as |child| }}
-    {{#createContextFor ../node.children @key ../treeMarkers ../isLastChild ../startTime }}
+    {{#createContextFor ../node.children @key ../treeMarkers ../isLastChild ../startTime ../transferSize }}
       {{> writeNode this }}
     {{/createContextFor }}
   {{/each}}
@@ -105,12 +105,15 @@
 <div class="cnc-tree">
   <div>Longest request chain (shorter is better): <strong>{{longestChain this}}</strong></div>
   <div>Longest chain duration (shorter is better): <strong>{{formatTime (longestDuration this)}}ms</strong></div>
+  <div>Longest chain transfer size (smaller is better): <strong>{{formatTransferSize (longestChainTransferSize this)}}KB</strong></div>
   <div>
     <div>Initial navigation</div>
-    {{#each this }}
-      {{#createContextFor .. @key undefined undefined undefined }}
-        {{> writeNode this }}
-      {{/createContextFor}}
-    {{/each}}
+    {{#createGlobalContext this}}
+      {{#each this.tree }}
+        {{#createContextFor ../tree @key undefined undefined ../startTime ../transferSize }}
+          {{> writeNode this }}
+        {{/createContextFor}}
+      {{/each}}
+    {{/createGlobalContext}}
   </div>
 </div>

--- a/lighthouse-core/formatters/partials/critical-request-chains.html
+++ b/lighthouse-core/formatters/partials/critical-request-chains.html
@@ -108,12 +108,12 @@
   <div>Longest chain transfer size (smaller is better): <strong>{{formatTransferSize (longestChainTransferSize this)}}KB</strong></div>
   <div>
     <div>Initial navigation</div>
-    {{#createGlobalContext this}}
+    {{#createTreeRenderContext this}}
       {{#each this.tree }}
         {{#createContextFor ../tree @key undefined undefined ../startTime ../transferSize }}
           {{> writeNode this }}
         {{/createContextFor}}
       {{/each}}
-    {{/createGlobalContext}}
+    {{/createTreeRenderContext}}
   </div>
 </div>

--- a/lighthouse-core/test/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/test/driver/gatherers/critical-request-chains.js
@@ -58,7 +58,8 @@ function constructEmptyRequest() {
     endTime: undefined,
     responseReceivedTime: undefined,
     startTime: undefined,
-    url: undefined
+    url: undefined,
+    transferSize: undefined
   };
 }
 

--- a/lighthouse-core/test/formatter/critical-request-chains.js
+++ b/lighthouse-core/test/formatter/critical-request-chains.js
@@ -27,7 +27,8 @@ const extendedInfo = {
       endTime: 1,
       responseReceivedTime: 5,
       startTime: 0,
-      url: 'https://example.com/'
+      url: 'https://example.com/',
+      transferSize: 1
     },
     children: {
       1: {
@@ -35,7 +36,8 @@ const extendedInfo = {
           endTime: 16,
           responseReceivedTime: 14,
           startTime: 11,
-          url: 'https://example.com/b.js'
+          url: 'https://example.com/b.js',
+          transferSize: 1
         },
         children: {}
       },
@@ -44,7 +46,8 @@ const extendedInfo = {
           endTime: 17,
           responseReceivedTime: 15,
           startTime: 12,
-          url: superLongName
+          url: superLongName,
+          transferSize: 1
         },
         children: {}
       }
@@ -105,7 +108,7 @@ describe('CRC Formatter', () => {
       '<span class="cnc-node__tree-value">',
       '<span class="cnc-node__tree-file">/b.js</span>',
       '<span class="cnc-node__tree-hostname">\\(example.com\\)</span>',
-      '- <span class="cnc-node__chain-duration">5000.00ms</span>',
+      '- <span class="cnc-node__chain-duration">16000.00ms, 0.00KB</span>',
       '</span>'
     ].join('\\s*'), 'im');
 


### PR DESCRIPTION
[@slightlyoff said](https://twitter.com/slightlylate/status/741884269144989700):

> if you have 100k of gzipped JS in your critical path, your users are gonna have a bad time

And I was like "we have a notion of critical path, why not add transfer size for the chain?"

## CLI
![screen shot 2016-06-16 at 11 46 24 am](https://cloud.githubusercontent.com/assets/617438/16114319/870a17ba-33b8-11e6-9428-3823b74083aa.png)

## Report
![screen shot 2016-06-16 at 11 46 37 am](https://cloud.githubusercontent.com/assets/617438/16114320/870ba6ac-33b8-11e6-9389-279c6d956104.png)

wdyt?

