### PR TITLE
Checks cache for start URL

### DIFF
--- a/lighthouse-core/audits/cache-start-url.js
+++ b/lighthouse-core/audits/cache-start-url.js
@@ -55,9 +55,9 @@ class CacheStartUrl extends Audit {
     const baseURL = artifacts.URL;
 
     // Remove any UTM strings.
-    const startURL = url.resolve(baseURL, manifest.start_url.raw)
-        .toString()
-        .replace(/\?utm_source=([^&]|$)*/, '')
+    const startURL = url.resolve(baseURL, manifest.start_url.raw).toString()
+    const altStartURL = startURL
+        .replace(/\?utm_([^=]*)=([^&]|$)*/, '')
         .replace(/\?$/, '');
 
     // Now find the start_url in the cacheContents. This test is less than ideal since the Service
@@ -66,7 +66,7 @@ class CacheStartUrl extends Audit {
     // URL. However that would also necessitate the cache contents gatherer relying on the manifest
     // gather rather than being independent of it.
     cacheHasStartUrl = cacheContents.find(req => {
-      return startURL === req;
+      return (startURL === req || altStartURL === req);
     });
 
     return CacheStartUrl.generateAuditResult({

--- a/lighthouse-core/audits/cache-start-url.js
+++ b/lighthouse-core/audits/cache-start-url.js
@@ -55,7 +55,7 @@ class CacheStartUrl extends Audit {
     const baseURL = artifacts.URL;
 
     // Remove any UTM strings.
-    const startURL = url.resolve(baseURL, manifest.start_url.raw).toString()
+    const startURL = url.resolve(baseURL, manifest.start_url.raw).toString();
     const altStartURL = startURL
         .replace(/\?utm_([^=]*)=([^&]|$)*/, '')
         .replace(/\?$/, '');

--- a/lighthouse-core/audits/cache-start-url.js
+++ b/lighthouse-core/audits/cache-start-url.js
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const url = require('url');
+const Audit = require('./audit');
+
+class CacheStartUrl extends Audit {
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return {
+      category: 'Manifest',
+      name: 'cache-start-url',
+      description: 'Cache contains start_url from manifest',
+      requiredArtifacts: ['CacheContents', 'Manifest', 'URL']
+    };
+  }
+
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    let cacheHasStartUrl = false;
+
+    if (!(artifacts.Manifest &&
+          artifacts.Manifest.value &&
+          artifacts.Manifest.value.start_url &&
+          Array.isArray(artifacts.CacheContents) &&
+          artifacts.URL)) {
+      return CacheStartUrl.generateAuditResult({
+        rawValue: false
+      });
+    }
+
+    const manifest = artifacts.Manifest.value;
+    const cacheContents = artifacts.CacheContents;
+    const baseURL = artifacts.URL;
+
+    // Remove any UTM strings.
+    const startURL = url.resolve(baseURL, manifest.start_url.raw)
+        .toString()
+        .replace(/\?utm_source=([^&]|$)*/, '')
+        .replace(/\?$/, '');
+
+    // Now find the start_url in the cacheContents
+    cacheHasStartUrl = cacheContents.find(req => {
+      return startURL === req;
+    });
+
+    return CacheStartUrl.generateAuditResult({
+      rawValue: (cacheHasStartUrl !== undefined)
+    });
+  }
+}
+
+module.exports = CacheStartUrl;

--- a/lighthouse-core/audits/cache-start-url.js
+++ b/lighthouse-core/audits/cache-start-url.js
@@ -60,7 +60,11 @@ class CacheStartUrl extends Audit {
         .replace(/\?utm_source=([^&]|$)*/, '')
         .replace(/\?$/, '');
 
-    // Now find the start_url in the cacheContents
+    // Now find the start_url in the cacheContents. This test is less than ideal since the Service
+    // Worker can rewrite a request from the start URL to anything else in the cache, and so a TODO
+    // here would be to resolve this more completely by asking the Service Worker about the start
+    // URL. However that would also necessitate the cache contents gatherer relying on the manifest
+    // gather rather than being independent of it.
     cacheHasStartUrl = cacheContents.find(req => {
       return startURL === req;
     });

--- a/lighthouse-core/closure/typedefs/Artifacts.js
+++ b/lighthouse-core/closure/typedefs/Artifacts.js
@@ -76,3 +76,6 @@ Artifacts.prototype.Speedline;
 
 /** @type {{scrollWidth: number, viewportWidth: number}} */
 Artifacts.prototype.ContentWidth;
+
+/** @type {!Array<string>} */
+Artifacts.prototype.CacheContents;

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -15,7 +15,8 @@
       "screenshots",
       "critical-request-chains",
       "speedline",
-      "content-width"
+      "content-width",
+      "cache-contents"
     ]
   },
   {
@@ -63,7 +64,8 @@
     "image-alt",
     "label",
     "tabindex",
-    "content-width"
+    "content-width",
+    "cache-start-url"
   ],
 
   "aggregations": [{
@@ -83,12 +85,9 @@
           "rawValue": true,
           "weight": 1
         },
-        "manifest-start-url": {
+        "cache-start-url": {
           "rawValue": true,
-          "weight": 0,
-          "comingSoon": true,
-          "description": "Manifest's start_url is in cache storage for offline use",
-          "category": "Offline"
+          "weight": 1
         }
       }
     },{

--- a/lighthouse-core/driver/gatherers/cache-contents.js
+++ b/lighthouse-core/driver/gatherers/cache-contents.js
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* global __returnResults, caches */
+
+const Gather = require('./gather');
+
+// This is run in the page, not Lighthouse itself.
+/* istanbul ignore next */
+function getCacheContents() {
+  // Get every cache by name.
+  caches.keys()
+
+      // Open each one.
+      .then(cacheNames => Promise.all(cacheNames.map(cacheName => caches.open(cacheName))))
+
+      .then(caches => {
+        const requests = [];
+
+        // Take each cache and get any requests is contains, and bounce each one down to its URL.
+        return Promise.all(caches.map(cache => {
+          return cache.keys()
+              .then(reqs => {
+                requests.push(...reqs.map(r => r.url));
+              });
+        })).then(_ => {
+          // __returnResults is magically inserted by driver.evaluateAsync
+          __returnResults(requests);
+        });
+      });
+}
+
+class CacheContents extends Gather {
+  static _error(errorString) {
+    return {
+      raw: undefined,
+      value: undefined,
+      debugString: errorString
+    };
+  }
+
+  afterPass(options) {
+    const driver = options.driver;
+
+    return driver
+        .evaluateAsync(`(${getCacheContents.toString()}())`)
+        .then(returnedValue => {
+          if (!returnedValue) {
+            this.artifact = CacheContents._error('Unable to retrieve cache contents');
+            return;
+          }
+          this.artifact = returnedValue;
+        }, _ => {
+          this.artifact = CacheContents._error('Unable to retrieve cache contents');
+        });
+  }
+}
+
+module.exports = CacheContents;

--- a/lighthouse-core/test/audits/cache-start-url.js
+++ b/lighthouse-core/test/audits/cache-start-url.js
@@ -20,6 +20,7 @@ const manifestParser = require('../../lib/manifest-parser');
 const Manifest = manifestParser(manifestSrc);
 const CacheContents = ['https://another.example.com/', 'https://example.com/'];
 const URL = 'https://example.com';
+const AltURL = 'https://example.com/?utm_source=http203';
 
 /* global describe, it*/
 
@@ -61,6 +62,14 @@ describe('Cache: start_url audit', () => {
       Manifest,
       CacheContents,
       URL
+    }).rawValue, true);
+  });
+
+  it('handles URLs with utm params', () => {
+    return assert.equal(Audit.audit({
+      Manifest,
+      CacheContents,
+      URL: AltURL
     }).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/cache-start-url.js
+++ b/lighthouse-core/test/audits/cache-start-url.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const Audit = require('../../audits/cache-start-url.js');
+const assert = require('assert');
+const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
+const manifestParser = require('../../lib/manifest-parser');
+const Manifest = manifestParser(manifestSrc);
+const CacheContents = ['https://another.example.com/', 'https://example.com/'];
+const URL = 'https://example.com';
+
+/* global describe, it*/
+
+describe('Cache: start_url audit', () => {
+  it('fails when no manifest present', () => {
+    return assert.equal(Audit.audit({Manifest: {
+      value: undefined
+    }}).rawValue, false);
+  });
+
+  it('fails when an empty manifest is present', () => {
+    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
+  });
+
+  it('fails when no cache contents given', () => {
+    return assert.equal(Audit.audit({Manifest, URL}).rawValue, false);
+  });
+
+  it('fails when no URL given', () => {
+    return assert.equal(Audit.audit({Manifest, CacheContents}).rawValue, false);
+  });
+
+  // Need to disable camelcase check for dealing with short_name.
+  /* eslint-disable camelcase */
+  it('fails when a manifest contains no start_url', () => {
+    const inputs = {
+      Manifest: {
+        start_url: null
+      }
+    };
+
+    return assert.equal(Audit.audit(inputs).rawValue, false);
+  });
+
+  /* eslint-enable camelcase */
+
+  it('succeeds when given a manifest with a start_url, cache contents, and a URL', () => {
+    return assert.equal(Audit.audit({
+      Manifest,
+      CacheContents,
+      URL
+    }).rawValue, true);
+  });
+});

--- a/lighthouse-core/test/driver/gatherers/cache-contents.js
+++ b/lighthouse-core/test/driver/gatherers/cache-contents.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* eslint-env mocha */
+
+const CacheContentGather = require('../../../driver/gatherers/cache-contents');
+const assert = require('assert');
+let cacheContentGather;
+
+const isExpectedOutput = artifact => {
+  return 'raw' in artifact && 'value' in artifact;
+};
+
+describe('Accessibility gatherer', () => {
+  // Reset the Gatherer before each test.
+  beforeEach(() => {
+    cacheContentGather = new CacheContentGather();
+  });
+
+  it('fails gracefully', () => {
+    return cacheContentGather.afterPass({
+      driver: {
+        evaluateAsync() {
+          return Promise.resolve();
+        }
+      }
+    }).then(_ => {
+      assert.ok(typeof cacheContentGather.artifact === 'object');
+    });
+  });
+
+  it('handles driver failure', () => {
+    return cacheContentGather.afterPass({
+      driver: {
+        evaluateAsync() {
+          return Promise.reject('such a fail');
+        }
+      }
+    }).then(_ => {
+      assert(false);
+    }).catch(_ => {
+      assert.ok(isExpectedOutput(cacheContentGather.artifact));
+    });
+  });
+
+  it('propagates error retrieving the results', () => {
+    const error = 'Unable to retrieve cache contents';
+    return cacheContentGather.afterPass({
+      driver: {
+        evaluateAsync() {
+          return Promise.reject(error);
+        }
+      }
+    }).then(_ => {
+      assert.ok(cacheContentGather.artifact.debugString === error);
+    });
+  });
+
+  it('creates an object for valid results', () => {
+    return cacheContentGather.afterPass({
+      driver: {
+        evaluateAsync() {
+          return Promise.resolve(['a', 'b', 'c']);
+        }
+      }
+    }).then(_ => {
+      assert.ok(Array.isArray(cacheContentGather.artifact));
+      assert.equal(cacheContentGather.artifact[0], 'a');
+    });
+  });
+});

--- a/lighthouse-core/test/driver/gatherers/cache-contents.js
+++ b/lighthouse-core/test/driver/gatherers/cache-contents.js
@@ -25,7 +25,7 @@ const isExpectedOutput = artifact => {
   return 'raw' in artifact && 'value' in artifact;
 };
 
-describe('Accessibility gatherer', () => {
+describe('Cache Contents gatherer', () => {
   // Reset the Gatherer before each test.
   beforeEach(() => {
     cacheContentGather = new CacheContentGather();


### PR DESCRIPTION
I'm opting to collect the contents of the caches from the page as a gatherer and then check in the audit. It's not foolproof because of the fact that the SW could realistically rewrite the start URL to something else in the cache, but this way at least avoids making one gatherer rely on another.