### PR TITLE
fix audit, gatherer, and computed artifact browserify import

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -142,15 +142,14 @@ function requireAudits(audits, rootPath) {
     return null;
   }
   const Runner = require('../runner');
+  const coreList = Runner.getAuditList();
 
   return audits.map(audit => {
-    // Firstly see if the audit is in Lighthouse itself.
-    const list = Runner.getAuditList();
-    const coreAudit = list.find(a => a === `${audit}.js`);
-
-    // Assume it's a core audit first.
-    let requirePath = path.resolve(__dirname, `../audits/${audit}`);
     let AuditClass;
+
+    // Firstly see if the audit is in Lighthouse itself.
+    const coreAudit = coreList.find(a => a === `${audit}.js`);
+    let requirePath = `../audits/${audit}`;
 
     // If not, see if it can be found another way.
     if (!coreAudit) {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -267,12 +267,13 @@ class GatherRunner {
 
   static getGathererClass(gatherer, rootPath) {
     const Runner = require('../runner');
-    const list = Runner.getGathererList();
-    const coreGatherer = list.find(a => a === `${gatherer}.js`);
+    const coreList = Runner.getGathererList();
 
-    // Assume it's a core gatherer first.
-    let requirePath = path.resolve(__dirname, `./gatherers/${gatherer}`);
     let GathererClass;
+
+    // First see if it is a core gatherer in Lighthouse itself.
+    const coreGatherer = coreList.find(a => a === `${gatherer}.js`);
+    let requirePath = `./gatherers/${gatherer}`;
 
     // If not, see if it can be found another way.
     if (!coreGatherer) {
@@ -329,8 +330,9 @@ class GatherRunner {
 
   static instantiateComputedArtifacts() {
     let computedArtifacts = {};
-    var normalizedPath = require('path').join(__dirname, 'computed');
-    require('fs').readdirSync(normalizedPath).forEach(function(file) {
+    require('fs').readdirSync(path.join(__dirname, 'computed')).forEach(function(file) {
+      // Drop `.js` suffix to keep browserify import happy.
+      file = file.replace(/\.js$/, '');
       const ArtifactClass = require('./computed/' + file);
       const artifact = new ArtifactClass();
       // define the request* function that will be exposed on `artifacts`

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -24,6 +24,11 @@ const gatherers = fs.readdirSync(path.join(__dirname, '../', 'lighthouse-core/ga
     .filter(f => /\.js$/.test(f))
     .map(f => `../lighthouse-core/gather/gatherers/${f.replace(/\.js$/, '')}`);
 
+const computedArtifacts = fs.readdirSync(
+    path.join(__dirname, '../lighthouse-core/gather/computed/'))
+    .filter(f => /\.js$/.test(f))
+    .map(f => `../lighthouse-core/gather/computed/${f.replace(/\.js$/, '')}`);
+
 gulp.task('extras', () => {
   return gulp.src([
     'app/*.*',
@@ -118,7 +123,7 @@ gulp.task('browserify', () => {
         .ignore('chrome-remote-interface')
         .ignore('source-map');
 
-        // Expose the audits and gatherers so they can be dynamically loaded.
+        // Expose the audits, gatherers, and computed artifacts so they can be dynamically loaded.
         const corePath = '../lighthouse-core/';
         const driverPath = `${corePath}gather/`;
         audits.forEach(audit => {
@@ -126,6 +131,9 @@ gulp.task('browserify', () => {
         });
         gatherers.forEach(gatherer => {
           bundle = bundle.require(gatherer, {expose: gatherer.replace(driverPath, './')});
+        });
+        computedArtifacts.forEach(artifact => {
+          bundle = bundle.require(artifact, {expose: artifact.replace(driverPath, './')});
         });
       }
       // Inject the new browserified contents back into our gulp pipeline


### PR DESCRIPTION
fixes extension (currently breaking on audit `require` on master) by matching paths to what browserify expects and making sure computed artifacts are unconditionally included in bundle.

With options fix in #614, extension should be good to go again