### PR TITLE
Allow each pass to save its own trace

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -16,7 +16,16 @@
  */
 'use strict';
 
+const DEFAULT_TRACE = 'defaultPass';
+
 class Audit {
+  /**
+   * @return {!String}
+   */
+  static get DEFAULT_TRACE() {
+    return DEFAULT_TRACE;
+  }
+
   /**
    * @return {!AuditMeta}
    */

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -51,7 +51,7 @@ class EstimatedInputLatency extends Audit {
       // Use speedline's first paint as start of range for input latency check.
       const startTime = artifacts.Speedline.first;
 
-      const trace = artifacts[TRACE_NAME] && artifacts[TRACE_NAME].traceContents;
+      const trace = artifacts.traces[TRACE_NAME] && artifacts.traces[TRACE_NAME].traceContents;
       const tracingProcessor = new TracingProcessor();
       const model = tracingProcessor.init(trace);
       const latencyPercentiles = TracingProcessor.getRiskToResponsiveness(model, trace, startTime);

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -24,6 +24,7 @@ const Formatter = require('../formatters/formatter');
 // https://www.desmos.com/calculator/srv0hqhf7d
 const SCORING_POINT_OF_DIMINISHING_RETURNS = 50;
 const SCORING_MEDIAN = 100;
+const TRACE_NAME = 'firstPass';
 
 class EstimatedInputLatency extends Audit {
   /**
@@ -50,9 +51,9 @@ class EstimatedInputLatency extends Audit {
       // Use speedline's first paint as start of range for input latency check.
       const startTime = artifacts.Speedline.first;
 
-      const trace = artifacts.traceContents;
+      const trace = artifacts[TRACE_NAME] && artifacts[TRACE_NAME].traceContents;
       const tracingProcessor = new TracingProcessor();
-      const model = tracingProcessor.init(artifacts.traceContents);
+      const model = tracingProcessor.init(trace);
       const latencyPercentiles = TracingProcessor.getRiskToResponsiveness(model, trace, startTime);
 
       const ninetieth = latencyPercentiles.find(result => result.percentile === 0.9);

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -24,7 +24,6 @@ const Formatter = require('../formatters/formatter');
 // https://www.desmos.com/calculator/srv0hqhf7d
 const SCORING_POINT_OF_DIMINISHING_RETURNS = 50;
 const SCORING_MEDIAN = 100;
-const TRACE_NAME = 'firstPass';
 
 class EstimatedInputLatency extends Audit {
   /**
@@ -51,7 +50,8 @@ class EstimatedInputLatency extends Audit {
       // Use speedline's first paint as start of range for input latency check.
       const startTime = artifacts.Speedline.first;
 
-      const trace = artifacts.traces[TRACE_NAME] && artifacts.traces[TRACE_NAME].traceContents;
+      const trace = artifacts.traces[this.DEFAULT_TRACE] &&
+        artifacts.traces[this.DEFAULT_TRACE].traceContents;
       const tracingProcessor = new TracingProcessor();
       const model = tracingProcessor.init(trace);
       const latencyPercentiles = TracingProcessor.getRiskToResponsiveness(model, trace, startTime);

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -30,8 +30,6 @@ const SCORING_MEDIAN = 4000;
 
 const BLOCK_FIRST_MEANINGFUL_PAINT_IF_BLANK_CHARACTERS_MORE_THAN = 200;
 
-const TRACE_NAME = 'firstPass';
-
 class FirstMeaningfulPaint extends Audit {
   /**
    * @return {!AuditMeta}
@@ -55,7 +53,7 @@ class FirstMeaningfulPaint extends Audit {
    */
   static audit(artifacts) {
     return new Promise((resolve, reject) => {
-      const traceContents = artifacts.traces[TRACE_NAME].traceContents;
+      const traceContents = artifacts.traces[this.DEFAULT_TRACE].traceContents;
       if (!traceContents || !Array.isArray(traceContents)) {
         throw new Error(FAILURE_MESSAGE);
       }

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -30,6 +30,8 @@ const SCORING_MEDIAN = 4000;
 
 const BLOCK_FIRST_MEANINGFUL_PAINT_IF_BLANK_CHARACTERS_MORE_THAN = 200;
 
+const TRACE_NAME = 'firstPass';
+
 class FirstMeaningfulPaint extends Audit {
   /**
    * @return {!AuditMeta}
@@ -53,11 +55,12 @@ class FirstMeaningfulPaint extends Audit {
    */
   static audit(artifacts) {
     return new Promise((resolve, reject) => {
-      if (!artifacts.traceContents || !Array.isArray(artifacts.traceContents)) {
+      const traceContents = artifacts[TRACE_NAME].traceContents;
+      if (!traceContents || !Array.isArray(traceContents)) {
         throw new Error(FAILURE_MESSAGE);
       }
 
-      const evts = this.collectEvents(artifacts.traceContents);
+      const evts = this.collectEvents(traceContents);
 
       const navStart = evts.navigationStart;
       const fCP = evts.firstContentfulPaint;

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -55,7 +55,7 @@ class FirstMeaningfulPaint extends Audit {
    */
   static audit(artifacts) {
     return new Promise((resolve, reject) => {
-      const traceContents = artifacts[TRACE_NAME].traceContents;
+      const traceContents = artifacts.traces[TRACE_NAME].traceContents;
       if (!traceContents || !Array.isArray(traceContents)) {
         throw new Error(FAILURE_MESSAGE);
       }

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -68,7 +68,8 @@ class TTIMetric extends Audit {
 
       // Process the trace
       const tracingProcessor = new TracingProcessor();
-      const model = tracingProcessor.init(artifacts.traceContents);
+      const traceContents = artifacts.traces[Audit.DEFAULT_TRACE].traceContents;
+      const model = tracingProcessor.init(traceContents);
       const endOfTraceTime = model.bounds.max;
 
       // TODO: Wait for DOMContentLoadedEndEvent
@@ -109,7 +110,7 @@ class TTIMetric extends Audit {
         }
         // Get our expected latency for the time window
         const latencies = TracingProcessor.getRiskToResponsiveness(
-          model, artifacts.traceContents, startTime, endTime, percentiles);
+          model, traceContents, startTime, endTime, percentiles);
         const estLatency = latencies[0].time.toFixed(2);
         foundLatencies.push({
           estLatency: estLatency,

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -22,7 +22,6 @@ const Formatter = require('../formatters/formatter');
 const TimelineModel = require('../lib/traces/devtools-timeline-model');
 
 const FAILURE_MESSAGE = 'Trace data not found.';
-const TRACE_NAME = 'firstPass';
 
 /**
  * @param {!Array<!Object>} traceData
@@ -130,7 +129,8 @@ class UserTimings extends Audit {
   static audit(artifacts) {
     return new Promise((resolve, reject) => {
       const traceContents =
-        artifacts.traces[TRACE_NAME] && artifacts.traces[TRACE_NAME].traceContents;
+        artifacts.traces[this.DEFAULT_TRACE] &&
+        artifacts.traces[this.DEFAULT_TRACE].traceContents;
       if (!traceContents || !Array.isArray(traceContents)) {
         throw new Error(FAILURE_MESSAGE);
       }

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -22,6 +22,7 @@ const Formatter = require('../formatters/formatter');
 const TimelineModel = require('../lib/traces/devtools-timeline-model');
 
 const FAILURE_MESSAGE = 'Trace data not found.';
+const TRACE_NAME = 'firstPass';
 
 /**
  * @param {!Array<!Object>} traceData
@@ -128,12 +129,12 @@ class UserTimings extends Audit {
    */
   static audit(artifacts) {
     return new Promise((resolve, reject) => {
-      if (!artifacts.traceContents || !Array.isArray(artifacts.traceContents)) {
+      const traceContents = artifacts[TRACE_NAME] && artifacts[TRACE_NAME].traceContents;
+      if (!traceContents || !Array.isArray(traceContents)) {
         throw new Error(FAILURE_MESSAGE);
       }
 
-      const userTimings = filterTrace(artifacts.traceContents);
-
+      const userTimings = filterTrace(traceContents);
       resolve(UserTimings.generateAuditResult({
         rawValue: userTimings.length,
         extendedInfo: {

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -129,7 +129,8 @@ class UserTimings extends Audit {
    */
   static audit(artifacts) {
     return new Promise((resolve, reject) => {
-      const traceContents = artifacts[TRACE_NAME] && artifacts[TRACE_NAME].traceContents;
+      const traceContents =
+        artifacts.traces[TRACE_NAME] && artifacts.traces[TRACE_NAME].traceContents;
       if (!traceContents || !Array.isArray(traceContents)) {
         throw new Error(FAILURE_MESSAGE);
       }

--- a/lighthouse-core/closure/typedefs/Artifacts.js
+++ b/lighthouse-core/closure/typedefs/Artifacts.js
@@ -36,10 +36,7 @@ Artifacts.prototype.HTMLWithoutJavaScript;
 Artifacts.prototype.HTTPS;
 
 /** @type {!Array<!Object>} */
-Artifacts.prototype.networkRecords;
-
-/** @type {?} */
-Artifacts.prototype.traceContents;
+Artifacts.prototype.traces;
 
 /** @type {!ManifestNode<(!Manifest|undefined)>} */
 Artifacts.prototype.Manifest;

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -2,7 +2,7 @@
   "passes": [{
     "network": true,
     "trace": true,
-    "loadDataName": "first-pass",
+    "traceName": "firstPass",
     "loadPage": true,
     "gatherers": [
       "url",

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -2,7 +2,6 @@
   "passes": [{
     "network": true,
     "trace": true,
-    "traceName": "firstPass",
     "loadPage": true,
     "gatherers": [
       "url",

--- a/lighthouse-core/config/index.js
+++ b/lighthouse-core/config/index.js
@@ -100,8 +100,13 @@ function expandArtifacts(artifacts) {
   const expandedArtifacts = Object.assign({}, artifacts);
 
   // currently only trace logs and performance logs should be imported
-  if (artifacts.traceContents) {
-    expandedArtifacts.traceContents = require(artifacts.traceContents);
+  if (artifacts.traces) {
+    Object.keys(artifacts.traces).forEach(key => {
+      if (artifacts.traces[key].traceContents) {
+        expandedArtifacts.traces[key].traceContents =
+          require(artifacts.traces[key].traceContents);
+      }
+    });
   }
   if (artifacts.performanceLog) {
     expandedArtifacts.CriticalRequestChains =

--- a/lighthouse-core/driver/gatherers/screenshots.js
+++ b/lighthouse-core/driver/gatherers/screenshots.js
@@ -46,9 +46,10 @@ class ScreenshotFilmstrip extends Gather {
   }
 
   afterPass(options, tracingData) {
-    return this.getScreenshots(tracingData.traceContents).then(screenshots => {
-      this.artifact = screenshots;
-    });
+    return this.getScreenshots(tracingData.traceContents)
+      .then(screenshots => {
+        this.artifact = screenshots;
+      });
   }
 }
 

--- a/lighthouse-core/driver/gatherers/speedline.js
+++ b/lighthouse-core/driver/gatherers/speedline.js
@@ -16,19 +16,21 @@
  */
 'use strict';
 
+const Audit = require('../../audits/audit');
 const Gather = require('./gather');
 const speedline = require('speedline');
 
 class Speedline extends Gather {
 
   afterPass(options, tracingData) {
-    return speedline(tracingData.traceContents).then(results => {
-      this.artifact = results;
-    }).catch(err => {
-      this.artifact = {
-        debugString: err.message
-      };
-    });
+    return speedline(tracingData.traces[Audit.DEFAULT_TRACE].traceContents)
+      .then(results => {
+        this.artifact = results;
+      }).catch(err => {
+        this.artifact = {
+          debugString: err.message
+        };
+      });
   }
 }
 

--- a/lighthouse-core/driver/index.js
+++ b/lighthouse-core/driver/index.js
@@ -155,7 +155,7 @@ class Driver {
 
   static run(passes, options) {
     const driver = options.driver;
-    const tracingData = {};
+    const tracingData = {traces: {}};
 
     if (typeof options.url !== 'string' || options.url.length === 0) {
       return Promise.reject(new Error('You must provide a url to the driver'));
@@ -195,13 +195,13 @@ class Driver {
                 if (!config.traceName) {
                   return;
                 }
-                tracingData[config.traceName] = {};
+                tracingData.traces[config.traceName] = {};
                 if (config.trace) {
-                  tracingData[config.traceName].traceContents =
+                  tracingData.traces[config.traceName].traceContents =
                     loadData.traceContents;
                 }
                 if (config.network) {
-                  tracingData[config.traceName].networkRecords =
+                  tracingData.traces[config.traceName].networkRecords =
                     loadData.networkRecords;
                 }
               })

--- a/lighthouse-core/driver/index.js
+++ b/lighthouse-core/driver/index.js
@@ -191,6 +191,19 @@ class Driver {
               .then(_ => this.afterPass(runOptions))
               .then(loadData => {
                 Object.assign(tracingData, loadData);
+
+                if (!config.traceName) {
+                  return;
+                }
+                tracingData[config.traceName] = {};
+                if (config.trace) {
+                  tracingData[config.traceName].traceContents =
+                    loadData.traceContents;
+                }
+                if (config.network) {
+                  tracingData[config.traceName].networkRecords =
+                    loadData.networkRecords;
+                }
               })
               .then(_ => this.tearDown(runOptions));
         }, Promise.resolve());
@@ -215,7 +228,6 @@ class Driver {
             artifacts[gatherer.name] = gatherer.artifact;
           });
         });
-
         return artifacts;
       });
   }

--- a/lighthouse-core/driver/index.js
+++ b/lighthouse-core/driver/index.js
@@ -17,9 +17,9 @@
 'use strict';
 
 const log = require('../lib/log.js');
+const Audit = require('../audits/audit');
 
 class Driver {
-
   static loadPage(driver, options) {
     // Since a Page.reload command does not let a service worker take over, we
     // navigate away and then come back to reload. We do not `waitForLoad` on
@@ -191,10 +191,7 @@ class Driver {
               .then(_ => this.afterPass(runOptions))
               .then(loadData => {
                 Object.assign(tracingData, loadData);
-
-                if (config.traceName) {
-                  tracingData.traces[config.traceName] = loadData;
-                }
+                tracingData.traces[config.traceName || Audit.DEFAULT_TRACE] = loadData;
               })
               .then(_ => this.tearDown(runOptions));
         }, Promise.resolve());

--- a/lighthouse-core/driver/index.js
+++ b/lighthouse-core/driver/index.js
@@ -192,17 +192,8 @@ class Driver {
               .then(loadData => {
                 Object.assign(tracingData, loadData);
 
-                if (!config.traceName) {
-                  return;
-                }
-                tracingData.traces[config.traceName] = {};
-                if (config.trace) {
-                  tracingData.traces[config.traceName].traceContents =
-                    loadData.traceContents;
-                }
-                if (config.network) {
-                  tracingData.traces[config.traceName].networkRecords =
-                    loadData.networkRecords;
+                if (config.traceName) {
+                  tracingData.traces[config.traceName] = loadData;
                 }
               })
               .then(_ => this.tearDown(runOptions));

--- a/lighthouse-core/test/audits/estimated-input-latency.js
+++ b/lighthouse-core/test/audits/estimated-input-latency.js
@@ -24,7 +24,7 @@ const traceContents = require('../fixtures/traces/progressive-app.json');
 describe('Performance: estimated-input-latency audit', () => {
   it('scores a -1 with invalid trace data', () => {
     const output = Audit.audit({
-      firstPass: {traceContents: '[{"pid": 15256,"tid": 1295,"t'},
+      traces: {firstPass: {traceContents: '[{"pid": 15256,"tid": 1295,"t'}},
       Speedline: {
         first: 500
       }
@@ -35,7 +35,7 @@ describe('Performance: estimated-input-latency audit', () => {
 
   it('evaluates valid input correctly', () => {
     const output = Audit.audit({
-      firstPass: {traceContents},
+      traces: {firstPass: {traceContents}},
       Speedline: {
         first: 500
       }

--- a/lighthouse-core/test/audits/estimated-input-latency.js
+++ b/lighthouse-core/test/audits/estimated-input-latency.js
@@ -24,7 +24,7 @@ const traceContents = require('../fixtures/traces/progressive-app.json');
 describe('Performance: estimated-input-latency audit', () => {
   it('scores a -1 with invalid trace data', () => {
     const output = Audit.audit({
-      traceContents: '[{"pid": 15256,"tid": 1295,"t',
+      firstPass: {traceContents: '[{"pid": 15256,"tid": 1295,"t'},
       Speedline: {
         first: 500
       }
@@ -35,7 +35,7 @@ describe('Performance: estimated-input-latency audit', () => {
 
   it('evaluates valid input correctly', () => {
     const output = Audit.audit({
-      traceContents,
+      firstPass: {traceContents},
       Speedline: {
         first: 500
       }

--- a/lighthouse-core/test/audits/estimated-input-latency.js
+++ b/lighthouse-core/test/audits/estimated-input-latency.js
@@ -24,7 +24,7 @@ const traceContents = require('../fixtures/traces/progressive-app.json');
 describe('Performance: estimated-input-latency audit', () => {
   it('scores a -1 with invalid trace data', () => {
     const output = Audit.audit({
-      traces: {firstPass: {traceContents: '[{"pid": 15256,"tid": 1295,"t'}},
+      traces: {[Audit.DEFAULT_TRACE]: {traceContents: '[{"pid": 15256,"tid": 1295,"t'}},
       Speedline: {
         first: 500
       }
@@ -35,7 +35,7 @@ describe('Performance: estimated-input-latency audit', () => {
 
   it('evaluates valid input correctly', () => {
     const output = Audit.audit({
-      traces: {firstPass: {traceContents}},
+      traces: {[Audit.DEFAULT_TRACE]: {traceContents}},
       Speedline: {
         first: 500
       }

--- a/lighthouse-core/test/audits/first-meaningful-paint.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint.js
@@ -38,7 +38,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     it('processes a valid trace file', done => {
       const traceData = require('../fixtures/traces/progressive-app.json');
       assert.doesNotThrow(_ => {
-        Audit.audit({firstPass: {traceContents: traceData}}).then(response => {
+        Audit.audit({traces: {firstPass: {traceContents: traceData}}}).then(response => {
           fmpResult = response;
           done();
         });

--- a/lighthouse-core/test/audits/first-meaningful-paint.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint.js
@@ -38,10 +38,11 @@ describe('Performance: first-meaningful-paint audit', () => {
     it('processes a valid trace file', done => {
       const traceData = require('../fixtures/traces/progressive-app.json');
       assert.doesNotThrow(_ => {
-        Audit.audit({traces: {firstPass: {traceContents: traceData}}}).then(response => {
-          fmpResult = response;
-          done();
-        });
+        Audit.audit({traces: {[Audit.DEFAULT_TRACE]: {traceContents: traceData}}})
+          .then(response => {
+            fmpResult = response;
+            done();
+          });
       });
     });
 

--- a/lighthouse-core/test/audits/first-meaningful-paint.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint.js
@@ -38,7 +38,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     it('processes a valid trace file', done => {
       const traceData = require('../fixtures/traces/progressive-app.json');
       assert.doesNotThrow(_ => {
-        Audit.audit({traceContents: traceData}).then(response => {
+        Audit.audit({firstPass: {traceContents: traceData}}).then(response => {
           fmpResult = response;
           done();
         });

--- a/lighthouse-core/test/audits/time-to-interactive.js
+++ b/lighthouse-core/test/audits/time-to-interactive.js
@@ -26,7 +26,11 @@ const speedlineGather = new SpeedlineGather();
 describe('Performance: time-to-interactive audit', () => {
   it('scores a -1 with invalid trace data', () => {
     return Audit.audit({
-      traceContents: '[{"pid": 15256,"tid": 1295,"t',
+      traces: {
+        [Audit.DEFAULT_TRACE]: {
+          traceContents: '[{"pid": 15256,"tid": 1295,"t'
+        }
+      },
       Speedline: {
         first: 500
       }
@@ -38,7 +42,11 @@ describe('Performance: time-to-interactive audit', () => {
 
   it('evaluates valid input correctly', () => {
     let artifacts = {
-      traceContents: traceContents
+      traces: {
+        [Audit.DEFAULT_TRACE]: {
+          traceContents: traceContents
+        }
+      }
     };
     return speedlineGather.afterPass({}, artifacts).then(_ => {
       artifacts.Speedline = speedlineGather.artifact;

--- a/lighthouse-core/test/audits/user-timing.js
+++ b/lighthouse-core/test/audits/user-timing.js
@@ -29,7 +29,7 @@ describe('Performance: user-timings audit', () => {
   });
 
   it('evaluates valid input correctly', () => {
-    return Audit.audit({traces: {firstPass: {traceContents}}})
+    return Audit.audit({traces: {[Audit.DEFAULT_TRACE]: {traceContents}}})
       .then(response => {
         assert.equal(response.score, 2);
         assert.ok(!Number.isNaN(response.extendedInfo.value[0].startTime));

--- a/lighthouse-core/test/audits/user-timing.js
+++ b/lighthouse-core/test/audits/user-timing.js
@@ -29,7 +29,7 @@ describe('Performance: user-timings audit', () => {
   });
 
   it('evaluates valid input correctly', () => {
-    return Audit.audit({firstPass: {traceContents}})
+    return Audit.audit({traces: {firstPass: {traceContents}}})
       .then(response => {
         assert.equal(response.score, 2);
         assert.ok(!Number.isNaN(response.extendedInfo.value[0].startTime));

--- a/lighthouse-core/test/audits/user-timing.js
+++ b/lighthouse-core/test/audits/user-timing.js
@@ -29,14 +29,15 @@ describe('Performance: user-timings audit', () => {
   });
 
   it('evaluates valid input correctly', () => {
-    return Audit.audit({traceContents}).then(response => {
-      assert.equal(response.score, 2);
-      assert.ok(!Number.isNaN(response.extendedInfo.value[0].startTime));
-      assert.ok(typeof response.extendedInfo.value[0].endTime === 'undefined');
-      assert.ok(typeof response.extendedInfo.value[0].duration === 'undefined');
-      assert.ok(!Number.isNaN(response.extendedInfo.value[1].startTime));
-      assert.ok(!Number.isNaN(response.extendedInfo.value[1].endTime));
-      assert.ok(!Number.isNaN(response.extendedInfo.value[1].duration));
-    });
+    return Audit.audit({firstPass: {traceContents}})
+      .then(response => {
+        assert.equal(response.score, 2);
+        assert.ok(!Number.isNaN(response.extendedInfo.value[0].startTime));
+        assert.ok(typeof response.extendedInfo.value[0].endTime === 'undefined');
+        assert.ok(typeof response.extendedInfo.value[0].duration === 'undefined');
+        assert.ok(!Number.isNaN(response.extendedInfo.value[1].startTime));
+        assert.ok(!Number.isNaN(response.extendedInfo.value[1].endTime));
+        assert.ok(!Number.isNaN(response.extendedInfo.value[1].duration));
+      });
   });
 });

--- a/lighthouse-core/test/config/index.js
+++ b/lighthouse-core/test/config/index.js
@@ -130,12 +130,16 @@ describe('Config', () => {
   it('expands artifacts', () => {
     const config = new Config({
       artifacts: {
-        traceContents: path.resolve(__dirname, '../fixtures/traces/trace-user-timings.json'),
+        traces: {
+          firstPass: {
+            traceContents: path.resolve(__dirname, '../fixtures/traces/trace-user-timings.json')
+          }
+        },
         performanceLog: path.resolve(__dirname, '../fixtures/perflog.json')
       }
     });
     const traceUserTimings = require('../fixtures/traces/trace-user-timings.json');
-    assert.deepStrictEqual(config.artifacts.traceContents, traceUserTimings);
+    assert.deepStrictEqual(config.artifacts.traces.firstPass.traceContents, traceUserTimings);
     assert.ok(config.artifacts.CriticalRequestChains);
     assert.ok(config.artifacts.CriticalRequestChains['93149.1']);
     assert.ok(config.artifacts.CriticalRequestChains['93149.1'].request);

--- a/lighthouse-core/test/driver/gatherers/speedline.js
+++ b/lighthouse-core/test/driver/gatherers/speedline.js
@@ -17,6 +17,7 @@
 
 /* eslint-env mocha */
 
+const Audit = require('../../../audits/audit.js');
 const SpeedlineGather = require('../../../driver/gatherers/speedline.js');
 const assert = require('assert');
 
@@ -24,7 +25,13 @@ describe('Speedline gatherer', () => {
   it('returns an error debugString on faulty trace data', done => {
     const speedlineGather = new SpeedlineGather();
 
-    speedlineGather.afterPass({}, {traceContents: {boo: 'ya'}}).then(_ => {
+    speedlineGather.afterPass({}, {
+      traces: {
+        [Audit.DEFAULT_TRACE]: {
+          traceContents: {boo: 'ya'}
+        }
+      }
+    }).then(_ => {
       assert.ok(speedlineGather.artifact.debugString);
       assert.ok(speedlineGather.artifact.debugString.length);
       done();
@@ -36,7 +43,13 @@ describe('Speedline gatherer', () => {
     const speedlineGather = new SpeedlineGather();
     const traceContents = require('../../fixtures/traces/progressive-app.json');
 
-    return speedlineGather.afterPass({}, {traceContents}).then(_ => {
+    return speedlineGather.afterPass({}, {
+      traces: {
+        [Audit.DEFAULT_TRACE]: {
+          traceContents
+        }
+      }
+    }).then(_ => {
       const speedline = speedlineGather.artifact;
       return assert.equal(Math.round(speedline.speedIndex), 831);
     });

--- a/lighthouse-core/test/driver/index.js
+++ b/lighthouse-core/test/driver/index.js
@@ -221,13 +221,14 @@ describe('Driver', function() {
     const passes = [{
       network: true,
       trace: true,
-      loadDataName: 'first-pass',
+      traceName: 'firstPass',
       loadPage: true,
       gatherers: [
         t1
       ]
     }, {
       loadPage: true,
+      traceName: 'secondPass',
       gatherers: [
         t2
       ]

--- a/lighthouse-core/test/runner.js
+++ b/lighthouse-core/test/runner.js
@@ -16,6 +16,7 @@
 const Runner = require('../runner');
 const fakeDriver = require('./driver/fake-driver');
 const Config = require('../config');
+const Audit = require('../audits/audit');
 const assert = require('assert');
 const path = require('path');
 
@@ -87,7 +88,7 @@ describe('Runner', () => {
 
       artifacts: {
         traces: {
-          firstPass: {
+          [Audit.DEFAULT_TRACE]: {
             traceContents: path.join(__dirname,
                            '/fixtures/traces/trace-user-timings.json')
           }

--- a/lighthouse-core/test/runner.js
+++ b/lighthouse-core/test/runner.js
@@ -86,8 +86,12 @@ describe('Runner', () => {
       ],
 
       artifacts: {
-        traceContents: path.join(__dirname,
+        traces: {
+          firstPass: {
+            traceContents: path.join(__dirname,
                            '/fixtures/traces/trace-user-timings.json')
+          }
+        }
       }
     }, flags.auditWhitelist);
 


### PR DESCRIPTION
Config for passes now accepts a parameter `traceName` (formerly ignored parameter `loadDataName`), allowing each pass to store its own trace.

Currently, the name for the pass needed by an audit is hardcoded in the audit. This should probably be abstracted further in a future PR.

PTAL :)