### PR TITLE
Remove redirect hack 

### DIFF
--- a/lighthouse-core/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/driver/gatherers/critical-request-chains.js
@@ -41,20 +41,6 @@ class CriticalRequestChains extends Gather {
     return includes(['VeryHigh', 'High', 'Medium'], request.initialPriority());
   }
 
-  static _fixRedirectPriorities(requestIdToRequests) {
-    // This hack doesn't work if there is more than one consecutive redirect
-    for (let request of requestIdToRequests.values()) {
-      const requestId = request.requestId;
-      if (requestId.includes('redirected')) {
-        const originalRequestId = requestId.substring(0, requestId.indexOf(':'));
-        if (requestIdToRequests.has(originalRequestId)) {
-          const originalRequest = requestIdToRequests.get(originalRequestId);
-          originalRequest.setInitialPriority(request.initialPriority());
-        }
-      }
-    }
-  }
-
   afterPass(options, tracingData) {
     const networkRecords = tracingData.networkRecords;
 
@@ -63,10 +49,6 @@ class CriticalRequestChains extends Gather {
     for (let request of networkRecords) {
       requestIdToRequests.set(request.requestId, request);
     }
-
-    // This should go away once we fix
-    // https://github.com/GoogleChrome/lighthouse/issues/326
-    CriticalRequestChains._fixRedirectPriorities(requestIdToRequests);
 
     // Get all the critical requests.
     /** @type {!Array<NetworkRequest>} */

--- a/lighthouse-core/test/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/test/driver/gatherers/critical-request-chains.js
@@ -273,13 +273,13 @@ describe('CriticalRequestChain gatherer: getCriticalChain function', () => {
     const criticalChains = Gatherer.artifact;
 
     assert.deepEqual(criticalChains, {
-      '0': {
+      0: {
         request: constructEmptyRequest(),
         children: {
           '1:redirected.0': {
             request: constructEmptyRequest(),
             children: {
-              '1': {
+              1: {
                 request: constructEmptyRequest(),
                 children: {}
               }

--- a/lighthouse-core/test/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/test/driver/gatherers/critical-request-chains.js
@@ -264,26 +264,28 @@ describe('CriticalRequestChain gatherer: getCriticalChain function', () => {
     }));
 
   it('handles redirects', () => {
-    const networkRecords = mockTracingData([HIGH, LOW, HIGH], [[1, 2]]);
+    const networkRecords = mockTracingData([HIGH, HIGH, HIGH], [[0, 1], [1, 2]]);
 
     // Make a fake redirect
-    networkRecords[0].requestId = '1:redirected.1';
+    networkRecords[1].requestId = '1:redirected.0';
+    networkRecords[2].requestId = '1';
     Gatherer.afterPass(null, {networkRecords});
     const criticalChains = Gatherer.artifact;
 
     assert.deepEqual(criticalChains, {
-      '1': {
+      '0': {
         request: constructEmptyRequest(),
         children: {
-          2: {
+          '1:redirected.0': {
             request: constructEmptyRequest(),
-            children: {}
+            children: {
+              '1': {
+                request: constructEmptyRequest(),
+                children: {}
+              }
+            }
           }
         }
-      },
-      '1:redirected.1': {
-        request: constructEmptyRequest(),
-        children: {}
       }
     });
   });


### PR DESCRIPTION
Since #326 was fixed in chromium we can remove our hack to fix redirect priorities.

Fixes #326 