### PR TITLE
Update devtools version and resource priority handling

### DIFF
--- a/lighthouse-core/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/driver/gatherers/critical-request-chains.js
@@ -36,9 +36,7 @@ class CriticalRequestChains extends Gather {
     if (resourceTypeCategory === WebInspector.resourceTypes.XHR._category) {
       return false;
     }
-    // TODO(deepanjanroy): When devtools-frontend module is updated,
-    // change `initialPriority -> CurrentPriority`
-    return includes(['VeryHigh', 'High', 'Medium'], request.initialPriority());
+    return includes(['VeryHigh', 'High', 'Medium'], request.priority());
   }
 
   afterPass(options, tracingData) {

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -81,8 +81,9 @@ class NetworkRecorder {
         data.blockedReason);
   }
 
-  onResourceChangedPriority() {
-    // TODO: Add call to dispatcher after devtools dependency is updated
+  onResourceChangedPriority(data) {
+    this.networkManager._dispatcher.resourceChangedPriority(data.requestId,
+      data.newPriority, data.timestamp);
   }
 }
 

--- a/lighthouse-core/lib/web-inspector.js
+++ b/lighthouse-core/lib/web-inspector.js
@@ -42,6 +42,16 @@ module.exports = (function() {
       }
     }
   };
+  global.Runtime.queryParam = function(arg) {
+    switch (arg) {
+      case 'remoteFrontend':
+        return false;
+      case 'ws':
+        return false;
+      default:
+        throw Error('Mock queryParam case not implemented.');
+    }
+  };
 
   global.TreeElement = {};
   global.WorkerRuntime = {};
@@ -151,7 +161,14 @@ module.exports = (function() {
     observeTargets() {}
   };
   WebInspector.settings = {
-    createSetting() {}
+    createSetting() {
+      return {
+        get() {
+          return false;
+        },
+        addChangeListener() {}
+      };
+    }
   };
   WebInspector.console = {
     error() {}
@@ -165,17 +182,18 @@ module.exports = (function() {
   require('chrome-devtools-frontend/front_end/common/SegmentedRange.js');
   require('chrome-devtools-frontend/front_end/bindings/TempFile.js');
   require('chrome-devtools-frontend/front_end/sdk/TracingModel.js');
-  require('chrome-devtools-frontend/front_end/timeline/TimelineJSProfile.js');
+  require('chrome-devtools-frontend/front_end/sdk/ProfileTreeModel.js');
   require('chrome-devtools-frontend/front_end/timeline/TimelineUIUtils.js');
+  require('chrome-devtools-frontend/front_end/timeline_model/TimelineJSProfile.js');
   require('chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js');
-  require('chrome-devtools-frontend/front_end/timeline/LayerTreeModel.js');
-  require('chrome-devtools-frontend/front_end/timeline/TimelineModel.js');
+  require('chrome-devtools-frontend/front_end/timeline_model/LayerTreeModel.js');
+  require('chrome-devtools-frontend/front_end/timeline_model/TimelineModel.js');
   require('chrome-devtools-frontend/front_end/ui_lazy/SortableDataGrid.js');
   require('chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js');
-  require('chrome-devtools-frontend/front_end/timeline/TimelineProfileTree.js');
+  require('chrome-devtools-frontend/front_end/timeline_model/TimelineProfileTree.js');
   require('chrome-devtools-frontend/front_end/components_lazy/FilmStripModel.js');
-  require('chrome-devtools-frontend/front_end/timeline/TimelineIRModel.js');
-  require('chrome-devtools-frontend/front_end/timeline/TimelineFrameModel.js');
+  require('chrome-devtools-frontend/front_end/timeline_model/TimelineIRModel.js');
+  require('chrome-devtools-frontend/front_end/timeline_model/TimelineFrameModel.js');
 
   // DevTools makes a few assumptions about using backing storage to hold traces.
   WebInspector.DeferredTempFile = function() {};

--- a/lighthouse-core/package.json
+++ b/lighthouse-core/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/googlechrome/lighthouse#readme",
   "dependencies": {
     "axe-core": "^1.1.1",
-    "chrome-devtools-frontend": "1.0.400960",
+    "chrome-devtools-frontend": "1.0.401423",
     "chrome-remote-interface": "^0.11.0",
     "devtools-timeline-model": "1.1.4",
     "gl-matrix": "2.3.2",

--- a/lighthouse-core/package.json
+++ b/lighthouse-core/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/googlechrome/lighthouse#readme",
   "dependencies": {
     "axe-core": "^1.1.1",
-    "chrome-devtools-frontend": "1.0.381789",
+    "chrome-devtools-frontend": "1.0.400960",
     "chrome-remote-interface": "^0.11.0",
     "devtools-timeline-model": "1.1.4",
     "gl-matrix": "2.3.2",

--- a/lighthouse-core/test/driver/gatherers/critical-request-chains.js
+++ b/lighthouse-core/test/driver/gatherers/critical-request-chains.js
@@ -33,11 +33,8 @@ function mockTracingData(prioritiesList, edges) {
         _resourceType: {
           _category: 'fake'
         },
-        initialPriority: () => priority,
-        initiatorRequest: () => null,
-        setInitialPriority: newPrio => {
-          priority = newPrio;
-        }
+        priority: () => priority,
+        initiatorRequest: () => null
       }));
 
   // add mock initiator information


### PR DESCRIPTION
Working on #454. `lib/traces/devtools-timeline-model` unit tests are currently failing and need to be updated to match the new devtools code. Can someone confirm whether I can just change the tests, or whether we need to adapt our code elsewhere?