### PR TITLE
Refactor npm scripts 

### DIFF
--- a/lighthouse-core/closure/closure-type-checking.js
+++ b/lighthouse-core/closure/closure-type-checking.js
@@ -51,7 +51,7 @@ gulp.task('js-compile', function() {
       checks_only: true,
       language_in: 'ECMASCRIPT6_STRICT',
       language_out: 'ECMASCRIPT5_STRICT',
-      warning_level: 'VERBOSE',
+      warning_level: process.env.CI ? 'QUIET' : 'VERBOSE',
       jscomp_error: [
         'checkTypes',
         'conformanceViolations'

--- a/lighthouse-core/scripts/run-mocha.sh
+++ b/lighthouse-core/scripts/run-mocha.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+flag=$1
+
+function _runmocha() {
+  mocha $2 $__node_harmony $(find $1/test -name '*.js') --timeout 60000;
+}
+
+if [ "$flag" == '--watch' ]; then
+    _runmocha '*' '--watch'
+elif [ "$flag" == '--cli' ]; then
+    _runmocha 'lighthouse-cli'
+else
+    _runmocha 'lighthouse-cli' && _runmocha 'lighthouse-core'
+fi

--- a/package.json
+++ b/package.json
@@ -8,17 +8,16 @@
     "node": ">=5"
   },
   "scripts": {
-    "//": "// passing through tasks to core",
-    "lint": "eslint .",
+    "lint": "[ \"$CI\" = true ] && eslint --quiet . || eslint .",
     "smoke": "lighthouse-cli/scripts/run-smoke-tests.sh",
-    "coverage": "node $(echo $__node_harmony) $(npm bin)/istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*.js') --timeout 60000",
+    "coverage": "node $__node_harmony $(npm bin)/istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*.js') --timeout 60000 --reporter progress",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "start": "node ./lighthouse-cli/index.js",
     "test": "npm run lint --silent && npm run unit && npm run closure",
-    "cli-unit": "mocha $(echo $__node_harmony) $(find lighthouse-cli/test lighthouse-core/test -name '*.js') --timeout 60000",
-    "unit": "npm run cli-unit",
+    "cli-unit": "lighthouse-core/scripts/run-mocha.sh --cli",
+    "unit": "lighthouse-core/scripts/run-mocha.sh --default",
     "closure": "cd lighthouse-core && closure/closure-type-checking.js",
-    "watch": "find lighthouse-core lighthouse-cli -name '*.js' -not -path '*/node_modules/*' -not -path '*/extension/*' | entr npm run unit",
+    "watch": "lighthouse-core/scripts/run-mocha.sh --watch",
     "chrome": "lighthouse-core/scripts/launch-chrome.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
This changes a few things, but ultimately should have far more effective test output. Less noise, more signal, especially in Travis.

* Fixes missing stacks bug (described below)
* Simplify `npm run watch` to reuse `mocha --watch`
* Closure warnings not outputted on Travis
* Eslint warnings not outputted on travis
* Coverage run of mocha uses different reporter so we don't have such long travis logs
* Restore `cli-unit` test to only test those files.

### Missing mocha stacks bug
A curious bug crept in that looked something like this:

```sh
mocha  */test/**  # no stack attached to exception
mocha  lighthouse-core/test/** # has full stack 
```

![image](https://cloud.githubusercontent.com/assets/39191/17311942/d8402ec0-5803-11e6-82ef-021f5efa46c4.png)

This PR will make sure any mocha exceptions always have complete stacks.