### PR TITLE
Fix exception on missing manifest start_url

### DIFF
--- a/lighthouse-core/audits/cache-start-url.js
+++ b/lighthouse-core/audits/cache-start-url.js
@@ -43,7 +43,7 @@ class CacheStartUrl extends Audit {
     const cacheContents = artifacts.CacheContents;
     const baseURL = artifacts.URL;
 
-    if (!(manifest && manifest.start_url && manifest.start_url.raw)) {
+    if (!(manifest && manifest.start_url && manifest.start_url.value)) {
       return CacheStartUrl.generateAuditResult({
         rawValue: false,
         debugString: 'start_url not present in Manifest'
@@ -58,7 +58,7 @@ class CacheStartUrl extends Audit {
     }
 
     // Remove any UTM strings.
-    const startURL = url.resolve(baseURL, manifest.start_url.raw).toString();
+    const startURL = url.resolve(baseURL, manifest.start_url.value).toString();
     const altStartURL = startURL
         .replace(/\?utm_([^=]*)=([^&]|$)*/, '')
         .replace(/\?$/, '');

--- a/lighthouse-core/audits/cache-start-url.js
+++ b/lighthouse-core/audits/cache-start-url.js
@@ -39,20 +39,23 @@ class CacheStartUrl extends Audit {
    */
   static audit(artifacts) {
     let cacheHasStartUrl = false;
+    const manifest = artifacts.Manifest && artifacts.Manifest.value;
+    const cacheContents = artifacts.CacheContents;
+    const baseURL = artifacts.URL;
 
-    if (!(artifacts.Manifest &&
-          artifacts.Manifest.value &&
-          artifacts.Manifest.value.start_url &&
-          Array.isArray(artifacts.CacheContents) &&
-          artifacts.URL)) {
+    if (!(manifest && manifest.start_url && manifest.start_url.raw)) {
       return CacheStartUrl.generateAuditResult({
-        rawValue: false
+        rawValue: false,
+        debugString: 'start_url not present in Manifest'
       });
     }
 
-    const manifest = artifacts.Manifest.value;
-    const cacheContents = artifacts.CacheContents;
-    const baseURL = artifacts.URL;
+    if (!(Array.isArray(cacheContents) && artifacts.URL)) {
+      return CacheStartUrl.generateAuditResult({
+        rawValue: false,
+        debugString: 'No cache or URL detected'
+      });
+    }
 
     // Remove any UTM strings.
     const startURL = url.resolve(baseURL, manifest.start_url.raw).toString();

--- a/lighthouse-core/test/audits/cache-start-url.js
+++ b/lighthouse-core/test/audits/cache-start-url.js
@@ -25,13 +25,7 @@ const AltURL = 'https://example.com/?utm_source=http203';
 /* global describe, it*/
 
 describe('Cache: start_url audit', () => {
-  it('fails when no manifest present', () => {
-    return assert.equal(Audit.audit({Manifest: {
-      value: undefined
-    }}).rawValue, false);
-  });
-
-  it('fails when an empty manifest is present', () => {
+  it('fails when an empty manifest artifact is present', () => {
     return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
   });
 
@@ -43,30 +37,30 @@ describe('Cache: start_url audit', () => {
     return assert.equal(Audit.audit({Manifest, CacheContents}).rawValue, false);
   });
 
-  // Need to disable camelcase check for dealing with short_name.
+  // Need to disable camelcase check for dealing with start_url.
   /* eslint-disable camelcase */
-  it('fails when a manifest contains no start_url', () => {
+  it('fails when a manifest artifact contains no start_url', () => {
     const inputs = {
-      Manifest: {
-
-      }
+      Manifest: { }
     };
-
     return assert.equal(Audit.audit(inputs).rawValue, false);
   });
 
-  // Need to disable camelcase check for dealing with short_name.
-  /* eslint-disable camelcase */
-  it('fails when a manifest contains no start_url', () => {
+  it('fails when a manifest artifact contains a null start_url', () => {
     const inputs = {
       Manifest: {
         start_url: null
       }
     };
-
     return assert.equal(Audit.audit(inputs).rawValue, false);
   });
 
+  it('fails when a manifest contains no start_url', () => {
+    const inputs = {
+      Manifest: manifestParser({})
+    };
+    return assert.equal(Audit.audit(inputs).rawValue, false);
+  });
   /* eslint-enable camelcase */
 
   it('succeeds when given a manifest with a start_url, cache contents, and a URL', () => {

--- a/lighthouse-core/test/audits/cache-start-url.js
+++ b/lighthouse-core/test/audits/cache-start-url.js
@@ -48,6 +48,18 @@ describe('Cache: start_url audit', () => {
   it('fails when a manifest contains no start_url', () => {
     const inputs = {
       Manifest: {
+
+      }
+    };
+
+    return assert.equal(Audit.audit(inputs).rawValue, false);
+  });
+
+  // Need to disable camelcase check for dealing with short_name.
+  /* eslint-disable camelcase */
+  it('fails when a manifest contains no start_url', () => {
+    const inputs = {
+      Manifest: {
         start_url: null
       }
     };


### PR DESCRIPTION
This may fix #557, however I was unable to reproduce the exception, even trying a manifest with "start_url: undefined` and missing the property entirely.

@surma can you try this out?