### PR TITLE
Change logging library to debug (take 2)

### DIFF
--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -19,7 +19,6 @@
 'use strict';
 
 const yargs = require('yargs');
-const log = require('../lighthouse-core/lib/log.js');
 const semver = require('semver');
 const Printer = require('./printer');
 const lighthouse = require('../lighthouse-core');
@@ -132,12 +131,6 @@ const outputMode = cli.output;
 const outputPath = cli.outputPath;
 const flags = cli;
 const config = (cli.configPath && require(cli.configPath)) || null;
-
-// If the URL isn't https or localhost complain to the user.
-if (url.indexOf('https') !== 0 && url.indexOf('http://localhost') !== 0) {
-  log.warn('Lighthouse', 'The URL provided should be on HTTPS');
-  log.warn('Lighthouse', 'Performance stats will be skewed redirecting from HTTP to HTTPS.');
-}
 
 // set logging preferences
 flags.logLevel = 'info';

--- a/lighthouse-cli/printer.js
+++ b/lighthouse-cli/printer.js
@@ -44,7 +44,7 @@ const OUTPUT_MODE = {
  */
 function checkOutputMode(mode) {
   if (!OUTPUT_MODE.hasOwnProperty(mode)) {
-    log.log('warn', `Unknown output mode ${mode}; using pretty`);
+    log.warn('Printer', `Unknown output mode ${mode}; using pretty`);
     return OUTPUT_MODE.pretty;
   }
 
@@ -57,7 +57,7 @@ function checkOutputMode(mode) {
  */
 function checkOutputPath(path) {
   if (!path) {
-    log.log('warn', 'No output path set; using stdout');
+    log.warn('Printer', 'No output path set; using stdout');
     return 'stdout';
   }
 
@@ -148,7 +148,7 @@ function writeFile(filePath, output, outputMode) {
       if (err) {
         return reject(err);
       }
-      log.info('printer', `${outputMode} output written to ${filePath}`);
+      log.log('Printer', `${outputMode} output written to ${filePath}`);
       resolve();
     });
   });

--- a/lighthouse-core/core.js
+++ b/lighthouse-core/core.js
@@ -86,8 +86,8 @@ class Core {
     });
 
     if (rejected.length) {
-      log.log('info', 'Running these audits:', `${filteredAudits.join(', ')}`);
-      log.log('info', 'Skipping these audits:', `${rejected.join(', ')}`);
+      log.log('Running these audits:', `${filteredAudits.join(', ')}`);
+      log.log('Skipping these audits:', `${rejected.join(', ')}`);
     }
 
     return filteredAudits;

--- a/lighthouse-core/driver/drivers/cri.js
+++ b/lighthouse-core/driver/drivers/cri.js
@@ -84,7 +84,7 @@ class CriDriver extends Driver {
 
   beginLogging() {
     // log events received
-    this._chrome.on('event', req => _log('verbose', '<=', req));
+    this._chrome.on('event', req => _log('<=', req, 'verbose'));
   }
 
   /**
@@ -97,7 +97,7 @@ class CriDriver extends Driver {
       throw new Error('connect() must be called before attempting to listen to events.');
     }
     // log event listeners being bound
-    _log('info', 'listen for event =>', {method: eventName});
+    _log('listen for event =>', {method: eventName});
     this._chrome.on(eventName, cb);
   }
 
@@ -112,7 +112,7 @@ class CriDriver extends Driver {
       throw new Error('connect() must be called before attempting to listen to events.');
     }
     // log event listeners being bound
-    _log('info', 'listen once for event =>', {method: eventName});
+    _log('listen once for event =>', {method: eventName});
     this._chrome.once(eventName, cb);
   }
 
@@ -141,25 +141,25 @@ class CriDriver extends Driver {
     }
 
     return new Promise((resolve, reject) => {
-      _log('http', 'method => browser', {method: command, params: params});
+      _log('method => browser', {method: command, params: params});
 
       this._chrome.send(command, params, (err, result) => {
         if (err) {
-          _log('error', 'method <= browser', {method: command, params: result});
+          _log('method <= browser ERR', {method: command, params: result}, 'error');
           return reject(result);
         }
-        _log('http', 'method <= browser OK', {method: command, params: result});
+        _log('method <= browser OK', {method: command, params: result});
         resolve(result);
       });
     });
   }
 }
 
-function _log(level, prefix, data) {
+function _log(prefix, data, level) {
   const columns = (typeof process === 'undefined') ? Infinity : process.stdout.columns;
-  const maxLength = columns - data.method.length - prefix.length - 7;
+  const maxLength = columns - data.method.length - prefix.length - 18;
   const snippet = data.params ? JSON.stringify(data.params).substr(0, maxLength) : '';
-  log.log(level, prefix, data.method, snippet);
+  log[level ? level : 'log'](prefix, data.method, snippet);
 }
 
 module.exports = CriDriver;

--- a/lighthouse-core/driver/drivers/extension.js
+++ b/lighthouse-core/driver/drivers/extension.js
@@ -123,11 +123,11 @@ class ExtensionDriver extends Driver {
     return new Promise((resolve, reject) => {
       log.log('method => browser', command, params);
       if (!this._tabId) {
-        log.log('error', 'No tabId set for sendCommand');
+        log.error('No tabId set for sendCommand');
       }
       chrome.debugger.sendCommand({tabId: this._tabId}, command, params, result => {
         if (chrome.runtime.lastError) {
-          log.log('error', 'method <= browser', command, result);
+          log.error('method <= browser', command, result);
           return reject(chrome.runtime.lastError);
         }
 

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -33,6 +33,17 @@ module.exports = function(url, flags, config) {
     if (!url) {
       return reject(new Error('Lighthouse requires a URL'));
     }
+
+    // set logging preferences, assume quiet
+    flags.logLevel = flags.logLevel || 'error';
+    log.setLevel(flags.logLevel);
+
+    // If the URL isn't https or localhost complain to the user.
+    if (url.indexOf('https') !== 0 && url.indexOf('http://localhost') !== 0) {
+      log.warn('Lighthouse', 'The URL provided should be on HTTPS');
+      log.warn('Lighthouse', 'Performance stats will be skewed redirecting from HTTP to HTTPS.');
+    }
+
     flags = flags || {};
 
     // Override the default config with any user config.
@@ -41,15 +52,6 @@ module.exports = function(url, flags, config) {
     }
 
     const driver = new ChromeProtocol();
-
-    // set logging preferences, assume quiet
-    log.level = 'error';
-
-    // There's little point in testing the logging level, so skip.
-    /* istanbul ignore if */
-    if (flags.logLevel) {
-      log.level = flags.logLevel;
-    }
 
     // kick off a lighthouse run
     resolve(Runner.run(driver, {url, flags, config}));

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -77,7 +77,7 @@ img {
 function saveArtifacts(artifacts, filename) {
   const artifactsFilename = filename || 'artifacts.log';
   fs.writeFileSync(artifactsFilename, stringify(artifacts));
-  log.log('info', 'artifacts file saved to disk', artifactsFilename);
+  log.log('artifacts file saved to disk', artifactsFilename);
 }
 
 function prepareAssets(options, artifacts) {
@@ -91,11 +91,11 @@ function saveAssets(options, artifacts) {
 
   const traceFilename = getFilenamePrefix(options);
   fs.writeFileSync(traceFilename + '.trace.json', stringify(assets.traceData, null, 2));
-  log.log('info', 'trace file saved to disk', traceFilename);
+  log.log('trace file saved to disk', traceFilename);
 
   const screenshotsFilename = getFilenamePrefix(options);
   fs.writeFileSync(screenshotsFilename + '.screenshots.html', assets.html);
-  log.log('info', 'screenshots saved to disk', screenshotsFilename);
+  log.log('screenshots saved to disk', screenshotsFilename);
 }
 
 module.exports = {

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -16,9 +16,39 @@
  */
 'use strict';
 
-const npmlog = require('npmlog');
+const debug = require('debug');
 
-// Use `npmlog` in node, `console` in browser and electron.
-const isNode = !!process && !process.browser && !process.versions.electron;
+function setLevel(level) {
+  if (level === 'verbose') {
+    debug.enable('*');
+  } else if (level === 'error') {
+    debug.enable('*:error');
+  } else {
+    debug.enable('*, -*:verbose');
+  }
+}
 
-module.exports = isNode ? npmlog : console;
+const loggers = {};
+function _log(title, logargs) {
+  const args = [...logargs].slice(1);
+  if (!loggers[title]) {
+    loggers[title] = debug(title);
+  }
+  return loggers[title](...args);
+}
+
+module.exports = {
+  setLevel,
+  log(title) {
+    return _log(title, arguments);
+  },
+  warn(title) {
+    return _log(`${title}:warn`, arguments);
+  },
+  error(title) {
+    return _log(`${title}:error`, arguments);
+  },
+  verbose(title) {
+    return _log(`${title}:verbose`, arguments);
+  }
+};

--- a/lighthouse-core/package.json
+++ b/lighthouse-core/package.json
@@ -30,12 +30,12 @@
     "axe-core": "^1.1.1",
     "chrome-devtools-frontend": "1.0.401423",
     "chrome-remote-interface": "^0.11.0",
+    "debug": "^2.2.0",
     "devtools-timeline-model": "1.1.6",
     "gl-matrix": "2.3.2",
     "handlebars": "^4.0.5",
     "json-stringify-safe": "^5.0.1",
     "jszip": "2.6.0",
-    "npmlog": "^2.0.3",
     "semver": ">=4.3.3",
     "speedline": "0.2.2"
   },

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -20,6 +20,7 @@
 const ExtensionProtocol = require('../../../lighthouse-core/driver/drivers/extension');
 const Runner = require('../../../lighthouse-core/runner');
 const config = require('../../../lighthouse-core/config/default.json');
+const log = require('../../../lighthouse-core/lib/log');
 
 window.createPageAndPopulate = function(results) {
   const tabURL = chrome.extension.getURL('/pages/report.html');
@@ -36,6 +37,9 @@ window.createPageAndPopulate = function(results) {
 };
 
 window.runAudits = function(options) {
+  // Default to 'info' logging level.
+  log.setLevel('info');
+
   const driver = new ExtensionProtocol();
 
   return driver.getCurrentTabURL()

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -114,7 +114,6 @@ gulp.task('browserify', () => {
       .transform('./dtm-transform.js', {
         global: true
       })
-      .ignore('npmlog')
       .ignore('chrome-remote-interface');
 
       const corePath = /\.\.\/lighthouse-core\//;


### PR DESCRIPTION
@paulirish @zhaoz 
reapplying #430 but avoiding the really messy rebase or merge.

Basically the same PR, changes are
- moving the url-is-http warning to core/index.js so it's logged (debug logs nothing without `debug.enable(something)` first)
- enabling extension logging to the same level npmlog had as its default
- a few log titles here and there to avoid `undefined`s in the output

the last bullet point still isn't perfect, but we can tweak in the future

