### PR TITLE
Add custom config example: just the perf

### DIFF
--- a/lighthouse-core/config/perf.example-custom.json
+++ b/lighthouse-core/config/perf.example-custom.json
@@ -1,0 +1,69 @@
+{
+  "passes": [{
+    "network": true,
+    "trace": true,
+    "loadPage": true,
+    "gatherers": [
+      "url",
+      "critical-request-chains",
+      "screenshots",
+      "speedline"
+    ]
+  }],
+
+  "audits": [
+    "first-meaningful-paint",
+    "speed-index-metric",
+    "estimated-input-latency",
+    "time-to-interactive",
+    "user-timings",
+    "screenshots",
+    "critical-request-chains"
+  ],
+
+  "aggregations": [{
+    "name": "Perf metrics",
+    "description": "",
+    "scored": true,
+    "categorizable": true,
+    "items": [{
+      "name": "Page load performance is fast",
+      "description": "",
+      "criteria": {
+        "first-meaningful-paint": {
+          "rawValue": 100,
+          "weight": 1
+        },
+        "speed-index-metric": {
+          "rawValue": 100,
+          "weight": 1
+        },
+        "estimated-input-latency": {
+          "rawValue": 100,
+          "weight": 1
+        },
+        "time-to-interactive": {
+          "rawValue": 100,
+          "weight": 1
+        }
+      }
+    }]
+  },{
+    "name": "Performance diagnostics",
+    "description": "",
+    "scored": false,
+    "categorizable": false,
+    "items": [{
+      "criteria": {
+        "critical-request-chains": {
+          "rawValue": 0,
+          "weight": 1
+        },
+        "user-timings": {
+          "rawValue": 0,
+          "weight": 1
+        }
+      }
+    }]
+  }]
+}


### PR DESCRIPTION
This serves two purposes:

1. It's a simple but useful example of how to put together a custom config file.
2. It serves as a handy config for folks wanting to use Lighthouse for perf-only.

Usage: 

```sh
# adjust path 'n all that
lighthouse http://theverge.com --output=json --config-path=$HOME/code/lighthouse/lighthouse-core/config/perf.json
```