### PR TITLE
Fallback to reuse existing tab

### DIFF
--- a/lighthouse-core/driver/drivers/cri.js
+++ b/lighthouse-core/driver/drivers/cri.js
@@ -38,7 +38,7 @@ class CriDriver extends Driver {
       /* eslint-disable new-cap */
       chromeRemoteInterface.New((err, tab) => {
         if (err) {
-          return reject(err);
+          log.warn('CRI driver', 'cannot create new tab, will reuse tab.', err);
         }
 
         chromeRemoteInterface({port: port, chooseTab: tab}, chrome => {
@@ -57,6 +57,7 @@ class CriDriver extends Driver {
   disconnect() {
     return new Promise((resolve, reject) => {
       if (!this._tab) {
+        this._chrome.close();
         return resolve();
       }
 


### PR DESCRIPTION
Was testing out Chrome headless with Lighthouse. :)

It works except for two things.

1) It doesn't support creating new tabs. filed at https://bugs.chromium.org/p/chromium/issues/detail?id=626847
2) the devtools.screenshot trace category doesnt capture anything. (However other screenshots do work)

Anyhow, this fixes #1 by letting us fallback to reusing the same tab if the protocol wont allow us to create a new one.