### PR TITLE
smoketest: do full default run against our basic html page.

### DIFF
--- a/lighthouse-cli/scripts/run-smoke-tests.sh
+++ b/lighthouse-cli/scripts/run-smoke-tests.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
-cd lighthouse-cli/test/fixtures && python -m SimpleHTTPServer 9999 &
+cd lighthouse-cli/test/fixtures && python -m SimpleHTTPServer 10200 &
 
 NODE=$([ $(node -v | grep -E "v4") ] && echo "node --harmony" || echo "node")
-config="$PWD/lighthouse-cli/test/fixtures/smoketest-config.json"
-flags="--config-path=$config"
+#config="$PWD/lighthouse-cli/test/fixtures/smoketest-config.json"
+#flags="--config-path=$config"
 
 offline200result="URL responds with a 200 when offline"
 
-$NODE lighthouse-cli $flags http://localhost:9999/online-only.html > results
+# run default lighthouse run against a boring basic page
+$NODE lighthouse-cli --quiet http://localhost:10200/online-only.html > results
 
 # test that we have results
 if ! grep -q "$offline200result" results; then
@@ -34,10 +35,10 @@ fi
 #
 # # test mojibrush which should pass the offline test
 # $NODE lighthouse-cli $flags https://www.moji-brush.com > results
-# 
+#
 # if ! grep -q "$offline200result: true" results; then
 #   echo "Fail! offline ready site did not work while offline"
 #   cat results
 #   exit 1
 # fi
-# 
+#


### PR DESCRIPTION
This is the same as #528 but against master, as the SW smoketest still stuck on our shared port SW origin matching issue #532 

I want this in before we pull #531 again