### PR TITLE
Better filenames to save to disk.

### DIFF
--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -21,11 +21,15 @@ const log = require('../../lighthouse-core/lib/log.js');
 const stringify = require('json-stringify-safe');
 
 function getFilenamePrefix(options) {
-  const date = options.date || new Date();
   const url = options.url;
-
   const hostname = url.match(/^.*?\/\/(.*?)(:?\/|$)/)[1];
-  const filenamePrefix = hostname + '_' + date.toISOString();
+
+  const date = options.date || new Date();
+  const resolvedLocale = new Intl.DateTimeFormat().resolvedOptions().locale;
+  const time = date.toLocaleTimeString(resolvedLocale, {hour12: false});
+  const timeStampStr = date.toISOString().replace(/T.*/, '_' + time);
+
+  const filenamePrefix = hostname + '_' + timeStampStr;
   // replace characters that are unfriendly to filenames
   return (filenamePrefix).replace(/[\/\?<>\\:\*\|":]/g, '-');
 }


### PR DESCRIPTION
Small cosmetic change here

Before and after:

```sh
paulirish.com_2016-09-14T00:46:44.232Z.html # before
paulirish.com_2016-09-14_17:46:44.html      # after
```

Uses local time zone to make it look a bit more human readable.

(Personally I don't love `.replace()`ing the toISOString, but there's actually no clean way to otherwise get yyyy-mm-dd even with the new formatting APIs)

cc @addyosmani 