### PR TITLE
Keep track of the document URL post-redirects

### DIFF
--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -351,7 +351,7 @@ class Driver {
     return new Promise((resolve, reject) => {
       this._networkRecords = [];
       this._networkRecorder = new NetworkRecorder(this._networkRecords);
-      this.updateUrlIfRedirected(opts, NetworkRecorder);
+      this.updateUrlIfRedirected(opts);
 
       this.on('Network.requestWillBeSent', this._networkRecorder.onRequestWillBeSent);
       this.on('Network.requestServedFromCache', this._networkRecorder.onRequestServedFromCache);

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -25,19 +25,10 @@ const log = require('../../lib/log.js');
 class Driver {
 
   constructor() {
-    this._url = null;
     this.PAUSE_AFTER_LOAD = 500;
     this._traceEvents = [];
     this._traceCategories = Driver.traceCategories;
     this._eventEmitter = null;
-  }
-
-  get url() {
-    return this._url;
-  }
-
-  set url(_url) {
-    this._url = _url;
   }
 
   static get traceCategories() {

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -217,14 +217,12 @@ class Driver {
    * Caveat: only works when network recording enabled for a pass
    */
   enableUrlUpdateIfRedirected(opts) {
-    const networkManager = this._networkRecorder.networkManager;
-    networkManager.addEventListener(this._networkRecorder.EventTypes.RequestFinished, request => {
+    this._networkRecorder.on('requestloaded', redirectRequest => {
       // Quit if this is not a redirected request
-      if (!request.data.redirectSource) {
+      if (!redirectRequest.redirectSource) {
         return;
       }
-      const earlierRequest = request.data.redirectSource;
-      const redirectRequest = request.data;
+      const earlierRequest = redirectRequest.redirectSource;
       if (earlierRequest.url === opts.url) {
         opts.url = redirectRequest.url;
       }

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -216,7 +216,7 @@ class Driver {
    *
    * Caveat: only works when network recording enabled for a pass
    */
-  updateUrlIfRedirected(opts) {
+  enableUrlUpdateIfRedirected(opts) {
     const networkManager = this._networkRecorder.networkManager;
     networkManager.addEventListener(this._networkRecorder.EventTypes.RequestFinished, request => {
       // Quit if this is not a redirected request
@@ -345,7 +345,7 @@ class Driver {
     return new Promise((resolve, reject) => {
       this._networkRecords = [];
       this._networkRecorder = new NetworkRecorder(this._networkRecords);
-      this.updateUrlIfRedirected(opts);
+      this.enableUrlUpdateIfRedirected(opts);
 
       this.on('Network.requestWillBeSent', this._networkRecorder.onRequestWillBeSent);
       this.on('Network.requestServedFromCache', this._networkRecorder.onRequestServedFromCache);

--- a/lighthouse-core/gather/drivers/extension.js
+++ b/lighthouse-core/gather/drivers/extension.js
@@ -47,7 +47,6 @@ class ExtensionDriver extends Driver {
 
   _detachCleanup() {
     this._tabId = null;
-    this.url = null;
     chrome.debugger.onEvent.removeListener(this._onEvent);
     chrome.debugger.onDetach.removeListener(this._onUnexpectedDetach);
     this._eventEmitter.removeAllListeners();
@@ -60,8 +59,8 @@ class ExtensionDriver extends Driver {
     }
 
     return this.queryCurrentTab_()
-      .then(tabId => {
-        this._tabId = tabId;
+      .then(tab => {
+        const tabId = this._tabId = tab.id;
         chrome.debugger.onEvent.addListener(this._onEvent);
         chrome.debugger.onDetach.addListener(this._onUnexpectedDetach);
 
@@ -142,18 +141,16 @@ class ExtensionDriver extends Driver {
           return reject(chrome.runtime.lastError);
         }
 
-        this.url = tabs[0].url;
-        resolve(tabs[0].id);
+        resolve(tabs[0]);
       });
     });
   }
 
+  /**
+   * Used by lighthouse-background to kick off the run on the current page
+   */
   getCurrentTabURL() {
-    if (this.url === undefined || this.url === null) {
-      return this.queryCurrentTab_().then(_ => this.url);
-    }
-
-    return Promise.resolve(this.url);
+    return this.queryCurrentTab_().then(tab => tab.url);
   }
 }
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -62,7 +62,7 @@ class GatherRunner {
     }
 
     if (config.network) {
-      pass = pass.then(_ => driver.beginNetworkCollect());
+      pass = pass.then(_ => driver.beginNetworkCollect(options));
     }
 
     return gatherers.reduce((chain, gatherer) => {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -199,24 +199,19 @@ class GatherRunner {
         // If the main document redirects, we'll update this to keep track
         let urlAfterRedirects;
         return passes.reduce((chain, config, passIndex) => {
-          let runOptions;
+          const runOptions = Object.assign({}, options, {config});
           return chain
-              .then(_ => {
-                runOptions = Object.assign({}, options, {config});
-              })
-              .then(_ => GatherRunner.beforePass(runOptions))
-              .then(_ => GatherRunner.pass(runOptions))
-              .then(_ => GatherRunner.afterPass(runOptions))
-              .then(loadData => {
-                // Merge pass trace and network data into tracingData.
-                config.trace && Object.assign(tracingData.traces, loadData.traces);
-                config.network && (tracingData.networkRecords = loadData.networkRecords);
-              })
-              .then(_ => {
-                if (passIndex === 0) {
-                  urlAfterRedirects = runOptions.url;
-                }
-              });
+            .then(_ => GatherRunner.beforePass(runOptions))
+            .then(_ => GatherRunner.pass(runOptions))
+            .then(_ => GatherRunner.afterPass(runOptions))
+            .then(loadData => {
+              // Merge pass trace and network data into tracingData.
+              config.trace && Object.assign(tracingData.traces, loadData.traces);
+              config.network && (tracingData.networkRecords = loadData.networkRecords);
+              if (passIndex === 0) {
+                urlAfterRedirects = runOptions.url;
+              }
+            });
         }, Promise.resolve()).then(_ => {
           options.url = urlAfterRedirects;
         });

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -18,6 +18,11 @@
 
 const Gatherer = require('./gatherer');
 
+/**
+ * This gatherer changes the options.url so that its pass loads the http page.
+ * After load it detects if its on a crypographic scheme.
+ * TODO: Instead of abusing a loadPage pass for this test, it could likely just do an XHR instead
+ */
 class HTTPRedirect extends Gatherer {
 
   constructor() {

--- a/lighthouse-core/gather/gatherers/url.js
+++ b/lighthouse-core/gather/gatherers/url.js
@@ -20,7 +20,7 @@ const Gatherer = require('./gatherer');
 
 class URL extends Gatherer {
 
-  beforePass(options) {
+  afterPass(options) {
     // Used currently by cache-start-url audit, which wants to know if the start_url
     // in the manifest is stored in the cache.
     // Instead of the originally inputted URL (options.initialUrl), we want the resolved

--- a/lighthouse-core/gather/gatherers/url.js
+++ b/lighthouse-core/gather/gatherers/url.js
@@ -21,7 +21,11 @@ const Gatherer = require('./gatherer');
 class URL extends Gatherer {
 
   beforePass(options) {
-    this.artifact = options.url || options.driver.url;
+    // Used currently by cache-start-url audit, which wants to know if the start_url
+    // in the manifest is stored in the cache.
+    // Instead of the originally inputted URL (options.initialUrl), we want the resolved
+    // post-redirect URL (which is here at options.url)
+    this.artifact = options.url;
   }
 }
 

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -55,12 +55,6 @@ module.exports = function(url, flags, configJSON) {
     flags.logLevel = flags.logLevel || 'error';
     log.setLevel(flags.logLevel);
 
-    // If the URL isn't https or localhost complain to the user.
-    if (url.indexOf('https') !== 0 && url.indexOf('http://localhost') !== 0) {
-      log.warn('Lighthouse', 'The URL provided should be on HTTPS');
-      log.warn('Lighthouse', 'Performance stats will be skewed redirecting from HTTP to HTTPS.');
-    }
-
     // Use ConfigParser to generate a valid config file
     const config = new Config(configJSON, flags.auditWhitelist);
 

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -18,8 +18,6 @@
 
 const NetworkManager = require('./web-inspector').NetworkManager;
 
-const REQUEST_FINISHED = NetworkManager.EventTypes.RequestFinished;
-
 class NetworkRecorder {
   constructor(recordArray) {
     this._records = recordArray;
@@ -27,7 +25,7 @@ class NetworkRecorder {
     this.networkManager = NetworkManager.createWithFakeTarget();
 
     // TODO(bckenny): loadingFailed calls are not recorded in REQUEST_FINISHED.
-    this.networkManager.addEventListener(REQUEST_FINISHED, request => {
+    this.networkManager.addEventListener(this.EventTypes.RequestFinished, request => {
       this._records.push(request.data);
     });
 
@@ -38,6 +36,10 @@ class NetworkRecorder {
     this.onLoadingFinished = this.onLoadingFinished.bind(this);
     this.onLoadingFailed = this.onLoadingFailed.bind(this);
     this.onResourceChangedPriority = this.onResourceChangedPriority.bind(this);
+  }
+
+  get EventTypes() {
+    return NetworkManager.EventTypes;
   }
 
   // There are a few differences between the debugging protocol naming and

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -17,16 +17,19 @@
 'use strict';
 
 const NetworkManager = require('./web-inspector').NetworkManager;
+const EventEmitter = require('events').EventEmitter;
 
-class NetworkRecorder {
+class NetworkRecorder extends EventEmitter {
   constructor(recordArray) {
-    this._records = recordArray;
+    super();
 
+    this._records = recordArray;
     this.networkManager = NetworkManager.createWithFakeTarget();
 
     // TODO(bckenny): loadingFailed calls are not recorded in REQUEST_FINISHED.
     this.networkManager.addEventListener(this.EventTypes.RequestFinished, request => {
       this._records.push(request.data);
+      this.emit('requestloaded', request.data);
     });
 
     this.onRequestWillBeSent = this.onRequestWillBeSent.bind(this);

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -33,8 +33,8 @@ class Runner {
     const parsedURL = url.parse(opts.url);
     // canonicalize URL with any trailing slashes neccessary
     opts.url = url.format(parsedURL);
-    // If the URL isn't https or localhost complain to the user.
-    if (!parsedURL.protocol.includes('https') || parsedURL.hostname === 'http://localhost') {
+    // If the URL isn't https and is also not localhost complain to the user.
+    if (!parsedURL.protocol.includes('https') && parsedURL.hostname !== 'localhost') {
       log.warn('Lighthouse', 'The URL provided should be on HTTPS');
       log.warn('Lighthouse', 'Performance stats will be skewed redirecting from HTTP to HTTPS.');
     }

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -22,10 +22,22 @@ const assetSaver = require('./lib/asset-saver');
 const log = require('./lib/log');
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 
 class Runner {
   static run(driver, opts) {
     const config = opts.config;
+
+    // save the initialUrl provided by the user
+    opts.initialUrl = opts.url;
+    const parsedURL = url.parse(opts.url);
+    // canonicalize URL with any trailing slashes neccessary
+    opts.url = url.format(parsedURL);
+    // If the URL isn't https or localhost complain to the user.
+    if (!parsedURL.protocol.includes('https') || parsedURL.hostname === 'http://localhost') {
+      log.warn('Lighthouse', 'The URL provided should be on HTTPS');
+      log.warn('Lighthouse', 'Performance stats will be skewed redirecting from HTTP to HTTPS.');
+    }
 
     // Check that there are passes & audits...
     const validPassesAndAudits = config.passes && config.audits;
@@ -95,6 +107,7 @@ class Runner {
               return formatted;
             }, {});
             return {
+              initialUrl: opts.initialUrl,
               url: opts.url,
               audits: formattedAudits,
               aggregations

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -52,8 +52,9 @@ class Runner {
     // to check that there are artifacts specified in the config, and throw if not.
     if (validPassesAndAudits || validArtifactsAndAudits) {
       if (validPassesAndAudits) {
+        opts.driver = driver;
         // Finally set up the driver to gather.
-        run = run.then(_ => GatherRunner.run(config.passes, Object.assign({}, opts, {driver})));
+        run = run.then(_ => GatherRunner.run(config.passes, opts));
       } else if (validArtifactsAndAudits) {
         run = run.then(_ => config.artifacts);
       }
@@ -106,6 +107,7 @@ class Runner {
               formatted[audit.name] = audit;
               return formatted;
             }, {});
+
             return {
               initialUrl: opts.initialUrl,
               url: opts.url,

--- a/lighthouse-core/test/gather/gatherers/url.js
+++ b/lighthouse-core/test/gather/gatherers/url.js
@@ -35,28 +35,4 @@ describe('URL gatherer', () => {
 
     return assert.equal(urlGather.artifact, url);
   });
-
-  it('returns the correct URL from options.driver', () => {
-    const url = 'https://example.com';
-    urlGather.beforePass({
-      driver: {
-        url
-      }
-    });
-
-    return assert.equal(urlGather.artifact, url);
-  });
-
-  it('chooses the URL from options over options.driver', () => {
-    const url = 'https://example.com';
-    const driverUrl = 'https://example2.com';
-    urlGather.beforePass({
-      url,
-      driver: {
-        url: driverUrl
-      }
-    });
-
-    return assert.equal(urlGather.artifact, url);
-  });
 });

--- a/lighthouse-core/test/gather/gatherers/url.js
+++ b/lighthouse-core/test/gather/gatherers/url.js
@@ -19,18 +19,13 @@
 
 const URLGather = require('../../../gather/gatherers/url');
 const assert = require('assert');
-let urlGather;
 
-describe('URL gatherer', () => {
-  // Reset the Gatherer before each test.
-  beforeEach(() => {
-    urlGather = new URLGather();
-  });
-
+describe.only('URL gatherer', () => {
   it('returns the correct URL from options', () => {
+    const urlGather = new URLGather();
     const url = 'https://example.com';
-    urlGather.beforePass({
-      url
+    urlGather.afterPass({
+      url: url
     });
 
     return assert.equal(urlGather.artifact, url);

--- a/lighthouse-core/test/lib/drivers/driver.js
+++ b/lighthouse-core/test/lib/drivers/driver.js
@@ -19,11 +19,12 @@
 
 const Driver = require('../../../gather/drivers/cri.js');
 const Element = require('../../../lib/element.js');
+const NetworkRecorder = require('../../../lib/network-recorder');
 const assert = require('assert');
 
-let DriverStub = new Driver();
+let driverStub = new Driver();
 
-DriverStub.sendCommand = function(command, params) {
+driverStub.sendCommand = function(command, params) {
   switch (command) {
     case 'DOM.getDocument':
       return Promise.resolve({root: {nodeId: 249}});
@@ -36,17 +37,47 @@ DriverStub.sendCommand = function(command, params) {
   }
 };
 
+// mock redirects to test out updateUrlIfRedirected
+const req1 = {
+  url: 'http://aliexpress.com/'
+};
+const req2 = {
+  redirectSource: req1,
+  url: 'http://www.aliexpress.com/'
+};
+const req3 = {
+  redirectSource: req2,
+  url: 'http://m.aliexpress.com/?tracelog=wwwhome2mobilesitehome'
+};
+const mockRedirects = [req1, req2, req3];
+
 /* global describe, it */
 describe('Browser Driver', () => {
   it('returns null when DOM.querySelector finds no node', () => {
-    return DriverStub.querySelector('invalid').then(value => {
+    return driverStub.querySelector('invalid').then(value => {
       assert.equal(value, null);
     });
   });
 
   it('returns element when DOM.querySelector finds node', () => {
-    return DriverStub.querySelector('meta head').then(value => {
+    return driverStub.querySelector('meta head').then(value => {
       assert.equal(value instanceof Element, true);
     });
+  });
+
+  it('will update the options.url through redirects', () => {
+    const networkRecorder = driverStub._networkRecorder = new NetworkRecorder([]);
+    let opts = {url: req1.url};
+    driverStub.updateUrlIfRedirected(opts);
+
+    // Fake some reqFinished events
+    const networkManager = networkRecorder.networkManager;
+    mockRedirects.forEach(request => {
+      networkManager.dispatchEventToListeners(networkRecorder.EventTypes.RequestFinished, request);
+    });
+
+    // The above event is handled synchronously by updateUrlIfRedirected and will be all set
+    assert.notEqual(opts.url, req1.url, 'opts.url changed after the redirects');
+    assert.equal(opts.url, req3.url, 'opts.url matches the last redirect');
   });
 });

--- a/lighthouse-core/test/lib/drivers/driver.js
+++ b/lighthouse-core/test/lib/drivers/driver.js
@@ -37,7 +37,7 @@ driverStub.sendCommand = function(command, params) {
   }
 };
 
-// mock redirects to test out updateUrlIfRedirected
+// mock redirects to test out enableUrlUpdateIfRedirected
 const req1 = {
   url: 'http://aliexpress.com/'
 };
@@ -68,7 +68,7 @@ describe('Browser Driver', () => {
   it('will update the options.url through redirects', () => {
     const networkRecorder = driverStub._networkRecorder = new NetworkRecorder([]);
     let opts = {url: req1.url};
-    driverStub.updateUrlIfRedirected(opts);
+    driverStub.enableUrlUpdateIfRedirected(opts);
 
     // Fake some reqFinished events
     const networkManager = networkRecorder.networkManager;
@@ -76,7 +76,7 @@ describe('Browser Driver', () => {
       networkManager.dispatchEventToListeners(networkRecorder.EventTypes.RequestFinished, request);
     });
 
-    // The above event is handled synchronously by updateUrlIfRedirected and will be all set
+    // The above event is handled synchronously by enableUrlUpdateIfRedirected and will be all set
     assert.notEqual(opts.url, req1.url, 'opts.url changed after the redirects');
     assert.equal(opts.url, req3.url, 'opts.url matches the last redirect');
   });

--- a/lighthouse-core/test/runner.js
+++ b/lighthouse-core/test/runner.js
@@ -219,7 +219,7 @@ describe('Runner', () => {
     }, flags.auditWhitelist);
 
     return Runner.run(fakeDriver, {url, config, flags}).then(results => {
-      assert.equal(results.url, url);
+      assert.equal(results.initialUrl, url);
       assert.equal(results.audits['is-on-https'].name, 'is-on-https');
       assert.equal(results.aggregations[0].score[0].overall, 1);
       assert.equal(results.aggregations[0].score[0].subItems[0], 'is-on-https');

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -114,6 +114,7 @@ gulp.task('browserify', () => {
         bundle.transform('./dtm-transform.js', {
           global: true
         })
+        .ignore('../lighthouse-core/lib/asset-saver.js') // relative from gulpfile location
         .ignore('chrome-remote-interface')
         .ignore('source-map');
 


### PR DESCRIPTION
Often from a non-extension the input URL may then be redirected. For example, there are 3 redirects if you attempt `http://aliexpress.com`: 

![image](https://cloud.githubusercontent.com/assets/39191/17577849/39c2d6ae-5f37-11e6-918f-ead0ff50c512.png)

There's a few places where we work with the current URL, including @jeffposnick's new #578 and the [unregsw](https://github.com/GoogleChrome/lighthouse/tree/unregsw) branch. And in these cases, we want the post-redirect URL.

This PR will update `options.url` as redirects change the document location.

Additionally, we used to have a `driver.url`, but only for the chrome extension. We now drop that completely, which simplifies our URL gatherer.