### PR TITLE
remove redundant gatherer lifecycle methods

### DIFF
--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -247,7 +247,7 @@ class Driver {
           return resolve();
         }
 
-        this.on('Page.loadEventFired', response => {
+        this.once('Page.loadEventFired', response => {
           setTimeout(_ => {
             resolve(response);
           }, this.PAUSE_AFTER_LOAD);

--- a/lighthouse-core/gather/gatherers/gatherer.js
+++ b/lighthouse-core/gather/gatherers/gatherer.js
@@ -34,15 +34,27 @@ class Gatherer {
 
   /* eslint-disable no-unused-vars */
 
-  setup(options) { }
-
+  /**
+   * Called before navigation to target url.
+   * @param {!Object} options
+   */
   beforePass(options) { }
 
+  /**
+   * Called after target page is loaded. If a trace is enabled for this pass,
+   * the trace is still being recorded.
+   * @param {!Object} options
+   */
   pass(options) { }
 
-  afterPass(options) { }
-
-  tearDown(options) { }
+  /**
+   * Called after target page is loaded, all gatherer `pass` methods have been
+   * executed, and — if generated in this pass — the trace is ended. The trace
+   * and record of network activity are provided in `loadData`.
+   * @param {!Object} options
+   * @param {{networkRecords: !Array, traceEvents: !Array} loadData
+   */
+  afterPass(options, loadData) { }
 
   /* eslint-enable no-unused-vars */
 

--- a/lighthouse-core/test/gather/gather-runner.js
+++ b/lighthouse-core/test/gather/gather-runner.js
@@ -33,7 +33,7 @@ class TestGatherer extends Gatherer {
     return 'test';
   }
 
-  setup() {
+  pass() {
     this.called = true;
   }
 }
@@ -132,12 +132,10 @@ describe('GatherRunner', function() {
 
     const config = {
       trace: true,
-      gatherers: [{
-        setup() {}
-      }]
+      gatherers: [{}]
     };
 
-    return GatherRunner.setup({driver, config}).then(_ => {
+    return GatherRunner.setupPass({driver, config}).then(_ => {
       assert.equal(calledTrace, true);
     });
   });
@@ -195,12 +193,10 @@ describe('GatherRunner', function() {
 
     const config = {
       network: true,
-      gatherers: [{
-        setup() {}
-      }]
+      gatherers: [{}]
     };
 
-    return GatherRunner.setup({driver, config}).then(_ => {
+    return GatherRunner.setupPass({driver, config}).then(_ => {
       assert.equal(calledNetworkCollect, true);
     });
   });


### PR DESCRIPTION
Due to the way gather-runner runs our gatherers, `gatherer.setup()` and `gatherer.tearDown()` are redundant with `gatherer.beforePass()` and `gatherer.afterPass()`, respectively. They also happen to be unused by any gatherer at this point, so removing them is super simple.