### PR TITLE
Improve the robustness of the manifest unittests

### DIFF
--- a/lighthouse-core/audits/manifest-background-color.js
+++ b/lighthouse-core/audits/manifest-background-color.js
@@ -18,6 +18,8 @@
 'use strict';
 
 const Audit = require('./audit');
+const Formatter = require('../formatters/formatter');
+
 
 class ManifestBackgroundColor extends Audit {
   /**
@@ -39,7 +41,7 @@ class ManifestBackgroundColor extends Audit {
   static hasBackgroundColorValue(manifest) {
     return manifest !== undefined &&
       manifest.background_color !== undefined &&
-      manifest.background_color.value !== undefined;
+      manifest.background_color.value;
   }
 
   /**
@@ -47,11 +49,16 @@ class ManifestBackgroundColor extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const hasBackgroundColor = ManifestBackgroundColor
-        .hasBackgroundColorValue(artifacts.Manifest.value);
+    const bgColor = ManifestBackgroundColor.hasBackgroundColorValue(artifacts.Manifest.value);
 
     return ManifestBackgroundColor.generateAuditResult({
-      rawValue: hasBackgroundColor
+      rawValue: !!bgColor,
+      extendedInfo: {
+        value: {
+          color: bgColor
+        },
+        formatter: Formatter.SUPPORTED_FORMATS.NULL
+      }
     });
   }
 }

--- a/lighthouse-core/audits/manifest-background-color.js
+++ b/lighthouse-core/audits/manifest-background-color.js
@@ -20,7 +20,6 @@
 const Audit = require('./audit');
 const Formatter = require('../formatters/formatter');
 
-
 class ManifestBackgroundColor extends Audit {
   /**
    * @return {!AuditMeta}

--- a/lighthouse-core/audits/manifest-background-color.js
+++ b/lighthouse-core/audits/manifest-background-color.js
@@ -39,7 +39,6 @@ class ManifestBackgroundColor extends Audit {
    */
   static getBackgroundColorValue(manifest) {
     return manifest !== undefined &&
-      manifest.background_color !== undefined &&
       manifest.background_color.value;
   }
 
@@ -53,9 +52,7 @@ class ManifestBackgroundColor extends Audit {
     return ManifestBackgroundColor.generateAuditResult({
       rawValue: !!bgColor,
       extendedInfo: {
-        value: {
-          color: bgColor
-        },
+        value: bgColor,
         formatter: Formatter.SUPPORTED_FORMATS.NULL
       }
     });

--- a/lighthouse-core/audits/manifest-background-color.js
+++ b/lighthouse-core/audits/manifest-background-color.js
@@ -37,7 +37,7 @@ class ManifestBackgroundColor extends Audit {
    * @param {!Manifest=} manifest
    * @return {boolean}
    */
-  static hasBackgroundColorValue(manifest) {
+  static getBackgroundColorValue(manifest) {
     return manifest !== undefined &&
       manifest.background_color !== undefined &&
       manifest.background_color.value;
@@ -48,7 +48,7 @@ class ManifestBackgroundColor extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const bgColor = ManifestBackgroundColor.hasBackgroundColorValue(artifacts.Manifest.value);
+    const bgColor = ManifestBackgroundColor.getBackgroundColorValue(artifacts.Manifest.value);
 
     return ManifestBackgroundColor.generateAuditResult({
       rawValue: !!bgColor,

--- a/lighthouse-core/test/audits/background-color.js
+++ b/lighthouse-core/test/audits/background-color.js
@@ -67,7 +67,7 @@ describe('Manifest: background color audit', () => {
     };
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, true);
-    assert.equal(output.extendedInfo.value.color, '#FAFAFA');
+    assert.equal(output.extendedInfo.value, '#FAFAFA');
   });
 
   it('succeeds when a complete manifest contains a background_color', () => {

--- a/lighthouse-core/test/audits/background-color.js
+++ b/lighthouse-core/test/audits/background-color.js
@@ -19,7 +19,6 @@ const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
 const exampleManifest = manifestParser(manifestSrc);
 
-
 /* global describe, it*/
 
 // Need to disable camelcase check for dealing with background_color.
@@ -44,7 +43,9 @@ describe('Manifest: background color audit', () => {
         start_url: '/'
       }))
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, undefined);
   });
 
   it('fails when a minimal manifest contains an invalid background_color', () => {
@@ -53,7 +54,9 @@ describe('Manifest: background color audit', () => {
         background_color: 'no'
       }))
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, undefined);
   });
 
   it('succeeds when a minimal manifest contains a valid background_color', () => {

--- a/lighthouse-core/test/audits/cache-start-url.js
+++ b/lighthouse-core/test/audits/cache-start-url.js
@@ -30,11 +30,17 @@ describe('Cache: start_url audit', () => {
   });
 
   it('fails when no cache contents given', () => {
-    return assert.equal(Audit.audit({Manifest: exampleManifest, URL}).rawValue, false);
+    const artifacts = {Manifest: exampleManifest, URL};
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, 'No cache or URL detected');
   });
 
   it('fails when no URL given', () => {
-    return assert.equal(Audit.audit({Manifest: exampleManifest, CacheContents}).rawValue, false);
+    const artifacts = {Manifest: exampleManifest, CacheContents};
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, 'No cache or URL detected');
   });
 
   // Need to disable camelcase check for dealing with start_url.
@@ -43,23 +49,18 @@ describe('Cache: start_url audit', () => {
     const artifacts = {
       Manifest: { }
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
-  });
-
-  it('fails when a manifest artifact contains a null start_url', () => {
-    const artifacts = {
-      Manifest: {
-        start_url: null
-      }
-    };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, 'start_url not present in Manifest');
   });
 
   it('fails when a manifest contains no start_url', () => {
     const artifacts = {
       Manifest: manifestParser('{}')
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, 'start_url not present in Manifest');
   });
   /* eslint-enable camelcase */
 

--- a/lighthouse-core/test/audits/cache-start-url.js
+++ b/lighthouse-core/test/audits/cache-start-url.js
@@ -17,7 +17,7 @@ const Audit = require('../../audits/cache-start-url.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
-const Manifest = manifestParser(manifestSrc);
+const exampleManifest = manifestParser(manifestSrc);
 const CacheContents = ['https://another.example.com/', 'https://example.com/'];
 const URL = 'https://example.com';
 const AltURL = 'https://example.com/?utm_source=http203';
@@ -30,42 +30,42 @@ describe('Cache: start_url audit', () => {
   });
 
   it('fails when no cache contents given', () => {
-    return assert.equal(Audit.audit({Manifest, URL}).rawValue, false);
+    return assert.equal(Audit.audit({Manifest: exampleManifest, URL}).rawValue, false);
   });
 
   it('fails when no URL given', () => {
-    return assert.equal(Audit.audit({Manifest, CacheContents}).rawValue, false);
+    return assert.equal(Audit.audit({Manifest: exampleManifest, CacheContents}).rawValue, false);
   });
 
   // Need to disable camelcase check for dealing with start_url.
   /* eslint-disable camelcase */
   it('fails when a manifest artifact contains no start_url', () => {
-    const inputs = {
+    const artifacts = {
       Manifest: { }
     };
-    return assert.equal(Audit.audit(inputs).rawValue, false);
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
 
   it('fails when a manifest artifact contains a null start_url', () => {
-    const inputs = {
+    const artifacts = {
       Manifest: {
         start_url: null
       }
     };
-    return assert.equal(Audit.audit(inputs).rawValue, false);
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
 
   it('fails when a manifest contains no start_url', () => {
-    const inputs = {
-      Manifest: manifestParser({})
+    const artifacts = {
+      Manifest: manifestParser('{}')
     };
-    return assert.equal(Audit.audit(inputs).rawValue, false);
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
   /* eslint-enable camelcase */
 
   it('succeeds when given a manifest with a start_url, cache contents, and a URL', () => {
     return assert.equal(Audit.audit({
-      Manifest,
+      Manifest: exampleManifest,
       CacheContents,
       URL
     }).rawValue, true);
@@ -73,7 +73,7 @@ describe('Cache: start_url audit', () => {
 
   it('handles URLs with utm params', () => {
     return assert.equal(Audit.audit({
-      Manifest,
+      Manifest: exampleManifest,
       CacheContents,
       URL: AltURL
     }).rawValue, true);

--- a/lighthouse-core/test/audits/cache-start-url.js
+++ b/lighthouse-core/test/audits/cache-start-url.js
@@ -45,15 +45,6 @@ describe('Cache: start_url audit', () => {
 
   // Need to disable camelcase check for dealing with start_url.
   /* eslint-disable camelcase */
-  it('fails when a manifest artifact contains no start_url', () => {
-    const artifacts = {
-      Manifest: { }
-    };
-    const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
-    assert.equal(output.debugString, 'start_url not present in Manifest');
-  });
-
   it('fails when a manifest contains no start_url', () => {
     const artifacts = {
       Manifest: manifestParser('{}')

--- a/lighthouse-core/test/audits/display.js
+++ b/lighthouse-core/test/audits/display.js
@@ -38,7 +38,7 @@ describe('Mobile-friendly: display audit', () => {
 
   it('handles the case where there is no manifest display property', () => {
     const artifacts = {
-      Manifest: manifestParser({})
+      Manifest: manifestParser('{}')
     };
     const output = Audit.audit(artifacts);
 

--- a/lighthouse-core/test/audits/display.js
+++ b/lighthouse-core/test/audits/display.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 const Audit = require('../../audits/manifest-display.js');
+const manifestParser = require('../../lib/manifest-parser');
 const assert = require('assert');
+
+const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
+const exampleManifest = manifestParser(manifestSrc);
 
 /* global describe, it*/
 
@@ -26,28 +30,36 @@ describe('Mobile-friendly: display audit', () => {
     assert.equal(Audit.hasRecommendedValue(undefined), false);
   });
 
-  it('handles the case where there is no display property', () => {
-    const output = Audit.audit({Manifest: {}});
+  it('fails when no manifest artifact present', () => {
+    return assert.equal(Audit.audit({Manifest: {
+      value: undefined
+    }}).rawValue, false);
+  });
+
+  it('handles the case where there is no manifest display property', () => {
+    const artifacts = {
+      Manifest: manifestParser({})
+    };
+    const output = Audit.audit(artifacts);
 
     assert.equal(output.score, false);
     assert.equal(output.displayValue, '');
     assert.equal(output.rawValue, false);
   });
 
-  it('audits a manifest\'s display property', () => {
-    const expected = 'standalone';
-    const output = Audit.audit({
-      Manifest: {
-        value: {
-          display: {
-            value: expected
-          }
-        }
-      }
-    });
-
+  it('succeeds when a manifest has a display property', () => {
+    const artifacts = {
+      Manifest: manifestParser(JSON.stringify({
+        display: 'standalone'
+      }))
+    };
+    const output = Audit.audit(artifacts);
     assert.equal(output.score, true);
-    assert.equal(output.displayValue, expected);
+    assert.equal(output.displayValue, 'standalone');
     assert.equal(output.rawValue, true);
+  });
+
+  it('succeeds when a complete manifest contains a display property', () => {
+    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/exists.js
+++ b/lighthouse-core/test/audits/exists.js
@@ -35,13 +35,24 @@ describe('Manifest: exists audit', () => {
     }}).rawValue, true);
   });
 
-  it('succeeds when a minimal manifest contains a valid background_color', () => {
+  it('succeeds with a valid minimal manifest', () => {
+    const artifacts = {
+      Manifest: manifestParser('{}')
+    };
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
+  });
+
+  it('succeeds with a valid minimal manifest', () => {
     const artifacts = {
       Manifest: manifestParser(JSON.stringify({
         name: 'Lighthouse PWA'
       }))
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, true);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
 
   it('correctly passes through debug strings', () => {
@@ -53,6 +64,15 @@ describe('Manifest: exists audit', () => {
         debugString
       }
     }).debugString, debugString);
+  });
+
+  it('correctly passes through a JSON parsing failure', () => {
+    const artifacts = {
+      Manifest: manifestParser('{ \name: Definitely not valid JSON }')
+    };
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.ok(output.debugString.includes('Unexpected token'), 'No JSON error message');
   });
 
   it('succeeds with a complete manifest', () => {

--- a/lighthouse-core/test/audits/exists.js
+++ b/lighthouse-core/test/audits/exists.js
@@ -16,19 +16,32 @@
 const Audit = require('../../audits/manifest-exists.js');
 const assert = require('assert');
 
+const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
+const manifestParser = require('../../lib/manifest-parser');
+const exampleManifest = manifestParser(manifestSrc);
+
 /* global describe, it*/
 
 describe('Manifest: exists audit', () => {
-  it('fails when no manifest present', () => {
+  it('fails when no manifest artifact present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
     }}).rawValue, false);
   });
 
-  it('succeeds when a manifest is present', () => {
+  it('succeeds when a manifest artifact is present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: {}
     }}).rawValue, true);
+  });
+
+  it('succeeds when a minimal manifest contains a valid background_color', () => {
+    const artifacts = {
+      Manifest: manifestParser(JSON.stringify({
+        name: 'Lighthouse PWA'
+      }))
+    };
+    return assert.equal(Audit.audit(artifacts).rawValue, true);
   });
 
   it('correctly passes through debug strings', () => {
@@ -40,5 +53,9 @@ describe('Manifest: exists audit', () => {
         debugString
       }
     }).debugString, debugString);
+  });
+
+  it('succeeds with a complete manifest', () => {
+    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/exists.js
+++ b/lighthouse-core/test/audits/exists.js
@@ -29,12 +29,6 @@ describe('Manifest: exists audit', () => {
     }}).rawValue, false);
   });
 
-  it('succeeds when a manifest artifact is present', () => {
-    return assert.equal(Audit.audit({Manifest: {
-      value: {}
-    }}).rawValue, true);
-  });
-
   it('succeeds with a valid minimal manifest', () => {
     const artifacts = {
       Manifest: manifestParser('{}')

--- a/lighthouse-core/test/audits/icons.js
+++ b/lighthouse-core/test/audits/icons.js
@@ -19,6 +19,7 @@ const Audit144 = require('../../audits/manifest-icons-min-144.js');
 const Audit192 = require('../../audits/manifest-icons-min-192.js');
 const assert = require('assert');
 const manifestParser = require('../../lib/manifest-parser');
+const exampleManifest = JSON.stringify(require('../fixtures/manifest.json'));
 
 /* global describe, it*/
 
@@ -58,8 +59,7 @@ describe('Manifest: icons audits', () => {
 
     it('succeeds when a manifest contains icons that are large enough', () => {
       // stub manifest contains a 192 icon
-      const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
-      const Manifest = manifestParser(manifestSrc);
+      const Manifest = manifestParser(exampleManifest);
       assert.equal(Audit144.audit({Manifest}).rawValue, true);
       assert.equal(Audit192.audit({Manifest}).rawValue, true);
     });

--- a/lighthouse-core/test/audits/name.js
+++ b/lighthouse-core/test/audits/name.js
@@ -17,32 +17,43 @@ const Audit = require('../../audits/manifest-name.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
-const manifest = manifestParser(manifestSrc);
+const exampleManifest = manifestParser(manifestSrc);
 
 /* global describe, it*/
 
 describe('Manifest: name audit', () => {
-  it('fails when no manifest present', () => {
+  it('fails when no manifest artifact present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
     }}).rawValue, false);
   });
 
   it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
+    const artifacts = {
+      Manifest: manifestParser('{}')
+    };
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
 
   it('fails when a manifest contains no name', () => {
-    const inputs = {
-      Manifest: {
-        name: null
-      }
+    const artifacts = {
+      Manifest: manifestParser(JSON.stringify({
+        display: '/'
+      }))
     };
-
-    return assert.equal(Audit.audit(inputs).rawValue, false);
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
 
-  it('succeeds when a manifest contains a name', () => {
-    return assert.equal(Audit.audit({Manifest: manifest}).rawValue, true);
+  it('succeeds when a minimal manifest contains a name', () => {
+    const artifacts = {
+      Manifest: manifestParser(JSON.stringify({
+        name: 'Lighthouse PWA'
+      }))
+    };
+    return assert.equal(Audit.audit(artifacts).rawValue, true);
+  });
+
+  it('succeeds when a complete manifest contains a name', () => {
+    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/short-name.js
+++ b/lighthouse-core/test/audits/short-name.js
@@ -17,45 +17,48 @@ const Audit = require('../../audits/manifest-short-name.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
-const Manifest = manifestParser(manifestSrc);
+const exampleManifest = manifestParser(manifestSrc);
 
 /* global describe, it*/
 
 describe('Manifest: short_name audit', () => {
-  it('fails when no manifest present', () => {
+  it('fails when no manifest artfifact present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
     }}).rawValue, false);
   });
 
   it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
+    const artifacts = {
+      Manifest: manifestParser('{}')
+    };
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
 
   // Need to disable camelcase check for dealing with short_name.
   /* eslint-disable camelcase */
   it('fails when a manifest contains no short_name and no name', () => {
-    const inputs = JSON.stringify({
+    const artifacts = {
       name: null,
       short_name: null
-    });
-    const Manifest = manifestParser(inputs);
+    };
+    const Manifest = manifestParser(JSON.stringify(artifacts));
 
     return assert.equal(Audit.audit({Manifest}).rawValue, false);
   });
 
   it('succeeds when a manifest contains no short_name but a name', () => {
-    const inputs = JSON.stringify({
+    const artifacts = {
       short_name: undefined,
       name: 'Example App'
-    });
-    const Manifest = manifestParser(inputs);
+    };
+    const Manifest = manifestParser(JSON.stringify(artifacts));
 
     return assert.equal(Audit.audit({Manifest}).rawValue, true);
   });
   /* eslint-enable camelcase */
 
   it('succeeds when a manifest contains a short_name', () => {
-    return assert.equal(Audit.audit({Manifest}).rawValue, true);
+    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/short-name.js
+++ b/lighthouse-core/test/audits/short-name.js
@@ -39,26 +39,34 @@ describe('Manifest: short_name audit', () => {
   /* eslint-disable camelcase */
   it('fails when a manifest contains no short_name and no name', () => {
     const artifacts = {
-      name: null,
-      short_name: null
+      Manifest: manifestParser(JSON.stringify({
+        name: undefined,
+        short_name: undefined
+      }))
     };
-    const Manifest = manifestParser(JSON.stringify(artifacts));
 
-    return assert.equal(Audit.audit({Manifest}).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, undefined);
   });
 
   it('succeeds when a manifest contains no short_name but a name', () => {
     const artifacts = {
-      short_name: undefined,
-      name: 'Example App'
+      Manifest: manifestParser(JSON.stringify({
+        short_name: undefined,
+        name: 'Example App'
+      }))
     };
-    const Manifest = manifestParser(JSON.stringify(artifacts));
 
-    return assert.equal(Audit.audit({Manifest}).rawValue, true);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
   /* eslint-enable camelcase */
 
   it('succeeds when a manifest contains a short_name', () => {
-    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
+    const output = Audit.audit({Manifest: exampleManifest});
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
 });

--- a/lighthouse-core/test/audits/start-url.js
+++ b/lighthouse-core/test/audits/start-url.js
@@ -17,36 +17,46 @@ const Audit = require('../../audits/manifest-start-url.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
-const Manifest = manifestParser(manifestSrc);
+const exampleManifest = manifestParser(manifestSrc);
 
 /* global describe, it*/
 
 describe('Manifest: start_url audit', () => {
-  it('fails when no manifest present', () => {
+  it('fails when no manifest artifact present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
     }}).rawValue, false);
   });
 
   it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
+    const artifacts = {
+      Manifest: manifestParser('{}')
+    };
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
 
   // Need to disable camelcase check for dealing with short_name.
   /* eslint-disable camelcase */
   it('fails when a manifest contains no start_url', () => {
-    const inputs = {
-      Manifest: {
-        start_url: null
-      }
+    const artifacts = {
+      Manifest: manifestParser(JSON.stringify({
+        start_url: undefined
+      }))
     };
-
-    return assert.equal(Audit.audit(inputs).rawValue, false);
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
 
+  it('succeeds when a minimal manifest contains a start_url', () => {
+    const artifacts = {
+      Manifest: manifestParser(JSON.stringify({
+        start_url: '/'
+      }))
+    };
+    return assert.equal(Audit.audit(artifacts).rawValue, true);
+  });
   /* eslint-enable camelcase */
 
-  it('succeeds when a manifest contains a start_url', () => {
-    return assert.equal(Audit.audit({Manifest}).rawValue, true);
+  it('succeeds when a complete manifest contains a start_url', () => {
+    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/start-url.js
+++ b/lighthouse-core/test/audits/start-url.js
@@ -37,7 +37,7 @@ describe('Manifest: start_url audit', () => {
     assert.equal(output.debugString, undefined);
   });
 
-  // Need to disable camelcase check for dealing with short_name.
+  // Need to disable camelcase check for dealing with start_url.
   /* eslint-disable camelcase */
   it('fails when a manifest contains no start_url', () => {
     const artifacts = {

--- a/lighthouse-core/test/audits/start-url.js
+++ b/lighthouse-core/test/audits/start-url.js
@@ -32,7 +32,9 @@ describe('Manifest: start_url audit', () => {
     const artifacts = {
       Manifest: manifestParser('{}')
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, undefined);
   });
 
   // Need to disable camelcase check for dealing with short_name.
@@ -43,7 +45,9 @@ describe('Manifest: start_url audit', () => {
         start_url: undefined
       }))
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, undefined);
   });
 
   it('succeeds when a minimal manifest contains a start_url', () => {
@@ -52,7 +56,9 @@ describe('Manifest: start_url audit', () => {
         start_url: '/'
       }))
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, true);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
   /* eslint-enable camelcase */
 

--- a/lighthouse-core/test/audits/theme-color.js
+++ b/lighthouse-core/test/audits/theme-color.js
@@ -17,36 +17,47 @@ const Audit = require('../../audits/manifest-theme-color.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
-const Manifest = manifestParser(manifestSrc);
+const exampleManifest = manifestParser(manifestSrc);
 
 /* global describe, it*/
 
 describe('Manifest: theme_color audit', () => {
-  it('fails when no manifest present', () => {
+  it('fails when no manifest artifact present', () => {
     return assert.equal(Audit.audit({Manifest: {
       value: undefined
     }}).rawValue, false);
   });
 
   it('fails when an empty manifest is present', () => {
-    return assert.equal(Audit.audit({Manifest: {}}).rawValue, false);
+    const artifacts = {
+      Manifest: manifestParser('{}')
+    };
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
   });
 
   // Need to disable camelcase check for dealing with theme_color.
   /* eslint-disable camelcase */
-  it('fails when a manifest contains no theme_color', () => {
-    const inputs = {
-      Manifest: {
-        theme_color: null
-      }
+  it('fails when a minimal manifest contains no theme_color', () => {
+    const artifacts = {
+      Manifest: manifestParser(JSON.stringify({
+        start_url: '/'
+      }))
     };
+    return assert.equal(Audit.audit(artifacts).rawValue, false);
+  });
 
-    return assert.equal(Audit.audit(inputs).rawValue, false);
+  it('succeeds when a minimal manifest contains a theme_color', () => {
+    const artifacts = {
+      Manifest: manifestParser(JSON.stringify({
+        theme_color: '#bada55'
+      }))
+    };
+    return assert.equal(Audit.audit(artifacts).rawValue, true);
   });
 
   /* eslint-enable camelcase */
 
-  it('succeeds when a manifest contains a theme_color', () => {
-    return assert.equal(Audit.audit({Manifest}).rawValue, true);
+  it('succeeds when a complete manifest contains a theme_color', () => {
+    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/theme-color.js
+++ b/lighthouse-core/test/audits/theme-color.js
@@ -32,7 +32,9 @@ describe('Manifest: theme_color audit', () => {
     const artifacts = {
       Manifest: manifestParser('{}')
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, undefined);
   });
 
   // Need to disable camelcase check for dealing with theme_color.
@@ -43,7 +45,9 @@ describe('Manifest: theme_color audit', () => {
         start_url: '/'
       }))
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString, undefined);
   });
 
   it('succeeds when a minimal manifest contains a theme_color', () => {
@@ -52,7 +56,9 @@ describe('Manifest: theme_color audit', () => {
         theme_color: '#bada55'
       }))
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, true);
+    const output = Audit.audit(artifacts);
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
 
   /* eslint-enable camelcase */


### PR DESCRIPTION
In #558 we found that some tests were building mock parsedManifest artifacts incorrectly. As a result, we didn't test for a case for a found manifest but missing `start_url` and consequently threw an exception. 

This PR has two commits. The 1st commit (12bfb3a) migrates all manifest-related unit tests to properly use the manifestParser, and does not rely on mock artifact objects.

After implementing, I discovered it can be trivial to get a false negative. Many tests have only a single assertion, which is `rawValue === false`. As `rawValue` can end up as `false` for many reasons, it's not a reliable signal. For example the manifest-exists audit returned the following result:
![image](https://cloud.githubusercontent.com/assets/39191/17424500/3fc7d454-5a79-11e6-8d2d-fd8eccb7cc1c.png)

If only looking for `rawValue === false`, then we would miss the failure is due to a JSON exception inside the manifestParser.  The 2nd commit (72d1379) here adds additional assertions about the state of debugString.

