### PR TITLE
eslintignore extension code at root level

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,7 @@
 **/node_modules/**
 **/third_party/**
 
-**/dist/
+lighthouse-extension/
 
 **/closure/*/*
 coverage/**


### PR DESCRIPTION
right now `npm run lint` is running over code in lighthouse-extension/, which is fine if you've never built the extension before (like on travis, where the extension is built last), but fails if you have built it.

the extension has its own lint task anyways, and the task is run in the `gulp build` task in our travis.yml, so ignoring the whole directory is fine