### PR TITLE
Adding notice about minimal version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@
 
 _status: ready for use! please report any issues or questions you have_
 
+**Lighthouse requires Chrome 52 or later**
+
 ## Install Chrome extension
 
 [chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk)


### PR DESCRIPTION
During training we found users who could had not upgraded to latest version of Chrome. 

I've updated the readme to indicate that Lighthouse needs version 52 or later. This will help reduce issues of non-supported versions.