### PR TITLE
correctly clip tasks to window given to getRiskToResponsiveness

### DIFF
--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -125,37 +125,60 @@ class TraceProcessor {
   /**
    * Calculate duration at specified percentiles for given population of
    * durations.
+   * If one of the durations overlaps the end of the window, the full
+   * duration should be in the duration array, but the length not included
+   * within the window should be given as `clippedLength`. For instance, if a
+   * 50ms duration occurs 10ms before the end of the window, `50` should be in
+   * the `durations` array, and `clippedLength` should be set to 40.
+   * @see https://docs.google.com/document/d/18gvP-CBA2BiBpi3Rz1I1ISciKGhniTSZ9TY0XCnXS7E/preview
    * @param {!Array<number>} durations Array of durations, sorted in ascending order.
    * @param {number} totalTime Total time (in ms) of interval containing durations.
    * @param {!Array<number>} percentiles Array of percentiles of interest, in ascending order.
+   * @param {number=} clippedLength Optional length clipped from a duration overlapping end of window. Default of 0.
    * @return {!Array<{percentile: number, time: number}>}
    * @private
    */
-  static _riskPercentiles(durations, totalTime, percentiles) {
+  static _riskPercentiles(durations, totalTime, percentiles, clippedLength) {
+    clippedLength = clippedLength || 0;
+
     let busyTime = 0;
     for (let i = 0; i < durations.length; i++) {
       busyTime += durations[i];
     }
+    busyTime -= clippedLength;
 
     // Start with idle time already complete.
     let completedTime = totalTime - busyTime;
     let duration = 0;
     let cdfTime = completedTime;
-    let remainingCount = durations.length + 1;
     const results = [];
+
+    let durationIndex = -1;
+    let remainingCount = durations.length + 1;
+    if (clippedLength > 0) {
+      // If there was a clipped duration, one less in count since one hasn't started yet.
+      remainingCount--;
+    }
 
     // Find percentiles of interest, in order.
     for (let percentile of percentiles) {
       // Loop over durations, calculating a CDF value for each until it is above
       // the target percentile.
       const percentileTime = percentile * totalTime;
-      while (cdfTime < percentileTime && remainingCount > 1) {
+      while (cdfTime < percentileTime && durationIndex < durations.length) {
         completedTime += duration;
-        remainingCount--;
-        duration = durations[durations.length - remainingCount];
+        remainingCount -= (duration < 0 ? -1 : 1);
+
+        if (clippedLength > 0 && clippedLength < durations[durationIndex + 1]) {
+          duration = -clippedLength;
+          clippedLength = 0;
+        } else {
+          durationIndex++;
+          duration = durations[durationIndex];
+        }
 
         // Calculate value of CDF (multiplied by totalTime) for the end of this duration.
-        cdfTime = completedTime + duration * remainingCount;
+        cdfTime = completedTime + Math.abs(duration) * remainingCount;
       }
 
       // Negative results are within idle time (0ms wait by definition), so clamp at zero.
@@ -171,6 +194,7 @@ class TraceProcessor {
   /**
    * Calculates the maximum queueing time (in ms) of high priority tasks for
    * selected percentiles within a window of the main thread.
+   * @see https://docs.google.com/document/d/18gvP-CBA2BiBpi3Rz1I1ISciKGhniTSZ9TY0XCnXS7E/preview
    * @param {!traceviewer.Model} model
    * @param {!Array<!Object>} trace
    * @param {number=} startTime Optional start time (in ms) of range of interest. Defaults to trace start.
@@ -183,8 +207,11 @@ class TraceProcessor {
     startTime = startTime === undefined ? model.bounds.min : startTime;
     endTime = endTime === undefined ? model.bounds.max : endTime;
     const totalTime = endTime - startTime;
-
-    percentiles = percentiles || [0.5, 0.75, 0.9, 0.99, 1];
+    if (percentiles) {
+      percentiles.sort((a, b) => a - b);
+    } else {
+      percentiles = [0.5, 0.75, 0.9, 0.99, 1];
+    }
 
     // Find the main thread.
     const startEvent = trace.find(event => {
@@ -195,18 +222,32 @@ class TraceProcessor {
     // Find durations of all slices in range of interest.
     // TODO(bckenny): filter for top level slices ourselves?
     const durations = [];
+    let clippedLength = 0;
     mainThread.sliceGroup.topLevelSlices.forEach(slice => {
       // Discard slices outside range.
       if (slice.end <= startTime || slice.start >= endTime) {
         return;
       }
 
-      durations.push(slice.duration);
+      // Clip any at edges of range.
+      let duration = slice.duration;
+      let sliceStart = slice.start;
+      if (sliceStart < startTime) {
+        // Any part of task before window can be discarded.
+        sliceStart = startTime;
+        duration = slice.end - sliceStart;
+      }
+      if (slice.end > endTime) {
+        // Any part of task after window must be clipped but accounted for.
+        clippedLength = duration - (endTime - sliceStart);
+      }
+
+      durations.push(duration);
     });
     durations.sort((a, b) => a - b);
 
     // Actual calculation of percentiles done in _riskPercentiles.
-    return TraceProcessor._riskPercentiles(durations, totalTime, percentiles);
+    return TraceProcessor._riskPercentiles(durations, totalTime, percentiles, clippedLength);
   }
 
   /**

--- a/lighthouse-core/test/lib/traces/tracing-processor.js
+++ b/lighthouse-core/test/lib/traces/tracing-processor.js
@@ -26,7 +26,7 @@ const defaultPercentiles = [0, 0.25, 0.5, 0.75, 0.9, 0.99, 1];
  * Create a riskPercentiles result object by matching the values in percentiles
  * and times.
  * @param {!Array<number>} percentiles
- * @param {!array<number>} times
+ * @param {!Array<number>} times
  * @return {!Array<{percentile: number, time: number}>}
  */
 function createRiskPercentiles(percentiles, times) {
@@ -69,6 +69,75 @@ describe('TracingProcessor lib', () => {
       const results = TracingProcessor._riskPercentiles([0, 0, 0, 10, 20, 20, 30, 30, 120], 320,
           defaultPercentiles);
       const expected = createRiskPercentiles(defaultPercentiles, [16, 16, 28, 56, 104, 132.8, 136]);
+      assert.deepEqual(results, expected);
+    });
+
+    // Three tasks of one second each, all within a five-second window.
+    // Mean Queueing Time of 300ms.
+    it('correctly calculates percentiles of three one-second tasks in a five-second window', () => {
+      const results = TracingProcessor._riskPercentiles([1000, 1000, 1000], 5000,
+          defaultPercentiles, 0);
+      // Round to hundredths to simplify floating point comparison.
+      results.forEach(result => {
+        result.time = Number(result.time.toFixed(2));
+      });
+
+      const expected = createRiskPercentiles(defaultPercentiles,
+          [16, 16, 182.67, 599.33, 849.33, 999.33, 1016]);
+      assert.deepEqual(results, expected);
+    });
+
+    it('correctly calculates percentiles of tasks with a clipped task', () => {
+      const results = TracingProcessor._riskPercentiles([10, 20, 50, 60, 90, 100], 300,
+          defaultPercentiles, 30);
+      // Round to hundredths to simplify floating point comparison.
+      results.forEach(result => {
+        result.time = Number(result.time.toFixed(2));
+      });
+
+      const expected = createRiskPercentiles(defaultPercentiles,
+          [16, 32.25, 53.5, 74.33, 96, 113, 116]);
+      assert.deepEqual(results, expected);
+    });
+
+    // One 20 second long task over three five-second windows.
+    it('correctly calculates percentiles of single task over multiple windows', () => {
+      // Starts 3 seconds into the first window. Mean Queueing Time = 7600ms.
+      const TASK_LENGTH = 20000;
+      let results1 = TracingProcessor._riskPercentiles([TASK_LENGTH], 5000,
+          defaultPercentiles, TASK_LENGTH - 2000);
+      const expected1 = createRiskPercentiles(defaultPercentiles,
+          [16, 16, 16, 18766, 19516, 19966, 20016]);
+      assert.deepEqual(results1, expected1);
+
+      // Starts 2 seconds before and ends 13 seconds after. Mean Queueing Time = 15500ms.
+      const results2 = TracingProcessor._riskPercentiles([TASK_LENGTH - 2000], 5000,
+          defaultPercentiles, TASK_LENGTH - 7000);
+      const expected2 = createRiskPercentiles(defaultPercentiles,
+          [16, 14266, 15516, 16766, 17516, 17966, 18016]);
+      assert.deepEqual(results2, expected2);
+
+      // Starts 17 seconds before and ends 3 seconds into the window. Mean Queueing Time = 900ms.
+      const results3 = TracingProcessor._riskPercentiles([TASK_LENGTH - 17000], 5000,
+          defaultPercentiles, 0);
+      const expected3 = createRiskPercentiles(defaultPercentiles,
+          [16, 16, 516, 1766, 2516, 2966, 3016]);
+      assert.deepEqual(results3, expected3);
+    });
+
+    it('correctly calculates with a task shorter than the clipped length of another', () => {
+      const results = TracingProcessor._riskPercentiles([40, 100], 100,
+          defaultPercentiles, 50);
+      const expected = createRiskPercentiles(defaultPercentiles,
+          [16, 31, 56, 91, 106, 115, 116]);
+      assert.deepEqual(results, expected);
+    });
+
+    it('correctly calculates with a task clipped completely', () => {
+      const results = TracingProcessor._riskPercentiles([40, 100], 100,
+          defaultPercentiles, 100);
+      const expected = createRiskPercentiles(defaultPercentiles,
+          [16, 16, 16, 31, 46, 55, 56]);
       assert.deepEqual(results, expected);
     });
   });


### PR DESCRIPTION
This might not be exactly what we need after we figure out how we want to report Estimated Input Latency/TTI, but makes existing EIL calculations and #450 correct. I'll add a better writeup in the (in progress) design doc.

This PR makes EIL clip any tasks that overlap the edges of the window of interest. For tasks that start before the window, a shorter task is equivalent to a clipped one, so they can just be shortened. For tasks that start during (or before) the window and end afterwards, it's more complicated.

Quick representation of a **100ms window** and a **200ms task** starting at **40ms into the window**:

![window_clipped_task](https://cloud.githubusercontent.com/assets/316891/16323633/263d2fcc-3961-11e6-8725-09cb77215b1a.png)

The intensity of the green at any point represents the time an input task queued at that moment would have to wait until it could be executed. Since the task is 200ms long, an input task queued, for example, at 41ms into the window of interest would need to wait 199ms before it could be executed.

- If naively clipped, the clipped task just becomes a much shorter task with much shorter queueing times:

  ![window_clipped_task_naive](https://cloud.githubusercontent.com/assets/316891/16324157/71549e14-3966-11e6-95a1-51fa146174ee.png)

  for the example above, treating the 200ms task as a 60ms task, **when clipped to the 100ms window in the naive manner, the median queue time is 10ms and the 90th percentile has a queue time of 50ms**. Not at all representative of the above example when over half of the window is covered by queue times approaching 200ms.

- The window can instead be lengthened to include the task over the edge, as is currently happening on master:

  ![window_clipped_task_extended](https://cloud.githubusercontent.com/assets/316891/16323910/9c764bd6-3963-11e6-8f8c-2f9d5ae5e23c.png)

  This distorts the queue time distribution. The proportion of time spent in idle in the window shrinks and all the short queue times at the end of the task are included even though well outside the window of interest. For the example above, **when the window is expanded to 240ms, the median queue time is 80ms and the 90th percentile has a queue time of 176ms**. Closer, but still significantly underestimated.

  This approach also changes the end of the window from the one explicitly specified by the caller, *and it causes unpredictable changes when doing multiple EIL calculations on a rolling basis like the current TTI PR*: consecutive windows can have the exact same end point as the window extends to cover long tasks. It

- Finally there is the solution in this PR, which continues to treat the task by its full duration but doesn't let anything outside the window contribute to the distribution of queue times.

  ![window_clipped_task_correct](https://cloud.githubusercontent.com/assets/316891/16324028/cce308f8-3964-11e6-94a0-d0311748f26c.png)

  It does this by inserting a fake duration inside the list of task durations which represents the amount of time outside of the window of interest and, when that duration is reached, subtracting it from the running total. This could be solved more generally for many clipped tasks, but since there can only ever be one task overlapping the end of the window, it's special cased into the existing loop.

  For the example above, **when properly clipped to the 100ms window, the median queue time is 150ms and the 90th percentile has a queue time of 190ms**.

