### PR TITLE
properly throw debug error when page does not include manifest

### DIFF
--- a/lighthouse-core/gather/gatherers/manifest.js
+++ b/lighthouse-core/gather/gatherers/manifest.js
@@ -39,7 +39,18 @@ class Manifest extends Gatherer {
     return driver.sendCommand('Page.getAppManifest')
       .then(response => {
         if (response.errors.length) {
-          this.artifact = Manifest._errorManifest(response.errors.join(', '));
+          let errorString;
+          if (response.url) {
+            errorString = `Unable to retrieve manifest at ${response.url}: `;
+          }
+          this.artifact = Manifest._errorManifest(errorString + response.errors.join(', '));
+          return;
+        }
+
+        // The driver will return an empty string for url and the data if the
+        // page has no manifest.
+        if (!response.data.length && !response.data.url) {
+          this.artifact = Manifest._errorManifest('No manifest found.');
           return;
         }
 

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -35,7 +35,11 @@ describe('Manifest gatherer', () => {
     return manifestGather.afterPass({
       driver: {
         sendCommand() {
-          return Promise.resolve({data: '', errors: [], url: 'https://example.com/manifest.json'});
+          return Promise.resolve({
+            data: '{}',
+            errors: [],
+            url: 'https://example.com/manifest.json'
+          });
         }
       }
     }).then(_ => {
@@ -68,7 +72,23 @@ describe('Manifest gatherer', () => {
         }
       }
     }).then(_ => {
-      assert.ok(manifestGather.artifact.debugString === error);
+      assert.notStrictEqual(manifestGather.artifact.debugString.indexOf(error), -1);
+    });
+  });
+
+  it('emits an error when there was no manifest', () => {
+    return manifestGather.afterPass({
+      driver: {
+        sendCommand() {
+          return Promise.resolve({
+            data: '',
+            errors: [],
+            url: ''
+          });
+        }
+      }
+    }).then(_ => {
+      assert.ok(manifestGather.artifact.debugString);
     });
   });
 


### PR DESCRIPTION
After #600, when the devtools protocol is used to fetch a manifest from a page with no manifest, the response wasn't flagged as an error by the protocol, it just has an empty url and manifest body. This PR adds a `debugString` of 'No manifest found' in that case instead of trying to `JSON.parse` the empty string and getting an error at the later manifest parser stage.

I also noticed the error messages for manifest fetching aren't very helpful (e.g. a 404 gives `"Line: 1, column: 1, Unexpected token."`), so I add the URL that devtools tried to retrieve to the `debugString` to make it easier to spot when you've messed up your manifest path.