### PR TITLE
cli: use logger to print status messages

### DIFF
--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -44,13 +44,9 @@ const events = new Emitter();
 module.exports = {
   setLevel,
   events,
-  log(title, msg) {
-    if (title === 'status') {
-      console.time(msg);
-      events.emit('status', arguments);
-    }
-    if (title === 'statusEnd') {
-      console.timeEnd(msg);
+  log(title) {
+    if (title === 'status' || title === 'statusEnd') {
+      events.emit(title, arguments);
     }
     return _log(title, arguments);
   },


### PR DESCRIPTION
When cli is run with the output directed to stdout, it may become quite inconvenient for the progress status messages to pop up on the stdout as they are being mixed with the audit formatted results.

This change makes both `status` and `statusEnd` events be emitted on `log.events`, and replaces `console.time` and `console.timeEnd` with outputting the timers using lighthouse logger, so that all timer messages go to the same place, usually stderr.

In any event, this change makes it easier to control and redirect status messages in the same way all other logging is done.