### PR TITLE
support collecting network records per pass

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -16,14 +16,14 @@
  */
 'use strict';
 
-const DEFAULT_TRACE = 'defaultPass';
+const DEFAULT_PASS = 'defaultPass';
 
 class Audit {
   /**
    * @return {!String}
    */
-  static get DEFAULT_TRACE() {
-    return DEFAULT_TRACE;
+  static get DEFAULT_PASS() {
+    return DEFAULT_PASS;
   }
 
   /**

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -40,8 +40,8 @@ class CriticalRequestChains extends Audit {
    * @return {!AuditResult} The score from the audit, ranging from 0-100.
    */
   static audit(artifacts) {
-    const networkRecord = artifacts.networkRecords[Audit.DEFAULT_PASS];
-    return artifacts.requestCriticalRequestChains(networkRecord).then(chains => {
+    const networkRecords = artifacts.networkRecords[Audit.DEFAULT_PASS];
+    return artifacts.requestCriticalRequestChains(networkRecords).then(chains => {
       let chainCount = 0;
       function walk(node, depth) {
         const children = Object.keys(node);

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -40,7 +40,8 @@ class CriticalRequestChains extends Audit {
    * @return {!AuditResult} The score from the audit, ranging from 0-100.
    */
   static audit(artifacts) {
-    return artifacts.requestCriticalRequestChains(artifacts.networkRecords).then(chains => {
+    const networkRecord = artifacts.networkRecords[Audit.DEFAULT_PASS];
+    return artifacts.requestCriticalRequestChains(networkRecord).then(chains => {
       let chainCount = 0;
       function walk(node, depth) {
         const children = Object.keys(node);

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -79,7 +79,7 @@ class EstimatedInputLatency extends Audit {
    * @return {!Promise<!AuditResult>} The score from the audit, ranging from 0-100.
    */
   static audit(artifacts) {
-    const trace = artifacts.traces[this.DEFAULT_TRACE];
+    const trace = artifacts.traces[this.DEFAULT_PASS];
 
     return artifacts.requestSpeedline(trace)
       .then(speedline => EstimatedInputLatency.calculate(speedline, trace))

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -53,7 +53,7 @@ class FirstMeaningfulPaint extends Audit {
    */
   static audit(artifacts) {
     return new Promise((resolve, reject) => {
-      const traceContents = artifacts.traces[this.DEFAULT_TRACE].traceEvents;
+      const traceContents = artifacts.traces[this.DEFAULT_PASS].traceEvents;
       if (!traceContents || !Array.isArray(traceContents)) {
         throw new Error(FAILURE_MESSAGE);
       }

--- a/lighthouse-core/audits/screenshots.js
+++ b/lighthouse-core/audits/screenshots.js
@@ -38,7 +38,7 @@ class Screenshots extends Audit {
    * @return {!Promise<!AuditResult>}
    */
   static audit(artifacts) {
-    const trace = artifacts.traces[this.DEFAULT_TRACE];
+    const trace = artifacts.traces[this.DEFAULT_PASS];
     if (typeof trace === 'undefined') {
       return Promise.resolve(Screenshots.generateAuditResult({
         rawValue: -1,

--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -47,7 +47,7 @@ class SpeedIndexMetric extends Audit {
    * @return {!Promise<!AuditResult>} The score from the audit, ranging from 0-100.
    */
   static audit(artifacts) {
-    const trace = artifacts.traces[this.DEFAULT_TRACE];
+    const trace = artifacts.traces[this.DEFAULT_PASS];
     if (typeof trace === 'undefined') {
       return SpeedIndexMetric.generateAuditResult({
         rawValue: -1,

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -57,7 +57,7 @@ class TTIMetric extends Audit {
    * @return {!Promise<!AuditResult>} The score from the audit, ranging from 0-100.
    */
   static audit(artifacts) {
-    const trace = artifacts.traces[Audit.DEFAULT_TRACE];
+    const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const pendingSpeedline = artifacts.requestSpeedline(trace);
     const pendingFMP = FMPMetric.audit(artifacts);
 
@@ -74,7 +74,7 @@ class TTIMetric extends Audit {
 
       // Process the trace
       const tracingProcessor = new TracingProcessor();
-      const trace = artifacts.traces[Audit.DEFAULT_TRACE];
+      const trace = artifacts.traces[Audit.DEFAULT_PASS];
       const model = tracingProcessor.init(trace);
       const endOfTraceTime = model.bounds.max;
 

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -129,8 +129,8 @@ class UserTimings extends Audit {
   static audit(artifacts) {
     return new Promise((resolve, reject) => {
       const traceContents =
-        artifacts.traces[this.DEFAULT_TRACE] &&
-        artifacts.traces[this.DEFAULT_TRACE].traceEvents;
+        artifacts.traces[this.DEFAULT_PASS] &&
+        artifacts.traces[this.DEFAULT_PASS].traceEvents;
       if (!traceContents || !Array.isArray(traceContents)) {
         throw new Error(FAILURE_MESSAGE);
       }

--- a/lighthouse-core/closure/typedefs/Artifacts.js
+++ b/lighthouse-core/closure/typedefs/Artifacts.js
@@ -38,6 +38,9 @@ Artifacts.prototype.HTTPS;
 /** @type {!Array<!Object>} */
 Artifacts.prototype.traces;
 
+/** @type {!Object<!Array>} */
+Artifacts.prototype.networkRecords;
+
 /** @type {!ManifestNode<(!Manifest|undefined)>} */
 Artifacts.prototype.Manifest;
 

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -22,6 +22,7 @@ const recordsFromLogs = require('../lib/network-recorder').recordsFromLogs;
 const GatherRunner = require('../gather/gather-runner');
 const log = require('../lib/log');
 const path = require('path');
+const Audit = require('../audits/audit');
 
 // cleanTrace is run to remove duplicate TracingStartedInPage events,
 // and to change TracingStartedInBrowser events into TracingStartedInPage.
@@ -121,6 +122,21 @@ function validatePasses(passes, audits, rootPath) {
         log.warn('config', `${GathererClass.name} is included, however no audit requires it.`);
       }
     });
+  });
+
+  // Log if multiple passes require trace or network data and could overwrite one another.
+  const usedNames = new Set();
+  passes.forEach((pass, index) => {
+    if (!pass.network && !pass.trace) {
+      return;
+    }
+
+    const passName = pass.traceName || Audit.DEFAULT_PASS;
+    if (usedNames.has(passName)) {
+      log.warn('config', `passes[${index}] may overwrite trace or network ` +
+          `data of earlier pass without a unique traceName (repeated name: ${passName}.`);
+    }
+    usedNames.add(passName);
   });
 }
 
@@ -238,8 +254,21 @@ function expandArtifacts(artifacts) {
       artifacts.traces[key] = trace;
     });
   }
+
   if (artifacts.performanceLog) {
-    artifacts.networkRecords = recordsFromLogs(require(artifacts.performanceLog));
+    if (typeof artifacts.performanceLog === 'string') {
+      // Support older format of a single performance log.
+      const log = require(artifacts.performanceLog);
+      artifacts.networkRecords = {
+        [Audit.DEFAULT_PASS]: recordsFromLogs(log)
+      };
+    } else {
+      artifacts.networkRecords = {};
+      Object.keys(artifacts.performanceLog).forEach(key => {
+        const log = require(artifacts.performanceLog[key]);
+        artifacts.networkRecords[key] = recordsFromLogs(log);
+      });
+    }
   }
 
   return artifacts;

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -131,10 +131,10 @@ function validatePasses(passes, audits, rootPath) {
       return;
     }
 
-    const passName = pass.traceName || Audit.DEFAULT_PASS;
+    const passName = pass.passName || Audit.DEFAULT_PASS;
     if (usedNames.has(passName)) {
       log.warn('config', `passes[${index}] may overwrite trace or network ` +
-          `data of earlier pass without a unique traceName (repeated name: ${passName}.`);
+          `data of earlier pass without a unique passName (repeated name: ${passName}.`);
     }
     usedNames.add(passName);
   });

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -213,8 +213,6 @@ class Driver {
    * If our main document URL redirects, we will update options.url accordingly
    * As such, options.url will always represent the post-redirected URL.
    * options.initialUrl is the pre-redirect URL that things started with
-   *
-   * Caveat: only works when network recording enabled for a pass
    */
   enableUrlUpdateIfRedirected(opts) {
     this._networkRecorder.on('requestloaded', redirectRequest => {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -176,7 +176,7 @@ class GatherRunner {
       });
     }, pass);
 
-    // Resolve on tracing data using traceName from config.
+    // Resolve on tracing data using passName from config.
     return pass.then(_ => loadData);
   }
 
@@ -227,7 +227,7 @@ class GatherRunner {
             .then(passData => {
               // If requested by config, merge trace and network data for this
               // pass into tracingData.
-              const passName = config.traceName || Audit.DEFAULT_PASS;
+              const passName = config.passName || Audit.DEFAULT_PASS;
               config.trace && (tracingData.traces[passName] = passData.trace);
               config.network && (tracingData.networkRecords[passName] = passData.networkRecords);
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -37,11 +37,11 @@ const path = require('path');
  *   B. GatherRunner.pass()
  *     i. GatherRunner.loadPage()
  *       a. navigate to about:blank
- *       b. beginTrace & beginNetworkCollect (if requested)
+ *       b. beginTrace (if requested) & beginNetworkCollect
  *       c. navigate to options.url (and wait for onload)
  *     ii. all gatherer's pass()
  *   C. GatherRunner.afterPass()
- *     i. endTrace & endNetworkCollect (if requested)
+ *     i. endTrace (if requested) & endNetworkCollect
  *     ii. all gatherer's afterPass()
  *
  * 3. Teardown
@@ -57,9 +57,10 @@ class GatherRunner {
     return driver.gotoURL('about:blank')
       // Wait a bit for about:blank to "take hold" before switching back to the page.
       .then(_ => new Promise((resolve, reject) => setTimeout(resolve, 300)))
-      // Begin tracing and network recording if required.
+      // Begin tracing if required.
       .then(_ => options.config.trace && driver.beginTrace())
-      .then(_ => options.config.network && driver.beginNetworkCollect(options))
+      // Begin network recording.
+      .then(_ => driver.beginNetworkCollect(options))
       // Navigate.
       .then(_ => driver.gotoURL(options.url, {
         waitForLoad: true,
@@ -135,7 +136,8 @@ class GatherRunner {
     const driver = options.driver;
     const config = options.config;
     const gatherers = config.gatherers;
-    const loadData = {traces: {}};
+    const loadData = {};
+
     let pass = Promise.resolve();
 
     if (config.trace) {
@@ -144,32 +146,24 @@ class GatherRunner {
         return driver.endTrace();
       }).then(traceContents => {
         // Before Chrome 54.0.2816 (codereview.chromium.org/2161583004),
-        // traceContents was an array of trace events. After this point,
-        // traceContents is an object with a traceEvents property. Normalize
-        // to new format.
-        if (Array.isArray(traceContents)) {
-          traceContents = {
-            traceEvents: traceContents
-          };
-        }
-
-        const traceName = config.traceName || Audit.DEFAULT_TRACE;
-        loadData.traces[traceName] = traceContents;
-        loadData.traceEvents = traceContents.traceEvents;
+        // traceContents was an array of trace events; after, traceContents is
+        // an object with a traceEvents property. Normalize to object form.
+        loadData.trace = Array.isArray(traceContents) ? {
+          traceEvents: traceContents
+        } : traceContents;
         log.verbose('statusEnd', 'Retrieving trace');
       });
     }
 
-    if (config.network) {
-      const status = 'Retrieving network records';
-      pass = pass.then(_ => {
-        log.log('status', status);
-        return driver.endNetworkCollect();
-      }).then(networkRecords => {
-        loadData.networkRecords = networkRecords;
-        log.verbose('statusEnd', status);
-      });
-    }
+    const status = 'Retrieving network records';
+    pass = pass.then(_ => {
+      log.log('status', status);
+      return driver.endNetworkCollect();
+    }).then(networkRecords => {
+      // Network records only given to gatherers if requested by config.
+      config.network && (loadData.networkRecords = networkRecords);
+      log.verbose('statusEnd', status);
+    });
 
     pass = gatherers.reduce((chain, gatherer) => {
       const status = `Retrieving: ${gatherer.name}`;
@@ -182,13 +176,16 @@ class GatherRunner {
       });
     }, pass);
 
-    // Resolve on loadData.
+    // Resolve on tracing data using traceName from config.
     return pass.then(_ => loadData);
   }
 
   static run(passes, options) {
     const driver = options.driver;
-    const tracingData = {traces: {}};
+    const tracingData = {
+      traces: {},
+      networkRecords: {}
+    };
 
     if (typeof options.url !== 'string' || options.url.length === 0) {
       return Promise.reject(new Error('You must provide a url to the driver'));
@@ -227,10 +224,13 @@ class GatherRunner {
             .then(_ => GatherRunner.beforePass(runOptions))
             .then(_ => GatherRunner.pass(runOptions))
             .then(_ => GatherRunner.afterPass(runOptions))
-            .then(loadData => {
-              // Merge pass trace and network data into tracingData.
-              config.trace && Object.assign(tracingData.traces, loadData.traces);
-              config.network && (tracingData.networkRecords = loadData.networkRecords);
+            .then(passData => {
+              // If requested by config, merge trace and network data for this
+              // pass into tracingData.
+              const passName = config.traceName || Audit.DEFAULT_PASS;
+              config.trace && (tracingData.traces[passName] = passData.trace);
+              config.network && (tracingData.networkRecords[passName] = passData.networkRecords);
+
               if (passIndex === 0) {
                 urlAfterRedirects = runOptions.url;
               }

--- a/lighthouse-core/gather/gatherers/gatherer.js
+++ b/lighthouse-core/gather/gatherers/gatherer.js
@@ -52,7 +52,7 @@ class Gatherer {
    * executed, and — if generated in this pass — the trace is ended. The trace
    * and record of network activity are provided in `loadData`.
    * @param {!Object} options
-   * @param {{networkRecords: !Array, traceEvents: !Array} loadData
+   * @param {{networkRecords: !Array, trace: {traceEvents: !Array}} loadData
    */
   afterPass(options, loadData) { }
 

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -81,8 +81,8 @@ function saveArtifacts(artifacts, filename) {
 }
 
 function prepareAssets(options, artifacts) {
-  const traceData = Object.keys(artifacts.traces).map(traceName => {
-    const filteredTrace = Object.assign({}, artifacts.traces[traceName]);
+  const traceData = Object.keys(artifacts.traces).map(passName => {
+    const filteredTrace = Object.assign({}, artifacts.traces[passName]);
     filteredTrace.traceEvents = filterForSize(filteredTrace.traceEvents);
     return filteredTrace;
   });

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -39,12 +39,22 @@ function _log(title, logargs) {
 }
 
 class Emitter extends EventEmitter {
-  // issueStatus fires off all status updates
-  // listen with `require('lib/log').events.addListener('status', callback)`
+  /**
+   * Fires off all status updates. Listen with
+   * `require('lib/log').events.addListener('status', callback)`
+   */
   issueStatus(title, args) {
     if (title === 'status' || title === 'statusEnd') {
       this.emit(title, args);
     }
+  }
+
+  /**
+   * Fires off all warnings. Listen with
+   * `require('lib/log').events.addListener('warning', callback)`
+   */
+  issueWarning(args) {
+    this.emit('warning', args);
   }
 }
 
@@ -57,6 +67,7 @@ module.exports = {
   },
 
   warn(title) {
+    this.events.issueWarning(arguments);
     return _log(`${title}:warn`, arguments);
   },
 

--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -50,6 +50,9 @@ const CriticalRequestChains = {
 };
 
 const mockArtifacts = {
+  networkRecords: {
+    [Audit.DEFAULT_PASS]: []
+  },
   requestCriticalRequestChains: function() {
     return Promise.resolve(CriticalRequestChains);
   }

--- a/lighthouse-core/test/audits/estimated-input-latency-test.js
+++ b/lighthouse-core/test/audits/estimated-input-latency-test.js
@@ -26,7 +26,7 @@ let computedArtifacts = GatherRunner.instantiateComputedArtifacts();
 function generateArtifactsWithTrace(trace) {
   return Object.assign(computedArtifacts, {
     traces: {
-      [Audit.DEFAULT_TRACE]: trace
+      [Audit.DEFAULT_PASS]: trace
     }
   });
 }

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -38,7 +38,7 @@ describe('Performance: first-meaningful-paint audit', () => {
 
     it('processes a valid trace file', done => {
       assert.doesNotThrow(_ => {
-        Audit.audit({traces: {[Audit.DEFAULT_TRACE]: {traceEvents}}})
+        Audit.audit({traces: {[Audit.DEFAULT_PASS]: {traceEvents}}})
           .then(response => {
             fmpResult = response;
             done();

--- a/lighthouse-core/test/audits/time-to-interactive-test.js
+++ b/lighthouse-core/test/audits/time-to-interactive-test.js
@@ -28,7 +28,7 @@ describe('Performance: time-to-interactive audit', () => {
   it('scores a -1 with invalid trace data', () => {
     return Audit.audit({
       traces: {
-        [Audit.DEFAULT_TRACE]: {
+        [Audit.DEFAULT_PASS]: {
           traceEvents: '[{"pid": 15256,"tid": 1295,"t'
         }
       },
@@ -44,7 +44,7 @@ describe('Performance: time-to-interactive audit', () => {
   it('evaluates valid input correctly', () => {
     let artifacts = mockArtifacts;
     artifacts.traces = {
-      [Audit.DEFAULT_TRACE]: {
+      [Audit.DEFAULT_PASS]: {
         traceEvents: pwaTrace
       }
     };

--- a/lighthouse-core/test/audits/user-timing-test.js
+++ b/lighthouse-core/test/audits/user-timing-test.js
@@ -29,7 +29,7 @@ describe('Performance: user-timings audit', () => {
   });
 
   it('evaluates valid input correctly', () => {
-    return Audit.audit({traces: {[Audit.DEFAULT_TRACE]: {traceEvents}}})
+    return Audit.audit({traces: {[Audit.DEFAULT_PASS]: {traceEvents}}})
       .then(response => {
         assert.equal(response.score, 2);
         assert.ok(!Number.isNaN(response.extendedInfo.value[0].startTime));

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -39,16 +39,16 @@ describe('Config', () => {
     assert.equal(defaultConfig.audits.length, config.audits.length);
   });
 
-  it('warns when a traceName is used twice', () => {
+  it('warns when a passName is used twice', () => {
     const unlikelyPassName = 'unlikelyPassName';
     const configJson = {
       passes: [{
         network: true,
-        traceName: unlikelyPassName,
+        passName: unlikelyPassName,
         gatherers: []
       }, {
         network: true,
-        traceName: unlikelyPassName,
+        passName: unlikelyPassName,
         gatherers: []
       }],
       audits: []
@@ -68,7 +68,7 @@ describe('Config', () => {
     });
   });
 
-  it('warns when traced twice with no traceNames', () => {
+  it('warns when traced twice with no passNames specified', () => {
     const configJson = {
       passes: [{
         network: true,

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -19,6 +19,8 @@ const Config = require('../../config/config');
 const assert = require('assert');
 const path = require('path');
 const defaultConfig = require('../../config/default.json');
+const log = require('../../lib/log');
+const Audit = require('../../audits/audit');
 
 /* eslint-env mocha */
 
@@ -35,6 +37,61 @@ describe('Config', () => {
     const config = new Config();
     assert.deepStrictEqual(defaultConfig.aggregations, config.aggregations);
     assert.equal(defaultConfig.audits.length, config.audits.length);
+  });
+
+  it('warns when a traceName is used twice', () => {
+    const unlikelyPassName = 'unlikelyPassName';
+    const configJson = {
+      passes: [{
+        network: true,
+        traceName: unlikelyPassName,
+        gatherers: []
+      }, {
+        network: true,
+        traceName: unlikelyPassName,
+        gatherers: []
+      }],
+      audits: []
+    };
+
+    return new Promise((resolve, reject) => {
+      const warningListener = function(args) {
+        const warningMsg = args[1];
+        if (new RegExp(`overwrite.+${unlikelyPassName}`).test(warningMsg)) {
+          log.events.removeListener('warning', warningListener);
+          resolve();
+        }
+      };
+      log.events.addListener('warning', warningListener);
+
+      const _ = new Config(configJson);
+    });
+  });
+
+  it('warns when traced twice with no traceNames', () => {
+    const configJson = {
+      passes: [{
+        network: true,
+        gatherers: []
+      }, {
+        network: true,
+        gatherers: []
+      }],
+      audits: []
+    };
+
+    return new Promise((resolve, reject) => {
+      const warningListener = function(args) {
+        const warningMsg = args[1];
+        if (new RegExp(`overwrite.+${Audit.DEFAULT_PASS}`).test(warningMsg)) {
+          log.events.removeListener('warning', warningListener);
+          resolve();
+        }
+      };
+      log.events.addListener('warning', warningListener);
+
+      const _ = new Config(configJson);
+    });
   });
 
   it('throws for unknown gatherers', () => {
@@ -151,7 +208,27 @@ describe('Config', () => {
     });
     const traceUserTimings = require('../fixtures/traces/trace-user-timings.json');
     assert.deepStrictEqual(config.artifacts.traces.defaultPass.traceEvents, traceUserTimings);
-    assert.equal(config.artifacts.networkRecords.length, 76);
+    assert.equal(config.artifacts.networkRecords.defaultPass.length, 76);
+  });
+
+  it('expands artifacts with multiple named passes', () => {
+    const config = new Config({
+      artifacts: {
+        traces: {
+          defaultPass: path.resolve(__dirname, '../fixtures/traces/trace-user-timings.json'),
+          otherPass: path.resolve(__dirname, '../fixtures/traces/trace-user-timings.json')
+        },
+        performanceLog: {
+          defaultPass: path.resolve(__dirname, '../fixtures/perflog.json'),
+          otherPass: path.resolve(__dirname, '../fixtures/perflog.json')
+        }
+      }
+    });
+    const traceUserTimings = require('../fixtures/traces/trace-user-timings.json');
+    assert.deepStrictEqual(config.artifacts.traces.defaultPass.traceEvents, traceUserTimings);
+    assert.deepStrictEqual(config.artifacts.traces.otherPass.traceEvents, traceUserTimings);
+    assert.equal(config.artifacts.networkRecords.defaultPass.length, 76);
+    assert.equal(config.artifacts.networkRecords.otherPass.length, 76);
   });
 
   it('handles traces with no TracingStartedInPage events', () => {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -165,10 +165,11 @@ describe('GatherRunner', function() {
 
   it('tells the driver to end tracing', () => {
     let calledTrace = false;
+    const fakeTraceData = {traceEvents: ['reallyBelievableTraceEvents']};
     const driver = {
       endTrace() {
         calledTrace = true;
-        return Promise.resolve({x: 1});
+        return Promise.resolve(fakeTraceData);
       },
       endNetworkCollect() {
         return Promise.resolve();
@@ -182,9 +183,9 @@ describe('GatherRunner', function() {
       }]
     };
 
-    return GatherRunner.afterPass({driver, config}).then(vals => {
+    return GatherRunner.afterPass({driver, config}).then(passData => {
       assert.equal(calledTrace, true);
-      assert.deepEqual(vals.trace, {x: 1});
+      assert.equal(passData.trace, fakeTraceData);
     });
   });
 

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -256,14 +256,14 @@ describe('GatherRunner', function() {
     const passes = [{
       network: true,
       trace: true,
-      traceName: 'firstPass',
+      passName: 'firstPass',
       loadPage: true,
       gatherers: [
         t1
       ]
     }, {
       loadPage: true,
-      traceName: 'secondPass',
+      passName: 'secondPass',
       gatherers: [
         t2
       ]
@@ -286,13 +286,13 @@ describe('GatherRunner', function() {
     const passes = [{
       network: true,
       trace: true,
-      traceName: 'firstPass',
+      passName: 'firstPass',
       loadPage: true,
       gatherers: [new TestGatherer()]
     }, {
       network: true,
       trace: true,
-      traceName: 'secondPass',
+      passName: 'secondPass',
       loadPage: true,
       gatherers: [new TestGatherer()]
     }];
@@ -315,7 +315,7 @@ describe('GatherRunner', function() {
     const passes = [{
       network: true,
       trace: true,
-      traceName: 'firstPass',
+      passName: 'firstPass',
       loadPage: true,
       gatherers: [
         t1
@@ -365,7 +365,7 @@ describe('GatherRunner', function() {
     const passes = [{
       network: true,
       trace: true,
-      traceName: 'firstPass',
+      passName: 'firstPass',
       loadPage: true,
       gatherers: [new TestGatherer()]
     }];

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -44,7 +44,7 @@ describe('asset-saver helper', () => {
     };
     const artifacts = {
       traces: {
-        [Audit.DEFAULT_TRACE]: {
+        [Audit.DEFAULT_PASS]: {
           traceEvents
         }
       },

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -76,7 +76,7 @@ describe('Runner', () => {
 
       artifacts: {
         traces: {
-          [Audit.DEFAULT_TRACE]: path.join(__dirname, '/fixtures/traces/trace-user-timings.json')
+          [Audit.DEFAULT_PASS]: path.join(__dirname, '/fixtures/traces/trace-user-timings.json')
         }
       }
     });


### PR DESCRIPTION
- always records network information (fixing #604)
- allows recording the network activity for multiple passes, paving the way for audits like #578
- warns you if your current config has conflicting names for its trace data
- renames `traceName` in config files to the more accurate `passName`

This does use the same naming method as the earlier trace bucket PR. We still need to find a different solution, but at least tracing and network will be unified again, making them easier to change together.