### PR TITLE
Do the last (clean-state) reload in parallel with finishing the report

### DIFF
--- a/lighthouse-core/driver/drivers/driver.js
+++ b/lighthouse-core/driver/drivers/driver.js
@@ -212,6 +212,10 @@ class DriverBase {
     });
   }
 
+  reloadForCleanStateIfNeeded() {
+    return Promise.resolve();
+  }
+
   /**
    * @param {string} selector Selector to find in the DOM
    * @return {!Promise<Element>} The found element, or null, resolved in a promise

--- a/lighthouse-core/driver/drivers/extension.js
+++ b/lighthouse-core/driver/drivers/extension.js
@@ -59,6 +59,15 @@ class ExtensionDriver extends Driver {
         });
   }
 
+  reloadForCleanStateIfNeeded(options) {
+    // Reload the page to remove any side-effects (like disabling JavaScript).
+    const status = 'Reloading page to reset state';
+    log.log('status', status);
+    return this.gotoURL(options.url).then(_ => {
+      log.log('statusEnd', status);
+    });
+  }
+
   beginLogging() {
     // log events received
     chrome.debugger.onEvent.addListener((source, method, params) =>

--- a/lighthouse-core/driver/index.js
+++ b/lighthouse-core/driver/index.js
@@ -196,18 +196,12 @@ class Driver {
         }, Promise.resolve());
       })
       .then(_ => {
-        // Reload the page to remove any side-effects (like disabling JavaScript).
-        const status = 'Reloading page to reset state';
-        log.log('status', status);
-        this.loadPage(driver, options)
-          // Then, finish and teardown.
-          .then(_ => {
-            log.log('statusEnd', status);
-            log.log('status', 'Disconnecting from browser...');
-            driver.disconnect()
-          });
-        // But we dont want to hold up the reporting for the reload,
-        // so they proceed in parallel
+        // We dont need to hold up the reporting for the reload/disconnect,
+        // so we will not return a promise in here.
+        driver.reloadForCleanStateIfNeeded(options).then(_ => {
+          log.log('status', 'Disconnecting from browser...');
+          driver.disconnect();
+        });
         return undefined;
       })
       .then(_ => {

--- a/lighthouse-core/driver/index.js
+++ b/lighthouse-core/driver/index.js
@@ -169,12 +169,15 @@ class Driver {
               .then(_ => this.tearDown(runOptions));
         }, Promise.resolve());
       })
-
-      // Reload the page to remove any side-effects of Lighthouse (like disabling JavaScript).
-      .then(_ => this.loadPage(driver, options))
-
-       // Finish and teardown.
-      .then(_ => driver.disconnect())
+      .then(_ => {
+        // Reload the page to remove any side-effects (like disabling JavaScript).
+        this.loadPage(driver, options)
+          // Then, finish and teardown.
+          .then(_ => driver.disconnect());
+        // But we dont want to hold up the reporting for the reload,
+        // so they proceed in parallel
+        return undefined;
+      })
       .then(_ => {
         // Collate all the gatherer results.
         const artifacts = Object.assign({}, tracingData);

--- a/lighthouse-core/test/driver/fake-driver.js
+++ b/lighthouse-core/test/driver/fake-driver.js
@@ -31,6 +31,9 @@ module.exports = {
 
   cleanAndDisableBrowserCaches() {},
   forceUpdateServiceWorkers() {},
+  reloadForCleanStateIfNeeded() {
+    return Promise.resolve();
+  },
   beginTrace() {
     return Promise.resolve();
   },


### PR DESCRIPTION
We reload at the end so the page doesn't have disabled JS. However we hold up reporting everything until this reload is done, which is kinda unnecessary.

This changes it (almost) to a fire-and-forget. 
The last reload will now happen in parallel with the reporting our run results.

Numbers: It makes the run from ~3-9 seconds faster depending on how long navStart to window.onload is.

It does change behavior a touch though. Typically the reload takes longer than reporting, so the program terminates a few seconds after the report is done. (once the reload/disconnect promises resolve).

Thoughts?