### PR TITLE
fix HTTPS audit to actually fail on insecure URLs

### DIFF
--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -37,7 +37,8 @@ class HTTPS extends Audit {
    */
   static audit(artifacts) {
     return HTTPS.generateAuditResult({
-      value: !!artifacts.HTTPS
+      value: artifacts.HTTPS.value,
+      debugString: artifacts.HTTPS.debugString
     });
   }
 }

--- a/lighthouse-core/test/audits/is-on-https.js
+++ b/lighthouse-core/test/audits/is-on-https.js
@@ -13,25 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/is-on-https.js');
 const assert = require('assert');
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('Security: HTTPS audit', () => {
-  it('fails when no input present', () => {
-    return assert.equal(Audit.audit({}).value, false);
-  });
-
   it('fails when not on HTTPS', () => {
-    return assert.equal(Audit.audit({
-      HTTPS: false
-    }).value, false);
+    const debugString = 'Error string';
+    const result = Audit.audit({
+      HTTPS: {
+        value: false,
+        debugString
+      }
+    });
+    assert.strictEqual(result.value, false);
+    assert.strictEqual(result.debugString, debugString);
   });
 
   it('passes when on HTTPS', () => {
-    return assert.equal(Audit.audit({
-      HTTPS: true
-    }).value, true);
+    const result = Audit.audit({
+      HTTPS: {
+        value: true
+      }
+    });
+    assert.strictEqual(result.value, true);
   });
 });

--- a/lighthouse-core/test/core.js
+++ b/lighthouse-core/test/core.js
@@ -21,7 +21,11 @@ const assert = require('assert');
 describe('Core', () => {
   it('maps all audits to an array of Promises', () => {
     return Core
-      .audit([{}], ['is-on-https'])
+      .audit({
+        HTTPS: {
+          value: false
+        }
+      }, ['is-on-https'])
       .then(modifiedResults => {
         assert.ok(Array.isArray(modifiedResults));
         assert.equal(modifiedResults.length, 1);


### PR DESCRIPTION
fixes #479 

In #353, the `HTTPS` artifact changed to returning an object with a `value` property, but the audit was still checking if the `HTTPS` artifact was truthy or not. Since an object is always truthy, the audit was always passing.