### PR TITLE
refactor of gather-runner to clarify lifecycle

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -25,6 +25,23 @@ const path = require('path');
 
 class Runner {
   static run(driver, opts) {
+    // Clean opts input.
+    if (typeof opts.url !== 'string' || opts.url.length === 0) {
+      return Promise.reject(new Error('You must provide a url to the driver'));
+    }
+
+    opts.flags = opts.flags || {};
+
+    // Default mobile emulation and page loading to true.
+    // The extension will switch these off initially.
+    if (typeof opts.flags.mobile === 'undefined') {
+      opts.flags.mobile = true;
+    }
+
+    if (typeof opts.flags.loadPage === 'undefined') {
+      opts.flags.loadPage = true;
+    }
+
     const config = opts.config;
 
     // Check that there are passes & audits...

--- a/lighthouse-core/test/gather/gather-runner.js
+++ b/lighthouse-core/test/gather/gather-runner.js
@@ -48,22 +48,13 @@ describe('GatherRunner', function() {
       }
     };
 
-    return GatherRunner.loadPage(driver, {}, {
+    return GatherRunner.loadPage(driver, {
       flags: {
         loadPage: true
-      }
+      },
+      config: {}
     }).then(res => {
       assert.equal(res, true);
-    });
-  });
-
-  it('creates flags if needed', () => {
-    const url = 'https://example.com';
-    const driver = fakeDriver;
-    const options = {url, driver};
-
-    return GatherRunner.run([], options).then(_ => {
-      assert.equal(typeof options.flags, 'object');
     });
   });
 
@@ -79,10 +70,12 @@ describe('GatherRunner', function() {
       }
     };
 
-    return GatherRunner.loadPage(driver, {url: 'https://example.com'})
-        .then(res => {
-          assert.equal(res, true);
-        });
+    return GatherRunner.loadPage(driver, {
+      url: 'https://example.com',
+      config: {}
+    }).then(res => {
+      assert.equal(res, true);
+    });
   });
 
   it('sets up the driver to begin emulation when mobile == true', () => {
@@ -95,7 +88,7 @@ describe('GatherRunner', function() {
       forceUpdateServiceWorkers() {}
     };
 
-    return GatherRunner.setupDriver(driver, {}, {
+    return GatherRunner.setupDriver(driver, {
       flags: {
         mobile: true
       }
@@ -114,7 +107,7 @@ describe('GatherRunner', function() {
       forceUpdateServiceWorkers() {}
     };
 
-    return GatherRunner.setupDriver(driver, {}, {
+    return GatherRunner.setupDriver(driver, {
       flags: {}
     }).then(_ => {
       assert.equal(calledEmulation, false);
@@ -127,6 +120,9 @@ describe('GatherRunner', function() {
       beginTrace() {
         calledTrace = true;
         return Promise.resolve();
+      },
+      gotoURL() {
+        return Promise.resolve();
       }
     };
 
@@ -135,7 +131,7 @@ describe('GatherRunner', function() {
       gatherers: [{}]
     };
 
-    return GatherRunner.setupPass({driver, config}).then(_ => {
+    return GatherRunner.loadPage(driver, {config}).then(_ => {
       assert.equal(calledTrace, true);
     });
   });
@@ -188,6 +184,9 @@ describe('GatherRunner', function() {
       beginNetworkCollect() {
         calledNetworkCollect = true;
         return Promise.resolve();
+      },
+      gotoURL() {
+        return Promise.resolve();
       }
     };
 
@@ -196,7 +195,7 @@ describe('GatherRunner', function() {
       gatherers: [{}]
     };
 
-    return GatherRunner.setupPass({driver, config}).then(_ => {
+    return GatherRunner.loadPage(driver, {config}).then(_ => {
       assert.equal(calledNetworkCollect, true);
     });
   });
@@ -221,14 +220,6 @@ describe('GatherRunner', function() {
       assert.equal(calledNetworkCollect, true);
       assert.deepEqual(vals.networkRecords, {x: 1});
     });
-  });
-
-  it('rejects when not given a URL', () => {
-    return GatherRunner.run({}, {}).then(_ => assert.ok(false), _ => assert.ok(true));
-  });
-
-  it('rejects when given a URL of zero length', () => {
-    return GatherRunner.run({}, {url: ''}).then(_ => assert.ok(false), _ => assert.ok(true));
   });
 
   it('does as many passes as are required', () => {

--- a/lighthouse-core/test/runner.js
+++ b/lighthouse-core/test/runner.js
@@ -225,4 +225,12 @@ describe('Runner', () => {
       assert.equal(results.aggregations[0].score[0].subItems[0], 'is-on-https');
     });
   });
+
+  it('rejects when not given a URL', () => {
+    return Runner.run({}, {}).then(_ => assert.ok(false), _ => assert.ok(true));
+  });
+
+  it('rejects when given a URL of zero length', () => {
+    return Runner.run({}, {url: ''}).then(_ => assert.ok(false), _ => assert.ok(true));
+  });
 });


### PR DESCRIPTION
some of this is bikeshedding to (hopefully) simplify gather-runner, but key is better defined lifecycle of gather passes. Building on #572 where redundant steps were removed, we now:

- setupDriver (begin emulation, clear caches and SWs)
- for each pass:
  - create clean `options` object (in case gatherers make changes)
  - call `beforePass` on gatherers
  - navigate to `about:blank`
  - begin tracing/network recording (if requested)
  - navigate to URL, wait for load
  - call `pass` on gatherers
  - end tracing/network recording (if started)
  - call `afterPass` on gatherers

much of this is the same, but the biggest change is that before tracing started before both `beforePass` (so all `beforePass` activity was being recorded in the trace) and before the navigation to `about:blank`, so both navigations would be in the trace.

`options` normalization, defining default values, is also moved up from gather-runner to runner so that stuff is centralized.