### PR TITLE
--list-all-audits and --list-trace-categories no longer require a url.

### DIFF
--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -36,7 +36,6 @@ const cli = yargs
   .showHelpOnFail(false, 'Specify --help for available options')
 
   .usage('$0 url')
-  .demand(1, 'Please provide a url')
 
   // List of options
   .group([
@@ -99,6 +98,15 @@ Example: --output-path=./lighthouse-results.html`
   .default('audit-whitelist', 'all')
   .default('output', Printer.OUTPUT_MODE.pretty)
   .default('output-path', 'stdout')
+  .check(argv => {
+    // Make sure lighthouse has been passed a url, or at least one of --list-all-audits
+    // or --list-trace-categories. If not, stop the program and ask for a url
+    if (!argv.listAllAudits && !argv.listTraceCategories && argv._.length === 0) {
+      throw new Error('Please provide a url');
+    }
+
+    return true;
+  })
   .argv;
 
 if (cli.listAllAudits) {
@@ -113,9 +121,9 @@ if (cli.listAllAudits) {
 }
 
 if (cli.listTraceCategories) {
-  const categories = lighthouse.traceCategories;
+  const traceCategories = lighthouse.traceCategories;
 
-  process.stdout.write(JSON.stringify({traceCategories: categories}));
+  process.stdout.write(JSON.stringify({traceCategories}));
   process.exit(0);
 }
 

--- a/lighthouse-cli/test/cli/index.js
+++ b/lighthouse-cli/test/cli/index.js
@@ -21,16 +21,20 @@ const assert = require('assert');
 const childProcess = require('child_process');
 
 describe('CLI Tests', function() {
-  it('should list all audits and exit immediately after', () => {
+  it('fails if a url is not provided', () => {
+    assert.throws(() => childProcess.execSync('node lighthouse-cli/index.js'));
+  });
+
+  it('should list all audits without a url and exit immediately after', () => {
     const output = JSON.parse(childProcess.execSync(
-          'node lighthouse-cli/index.js https://example.com --list-all-audits').toString());
+          'node lighthouse-cli/index.js --list-all-audits').toString());
     assert(Array.isArray(output.audits));
     assert(output.audits.length > 0);
   });
 
-  it('should print trace categories list-trace-categories flag and exit immediately after', () => {
+  it('accepts just the list-trace-categories flag and exit immediately after', () => {
     const output = JSON.parse(childProcess.execSync(
-          'node lighthouse-cli/index.js https://example.com --list-trace-categories').toString());
+          'node lighthouse-cli/index.js --list-trace-categories').toString());
     assert(Array.isArray(output.traceCategories));
     assert(output.traceCategories.length > 0);
   });


### PR DESCRIPTION
#474 