### PR TITLE
bump dtm to latest. 

### DIFF
--- a/lighthouse-core/package.json
+++ b/lighthouse-core/package.json
@@ -30,7 +30,7 @@
     "axe-core": "^1.1.1",
     "chrome-devtools-frontend": "1.0.401423",
     "chrome-remote-interface": "^0.11.0",
-    "devtools-timeline-model": "1.1.4",
+    "devtools-timeline-model": "1.1.6",
     "gl-matrix": "2.3.2",
     "handlebars": "^4.0.5",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
Now devtools-timeline-model also uses the same sub-dependency of
> "chrome-devtools-frontend": "1.0.401423",