### PR TITLE
cleanup of extension driver attachment and event registration

### DIFF
--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -27,7 +27,6 @@ class Driver {
   constructor() {
     this._url = null;
     this.PAUSE_AFTER_LOAD = 500;
-    this._chrome = null;
     this._traceEvents = [];
     this._traceCategories = Driver.traceCategories;
     this._eventEmitter = null;


### PR DESCRIPTION
This started as moving the driver event handling (`on`, `once`, and `off`) to the base `Driver` class so the subclasses could share an implementation since browserify offers an `EventEmitter` polyfill. However, it turned into a refactor of the extension driver to simplify it and to make sure we remove any extension API listeners we add in setup. These are mostly separated into the two commits so it may make sense to review separately.

Earlier speculation was that some of our fleeting extension bugs are due to event listeners that are never removed since `chrome.debugger.*` persists between runs even when the debugger attachment does not. I'm seeing fewer exceptions with extension runs now, but it's difficult to tell for sure since the bugs are difficult to reproduce reliably.