### PR TITLE
Fix cachecontents gather on HTTP pages

### DIFF
--- a/lighthouse-core/driver/gatherers/cache-contents.js
+++ b/lighthouse-core/driver/gatherers/cache-contents.js
@@ -42,6 +42,8 @@ function getCacheContents() {
           // __returnResults is magically inserted by driver.evaluateAsync
           __returnResults(requests);
         });
+      }).catch(_ => {
+        __returnResults(undefined);
       });
 }
 


### PR DESCRIPTION
The `caches.open` throws an exception on HTTP, but it wasn't caught so the asyncEvaluate times out at 60s. 

![image](https://cloud.githubusercontent.com/assets/39191/16892193/312a4c60-4ac0-11e6-8b62-136a82d14aa4.png)

you can see the 60s gap here.

Luckily we have the 60s safety catch:

```js
      // If this gets to 60s and it hasn't been resolved, reject the Promise.
      asyncTimeout = setTimeout(
        (_ => reject(new Error('The asynchronous expression exceeded the allotted time of 60s'))),
        60000
      );
```

The results only had a "No" without any exception, so I'm not sure if the gather was handling this reject correctly? Might have some followup.
cc @paullewis 