### PR TITLE
eliminate non-functional loadPage cli flag

### DIFF
--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -47,7 +47,6 @@ const cli = yargs
 
   .group([
     'mobile',
-    'load-page',
     'save-assets',
     'save-artifacts',
     'list-all-audits',
@@ -56,7 +55,6 @@ const cli = yargs
   ], 'Configuration:')
   .describe({
     'mobile': 'Emulates a Nexus 5X',
-    'load-page': 'Loads the page',
     'save-assets': 'Save the trace contents & screenshots to disk',
     'save-artifacts': 'Save all gathered artifacts to disk',
     'list-all-audits': 'Prints a list of all available audits and exits',
@@ -89,7 +87,6 @@ Example: --output-path=./lighthouse-results.html`
 
   // default values
   .default('mobile', true)
-  .default('load-page', true)
   .default('output', Printer.OUTPUT_MODE.pretty)
   .default('output-path', 'stdout')
   .check(argv => {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -217,10 +217,6 @@ class GatherRunner {
       options.flags.mobile = true;
     }
 
-    if (typeof options.flags.loadPage === 'undefined') {
-      options.flags.loadPage = true;
-    }
-
     passes = this.instantiateGatherers(passes, options.config.configDir);
 
     return driver.connect()

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -35,10 +35,6 @@ class Runner {
       opts.flags.mobile = true;
     }
 
-    if (typeof opts.flags.loadPage === 'undefined') {
-      opts.flags.loadPage = true;
-    }
-
     const config = opts.config;
 
     // save the initialUrl provided by the user

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -59,9 +59,7 @@ describe('GatherRunner', function() {
     };
 
     return GatherRunner.loadPage(driver, {
-      flags: {
-        loadPage: true
-      },
+      flags: {},
       config: {}
     }).then(res => {
       assert.equal(res, true);

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -125,8 +125,7 @@ document.addEventListener('DOMContentLoaded', _ => {
     .then(selectedAudits => {
       return background.runLighthouse({
         flags: {
-          mobile: true,
-          loadPage: true
+          mobile: true
         }
       }, selectedAudits);
     })

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,6 @@ Logging:
 
 Configuration:
   --mobile                 Emulates a Nexus 5X                                  [default: true]
-  --load-page              Loads the page                                       [default: true]
   --save-assets            Save the trace contents & screenshots to disk              [boolean]
   --save-artifacts         Save all gathered artifacts to disk                        [boolean]
   --list-all-audits        Prints a list of all available audits and exits            [boolean]


### PR DESCRIPTION
the `--load-page`/`loadPage` options flag has been non-functional since at least when the config file was added. This removes the last traces of it.

Note that this is *not* the `loadPage` included in passes in the config file (that's #589)