### PR TITLE
Exclude XHRs from critical chains.

### DIFF
--- a/lighthouse-core/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/driver/gatherers/critical-request-chains.js
@@ -18,27 +18,26 @@
 'use strict';
 
 const Gather = require('./gather');
+const WebInspector = require('../web-inspector');
 
 const includes = (arr, elm) => arr.indexOf(elm) > -1;
 
 class CriticalRequestChains extends Gather {
 
-  /** @return {String} */
-  get criticalPriorities() {
-    // For now, critical request == render blocking request (as decided by
-    // blink). Blink treats requests with the following priority levels as
-    // render blocking.
-    // See https://docs.google.com/document/d/1bCDuq9H1ih9iNjgzyAL0gpwNFiEP4TZS-YLRp_RuMlc
-    return ['VeryHigh', 'High', 'Medium'];
-  }
-
+  /**
+   * For now, we use network priorities as a proxy for "render-blocking"/critical-ness.
+   * It's imperfect, but there is not a higher-fidelity signal available yet.
+   * @see https://docs.google.com/document/d/1bCDuq9H1ih9iNjgzyAL0gpwNFiEP4TZS-YLRp_RuMlc
+   * @param  {any} request
+   */
   isCritical(request) {
+    // XHRs are fetched at High priority, but we exclude them, as they are unlikely to be critical
     if (request._resourceType._category === WebInspector.resourceTypes.XHR._category) {
       return false;
     }
-    // TODO(deepanjanroy): When possible, chanage
-    // initialPriority -> CurrentPriority
-    return includes(this.criticalPriorities, request.initialPriority());
+    // TODO(deepanjanroy): When devtools-frontend module is updated,
+    // change `initialPriority -> CurrentPriority`
+    return includes(['VeryHigh', 'High', 'Medium'], request.initialPriority());
   }
 
   static _fixRedirectPriorities(requestIdToRequests) {

--- a/lighthouse-core/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/driver/gatherers/critical-request-chains.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const Gather = require('./gather');
-const WebInspector = require('../lib/web-inspector');
+const WebInspector = require('../../lib/web-inspector');
 
 const includes = (arr, elm) => arr.indexOf(elm) > -1;
 

--- a/lighthouse-core/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/driver/gatherers/critical-request-chains.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const Gather = require('./gather');
-const WebInspector = require('../web-inspector');
+const WebInspector = require('../lib/web-inspector');
 
 const includes = (arr, elm) => arr.indexOf(elm) > -1;
 

--- a/lighthouse-core/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/driver/gatherers/critical-request-chains.js
@@ -33,6 +33,9 @@ class CriticalRequestChains extends Gather {
   }
 
   isCritical(request) {
+    if (request._resourceType._category === WebInspector.resourceTypes.XHR._category) {
+      return false;
+    }
     // TODO(deepanjanroy): When possible, chanage
     // initialPriority -> CurrentPriority
     return includes(this.criticalPriorities, request.initialPriority());

--- a/lighthouse-core/test/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/test/driver/gatherers/critical-request-chains.js
@@ -30,6 +30,9 @@ const VERY_LOW = 'VeryLow';
 function mockTracingData(prioritiesList, edges) {
   const networkRecords = prioritiesList.map((priority, index) =>
       ({requestId: index.toString(),
+        _resourceType: {
+          _category: 'fake'
+        },
         initialPriority: () => priority,
         initiatorRequest: () => null,
         setInitialPriority: newPrio => {


### PR DESCRIPTION
XHRs are high priority ([priority doc](https://docs.google.com/document/u/1/d/1bCDuq9H1ih9iNjgzyAL0gpwNFiEP4TZS-YLRp_RuMlc/mobilebasic)), but they dont meet our definition of critical


You can see here a few oddballs like the `.json` and `api/` calls.
![image](https://cloud.githubusercontent.com/assets/39191/16121136/67228322-33e2-11e6-88d2-807748bac6b9.png)
