### PR TITLE
correctly fall back on erroneous manifest display modes

### DIFF
--- a/lighthouse-core/audits/manifest-display.js
+++ b/lighthouse-core/audits/manifest-display.js
@@ -46,7 +46,7 @@ class ManifestDisplay extends Audit {
    */
   static audit(artifacts) {
     const manifest = artifacts.Manifest.value;
-    const displayValue = (!manifest || !manifest.display) ? undefined : manifest.display.value;
+    const displayValue = manifest && manifest.display.value;
 
     const hasRecommendedValue = ManifestDisplay.hasRecommendedValue(displayValue);
 

--- a/lighthouse-core/closure/typedefs/Manifest.js
+++ b/lighthouse-core/closure/typedefs/Manifest.js
@@ -94,7 +94,7 @@ Manifest.prototype.short_name;
 /** @type {!ManifestNode<(string|undefined)>} */
 Manifest.prototype.start_url;
 
-/** @type {!ManifestNode<(string|undefined)>} */
+/** @type {!ManifestNode<string>} */
 Manifest.prototype.display;
 
 /** @type {!ManifestNode<(string|undefined)>} */

--- a/lighthouse-core/lib/manifest-parser.js
+++ b/lighthouse-core/lib/manifest-parser.js
@@ -24,6 +24,11 @@ const ALLOWED_DISPLAY_VALUES = [
   'minimal-ui',
   'browser'
 ];
+/**
+ * All display-mode fallbacks, including when unset, lead to default display mode 'browser'.
+ * @see https://w3c.github.io/manifest/#dfn-default-display-mode
+ */
+const DEFAULT_DISPLAY_MODE = 'browser';
 
 const ALLOWED_ORIENTATION_VALUES = [
   'any',
@@ -98,9 +103,16 @@ function parseStartUrl(jsonInput) {
 function parseDisplay(jsonInput) {
   let display = parseString(jsonInput.display, true);
 
-  if (display.value && ALLOWED_DISPLAY_VALUES.indexOf(display.value.toLowerCase()) === -1) {
-    display.value = undefined;
-    display.debugString = 'ERROR: \'display\' has an invalid value, will be ignored.';
+  if (!display.value) {
+    display.value = DEFAULT_DISPLAY_MODE;
+    return display;
+  }
+
+  display.value = display.value.toLowerCase();
+  if (ALLOWED_DISPLAY_VALUES.indexOf(display.value) === -1) {
+    display.debugString = 'ERROR: \'display\' has invalid value ' + display.value +
+        ` will fall back to ${DEFAULT_DISPLAY_MODE}.`;
+    display.value = DEFAULT_DISPLAY_MODE;
   }
 
   return display;

--- a/lighthouse-core/test/audits/display.js
+++ b/lighthouse-core/test/audits/display.js
@@ -36,15 +36,15 @@ describe('Mobile-friendly: display audit', () => {
     }}).rawValue, false);
   });
 
-  it('handles the case where there is no manifest display property', () => {
+  it('falls back to the successful default when there is no manifest display property', () => {
     const artifacts = {
       Manifest: manifestParser('{}')
     };
     const output = Audit.audit(artifacts);
 
-    assert.equal(output.score, false);
-    assert.equal(output.displayValue, '');
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, true);
+    assert.equal(output.displayValue, 'browser');
+    assert.equal(output.rawValue, true);
   });
 
   it('succeeds when a manifest has a display property', () => {


### PR DESCRIPTION
Came up in the course of #495. To better match spec for [parsing `display`](https://w3c.github.io/manifest/#display-member):
- always fall back to `browser` for display mode (can never be `undefined`)
- always report lowercase value