### PR TITLE
Resolve audit result

### DIFF
--- a/lighthouse-cli/printer.js
+++ b/lighthouse-cli/printer.js
@@ -99,9 +99,9 @@ function createOutput(results, outputMode) {
       }
 
       item.subItems.forEach(subitem => {
-        let lineItem = ` -- ${subitem.description}: ${subitem.value}`;
-        if (typeof subitem.rawValue !== 'undefined') {
-          lineItem += ` (${subitem.rawValue})`;
+        let lineItem = ` -- ${subitem.description}: ${subitem.score}`;
+        if (subitem.displayValue) {
+          lineItem += ` (${subitem.displayValue})`;
         }
         output += `${lineItem}\n`;
         if (subitem.debugString) {

--- a/lighthouse-cli/test/fixtures/sample.json
+++ b/lighthouse-cli/test/fixtures/sample.json
@@ -39,8 +39,9 @@
           "description": "Users notice if sites and apps don't perform well. These top-level metrics capture the most important perceived performance concerns.",
           "subItems": [
             {
-              "value": 100,
-              "rawValue": "920.5ms",
+              "score": 100,
+              "displayValue": "920.5ms",
+              "rawValue": "920.5",
               "optimalValue": "1,600ms",
               "extendedInfo": {
                 "timings": {
@@ -57,6 +58,7 @@
             },
             {
               "value": 99,
+              "displayValue": "1068",
               "rawValue": 1068,
               "optimalValue": "1,250",
               "extendedInfo": {
@@ -301,6 +303,7 @@
             },
             {
               "value": true,
+              "displayValue": "#4527A0",
               "rawValue": "#4527A0",
               "name": "theme-color-meta",
               "category": "HTML",

--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -79,21 +79,21 @@ class Aggregate {
     }
 
     if (typeof result === 'undefined' ||
-        typeof result.value === 'undefined') {
+        typeof result.score === 'undefined') {
       return weight;
     }
 
-    if (typeof result.value !== typeof expected.value) {
+    if (typeof result.score !== typeof expected.value) {
       return weight;
     }
 
     switch (typeof expected.value) {
       case 'boolean':
-        weight = this._convertBooleanToWeight(result.value, expected.value, expected.weight);
+        weight = this._convertBooleanToWeight(result.score, expected.value, expected.weight);
         break;
 
       case 'number':
-        weight = this._convertNumberToWeight(result.value, expected.value, expected.weight);
+        weight = this._convertNumberToWeight(result.score, expected.value, expected.weight);
         break;
 
       default:
@@ -154,7 +154,7 @@ class Aggregate {
         // TODO(paullewis): Remove once coming soon audits have landed.
         if (item.criteria[e].comingSoon) {
           subItems.push({
-            value: '¯\\_(ツ)_/¯', // TODO(samthor): Patch going to Closure, String.raw is badly typed
+            score: '¯\\_(ツ)_/¯', // TODO(samthor): Patch going to Closure, String.raw is badly typed
             name: 'coming-soon',
             category: item.criteria[e].category,
             description: item.criteria[e].description,

--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -73,27 +73,28 @@ class Aggregate {
     let weight = 0;
 
     if (typeof expected === 'undefined' ||
-        typeof expected.value === 'undefined' ||
+        typeof expected.rawValue === 'undefined' ||
         typeof expected.weight === 'undefined') {
       return weight;
     }
 
     if (typeof result === 'undefined' ||
+        typeof result.rawValue === 'undefined' ||
         typeof result.score === 'undefined') {
       return weight;
     }
 
-    if (typeof result.score !== typeof expected.value) {
+    if (typeof result.rawValue !== typeof expected.rawValue) {
       return weight;
     }
 
-    switch (typeof expected.value) {
+    switch (typeof expected.rawValue) {
       case 'boolean':
-        weight = this._convertBooleanToWeight(result.score, expected.value, expected.weight);
+        weight = this._convertBooleanToWeight(result.score, expected.rawValue, expected.weight);
         break;
 
       case 'number':
-        weight = this._convertNumberToWeight(result.score, expected.value, expected.weight);
+        weight = this._convertNumberToWeight(result.score, expected.rawValue, expected.weight);
         break;
 
       default:

--- a/lighthouse-core/audits/aria-allowed-attr.js
+++ b/lighthouse-core/audits/aria-allowed-attr.js
@@ -42,7 +42,7 @@ class ARIAAllowedAttr extends Audit {
         artifacts.Accessibility.violations.find(result => result.id === 'aria-allowed-attr');
 
     return ARIAAllowedAttr.generateAuditResult({
-      value: typeof rule === 'undefined',
+      rawValue: typeof rule === 'undefined',
       debugString: this.createDebugString(rule),
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.ACCESSIBILITY,

--- a/lighthouse-core/audits/aria-valid-attr.js
+++ b/lighthouse-core/audits/aria-valid-attr.js
@@ -42,7 +42,7 @@ class ARIAValidAttr extends Audit {
         artifacts.Accessibility.violations.find(result => result.id === 'aria-valid-attr');
 
     return ARIAValidAttr.generateAuditResult({
-      value: typeof rule === 'undefined',
+      rawValue: typeof rule === 'undefined',
       debugString: this.createDebugString(rule),
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.ACCESSIBILITY,

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -33,17 +33,19 @@ class Audit {
       throw new Error('generateAuditResult requires a rawValue');
     }
 
+    let score = result.score ? result.score : result.rawValue;
     let displayValue = result.displayValue;
     if (!displayValue) {
       displayValue = result.rawValue ? result.rawValue : '';
     }
 
-    if (displayValue === true) {
+    // The same value or true should be '' it doesn't add value to the report
+    if (displayValue === score) {
       displayValue = '';
     }
 
     return {
-      score: result.score ? result.score : result.rawValue,
+      score,
       displayValue: `${displayValue}`,
       rawValue: result.rawValue,
       debugString: result.debugString,

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -33,9 +33,9 @@ class Audit {
       throw new Error('generateAuditResult requires a rawValue');
     }
 
-    let score = result.score ? result.score : result.rawValue;
+    let score = typeof result.score === 'undefined' ? result.rawValue : result.score;
     let displayValue = result.displayValue;
-    if (!displayValue) {
+    if (typeof displayValue === 'undefined') {
       displayValue = result.rawValue ? result.rawValue : '';
     }
 

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -29,12 +29,22 @@ class Audit {
    * @return {!AuditResult}
    */
   static generateAuditResult(result) {
-    if (typeof result.value === 'undefined') {
-      throw new Error('generateAuditResult requires a value');
+    if (typeof result.rawValue === 'undefined') {
+      throw new Error('generateAuditResult requires a rawValue');
+    }
+
+    let displayValue = result.displayValue;
+    if (!displayValue) {
+      displayValue = result.rawValue ? result.rawValue : '';
+    }
+
+    if (displayValue === true) {
+      displayValue = '';
     }
 
     return {
-      value: result.value,
+      score: result.score ? result.score : result.rawValue,
+      displayValue: `${displayValue}`,
       rawValue: result.rawValue,
       debugString: result.debugString,
       optimalValue: result.optimalValue,

--- a/lighthouse-core/audits/color-contrast.js
+++ b/lighthouse-core/audits/color-contrast.js
@@ -42,7 +42,7 @@ class ColorContrast extends Audit {
         artifacts.Accessibility.violations.find(result => result.id === 'color-contrast');
 
     return ColorContrast.generateAuditResult({
-      value: typeof rule === 'undefined',
+      rawValue: typeof rule === 'undefined',
       debugString: this.createDebugString(rule),
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.ACCESSIBILITY,

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -59,7 +59,7 @@ class CriticalRequestChains extends Audit {
     walk(artifacts.CriticalRequestChains, 0);
 
     return CriticalRequestChains.generateAuditResult({
-      value: chainCount,
+      rawValue: chainCount,
       optimalValue: this.meta.optimalValue,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.CRITICAL_REQUEST_CHAINS,

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -56,7 +56,7 @@ class EstimatedInputLatency extends Audit {
       const latencyPercentiles = TracingProcessor.getRiskToResponsiveness(model, trace, startTime);
 
       const ninetieth = latencyPercentiles.find(result => result.percentile === 0.9);
-      const rawValue = ninetieth.time.toFixed(1) + 'ms';
+      const rawValue = ninetieth.time.toFixed(1);
 
       // Use the CDF of a log-normal distribution for scoring.
       //  10th Percentile ≈ 58ms
@@ -69,9 +69,10 @@ class EstimatedInputLatency extends Audit {
       let score = 100 * distribution.computeComplementaryPercentile(ninetieth.time);
 
       return EstimatedInputLatency.generateAuditResult({
-        value: Math.round(score),
+        score: Math.round(score),
         optimalValue: this.meta.optimalValue,
         rawValue,
+        displayValue: `${rawValue}ms`,
         extendedInfo: {
           value: latencyPercentiles,
           formatter: Formatter.SUPPORTED_FORMATS.ESTIMATED_INPUT_LATENCY
@@ -79,7 +80,7 @@ class EstimatedInputLatency extends Audit {
       });
     } catch (err) {
       return EstimatedInputLatency.generateAuditResult({
-        value: -1,
+        rawValue: -1,
         debugString: 'Unable to parse trace contents: ' + err.message
       });
     }

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -79,8 +79,9 @@ class FirstMeaningfulPaint extends Audit {
       const result = this.calculateScore(data);
 
       resolve(FirstMeaningfulPaint.generateAuditResult({
-        value: result.score,
+        score: result.score,
         rawValue: result.duration,
+        displayValue: `${result.duration}ms`,
         debugString: result.debugString,
         optimalValue: this.meta.optimalValue,
         extendedInfo: result.extendedInfo
@@ -88,7 +89,7 @@ class FirstMeaningfulPaint extends Audit {
     }).catch(err => {
       // Recover from trace parsing failures.
       return FirstMeaningfulPaint.generateAuditResult({
-        value: -1,
+        rawValue: -1,
         debugString: err.message
       });
     });
@@ -127,8 +128,9 @@ class FirstMeaningfulPaint extends Audit {
     score = Math.max(0, score);
 
     return {
-      duration: `${firstMeaningfulPaint.toFixed(1)}ms`,
+      duration: `${firstMeaningfulPaint.toFixed(1)}`,
       score: Math.round(score),
+      rawValue: firstMeaningfulPaint.toFixed(1),
       extendedInfo: {timings}
     };
   }

--- a/lighthouse-core/audits/image-alt.js
+++ b/lighthouse-core/audits/image-alt.js
@@ -42,7 +42,7 @@ class ImageAlt extends Audit {
         artifacts.Accessibility.violations.find(result => result.id === 'image-alt');
 
     return ImageAlt.generateAuditResult({
-      value: typeof rule === 'undefined',
+      rawValue: typeof rule === 'undefined',
       debugString: this.createDebugString(rule),
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.ACCESSIBILITY,

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -37,7 +37,7 @@ class HTTPS extends Audit {
    */
   static audit(artifacts) {
     return HTTPS.generateAuditResult({
-      value: artifacts.HTTPS.value,
+      rawValue: artifacts.HTTPS.value,
       debugString: artifacts.HTTPS.debugString
     });
   }

--- a/lighthouse-core/audits/label.js
+++ b/lighthouse-core/audits/label.js
@@ -42,7 +42,7 @@ class Label extends Audit {
         artifacts.Accessibility.violations.find(result => result.id === 'label');
 
     return Label.generateAuditResult({
-      value: typeof rule === 'undefined',
+      rawValue: typeof rule === 'undefined',
       debugString: this.createDebugString(rule),
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.ACCESSIBILITY,

--- a/lighthouse-core/audits/manifest-background-color.js
+++ b/lighthouse-core/audits/manifest-background-color.js
@@ -51,7 +51,7 @@ class ManifestBackgroundColor extends Audit {
         .hasBackgroundColorValue(artifacts.Manifest.value);
 
     return ManifestBackgroundColor.generateAuditResult({
-      value: hasBackgroundColor
+      rawValue: hasBackgroundColor
     });
   }
 }

--- a/lighthouse-core/audits/manifest-display.js
+++ b/lighthouse-core/audits/manifest-display.js
@@ -52,8 +52,8 @@ class ManifestDisplay extends Audit {
     const hasRecommendedValue = ManifestDisplay.hasRecommendedValue(displayValue);
 
     return ManifestDisplay.generateAuditResult({
-      value: hasRecommendedValue,
-      rawValue: displayValue,
+      rawValue: hasRecommendedValue,
+      displayValue,
       debugString: 'Manifest display property should be standalone or fullscreen.'
     });
   }

--- a/lighthouse-core/audits/manifest-exists.js
+++ b/lighthouse-core/audits/manifest-exists.js
@@ -38,7 +38,7 @@ class ManifestExists extends Audit {
    */
   static audit(artifacts) {
     return ManifestExists.generateAuditResult({
-      value: typeof artifacts.Manifest.value !== 'undefined',
+      rawValue: typeof artifacts.Manifest.value !== 'undefined',
       debugString: artifacts.Manifest.debugString
     });
   }

--- a/lighthouse-core/audits/manifest-icons-min-144.js
+++ b/lighthouse-core/audits/manifest-icons-min-144.js
@@ -42,7 +42,7 @@ class ManifestIconsMin144 extends Audit {
 
     if (icons.doExist(manifest) === false) {
       return ManifestIconsMin144.generateAuditResult({
-        value: false,
+        rawValue: false,
         debugString: 'WARNING: No icons found in the manifest'
       });
     }
@@ -51,7 +51,7 @@ class ManifestIconsMin144 extends Audit {
     const foundSizesDebug = matchingIcons.length ?
         `Found icons of sizes: ${matchingIcons}` : undefined;
     return ManifestIconsMin144.generateAuditResult({
-      value: !!matchingIcons.length,
+      rawValue: !!matchingIcons.length,
       debugString: foundSizesDebug
     });
   }

--- a/lighthouse-core/audits/manifest-icons-min-192.js
+++ b/lighthouse-core/audits/manifest-icons-min-192.js
@@ -42,7 +42,7 @@ class ManifestIconsMin192 extends Audit {
 
     if (icons.doExist(manifest) === false) {
       return ManifestIconsMin192.generateAuditResult({
-        value: false,
+        rawValue: false,
         debugString: 'WARNING: No icons found in the manifest'
       });
     }
@@ -52,7 +52,7 @@ class ManifestIconsMin192 extends Audit {
     const foundSizesDebug = matchingIcons.length ?
         `Found icons of sizes: ${matchingIcons}` : undefined;
     return ManifestIconsMin192.generateAuditResult({
-      value: !!matchingIcons.length,
+      rawValue: !!matchingIcons.length,
       debugString: foundSizesDebug
     });
   }

--- a/lighthouse-core/audits/manifest-name.js
+++ b/lighthouse-core/audits/manifest-name.js
@@ -45,7 +45,7 @@ class ManifestName extends Audit {
     }
 
     return ManifestName.generateAuditResult({
-      value: hasName
+      rawValue: hasName
     });
   }
 }

--- a/lighthouse-core/audits/manifest-short-name-length.js
+++ b/lighthouse-core/audits/manifest-short-name-length.js
@@ -57,7 +57,7 @@ class ManifestShortNameLength extends Audit {
     }
 
     return ManifestShortNameLength.generateAuditResult({
-      value: isShortNameShortEnough,
+      rawValue: isShortNameShortEnough,
       debugString
     });
   }

--- a/lighthouse-core/audits/manifest-short-name.js
+++ b/lighthouse-core/audits/manifest-short-name.js
@@ -45,7 +45,7 @@ class ManifestShortName extends Audit {
     }
 
     return ManifestShortName.generateAuditResult({
-      value: hasShortName
+      rawValue: hasShortName
     });
   }
 }

--- a/lighthouse-core/audits/manifest-start-url.js
+++ b/lighthouse-core/audits/manifest-start-url.js
@@ -45,7 +45,7 @@ class ManifestStartUrl extends Audit {
     }
 
     return ManifestStartUrl.generateAuditResult({
-      value: hasStartUrl
+      rawValue: hasStartUrl
     });
   }
 }

--- a/lighthouse-core/audits/manifest-theme-color.js
+++ b/lighthouse-core/audits/manifest-theme-color.js
@@ -45,7 +45,7 @@ class ManifestThemeColor extends Audit {
     }
 
     return ManifestThemeColor.generateAuditResult({
-      value: hasThemeColor
+      rawValue: hasThemeColor
     });
   }
 }

--- a/lighthouse-core/audits/meta-theme-color.js
+++ b/lighthouse-core/audits/meta-theme-color.js
@@ -40,22 +40,22 @@ class ThemeColor extends Audit {
     const themeColorMeta = artifacts.ThemeColor;
     if (!themeColorMeta) {
       return ThemeColor.generateAuditResult({
-        value: false,
+        rawValue: false,
         debugString: 'No valid theme-color meta tag found.'
       });
     }
 
     if (!validColor(themeColorMeta)) {
       return ThemeColor.generateAuditResult({
-        value: false,
-        rawValue: themeColorMeta,
+        displayValue: themeColorMeta,
+        rawValue: false,
         debugString: 'The theme-color meta tag did not contain a valid CSS color.'
       });
     }
 
     return ThemeColor.generateAuditResult({
-      value: true,
-      rawValue: themeColorMeta
+      displayValue: themeColorMeta,
+      rawValue: true
     });
   }
 }

--- a/lighthouse-core/audits/redirects-http.js
+++ b/lighthouse-core/audits/redirects-http.js
@@ -39,12 +39,12 @@ class RedirectsHTTP extends Audit {
     if (!artifacts.HTTPRedirect ||
         !artifacts.HTTPRedirect.value) {
       return RedirectsHTTP.generateAuditResult({
-        value: false
+        rawValue: false
       });
     }
 
     return RedirectsHTTP.generateAuditResult({
-      value: artifacts.HTTPRedirect.value,
+      rawValue: artifacts.HTTPRedirect.value,
       debugString: artifacts.HTTPRedirect.debugString
     });
   }

--- a/lighthouse-core/audits/screenshots.js
+++ b/lighthouse-core/audits/screenshots.js
@@ -42,13 +42,13 @@ class Screenshots extends Audit {
 
     if (typeof screenshots === 'undefined') {
       return Screenshots.generateAuditResult({
-        value: -1,
+        rawValue: -1,
         debugString: 'No screenshot artifact'
       });
     }
 
     return Screenshots.generateAuditResult({
-      value: screenshots.length || 0,
+      rawValue: screenshots.length || 0,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.NULL,
         value: screenshots

--- a/lighthouse-core/audits/service-worker.js
+++ b/lighthouse-core/audits/service-worker.js
@@ -38,7 +38,7 @@ class ServiceWorker extends Audit {
    */
   static audit(artifacts) {
     return ServiceWorker.generateAuditResult({
-      value: !!artifacts.ServiceWorker.version,
+      rawValue: !!artifacts.ServiceWorker.version,
       debugString: artifacts.ServiceWorker.debugString
     });
   }

--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -53,28 +53,28 @@ class SpeedIndexMetric extends Audit {
       // Speedline gather failed; pass on error condition.
       if (speedline.debugString) {
         return resolve(SpeedIndexMetric.generateAuditResult({
-          value: -1,
+          rawValue: -1,
           debugString: speedline.debugString
         }));
       }
 
       if (speedline.frames.length === 0) {
         return resolve(SpeedIndexMetric.generateAuditResult({
-          value: -1,
+          rawValue: -1,
           debugString: 'Trace unable to find visual progress frames.'
         }));
       }
 
       if (speedline.frames.length < 3) {
         return resolve(SpeedIndexMetric.generateAuditResult({
-          value: -1,
+          rawValue: -1,
           debugString: 'Trace unable to find sufficient frames to evaluate Speed Index.'
         }));
       }
 
       if (speedline.speedIndex === 0) {
         return resolve(SpeedIndexMetric.generateAuditResult({
-          value: -1,
+          rawValue: -1,
           debugString: 'Error in Speedline calculating Speed Index (speedIndex of 0).'
         }));
       }
@@ -106,7 +106,7 @@ class SpeedIndexMetric extends Audit {
       };
 
       resolve(SpeedIndexMetric.generateAuditResult({
-        value: Math.round(score),
+        score: Math.round(score),
         rawValue: Math.round(speedline.speedIndex),
         optimalValue: this.meta.optimalValue,
         extendedInfo: {

--- a/lighthouse-core/audits/tabindex.js
+++ b/lighthouse-core/audits/tabindex.js
@@ -42,7 +42,7 @@ class TabIndex extends Audit {
         artifacts.Accessibility.violations.find(result => result.id === 'tabindex');
 
     return TabIndex.generateAuditResult({
-      value: typeof rule === 'undefined',
+      rawValue: typeof rule === 'undefined',
       debugString: this.createDebugString(rule),
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.ACCESSIBILITY,

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -129,7 +129,7 @@ class UserTimings extends Audit {
   static audit(artifacts) {
     if (!artifacts.traceContents || !Array.isArray(artifacts.traceContents)) {
       return UserTimings.generateAuditResult({
-        value: -1,
+        rawValue: -1,
         debugString: FAILURE_MESSAGE
       });
     }
@@ -137,7 +137,7 @@ class UserTimings extends Audit {
     const userTimings = filterTrace(artifacts.traceContents);
 
     return UserTimings.generateAuditResult({
-      value: userTimings.length,
+      rawValue: userTimings.length,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.USER_TIMINGS,
         value: userTimings

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -39,7 +39,7 @@ class Viewport extends Audit {
     const hasMobileViewport = typeof artifacts.Viewport === 'string' &&
         artifacts.Viewport.includes('width=');
     return Viewport.generateAuditResult({
-      value: !!hasMobileViewport
+      rawValue: !!hasMobileViewport
     });
   }
 }

--- a/lighthouse-core/audits/without-javascript.js
+++ b/lighthouse-core/audits/without-javascript.js
@@ -45,7 +45,7 @@ class WithoutJavaScript extends Audit {
     }
 
     return WithoutJavaScript.generateAuditResult({
-      value: bodyHasContent,
+      rawValue: bodyHasContent,
       debugString
     });
   }

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -37,7 +37,7 @@ class WorksOffline extends Audit {
    */
   static audit(artifacts) {
     return WorksOffline.generateAuditResult({
-      value: artifacts.Offline === 200
+      rawValue: artifacts.Offline === 200
     });
   }
 }

--- a/lighthouse-core/closure/typedefs/Aggregation.js
+++ b/lighthouse-core/closure/typedefs/Aggregation.js
@@ -27,7 +27,7 @@
 function AggregationCriterion() {}
 
 /** @type {(boolean|number|undefined)} */
-AggregationCriterion.prototype.value;
+AggregationCriterion.prototype.rawValue;
 
 /** @type {number} */
 AggregationCriterion.prototype.weight;

--- a/lighthouse-core/closure/typedefs/AuditResult.js
+++ b/lighthouse-core/closure/typedefs/AuditResult.js
@@ -27,10 +27,13 @@
 function AuditResultInput() {}
 
 /** @type {(boolean|number|string)} */
-AuditResultInput.prototype.value;
+AuditResultInput.prototype.score;
 
-/** @type {(boolean|number|string|undefined|null)} */
+/** @type {(boolean|number|undefined|null)} */
 AuditResultInput.prototype.rawValue;
+
+/** @type {(string)} */
+AuditResultInput.prototype.displayValue;
 
 /** @type {(string|undefined)} */
 AuditResultInput.prototype.debugString;

--- a/lighthouse-core/closure/typedefs/AuditResult.js
+++ b/lighthouse-core/closure/typedefs/AuditResult.js
@@ -29,7 +29,7 @@ function AuditResultInput() {}
 /** @type {(boolean|number|string)} */
 AuditResultInput.prototype.score;
 
-/** @type {(boolean|number|undefined|null)} */
+/** @type {(boolean|number|undefined)} */
 AuditResultInput.prototype.rawValue;
 
 /** @type {(string)} */
@@ -89,7 +89,7 @@ UserTimingsExtendedInfo.prototype.duration;
 function AuditResult() {}
 
 /** @type {(boolean|number|string)} */
-AuditResult.prototype.value;
+AuditResult.prototype.score;
 
 /** @type {(boolean|number|string|undefined|null)} */
 AuditResult.prototype.rawValue;

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -74,15 +74,15 @@
       "description": "Ensuring your web app can respond when the network connection is unavailable or flaky is critical to providing your users a good experience. This is achieved through use of a <a href=\"https://developers.google.com/web/fundamentals/primers/service-worker/\">Service Worker</a>.",
       "criteria": {
         "service-worker": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "works-offline": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-start-url": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Manifest's start_url is in cache storage for offline use",
@@ -94,33 +94,33 @@
       "description": "Users notice if sites and apps don't perform well. These top-level metrics capture the most important perceived performance concerns.",
       "criteria": {
         "first-meaningful-paint": {
-          "value": 100,
+          "rawValue": 100,
           "weight": 1
         },
         "speed-index-metric": {
-          "value": 100,
+          "rawValue": 100,
           "weight": 1
         },
         "estimated-input-latency": {
-          "value": 100,
+          "rawValue": 100,
           "weight": 1
         },
         "scrolling-60fps": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Content scrolls at 60fps",
           "category": "UX"
         },
         "touch-150ms": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Touch input gets a response in < 150ms",
           "category": "UX"
         },
         "fmp-no-jank": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "App is interactive without jank after the first meaningful paint",
@@ -132,7 +132,7 @@
       "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but not unfunctioning experience.",
       "criteria": {
         "without-javascript": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         }
       }
@@ -141,11 +141,11 @@
       "description": "Security is an important part of the web for both developers and users. Moving forward, Transport Layer Security (TLS) support will be required for many APIs.",
       "criteria": {
         "is-on-https": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "redirects-http": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         }
       }
@@ -155,23 +155,23 @@
       "see": "https://github.com/GoogleChrome/lighthouse/issues/23",
       "criteria": {
         "service-worker": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-exists": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-start-url": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-icons-min-144": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-short-name": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         }
       }
@@ -181,23 +181,23 @@
       "see": "https://github.com/GoogleChrome/lighthouse/issues/24",
       "criteria": {
         "manifest-exists": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-name": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-background-color": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-theme-color": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-icons-min-192": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         }
       }
@@ -206,15 +206,15 @@
       "description": "The browser address bar can be themed to match your site. A theme-color <a href=\"https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android\">meta tag</a> will upgrade the address bar when a user browses the site, and the <a href=\"https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color\">manifest theme-color</a> will apply the same theme site-wide once it's been added to homescreen.",
       "criteria": {
         "manifest-exists": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "theme-color-meta": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-theme-color": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         }
       }
@@ -223,7 +223,7 @@
       "description": "Users increasingly experience your app on mobile devices, so it's important to ensure that the experience can adapt to smaller screens.",
       "criteria": {
         "viewport": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         }
       }
@@ -236,67 +236,67 @@
     "items": [{
       "criteria": {
         "aria-allowed-attr": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "aria-valid-attr": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "color-contrast": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "image-alt": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "label": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "tabindex": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-short-name-length": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "manifest-display": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         },
         "serviceworker-push": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Service worker makes use of push notifications, if appropriate",
           "category": "UX"
         },
         "tap-targets": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Tap targets are appropriately sized for touch",
           "category": "UX"
         },
         "payments-autocomplete": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Payment forms marked up with [autocomplete] attributes",
           "category": "UX"
         },
         "login-autocomplete": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Login forms marked up with [autocomplete] attributes",
           "category": "UX"
         },
         "input-type": {
-          "value": true,
+          "rawValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Input fields use appropriate [type] attributes for custom keyboards",
@@ -312,11 +312,11 @@
     "items": [{
       "criteria": {
         "critical-request-chains": {
-          "value": 0,
+          "rawValue": 0,
           "weight": 1
         },
         "user-timings": {
-          "value": 0,
+          "rawValue": 0,
           "weight": 1
         }
       }

--- a/lighthouse-core/report/templates/report.html
+++ b/lighthouse-core/report/templates/report.html
@@ -111,10 +111,10 @@ limitations under the License.
                       (Coming soon)
                       {{/if}}
                     </span>
-                    {{#if subItem.rawValue }}
-                    <span class="report-section__item-raw-value">({{ subItem.rawValue }})&nbsp;</span>
+                    {{#if subItem.displayValue }}
+                    <span class="report-section__item-raw-value">({{ subItem.displayValue }})&nbsp;</span>
                     {{/if }}
-                    <span class="report-section__item-value report-section__item-value--{{ getItemRating subItem.value }}">{{ getItemValue subItem.value }}</span>
+                    <span class="report-section__item-value report-section__item-value--{{ getItemRating subItem.score }}">{{ getItemValue subItem.score }}</span>
                   </div>
                   {{#if subItem.extendedInfo.value}}
                     <div class="report-section__item-extended-info">

--- a/lighthouse-core/test/aggregator/aggregate.js
+++ b/lighthouse-core/test/aggregator/aggregate.js
@@ -86,28 +86,28 @@ describe('Aggregate', () => {
   it('remaps results to an object', () => {
     const a = [{
       name: 'test',
-      value: 1
+      rawValue: 1
     }, {
       name: 'test-2',
-      value: 2
+      rawValue: 2
     }, {
       name: 'test-3',
-      value: 3
+      rawValue: 3
     }];
 
     const remapped = Aggregate._remapResultsByName(a);
     return assert.deepEqual(remapped, {
       'test': {
         name: 'test',
-        value: 1
+        rawValue: 1
       },
       'test-2': {
         name: 'test-2',
-        value: 2
+        rawValue: 2
       },
       'test-3': {
         name: 'test-3',
-        value: 3
+        rawValue: 3
       }
     });
   });
@@ -115,10 +115,10 @@ describe('Aggregate', () => {
   it('throws if key already exists during remapping', () => {
     const a = [{
       name: 'test',
-      value: 1
+      rawValue: 1
     }, {
       name: 'test',
-      value: 2
+      rawValue: 2
     }];
 
     return assert.throws(_ => Aggregate._remapResultsByName(a),
@@ -131,7 +131,7 @@ describe('Aggregate', () => {
 
   it('returns a weight of zero for undefined results', () => {
     const expected = {
-      value: true,
+      rawValue: true,
       weight: 10
     };
     return assert.equal(Aggregate._convertToWeight(undefined, expected), 0);
@@ -139,19 +139,23 @@ describe('Aggregate', () => {
 
   it('returns a weight of zero for undefined expectations', () => {
     const result = {
-      value: true
+      rawValue: true,
+      score: true,
+      displayValue: ''
     };
     return assert.equal(Aggregate._convertToWeight(result, undefined), 0);
   });
 
   it('returns the correct weight for a boolean result', () => {
     const expected = {
-      value: true,
+      rawValue: true,
       weight: 10
     };
 
     const result = {
-      value: true
+      rawValue: true,
+      score: true,
+      displayValue: ''
     };
 
     return assert.equal(Aggregate._convertToWeight(result, expected), 10);
@@ -159,12 +163,14 @@ describe('Aggregate', () => {
 
   it('returns the correct weight for a numeric result', () => {
     const expected = {
-      value: 100,
+      rawValue: 100,
       weight: 10
     };
 
     const result = {
-      value: 50
+      rawValue: 50,
+      score: 50,
+      displayValue: '50'
     };
 
     return assert.equal(Aggregate._convertToWeight(result, expected), 5);
@@ -172,11 +178,13 @@ describe('Aggregate', () => {
 
   it('returns the a weight of zero if weight is missing from the expected', () => {
     const expected = {
-      value: 100
+      rawValue: 100
     };
 
     const result = {
-      value: 50
+      rawValue: 50,
+      score: 50,
+      displayValue: '50'
     };
 
     return assert.equal(Aggregate._convertToWeight(result, expected), 0);
@@ -184,12 +192,14 @@ describe('Aggregate', () => {
 
   it('returns a weight of zero for other inputs', () => {
     const expected = {
-      value: [],
+      rawValue: [],
       weight: 10
     };
 
     const result = {
-      value: []
+      rawValue: [],
+      score: [],
+      displayValue: ''
     };
 
     return assert.equal(Aggregate._convertToWeight(result, expected), 0);
@@ -197,12 +207,14 @@ describe('Aggregate', () => {
 
   it('returns a weight of zero if types do not match', () => {
     const expected = {
-      value: true,
+      rawValue: true,
       weight: 10
     };
 
     const result = {
-      value: 20
+      rawValue: 20,
+      score: 20,
+      displayValue: '20'
     };
 
     return assert.equal(Aggregate._convertToWeight(result, expected), 0);
@@ -212,11 +224,11 @@ describe('Aggregate', () => {
     const items = [{
       criteria: {
         'test': {
-          value: true,
+          rawValue: true,
           weight: 1
         },
         'alternate-test': {
-          value: 100,
+          rawValue: 100,
           weight: 3
         }
       }
@@ -224,10 +236,14 @@ describe('Aggregate', () => {
 
     const results = [{
       name: 'test',
-      value: false
+      rawValue: false,
+      score: false,
+      displayValue: ''
     }, {
       name: 'alternate-test',
-      value: 50
+      rawValue: 50,
+      score: 50,
+      displayValue: '50'
     }];
     const scored = true;
 
@@ -237,11 +253,15 @@ describe('Aggregate', () => {
       description: undefined,
       subItems: [{
         name: 'test',
-        value: false
+        rawValue: false,
+        score: false,
+        displayValue: ''
       },
       {
         name: 'alternate-test',
-        value: 50
+        rawValue: 50,
+        score: 50,
+        displayValue: '50'
       }]
     });
   });
@@ -250,11 +270,11 @@ describe('Aggregate', () => {
     const items = [{
       criteria: {
         'test': {
-          value: true,
+          rawValue: true,
           weight: 1
         },
         'alternate-test': {
-          value: 100,
+          rawValue: 100,
           weight: 3
         }
       }
@@ -262,10 +282,14 @@ describe('Aggregate', () => {
 
     const results = [{
       name: 'test',
-      value: false
+      rawValue: false,
+      score: false,
+      displayValue: ''
     }, {
       name: 'alternate-test',
-      value: 50
+      rawValue: 50,
+      score: 50,
+      displayValue: '50'
     }];
     const scored = false;
 
@@ -275,11 +299,15 @@ describe('Aggregate', () => {
       description: undefined,
       subItems: [{
         name: 'test',
-        value: false
+        rawValue: false,
+        score: false,
+        displayValue: ''
       },
       {
         name: 'alternate-test',
-        value: 50
+        rawValue: 50,
+        score: 50,
+        displayValue: '50'
       }]
     });
   });
@@ -288,7 +316,7 @@ describe('Aggregate', () => {
     const items = [{
       criteria: {
         test: {
-          value: true,
+          rawValue: true,
           weight: 1
         }
       }
@@ -296,7 +324,9 @@ describe('Aggregate', () => {
 
     const results = [{
       name: 'alternate-test',
-      value: 50,
+      rawValue: 50,
+      score: 50,
+      displayValue: '50',
       contributesToScore: true
     }];
 
@@ -314,7 +344,7 @@ describe('Aggregate', () => {
     const items = [{
       criteria: {
         test: {
-          value: true,
+          rawValue: true,
           weight: 1
         }
       }
@@ -322,7 +352,9 @@ describe('Aggregate', () => {
 
     const results = [{
       name: 'test',
-      value: true
+      rawValue: true,
+      score: true,
+      displayValue: ''
     }];
     const scored = true;
     return assert.equal(Aggregate.compare(results, items, scored)[0].overall, 1);
@@ -332,7 +364,7 @@ describe('Aggregate', () => {
     const items = [{
       criteria: {
         test: {
-          value: true,
+          rawValue: true,
           weight: 1
         }
       }
@@ -340,7 +372,9 @@ describe('Aggregate', () => {
 
     const results = [{
       name: 'test',
-      value: true
+      rawValue: true,
+      score: true,
+      displayValue: ''
     }];
 
     const scored = true;
@@ -359,7 +393,7 @@ describe('Aggregate', () => {
       items: [{
         criteria: {
           test: {
-            value: true,
+            rawValue: true,
             weight: 1
           }
         }
@@ -368,7 +402,9 @@ describe('Aggregate', () => {
 
     const results = [{
       name: 'test',
-      value: true
+      rawValue: true,
+      score: true,
+      displayValue: ''
     }];
 
     const output = Aggregate.aggregate(aggregation, results);

--- a/lighthouse-core/test/aggregator/index.js
+++ b/lighthouse-core/test/aggregator/index.js
@@ -29,7 +29,7 @@ describe('Aggregator', () => {
         description: 'item description',
         criteria: {
           'first-meaningful-paint': {
-            value: 100,
+            rawValue: 100,
             weight: 1
           }
         }
@@ -38,7 +38,9 @@ describe('Aggregator', () => {
     return Aggregator
       .aggregate(fakeAggregations, [{
         name: 'first-meaningful-paint',
-        value: 90
+        rawValue: 90,
+        score: 90,
+        displayValue: '90'
       }])
       .then(modifiedResults => {
         assert.equal(modifiedResults[0].name, fakeAggregations[0].name);

--- a/lighthouse-core/test/audits/aria-allowed-attr.js
+++ b/lighthouse-core/test/audits/aria-allowed-attr.js
@@ -46,7 +46,8 @@ describe('Accessibility: aria-allowed-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.displayValue, '');
     assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
@@ -62,7 +63,8 @@ describe('Accessibility: aria-allowed-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.displayValue, '');
     assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 });

--- a/lighthouse-core/test/audits/aria-valid-attr.js
+++ b/lighthouse-core/test/audits/aria-valid-attr.js
@@ -46,7 +46,7 @@ describe('Accessibility: aria-valid-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
@@ -62,7 +62,7 @@ describe('Accessibility: aria-valid-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 });

--- a/lighthouse-core/test/audits/background-color.js
+++ b/lighthouse-core/test/audits/background-color.js
@@ -24,7 +24,7 @@ describe('Manifest: background color audit', () => {
   it('fails when no manifest present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
-    }}).value, false);
+    }}).rawValue, false);
   });
 
   it('fails when no background color present', () => {
@@ -32,7 +32,7 @@ describe('Manifest: background color audit', () => {
       value: {
         foo: 1
       }
-    }}).value, false);
+    }}).rawValue, false);
   });
 
   it('fails when no background color value present', () => {
@@ -40,7 +40,7 @@ describe('Manifest: background color audit', () => {
       value: {
         background_color: 'no'
       }
-    }}).value, false);
+    }}).rawValue, false);
   });
 
   it('passes when color is present', () => {
@@ -48,7 +48,7 @@ describe('Manifest: background color audit', () => {
       value: {
         background_color: {value: 'black'}
       }
-    }}).value, true);
+    }}).rawValue, true);
   });
 });
 /* eslint-enable */

--- a/lighthouse-core/test/audits/color-contrast.js
+++ b/lighthouse-core/test/audits/color-contrast.js
@@ -46,7 +46,7 @@ describe('Accessibility: color-contrast audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
@@ -62,7 +62,7 @@ describe('Accessibility: color-contrast audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 });

--- a/lighthouse-core/test/audits/critical-request-chains.js
+++ b/lighthouse-core/test/audits/critical-request-chains.js
@@ -53,6 +53,6 @@ const CriticalRequestChains = {
 describe('Performance: critical-request-chains audit', () => {
   it('calculates the correct chain length', () => {
     const output = Audit.audit({CriticalRequestChains});
-    assert.equal(output.value, 2);
+    assert.equal(output.score, 2);
   });
 });

--- a/lighthouse-core/test/audits/display.js
+++ b/lighthouse-core/test/audits/display.js
@@ -28,8 +28,9 @@ describe('Mobile-friendly: display audit', () => {
   it('handles the case where there is no display property', () => {
     const output = Audit.audit({Manifest: {}});
 
-    assert.equal(output.value, false);
-    assert.equal(output.rawValue, undefined);
+    assert.equal(output.score, false);
+    assert.equal(output.displayValue, '');
+    assert.equal(output.rawValue, false);
   });
 
   it('audits a manifest\'s display property', () => {
@@ -44,7 +45,8 @@ describe('Mobile-friendly: display audit', () => {
       }
     });
 
-    assert.equal(output.value, true);
-    assert.equal(output.rawValue, expected);
+    assert.equal(output.score, true);
+    assert.equal(output.displayValue, expected);
+    assert.equal(output.rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/estimated-input-latency.js
+++ b/lighthouse-core/test/audits/estimated-input-latency.js
@@ -29,7 +29,7 @@ describe('Performance: estimated-input-latency audit', () => {
         first: 500
       }
     });
-    assert.equal(output.value, -1);
+    assert.equal(output.score, -1);
     assert(output.debugString);
   });
 
@@ -41,7 +41,8 @@ describe('Performance: estimated-input-latency audit', () => {
       }
     });
 
-    assert.equal(output.rawValue, '17.4ms');
-    assert.equal(output.value, 100);
+    assert.equal(output.rawValue, 17.4);
+    assert.equal(output.displayValue, '17.4ms');
+    assert.equal(output.score, 100);
   });
 });

--- a/lighthouse-core/test/audits/exists.js
+++ b/lighthouse-core/test/audits/exists.js
@@ -22,13 +22,13 @@ describe('Manifest: exists audit', () => {
   it('fails when no manifest present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
-    }}).value, false);
+    }}).rawValue, false);
   });
 
   it('succeeds when a manifest is present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: {}
-    }}).value, true);
+    }}).rawValue, true);
   });
 
   it('correctly passes through debug strings', () => {

--- a/lighthouse-core/test/audits/first-meaningful-paint.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint.js
@@ -22,13 +22,13 @@ const assert = require('assert');
 describe('Performance: first-meaningful-paint audit', () => {
   it('scores a -1 when no trace data is present', () => {
     return Audit.audit({}).then(response => {
-      return assert.equal(response.value, -1);
+      return assert.equal(response.score, -1);
     });
   });
 
   it('scores a -1 when faulty trace data is present', () => {
     return Audit.audit({boo: 'ya'}).then(response => {
-      return assert.equal(response.value, -1);
+      return assert.equal(response.score, -1);
     });
   });
 
@@ -43,7 +43,8 @@ describe('Performance: first-meaningful-paint audit', () => {
     });
 
     it('finds the expected fMP', () => {
-      assert.equal(fmpResult.rawValue, '1099.5ms');
+      assert.equal(fmpResult.displayValue, '1099.5ms');
+      assert.equal(fmpResult.rawValue, 1099.5);
     });
 
     it('finds the correct fCP + fMP timings', () => {
@@ -55,7 +56,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     });
 
     it('scores the fMP correctly', () => {
-      assert.equal(fmpResult.value, 99);
+      assert.equal(fmpResult.score, 99);
     });
   });
 });

--- a/lighthouse-core/test/audits/icons.js
+++ b/lighthouse-core/test/audits/icons.js
@@ -29,8 +29,8 @@ describe('Manifest: icons audits', () => {
         name: 'NoIconsHere'
       });
       const Manifest = manifestParser(manifestSrc);
-      assert.equal(Audit144.audit({Manifest}).value, false);
-      assert.equal(Audit192.audit({Manifest}).value, false);
+      assert.equal(Audit144.audit({Manifest}).rawValue, false);
+      assert.equal(Audit192.audit({Manifest}).rawValue, false);
     });
 
     it('fails when a manifest contains no icons', () => {
@@ -38,8 +38,8 @@ describe('Manifest: icons audits', () => {
         icons: []
       });
       const Manifest = manifestParser(manifestSrc);
-      assert.equal(Audit144.audit({Manifest}).value, false);
-      assert.equal(Audit192.audit({Manifest}).value, false);
+      assert.equal(Audit144.audit({Manifest}).rawValue, false);
+      assert.equal(Audit192.audit({Manifest}).rawValue, false);
     });
   });
 
@@ -52,16 +52,16 @@ describe('Manifest: icons audits', () => {
       });
       const Manifest = manifestParser(manifestSrc);
 
-      assert.equal(Audit144.audit({Manifest}).value, false);
-      assert.equal(Audit192.audit({Manifest}).value, false);
+      assert.equal(Audit144.audit({Manifest}).rawValue, false);
+      assert.equal(Audit192.audit({Manifest}).rawValue, false);
     });
 
     it('succeeds when a manifest contains icons that are large enough', () => {
       // stub manifest contains a 192 icon
       const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
       const Manifest = manifestParser(manifestSrc);
-      assert.equal(Audit144.audit({Manifest}).value, true);
-      assert.equal(Audit192.audit({Manifest}).value, true);
+      assert.equal(Audit144.audit({Manifest}).rawValue, true);
+      assert.equal(Audit192.audit({Manifest}).rawValue, true);
     });
 
     it('succeeds when there\'s one icon with multiple sizes, and one is valid', () => {
@@ -73,8 +73,8 @@ describe('Manifest: icons audits', () => {
       });
       const Manifest = manifestParser(manifestSrc);
 
-      assert.equal(Audit144.audit({Manifest}).value, true);
-      assert.equal(Audit192.audit({Manifest}).value, true);
+      assert.equal(Audit144.audit({Manifest}).rawValue, true);
+      assert.equal(Audit192.audit({Manifest}).rawValue, true);
     });
 
     it('succeeds when there\'s two icons, one without sizes; the other with a valid size', () => {
@@ -87,8 +87,8 @@ describe('Manifest: icons audits', () => {
         }]
       });
       const Manifest = manifestParser(manifestSrc);
-      assert.equal(Audit144.audit({Manifest}).value, true);
-      assert.equal(Audit192.audit({Manifest}).value, true);
+      assert.equal(Audit144.audit({Manifest}).rawValue, true);
+      assert.equal(Audit192.audit({Manifest}).rawValue, true);
     });
 
     it('fails when an icon has a valid size, though it\'s non-square.', () => {
@@ -100,8 +100,8 @@ describe('Manifest: icons audits', () => {
         }]
       });
       const Manifest = manifestParser(manifestSrc);
-      assert.equal(Audit144.audit({Manifest}).value, false);
-      assert.equal(Audit192.audit({Manifest}).value, false);
+      assert.equal(Audit144.audit({Manifest}).rawValue, false);
+      assert.equal(Audit192.audit({Manifest}).rawValue, false);
     });
   });
 });

--- a/lighthouse-core/test/audits/image-alt.js
+++ b/lighthouse-core/test/audits/image-alt.js
@@ -46,7 +46,7 @@ describe('Accessibility: image-alt audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
@@ -62,7 +62,7 @@ describe('Accessibility: image-alt audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 });

--- a/lighthouse-core/test/audits/is-on-https.js
+++ b/lighthouse-core/test/audits/is-on-https.js
@@ -29,7 +29,7 @@ describe('Security: HTTPS audit', () => {
         debugString
       }
     });
-    assert.strictEqual(result.value, false);
+    assert.strictEqual(result.score, false);
     assert.strictEqual(result.debugString, debugString);
   });
 
@@ -39,6 +39,6 @@ describe('Security: HTTPS audit', () => {
         value: true
       }
     });
-    assert.strictEqual(result.value, true);
+    assert.strictEqual(result.score, true);
   });
 });

--- a/lighthouse-core/test/audits/label.js
+++ b/lighthouse-core/test/audits/label.js
@@ -46,7 +46,7 @@ describe('Accessibility: label audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
@@ -62,7 +62,7 @@ describe('Accessibility: label audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 });

--- a/lighthouse-core/test/audits/name.js
+++ b/lighthouse-core/test/audits/name.js
@@ -25,11 +25,11 @@ describe('Manifest: name audit', () => {
   it('fails when no manifest present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
-    }}).value, false);
+    }}).rawValue, false);
   });
 
   it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({Manifest: {}}).value, false);
+    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
   });
 
   it('fails when a manifest contains no name', () => {
@@ -39,10 +39,10 @@ describe('Manifest: name audit', () => {
       }
     };
 
-    return assert.equal(Audit.audit(inputs).value, false);
+    return assert.equal(Audit.audit(inputs).rawValue, false);
   });
 
   it('succeeds when a manifest contains a name', () => {
-    return assert.equal(Audit.audit({Manifest: manifest}).value, true);
+    return assert.equal(Audit.audit({Manifest: manifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/redirects-http.js
+++ b/lighthouse-core/test/audits/redirects-http.js
@@ -20,7 +20,7 @@ const assert = require('assert');
 
 describe('Security: HTTP->HTTPS audit', () => {
   it('fails when no input present', () => {
-    return assert.equal(Audit.audit({}).value, false);
+    return assert.equal(Audit.audit({}).rawValue, false);
   });
 
   it('fails when no redirect detected', () => {
@@ -28,7 +28,7 @@ describe('Security: HTTP->HTTPS audit', () => {
       HTTPRedirect: {
         value: false
       }
-    }).value, false);
+    }).rawValue, false);
   });
 
   it('passes when redirect detected', () => {
@@ -36,6 +36,6 @@ describe('Security: HTTP->HTTPS audit', () => {
       HTTPRedirect: {
         value: true
       }
-    }).value, true);
+    }).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/screenshots.js
+++ b/lighthouse-core/test/audits/screenshots.js
@@ -22,11 +22,11 @@ const assert = require('assert');
 describe('Performance: screenshots audit', () => {
   it('fails gracefully', () => {
     const output = Audit.audit({});
-    assert.equal(output.value, -1);
+    assert.equal(output.score, -1);
   });
 
   it('processes an empty trace for screenshot data', () => {
     const output = Audit.audit({ScreenshotFilmstrip: []});
-    assert.equal(output.value, 0);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/service-worker.js
+++ b/lighthouse-core/test/audits/service-worker.js
@@ -30,7 +30,7 @@ describe('Offline: Service Worker audit', () => {
       }
     });
 
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, debugString);
   });
 
@@ -41,6 +41,6 @@ describe('Offline: Service Worker audit', () => {
       }
     });
 
-    return assert.equal(output.value, true);
+    return assert.equal(output.score, true);
   });
 });

--- a/lighthouse-core/test/audits/short-name-length.js
+++ b/lighthouse-core/test/audits/short-name-length.js
@@ -22,7 +22,7 @@ const manifestParser = require('../../lib/manifest-parser');
 describe('Manifest: short_name_length audit', () => {
   it('fails when an empty manifest is present', () => {
     const Manifest = manifestParser('{}');
-    return assert.equal(Audit.audit({Manifest}).value, false);
+    return assert.equal(Audit.audit({Manifest}).rawValue, false);
   });
 
   it('fails when a manifest contains no short_name and too long name', () => {
@@ -31,7 +31,7 @@ describe('Manifest: short_name_length audit', () => {
     });
     const Manifest = manifestParser(manifestSrc);
     const out = Audit.audit({Manifest});
-    assert.equal(out.value, false);
+    assert.equal(out.rawValue, false);
     assert.notEqual(out.debugString, undefined);
   });
 
@@ -43,7 +43,7 @@ describe('Manifest: short_name_length audit', () => {
     });
     const Manifest = manifestParser(manifestSrc);
     const out = Audit.audit({Manifest});
-    assert.equal(out.value, false);
+    assert.equal(out.rawValue, false);
     assert.notEqual(out.debugString, undefined);
   });
 
@@ -52,7 +52,7 @@ describe('Manifest: short_name_length audit', () => {
       short_name: 'Lighthouse'
     });
     const Manifest = manifestParser(manifestSrc);
-    return assert.equal(Audit.audit({Manifest}).value, true);
+    return assert.equal(Audit.audit({Manifest}).rawValue, true);
   });
   /* eslint-enable camelcase */
 });

--- a/lighthouse-core/test/audits/short-name.js
+++ b/lighthouse-core/test/audits/short-name.js
@@ -25,11 +25,11 @@ describe('Manifest: short_name audit', () => {
   it('fails when no manifest present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
-    }}).value, false);
+    }}).rawValue, false);
   });
 
   it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({Manifest: {}}).value, false);
+    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
   });
 
   // Need to disable camelcase check for dealing with short_name.
@@ -41,7 +41,7 @@ describe('Manifest: short_name audit', () => {
     });
     const Manifest = manifestParser(inputs);
 
-    return assert.equal(Audit.audit({Manifest}).value, false);
+    return assert.equal(Audit.audit({Manifest}).rawValue, false);
   });
 
   it('succeeds when a manifest contains no short_name but a name', () => {
@@ -51,11 +51,11 @@ describe('Manifest: short_name audit', () => {
     });
     const Manifest = manifestParser(inputs);
 
-    return assert.equal(Audit.audit({Manifest}).value, true);
+    return assert.equal(Audit.audit({Manifest}).rawValue, true);
   });
   /* eslint-enable camelcase */
 
   it('succeeds when a manifest contains a short_name', () => {
-    return assert.equal(Audit.audit({Manifest}).value, true);
+    return assert.equal(Audit.audit({Manifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/speed-index-metric.js
+++ b/lighthouse-core/test/audits/speed-index-metric.js
@@ -34,7 +34,7 @@ describe('Performance: speed-index-metric audit', () => {
   it('passes on errors from gatherer', () => {
     const debugString = 'Real emergency here.';
     return Audit.audit({Speedline: {debugString}}).then(response => {
-      assert.equal(response.value, -1);
+      assert.equal(response.rawValue, -1);
       assert.equal(response.debugString, debugString);
     });
   });
@@ -42,7 +42,7 @@ describe('Performance: speed-index-metric audit', () => {
   it('gives error string if no frames', () => {
     const artifacts = {Speedline: {frames: []}};
     return Audit.audit(artifacts).then(response => {
-      assert.equal(response.value, -1);
+      assert.equal(response.rawValue, -1);
       assert(response.debugString);
     });
   });
@@ -50,7 +50,7 @@ describe('Performance: speed-index-metric audit', () => {
   it('gives error string if too few frames to determine speed index', () => {
     const artifacts = {Speedline: {frames: [frame()]}};
     return Audit.audit(artifacts).then(response => {
-      assert.equal(response.value, -1);
+      assert.equal(response.rawValue, -1);
       assert(response.debugString);
     });
   });
@@ -62,7 +62,7 @@ describe('Performance: speed-index-metric audit', () => {
     };
 
     return Audit.audit({Speedline}).then(response => {
-      assert.equal(response.value, -1);
+      assert.equal(response.rawValue, -1);
       assert(response.debugString);
     });
   });
@@ -74,8 +74,9 @@ describe('Performance: speed-index-metric audit', () => {
     };
 
     return Audit.audit({Speedline}).then(response => {
+      assert.equal(response.displayValue, '831');
       assert.equal(response.rawValue, 831);
-      assert.equal(response.value, 100);
+      assert.equal(response.score, 100);
     });
   });
 });

--- a/lighthouse-core/test/audits/start-url.js
+++ b/lighthouse-core/test/audits/start-url.js
@@ -25,11 +25,11 @@ describe('Manifest: start_url audit', () => {
   it('fails when no manifest present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
-    }}).value, false);
+    }}).rawValue, false);
   });
 
   it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({Manifest: {}}).value, false);
+    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
   });
 
   // Need to disable camelcase check for dealing with short_name.
@@ -41,12 +41,12 @@ describe('Manifest: start_url audit', () => {
       }
     };
 
-    return assert.equal(Audit.audit(inputs).value, false);
+    return assert.equal(Audit.audit(inputs).rawValue, false);
   });
 
   /* eslint-enable camelcase */
 
   it('succeeds when a manifest contains a start_url', () => {
-    return assert.equal(Audit.audit({Manifest}).value, true);
+    return assert.equal(Audit.audit({Manifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/tabindex.js
+++ b/lighthouse-core/test/audits/tabindex.js
@@ -46,7 +46,7 @@ describe('Accessibility: tabindex audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
@@ -62,7 +62,7 @@ describe('Accessibility: tabindex audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.value, false);
+    assert.equal(output.score, false);
     assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 });

--- a/lighthouse-core/test/audits/theme-color.js
+++ b/lighthouse-core/test/audits/theme-color.js
@@ -25,11 +25,11 @@ describe('Manifest: theme_color audit', () => {
   it('fails when no manifest present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
-    }}).value, false);
+    }}).rawValue, false);
   });
 
   it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({Manifest: {}}).value, false);
+    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
   });
 
   // Need to disable camelcase check for dealing with theme_color.
@@ -41,12 +41,12 @@ describe('Manifest: theme_color audit', () => {
       }
     };
 
-    return assert.equal(Audit.audit(inputs).value, false);
+    return assert.equal(Audit.audit(inputs).rawValue, false);
   });
 
   /* eslint-enable camelcase */
 
   it('succeeds when a manifest contains a theme_color', () => {
-    return assert.equal(Audit.audit({Manifest}).value, true);
+    return assert.equal(Audit.audit({Manifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/theme-colors.js
+++ b/lighthouse-core/test/audits/theme-colors.js
@@ -23,7 +23,7 @@ describe('HTML: theme-color audit', () => {
   it('fails and warns when no window or html present', () => {
     const emptyAudit = Audit.audit({});
 
-    assert.equal(emptyAudit.value, false);
+    assert.equal(emptyAudit.rawValue, false);
     assert(emptyAudit.debugString);
   });
 
@@ -32,7 +32,7 @@ describe('HTML: theme-color audit', () => {
       ThemeColor: null
     });
 
-    assert.equal(nullColorAudit.value, false);
+    assert.equal(nullColorAudit.rawValue, false);
     assert(nullColorAudit.debugString);
   });
 
@@ -41,19 +41,19 @@ describe('HTML: theme-color audit', () => {
       ThemeColor: '#1234567'
     });
 
-    assert.equal(invalidColorAudit.value, false);
+    assert.equal(invalidColorAudit.rawValue, false);
     assert(invalidColorAudit.debugString);
   });
 
   it('succeeds when theme-color present in the html', () => {
     assert.equal(Audit.audit({
       ThemeColor: '#fafa33'
-    }).value, true);
+    }).rawValue, true);
   });
 
   it('succeeds when theme-color has a CSS nickname content value', () => {
     assert.equal(Audit.audit({
       ThemeColor: 'red'
-    }).value, true);
+    }).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/user-timing.js
+++ b/lighthouse-core/test/audits/user-timing.js
@@ -24,12 +24,12 @@ const traceContents = require('../fixtures/traces/trace-user-timings.json');
 describe('Performance: user-timings audit', () => {
   it('fails gracefully', () => {
     const output = Audit.audit({});
-    assert.equal(output.value, -1);
+    assert.equal(output.score, -1);
   });
 
   it('evaluates valid input correctly', () => {
     const output = Audit.audit({traceContents});
-    assert.equal(output.value, 2);
+    assert.equal(output.score, 2);
     assert.ok(!Number.isNaN(output.extendedInfo.value[0].startTime));
     assert.ok(typeof output.extendedInfo.value[0].endTime === 'undefined');
     assert.ok(typeof output.extendedInfo.value[0].duration === 'undefined');

--- a/lighthouse-core/test/audits/viewport.js
+++ b/lighthouse-core/test/audits/viewport.js
@@ -20,18 +20,18 @@ const assert = require('assert');
 
 describe('Mobile-friendly: viewport audit', () => {
   it('fails when no input present', () => {
-    return assert.equal(Audit.audit({}).value, false);
+    return assert.equal(Audit.audit({}).rawValue, false);
   });
 
   it('fails when HTML does not contain a viewport meta tag', () => {
     return assert.equal(Audit.audit({
       Viewport: ''
-    }).value, false);
+    }).rawValue, false);
   });
 
   it('passes when a viewport is provided', () => {
     return assert.equal(Audit.audit({
       Viewport: 'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1'
-    }).value, true);
+    }).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/without-javascript.js
+++ b/lighthouse-core/test/audits/without-javascript.js
@@ -21,13 +21,13 @@ const assert = require('assert');
 /* eslint-disable no-script-url */
 describe('JavaScript: scripting audit', () => {
   it('fails when the js-less body is empty', () => {
-    return assert.equal(Audit.audit({HTMLWithoutJavaScript: ''}).value, false);
+    return assert.equal(Audit.audit({HTMLWithoutJavaScript: ''}).score, false);
   });
   it('fails when the js-less body is whitespace', () => {
-    return assert.equal(Audit.audit({HTMLWithoutJavaScript: '        '}).value, false);
+    return assert.equal(Audit.audit({HTMLWithoutJavaScript: '        '}).score, false);
   });
   it('succeeds when the js-less body contains some content', () => {
-    return assert.equal(Audit.audit({HTMLWithoutJavaScript: 'test'}).value, true);
+    return assert.equal(Audit.audit({HTMLWithoutJavaScript: 'test'}).score, true);
   });
 });
 /* eslint-enable */

--- a/lighthouse-core/test/audits/works-offline.js
+++ b/lighthouse-core/test/audits/works-offline.js
@@ -22,18 +22,18 @@ describe('Offline: works-offline audit', () => {
   it('fails gracefully', () => {
     const output = Audit.audit({});
 
-    return assert.equal(output.value, false);
+    return assert.equal(output.score, false);
   });
 
   it('correctly audits a 200 code', () => {
     const output = Audit.audit({Offline: 200});
 
-    return assert.equal(output.value, true);
+    return assert.equal(output.score, true);
   });
 
   it('correctly audits a non-200 code', () => {
     const output = Audit.audit({Offline: 203});
 
-    return assert.equal(output.value, false);
+    return assert.equal(output.score, false);
   });
 });

--- a/lighthouse-core/test/runner.js
+++ b/lighthouse-core/test/runner.js
@@ -182,7 +182,9 @@ describe('Runner', () => {
     const config = {
       auditResults: [{
         name: 'is-on-https',
-        value: true
+        rawValue: true,
+        score: true,
+        displayValue: ''
       }],
 
       aggregations: [{
@@ -195,7 +197,7 @@ describe('Runner', () => {
           description: 'description',
           criteria: {
             'is-on-https': {
-              value: true,
+              rawValue: true,
               weight: 1
             }
           }


### PR DESCRIPTION
Should fix #458 
No idea if I did any good but basically this is what i've done.

Every value is mapped to rawValue (so value => rawValue).
Score is equal to score, if no score is set we fallback to rawValue
display value uses rawvalue with minor adaptation like adding ms or fallbacks to string representation of rawValue. If displayValue === score we make it empty so we don't display it in our reporting