### PR TITLE
fix off-by-one error causing Infinity in 100% EIL

### DIFF
--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -165,7 +165,7 @@ class TraceProcessor {
       // Loop over durations, calculating a CDF value for each until it is above
       // the target percentile.
       const percentileTime = percentile * totalTime;
-      while (cdfTime < percentileTime && durationIndex < durations.length) {
+      while (cdfTime < percentileTime && durationIndex < durations.length - 1) {
         completedTime += duration;
         remainingCount -= (duration < 0 ? -1 : 1);
 

--- a/lighthouse-core/test/lib/traces/tracing-processor.js
+++ b/lighthouse-core/test/lib/traces/tracing-processor.js
@@ -140,5 +140,17 @@ describe('TracingProcessor lib', () => {
           [16, 16, 16, 31, 46, 55, 56]);
       assert.deepEqual(results, expected);
     });
+
+    it('does not divide by zero when duration sum is less than whole', () => {
+      // Durations chosen such that, due to floating point error:
+      //   const idleTime = totalTime - (duration1 + duration2);
+      //   (idleTime + duration1 + duration2) < totalTime
+      const duration1 = 67 / 107;
+      const duration2 = 67 / 53;
+      const totalTime = 10;
+      const results = TracingProcessor._riskPercentiles([duration1, duration2], totalTime, [1], 0);
+      const expected = createRiskPercentiles([1], [16 + duration2]);
+      assert.deepEqual(results, expected);
+    });
   });
 });


### PR DESCRIPTION
Fixes one of the remaining extension issues—occasional infinite loading spinner on the report page.

The conditional for the EIL calc loop was sometimes going one higher than it should due to floating point issues. This would only affect the 100th percentile result (so wasn't used in any calculations (yet)), but would end up putting an `Infinity` in the `extendedInfo` due to a divide by 0. It then was `JSON.stringify`ed and `JSON.parse`d, which roundtrips `Infinity` to `null`, thus giving the `TypeError: Cannot read property 'toFixed' of null` exception causing the infinite spinner.