### PR TITLE
remove empty-module as a dependency

### DIFF
--- a/lighthouse-core/lib/empty-stub.js
+++ b/lighthouse-core/lib/empty-stub.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Exports an empty object for when the module loading system needs *something*
+ * to be loaded but it doesn't care what it is.
+ */
+module.exports = {};

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -40,7 +40,7 @@ global.JSZip = require('jszip/dist/jszip.min.js');
 global.HTMLImportsLoader = {};
 global.HTMLImportsLoader.hrefToAbsolutePath = function(path) {
   if (path === '/gl-matrix-min.js') {
-    return 'empty-module';
+    return '../../../lib/empty-stub.js';
   }
   if (path === '/jszip.min.js') {
     return 'jszip/dist/jszip.min.js';

--- a/lighthouse-core/package.json
+++ b/lighthouse-core/package.json
@@ -31,7 +31,6 @@
     "chrome-devtools-frontend": "1.0.381789",
     "chrome-remote-interface": "^0.11.0",
     "devtools-timeline-model": "1.1.4",
-    "empty-module": "0.0.2",
     "gl-matrix": "2.3.2",
     "handlebars": "^4.0.5",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
helps with #428 

@zhaoz 

hard codes the path relative to `third_party/src/traceviewer-js`, but worth the tradeoff (and yet another incentive to fix our traceviewer import issues upstream)