### PR TITLE
Add support for sequentially batch-running URLs

### DIFF
--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -28,6 +28,7 @@ const path = require('path');
 const yargs = require('yargs');
 const Printer = require('./printer');
 const lighthouse = require('../lighthouse-core');
+const assetSaver = require('../lighthouse-core/lib/asset-saver.js');
 
 const cli = yargs
   .help('help')
@@ -150,7 +151,8 @@ function runLighthouse(addresses) {
     .then(results => Printer.write(results, outputMode, outputPath))
     .then(results => {
       if (outputMode !== 'html') {
-        Printer.write(results, 'html', './last-run-results-' + Math.random() + '.html');
+        const filename = './' + assetSaver.getFilenamePrefix({url: address}) + '.html';
+        Printer.write(results, 'html', filename);
       }
       runLighthouse(addresses);
       return;
@@ -159,7 +161,6 @@ function runLighthouse(addresses) {
       if (err.code === 'ECONNREFUSED') {
         console.error('Unable to connect to Chrome.');
         console.error('Please run Chrome w/ debugging port 9222 open:');
-        console.error('npm run chrome');
         console.error('    npm explore -g lighthouse -- npm run chrome');
       } else {
         console.error('Runtime error encountered:', err);

--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -160,6 +160,7 @@ function runLighthouse(addresses) {
         console.error('Unable to connect to Chrome.');
         console.error('Please run Chrome w/ debugging port 9222 open:');
         console.error('npm run chrome');
+        console.error('    npm explore -g lighthouse -- npm run chrome');
       } else {
         console.error('Runtime error encountered:', err);
         console.error(err.stack);

--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -141,7 +141,7 @@ if (cli.verbose) {
 
 function runLighthouse(addresses) {
   // Process URLs once at a time
-  let address = addresses.shift();
+  const address = addresses.shift();
   if (!address) {
     return;
   }

--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -142,28 +142,30 @@ if (cli.verbose) {
 function runLighthouse(addresses) {
   // Process URLs once at a time
   let address = addresses.shift();
-  if (address) {
-    lighthouse(address, flags, config)
-      .then(results => Printer.write(results, outputMode, outputPath))
-      .then(results => {
-        if (outputMode !== 'html') {
-          Printer.write(results, 'html', './last-run-results-' + Math.random() + '.html');
-        }
-        runLighthouse(addresses);
-        return;
-      })
-      .catch(err => {
-        if (err.code === 'ECONNREFUSED') {
-          console.error('Unable to connect to Chrome.');
-          console.error('Please run Chrome w/ debugging port 9222 open:');
-          console.error('npm run chrome');
-        } else {
-          console.error('Runtime error encountered:', err);
-          console.error(err.stack);
-        }
-        process.exit(1);
-      });
+  if (!address) {
+    return;
   }
+
+  lighthouse(address, flags, config)
+    .then(results => Printer.write(results, outputMode, outputPath))
+    .then(results => {
+      if (outputMode !== 'html') {
+        Printer.write(results, 'html', './last-run-results-' + Math.random() + '.html');
+      }
+      runLighthouse(addresses);
+      return;
+    })
+    .catch(err => {
+      if (err.code === 'ECONNREFUSED') {
+        console.error('Unable to connect to Chrome.');
+        console.error('Please run Chrome w/ debugging port 9222 open:');
+        console.error('npm run chrome');
+      } else {
+        console.error('Runtime error encountered:', err);
+        console.error(err.stack);
+      }
+      process.exit(1);
+    });
 }
 
 // kick off a lighthouse run


### PR DESCRIPTION
This PR adds support for batch-running multiple URLs through Lighthouse (in sequence) with minimal change to the CLI surface. 

**Usage:**

```sh
$ ./lighthouse-cli/index.js <url1> <url2> <url3>
```

**Demo:**
![rpd5eteubz](https://cloud.githubusercontent.com/assets/110953/18396220/4475e18e-7677-11e6-8d69-44c501239da8.gif)

The approach implemented will also continue to work with parameters like `--save-assets`, outputting trace files for all runs to disk:

```sh
$ ./lighthouse-cli/index.js <url1> <url2> <url3> --save-assets
```

![](https://i.imgur.com/galu0el.jpg)

Happy to rewrite or add tests if needed. This seems like a useful feature to support in the CLI directly vs. building as a separate module.

If this feature is interesting, I'd be happy to follow-up with a future PR that adds the ability to accept a JSON file (or something) with a list of URLs for folks that want to run LH against a predefined collection of sites.