### PR TITLE
remove redundant `npm run unit` in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,3 @@ script:
   - npm run smoke
   - cd lighthouse-extension
   - gulp build
-  - cd ../lighthouse-cli
-  - npm run unit


### PR DESCRIPTION
`npm run unit` is currently run twice (three times, if you count the coverage run) on travis since there is no `package.json` in lighthouse-cli/