### PR TITLE
smoke test: clean up backgrounded processes.

### DIFF
--- a/lighthouse-cli/scripts/run-smoke-tests.sh
+++ b/lighthouse-cli/scripts/run-smoke-tests.sh
@@ -9,26 +9,30 @@ config="$PWD/lighthouse-cli/test/fixtures/smoketest-offline-config.json"
 
 offline200result="URL responds with a 200 when offline"
 
+function killBGprocesses() {
+  kill $(jobs -p)
+}
+
 # run default lighthouse run against a boring basic page
 $NODE lighthouse-cli --quiet http://localhost:10200/online-only.html > results
 
 # test that we have results
 if ! grep -q "$offline200result" results; then
   echo "Fail! Lighthouse run didn't create a result file"
-  exit 1
+  killBGprocesses; exit 1
 fi
 
 # test that we have a meta viewport defined on a static page
 if ! grep -q "HTML has a viewport <meta>: true" results; then
   echo "Fail! Meta viewort not detected in the page"
-  exit 1
+  killBGprocesses; exit 1
 fi
 
 # test a static page which should fail the offline test
 if ! grep -q "$offline200result: false" results; then
   echo "Fail! online only site worked while offline"
   cat results
-  exit 1
+  killBGprocesses; exit 1
 fi
 
 sleep 0.5s
@@ -39,5 +43,7 @@ $NODE lighthouse-cli --config-path=$config --quiet http://localhost:10503/offlin
 if ! grep -q "$offline200result: true" results; then
   echo "Fail! offline ready site did not work while offline"
   cat results
-  exit 1
+  killBGprocesses; exit 1
 fi
+
+killBGprocesses


### PR DESCRIPTION
because running into ports already in use is a pain:

![image](https://cloud.githubusercontent.com/assets/39191/18219784/441316cc-7121-11e6-8fb0-0d489263b54a.png)

With this, we nuke the background node server when we exit.