### PR TITLE
Fixed headless documentation

### DIFF
--- a/API-and-internals.md
+++ b/API-and-internals.md
@@ -21,6 +21,7 @@ cd lighthouse && npm i && npm link
 ```
 
 ```sh
+export DISPLAY=:1.5
 
 # start up chromium inside xvfb
 xvfb-run --server-args='-screen 0, 1024x768x16' chromium-browser  --temp-profile --start-maximized --no-first-run  --remote-debugging-port=9222 "about:blank"

--- a/API-and-internals.md
+++ b/API-and-internals.md
@@ -13,7 +13,7 @@ curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # get chromium (stable) and Xvfb
-apt-get install chromium xvfb
+apt-get install chromium-browser xvfb
 
 # install lighthouse
 git clone https://github.com/GoogleChrome/lighthouse
@@ -21,11 +21,9 @@ cd lighthouse && npm i && npm link
 ```
 
 ```sh
-TMP_PROFILE_DIR=$(mktemp -d -t lighthouseXXXX)
-export DISPLAY=:1.5
 
 # start up chromium inside xvfb
-xvfb-run --server-args='-screen 0, 1024x768x16' chromium --start-maximized --remote-debugging-port=9222 --no-first-run --user-data-dir=$TMP_PROFILE_DIR "about:blank"
+xvfb-run --server-args='-screen 0, 1024x768x16' chromium-browser  --temp-profile --start-maximized --no-first-run  --remote-debugging-port=9222 "about:blank"
 
 # kick off your lighthouse run, saving assets to verify for later
 lighthouse http://github.com --save-assets


### PR DESCRIPTION
I got lighthouse running on Ubuntu 16.04 server and had to make the following changes. I don't know if the current instructions are for previous versions or if they contained errors. For example, I was unable to find a reference to a package ``` chromium``` ever existing.

Changes:

- Chromium package and executable are named ```chromium-browser``` in Ubuntu 16.04. 
- setting $DISPLAY seems not to be required
- chromium has a --temp-profile flag that seems to do the same previously done manually