### PR TITLE
bump speedline to 0.2.2

### DIFF
--- a/lighthouse-core/package.json
+++ b/lighthouse-core/package.json
@@ -37,7 +37,7 @@
     "jszip": "2.6.0",
     "npmlog": "^2.0.3",
     "semver": ">=4.3.3",
-    "speedline": "^0.1.2"
+    "speedline": "0.2.2"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",


### PR DESCRIPTION
Updates the downstream dependency tree to match our dtm and frontend versions

Also readies us to use perceptualSpeedIndex (and passing a dtm model into speedline directly). Both of these will come later.