### PR TITLE
Fixes scoring

### DIFF
--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -85,7 +85,9 @@ class Aggregate {
     }
 
     if (typeof result.rawValue !== typeof expected.rawValue) {
-      return weight;
+      const msg =
+          `Expected rawValue of type ${typeof expected.rawValue}, got ${typeof result.rawValue}`;
+      throw new Error(msg);
     }
 
     switch (typeof expected.rawValue) {

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -56,7 +56,7 @@ class EstimatedInputLatency extends Audit {
       const latencyPercentiles = TracingProcessor.getRiskToResponsiveness(model, trace, startTime);
 
       const ninetieth = latencyPercentiles.find(result => result.percentile === 0.9);
-      const rawValue = ninetieth.time.toFixed(1);
+      const rawValue = parseFloat(ninetieth.time.toFixed(1));
 
       // Use the CDF of a log-normal distribution for scoring.
       //  10th Percentile ≈ 58ms

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -80,7 +80,7 @@ class FirstMeaningfulPaint extends Audit {
 
       resolve(FirstMeaningfulPaint.generateAuditResult({
         score: result.score,
-        rawValue: result.duration,
+        rawValue: parseFloat(result.duration),
         displayValue: `${result.duration}ms`,
         debugString: result.debugString,
         optimalValue: this.meta.optimalValue,

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -229,7 +229,7 @@
           "weight": 1
         },
         "content-width": {
-          "value": true,
+          "rawValue": true,
           "weight": 1
         }
       }

--- a/lighthouse-core/test/aggregator/aggregate.js
+++ b/lighthouse-core/test/aggregator/aggregate.js
@@ -205,7 +205,7 @@ describe('Aggregate', () => {
     return assert.equal(Aggregate._convertToWeight(result, expected), 0);
   });
 
-  it('returns a weight of zero if types do not match', () => {
+  it('throws if types do not match', () => {
     const expected = {
       rawValue: true,
       weight: 10
@@ -217,7 +217,7 @@ describe('Aggregate', () => {
       displayValue: '20'
     };
 
-    return assert.equal(Aggregate._convertToWeight(result, expected), 0);
+    return assert.throws(_ => Aggregate._convertToWeight(result, expected));
   });
 
   it('scores a set correctly (contributesToScore: true)', () => {


### PR DESCRIPTION
A few per tests were using toFixed values (string) where the expected values were numbers. The aggregator was silently discarding them.

I have:
1. Fixed audits so they output the correct type
2. Changed the aggregator to throw on incorrect types so that we don't regress