### PR TITLE
add explicit eslint-config-xo dep for old node

### DIFF
--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -12,6 +12,7 @@
     "brfs": "^1.4.3",
     "browserify": "^13.0.0",
     "del": "^2.2.0",
+    "eslint-config-xo": "^0.10.1",
     "gulp": "^3.9.1",
     "gulp-chrome-manifest": "0.0.13",
     "gulp-debug": "^2.1.2",


### PR DESCRIPTION
something changed after #613 with linting the extension that didn't manifest until today, when I deleted the travis cache for testing #632. `eslint-config-google` is unable to find the `eslint-config-xo` module that it extends, but only on the node v4 (+ `--harmony`) test machine, and only when linting the extension (not `core/` or `cli/`). This is weird because `eslint-config-google` and `eslint-config-xo` sit right next to each other in `node_modules/`, and the first is always found.

I haven't been able to figure out what's causing the issue, but this small workaround fixes it, at the expense of having a copy of `eslint-config-xo` in both the root and extension `node_modules/` directories. Happy to consider an alternative, but we can also just keep this until we hit the happy land of #449

Should fix the broken builds (at least the extension linting part) for all currently open PRs