### PR TITLE
about:blank navigation moved to before gatherer.beforeClass()

### DIFF
--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -79,29 +79,6 @@ describe('GatherRunner', function() {
     });
   });
 
-  it('reloads a page via about:blank', () => {
-    const expected = [
-      'https://example.com',
-      'about:blank'
-    ];
-    const driver = {
-      gotoURL(url) {
-        assert(url, expected.pop());
-        return Promise.resolve(true);
-      },
-      beginNetworkCollect() {
-        return Promise.resolve();
-      }
-    };
-
-    return GatherRunner.loadPage(driver, {
-      url: 'https://example.com',
-      config: {}
-    }).then(res => {
-      assert.equal(res, true);
-    });
-  });
-
   it('sets up the driver to begin emulation when mobile == true', () => {
     let calledEmulation = false;
     const driver = {


### PR DESCRIPTION
On master, the beginning of a pass goes:
- `beforePass()` on all gatherers
- navigate to `about:blank`, then target url
- `pass()` on all gatherers
- etc

After this PR, each pass will begin:
- navigate to `about:blank`
- `beforePass()` on all gatherers
- navigate to target url
- `pass()` on all gatherers
- etc