### PR TITLE
filterPasses -> validatePasses

### DIFF
--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -50,7 +50,6 @@ const cli = yargs
     'load-page',
     'save-assets',
     'save-artifacts',
-    'audit-whitelist',
     'list-all-audits',
     'list-trace-categories',
     'config-path'
@@ -60,7 +59,6 @@ const cli = yargs
     'load-page': 'Loads the page',
     'save-assets': 'Save the trace contents & screenshots to disk',
     'save-artifacts': 'Save all gathered artifacts to disk',
-    'audit-whitelist': 'Comma separated list of audits to run',
     'list-all-audits': 'Prints a list of all available audits and exits',
     'list-trace-categories': 'Prints a list of all required trace categories and exits',
     'config-path': 'The absolute path to the config JSON.'
@@ -92,7 +90,6 @@ Example: --output-path=./lighthouse-results.html`
   // default values
   .default('mobile', true)
   .default('load-page', true)
-  .default('audit-whitelist', 'all')
   .default('output', Printer.OUTPUT_MODE.pretty)
   .default('output-path', 'stdout')
   .check(argv => {
@@ -136,13 +133,6 @@ if (cli.verbose) {
   flags.logLevel = 'verbose';
 } else if (cli.quiet) {
   flags.logLevel = 'error';
-}
-
-// Normalize audit whitelist.
-if (!flags.auditWhitelist || flags.auditWhitelist === 'all') {
-  flags.auditWhitelist = null;
-} else {
-  flags.auditWhitelist = new Set(flags.auditWhitelist.split(',').map(a => a.toLowerCase()));
 }
 
 // kick off a lighthouse run

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -137,33 +137,10 @@ function getGatherersNeededByAudits(audits) {
   }, new Set());
 }
 
-function filterAudits(audits, auditWhitelist) {
-  // If there is no whitelist, assume all.
-  if (!auditWhitelist) {
-    return Array.from(audits);
+function requireAudits(audits, rootPath) {
+  if (!audits) {
+    return null;
   }
-
-  const rejected = [];
-  const filteredAudits = audits.filter(a => {
-    const auditName = a.toLowerCase();
-    const inWhitelist = auditWhitelist.has(auditName);
-
-    if (!inWhitelist) {
-      rejected.push(auditName);
-    }
-
-    return inWhitelist;
-  });
-
-  if (rejected.length) {
-    log.log('info', 'Running these audits:', `${filteredAudits.join(', ')}`);
-    log.log('info', 'Skipping these audits:', `${rejected.join(', ')}`);
-  }
-
-  return filteredAudits;
-}
-
-function expandAudits(audits, rootPath) {
   const Runner = require('../runner');
 
   return audits.map(audit => {

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -107,9 +107,12 @@ function cleanTrace(trace) {
 }
 
 function validatePasses(passes, audits, rootPath) {
+  if (!Array.isArray(passes)) {
+    return;
+  }
   const requiredGatherers = getGatherersNeededByAudits(audits);
 
-  // Note if we are running gathers that are not needed by the audits listed in the config
+  // Log if we are running gathers that are not needed by the audits listed in the config
   passes.forEach(pass => {
     pass.gatherers.forEach(gatherer => {
       const GathererClass = GatherRunner.getGathererClass(gatherer, rootPath);
@@ -119,7 +122,6 @@ function validatePasses(passes, audits, rootPath) {
       }
     });
   });
-  return passes;
 }
 
 function getGatherersNeededByAudits(audits) {
@@ -282,13 +284,14 @@ class Config {
     // Store the directory of the config path, if one was provided.
     this._configDir = configPath ? path.dirname(configPath) : undefined;
 
-    this._audits = configJSON.audits ? expandAudits(
-        filterAudits(configJSON.audits, auditWhitelist), this._configDir
-        ) : null;
+    this._audits = null;
+    if (configJSON.audits) {
+      this._audits = expandAudits(filterAudits(configJSON.audits, auditWhitelist), this._configDir);
+    }
     // validatePasses expects audits to have been expanded
-    this._passes = configJSON.passes ?
-        validatePasses(configJSON.passes, this._audits, this._configDir) :
-        null;
+    validatePasses(configJSON.passes, this._audits, this._configDir);
+    this._passes = configJSON.passes ? Array.from(configJSON.passes) : null;
+
     this._auditResults = configJSON.auditResults ? Array.from(configJSON.auditResults) : null;
     this._artifacts = null;
     if (configJSON.artifacts) {

--- a/lighthouse-core/config/perf.example-custom.json
+++ b/lighthouse-core/config/perf.example-custom.json
@@ -3,12 +3,7 @@
     "network": true,
     "trace": true,
     "loadPage": true,
-    "gatherers": [
-      "url",
-      "critical-request-chains",
-      "screenshots",
-      "speedline"
-    ]
+    "gatherers": []
   }],
 
   "audits": [

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -51,22 +51,6 @@ describe('Config', () => {
         /Unable to locate/);
   });
 
-  it('filters gatherers from passes when no audits require them', () => {
-    const config = new Config({
-      passes: [{
-        gatherers: [
-          'url',
-          'html',
-          'viewport'
-        ]
-      }],
-
-      audits: ['viewport']
-    });
-
-    assert.equal(config.passes[0].gatherers.length, 1);
-  });
-
   it('doesn\'t mutate old gatherers when filtering passes', () => {
     const configJSON = {
       passes: [{

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -83,22 +83,13 @@ describe('Config', () => {
     }];
 
     const config = new Config(configJSON);
-    assert.notEqual(config, configJSON);
-    assert.ok(config.aggregations);
-    assert.ok(config.auditResults);
-    assert.deepStrictEqual(config.aggregations, configJSON.aggregations);
-    assert.notEqual(config.aggregations, configJSON.aggregations);
-    assert.notEqual(config.auditResults, configJSON.auditResults);
-    assert.deepStrictEqual(config.auditResults, configJSON.auditResults);
-  });
-
-  it('returns filtered audits when a whitelist is given', () => {
-    const config = new Config({
-      audits: ['is-on-https']
-    }, new Set(['b']));
-
-    assert.ok(Array.isArray(config.audits));
-    return assert.equal(config.audits.length, 0);
+    assert.notEqual(config, configJSON, 'Objects are strictly different');
+    assert.ok(config.aggregations, 'Aggregations array exists');
+    assert.ok(config.auditResults, 'Audits array exists');
+    assert.deepStrictEqual(config.aggregations, configJSON.aggregations, 'Aggregations match');
+    assert.notEqual(config.aggregations, configJSON.aggregations, 'Aggregations not same object');
+    assert.notEqual(config.auditResults, configJSON.auditResults, 'Audits not same object');
+    assert.deepStrictEqual(config.auditResults, configJSON.auditResults, 'Audits match');
   });
 
   it('expands audits', () => {
@@ -120,7 +111,7 @@ describe('Config', () => {
   it('loads an audit relative to a config', () => {
     return assert.doesNotThrow(_ => new Config({
       audits: ['../fixtures/valid-custom-audit']
-    }, null, __filename));
+    }, __filename));
   });
 
   it('throws when it finds invalid audits', () => {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -25,9 +25,6 @@ const path = require('path');
 describe('Runner', () => {
   it('expands gatherers', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
     const config = new Config({
       passes: [{
         gatherers: ['https']
@@ -37,31 +34,25 @@ describe('Runner', () => {
       ]
     });
 
-    return Runner.run(fakeDriver, {url, config, flags}).then(_ => {
+    return Runner.run(fakeDriver, {url, config}).then(_ => {
       assert.ok(typeof config.passes[0].gatherers[0] === 'object');
     });
   });
 
   it('throws when given neither passes nor artifacts', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
     const config = new Config({
       audits: [
         'is-on-https'
       ]
-    }, flags.auditWhitelist);
+    });
 
-    return assert.throws(_ => Runner.run(fakeDriver, {url, config, flags}),
+    return assert.throws(_ => Runner.run(fakeDriver, {url, config}),
         /The config must provide passes/);
   });
 
   it('accepts existing artifacts', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
     const config = new Config({
       audits: [
         'is-on-https'
@@ -70,16 +61,13 @@ describe('Runner', () => {
       artifacts: {
         HTTPS: true
       }
-    }, flags.auditWhitelist);
+    });
 
-    return assert.doesNotThrow(_ => Runner.run({}, {url, config, flags}));
+    return assert.doesNotThrow(_ => Runner.run({}, {url, config}));
   });
 
   it('accepts trace artifacts as paths and outputs appropriate data', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
 
     const config = new Config({
       audits: [
@@ -91,9 +79,9 @@ describe('Runner', () => {
           [Audit.DEFAULT_TRACE]: path.join(__dirname, '/fixtures/traces/trace-user-timings.json')
         }
       }
-    }, flags.auditWhitelist);
+    });
 
-    return Runner.run({}, {url, config, flags}).then(results => {
+    return Runner.run({}, {url, config}).then(results => {
       assert.equal(results[0].rawValue, 2);
       assert.equal(results[0].name, 'user-timings');
     });
@@ -101,9 +89,6 @@ describe('Runner', () => {
 
   it('fails gracefully with empty artifacts object', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
 
     const config = new Config({
       audits: [
@@ -112,9 +97,9 @@ describe('Runner', () => {
 
       artifacts: {
       }
-    }, flags.auditWhitelist);
+    });
 
-    return Runner.run({}, {url, config, flags}).then(results => {
+    return Runner.run({}, {url, config}).then(results => {
       assert.equal(results[0].rawValue, -1);
       assert(results[0].debugString);
     });
@@ -122,9 +107,6 @@ describe('Runner', () => {
 
   it('accepts performance logs as an artifact', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
     const config = new Config({
       audits: [
         'critical-request-chains'
@@ -133,9 +115,9 @@ describe('Runner', () => {
       artifacts: {
         performanceLog: path.join(__dirname, '/fixtures/perflog.json')
       }
-    }, flags.auditWhitelist);
+    });
 
-    return Runner.run({}, {url, config, flags}).then(results => {
+    return Runner.run({}, {url, config}).then(results => {
       assert.equal(results[0].rawValue, 9);
       assert.equal(results[0].name, 'critical-request-chains');
     });
@@ -143,24 +125,18 @@ describe('Runner', () => {
 
   it('throws when given neither audits nor auditResults', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
     const config = new Config({
       passes: [{
         gatherers: ['https']
       }]
-    }, flags.auditWhitelist);
+    });
 
-    return assert.throws(_ => Runner.run(fakeDriver, {url, config, flags}),
+    return assert.throws(_ => Runner.run(fakeDriver, {url, config}),
         /The config must provide passes/);
   });
 
   it('accepts existing auditResults', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
     const config = new Config({
       auditResults: {
         HTTPS: true
@@ -182,16 +158,13 @@ describe('Runner', () => {
           }
         }]
       }]
-    }, flags.auditWhitelist);
+    });
 
-    return assert.doesNotThrow(_ => Runner.run(fakeDriver, {url, config, flags}));
+    return assert.doesNotThrow(_ => Runner.run(fakeDriver, {url, config}));
   });
 
   it('returns an aggregation', () => {
     const url = 'https://example.com';
-    const flags = {
-      auditWhitelist: null
-    };
     const config = new Config({
       auditResults: [{
         name: 'is-on-https',
@@ -216,9 +189,9 @@ describe('Runner', () => {
           }
         }]
       }]
-    }, flags.auditWhitelist);
+    });
 
-    return Runner.run(fakeDriver, {url, config, flags}).then(results => {
+    return Runner.run(fakeDriver, {url, config}).then(results => {
       assert.equal(results.initialUrl, url);
       assert.equal(results.audits['is-on-https'].name, 'is-on-https');
       assert.equal(results.aggregations[0].score[0].overall, 1);

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,6 @@ Configuration:
   --load-page              Loads the page                                       [default: true]
   --save-assets            Save the trace contents & screenshots to disk              [boolean]
   --save-artifacts         Save all gathered artifacts to disk                        [boolean]
-  --audit-whitelist        Comma separated list of audits to run               [default: "all"]
   --list-all-audits        Prints a list of all available audits and exits            [boolean]
   --list-trace-categories  Prints a list of all required trace categories and exits   [boolean]
   --config-path            The absolute path to the config JSON.


### PR DESCRIPTION
The current filterPass behavior implies that the user can leave all default core gatherers in the config and we'll remove the ones that aren't needed.

This is a bit odd as audits and aggregation sections must be correct, so we shouldn't make gatherers in particular be so forgiving.

Furthermore, the custom perf config no longer requires any core gatherers. It only needs trace & network records, which, without this PR, will end up filtering out the only pass in the config. 

Now instead of changing the config, config.js will issue warnings when gatherers are specified in the config that appear to be unnecessary. The resolution is adjusting the config.