### PR TITLE
Save closure errors to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ last-run-results.html
 
 *.trace.json
 *.screenshots.html
+
+closure-error.log

--- a/lighthouse-core/closure/closure-type-checking.js
+++ b/lighthouse-core/closure/closure-type-checking.js
@@ -72,6 +72,9 @@ gulp.task('js-compile', function() {
       ],
       conformance_configs: 'closure/conformance_config.textproto'
     }))
+    .on('error', error => {
+      require('fs').writeFileSync('closure-error.log', error);
+    })
     .on('end', () => {
       gutil.log('Closure compilation successful.');
     });

--- a/lighthouse-core/closure/closure-type-checking.js
+++ b/lighthouse-core/closure/closure-type-checking.js
@@ -73,6 +73,7 @@ gulp.task('js-compile', function() {
       conformance_configs: 'closure/conformance_config.textproto'
     }))
     .on('error', error => {
+      gutil.log('Closure compilation failed. Check `closure-error.log` for details.');
       require('fs').writeFileSync('closure-error.log', error);
     })
     .on('end', () => {


### PR DESCRIPTION
Either node or closure mangles the error output on macOS. This is a dirty fix that saves the error log to a file so it can be examined after the run.

@brendankenny @paullewis WDYT?