### PR TITLE
Handle 'about:*' URLs in the CRC formatter

### DIFF
--- a/lighthouse-core/formatters/critical-request-chains.js
+++ b/lighthouse-core/formatters/critical-request-chains.js
@@ -208,11 +208,13 @@ class CriticalRequestChains extends Formatter {
     const MAX_FILENAME_LENGTH = 64;
     const parsedResourceURL = url.parse(resourceURL);
     const hostname = parsedResourceURL.hostname;
-    let file = parsedResourceURL.path
-        // Remove any query strings.
-        .replace(/\?.*/, '')
-        // Grab the last two parts of the path.
+    // Handle 'about:*' URLs specially since they have no path.
+    let file = parsedResourceURL.protocol === 'about:' ? parsedResourceURL.href :
+        // Otherwise, remove any query strings from the path.
+        parsedResourceURL.path.replace(/\?.*/, '')
+        // And grab the last two parts.
         .split('/').slice(-2).join('/');
+
     if (file.length > MAX_FILENAME_LENGTH) {
       file = file.slice(0, MAX_FILENAME_LENGTH) + '...';
     }

--- a/lighthouse-core/test/formatter/critical-request-chains.js
+++ b/lighthouse-core/test/formatter/critical-request-chains.js
@@ -50,12 +50,22 @@ const extendedInfo = {
           transferSize: 1
         },
         children: {}
+      },
+      3: {
+        request: {
+          endTime: 18,
+          responseReceivedTime: 16,
+          startTime: 13,
+          url: 'about:blank',
+          transferSize: 1
+        },
+        children: {}
       }
     }
   }
 };
 
-/* global describe, it */
+/* eslint-env mocha */
 
 describe('CRC Formatter', () => {
   it('copes with invalid input', () => {
@@ -74,6 +84,7 @@ describe('CRC Formatter', () => {
     assert.ok(/┗━┳ \/ \(example.com\)/im.test(output));
     assert.ok(/┣━━ \/b.js \(example.com\) - 5000.00ms/im.test(output));
     assert.ok(truncatedURLRegExp.test(output));
+    assert.ok(/about:blank/.test(output));
   });
 
   it('generates valid HTML output', () => {


### PR DESCRIPTION
fixes #483 