### PR TITLE
Fix (and speed up) extension browserify post-config refactor.

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -63,7 +63,9 @@ class Runner {
       }
 
       // Now run the audits.
-      run = run.then(artifacts => Promise.all(config.audits.map(audit => audit.audit(artifacts))));
+      run = run.then(artifacts => Promise.all(config.audits.map(audit => {
+        return audit.audit(artifacts);
+      })));
     } else if (config.auditResults) {
       // If there are existing audit results, surface those here.
       run = run.then(_ => config.auditResults);

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -19,7 +19,8 @@
 
 const ExtensionProtocol = require('../../../lighthouse-core/driver/drivers/extension');
 const Runner = require('../../../lighthouse-core/runner');
-const config = require('../../../lighthouse-core/config/default.json');
+const Config = require('../../../lighthouse-core/config');
+const configJSON = require('../../../lighthouse-core/config/default.json');
 const log = require('../../../lighthouse-core/lib/log');
 
 window.createPageAndPopulate = function(results) {
@@ -44,6 +45,9 @@ window.runAudits = function(options) {
 
   return driver.getCurrentTabURL()
       .then(url => {
+        // Setup the run config, false == no whitelist, run all audits
+        const config = new Config(configJSON, false);
+
         // Add in the URL to the options.
         return Runner.run(driver, Object.assign({}, options, {url, config}));
       });


### PR DESCRIPTION
The audit and gather resolving in the extension browserify was broken after the recent commits.

This fixes things.

The primary fixes are ` const config = new Config(configJSON, false);` in the extension and tweaking a `../` to `./` and vice versa. Love it.