### PR TITLE
Install child folder deps through helper script

### DIFF
--- a/_install_deps.js
+++ b/_install_deps.js
@@ -1,16 +1,24 @@
 const exec = require('child_process').exec;
 
-var cwd = require('path').resolve()
-
+var cwd = require('path').resolve();
 const corePath = `${cwd}/lighthouse-core`;
 const extPath = `${cwd}/lighthouse-extension`;
-const cmd = `npm --prefix ${corePath} install ${corePath} && npm --prefix ${extPath} install ${extPath}`;
+
+const npm = 'npm --prefix';
+const cmd = `${npm} ${corePath} install ${corePath} && ${npm} ${extPath} install ${extPath}`;
 
 console.log(cmd);
 console.log('...');
 
-console.log(process.cwd());
-
-const child = exec(cmd);
+const child = exec(cmd,
+  function(error, stdout, stderr) {
+    process.stderr.write(stderr);
+    process.stdout.write(stdout);
+    if (stdout.length === 0) {
+      console.log('The full install may not have completed.');
+      console.log('To manually install child dependencies:');
+      console.log(`    ${cmd}`);
+    }
+  });
 child.stderr.pipe(process.stderr);
 child.stdout.pipe(process.stdout);

--- a/_install_deps.js
+++ b/_install_deps.js
@@ -1,5 +1,6 @@
 const exec = require('child_process').exec;
 
+
 const corePath = './lighthouse-core';
 const extPath = './lighthouse-extension';
 const cmd = `npm --prefix ${corePath} install ${corePath} && npm --prefix ${extPath} install ${extPath}`;
@@ -7,6 +8,8 @@ const cmd = `npm --prefix ${corePath} install ${corePath} && npm --prefix ${extP
 console.log(cmd);
 console.log('...');
 
+
+console.log(process.cwd());
 exec(cmd,
   function(error, stdout) {
     console.log(stdout);

--- a/_install_deps.js
+++ b/_install_deps.js
@@ -1,19 +1,16 @@
 const exec = require('child_process').exec;
 
-const corePath = './lighthouse-core';
-const extPath = './lighthouse-extension';
+var cwd = require('path').resolve()
+
+const corePath = `${cwd}/lighthouse-core`;
+const extPath = `${cwd}/lighthouse-extension`;
 const cmd = `npm --prefix ${corePath} install ${corePath} && npm --prefix ${extPath} install ${extPath}`;
 
 console.log(cmd);
 console.log('...');
 
 console.log(process.cwd());
-console.log(process.pwd());
 
-exec(cmd,
-  function(error, stdout) {
-    console.log(stdout);
-    if (error !== null) {
-      console.log('exec error: ' + error);
-    }
-  }).stderr.pipe(process.stderr);
+const child = exec(cmd);
+child.stderr.pipe(process.stderr);
+child.stdout.pipe(process.stdout);

--- a/_install_deps.js
+++ b/_install_deps.js
@@ -1,0 +1,17 @@
+const exec = require('child_process').exec;
+
+const corePath = './lighthouse-core';
+const extPath = './lighthouse-extension';
+const cmd = `npm --prefix ${corePath} install ${corePath} && npm --prefix ${extPath} install ${extPath}`;
+
+console.log(cmd);
+console.log('...');
+
+exec(cmd,
+  function(error, stdout, stderr) {
+    console.log('stdout: ' + stdout);
+    console.log('stderr: ' + stderr);
+    if (error !== null) {
+      console.log('exec error: ' + error);
+    }
+  });

--- a/_install_deps.js
+++ b/_install_deps.js
@@ -8,10 +8,9 @@ console.log(cmd);
 console.log('...');
 
 exec(cmd,
-  function(error, stdout, stderr) {
-    console.log('stdout: ' + stdout);
-    console.log('stderr: ' + stderr);
+  function(error, stdout) {
+    console.log(stdout);
     if (error !== null) {
       console.log('exec error: ' + error);
     }
-  });
+  }).stderr.pipe(process.stderr);

--- a/_install_deps.js
+++ b/_install_deps.js
@@ -1,16 +1,36 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
 const exec = require('child_process').exec;
 
-var cwd = require('path').resolve();
+const cwd = require('path').resolve();
 const corePath = `${cwd}/lighthouse-core`;
 const extPath = `${cwd}/lighthouse-extension`;
 
 const npm = 'npm --prefix';
 const cmd = `${npm} ${corePath} install ${corePath} && ${npm} ${extPath} install ${extPath}`;
 
+// Tell the user what command we're about to execute
 console.log(cmd);
 console.log('...');
 
-const child = exec(cmd,
+exec(cmd,
   function(error, stdout, stderr) {
     process.stderr.write(stderr);
     process.stdout.write(stdout);
@@ -20,5 +40,4 @@ const child = exec(cmd,
       console.log(`    ${cmd}`);
     }
   });
-child.stderr.pipe(process.stderr);
-child.stdout.pipe(process.stdout);
+

--- a/_install_deps.js
+++ b/_install_deps.js
@@ -1,6 +1,5 @@
 const exec = require('child_process').exec;
 
-
 const corePath = './lighthouse-core';
 const extPath = './lighthouse-extension';
 const cmd = `npm --prefix ${corePath} install ${corePath} && npm --prefix ${extPath} install ${extPath}`;
@@ -8,8 +7,9 @@ const cmd = `npm --prefix ${corePath} install ${corePath} && npm --prefix ${extP
 console.log(cmd);
 console.log('...');
 
-
 console.log(process.cwd());
+console.log(process.pwd());
+
 exec(cmd,
   function(error, stdout) {
     console.log(stdout);

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   },
   "scripts": {
     "//": "// passing through tasks to core",
-    "postinstall": "npm run core-install && npm run extension-install",
-    "core-install": "npm --prefix ./lighthouse-core install ./lighthouse-core",
-    "extension-install": "npm --prefix ./lighthouse-extension install ./lighthouse-extension",
+    "postinstall": "_install_deps.js",
     "lint": "eslint .",
     "smoke": "lighthouse-cli/scripts/run-smoke-tests.sh",
     "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*.js') --timeout 60000",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "//": "// passing through tasks to core",
-    "postinstall": "_install_deps.js",
+    "postinstall": "node _install_deps.js",
     "lint": "eslint .",
     "smoke": "lighthouse-cli/scripts/run-smoke-tests.sh",
     "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*.js') --timeout 60000",


### PR DESCRIPTION
in #486 we discovered that the `npm install -g GoogleChrome/lighthouse` is failing. 
It appears to fail because the postinstall script runs before the `npm --prefix` will actually work.
As a result the -core and -extension installs are a noop.

This PR changes the postinstall to use a small helper script. (It's in JS, though it would work the same in bash).

In the case that install fails, we'll see something like this in the terminal:

![image](https://cloud.githubusercontent.com/assets/39191/16678597/7ed89f1a-4495-11e6-8301-11fd3911a8a1.png)

The user can then run that command manually, and it will work.
(I can't say I love this solution, but I cannot find another mechanism to get `npm install -g GoogleChrome/lighthouse` working.)