### PR TITLE
add h2 pushed requests artifact

### DIFF
--- a/lighthouse-core/gather/computed/pushed-requests.js
+++ b/lighthouse-core/gather/computed/pushed-requests.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ComputedArtifact = require('./computed-artifact');
+
+class PushedRequests extends ComputedArtifact {
+
+  get name() {
+    return 'PushedRequests';
+  }
+
+  filterPushed(records) {
+    const pushedRecords = records.filter(r => r._timing && !!r._timing.pushStart);
+    return Promise.resolve(pushedRecords);
+  }
+
+  request(networkRecords) {
+    if (this.cache.has(networkRecords)) {
+      return this.cache.get(networkRecords);
+    }
+
+    return this.filterPushed(networkRecords).then(records => {
+      this.cache.set(records, networkRecords);
+      return records;
+    });
+  }
+
+}
+
+module.exports = PushedRequests;

--- a/lighthouse-core/test/fixtures/networkRecords-h2push.json
+++ b/lighthouse-core/test/fixtures/networkRecords-h2push.json
@@ -1,0 +1,20339 @@
+[
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.0._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.0._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.1",
+    "_url": "https://webtide.com/http2-push-demo/",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/http2-push-demo/",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/http2-push-demo/",
+      "queryParams": "",
+      "folderPathComponents": "/http2-push-demo",
+      "lastPathComponent": ""
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "other"
+    },
+    "_issueTime": 123351.530487,
+    "_startTime": 123351.531997,
+    "_endTime": 123353.638886,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "document",
+      "_title": "Document",
+      "_category": {
+        "title": "Documents",
+        "shortTitle": "Doc"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/http2-push-demo/"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "upgrade-insecure-requests",
+        "value": "1"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831866.87349,
+    "_responseReceivedTime": 123353.424079,
+    "_mimeType": "text/html",
+    "_responseHeaders": [
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "x-pingback",
+        "value": "https://webtide.com/xmlrpc.php"
+      },
+      {
+        "name": "content-type",
+        "value": "text/html;charset=utf-8"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-store, no-cache, must-revalidate"
+      },
+      {
+        "name": "set-cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; path=/"
+      },
+      {
+        "name": "set-cookie",
+        "value": "wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; expires=Wed, 14-Sep-2016 15:44:28 GMT; Max-Age=36000; path=/"
+      },
+      {
+        "name": "link",
+        "value": "<https://webtide.com/wp-json/>; rel=\"https://api.w.org/\""
+      },
+      {
+        "name": "link",
+        "value": "<https://webtide.com/?p=2974>; rel=shortlink"
+      },
+      {
+        "name": "expires",
+        "value": "Thu, 19 Nov 1981 08:52:00 GMT"
+      }
+    ],
+    "_transferSize": 32071,
+    "_requestHeadersText": "",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123351.531997,
+      "proxyStart": 0.352999995811842,
+      "proxyEnd": 1329.31699999608,
+      "dnsStart": 1329.31699999608,
+      "dnsEnd": 1394.272000005,
+      "connectStart": 1394.272000005,
+      "connectEnd": 1626.58500000543,
+      "sslStart": 1483.60700000194,
+      "sslEnd": 1626.56699999934,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1627.19899999502,
+      "sendEnd": 1627.62300000759,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 1892.08200000576
+    },
+    "_resourceSize": 31044,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.1._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.1._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.4",
+    "_url": "https://webtide.com/wp-content/plugins/wp-pagenavi/pagenavi-css.css?ver=2.70",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/wp-pagenavi/pagenavi-css.css?ver=2.70",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/wp-pagenavi/pagenavi-css.css?ver=2.70",
+      "queryParams": "ver=2.70",
+      "folderPathComponents": "/wp-content/plugins/wp-pagenavi",
+      "lastPathComponent": "pagenavi-css.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 33
+    },
+    "_issueTime": 123354.192217,
+    "_startTime": 123354.193636,
+    "_endTime": 123354.378006,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53534,
+    "_responseReceivedTime": 123354.37605,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Fri, 01 Jul 2016 12:37:39 GMT"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "374"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 438,
+    "connectionReused": true,
+    "_fromDiskCache": true,
+    "_timing": {
+      "requestTime": 123354.193636,
+      "proxyStart": 6.26000000920612,
+      "proxyEnd": 6.94200000725687,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 12.3660000099335,
+      "sendEnd": 16.3880000036443,
+      "pushStart": 123353.244842,
+      "pushEnd": 123353.244857,
+      "receiveHeadersEnd": 182.414000009885
+    },
+    "_resourceSize": 374,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.2._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.2._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.24",
+    "_url": "https://www.google.com/recaptcha/api.js?hl=en",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.google.com/recaptcha/api.js?hl=en",
+      "scheme": "https",
+      "host": "www.google.com",
+      "path": "/recaptcha/api.js?hl=en",
+      "queryParams": "hl=en",
+      "folderPathComponents": "/recaptcha",
+      "lastPathComponent": "api.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 453
+    },
+    "_issueTime": 123354.218723,
+    "_startTime": 123354.221485,
+    "_endTime": 123354.427945,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Medium",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:807::2004]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "www.google.com",
+      "sanList": [
+        "www.google.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291496,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294117382,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3044022100A688267D1A44644516F7DB1383E6586CEB8C23F83F6CBC4AB6DCC281AB5A81BC021F73BB3CDAC5CFBCA95DF32CE9564B3674EC70C84D6F66FD58F0A67AB3941E5D"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294117951,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100CF0010B0CC6D5F757ED9E601DC52F8C170FDEE752868276ECB2E0FDF34F2BA12022100A58876BD1B7ECFAB6C7B1A1ACD9A33285A400669EFD2336F32CBCE61FCD3EBB7"
+        }
+      ]
+    },
+    "connectionId": "183",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/recaptcha/api.js?hl=en"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.google.com"
+      },
+      {
+        "name": "cookie",
+        "value": "NID=86=UA8sn8EjVDzbV-HK1jEfVtIxu23pgQVxnPSTwXX6I_cs_YMMDZAX6vbDYXVioIkClO7zKrZTg9GrGiEBO8Cav_otesPIsOKM7a8mHmtVuObzblXoRXK24Wl82e6RQrqo"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56185,
+    "_responseReceivedTime": 123354.425932,
+    "_mimeType": "text/javascript",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:44:29 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "server",
+        "value": "GSE"
+      },
+      {
+        "name": "x-frame-options",
+        "value": "SAMEORIGIN"
+      },
+      {
+        "name": "content-type",
+        "value": "text/javascript; charset=UTF-8"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "private, max-age=0"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "391"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 14 Sep 2016 05:44:29 GMT"
+      }
+    ],
+    "_transferSize": 443,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.221485,
+      "proxyStart": 12.4099999957252,
+      "proxyEnd": 12.825999991037,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 16.7459999938728,
+      "sendEnd": 19.7409999964293,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 204.446999996435
+    },
+    "_resourceSize": 678,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.3._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.3._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.13",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/library/js",
+      "lastPathComponent": "backtotop.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 48
+    },
+    "_issueTime": 123354.197911,
+    "_startTime": 123354.198832,
+    "_endTime": 123354.561241,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.54104,
+    "_responseReceivedTime": 123354.552655,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "577"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 630,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.198832,
+      "proxyStart": 8.76100000459701,
+      "proxyEnd": 9.2620000068564,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 13.0400000052759,
+      "sendEnd": 14.9180000007618,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 353.823000012198
+    },
+    "_resourceSize": 577,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.4._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.4._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.6",
+    "_url": "https://fonts.googleapis.com/css?family=Gentium+Basic&ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://fonts.googleapis.com/css?family=Gentium+Basic&ver=4.5.4",
+      "scheme": "https",
+      "host": "fonts.googleapis.com",
+      "path": "/css?family=Gentium+Basic&ver=4.5.4",
+      "queryParams": "family=Gentium+Basic&ver=4.5.4",
+      "folderPathComponents": "",
+      "lastPathComponent": "css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 35
+    },
+    "_issueTime": 123354.193122,
+    "_startTime": 123354.195606,
+    "_endTime": 123354.578919,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:400e:c03::5f]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.googleapis.com",
+      "sanList": [
+        "*.googleapis.com",
+        "*.clients6.google.com",
+        "*.cloudendpointsapis.com",
+        "cloudendpointsapis.com",
+        "googleapis.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473293189,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294595282,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100A26E3AB7BA20C908537C6995F4257007C3115A63E4D06D0C47D1787BDBBB2A7502210088403D158A8B1BDDB74143949060EACA0C392E38D843280D80FD0F0B51EBC6F3"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294595899,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3044022007E916AA7546E8D1896DA63227B209D293415A0481790CB2CCDA69E1DFFFBA3902202E6FC08108B32AA22454B5EEBD9F21807AD38A243F5D9B96607189FC996D4687"
+        }
+      ]
+    },
+    "connectionId": "457",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/css?family=Gentium+Basic&ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "fonts.googleapis.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53625,
+    "_responseReceivedTime": 123354.576668,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:44:29 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "br"
+      },
+      {
+        "name": "last-modified",
+        "value": "Wed, 14 Sep 2016 05:44:29 GMT"
+      },
+      {
+        "name": "server",
+        "value": "ESF"
+      },
+      {
+        "name": "link",
+        "value": "<https://fonts.gstatic.com>; rel=preconnect; crossorigin"
+      },
+      {
+        "name": "x-frame-options",
+        "value": "SAMEORIGIN"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css; charset=utf-8"
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "cache-control",
+        "value": "private, max-age=86400, stale-while-revalidate=604800"
+      },
+      {
+        "name": "timing-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 14 Sep 2016 05:44:29 GMT"
+      }
+    ],
+    "_transferSize": 653,
+    "_requestHeadersText": "",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123354.195606,
+      "proxyStart": 7.14300000981893,
+      "proxyEnd": 8.83900000189897,
+      "dnsStart": 8.93200001155492,
+      "dnsEnd": 40.9960000106366,
+      "connectStart": 40.9960000106366,
+      "connectEnd": 133.21200000064,
+      "sslStart": 70.915000003879,
+      "sslEnd": 133.18300001265,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 136.431999999331,
+      "sendEnd": 137.679999999818,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 381.062000000384
+    },
+    "_resourceSize": 785,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.5._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.5._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.18",
+    "_url": "https://fonts.googleapis.com/css?family=Gentium+Basic&ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://fonts.googleapis.com/css?family=Gentium+Basic&ver=4.5.4",
+      "scheme": "https",
+      "host": "fonts.googleapis.com",
+      "path": "/css?family=Gentium+Basic&ver=4.5.4",
+      "queryParams": "family=Gentium+Basic&ver=4.5.4",
+      "folderPathComponents": "",
+      "lastPathComponent": "css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 35
+    },
+    "_issueTime": 123354.215752,
+    "_startTime": 123354.216708,
+    "_endTime": 123354.583728,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:400e:c03::5f]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.googleapis.com",
+      "sanList": [
+        "*.googleapis.com",
+        "*.clients6.google.com",
+        "*.cloudendpointsapis.com",
+        "cloudendpointsapis.com",
+        "googleapis.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473293189,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294595282,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100A26E3AB7BA20C908537C6995F4257007C3115A63E4D06D0C47D1787BDBBB2A7502210088403D158A8B1BDDB74143949060EACA0C392E38D843280D80FD0F0B51EBC6F3"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294595899,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3044022007E916AA7546E8D1896DA63227B209D293415A0481790CB2CCDA69E1DFFFBA3902202E6FC08108B32AA22454B5EEBD9F21807AD38A243F5D9B96607189FC996D4687"
+        }
+      ]
+    },
+    "connectionId": "457",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/css?family=Gentium+Basic&ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "fonts.googleapis.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.55888,
+    "_responseReceivedTime": 123354.582872,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:44:29 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "br"
+      },
+      {
+        "name": "last-modified",
+        "value": "Wed, 14 Sep 2016 05:44:29 GMT"
+      },
+      {
+        "name": "server",
+        "value": "ESF"
+      },
+      {
+        "name": "link",
+        "value": "<https://fonts.gstatic.com>; rel=preconnect; crossorigin"
+      },
+      {
+        "name": "x-frame-options",
+        "value": "SAMEORIGIN"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css; charset=utf-8"
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "cache-control",
+        "value": "private, max-age=86400, stale-while-revalidate=604800"
+      },
+      {
+        "name": "timing-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 14 Sep 2016 05:44:29 GMT"
+      }
+    ],
+    "_transferSize": 367,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.216708,
+      "proxyStart": 0,
+      "proxyEnd": 0,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 115.487999995821,
+      "sendEnd": 116.592999998829,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 366.163999991841
+    },
+    "_resourceSize": 785,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.6._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.6._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.12",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/tinynav.js?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/tinynav.js?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/library/js/tinynav.js?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/library/js",
+      "lastPathComponent": "tinynav.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 47
+    },
+    "_issueTime": 123354.197735,
+    "_startTime": 123354.19845,
+    "_endTime": 123354.63482,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/library/js/tinynav.js?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.54086,
+    "_responseReceivedTime": 123354.54869,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "2276"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 2329,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.19845,
+      "proxyStart": 8.9529999968363,
+      "proxyEnd": 9.52500000130385,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 13.2850000081817,
+      "sendEnd": 15.2900000102818,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 350.239999999758
+    },
+    "_resourceSize": 2276,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.7._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.7._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.16",
+    "_url": "https://webtide.com/wp-content/plugins/wp-pagenavi/pagenavi-css.css?ver=2.70",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/wp-pagenavi/pagenavi-css.css?ver=2.70",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/wp-pagenavi/pagenavi-css.css?ver=2.70",
+      "queryParams": "ver=2.70",
+      "folderPathComponents": "/wp-content/plugins/wp-pagenavi",
+      "lastPathComponent": "pagenavi-css.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 33
+    },
+    "_issueTime": 123354.21439,
+    "_startTime": 123354.215344,
+    "_endTime": 123354.643607,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/wp-pagenavi/pagenavi-css.css?ver=2.70"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.55752,
+    "_responseReceivedTime": 123354.641635,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Fri, 01 Jul 2016 12:37:39 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "374"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 427,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.215344,
+      "proxyStart": 2.04700000176672,
+      "proxyEnd": 2.81800000811927,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 11.2000000081025,
+      "sendEnd": 20.5430000060005,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 426.291000010679
+    },
+    "_resourceSize": 374,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.8._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.8._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.23",
+    "_url": "https://webtide.com/wp-content/plugins/contact-form-with-captcha/cfwc.css",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/contact-form-with-captcha/cfwc.css",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/contact-form-with-captcha/cfwc.css",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/plugins/contact-form-with-captcha",
+      "lastPathComponent": "cfwc.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 421
+    },
+    "_issueTime": 123354.218518,
+    "_startTime": 123354.221186,
+    "_endTime": 123354.73356,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/contact-form-with-captcha/cfwc.css"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56165,
+    "_responseReceivedTime": 123354.732947,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 01 Sep 2015 17:40:20 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "794"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 847,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.221186,
+      "proxyStart": 12.5950000074226,
+      "proxyEnd": 12.8600000025472,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 16.9010000099661,
+      "sendEnd": 19.722000011825,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 511.76100000157
+    },
+    "_resourceSize": 794,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.9._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.9._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.21",
+    "_url": "https://webtide.com/wp-content/plugins/wp-spamshield/js/jscripts.php",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/wp-spamshield/js/jscripts.php",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/wp-spamshield/js/jscripts.php",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/plugins/wp-spamshield/js",
+      "lastPathComponent": "jscripts.php"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 247
+    },
+    "_issueTime": 123354.21714,
+    "_startTime": 123354.220384,
+    "_endTime": 123354.740525,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/wp-spamshield/js/jscripts.php"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56027,
+    "_responseReceivedTime": 123354.73962,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "surrogate-control",
+        "value": "no-cache, must-revalidate, max-age=0"
+      },
+      {
+        "name": "vary",
+        "value": "*"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript; charset=UTF-8"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "private, no-store, no-cache, must-revalidate, max-age=0, proxy-revalidate, s-maxage=0, no-transform"
+      },
+      {
+        "name": "set-cookie",
+        "value": "NCS_INENTIM=1473831869; expires=Wed, 14-Sep-2016 06:44:29 GMT; Max-Age=3600; path=/"
+      },
+      {
+        "name": "set-cookie",
+        "value": "9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; path=/"
+      },
+      {
+        "name": "expires",
+        "value": "Sat, 26 Jul 1997 05:00:00 GMT"
+      }
+    ],
+    "_transferSize": 1018,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.220384,
+      "proxyStart": 12.6630000013392,
+      "proxyEnd": 13.2210000010673,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 17.3789999971632,
+      "sendEnd": 20.606999998563,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 519.235999992816
+    },
+    "_resourceSize": 703,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.10._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.10._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.25",
+    "_url": "https://webtide.com/wp-includes/js/comment-reply.min.js?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-includes/js/comment-reply.min.js?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-includes/js/comment-reply.min.js?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-includes/js",
+      "lastPathComponent": "comment-reply.min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 523
+    },
+    "_issueTime": 123354.21891,
+    "_startTime": 123354.221754,
+    "_endTime": 123354.748225,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Medium",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-includes/js/comment-reply.min.js?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56204,
+    "_responseReceivedTime": 123354.747489,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Mon, 14 Dec 2015 15:43:14 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "1078"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 1131,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.221754,
+      "proxyStart": 12.4159999977564,
+      "proxyEnd": 12.7179999981308,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 16.6150000004563,
+      "sendEnd": 19.2479999968782,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 525.735000002896
+    },
+    "_resourceSize": 1078,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.11._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.11._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.27",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/cleanretina-custom-fancybox-script.js?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/cleanretina-custom-fancybox-script.js?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/library/js/cleanretina-custom-fancybox-script.js?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/library/js",
+      "lastPathComponent": "cleanretina-custom-fancybox-script.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 525
+    },
+    "_issueTime": 123354.219252,
+    "_startTime": 123354.222543,
+    "_endTime": 123354.762605,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Medium",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/library/js/cleanretina-custom-fancybox-script.js?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56238,
+    "_responseReceivedTime": 123354.761893,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "439"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 492,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.222543,
+      "proxyStart": 12.1510000026319,
+      "proxyEnd": 12.830000006943,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 16.2830000044778,
+      "sendEnd": 18.4779999981402,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 539.35000000638
+    },
+    "_resourceSize": 439,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.12._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.12._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.28",
+    "_url": "https://webtide.com/wp-content/plugins/wp-spamshield/js/jscripts-ftr-min.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/wp-spamshield/js/jscripts-ftr-min.js",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/wp-spamshield/js/jscripts-ftr-min.js",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/plugins/wp-spamshield/js",
+      "lastPathComponent": "jscripts-ftr-min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 526
+    },
+    "_issueTime": 123354.219417,
+    "_startTime": 123354.223975,
+    "_endTime": 123354.770014,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Medium",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/wp-spamshield/js/jscripts-ftr-min.js"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56255,
+    "_responseReceivedTime": 123354.769394,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 30 Aug 2016 02:31:12 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "945"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 998,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.223975,
+      "proxyStart": 11.4960000064457,
+      "proxyEnd": 11.8189999921015,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 15.0009999924805,
+      "sendEnd": 17.0559999969555,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 545.419000001857
+    },
+    "_resourceSize": 945,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.13._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.13._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.29",
+    "_url": "https://webtide.com/wp-includes/js/wp-embed.min.js?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-includes/js/wp-embed.min.js?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-includes/js/wp-embed.min.js?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-includes/js",
+      "lastPathComponent": "wp-embed.min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 527
+    },
+    "_issueTime": 123354.219636,
+    "_startTime": 123354.224371,
+    "_endTime": 123354.777036,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Medium",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-includes/js/wp-embed.min.js?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56276,
+    "_responseReceivedTime": 123354.776065,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 14:21:31 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "1403"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 1456,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.224371,
+      "proxyStart": 11.2050000025192,
+      "proxyEnd": 12.5499999994645,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 14.7969999961788,
+      "sendEnd": 16.6689999896335,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 551.693999994313
+    },
+    "_resourceSize": 1403,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.14._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.14._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.3",
+    "_url": "https://webtide.com/wp-content/plugins/delightful-downloads/assets/css/delightful-downloads.min.css?ver=1.6.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/delightful-downloads/assets/css/delightful-downloads.min.css?ver=1.6.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/delightful-downloads/assets/css/delightful-downloads.min.css?ver=1.6.4",
+      "queryParams": "ver=1.6.4",
+      "folderPathComponents": "/wp-content/plugins/delightful-downloads/assets/css",
+      "lastPathComponent": "delightful-downloads.min.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 32
+    },
+    "_issueTime": 123354.191916,
+    "_startTime": 123354.192831,
+    "_endTime": 123354.981573,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53504,
+    "_responseReceivedTime": 123354.4756,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 14:21:57 GMT"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "5825"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 5877,
+    "connectionReused": true,
+    "_fromDiskCache": true,
+    "_timing": {
+      "requestTime": 123354.192831,
+      "proxyStart": 6.91300000471529,
+      "proxyEnd": 7.54800000868272,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 13.1030000047758,
+      "sendEnd": 17.0720000023721,
+      "pushStart": 123353.413324,
+      "pushEnd": 123353.413496,
+      "receiveHeadersEnd": 282.769000012195
+    },
+    "_resourceSize": 5825,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.15._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.15._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.7",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/css/jquery.fancybox-1.3.4.css?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/css/jquery.fancybox-1.3.4.css?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/library/css/jquery.fancybox-1.3.4.css?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/library/css",
+      "lastPathComponent": "jquery.fancybox-1.3.4.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 36
+    },
+    "_issueTime": 123354.194785,
+    "_startTime": 123354.195979,
+    "_endTime": 123354.991919,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/library/css/jquery.fancybox-1.3.4.css?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53791,
+    "_responseReceivedTime": 123354.412588,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "9085"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 9138,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.195979,
+      "proxyStart": 9.30700000026263,
+      "proxyEnd": 9.77099999727216,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 13.5930000105873,
+      "sendEnd": 16.6540000063833,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 216.609000010067
+    },
+    "_resourceSize": 9085,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.16._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.16._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.15",
+    "_url": "https://webtide.com/wp-content/plugins/delightful-downloads/assets/css/delightful-downloads.min.css?ver=1.6.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/delightful-downloads/assets/css/delightful-downloads.min.css?ver=1.6.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/delightful-downloads/assets/css/delightful-downloads.min.css?ver=1.6.4",
+      "queryParams": "ver=1.6.4",
+      "folderPathComponents": "/wp-content/plugins/delightful-downloads/assets/css",
+      "lastPathComponent": "delightful-downloads.min.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 32
+    },
+    "_issueTime": 123354.214175,
+    "_startTime": 123354.214984,
+    "_endTime": 123355.015589,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/delightful-downloads/assets/css/delightful-downloads.min.css?ver=1.6.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.5573,
+    "_responseReceivedTime": 123354.564364,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 14:21:57 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "5825"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 5878,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.214984,
+      "proxyStart": 2.21399999281857,
+      "proxyEnd": 2.7540000010049,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 11.3730000011856,
+      "sendEnd": 20.8920000004582,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 349.379999999655
+    },
+    "_resourceSize": 5825,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.17._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.17._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.9",
+    "_url": "https://webtide.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1",
+      "queryParams": "ver=1.4.1",
+      "folderPathComponents": "/wp-includes/js/jquery",
+      "lastPathComponent": "jquery-migrate.min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 38
+    },
+    "_issueTime": 123354.196017,
+    "_startTime": 123354.197374,
+    "_endTime": 123355.148967,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53914,
+    "_responseReceivedTime": 123354.511992,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 21 Jun 2016 18:31:34 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "10056"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 10110,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.197374,
+      "proxyStart": 8.92400000884663,
+      "proxyEnd": 9.38800000585616,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 13.8950000109617,
+      "sendEnd": 16.3350000075297,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 314.618000003975
+    },
+    "_resourceSize": 10056,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.18._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.18._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.22",
+    "_url": "https://webtide.com/wp-content/uploads/2015/04/webtide-dark.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/uploads/2015/04/webtide-dark.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/uploads/2015/04/webtide-dark.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/uploads/2015/04",
+      "lastPathComponent": "webtide-dark.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 270
+    },
+    "_issueTime": 123354.217881,
+    "_startTime": 123354.220807,
+    "_endTime": 123355.177016,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/uploads/2015/04/webtide-dark.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56101,
+    "_responseReceivedTime": 123354.78302,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Thu, 23 Apr 2015 20:01:08 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "6860"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 6921,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.220807,
+      "proxyStart": 12.4009999999544,
+      "proxyEnd": 12.8779999940889,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 17.1279999922263,
+      "sendEnd": 20.2419999986887,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 562.212999997428
+    },
+    "_resourceSize": 6860,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.19._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.19._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.11",
+    "_url": "https://webtide.com/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2",
+      "queryParams": "ver=3.0.2",
+      "folderPathComponents": "/wp-content/plugins/wp-retina-2x/js",
+      "lastPathComponent": "picturefill.min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 46
+    },
+    "_issueTime": 123354.197454,
+    "_startTime": 123354.198146,
+    "_endTime": 123355.243117,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.54058,
+    "_responseReceivedTime": 123354.548165,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Fri, 01 Jul 2016 12:37:40 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "11808"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 11862,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.198146,
+      "proxyStart": 8.79900000290945,
+      "proxyEnd": 9.14400001056492,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 13.4490000054939,
+      "sendEnd": 15.5850000010105,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 350.019000004977
+    },
+    "_resourceSize": 11808,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.20._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.20._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.19",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/css/jquery.fancybox-1.3.4.css?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/css/jquery.fancybox-1.3.4.css?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/library/css/jquery.fancybox-1.3.4.css?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/library/css",
+      "lastPathComponent": "jquery.fancybox-1.3.4.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 36
+    },
+    "_issueTime": 123354.216174,
+    "_startTime": 123354.219626,
+    "_endTime": 123355.26466,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/library/css/jquery.fancybox-1.3.4.css?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.5593,
+    "_responseReceivedTime": 123354.655117,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "9085"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 9138,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.219626,
+      "proxyStart": 7.35200000053737,
+      "proxyEnd": 8.13799999014009,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 11.5599999990081,
+      "sendEnd": 19.6339999965858,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 435.490999996546
+    },
+    "_resourceSize": 9085,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.21._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.21._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.26",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/jquery.fancybox-1.3.4.pack.js?ver=1.3.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/jquery.fancybox-1.3.4.pack.js?ver=1.3.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/library/js/jquery.fancybox-1.3.4.pack.js?ver=1.3.4",
+      "queryParams": "ver=1.3.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/library/js",
+      "lastPathComponent": "jquery.fancybox-1.3.4.pack.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 524
+    },
+    "_issueTime": 123354.219077,
+    "_startTime": 123354.22208,
+    "_endTime": 123355.541741,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Medium",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/library/js/jquery.fancybox-1.3.4.pack.js?ver=1.3.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.5622,
+    "_responseReceivedTime": 123354.755117,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "15624"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 15678,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.22208,
+      "proxyStart": 12.4699999869335,
+      "proxyEnd": 12.7529999881517,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 16.4179999992484,
+      "sendEnd": 18.9319999917643,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 533.036999986507
+    },
+    "_resourceSize": 15624,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.22._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.22._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.14",
+    "_url": "https://webtide.com/wp-content/plugins/crayon-syntax-highlighter/css/min/crayon.min.css?ver=_2.7.2_beta",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/crayon-syntax-highlighter/css/min/crayon.min.css?ver=_2.7.2_beta",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/crayon-syntax-highlighter/css/min/crayon.min.css?ver=_2.7.2_beta",
+      "queryParams": "ver=_2.7.2_beta",
+      "folderPathComponents": "/wp-content/plugins/crayon-syntax-highlighter/css/min",
+      "lastPathComponent": "crayon.min.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 31
+    },
+    "_issueTime": 123354.213084,
+    "_startTime": 123354.213977,
+    "_endTime": 123355.612896,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/crayon-syntax-highlighter/css/min/crayon.min.css?ver=_2.7.2_beta"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.55621,
+    "_responseReceivedTime": 123354.562012,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Fri, 01 Jul 2016 12:37:35 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "20172"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 20235,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.213977,
+      "proxyStart": 0.543999994988553,
+      "proxyEnd": 1.64899999799673,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 3.59299998672213,
+      "sendEnd": 16.47299999604,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 348.034999988158
+    },
+    "_resourceSize": 20172,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.23._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.23._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.10",
+    "_url": "https://webtide.com/wp-content/plugins/crayon-syntax-highlighter/js/min/crayon.min.js?ver=_2.7.2_beta",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/crayon-syntax-highlighter/js/min/crayon.min.js?ver=_2.7.2_beta",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/crayon-syntax-highlighter/js/min/crayon.min.js?ver=_2.7.2_beta",
+      "queryParams": "ver=_2.7.2_beta",
+      "folderPathComponents": "/wp-content/plugins/crayon-syntax-highlighter/js/min",
+      "lastPathComponent": "crayon.min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 45
+    },
+    "_issueTime": 123354.196702,
+    "_startTime": 123354.197739,
+    "_endTime": 123355.643978,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/crayon-syntax-highlighter/js/min/crayon.min.js?ver=_2.7.2_beta"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53983,
+    "_responseReceivedTime": 123354.544918,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Fri, 01 Jul 2016 12:37:35 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "22337"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 22400,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.197739,
+      "proxyStart": 8.73600000340957,
+      "proxyEnd": 9.10999999905471,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 13.703999997233,
+      "sendEnd": 15.981999997166,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 347.179000003962
+    },
+    "_resourceSize": 22337,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.24._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.24._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.2",
+    "_url": "https://webtide.com/wp-content/plugins/crayon-syntax-highlighter/css/min/crayon.min.css?ver=_2.7.2_beta",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/crayon-syntax-highlighter/css/min/crayon.min.css?ver=_2.7.2_beta",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/crayon-syntax-highlighter/css/min/crayon.min.css?ver=_2.7.2_beta",
+      "queryParams": "ver=_2.7.2_beta",
+      "folderPathComponents": "/wp-content/plugins/crayon-syntax-highlighter/css/min",
+      "lastPathComponent": "crayon.min.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 31
+    },
+    "_issueTime": 123354.191624,
+    "_startTime": 123354.192083,
+    "_endTime": 123355.878078,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53475,
+    "_responseReceivedTime": 123355.283599,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Fri, 01 Jul 2016 12:37:35 GMT"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "20172"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 20234,
+    "connectionReused": true,
+    "_fromDiskCache": true,
+    "_timing": {
+      "requestTime": 123354.192083,
+      "proxyStart": 1.0690000053728,
+      "proxyEnd": 2.52599999657832,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 5.09099999908358,
+      "sendEnd": 8.76499999139924,
+      "pushStart": 123353.416532,
+      "pushEnd": 123353.417622,
+      "receiveHeadersEnd": 1091.51600000041
+    },
+    "_resourceSize": 20172,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.25._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.25._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.5",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro",
+      "lastPathComponent": "style.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 34
+    },
+    "_issueTime": 123354.192882,
+    "_startTime": 123354.194056,
+    "_endTime": 123356.207007,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53601,
+    "_responseReceivedTime": 123354.391507,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "53936"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 54017,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.194056,
+      "proxyStart": 6.69900000502821,
+      "proxyEnd": 7.1180000086315,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 12.0130000141216,
+      "sendEnd": 18.5650000057649,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 197.451000000001
+    },
+    "_resourceSize": 53936,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.26._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.26._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.17",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro",
+      "lastPathComponent": "style.css"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 34
+    },
+    "_issueTime": 123354.215025,
+    "_startTime": 123354.216356,
+    "_endTime": 123356.300236,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.55815,
+    "_responseReceivedTime": 123354.649127,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "53936"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      }
+    ],
+    "_transferSize": 54017,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.216356,
+      "proxyStart": 8.52599999052472,
+      "proxyEnd": 9.71199999912642,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 14.2249999917112,
+      "sendEnd": 19.5410000014817,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 432.770999992499
+    },
+    "_resourceSize": 53936,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.27._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.27._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.8",
+    "_url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+      "queryParams": "ver=1.12.4",
+      "folderPathComponents": "/wp-includes/js/jquery",
+      "lastPathComponent": "jquery.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 37
+    },
+    "_issueTime": 123354.195114,
+    "_startTime": 123354.196368,
+    "_endTime": 123356.671414,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-includes/js/jquery/jquery.js?ver=1.12.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.53824,
+    "_responseReceivedTime": 123354.418151,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 21 Jun 2016 18:31:34 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "97184"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 97300,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.196368,
+      "proxyStart": 9.03599998855498,
+      "proxyEnd": 9.45599999977276,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 13.3689999929629,
+      "sendEnd": 16.2750000017695,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 221.783000000869
+    },
+    "_resourceSize": 97184,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.28._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.28._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.20",
+    "_url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+      "queryParams": "ver=1.12.4",
+      "folderPathComponents": "/wp-includes/js/jquery",
+      "lastPathComponent": "jquery.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 37
+    },
+    "_issueTime": 123354.216549,
+    "_startTime": 123354.219978,
+    "_endTime": 123356.700535,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-includes/js/jquery/jquery.js?ver=1.12.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831869.55968,
+    "_responseReceivedTime": 123354.661737,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 21 Jun 2016 18:31:34 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "97184"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 97283,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123354.219978,
+      "proxyStart": 8.13000000198372,
+      "proxyEnd": 8.79700000223238,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 11.3750000018626,
+      "sendEnd": 19.2930000048364,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 441.75900000846
+    },
+    "_resourceSize": 97184,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.29._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.29._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.31",
+    "_url": "https://webtide.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1",
+      "queryParams": "ver=1.4.1",
+      "folderPathComponents": "/wp-includes/js/jquery",
+      "lastPathComponent": "jquery-migrate.min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 38
+    },
+    "_issueTime": 123356.763081,
+    "_startTime": 123356.765958,
+    "_endTime": 123357.014568,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831872.10633,
+    "_responseReceivedTime": 123356.928661,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 21 Jun 2016 18:31:34 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "10056"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 10110,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123356.765958,
+      "proxyStart": 1.05299999995623,
+      "proxyEnd": 1.53899998986162,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.64099999528844,
+      "sendEnd": 1.94699999701697,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 162.702999994508
+    },
+    "_resourceSize": 10056,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.30._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.30._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.30",
+    "_url": "https://platform.twitter.com/widgets.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://platform.twitter.com/widgets.js",
+      "scheme": "https",
+      "host": "platform.twitter.com",
+      "path": "/widgets.js",
+      "queryParams": "",
+      "folderPathComponents": "",
+      "lastPathComponent": "widgets.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 533
+    },
+    "_issueTime": 123354.220013,
+    "_startTime": 123356.671752,
+    "_endTime": 123357.129046,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "104.244.43.108:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "platform.twitter.com",
+      "sanList": [
+        "platform.twitter.com",
+        "preview.cdn.twitter.com",
+        "cdn.api.twitter.com",
+        "urls.api.twitter.com",
+        "cdn.digits.com",
+        "status.twitter.com"
+      ],
+      "issuer": "DigiCert SHA2 High Assurance Server CA",
+      "validFrom": 1461283200,
+      "validTo": 1493294400,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Pilot' log",
+          "logId": "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+          "timestamp": 1461353956111,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022007B3C00DDD442317F59924830EBDB66F24BF73EE97AC6EA89E69F75750C3A937022100A4E654BD8BF8EAB7FEC2E79908AE574297DD75FFEC9A51062CD3E6413BB73EEC"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Aviator' log",
+          "logId": "68F698F81F6482BE3A8CEEB9281D4CFC71515D6793D444D10A67ACBB4F4FFBC4",
+          "timestamp": 1461353956113,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450220541078EEC24A03E4B8927CF0D56F45C85BF80903204A02EC1108A1FAA391C0C4022100BBDC73AF636ABF5F366189EA7D1900CEFD52CEDBF11C1751B127C94492116921"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1461353956503,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502203DD2EE4A44E34C2D6CC3D773F3BEAC53F859A9D312F06F7EF46DD3974B96BFDE022100A5DF5B730D252EF5CF700E001C00DF0FA60C83769EDB05325CCB083A7361AC78"
+        }
+      ]
+    },
+    "connectionId": "600",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "platform.twitter.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831869.56314,
+    "_responseReceivedTime": 123356.921469,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:32 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "Age",
+        "value": "572"
+      },
+      {
+        "name": "X-Cache",
+        "value": "HIT"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"CAO DSP LAW CURa ADMa DEVa TAIa PSAa PSDa IVAa IVDa OUR BUS IND UNI COM NAV INT\""
+      },
+      {
+        "name": "Connection",
+        "value": "Keep-Alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "32744"
+      },
+      {
+        "name": "X-Served-By",
+        "value": "cache-tw-sjc1-cr1-12-TWSJC1"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 13 Sep 2016 19:55:32 GMT"
+      },
+      {
+        "name": "Server",
+        "value": "Apache"
+      },
+      {
+        "name": "X-Timer",
+        "value": "S1473831872.136812,VS0,VE0"
+      },
+      {
+        "name": "Etag",
+        "value": "\"30db321a195e7c07fba553c69fc689cf+gzip\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding,Host"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/javascript; charset=utf-8"
+      },
+      {
+        "name": "Via",
+        "value": "1.1 varnish"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "public, max-age=1800"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Keep-Alive",
+        "value": "timeout=7, max=50"
+      }
+    ],
+    "_transferSize": 33363,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nDate: Wed, 14 Sep 2016 05:44:32 GMT\r\nServer: Apache\r\nLast-Modified: Tue, 13 Sep 2016 19:55:32 GMT\r\nCache-Control: public, max-age=1800\r\nContent-Type: application/javascript; charset=utf-8\r\nEtag: \"30db321a195e7c07fba553c69fc689cf+gzip\"\r\nContent-Encoding: gzip\r\nContent-Length: 32744\r\nAccept-Ranges: bytes\r\nVia: 1.1 varnish\r\nAge: 572\r\nX-Served-By: cache-tw-sjc1-cr1-12-TWSJC1\r\nX-Cache: HIT\r\nX-Timer: S1473831872.136812,VS0,VE0\r\nVary: Accept-Encoding,Host\r\nP3P: CP=\"CAO DSP LAW CURa ADMa DEVa TAIa PSAa PSDa IVAa IVDa OUR BUS IND UNI COM NAV INT\"\r\nKeep-Alive: timeout=7, max=50\r\nConnection: Keep-Alive\r\n\r\n",
+    "_requestHeadersText": "GET /widgets.js HTTP/1.1\r\nHost: platform.twitter.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://webtide.com/http2-push-demo/\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123356.671752,
+      "proxyStart": 0.562000001082197,
+      "proxyEnd": 1.14900000335183,
+      "dnsStart": 1.47000000288244,
+      "dnsEnd": 30.2270000101998,
+      "connectStart": 30.2270000101998,
+      "connectEnd": 93.8960000057705,
+      "sslStart": 44.5180000097025,
+      "sslEnd": 93.8670000032289,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 94.7260000102688,
+      "sendEnd": 94.8740000021644,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 249.716999998782
+    },
+    "_resourceSize": 114738,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.31._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.31._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.32",
+    "_url": "https://webtide.com/wp-content/plugins/crayon-syntax-highlighter/js/min/crayon.min.js?ver=_2.7.2_beta",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/crayon-syntax-highlighter/js/min/crayon.min.js?ver=_2.7.2_beta",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/crayon-syntax-highlighter/js/min/crayon.min.js?ver=_2.7.2_beta",
+      "queryParams": "ver=_2.7.2_beta",
+      "folderPathComponents": "/wp-content/plugins/crayon-syntax-highlighter/js/min",
+      "lastPathComponent": "crayon.min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 45
+    },
+    "_issueTime": 123357.022504,
+    "_startTime": 123357.023122,
+    "_endTime": 123357.280572,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/crayon-syntax-highlighter/js/min/crayon.min.js?ver=_2.7.2_beta"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831872.36575,
+    "_responseReceivedTime": 123357.178826,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Fri, 01 Jul 2016 12:37:35 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "22337"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 22400,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.023122,
+      "proxyStart": 0.925000000279397,
+      "proxyEnd": 1.38200000219513,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.50600000051782,
+      "sendEnd": 1.81099999463186,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 155.704000004334
+    },
+    "_resourceSize": 22337,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.32._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.32._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.33",
+    "_url": "https://webtide.com/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2",
+      "queryParams": "ver=3.0.2",
+      "folderPathComponents": "/wp-content/plugins/wp-retina-2x/js",
+      "lastPathComponent": "picturefill.min.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 46
+    },
+    "_issueTime": 123357.286033,
+    "_startTime": 123357.286386,
+    "_endTime": 123357.49424,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831872.62928,
+    "_responseReceivedTime": 123357.44408,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Fri, 01 Jul 2016 12:37:40 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "11808"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 11862,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.286386,
+      "proxyStart": 0.584999987040646,
+      "proxyEnd": 1.23799999710172,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.36799999745563,
+      "sendEnd": 1.69199999072589,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 157.693999994081
+    },
+    "_resourceSize": 11808,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.33._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.33._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.34",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/tinynav.js?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/tinynav.js?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/library/js/tinynav.js?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/library/js",
+      "lastPathComponent": "tinynav.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 47
+    },
+    "_issueTime": 123357.501706,
+    "_startTime": 123357.516726,
+    "_endTime": 123357.693784,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/library/js/tinynav.js?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831872.84496,
+    "_responseReceivedTime": 123357.688048,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "2276"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 2329,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.516726,
+      "proxyStart": 8.27999999455642,
+      "proxyEnd": 10.3789999993751,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 11.6859999980079,
+      "sendEnd": 13.8940000033472,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 171.321999994689
+    },
+    "_resourceSize": 2276,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.34._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.34._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.35",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4",
+      "queryParams": "ver=4.5.4",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/library/js",
+      "lastPathComponent": "backtotop.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 48
+    },
+    "_issueTime": 123357.695318,
+    "_startTime": 123357.695735,
+    "_endTime": 123357.860307,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.03863,
+    "_responseReceivedTime": 123357.85954,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "577"
+      },
+      {
+        "name": "content-type",
+        "value": "application/javascript"
+      }
+    ],
+    "_transferSize": 630,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.695735,
+      "proxyStart": 2.89099999645259,
+      "proxyEnd": 3.94599999708589,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 4.19999999576248,
+      "sendEnd": 4.63500000478234,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 163.805000003777
+    },
+    "_resourceSize": 577,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.35._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.35._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.41",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/patterns/pattern-1.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/patterns/pattern-1.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/patterns/pattern-1.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images/patterns",
+      "lastPathComponent": "pattern-1.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 399
+    },
+    "_issueTime": 123357.872156,
+    "_startTime": 123357.874877,
+    "_endTime": 123358.038853,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/patterns/pattern-1.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.21547,
+    "_responseReceivedTime": 123358.038164,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "116"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 168,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.874877,
+      "proxyStart": 5.42600000335369,
+      "proxyEnd": 5.87700000323821,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 6.32400000176858,
+      "sendEnd": 7.05900001048576,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 163.287000003038
+    },
+    "_resourceSize": 116,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.36._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.36._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.42",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/access-bg@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/access-bg@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/access-bg@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "access-bg@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 399
+    },
+    "_issueTime": 123357.87289,
+    "_startTime": 123357.87724,
+    "_endTime": 123358.048766,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/access-bg@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.2162,
+    "_responseReceivedTime": 123358.046748,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "148"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 201,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.87724,
+      "proxyStart": 3.4109999978682,
+      "proxyEnd": 3.857000003336,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 4.16699999186676,
+      "sendEnd": 4.70799999311566,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 169.507999991765
+    },
+    "_resourceSize": 148,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.37._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.37._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.43",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/by-author@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/by-author@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/by-author@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "by-author@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 399
+    },
+    "_issueTime": 123357.882855,
+    "_startTime": 123357.883607,
+    "_endTime": 123358.084158,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/by-author@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.22617,
+    "_responseReceivedTime": 123358.073706,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "471"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 524,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.883607,
+      "proxyStart": 3.95100000605453,
+      "proxyEnd": 4.83200000599027,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 8.62500000221189,
+      "sendEnd": 23.7310000084108,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 190.098999999464
+    },
+    "_resourceSize": 471,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.38._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.38._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.44",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/date@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/date@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/date@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "date@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 399
+    },
+    "_issueTime": 123357.883343,
+    "_startTime": 123357.884778,
+    "_endTime": 123358.089969,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/date@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.22666,
+    "_responseReceivedTime": 123358.088635,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "747"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 800,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.884778,
+      "proxyStart": 7.77099998958875,
+      "proxyEnd": 8.8980000000447,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 20.9629999881145,
+      "sendEnd": 28.5019999864744,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 203.856999985874
+    },
+    "_resourceSize": 747,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.39._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.39._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.45",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/tags@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/tags@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/tags@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "tags@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 399
+    },
+    "_issueTime": 123357.88364,
+    "_startTime": 123357.885233,
+    "_endTime": 123358.090393,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/tags@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.22695,
+    "_responseReceivedTime": 123358.089901,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "717"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 770,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.885233,
+      "proxyStart": 17.5569999992149,
+      "proxyEnd": 18.7670000013895,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 21.5960000059567,
+      "sendEnd": 28.0650000058813,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 204.668000005768
+    },
+    "_resourceSize": 717,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.40._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.40._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.46",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/comments@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/comments@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/comments@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "comments@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 399
+    },
+    "_issueTime": 123357.883982,
+    "_startTime": 123357.885642,
+    "_endTime": 123358.09535,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/comments@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.22729,
+    "_responseReceivedTime": 123358.094416,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "500"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 552,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.885642,
+      "proxyStart": 18.4810000064317,
+      "proxyEnd": 19.0310000034515,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 21.3829999993322,
+      "sendEnd": 30.3010000061477,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 208.774000013364
+    },
+    "_resourceSize": 500,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.41._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.41._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.47",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/wp_page_numbers-bg@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/wp_page_numbers-bg@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/wp_page_numbers-bg@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "wp_page_numbers-bg@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 399
+    },
+    "_issueTime": 123357.884919,
+    "_startTime": 123357.886132,
+    "_endTime": 123358.103612,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/wp_page_numbers-bg@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.22823,
+    "_responseReceivedTime": 123358.103084,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "145"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 198,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123357.886132,
+      "proxyStart": 18.6620000022231,
+      "proxyEnd": 19.0799999982119,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 21.0709999955725,
+      "sendEnd": 29.8739999998361,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 216.952000002493
+    },
+    "_resourceSize": 145,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.42._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.42._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.40",
+    "_url": "https://fonts.gstatic.com/s/gentiumbasic/v8/KCktj43blvLkhOTolFn-MQgYcthoNQJTwaSsmU2sQE0.woff2",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://fonts.gstatic.com/s/gentiumbasic/v8/KCktj43blvLkhOTolFn-MQgYcthoNQJTwaSsmU2sQE0.woff2",
+      "scheme": "https",
+      "host": "fonts.gstatic.com",
+      "path": "/s/gentiumbasic/v8/KCktj43blvLkhOTolFn-MQgYcthoNQJTwaSsmU2sQE0.woff2",
+      "queryParams": "",
+      "folderPathComponents": "/s/gentiumbasic/v8",
+      "lastPathComponent": "KCktj43blvLkhOTolFn-MQgYcthoNQJTwaSsmU2sQE0.woff2"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 399
+    },
+    "_issueTime": 123357.882432,
+    "_startTime": 123357.88318,
+    "_endTime": 123358.178451,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "font",
+      "_title": "Font",
+      "_category": {
+        "title": "Fonts",
+        "shortTitle": "Font"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:804::2003]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_ECDSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google.com",
+      "sanList": [
+        "*.google.com",
+        "*.android.com",
+        "*.appengine.google.com",
+        "*.cloud.google.com",
+        "*.google-analytics.com",
+        "*.google.ca",
+        "*.google.cl",
+        "*.google.co.in",
+        "*.google.co.jp",
+        "*.google.co.uk",
+        "*.google.com.ar",
+        "*.google.com.au",
+        "*.google.com.br",
+        "*.google.com.co",
+        "*.google.com.mx",
+        "*.google.com.tr",
+        "*.google.com.vn",
+        "*.google.de",
+        "*.google.es",
+        "*.google.fr",
+        "*.google.hu",
+        "*.google.it",
+        "*.google.nl",
+        "*.google.pl",
+        "*.google.pt",
+        "*.googleadapis.com",
+        "*.googleapis.cn",
+        "*.googlecommerce.com",
+        "*.googlevideo.com",
+        "*.gstatic.cn",
+        "*.gstatic.com",
+        "*.gvt1.com",
+        "*.gvt2.com",
+        "*.metric.gstatic.com",
+        "*.urchin.com",
+        "*.url.google.com",
+        "*.youtube-nocookie.com",
+        "*.youtube.com",
+        "*.youtubeeducation.com",
+        "*.ytimg.com",
+        "android.clients.google.com",
+        "android.com",
+        "g.co",
+        "goo.gl",
+        "google-analytics.com",
+        "google.com",
+        "googlecommerce.com",
+        "policy.mta-sts.google.com",
+        "urchin.com",
+        "www.goo.gl",
+        "youtu.be",
+        "youtube.com",
+        "youtubeeducation.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291668,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294157675,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450221009055A6D69C0CB2E407BE909674D95CC4AF2DA70F0227C59306FE478C7180AF9F022013374116DD952AA4B0CE6354EE179866A06014C15C6069A83F5CE6BF5971BC94"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294158314,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100E14BE9F27C6A8BBC0B3629205B8160CECAB700729222DE0C3058655338B45A9E0221008C902D61453456BFE66625FCE56ECFF15667097CAF2EB83C088BA636CA83119C"
+        }
+      ]
+    },
+    "connectionId": "486",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/s/gentiumbasic/v8/KCktj43blvLkhOTolFn-MQgYcthoNQJTwaSsmU2sQE0.woff2"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "origin",
+        "value": "https://webtide.com"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "fonts.gstatic.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://fonts.googleapis.com/css?family=Gentium+Basic&ver=4.5.4"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.22575,
+    "_responseReceivedTime": 123358.061675,
+    "_mimeType": "font/woff2",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Wed, 31 Aug 2016 09:12:14 GMT"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Mon, 11 Jan 2016 21:20:48 GMT"
+      },
+      {
+        "name": "server",
+        "value": "sffe"
+      },
+      {
+        "name": "age",
+        "value": "1197139"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "content-type",
+        "value": "font/woff2"
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=31536000"
+      },
+      {
+        "name": "timing-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "15144"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Thu, 31 Aug 2017 09:12:14 GMT"
+      }
+    ],
+    "_transferSize": 15400,
+    "_requestHeadersText": "",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123357.88318,
+      "proxyStart": 3.32499999785796,
+      "proxyEnd": 3.72399999469053,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 8.87399999191985,
+      "sendEnd": 24.1390000010142,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 178.495000000112
+    },
+    "_resourceSize": 15144,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.43._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.43._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.51",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/twitter@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/twitter@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/twitter@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "twitter@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 503
+    },
+    "_issueTime": 123358.021015,
+    "_startTime": 123358.021389,
+    "_endTime": 123358.315657,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/twitter@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.36433,
+    "_responseReceivedTime": 123358.187485,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "1767"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 1820,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123358.021389,
+      "proxyStart": 0.757999994675629,
+      "proxyEnd": 1.30000000353903,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.62599999748636,
+      "sendEnd": 2.67299999541137,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 166.096000000834
+    },
+    "_resourceSize": 1767,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.44._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.44._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.38:redirected.0",
+    "_url": "https://www.slideshare.net/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.slideshare.net/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "scheme": "https",
+      "host": "www.slideshare.net",
+      "path": "/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "queryParams": "",
+      "folderPathComponents": "/slideshow/embed_code/key",
+      "lastPathComponent": "2bcPOKkYBQ6WnM"
+    },
+    "_documentURL": "https://www.slideshare.net/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 339
+    },
+    "_issueTime": 123357.868113,
+    "_startTime": 123357.880866,
+    "_endTime": 123358.777856,
+    "statusCode": 302,
+    "statusText": "Found",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2620:109:c002::6cae:a13]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "www.slideshare.net",
+      "sanList": [
+        "www.slideshare.net",
+        "rpublic.slideshare.net",
+        "slideshare.net",
+        "track.slideshare.net",
+        "stats.slideshare.net",
+        "email-events.slideshare.net",
+        "mobilestats.slideshare.net",
+        "autosuggest.slideshare.net",
+        "de.slideshare.net",
+        "fr.slideshare.net",
+        "es.slideshare.net",
+        "pt.slideshare.net"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1430438400,
+      "validTo": 1494417600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "715",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "www.slideshare.net"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "Upgrade-Insecure-Requests",
+        "value": "1"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831873.21143,
+    "_responseReceivedTime": 123358.400176,
+    "_mimeType": "",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:33 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      },
+      {
+        "name": "Location",
+        "value": "/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      },
+      {
+        "name": "Set-Cookie",
+        "value": "bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"; domain=.slideshare.net; Path=/; Expires=Fri, 14-Sep-2018 17:22:05 GMT"
+      },
+      {
+        "name": "Content-length",
+        "value": "0"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "WZ6pt0cadBQgX0RupisAAA=="
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "599ea9b7471a7414205f446ea62b0000"
+      }
+    ],
+    "_transferSize": 448,
+    "_responseHeadersText": "HTTP/1.1 302 Found\r\nCache-Control: no-cache\r\nContent-length: 0\r\nLocation: /mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nX-FS-UUID: 599ea9b7471a7414205f446ea62b0000\r\nDate: Wed, 14 Sep 2016 05:44:33 GMT\r\nX-Li-Fabric: prod-lva1\r\nSet-Cookie: bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"; domain=.slideshare.net; Path=/; Expires=Fri, 14-Sep-2018 17:22:05 GMT\r\nConnection: keep-alive\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: WZ6pt0cadBQgX0RupisAAA==\r\n\r\n",
+    "_requestHeadersText": "GET /slideshow/embed_code/key/2bcPOKkYBQ6WnM HTTP/1.1\r\nHost: www.slideshare.net\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUpgrade-Insecure-Requests: 1\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\nReferer: https://webtide.com/http2-push-demo/\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123357.880866,
+      "proxyStart": 0.995999987935647,
+      "proxyEnd": 1.96199999481905,
+      "dnsStart": 1.96199999481905,
+      "dnsEnd": 40.1639999909094,
+      "connectStart": 40.1639999909094,
+      "connectEnd": 102.783999987878,
+      "sslStart": 59.9599999986822,
+      "sslEnd": 102.761999994982,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 103.242999990471,
+      "sendEnd": 103.428999995231,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 519.309999988764
+    },
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.45._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.45._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.54",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/back-to-top@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/back-to-top@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/back-to-top@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "back-to-top@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 503
+    },
+    "_issueTime": 123358.024043,
+    "_startTime": 123358.024724,
+    "_endTime": 123358.432717,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/back-to-top@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.36735,
+    "_responseReceivedTime": 123358.399694,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "3497"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 3550,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123358.024724,
+      "proxyStart": 0.692000001436099,
+      "proxyEnd": 1.27300000167452,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.37699999322649,
+      "sendEnd": 1.61900000239257,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 374.970000004396
+    },
+    "_resourceSize": 3497,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.46._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.46._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.53",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/github@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/github@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/github@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "github@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 503
+    },
+    "_issueTime": 123358.02165,
+    "_startTime": 123358.022459,
+    "_endTime": 123358.472454,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/github@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.36496,
+    "_responseReceivedTime": 123358.394851,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "2019"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 2072,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123358.022459,
+      "proxyStart": 0.78600000415463,
+      "proxyEnd": 1.42000000050757,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.74300000071526,
+      "sendEnd": 2.5889999960782,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 372.392000004766
+    },
+    "_resourceSize": 2019,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.47._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.47._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.52",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/vimeo@2x.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/vimeo@2x.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/vimeo@2x.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "vimeo@2x.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 503
+    },
+    "_issueTime": 123358.021341,
+    "_startTime": 123358.021864,
+    "_endTime": 123358.473652,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/vimeo@2x.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.36465,
+    "_responseReceivedTime": 123358.394571,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "1946"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 1999,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123358.021864,
+      "proxyStart": 0.910000002477318,
+      "proxyEnd": 1.30000000353903,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 2.09700000414159,
+      "sendEnd": 3.17300000460818,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 372.707000002265
+    },
+    "_resourceSize": 1946,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.48._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.48._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.62",
+    "_url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/responsive-menu-bg.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/themes/clean-retina-pro/images/responsive-menu-bg.png",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/themes/clean-retina-pro/images/responsive-menu-bg.png",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/themes/clean-retina-pro/images",
+      "lastPathComponent": "responsive-menu-bg.png"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Sa",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 2,
+            "columnNumber": 27484
+          },
+          {
+            "functionName": "css",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 2,
+            "columnNumber": 30894
+          },
+          {
+            "functionName": "W",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 2,
+            "columnNumber": 3893
+          },
+          {
+            "functionName": "cb",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 2,
+            "columnNumber": 28888
+          },
+          {
+            "functionName": "hide",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 3,
+            "columnNumber": 613
+          },
+          {
+            "functionName": "n.fn.(anonymous function)",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 3,
+            "columnNumber": 7542
+          },
+          {
+            "functionName": "",
+            "scriptId": "40",
+            "url": "https://webtide.com/wp-content/themes/clean-retina-pro/library/js/backtotop.js?ver=4.5.4",
+            "lineNumber": 7,
+            "columnNumber": 24
+          },
+          {
+            "functionName": "i",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 1,
+            "columnNumber": 27448
+          },
+          {
+            "functionName": "fireWith",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 1,
+            "columnNumber": 28212
+          },
+          {
+            "functionName": "ready",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 1,
+            "columnNumber": 30005
+          },
+          {
+            "functionName": "K",
+            "scriptId": "33",
+            "url": "https://webtide.com/wp-includes/js/jquery/jquery.js?ver=1.12.4",
+            "lineNumber": 1,
+            "columnNumber": 30367
+          }
+        ]
+      }
+    },
+    "_issueTime": 123358.3246,
+    "_startTime": 123358.395497,
+    "_endTime": 123358.647008,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/themes/clean-retina-pro/images/responsive-menu-bg.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16; JCS_INENREF=; JCS_INENTIM=1473831873532"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/wp-content/themes/clean-retina-pro/style.css?ver=4.5.4"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.66791,
+    "_responseReceivedTime": 123358.646101,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 26 Apr 2016 15:08:27 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "240"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      }
+    ],
+    "_transferSize": 292,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123358.395497,
+      "proxyStart": 6.7809999891324,
+      "proxyEnd": 35.8659999910742,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 75.5819999903906,
+      "sendEnd": 86.69799999916,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 250.604000000749
+    },
+    "_resourceSize": 240,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.49._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.49._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.50",
+    "_url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+      "scheme": "https",
+      "host": "www.gstatic.com",
+      "path": "/recaptcha/api2/r20160908152041/recaptcha__en.js",
+      "queryParams": "",
+      "folderPathComponents": "/recaptcha/api2/r20160908152041",
+      "lastPathComponent": "recaptcha__en.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "44",
+            "url": "https://www.google.com/recaptcha/api.js?hl=en",
+            "lineNumber": 0,
+            "columnNumber": 653
+          },
+          {
+            "functionName": "",
+            "scriptId": "44",
+            "url": "https://www.google.com/recaptcha/api.js?hl=en",
+            "lineNumber": 0,
+            "columnNumber": 675
+          }
+        ]
+      }
+    },
+    "_issueTime": 123357.999912,
+    "_startTime": 123358.001199,
+    "_endTime": 123358.702413,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:806::2003]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_ECDSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google.com",
+      "sanList": [
+        "*.google.com",
+        "*.android.com",
+        "*.appengine.google.com",
+        "*.cloud.google.com",
+        "*.google-analytics.com",
+        "*.google.ca",
+        "*.google.cl",
+        "*.google.co.in",
+        "*.google.co.jp",
+        "*.google.co.uk",
+        "*.google.com.ar",
+        "*.google.com.au",
+        "*.google.com.br",
+        "*.google.com.co",
+        "*.google.com.mx",
+        "*.google.com.tr",
+        "*.google.com.vn",
+        "*.google.de",
+        "*.google.es",
+        "*.google.fr",
+        "*.google.hu",
+        "*.google.it",
+        "*.google.nl",
+        "*.google.pl",
+        "*.google.pt",
+        "*.googleadapis.com",
+        "*.googleapis.cn",
+        "*.googlecommerce.com",
+        "*.googlevideo.com",
+        "*.gstatic.cn",
+        "*.gstatic.com",
+        "*.gvt1.com",
+        "*.gvt2.com",
+        "*.metric.gstatic.com",
+        "*.urchin.com",
+        "*.url.google.com",
+        "*.youtube-nocookie.com",
+        "*.youtube.com",
+        "*.youtubeeducation.com",
+        "*.ytimg.com",
+        "android.clients.google.com",
+        "android.com",
+        "g.co",
+        "goo.gl",
+        "google-analytics.com",
+        "google.com",
+        "googlecommerce.com",
+        "policy.mta-sts.google.com",
+        "urchin.com",
+        "www.goo.gl",
+        "youtu.be",
+        "youtube.com",
+        "youtubeeducation.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291668,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294157675,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450221009055A6D69C0CB2E407BE909674D95CC4AF2DA70F0227C59306FE478C7180AF9F022013374116DD952AA4B0CE6354EE179866A06014C15C6069A83F5CE6BF5971BC94"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294158314,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100E14BE9F27C6A8BBC0B3629205B8160CECAB700729222DE0C3058655338B45A9E0221008C902D61453456BFE66625FCE56ECFF15667097CAF2EB83C088BA636CA83119C"
+        }
+      ]
+    },
+    "connectionId": "537",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/recaptcha/api2/r20160908152041/recaptcha__en.js"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.gstatic.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.34323,
+    "_responseReceivedTime": 123358.185768,
+    "_mimeType": "text/javascript",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Tue, 13 Sep 2016 18:09:55 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Thu, 08 Sep 2016 23:15:00 GMT"
+      },
+      {
+        "name": "server",
+        "value": "sffe"
+      },
+      {
+        "name": "age",
+        "value": "41678"
+      },
+      {
+        "name": "vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "content-type",
+        "value": "text/javascript"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=31536000"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "71283"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 13 Sep 2017 18:09:55 GMT"
+      }
+    ],
+    "_transferSize": 71454,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123358.001199,
+      "proxyStart": 4.01899999997113,
+      "proxyEnd": 7.60399999853689,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 7.77499999094289,
+      "sendEnd": 8.21400000131689,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 184.568999990006
+    },
+    "_resourceSize": 223052,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.50._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.50._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.55",
+    "_url": "https://stats.g.doubleclick.net/dc.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://stats.g.doubleclick.net/dc.js",
+      "scheme": "https",
+      "host": "stats.g.doubleclick.net",
+      "path": "/dc.js",
+      "queryParams": "",
+      "folderPathComponents": "",
+      "lastPathComponent": "dc.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "46",
+            "url": "https://webtide.com/http2-push-demo/",
+            "lineNumber": 521,
+            "columnNumber": 65
+          },
+          {
+            "functionName": "",
+            "scriptId": "46",
+            "url": "https://webtide.com/http2-push-demo/",
+            "lineNumber": 522,
+            "columnNumber": 2
+          }
+        ]
+      }
+    },
+    "_issueTime": 123358.176625,
+    "_startTime": 123358.180605,
+    "_endTime": 123358.753414,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:400e:c00::9a]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.g.doubleclick.net",
+      "sanList": [
+        "*.g.doubleclick.net",
+        "*.googleadservices.com",
+        "*.googlesyndication.com",
+        "*.googletagservices.com",
+        "*.invitemedia.com",
+        "g.doubleclick.net",
+        "googleadservices.com",
+        "googlesyndication.com",
+        "googletagservices.com",
+        "media.admob.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1472737500,
+      "validTo": 1479995100,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1472740522082,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450220673775E12CA5BA84800401AA2ABA155BD94DAFEE7AFAFACCBBD6B0CF402B6151022100B485566E644B3298B89BADE69D56E755C52EA96DABA5FF805203EB16CBE6630F"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1472740522681,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022100A854660206BE82EB5E88F4DD86615C7236D7B1B3200E6FA80C7AD38C947F3FA902206604B4919839B9A8D08215E7C4E329B87915F3ED5B0C62E4A7181B70D021BA7A"
+        }
+      ]
+    },
+    "connectionId": "794",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/dc.js"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "stats.g.doubleclick.net"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831873.51994,
+    "_responseReceivedTime": 123358.652296,
+    "_mimeType": "text/javascript",
+    "_responseHeaders": [
+      {
+        "name": "strict-transport-security",
+        "value": "max-age=10886400; includeSubDomains; preload"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Mon, 15 Aug 2016 04:25:11 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Golfe2"
+      },
+      {
+        "name": "age",
+        "value": "222"
+      },
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:40:51 GMT"
+      },
+      {
+        "name": "vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "content-type",
+        "value": "text/javascript"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=7200"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "15977"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 14 Sep 2016 07:40:51 GMT"
+      }
+    ],
+    "_transferSize": 16238,
+    "_requestHeadersText": "",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123358.180605,
+      "proxyStart": 1.62700000510085,
+      "proxyEnd": 3.37500000023283,
+      "dnsStart": 3.49000000278465,
+      "dnsEnd": 43.3130000019446,
+      "connectStart": 43.3130000019446,
+      "connectEnd": 254.203999997117,
+      "sslStart": 131.462999997893,
+      "sslEnd": 254.182000004221,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 301.24600000272,
+      "sendEnd": 304.061000002548,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 471.690999998827
+    },
+    "_resourceSize": 42873,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.51._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.51._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.63",
+    "_url": "https://platform.twitter.com/js/button.9c9dd7044dfaf420ee068697fbf32302.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://platform.twitter.com/js/button.9c9dd7044dfaf420ee068697fbf32302.js",
+      "scheme": "https",
+      "host": "platform.twitter.com",
+      "path": "/js/button.9c9dd7044dfaf420ee068697fbf32302.js",
+      "queryParams": "",
+      "folderPathComponents": "/js",
+      "lastPathComponent": "button.9c9dd7044dfaf420ee068697fbf32302.js"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Function.bind.test.window.__twttr.window.__twttr.widgets.window.__twttr.widgets.init.e.e",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 0,
+            "columnNumber": 1468
+          },
+          {
+            "functionName": "r",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 10,
+            "columnNumber": 7593
+          },
+          {
+            "functionName": "i.initialize",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 28643
+          },
+          {
+            "functionName": "",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 27602
+          },
+          {
+            "functionName": "",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 27577
+          },
+          {
+            "functionName": "o",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 7871
+          },
+          {
+            "functionName": "i",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 27540
+          },
+          {
+            "functionName": "r._flush",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 8,
+            "columnNumber": 1360
+          },
+          {
+            "functionName": "",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 8785
+          },
+          {
+            "functionName": "p",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 780
+          }
+        ]
+      }
+    },
+    "_issueTime": 123358.756888,
+    "_startTime": 123358.757562,
+    "_endTime": 123358.924021,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "104.244.43.108:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "platform.twitter.com",
+      "sanList": [
+        "platform.twitter.com",
+        "preview.cdn.twitter.com",
+        "cdn.api.twitter.com",
+        "urls.api.twitter.com",
+        "cdn.digits.com",
+        "status.twitter.com"
+      ],
+      "issuer": "DigiCert SHA2 High Assurance Server CA",
+      "validFrom": 1461283200,
+      "validTo": 1493294400,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Pilot' log",
+          "logId": "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+          "timestamp": 1461353956111,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022007B3C00DDD442317F59924830EBDB66F24BF73EE97AC6EA89E69F75750C3A937022100A4E654BD8BF8EAB7FEC2E79908AE574297DD75FFEC9A51062CD3E6413BB73EEC"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Aviator' log",
+          "logId": "68F698F81F6482BE3A8CEEB9281D4CFC71515D6793D444D10A67ACBB4F4FFBC4",
+          "timestamp": 1461353956113,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450220541078EEC24A03E4B8927CF0D56F45C85BF80903204A02EC1108A1FAA391C0C4022100BBDC73AF636ABF5F366189EA7D1900CEFD52CEDBF11C1751B127C94492116921"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1461353956503,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502203DD2EE4A44E34C2D6CC3D773F3BEAC53F859A9D312F06F7EF46DD3974B96BFDE022100A5DF5B730D252EF5CF700E001C00DF0FA60C83769EDB05325CCB083A7361AC78"
+        }
+      ]
+    },
+    "connectionId": "600",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "platform.twitter.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.1002,
+    "_responseReceivedTime": 123358.917223,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "Age",
+        "value": "34761"
+      },
+      {
+        "name": "X-Cache",
+        "value": "HIT"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"CAO DSP LAW CURa ADMa DEVa TAIa PSAa PSDa IVAa IVDa OUR BUS IND UNI COM NAV INT\""
+      },
+      {
+        "name": "Connection",
+        "value": "Keep-Alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "1476"
+      },
+      {
+        "name": "X-Served-By",
+        "value": "cache-tw-sjc1-cr1-12-TWSJC1"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 13 Sep 2016 19:54:57 GMT"
+      },
+      {
+        "name": "Server",
+        "value": "Apache"
+      },
+      {
+        "name": "X-Timer",
+        "value": "S1473831874.144248,VS0,VE0"
+      },
+      {
+        "name": "Etag",
+        "value": "\"f2ddd2f55fc6c5567a3ea5318c048e48+gzip\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding,Host"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/javascript; charset=utf-8"
+      },
+      {
+        "name": "Via",
+        "value": "1.1 varnish"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "public, max-age=315569260"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Keep-Alive",
+        "value": "timeout=7, max=49"
+      }
+    ],
+    "_transferSize": 2101,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nServer: Apache\r\nLast-Modified: Tue, 13 Sep 2016 19:54:57 GMT\r\nCache-Control: public, max-age=315569260\r\nContent-Type: application/javascript; charset=utf-8\r\nEtag: \"f2ddd2f55fc6c5567a3ea5318c048e48+gzip\"\r\nContent-Encoding: gzip\r\nContent-Length: 1476\r\nAccept-Ranges: bytes\r\nVia: 1.1 varnish\r\nAge: 34761\r\nX-Served-By: cache-tw-sjc1-cr1-12-TWSJC1\r\nX-Cache: HIT\r\nX-Timer: S1473831874.144248,VS0,VE0\r\nVary: Accept-Encoding,Host\r\nP3P: CP=\"CAO DSP LAW CURa ADMa DEVa TAIa PSAa PSDa IVAa IVDa OUR BUS IND UNI COM NAV INT\"\r\nKeep-Alive: timeout=7, max=49\r\nConnection: Keep-Alive\r\n\r\n",
+    "_requestHeadersText": "GET /js/button.9c9dd7044dfaf420ee068697fbf32302.js HTTP/1.1\r\nHost: platform.twitter.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://webtide.com/http2-push-demo/\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123358.757562,
+      "proxyStart": 0.581000000238419,
+      "proxyEnd": 1.05900000198744,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.47600000491366,
+      "sendEnd": 1.63400000019465,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 159.660999997868
+    },
+    "_resourceSize": 4328,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.52._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.52._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.38",
+    "_url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "scheme": "https",
+      "host": "www.slideshare.net",
+      "path": "/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "queryParams": "",
+      "folderPathComponents": "/mobile/slideshow/embed_code/key",
+      "lastPathComponent": "2bcPOKkYBQ6WnM"
+    },
+    "_documentURL": "https://www.slideshare.net/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://webtide.com/http2-push-demo/",
+      "lineNumber": 339
+    },
+    "_issueTime": 123358.777856,
+    "_startTime": 123358.780337,
+    "_endTime": 123359.22468,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "document",
+      "_title": "Document",
+      "_category": {
+        "title": "Documents",
+        "shortTitle": "Doc"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2620:109:c002::6cae:a13]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "www.slideshare.net",
+      "sanList": [
+        "www.slideshare.net",
+        "rpublic.slideshare.net",
+        "slideshare.net",
+        "track.slideshare.net",
+        "stats.slideshare.net",
+        "email-events.slideshare.net",
+        "mobilestats.slideshare.net",
+        "autosuggest.slideshare.net",
+        "de.slideshare.net",
+        "fr.slideshare.net",
+        "es.slideshare.net",
+        "pt.slideshare.net"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1430438400,
+      "validTo": 1494417600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "715",
+    "redirects": [
+      {
+        "_target": {
+          "_modelByConstructor": {},
+          "consoleModel": {},
+          "networkManager": {
+            "_target": "[Circular ~.networkRecords.defaultPass.52.redirects.0._target]",
+            "_dispatcher": {
+              "_manager": "[Circular ~.networkRecords.defaultPass.52.redirects.0._target.networkManager]",
+              "_inflightRequestsById": {},
+              "_inflightRequestsByURL": {}
+            },
+            "_networkAgent": {},
+            "_certificateDetailsCache": {},
+            "_bypassServiceWorkerSetting": {},
+            "_listeners": {}
+          },
+          "networkLog": {
+            "_requests": {}
+          }
+        },
+        "_requestId": "19748.38:redirected.0",
+        "_url": "https://www.slideshare.net/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+        "_parsedURL": {
+          "isValid": true,
+          "url": "https://www.slideshare.net/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+          "scheme": "https",
+          "host": "www.slideshare.net",
+          "path": "/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+          "queryParams": "",
+          "folderPathComponents": "/slideshow/embed_code/key",
+          "lastPathComponent": "2bcPOKkYBQ6WnM"
+        },
+        "_documentURL": "https://www.slideshare.net/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+        "_frameId": "19748.2",
+        "_loaderId": "19748.3",
+        "_initiator": {
+          "type": "parser",
+          "url": "https://webtide.com/http2-push-demo/",
+          "lineNumber": 339
+        },
+        "_issueTime": 123357.868113,
+        "_startTime": 123357.880866,
+        "_endTime": 123358.777856,
+        "statusCode": 302,
+        "statusText": "Found",
+        "requestMethod": "GET",
+        "requestTime": 0,
+        "protocol": "http/1.1",
+        "mixedContentType": "none",
+        "_initialPriority": "VeryHigh",
+        "_currentPriority": null,
+        "_contentEncoded": false,
+        "_pendingContentCallbacks": [],
+        "_frames": [],
+        "_eventSourceMessages": [],
+        "_responseHeaderValues": {},
+        "_remoteAddress": "[2620:109:c002::6cae:a13]:443",
+        "_securityState": "secure",
+        "_securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "www.slideshare.net",
+          "sanList": [
+            "www.slideshare.net",
+            "rpublic.slideshare.net",
+            "slideshare.net",
+            "track.slideshare.net",
+            "stats.slideshare.net",
+            "email-events.slideshare.net",
+            "mobilestats.slideshare.net",
+            "autosuggest.slideshare.net",
+            "de.slideshare.net",
+            "fr.slideshare.net",
+            "es.slideshare.net",
+            "pt.slideshare.net"
+          ],
+          "issuer": "DigiCert SHA2 Secure Server CA",
+          "validFrom": 1430438400,
+          "validTo": 1494417600,
+          "signedCertificateTimestampList": []
+        },
+        "connectionId": "715",
+        "hasNetworkData": true,
+        "_requestHeaders": [
+          {
+            "name": "Pragma",
+            "value": "no-cache"
+          },
+          {
+            "name": "Accept-Encoding",
+            "value": "gzip, deflate, sdch, br"
+          },
+          {
+            "name": "Host",
+            "value": "www.slideshare.net"
+          },
+          {
+            "name": "Accept-Language",
+            "value": "en-US,en;q=0.8"
+          },
+          {
+            "name": "Upgrade-Insecure-Requests",
+            "value": "1"
+          },
+          {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+          },
+          {
+            "name": "Accept",
+            "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+          },
+          {
+            "name": "Referer",
+            "value": "https://webtide.com/http2-push-demo/"
+          },
+          {
+            "name": "Connection",
+            "value": "keep-alive"
+          },
+          {
+            "name": "Cache-Control",
+            "value": "no-cache"
+          }
+        ],
+        "_wallIssueTime": 1473831873.21143,
+        "_responseReceivedTime": 123358.400176,
+        "_mimeType": "",
+        "_responseHeaders": [
+          {
+            "name": "Date",
+            "value": "Wed, 14 Sep 2016 05:44:33 GMT"
+          },
+          {
+            "name": "X-Li-Pop",
+            "value": "PROD-ELA4"
+          },
+          {
+            "name": "Connection",
+            "value": "keep-alive"
+          },
+          {
+            "name": "X-Li-Fabric",
+            "value": "prod-lva1"
+          },
+          {
+            "name": "Location",
+            "value": "/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+          },
+          {
+            "name": "Cache-Control",
+            "value": "no-cache"
+          },
+          {
+            "name": "Set-Cookie",
+            "value": "bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"; domain=.slideshare.net; Path=/; Expires=Fri, 14-Sep-2018 17:22:05 GMT"
+          },
+          {
+            "name": "Content-length",
+            "value": "0"
+          },
+          {
+            "name": "X-LI-UUID",
+            "value": "WZ6pt0cadBQgX0RupisAAA=="
+          },
+          {
+            "name": "X-FS-UUID",
+            "value": "599ea9b7471a7414205f446ea62b0000"
+          }
+        ],
+        "_transferSize": 448,
+        "_responseHeadersText": "HTTP/1.1 302 Found\r\nCache-Control: no-cache\r\nContent-length: 0\r\nLocation: /mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nX-FS-UUID: 599ea9b7471a7414205f446ea62b0000\r\nDate: Wed, 14 Sep 2016 05:44:33 GMT\r\nX-Li-Fabric: prod-lva1\r\nSet-Cookie: bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"; domain=.slideshare.net; Path=/; Expires=Fri, 14-Sep-2018 17:22:05 GMT\r\nConnection: keep-alive\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: WZ6pt0cadBQgX0RupisAAA==\r\n\r\n",
+        "_requestHeadersText": "GET /slideshow/embed_code/key/2bcPOKkYBQ6WnM HTTP/1.1\r\nHost: www.slideshare.net\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUpgrade-Insecure-Requests: 1\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\nReferer: https://webtide.com/http2-push-demo/\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+        "connectionReused": false,
+        "_timing": {
+          "requestTime": 123357.880866,
+          "proxyStart": 0.995999987935647,
+          "proxyEnd": 1.96199999481905,
+          "dnsStart": 1.96199999481905,
+          "dnsEnd": 40.1639999909094,
+          "connectStart": 40.1639999909094,
+          "connectEnd": 102.783999987878,
+          "sslStart": 59.9599999986822,
+          "sslEnd": 102.761999994982,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 103.242999990471,
+          "sendEnd": 103.428999995231,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 519.309999988764
+        },
+        "_finished": true
+      }
+    ],
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "www.slideshare.net"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "Upgrade-Insecure-Requests",
+        "value": "1"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": "Cookie",
+        "value": "bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.12117,
+    "_responseReceivedTime": 123359.16527,
+    "_mimeType": "text/html",
+    "_responseHeaders": [
+      {
+        "name": "X-FS-UUID",
+        "value": "140daae6471a741440928fbfa62b0000"
+      },
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "FA2q5kcadBRAko+/pisAAA=="
+      },
+      {
+        "name": "Age",
+        "value": "0"
+      },
+      {
+        "name": "Transfer-Encoding",
+        "value": "chunked"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Status",
+        "value": "200 OK"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "X-XSS-Protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "X-Request-Id",
+        "value": "b38df067a9d92ee359feac1dc75db676"
+      },
+      {
+        "name": "X-UA-Compatible",
+        "value": "IE=Edge,chrome=1"
+      },
+      {
+        "name": "X-Runtime",
+        "value": "0.191028"
+      },
+      {
+        "name": "X-Bench-Route",
+        "value": "slideshow/embed_code"
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "862803522"
+      },
+      {
+        "name": "X-Bench-ID",
+        "value": "s46622952/a75527122"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=0, private, must-revalidate"
+      },
+      {
+        "name": "X-Request-UUID",
+        "value": "zfL2vom0p7EhekztIhqRtA=="
+      },
+      {
+        "name": "Set-Cookie",
+        "value": "_uv_id=1379124875; Path=/; Domain=.slideshare.net"
+      },
+      {
+        "name": "Set-Cookie",
+        "value": "SERVERID=r87|V9jjx|V9jjx; path=/"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "text/html; charset=utf-8"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 10321,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nContent-Type: text/html; charset=utf-8\r\nStatus: 200 OK\r\nX-UA-Compatible: IE=Edge,chrome=1\r\nX-Runtime: 0.191028\r\nX-Request-UUID: zfL2vom0p7EhekztIhqRtA==\r\nX-Content-Type-Options: nosniff\r\nX-Bench-ID: s46622952/a75527122\r\nX-Bench-Route: slideshow/embed_code\r\nX-Request-Id: b38df067a9d92ee359feac1dc75db676\r\nX-XSS-Protection: 1; mode=block\r\nCache-Control: max-age=0, private, must-revalidate\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 862803522\r\nAge: 0\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 140daae6471a741440928fbfa62b0000\r\nX-Li-Fabric: prod-lva1\r\nSet-Cookie: _uv_id=1379124875; Path=/; Domain=.slideshare.net\r\nSet-Cookie: SERVERID=r87|V9jjx|V9jjx; path=/\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: FA2q5kcadBRAko+/pisAAA==\r\n\r\n",
+    "_requestHeadersText": "GET /mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM HTTP/1.1\r\nHost: www.slideshare.net\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUpgrade-Insecure-Requests: 1\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\nReferer: https://webtide.com/http2-push-demo/\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\nCookie: bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123358.780337,
+      "proxyStart": 0.587999995332211,
+      "proxyEnd": 1.10799999674782,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.2879999994766,
+      "sendEnd": 1.47299999662209,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 384.932999993907
+    },
+    "_resourceSize": 52965,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.53._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.53._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.64",
+    "_url": "https://stats.g.doubleclick.net/r/__utm.gif?utmwv=5.6.7dc&utms=1&utmn=902929427&utmhn=webtide.com&utmcs=UTF-8&utmsr=412x732&utmvp=412x732&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20Push%20Demo%20%E2%80%93%20Webtide&utmhid=1999594614&utmr=-&utmp=%2Fhttp2-push-demo%2F&utmht=1473831874557&utmac=UA-1149868-2&utmcc=__utma%3D124097164.1115498836.1473831874.1473831874.1473831874.1%3B%2B__utmz%3D124097164.1473831874.1.1.utmcsr%3D(direct)%7Cutmccn%3D(direct)%7Cutmcmd%3D(none)%3B&utmjid=326666954&utmredir=3&utmu=qAAAAAAAAAAAAAAAAAAAAAAE~",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://stats.g.doubleclick.net/r/__utm.gif?utmwv=5.6.7dc&utms=1&utmn=902929427&utmhn=webtide.com&utmcs=UTF-8&utmsr=412x732&utmvp=412x732&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20Push%20Demo%20%E2%80%93%20Webtide&utmhid=1999594614&utmr=-&utmp=%2Fhttp2-push-demo%2F&utmht=1473831874557&utmac=UA-1149868-2&utmcc=__utma%3D124097164.1115498836.1473831874.1473831874.1473831874.1%3B%2B__utmz%3D124097164.1473831874.1.1.utmcsr%3D(direct)%7Cutmccn%3D(direct)%7Cutmcmd%3D(none)%3B&utmjid=326666954&utmredir=3&utmu=qAAAAAAAAAAAAAAAAAAAAAAE~",
+      "scheme": "https",
+      "host": "stats.g.doubleclick.net",
+      "path": "/r/__utm.gif?utmwv=5.6.7dc&utms=1&utmn=902929427&utmhn=webtide.com&utmcs=UTF-8&utmsr=412x732&utmvp=412x732&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20Push%20Demo%20%E2%80%93%20Webtide&utmhid=1999594614&utmr=-&utmp=%2Fhttp2-push-demo%2F&utmht=1473831874557&utmac=UA-1149868-2&utmcc=__utma%3D124097164.1115498836.1473831874.1473831874.1473831874.1%3B%2B__utmz%3D124097164.1473831874.1.1.utmcsr%3D(direct)%7Cutmccn%3D(direct)%7Cutmcmd%3D(none)%3B&utmjid=326666954&utmredir=3&utmu=qAAAAAAAAAAAAAAAAAAAAAAE~",
+      "queryParams": "utmwv=5.6.7dc&utms=1&utmn=902929427&utmhn=webtide.com&utmcs=UTF-8&utmsr=412x732&utmvp=412x732&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20Push%20Demo%20%E2%80%93%20Webtide&utmhid=1999594614&utmr=-&utmp=%2Fhttp2-push-demo%2F&utmht=1473831874557&utmac=UA-1149868-2&utmcc=__utma%3D124097164.1115498836.1473831874.1473831874.1473831874.1%3B%2B__utmz%3D124097164.1473831874.1.1.utmcsr%3D(direct)%7Cutmccn%3D(direct)%7Cutmcmd%3D(none)%3B&utmjid=326666954&utmredir=3&utmu=qAAAAAAAAAAAAAAAAAAAAAAE~",
+      "folderPathComponents": "/r",
+      "lastPathComponent": "__utm.gif"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": []
+      }
+    },
+    "_issueTime": 123359.22116,
+    "_startTime": 123359.221744,
+    "_endTime": 123359.382677,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:400e:c00::9a]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.g.doubleclick.net",
+      "sanList": [
+        "*.g.doubleclick.net",
+        "*.googleadservices.com",
+        "*.googlesyndication.com",
+        "*.googletagservices.com",
+        "*.invitemedia.com",
+        "g.doubleclick.net",
+        "googleadservices.com",
+        "googlesyndication.com",
+        "googletagservices.com",
+        "media.admob.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1472737500,
+      "validTo": 1479995100,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1472740522082,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450220673775E12CA5BA84800401AA2ABA155BD94DAFEE7AFAFACCBBD6B0CF402B6151022100B485566E644B3298B89BADE69D56E755C52EA96DABA5FF805203EB16CBE6630F"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1472740522681,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022100A854660206BE82EB5E88F4DD86615C7236D7B1B3200E6FA80C7AD38C947F3FA902206604B4919839B9A8D08215E7C4E329B87915F3ED5B0C62E4A7181B70D021BA7A"
+        }
+      ]
+    },
+    "connectionId": "794",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/r/__utm.gif?utmwv=5.6.7dc&utms=1&utmn=902929427&utmhn=webtide.com&utmcs=UTF-8&utmsr=412x732&utmvp=412x732&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20Push%20Demo%20%E2%80%93%20Webtide&utmhid=1999594614&utmr=-&utmp=%2Fhttp2-push-demo%2F&utmht=1473831874557&utmac=UA-1149868-2&utmcc=__utma%3D124097164.1115498836.1473831874.1473831874.1473831874.1%3B%2B__utmz%3D124097164.1473831874.1.1.utmcsr%3D(direct)%7Cutmccn%3D(direct)%7Cutmcmd%3D(none)%3B&utmjid=326666954&utmredir=3&utmu=qAAAAAAAAAAAAAAAAAAAAAAE~"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "stats.g.doubleclick.net"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831874.56453,
+    "_responseReceivedTime": 123359.381845,
+    "_mimeType": "image/gif",
+    "_responseHeaders": [
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "strict-transport-security",
+        "value": "max-age=10886400; includeSubDomains; preload"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Sun, 17 May 1998 03:00:00 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Golfe2"
+      },
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "content-type",
+        "value": "image/gif"
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache, no-store, must-revalidate"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "35"
+      },
+      {
+        "name": "expires",
+        "value": "Fri, 01 Jan 1990 00:00:00 GMT"
+      }
+    ],
+    "_transferSize": 187,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123359.221744,
+      "proxyStart": 0.861000007716939,
+      "proxyEnd": 2.19700000889134,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 2.46300001163036,
+      "sendEnd": 3.56300000566989,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 160.101000001305
+    },
+    "_resourceSize": 35,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.54._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.54._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.65",
+    "_url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+      "scheme": "https",
+      "host": "www.google.com",
+      "path": "/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+      "queryParams": "k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+      "folderPathComponents": "/recaptcha/api2",
+      "lastPathComponent": "anchor"
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Lp",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 370,
+            "columnNumber": 408
+          },
+          {
+            "functionName": "Rp.render",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 375,
+            "columnNumber": 338
+          },
+          {
+            "functionName": "dq",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 377,
+            "columnNumber": 287
+          },
+          {
+            "functionName": "fq",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 381,
+            "columnNumber": 94
+          },
+          {
+            "functionName": "gq",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 382,
+            "columnNumber": 84
+          },
+          {
+            "functionName": "",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 384,
+            "columnNumber": 418
+          },
+          {
+            "functionName": "Gp",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 369,
+            "columnNumber": 612
+          },
+          {
+            "functionName": "",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 384,
+            "columnNumber": 378
+          },
+          {
+            "functionName": "",
+            "scriptId": "69",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 393,
+            "columnNumber": 1746
+          }
+        ]
+      }
+    },
+    "_issueTime": 123359.285093,
+    "_startTime": 123359.287528,
+    "_endTime": 123359.503793,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "document",
+      "_title": "Document",
+      "_category": {
+        "title": "Documents",
+        "shortTitle": "Doc"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:807::2004]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "www.google.com",
+      "sanList": [
+        "www.google.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291496,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294117382,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3044022100A688267D1A44644516F7DB1383E6586CEB8C23F83F6CBC4AB6DCC281AB5A81BC021F73BB3CDAC5CFBCA95DF32CE9564B3674EC70C84D6F66FD58F0A67AB3941E5D"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294117951,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100CF0010B0CC6D5F757ED9E601DC52F8C170FDEE752868276ECB2E0FDF34F2BA12022100A58876BD1B7ECFAB6C7B1A1ACD9A33285A400669EFD2336F32CBCE61FCD3EBB7"
+        }
+      ]
+    },
+    "connectionId": "183",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "upgrade-insecure-requests",
+        "value": "1"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.google.com"
+      },
+      {
+        "name": "cookie",
+        "value": "NID=86=UA8sn8EjVDzbV-HK1jEfVtIxu23pgQVxnPSTwXX6I_cs_YMMDZAX6vbDYXVioIkClO7zKrZTg9GrGiEBO8Cav_otesPIsOKM7a8mHmtVuObzblXoRXK24Wl82e6RQrqo; S=sso=oeb1g7nauNo"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831874.62847,
+    "_responseReceivedTime": 123359.45698,
+    "_mimeType": "text/html",
+    "_responseHeaders": [
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "server",
+        "value": "GSE"
+      },
+      {
+        "name": "content-type",
+        "value": "text/html; charset=utf-8"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache, no-store, max-age=0, must-revalidate"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "11995"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Mon, 01 Jan 1990 00:00:00 GMT"
+      }
+    ],
+    "_transferSize": 12129,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123359.287528,
+      "proxyStart": 0.476000001071952,
+      "proxyEnd": 0.94300000637304,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.06999999843538,
+      "sendEnd": 1.61099999968428,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 169.452000001911
+    },
+    "_resourceSize": 26923,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.55._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.55._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.66",
+    "_url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+      "scheme": "https",
+      "host": "platform.twitter.com",
+      "path": "/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+      "queryParams": "",
+      "folderPathComponents": "/widgets",
+      "lastPathComponent": "tweet_button.d59f1863bc12f58215682d9908af95aa.en.html"
+    },
+    "_documentURL": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+    "_frameId": "19748.4",
+    "_loaderId": "19748.6",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 9,
+            "columnNumber": 2865
+          },
+          {
+            "functionName": "",
+            "scriptId": "68",
+            "url": "https://platform.twitter.com/js/button.9c9dd7044dfaf420ee068697fbf32302.js",
+            "lineNumber": 0,
+            "columnNumber": 3961
+          },
+          {
+            "functionName": "",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 8,
+            "columnNumber": 6891
+          },
+          {
+            "functionName": "i.render",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 29628
+          },
+          {
+            "functionName": "",
+            "scriptId": "53",
+            "url": "https://platform.twitter.com/widgets.js",
+            "lineNumber": 7,
+            "columnNumber": 8785
+          }
+        ]
+      }
+    },
+    "_issueTime": 123359.393366,
+    "_startTime": 123359.39595,
+    "_endTime": 123359.612005,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "document",
+      "_title": "Document",
+      "_category": {
+        "title": "Documents",
+        "shortTitle": "Doc"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "104.244.43.108:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "platform.twitter.com",
+      "sanList": [
+        "platform.twitter.com",
+        "preview.cdn.twitter.com",
+        "cdn.api.twitter.com",
+        "urls.api.twitter.com",
+        "cdn.digits.com",
+        "status.twitter.com"
+      ],
+      "issuer": "DigiCert SHA2 High Assurance Server CA",
+      "validFrom": 1461283200,
+      "validTo": 1493294400,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Pilot' log",
+          "logId": "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+          "timestamp": 1461353956111,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022007B3C00DDD442317F59924830EBDB66F24BF73EE97AC6EA89E69F75750C3A937022100A4E654BD8BF8EAB7FEC2E79908AE574297DD75FFEC9A51062CD3E6413BB73EEC"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Aviator' log",
+          "logId": "68F698F81F6482BE3A8CEEB9281D4CFC71515D6793D444D10A67ACBB4F4FFBC4",
+          "timestamp": 1461353956113,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450220541078EEC24A03E4B8927CF0D56F45C85BF80903204A02EC1108A1FAA391C0C4022100BBDC73AF636ABF5F366189EA7D1900CEFD52CEDBF11C1751B127C94492116921"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1461353956503,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502203DD2EE4A44E34C2D6CC3D773F3BEAC53F859A9D312F06F7EF46DD3974B96BFDE022100A5DF5B730D252EF5CF700E001C00DF0FA60C83769EDB05325CCB083A7361AC78"
+        }
+      ]
+    },
+    "connectionId": "600",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "platform.twitter.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "Upgrade-Insecure-Requests",
+        "value": "1"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.73674,
+    "_responseReceivedTime": 123359.558573,
+    "_mimeType": "text/html",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "Age",
+        "value": "34732"
+      },
+      {
+        "name": "X-Cache",
+        "value": "HIT"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"CAO DSP LAW CURa ADMa DEVa TAIa PSAa PSDa IVAa IVDa OUR BUS IND UNI COM NAV INT\""
+      },
+      {
+        "name": "Connection",
+        "value": "Keep-Alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "11717"
+      },
+      {
+        "name": "X-Served-By",
+        "value": "cache-tw-sjc1-cr1-12-TWSJC1"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 13 Sep 2016 19:55:23 GMT"
+      },
+      {
+        "name": "Server",
+        "value": "Apache"
+      },
+      {
+        "name": "X-Timer",
+        "value": "S1473831874.770651,VS0,VE0"
+      },
+      {
+        "name": "Etag",
+        "value": "\"793dec7c700a19f180bbf63377395097+gzip\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding,Host"
+      },
+      {
+        "name": "Content-Type",
+        "value": "text/html; charset=utf-8"
+      },
+      {
+        "name": "Via",
+        "value": "1.1 varnish"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "public, max-age=315569260"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Keep-Alive",
+        "value": "timeout=7, max=48"
+      }
+    ],
+    "_transferSize": 12330,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nServer: Apache\r\nLast-Modified: Tue, 13 Sep 2016 19:55:23 GMT\r\nCache-Control: public, max-age=315569260\r\nContent-Type: text/html; charset=utf-8\r\nEtag: \"793dec7c700a19f180bbf63377395097+gzip\"\r\nContent-Encoding: gzip\r\nContent-Length: 11717\r\nAccept-Ranges: bytes\r\nVia: 1.1 varnish\r\nAge: 34732\r\nX-Served-By: cache-tw-sjc1-cr1-12-TWSJC1\r\nX-Cache: HIT\r\nX-Timer: S1473831874.770651,VS0,VE0\r\nVary: Accept-Encoding,Host\r\nP3P: CP=\"CAO DSP LAW CURa ADMa DEVa TAIa PSAa PSDa IVAa IVDa OUR BUS IND UNI COM NAV INT\"\r\nKeep-Alive: timeout=7, max=48\r\nConnection: Keep-Alive\r\n\r\n",
+    "_requestHeadersText": "GET /widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html HTTP/1.1\r\nHost: platform.twitter.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUpgrade-Insecure-Requests: 1\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\nReferer: https://webtide.com/http2-push-demo/\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123359.39595,
+      "proxyStart": 0.417999995988794,
+      "proxyEnd": 1.16799998795614,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.59299999359064,
+      "sendEnd": 1.75999999919441,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 162.622999996529
+    },
+    "_resourceSize": 30414,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.56._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.56._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.83",
+    "_url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2072%2072%22%3E%3Cpath%20fill%3D%22none%22%20d%3D%22M0%200h72v72H0z%22%2F%3E%3Cpath%20class%3D%22icon%22%20fill%3D%22%23fff%22%20d%3D%22M68.812%2015.14c-2.348%201.04-4.87%201.744-7.52%202.06%202.704-1.62%204.78-4.186%205.757-7.243-2.53%201.5-5.33%202.592-8.314%203.176C56.35%2010.59%2052.948%209%2049.182%209c-7.23%200-13.092%205.86-13.092%2013.093%200%201.026.118%202.02.338%202.98C25.543%2024.527%2015.9%2019.318%209.44%2011.396c-1.125%201.936-1.77%204.184-1.77%206.58%200%204.543%202.312%208.552%205.824%2010.9-2.146-.07-4.165-.658-5.93-1.64-.002.056-.002.11-.002.163%200%206.345%204.513%2011.638%2010.504%2012.84-1.1.298-2.256.457-3.45.457-.845%200-1.666-.078-2.464-.23%201.667%205.2%206.5%208.985%2012.23%209.09-4.482%203.51-10.13%205.605-16.26%205.605-1.055%200-2.096-.06-3.122-.184%205.794%203.717%2012.676%205.882%2020.067%205.882%2024.083%200%2037.25-19.95%2037.25-37.25%200-.565-.013-1.133-.038-1.693%202.558-1.847%204.778-4.15%206.532-6.774z%22%2F%3E%3C%2Fsvg%3E",
+    "_parsedURL": {
+      "isValid": false,
+      "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2072%2072%22%3E%3Cpath%20fill%3D%22none%22%20d%3D%22M0%200h72v72H0z%22%2F%3E%3Cpath%20class%3D%22icon%22%20fill%3D%22%23fff%22%20d%3D%22M68.812%2015.14c-2.348%201.04-4.87%201.744-7.52%202.06%202.704-1.62%204.78-4.186%205.757-7.243-2.53%201.5-5.33%202.592-8.314%203.176C56.35%2010.59%2052.948%209%2049.182%209c-7.23%200-13.092%205.86-13.092%2013.093%200%201.026.118%202.02.338%202.98C25.543%2024.527%2015.9%2019.318%209.44%2011.396c-1.125%201.936-1.77%204.184-1.77%206.58%200%204.543%202.312%208.552%205.824%2010.9-2.146-.07-4.165-.658-5.93-1.64-.002.056-.002.11-.002.163%200%206.345%204.513%2011.638%2010.504%2012.84-1.1.298-2.256.457-3.45.457-.845%200-1.666-.078-2.464-.23%201.667%205.2%206.5%208.985%2012.23%209.09-4.482%203.51-10.13%205.605-16.26%205.605-1.055%200-2.096-.06-3.122-.184%205.794%203.717%2012.676%205.882%2020.067%205.882%2024.083%200%2037.25-19.95%2037.25-37.25%200-.565-.013-1.133-.038-1.693%202.558-1.847%204.778-4.15%206.532-6.774z%22%2F%3E%3C%2Fsvg%3E",
+      "scheme": "data",
+      "host": "",
+      "port": "",
+      "path": "",
+      "queryParams": "",
+      "fragment": "",
+      "folderPathComponents": "",
+      "lastPathComponent": ""
+    },
+    "_documentURL": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+    "_frameId": "19748.4",
+    "_loaderId": "19748.6",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "a",
+            "scriptId": "76",
+            "url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+            "lineNumber": 0,
+            "columnNumber": 5316
+          },
+          {
+            "functionName": "u",
+            "scriptId": "76",
+            "url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+            "lineNumber": 0,
+            "columnNumber": 5417
+          },
+          {
+            "functionName": "Function.bind.test.t.exports",
+            "scriptId": "76",
+            "url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+            "lineNumber": 0,
+            "columnNumber": 6968
+          },
+          {
+            "functionName": "e",
+            "scriptId": "76",
+            "url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+            "lineNumber": 0,
+            "columnNumber": 4780
+          },
+          {
+            "functionName": "Function.bind.test.t",
+            "scriptId": "76",
+            "url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+            "lineNumber": 0,
+            "columnNumber": 4896
+          },
+          {
+            "functionName": "",
+            "scriptId": "76",
+            "url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+            "lineNumber": 0,
+            "columnNumber": 4901
+          },
+          {
+            "functionName": "",
+            "scriptId": "76",
+            "url": "https://platform.twitter.com/widgets/tweet_button.d59f1863bc12f58215682d9908af95aa.en.html",
+            "lineNumber": 0,
+            "columnNumber": 30387
+          }
+        ]
+      }
+    },
+    "_issueTime": 123359.643492,
+    "_startTime": 123359.643492,
+    "_endTime": 123359.643835,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "data",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryLow",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "",
+    "_securityState": "unknown",
+    "_securityDetails": null,
+    "connectionId": "0",
+    "hasNetworkData": true,
+    "_requestHeaders": [],
+    "_wallIssueTime": 1473831874.98687,
+    "_fromMemoryCache": true,
+    "_responseReceivedTime": 123359.643741,
+    "_mimeType": "image/svg+xml",
+    "_responseHeaders": [],
+    "connectionReused": false,
+    "_resourceSize": 822,
+    "_transferSize": 0,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.57._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.57._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.69",
+    "_url": "https://public.slidesharecdn.com/b/ss_foundation/combined_li_tracking.js?2b74bb650b",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_li_tracking.js?2b74bb650b",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/b/ss_foundation/combined_li_tracking.js?2b74bb650b",
+      "queryParams": "2b74bb650b",
+      "folderPathComponents": "/b/ss_foundation",
+      "lastPathComponent": "combined_li_tracking.js"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 43
+    },
+    "_issueTime": 123359.403429,
+    "_startTime": 123359.405888,
+    "_endTime": 123359.89844,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1056",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.7468,
+    "_responseReceivedTime": 123359.710869,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "3996"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "Wx5xPQUmchRAm97ctCoAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "5b1e713d05267214409bdedcb42a0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 06 Sep 2016 18:28:17 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "W/\"57cf0ac1-2dab\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "202070071 73917258"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/javascript; charset=utf-8"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 4586,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: application/javascript; charset=utf-8\r\nLast-Modified: Tue, 06 Sep 2016 18:28:17 GMT\r\nETag: W/\"57cf0ac1-2dab\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 202070071 73917258\r\nContent-Length: 3996\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 5b1e713d05267214409bdedcb42a0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: Wx5xPQUmchRAm97ctCoAAA==\r\nVary: Accept-Encoding\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /b/ss_foundation/combined_li_tracking.js?2b74bb650b HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123359.405888,
+      "proxyStart": 9.32000001193956,
+      "proxyEnd": 9.79900000675116,
+      "dnsStart": 10.1600000052713,
+      "dnsEnd": 50.6560000067111,
+      "connectStart": 50.6560000067111,
+      "connectEnd": 119.096000009449,
+      "sslStart": 75.6210000108695,
+      "sslEnd": 119.090000007418,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 120.694000012008,
+      "sendEnd": 120.805000013206,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 304.981000008411
+    },
+    "_resourceSize": 11691,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.58._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.58._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.70",
+    "_url": "https://public.slidesharecdn.com/b/stylesheets/font-awesome.css?8e2051b24c",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/b/stylesheets/font-awesome.css?8e2051b24c",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/b/stylesheets/font-awesome.css?8e2051b24c",
+      "queryParams": "8e2051b24c",
+      "folderPathComponents": "/b/stylesheets",
+      "lastPathComponent": "font-awesome.css"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 78
+    },
+    "_issueTime": 123359.403731,
+    "_startTime": 123359.406503,
+    "_endTime": 123359.926876,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1052",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.7471,
+    "_responseReceivedTime": 123359.681993,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "6018"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "8XhjldwKdBSgkZvjcSsAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "f1786395dc0a7414a0919be3712b0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Wed, 14 Sep 2016 00:38:08 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "W/\"57d89bf0-5cee\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "1066970231 1066350588"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "text/css"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 6582,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: text/css\r\nLast-Modified: Wed, 14 Sep 2016 00:38:08 GMT\r\nETag: W/\"57d89bf0-5cee\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 1066970231 1066350588\r\nContent-Length: 6018\r\nAccept-Ranges: bytes\r\nX-FS-UUID: f1786395dc0a7414a0919be3712b0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: 8XhjldwKdBSgkZvjcSsAAA==\r\nVary: Accept-Encoding\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /b/stylesheets/font-awesome.css?8e2051b24c HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: text/css,*/*;q=0.1\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123359.406503,
+      "proxyStart": 8.84399999631569,
+      "proxyEnd": 9.35199999366887,
+      "dnsStart": 9.35199999366887,
+      "dnsEnd": 49.4419999886304,
+      "connectStart": 49.4419999886304,
+      "connectEnd": 117.762999987463,
+      "sslStart": 69.3969999992987,
+      "sslEnd": 117.744999995921,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 119.312999988324,
+      "sendEnd": 119.435999993584,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 275.489999999991
+    },
+    "_resourceSize": 23790,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.59._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.59._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.87",
+    "_url": "https://syndication.twitter.com/i/jot?l=%7B%22widget_origin%22%3A%22https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F%22%2C%22widget_frame%22%3Afalse%2C%22language%22%3A%22en%22%2C%22message%22%3A%22m%3Anocount%3A%22%2C%22_category_%22%3A%22tfw_client_event%22%2C%22triggered_on%22%3A1473831875163%2C%22dnt%22%3Afalse%2C%22client_version%22%3A%220b9b320%3A1473786856308%22%2C%22format_version%22%3A1%2C%22event_namespace%22%3A%7B%22client%22%3A%22tfw%22%2C%22page%22%3A%22button%22%2C%22section%22%3A%22share%22%2C%22action%22%3A%22impression%22%7D%7D",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://syndication.twitter.com/i/jot?l=%7B%22widget_origin%22%3A%22https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F%22%2C%22widget_frame%22%3Afalse%2C%22language%22%3A%22en%22%2C%22message%22%3A%22m%3Anocount%3A%22%2C%22_category_%22%3A%22tfw_client_event%22%2C%22triggered_on%22%3A1473831875163%2C%22dnt%22%3Afalse%2C%22client_version%22%3A%220b9b320%3A1473786856308%22%2C%22format_version%22%3A1%2C%22event_namespace%22%3A%7B%22client%22%3A%22tfw%22%2C%22page%22%3A%22button%22%2C%22section%22%3A%22share%22%2C%22action%22%3A%22impression%22%7D%7D",
+      "scheme": "https",
+      "host": "syndication.twitter.com",
+      "path": "/i/jot?l=%7B%22widget_origin%22%3A%22https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F%22%2C%22widget_frame%22%3Afalse%2C%22language%22%3A%22en%22%2C%22message%22%3A%22m%3Anocount%3A%22%2C%22_category_%22%3A%22tfw_client_event%22%2C%22triggered_on%22%3A1473831875163%2C%22dnt%22%3Afalse%2C%22client_version%22%3A%220b9b320%3A1473786856308%22%2C%22format_version%22%3A1%2C%22event_namespace%22%3A%7B%22client%22%3A%22tfw%22%2C%22page%22%3A%22button%22%2C%22section%22%3A%22share%22%2C%22action%22%3A%22impression%22%7D%7D",
+      "queryParams": "l=%7B%22widget_origin%22%3A%22https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F%22%2C%22widget_frame%22%3Afalse%2C%22language%22%3A%22en%22%2C%22message%22%3A%22m%3Anocount%3A%22%2C%22_category_%22%3A%22tfw_client_event%22%2C%22triggered_on%22%3A1473831875163%2C%22dnt%22%3Afalse%2C%22client_version%22%3A%220b9b320%3A1473786856308%22%2C%22format_version%22%3A1%2C%22event_namespace%22%3A%7B%22client%22%3A%22tfw%22%2C%22page%22%3A%22button%22%2C%22section%22%3A%22share%22%2C%22action%22%3A%22impression%22%7D%7D",
+      "folderPathComponents": "/i",
+      "lastPathComponent": "jot"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": []
+      }
+    },
+    "_issueTime": 123359.837116,
+    "_startTime": 123359.838854,
+    "_endTime": 123360.137311,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "199.59.148.85:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "syndication.twitter.com",
+      "sanList": [
+        "syndication.twitter.com",
+        "cdn.syndication.twitter.com",
+        "syndication-o.twitter.com",
+        "syndication.twimg.com",
+        "cdn.syndication.twimg.com",
+        "syndication-o.twimg.com"
+      ],
+      "issuer": "DigiCert SHA2 High Assurance Server CA",
+      "validFrom": 1467158400,
+      "validTo": 1568635200,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Pilot' log",
+          "logId": "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+          "timestamp": 1467227882385,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022100BE6A1164F5341A85D78F264164E0741B19A0F30028AB421825E88FC874C6294002204E9A65388C41FA86E8F818298F78F66860A66A5FFE7BA6F69619AB2589C3200C"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Aviator' log",
+          "logId": "68F698F81F6482BE3A8CEEB9281D4CFC71515D6793D444D10A67ACBB4F4FFBC4",
+          "timestamp": 1467227882329,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450220226887A2DC3AF2CE41C44B125CAEC85ACCC36F50AA8217EA74D8C61DF36D0552022100C2F550FA33890633DE33652B8F76568E46005DA7FDF18518340C9DEC242D874F"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1467227882524,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100B60E93E9213C4CA2B7A16CE166DEE850CCB883B850AF10934A6592562C37DBEC02210099925588E96E6C0DD40C915C7BCAEE263F52623DEECFA11577DA76D77DEEAD92"
+        }
+      ]
+    },
+    "connectionId": "1082",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/i/jot?l=%7B%22widget_origin%22%3A%22https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F%22%2C%22widget_frame%22%3Afalse%2C%22language%22%3A%22en%22%2C%22message%22%3A%22m%3Anocount%3A%22%2C%22_category_%22%3A%22tfw_client_event%22%2C%22triggered_on%22%3A1473831875163%2C%22dnt%22%3Afalse%2C%22client_version%22%3A%220b9b320%3A1473786856308%22%2C%22format_version%22%3A1%2C%22event_namespace%22%3A%7B%22client%22%3A%22tfw%22%2C%22page%22%3A%22button%22%2C%22section%22%3A%22share%22%2C%22action%22%3A%22impression%22%7D%7D"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "syndication.twitter.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831875.18049,
+    "_responseReceivedTime": 123360.133385,
+    "_mimeType": "image/gif",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:44:35 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "status",
+        "value": "200 OK"
+      },
+      {
+        "name": "x-twitter-response-tags",
+        "value": "BouncerCompliant"
+      },
+      {
+        "name": "x-connection-hash",
+        "value": "cc684978af60de32c0adeaf90eedf7f3"
+      },
+      {
+        "name": "strict-transport-security",
+        "value": "max-age=631138519"
+      },
+      {
+        "name": "content-length",
+        "value": "65"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "x-response-time",
+        "value": "5"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "last-modified",
+        "value": "Wed, 14 Sep 2016 05:44:35 GMT"
+      },
+      {
+        "name": "server",
+        "value": "tsa_a"
+      },
+      {
+        "name": "x-frame-options",
+        "value": "SAMEORIGIN"
+      },
+      {
+        "name": "content-type",
+        "value": "image/gif;charset=utf-8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache, no-store, must-revalidate, pre-check=0, post-check=0"
+      },
+      {
+        "name": "set-cookie",
+        "value": "pid=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=.twitter.com"
+      },
+      {
+        "name": "x-transaction",
+        "value": "001aa554004e706e"
+      },
+      {
+        "name": "expires",
+        "value": "Tue, 31 Mar 1981 05:00:00 GMT"
+      }
+    ],
+    "_transferSize": 518,
+    "_requestHeadersText": "",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123359.838854,
+      "proxyStart": 3.65499999315944,
+      "proxyEnd": 5.87799999630079,
+      "dnsStart": 6.56799999705982,
+      "dnsEnd": 20.5379999970319,
+      "connectStart": 20.5379999970319,
+      "connectEnd": 79.001000005519,
+      "sslStart": 41.110000005574,
+      "sslEnd": 78.9749999967171,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 79.5550000038929,
+      "sendEnd": 79.9100000003818,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 294.530999992276
+    },
+    "_resourceSize": 43,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.60._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.60._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.68",
+    "_url": "https://public.slidesharecdn.com/b/javascripts/global.js?fcb9e2686f",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/b/javascripts/global.js?fcb9e2686f",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/b/javascripts/global.js?fcb9e2686f",
+      "queryParams": "fcb9e2686f",
+      "folderPathComponents": "/b/javascripts",
+      "lastPathComponent": "global.js"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 41
+    },
+    "_issueTime": 123359.403159,
+    "_startTime": 123359.404896,
+    "_endTime": 123360.397667,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1053",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.74653,
+    "_responseReceivedTime": 123359.703611,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "17768"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "C0saPQUmchTg997ctCoAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "0b4b1a3d05267214e0f7dedcb42a0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 06 Sep 2016 21:07:43 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "W/\"57cf301f-e345\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "212567432 76618773"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/javascript; charset=utf-8"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 18359,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: application/javascript; charset=utf-8\r\nLast-Modified: Tue, 06 Sep 2016 21:07:43 GMT\r\nETag: W/\"57cf301f-e345\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 212567432 76618773\r\nContent-Length: 17768\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 0b4b1a3d05267214e0f7dedcb42a0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: C0saPQUmchTg997ctCoAAA==\r\nVary: Accept-Encoding\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /b/javascripts/global.js?fcb9e2686f HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123359.404896,
+      "proxyStart": 6.38100001378916,
+      "proxyEnd": 8.86300001002383,
+      "dnsStart": 9.55900001281407,
+      "dnsEnd": 51.355000003241,
+      "connectStart": 51.355000003241,
+      "connectEnd": 119.938000003458,
+      "sslStart": 74.0560000122059,
+      "sslEnd": 119.932000001427,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 121.472000013455,
+      "sendEnd": 121.577000012621,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 298.715000011725
+    },
+    "_resourceSize": 58181,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.61._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.61._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.74",
+    "_url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/b/ss_foundation/combined_old_embed.js?34356cb730",
+      "queryParams": "34356cb730",
+      "folderPathComponents": "/b/ss_foundation",
+      "lastPathComponent": "combined_old_embed.js"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 433
+    },
+    "_issueTime": 123359.405519,
+    "_startTime": 123359.898954,
+    "_endTime": 123360.454795,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Medium",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1056",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.74889,
+    "_responseReceivedTime": 123360.112352,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:35 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "9744"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "4IoBZgUmchQA+9DLtCoAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "e08a01660526721400fbd0cbb42a0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 06 Sep 2016 18:28:16 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "W/\"57cf0ac0-67cb\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "211029810 133347093"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/javascript; charset=utf-8"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 10335,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: application/javascript; charset=utf-8\r\nLast-Modified: Tue, 06 Sep 2016 18:28:16 GMT\r\nETag: W/\"57cf0ac0-67cb\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 211029810 133347093\r\nContent-Length: 9744\r\nAccept-Ranges: bytes\r\nX-FS-UUID: e08a01660526721400fbd0cbb42a0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: 4IoBZgUmchQA+9DLtCoAAA==\r\nVary: Accept-Encoding\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:35 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /b/ss_foundation/combined_old_embed.js?34356cb730 HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123359.898954,
+      "proxyStart": 4.36099999933504,
+      "proxyEnd": 4.849999997532,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 5.06599999789614,
+      "sendEnd": 5.2469999936875,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 213.397999992594
+    },
+    "_resourceSize": 26571,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.62._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.62._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.73",
+    "_url": "https://image.slidesharecdn.com/http2-150403150729-conversion-gate01/95/http2-and-java-current-status-1-638.jpg?cb=1438699776",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://image.slidesharecdn.com/http2-150403150729-conversion-gate01/95/http2-and-java-current-status-1-638.jpg?cb=1438699776",
+      "scheme": "https",
+      "host": "image.slidesharecdn.com",
+      "path": "/http2-150403150729-conversion-gate01/95/http2-and-java-current-status-1-638.jpg?cb=1438699776",
+      "queryParams": "cb=1438699776",
+      "folderPathComponents": "/http2-150403150729-conversion-gate01/95",
+      "lastPathComponent": "http2-and-java-current-status-1-638.jpg"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 116
+    },
+    "_issueTime": 123359.404991,
+    "_startTime": 123359.40823,
+    "_endTime": 123360.58336,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1058",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "image.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.74836,
+    "_responseReceivedTime": 123359.82366,
+    "_mimeType": "image/jpeg",
+    "_responseHeaders": [
+      {
+        "name": "x-amz-version-id",
+        "value": "0Z3VqMQwPOi3Du6Ma90ui0rxSFJDsrj9"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 04 Aug 2015 14:49:29 GMT"
+      },
+      {
+        "name": "Server",
+        "value": "AmazonS3"
+      },
+      {
+        "name": "x-amz-request-id",
+        "value": "4F79D182AE9C814B"
+      },
+      {
+        "name": "ETag",
+        "value": "\"2f93096b68cc000e08bf98be2be36217\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "Content-Type",
+        "value": "image/jpeg"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=604800"
+      },
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Length",
+        "value": "21323"
+      },
+      {
+        "name": "x-amz-id-2",
+        "value": "tCT5+fTxXcqJ9cIv9H9OExRLuYBHvEpANrNCfVXRB6FAyBxjJx3X3NR2BlaTW5iOPuPM50Hczb8="
+      }
+    ],
+    "_transferSize": 21836,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nx-amz-id-2: tCT5+fTxXcqJ9cIv9H9OExRLuYBHvEpANrNCfVXRB6FAyBxjJx3X3NR2BlaTW5iOPuPM50Hczb8=\r\nx-amz-request-id: 4F79D182AE9C814B\r\nLast-Modified: Tue, 04 Aug 2015 14:49:29 GMT\r\nETag: \"2f93096b68cc000e08bf98be2be36217\"\r\nx-amz-version-id: 0Z3VqMQwPOi3Du6Ma90ui0rxSFJDsrj9\r\nAccept-Ranges: bytes\r\nContent-Type: image/jpeg\r\nServer: AmazonS3\r\nVary: Accept-Encoding\r\nContent-Encoding: gzip\r\nCache-Control: max-age=604800\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nContent-Length: 21323\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /http2-150403150729-conversion-gate01/95/http2-and-java-current-status-1-638.jpg?cb=1438699776 HTTP/1.1\r\nHost: image.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: image/webp,image/*,*/*;q=0.8\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123359.40823,
+      "proxyStart": 8.02900000417139,
+      "proxyEnd": 8.38800000201445,
+      "dnsStart": 8.44599999254569,
+      "dnsEnd": 70.2820000005886,
+      "connectStart": 70.2820000005886,
+      "connectEnd": 158.851000000141,
+      "sslStart": 109.599000003072,
+      "sslEnd": 158.800999997766,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 162.295999994967,
+      "sendEnd": 174.048999993829,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 415.429999993648
+    },
+    "_resourceSize": 24501,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.63._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.63._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.71",
+    "_url": "https://public.slidesharecdn.com/b/stylesheets/ssplayer/combined_presentation.css?9692d09516",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/b/stylesheets/ssplayer/combined_presentation.css?9692d09516",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/b/stylesheets/ssplayer/combined_presentation.css?9692d09516",
+      "queryParams": "9692d09516",
+      "folderPathComponents": "/b/stylesheets/ssplayer",
+      "lastPathComponent": "combined_presentation.css"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 80
+    },
+    "_issueTime": 123359.403979,
+    "_startTime": 123359.406929,
+    "_endTime": 123360.612313,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1055",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.74735,
+    "_responseReceivedTime": 123359.689292,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "25057"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "rWfrlNwKdBQA5YNgcSsAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "ad67eb94dc0a741400e58360712b0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Wed, 14 Sep 2016 00:39:16 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "W/\"57d89c34-140e1\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "3476348 1039495816"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "text/css"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 25620,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: text/css\r\nLast-Modified: Wed, 14 Sep 2016 00:39:16 GMT\r\nETag: W/\"57d89c34-140e1\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 3476348 1039495816\r\nContent-Length: 25057\r\nAccept-Ranges: bytes\r\nX-FS-UUID: ad67eb94dc0a741400e58360712b0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: rWfrlNwKdBQA5YNgcSsAAA==\r\nVary: Accept-Encoding\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /b/stylesheets/ssplayer/combined_presentation.css?9692d09516 HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: text/css,*/*;q=0.1\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123359.406929,
+      "proxyStart": 8.58699998934753,
+      "proxyEnd": 9.06099998974241,
+      "dnsStart": 9.06099998974241,
+      "dnsEnd": 49.5240000018384,
+      "connectStart": 49.5240000018384,
+      "connectEnd": 117.596999989473,
+      "sslStart": 72.1699999994598,
+      "sslEnd": 117.585999993025,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 119.082999997772,
+      "sendEnd": 119.192999991355,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 282.362999991165
+    },
+    "_resourceSize": 82145,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.64._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.64._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.67",
+    "_url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+      "queryParams": "8f7e6ae431",
+      "folderPathComponents": "/b/ss_foundation",
+      "lastPathComponent": "combined_jquery.js"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 16
+    },
+    "_issueTime": 123359.402847,
+    "_startTime": 123359.403558,
+    "_endTime": 123360.763558,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1054",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.74622,
+    "_responseReceivedTime": 123359.698078,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "33273"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "dOKINwUmchSg5m8itSoAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "74e2883705267214a0e66f22b52a0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Thu, 01 Sep 2016 19:43:13 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "W/\"57c884d1-148fb\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "207757323 9209707"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/javascript; charset=utf-8"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 33864,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: application/javascript; charset=utf-8\r\nLast-Modified: Thu, 01 Sep 2016 19:43:13 GMT\r\nETag: W/\"57c884d1-148fb\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 207757323 9209707\r\nContent-Length: 33273\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 74e2883705267214a0e66f22b52a0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: dOKINwUmchSg5m8itSoAAA==\r\nVary: Accept-Encoding\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /b/ss_foundation/combined_jquery.js?8f7e6ae431 HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123359.403558,
+      "proxyStart": 5.45199999760371,
+      "proxyEnd": 6.23099999211263,
+      "dnsStart": 12.2229999979027,
+      "dnsEnd": 52.8009999979986,
+      "connectStart": 52.8009999979986,
+      "connectEnd": 121.127999998862,
+      "sslStart": 75.6499999988591,
+      "sslEnd": 121.121999996831,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 122.629999998026,
+      "sendEnd": 122.738999998546,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 294.519999995828
+    },
+    "_resourceSize": 84219,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.65._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.65._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.72",
+    "_url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+      "queryParams": "b194f6aec5",
+      "folderPathComponents": "/b/ss_foundation",
+      "lastPathComponent": "combined_player_presentation.js"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 84
+    },
+    "_issueTime": 123359.404382,
+    "_startTime": 123359.407395,
+    "_endTime": 123361.070872,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1057",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831874.74776,
+    "_responseReceivedTime": 123359.720122,
+    "_mimeType": "application/javascript",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:34 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "54430"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "cr5ZVAUmchRAm97ctCoAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "72be595405267214409bdedcb42a0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 06 Sep 2016 18:29:36 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "W/\"57cf0b10-2afb9\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "212502788 71464458"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/javascript; charset=utf-8"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 55022,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: application/javascript; charset=utf-8\r\nLast-Modified: Tue, 06 Sep 2016 18:29:36 GMT\r\nETag: W/\"57cf0b10-2afb9\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 212502788 71464458\r\nContent-Length: 54430\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 72be595405267214409bdedcb42a0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: cr5ZVAUmchRAm97ctCoAAA==\r\nVary: Accept-Encoding\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:34 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /b/ss_foundation/combined_player_presentation.js?b194f6aec5 HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123359.407395,
+      "proxyStart": 8.75300000188872,
+      "proxyEnd": 9.08899999922141,
+      "dnsStart": 9.15299999178387,
+      "dnsEnd": 49.2510000040056,
+      "connectStart": 49.2510000040056,
+      "connectEnd": 117.733999999473,
+      "sslStart": 83.755999992718,
+      "sslEnd": 117.729000005056,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 119.410999992397,
+      "sendEnd": 119.510999997146,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 312.726999996812
+    },
+    "_resourceSize": 176057,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.66._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.66._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.91",
+    "_url": "https://sb.scorecardresearch.com/beacon.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://sb.scorecardresearch.com/beacon.js",
+      "scheme": "https",
+      "host": "sb.scorecardresearch.com",
+      "path": "/beacon.js",
+      "queryParams": "",
+      "folderPathComponents": "",
+      "lastPathComponent": "beacon.js"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "87",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 73,
+            "columnNumber": 23
+          },
+          {
+            "functionName": "",
+            "scriptId": "87",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 75,
+            "columnNumber": 10
+          }
+        ]
+      }
+    },
+    "_issueTime": 123360.803652,
+    "_startTime": 123360.804436,
+    "_endTime": 123361.126823,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.34.168.146:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.scorecardresearch.com",
+      "sanList": [
+        "*.scorecardresearch.com",
+        "scorecardresearch.com"
+      ],
+      "issuer": "Symantec Class 3 Secure Server CA - G4",
+      "validFrom": 1468540800,
+      "validTo": 1500163199,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Symantec log",
+          "logId": "DDEB1D2B7A0D4FA6208B81AD8168707E2E8E9D01D55C888D3D11C4CDB6ECBECC",
+          "timestamp": 1468601402062,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304402205602EF7560924EE5A61F65A6EE7398EAAE4D0CDF682AB1870CB4BE74F7D8EA3502207ADC953A6D21A45212B9340BE0355480463290CFE5CD0E646FCB753374EFCC50"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Pilot' log",
+          "logId": "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+          "timestamp": 1468601402099,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502200AA6DE589387048B571CB45068A48882DF8BF66D9A0D4AF607C2ED4AB84A7E3C022100E1824357CF5F45E785F4A5CE9010DCEFA04EDD62D40211E81BA91EF30F51EB84"
+        }
+      ]
+    },
+    "connectionId": "1110",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "sb.scorecardresearch.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.14709,
+    "_responseReceivedTime": 123361.098076,
+    "_mimeType": "application/x-javascript",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/x-javascript"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "private, no-transform, max-age=1209600"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "2042"
+      },
+      {
+        "name": "Expires",
+        "value": "Wed, 28 Sep 2016 05:44:36 GMT"
+      }
+    ],
+    "_transferSize": 2326,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nContent-Type: application/x-javascript\r\nVary: Accept-Encoding\r\nContent-Encoding: gzip\r\nExpires: Wed, 28 Sep 2016 05:44:36 GMT\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nContent-Length: 2042\r\nConnection: keep-alive\r\nCache-Control: private, no-transform, max-age=1209600\r\n\r\n",
+    "_requestHeadersText": "GET /beacon.js HTTP/1.1\r\nHost: sb.scorecardresearch.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123360.804436,
+      "proxyStart": 1.79599999682978,
+      "proxyEnd": 2.20099999569356,
+      "dnsStart": 2.3149999906309,
+      "dnsEnd": 60.0719999929424,
+      "connectStart": 60.0719999929424,
+      "connectEnd": 114.841999995406,
+      "sslStart": 84.021999995457,
+      "sslEnd": 114.825999989989,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 114.948999995249,
+      "sendEnd": 115.046999999322,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 293.639999988955
+    },
+    "_resourceSize": 3717,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.67._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.67._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.99",
+    "_url": "https://public.slidesharecdn.com/images/1x1.gif?cb=1473813555",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/images/1x1.gif?cb=1473813555",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/images/1x1.gif?cb=1473813555",
+      "queryParams": "cb=1473813555",
+      "folderPathComponents": "/images",
+      "lastPathComponent": "1x1.gif"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "90",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 417,
+            "columnNumber": 58
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.096954,
+    "_startTime": 123361.097358,
+    "_endTime": 123361.270846,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1057",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://public.slidesharecdn.com/b/stylesheets/ssplayer/combined_presentation.css?9692d09516"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.44039,
+    "_responseReceivedTime": 123361.269875,
+    "_mimeType": "image/gif",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "35"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "iA7jc9sKdBTA/amncSsAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "1070438793"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Wed, 14 Sep 2016 01:00:26 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "\"57d8a12a-23\""
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "image/gif"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "880ee373db0a7414c0fda9a7712b0000"
+      }
+    ],
+    "_transferSize": 536,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: image/gif\r\nLast-Modified: Wed, 14 Sep 2016 01:00:26 GMT\r\nETag: \"57d8a12a-23\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nX-Varnish: 1070438793\r\nContent-Length: 35\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 880ee373db0a7414c0fda9a7712b0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: iA7jc9sKdBTA/amncSsAAA==\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /images/1x1.gif?cb=1473813555 HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: image/webp,image/*,*/*;q=0.8\r\nReferer: https://public.slidesharecdn.com/b/stylesheets/ssplayer/combined_presentation.css?9692d09516\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.097358,
+      "proxyStart": 0.421999997342937,
+      "proxyEnd": 1.04699999792501,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.27199999406002,
+      "sendEnd": 1.42299999424722,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 172.516999999061
+    },
+    "_resourceSize": 35,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.68._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.68._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.100",
+    "_url": "https://public.slidesharecdn.com/images/logo/linkedin-ss/logo_embed_20x20_v1.png?cb=1473813555",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/images/logo/linkedin-ss/logo_embed_20x20_v1.png?cb=1473813555",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/images/logo/linkedin-ss/logo_embed_20x20_v1.png?cb=1473813555",
+      "queryParams": "cb=1473813555",
+      "folderPathComponents": "/images/logo/linkedin-ss",
+      "lastPathComponent": "logo_embed_20x20_v1.png"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "90",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 417,
+            "columnNumber": 58
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.100054,
+    "_startTime": 123361.100498,
+    "_endTime": 123361.287205,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1054",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://public.slidesharecdn.com/b/stylesheets/ssplayer/combined_presentation.css?9692d09516"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.44349,
+    "_responseReceivedTime": 123361.284996,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "317"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "qc0Ic9sKdBQgj6uncSsAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "108198"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Wed, 14 Sep 2016 01:00:26 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "\"57d8a12a-13d\""
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "image/png"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "a9cd0873db0a7414208faba7712b0000"
+      }
+    ],
+    "_transferSize": 816,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: image/png\r\nLast-Modified: Wed, 14 Sep 2016 01:00:26 GMT\r\nETag: \"57d8a12a-13d\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nX-Varnish: 108198\r\nContent-Length: 317\r\nAccept-Ranges: bytes\r\nX-FS-UUID: a9cd0873db0a7414208faba7712b0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: qc0Ic9sKdBQgj6uncSsAAA==\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /images/logo/linkedin-ss/logo_embed_20x20_v1.png?cb=1473813555 HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: image/webp,image/*,*/*;q=0.8\r\nReferer: https://public.slidesharecdn.com/b/stylesheets/ssplayer/combined_presentation.css?9692d09516\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.100498,
+      "proxyStart": 1.3009999966016,
+      "proxyEnd": 1.85499999497551,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 2.0409999997355,
+      "sendEnd": 2.22799999755807,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 184.49800000235
+    },
+    "_resourceSize": 317,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.69._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.69._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.90",
+    "_url": "https://ssl.google-analytics.com/ga.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://ssl.google-analytics.com/ga.js",
+      "scheme": "https",
+      "host": "ssl.google-analytics.com",
+      "path": "/ga.js",
+      "queryParams": "",
+      "folderPathComponents": "",
+      "lastPathComponent": "ga.js"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "87",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 62,
+            "columnNumber": 23
+          },
+          {
+            "functionName": "",
+            "scriptId": "87",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 75,
+            "columnNumber": 10
+          }
+        ]
+      }
+    },
+    "_issueTime": 123360.803321,
+    "_startTime": 123360.803861,
+    "_endTime": 123361.320644,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:804::2008]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google-analytics.com",
+      "sanList": [
+        "*.google-analytics.com",
+        "app-measurement.com",
+        "google-analytics.com",
+        "googletagmanager.com",
+        "service.urchin.com",
+        "ssl.google-analytics.com",
+        "urchin.com",
+        "www.google-analytics.com",
+        "www.googletagmanager.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473292752,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Aviator' log",
+          "logId": "68F698F81F6482BE3A8CEEB9281D4CFC71515D6793D444D10A67ACBB4F4FFBC4",
+          "timestamp": 1473294457080,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022027A43B90AC9A6B5AA9CFA1AC575A22272BD590FC67F0B870825A210A3D6DF8E3022100BCAFA391F8FEC23ABE5F14084E2A3C43477F303AA270CC8682C801CE7BFE2728"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294457641,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502207E88D18CD758F452384AFA5DEF793172C0AAC8761D8788D62CD19A5DEABD9CC8022100E0501E846BE012C2A74ED719E251CB5B357E4BCF94DD133982E2C83CDCA72585"
+        }
+      ]
+    },
+    "connectionId": "1108",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/ga.js"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "ssl.google-analytics.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831876.14676,
+    "_responseReceivedTime": 123361.077228,
+    "_mimeType": "text/javascript",
+    "_responseHeaders": [
+      {
+        "name": "strict-transport-security",
+        "value": "max-age=10886400; includeSubDomains; preload"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Mon, 15 Aug 2016 04:25:11 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Golfe2"
+      },
+      {
+        "name": "age",
+        "value": "2511"
+      },
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:02:45 GMT"
+      },
+      {
+        "name": "vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "content-type",
+        "value": "text/javascript"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=7200"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "16022"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 14 Sep 2016 07:02:45 GMT"
+      }
+    ],
+    "_transferSize": 16284,
+    "_requestHeadersText": "",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123360.803861,
+      "proxyStart": 0.872000004164875,
+      "proxyEnd": 1.40000000828877,
+      "dnsStart": 1.52700000035111,
+      "dnsEnd": 35.8110000088345,
+      "connectStart": 35.8110000088345,
+      "connectEnd": 98.2220000005327,
+      "sslStart": 47.7750000136439,
+      "sslEnd": 98.2050000020536,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 98.7390000082087,
+      "sendEnd": 99.2490000062389,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 273.367000001599
+    },
+    "_resourceSize": 43082,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.70._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.70._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.101",
+    "_url": "https://www.slideshare.net/pingback/embed_or_homepageplayerhits/46622952?ref=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&_=1473831876131",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.slideshare.net/pingback/embed_or_homepageplayerhits/46622952?ref=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&_=1473831876131",
+      "scheme": "https",
+      "host": "www.slideshare.net",
+      "path": "/pingback/embed_or_homepageplayerhits/46622952?ref=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&_=1473831876131",
+      "queryParams": "ref=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&_=1473831876131",
+      "folderPathComponents": "/pingback/embed_or_homepageplayerhits",
+      "lastPathComponent": "46622952"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "send",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 2,
+            "columnNumber": 14905
+          },
+          {
+            "functionName": "ajax",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 2,
+            "columnNumber": 11573
+          },
+          {
+            "functionName": "",
+            "scriptId": "91",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 423,
+            "columnNumber": 8
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.154324,
+    "_startTime": 123361.154811,
+    "_endTime": 123361.335471,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "xhr",
+      "_title": "XHR",
+      "_category": {
+        "title": "XHR and Fetch",
+        "shortTitle": "XHR"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2620:109:c002::6cae:a13]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "www.slideshare.net",
+      "sanList": [
+        "www.slideshare.net",
+        "rpublic.slideshare.net",
+        "slideshare.net",
+        "track.slideshare.net",
+        "stats.slideshare.net",
+        "email-events.slideshare.net",
+        "mobilestats.slideshare.net",
+        "autosuggest.slideshare.net",
+        "de.slideshare.net",
+        "fr.slideshare.net",
+        "es.slideshare.net",
+        "pt.slideshare.net"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1430438400,
+      "validTo": 1494417600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "715",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "www.slideshare.net"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "X-Requested-With",
+        "value": "XMLHttpRequest"
+      },
+      {
+        "name": "Cookie",
+        "value": "bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"; _uv_id=1379124875; SERVERID=r87|V9jjx|V9jjx"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.49776,
+    "_responseReceivedTime": 123361.334426,
+    "_mimeType": "text/html",
+    "_responseHeaders": [
+      {
+        "name": "X-FS-UUID",
+        "value": "20737873481a741400f19f6da62b0000"
+      },
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "IHN4c0gadBQA8Z9tpisAAA=="
+      },
+      {
+        "name": "Age",
+        "value": "0"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Status",
+        "value": "200 OK"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "21"
+      },
+      {
+        "name": "X-XSS-Protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "X-Request-Id",
+        "value": "b43542e149431113f97bc4777394c85e"
+      },
+      {
+        "name": "X-UA-Compatible",
+        "value": "IE=Edge,chrome=1"
+      },
+      {
+        "name": "X-Runtime",
+        "value": "0.015052"
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "X-Frame-Options",
+        "value": "SAMEORIGIN"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "1072981686"
+      },
+      {
+        "name": "X-Bench-ID",
+        "value": "s46622952/a75527122"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=0, private, must-revalidate"
+      },
+      {
+        "name": "X-Request-UUID",
+        "value": "M37YzM1bycu/bB4aHXdv+Q=="
+      },
+      {
+        "name": "X-Bench-Route",
+        "value": "pingback/embed_or_homepageplayerhits"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "text/html; charset=utf-8"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 864,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nContent-Type: text/html; charset=utf-8\r\nStatus: 200 OK\r\nX-Request-UUID: M37YzM1bycu/bB4aHXdv+Q==\r\nCache-Control: max-age=0, private, must-revalidate\r\nX-Request-Id: b43542e149431113f97bc4777394c85e\r\nX-UA-Compatible: IE=Edge,chrome=1\r\nX-Frame-Options: SAMEORIGIN\r\nX-Runtime: 0.015052\r\nX-Bench-ID: s46622952/a75527122\r\nX-Content-Type-Options: nosniff\r\nX-Bench-Route: pingback/embed_or_homepageplayerhits\r\nX-XSS-Protection: 1; mode=block\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 1072981686\r\nAge: 0\r\nContent-Length: 21\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 20737873481a741400f19f6da62b0000\r\nX-Li-Fabric: prod-lva1\r\nConnection: keep-alive\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: IHN4c0gadBQA8Z9tpisAAA==\r\n\r\n",
+    "_requestHeadersText": "GET /pingback/embed_or_homepageplayerhits/46622952?ref=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&_=1473831876131 HTTP/1.1\r\nHost: www.slideshare.net\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nAccept: */*\r\nX-Requested-With: XMLHttpRequest\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\nCookie: bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"; _uv_id=1379124875; SERVERID=r87|V9jjx|V9jjx\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.154811,
+      "proxyStart": 0.600999992457219,
+      "proxyEnd": 1.17699999827892,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.96100000175647,
+      "sendEnd": 2.06899999466259,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 179.615000000922
+    },
+    "_resourceSize": 1,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.71._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.71._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.77",
+    "_url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+      "scheme": "https",
+      "host": "www.gstatic.com",
+      "path": "/recaptcha/api2/r20160908152041/recaptcha__en.js",
+      "queryParams": "",
+      "folderPathComponents": "/recaptcha/api2/r20160908152041",
+      "lastPathComponent": "recaptcha__en.js"
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+      "lineNumber": 25
+    },
+    "_issueTime": 123359.518038,
+    "_startTime": 123359.522318,
+    "_endTime": 123361.357072,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:806::2003]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_ECDSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google.com",
+      "sanList": [
+        "*.google.com",
+        "*.android.com",
+        "*.appengine.google.com",
+        "*.cloud.google.com",
+        "*.google-analytics.com",
+        "*.google.ca",
+        "*.google.cl",
+        "*.google.co.in",
+        "*.google.co.jp",
+        "*.google.co.uk",
+        "*.google.com.ar",
+        "*.google.com.au",
+        "*.google.com.br",
+        "*.google.com.co",
+        "*.google.com.mx",
+        "*.google.com.tr",
+        "*.google.com.vn",
+        "*.google.de",
+        "*.google.es",
+        "*.google.fr",
+        "*.google.hu",
+        "*.google.it",
+        "*.google.nl",
+        "*.google.pl",
+        "*.google.pt",
+        "*.googleadapis.com",
+        "*.googleapis.cn",
+        "*.googlecommerce.com",
+        "*.googlevideo.com",
+        "*.gstatic.cn",
+        "*.gstatic.com",
+        "*.gvt1.com",
+        "*.gvt2.com",
+        "*.metric.gstatic.com",
+        "*.urchin.com",
+        "*.url.google.com",
+        "*.youtube-nocookie.com",
+        "*.youtube.com",
+        "*.youtubeeducation.com",
+        "*.ytimg.com",
+        "android.clients.google.com",
+        "android.com",
+        "g.co",
+        "goo.gl",
+        "google-analytics.com",
+        "google.com",
+        "googlecommerce.com",
+        "policy.mta-sts.google.com",
+        "urchin.com",
+        "www.goo.gl",
+        "youtu.be",
+        "youtube.com",
+        "youtubeeducation.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291668,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294157675,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450221009055A6D69C0CB2E407BE909674D95CC4AF2DA70F0227C59306FE478C7180AF9F022013374116DD952AA4B0CE6354EE179866A06014C15C6069A83F5CE6BF5971BC94"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294158314,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100E14BE9F27C6A8BBC0B3629205B8160CECAB700729222DE0C3058655338B45A9E0221008C902D61453456BFE66625FCE56ECFF15667097CAF2EB83C088BA636CA83119C"
+        }
+      ]
+    },
+    "connectionId": "537",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/recaptcha/api2/r20160908152041/recaptcha__en.js"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.gstatic.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831874.86141,
+    "_responseReceivedTime": 123359.732166,
+    "_mimeType": "text/javascript",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Tue, 13 Sep 2016 18:09:55 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Thu, 08 Sep 2016 23:15:00 GMT"
+      },
+      {
+        "name": "server",
+        "value": "sffe"
+      },
+      {
+        "name": "age",
+        "value": "41679"
+      },
+      {
+        "name": "vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "content-type",
+        "value": "text/javascript"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=31536000"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "71283"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 13 Sep 2017 18:09:55 GMT"
+      }
+    ],
+    "_transferSize": 71356,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123359.522318,
+      "proxyStart": 0.91200000315439,
+      "proxyEnd": 1.50899999425747,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 3.02699999883771,
+      "sendEnd": 4.62799999513663,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 209.847999998601
+    },
+    "_resourceSize": 223052,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.72._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.72._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.95",
+    "_url": "https://public.slidesharecdn.com/fonts/fontawesome-webfont.woff2?v=4.3.0?cb=1473813487",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/fonts/fontawesome-webfont.woff2?v=4.3.0?cb=1473813487",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/fonts/fontawesome-webfont.woff2?v=4.3.0?cb=1473813487",
+      "queryParams": "v=4.3.0?cb=1473813487",
+      "folderPathComponents": "/fonts",
+      "lastPathComponent": "fontawesome-webfont.woff2"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "90",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 417,
+            "columnNumber": 58
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.099331,
+    "_startTime": 123361.099331,
+    "_endTime": 123361.395463,
+    "statusCode": 0,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "other",
+      "_title": "Other",
+      "_category": {
+        "title": "Other",
+        "shortTitle": "Other"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "",
+    "_securityState": "unknown",
+    "_securityDetails": null,
+    "connectionId": "0",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Referer",
+        "value": "https://public.slidesharecdn.com/b/stylesheets/font-awesome.css?8e2051b24c"
+      },
+      {
+        "name": "Origin",
+        "value": "https://www.slideshare.net"
+      }
+    ],
+    "_wallIssueTime": 1473831876.44277,
+    "_failed": true,
+    "_canceled": true,
+    "localizedFailDescription": "",
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.73._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.73._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.103",
+    "_url": "https://www.slideshare.net/slideshow/2bcPOKkYBQ6WnM/lead-form?locale=en?embed=true",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.slideshare.net/slideshow/2bcPOKkYBQ6WnM/lead-form?locale=en?embed=true",
+      "scheme": "https",
+      "host": "www.slideshare.net",
+      "path": "/slideshow/2bcPOKkYBQ6WnM/lead-form?locale=en?embed=true",
+      "queryParams": "locale=en?embed=true",
+      "folderPathComponents": "/slideshow/2bcPOKkYBQ6WnM",
+      "lastPathComponent": "lead-form"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "send",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 2,
+            "columnNumber": 14905
+          },
+          {
+            "functionName": "ajax",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 2,
+            "columnNumber": 11573
+          },
+          {
+            "functionName": "SSLeadForm._load",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 1,
+            "columnNumber": 26328
+          },
+          {
+            "functionName": "SSLeadForm",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 0,
+            "columnNumber": 479
+          },
+          {
+            "functionName": "SSPlayerController._createComponentSet",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 3,
+            "columnNumber": 5593
+          },
+          {
+            "functionName": "SSPlayerController._init",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 2,
+            "columnNumber": 25299
+          },
+          {
+            "functionName": "SSPlayerController",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 0,
+            "columnNumber": 4151
+          },
+          {
+            "functionName": "SSPlayer._init",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 4,
+            "columnNumber": 5718
+          },
+          {
+            "functionName": "SSPlayer",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 0,
+            "columnNumber": 4390
+          },
+          {
+            "functionName": "",
+            "scriptId": "89",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 92,
+            "columnNumber": 19
+          },
+          {
+            "functionName": "c",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 3464
+          },
+          {
+            "functionName": "fireWith",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 4276
+          },
+          {
+            "functionName": "ready",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 6072
+          },
+          {
+            "functionName": "s",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 0,
+            "columnNumber": 961
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.190962,
+    "_startTime": 123361.191766,
+    "_endTime": 123361.438056,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "xhr",
+      "_title": "XHR",
+      "_category": {
+        "title": "XHR and Fetch",
+        "shortTitle": "XHR"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2620:109:c002::6cae:a13]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "www.slideshare.net",
+      "sanList": [
+        "www.slideshare.net",
+        "rpublic.slideshare.net",
+        "slideshare.net",
+        "track.slideshare.net",
+        "stats.slideshare.net",
+        "email-events.slideshare.net",
+        "mobilestats.slideshare.net",
+        "autosuggest.slideshare.net",
+        "de.slideshare.net",
+        "fr.slideshare.net",
+        "es.slideshare.net",
+        "pt.slideshare.net"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1430438400,
+      "validTo": 1494417600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "716",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "www.slideshare.net"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "application/json, text/javascript, */*; q=0.01"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "X-Requested-With",
+        "value": "XMLHttpRequest"
+      },
+      {
+        "name": "Cookie",
+        "value": "bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"; SERVERID=r87|V9jjx|V9jjx; _uv_id=1379124875"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.5344,
+    "_responseReceivedTime": 123361.435535,
+    "_mimeType": "application/json",
+    "_responseHeaders": [
+      {
+        "name": "X-FS-UUID",
+        "value": "ab0c8f75481a741460858d9b7c2b0000"
+      },
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "qwyPdUgadBRghY2bfCsAAA=="
+      },
+      {
+        "name": "Age",
+        "value": "0"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Status",
+        "value": "200 OK"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "59"
+      },
+      {
+        "name": "X-XSS-Protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "X-Request-Id",
+        "value": "fb48791f42b2c8dc3be62b1b76bc974a"
+      },
+      {
+        "name": "X-UA-Compatible",
+        "value": "IE=Edge,chrome=1"
+      },
+      {
+        "name": "X-Runtime",
+        "value": "0.032682"
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "X-Frame-Options",
+        "value": "SAMEORIGIN"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "15381499"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=0, private, must-revalidate"
+      },
+      {
+        "name": "X-Request-UUID",
+        "value": "lfdunYpeT1Bq0glsCJXzTw=="
+      },
+      {
+        "name": "X-Bench-Route",
+        "value": "lead_campaigns_v2/get_lead_form"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/json; charset=utf-8"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 869,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nContent-Type: application/json; charset=utf-8\r\nStatus: 200 OK\r\nX-Runtime: 0.032682\r\nX-Bench-Route: lead_campaigns_v2/get_lead_form\r\nX-UA-Compatible: IE=Edge,chrome=1\r\nX-XSS-Protection: 1; mode=block\r\nCache-Control: max-age=0, private, must-revalidate\r\nX-Content-Type-Options: nosniff\r\nX-Frame-Options: SAMEORIGIN\r\nX-Request-Id: fb48791f42b2c8dc3be62b1b76bc974a\r\nX-Request-UUID: lfdunYpeT1Bq0glsCJXzTw==\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 15381499\r\nAge: 0\r\nContent-Length: 59\r\nAccept-Ranges: bytes\r\nX-FS-UUID: ab0c8f75481a741460858d9b7c2b0000\r\nX-Li-Fabric: prod-lva1\r\nConnection: keep-alive\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: qwyPdUgadBRghY2bfCsAAA==\r\n\r\n",
+    "_requestHeadersText": "GET /slideshow/2bcPOKkYBQ6WnM/lead-form?locale=en?embed=true HTTP/1.1\r\nHost: www.slideshare.net\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nAccept: application/json, text/javascript, */*; q=0.01\r\nX-Requested-With: XMLHttpRequest\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\nCookie: bcookie=\"v=2&557bf1ca-d277-4b83-8f7e-bc60dca0b455\"; SERVERID=r87|V9jjx|V9jjx; _uv_id=1379124875\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.191766,
+      "proxyStart": 0.53999999363441,
+      "proxyEnd": 0.975000002654269,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.18199999269564,
+      "sendEnd": 1.35900000168476,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 243.768999993335
+    },
+    "_resourceSize": 39,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.74._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.74._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.107:redirected.0",
+    "_url": "https://sb.scorecardresearch.com/b?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://sb.scorecardresearch.com/b?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+      "scheme": "https",
+      "host": "sb.scorecardresearch.com",
+      "path": "/b?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+      "queryParams": "c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+      "folderPathComponents": "",
+      "lastPathComponent": "b"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": []
+      }
+    },
+    "_issueTime": 123361.303716,
+    "_startTime": 123361.304172,
+    "_endTime": 123361.479015,
+    "statusCode": 302,
+    "statusText": "Moved Temporarily",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.34.168.146:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.scorecardresearch.com",
+      "sanList": [
+        "*.scorecardresearch.com",
+        "scorecardresearch.com"
+      ],
+      "issuer": "Symantec Class 3 Secure Server CA - G4",
+      "validFrom": 1468540800,
+      "validTo": 1500163199,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Symantec log",
+          "logId": "DDEB1D2B7A0D4FA6208B81AD8168707E2E8E9D01D55C888D3D11C4CDB6ECBECC",
+          "timestamp": 1468601402062,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304402205602EF7560924EE5A61F65A6EE7398EAAE4D0CDF682AB1870CB4BE74F7D8EA3502207ADC953A6D21A45212B9340BE0355480463290CFE5CD0E646FCB753374EFCC50"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Pilot' log",
+          "logId": "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+          "timestamp": 1468601402099,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502200AA6DE589387048B571CB45068A48882DF8BF66D9A0D4AF607C2ED4AB84A7E3C022100E1824357CF5F45E785F4A5CE9010DCEFA04EDD62D40211E81BA91EF30F51EB84"
+        }
+      ]
+    },
+    "connectionId": "1110",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "sb.scorecardresearch.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.64715,
+    "_responseReceivedTime": 123361.476963,
+    "_mimeType": "",
+    "_responseHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "Location",
+        "value": "https://sb.scorecardresearch.com/b2?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F"
+      },
+      {
+        "name": "Set-Cookie",
+        "value": "UID=14020910720713a3c809abg1473831876; expires=Tue, 04-Sep-2018 05:44:36 GMT; path=/; domain=.scorecardresearch.com"
+      },
+      {
+        "name": "Set-Cookie",
+        "value": "UIDR=1473831876; expires=Tue, 04-Sep-2018 05:44:36 GMT; path=/; domain=.scorecardresearch.com"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "private, no-cache, no-cache=Set-Cookie, no-store, proxy-revalidate"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "0"
+      },
+      {
+        "name": "Expires",
+        "value": "Mon, 01 Jan 1990 00:00:00 GMT"
+      }
+    ],
+    "_transferSize": 796,
+    "_responseHeadersText": "HTTP/1.1 302 Moved Temporarily\r\nContent-Length: 0\r\nLocation: https://sb.scorecardresearch.com/b2?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nConnection: keep-alive\r\nSet-Cookie: UID=14020910720713a3c809abg1473831876; expires=Tue, 04-Sep-2018 05:44:36 GMT; path=/; domain=.scorecardresearch.com\r\nSet-Cookie: UIDR=1473831876; expires=Tue, 04-Sep-2018 05:44:36 GMT; path=/; domain=.scorecardresearch.com\r\nPragma: no-cache\r\nExpires: Mon, 01 Jan 1990 00:00:00 GMT\r\nCache-Control: private, no-cache, no-cache=Set-Cookie, no-store, proxy-revalidate\r\n\r\n",
+    "_requestHeadersText": "GET /b?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F HTTP/1.1\r\nHost: sb.scorecardresearch.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: image/webp,image/*,*/*;q=0.8\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.304172,
+      "proxyStart": 1.26900000032038,
+      "proxyEnd": 1.97399999888148,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 2.20000000263099,
+      "sendEnd": 2.31099998927675,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 172.790999989957
+    },
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.75._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.75._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.109",
+    "_url": "https://ssl.google-analytics.com/__utm.gif?utmwv=5.6.7&utms=2&utmn=2074694580&utmhn=www.slideshare.net&utmt=event&utme=5(jsplayer*embed*player_initialized)8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&utmht=1473831876730&utmac=UA-2330466-1&utmni=1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=&utmu=6RCAACAAAAAAAAAAAAAAAAAE~",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://ssl.google-analytics.com/__utm.gif?utmwv=5.6.7&utms=2&utmn=2074694580&utmhn=www.slideshare.net&utmt=event&utme=5(jsplayer*embed*player_initialized)8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&utmht=1473831876730&utmac=UA-2330466-1&utmni=1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=&utmu=6RCAACAAAAAAAAAAAAAAAAAE~",
+      "scheme": "https",
+      "host": "ssl.google-analytics.com",
+      "path": "/__utm.gif?utmwv=5.6.7&utms=2&utmn=2074694580&utmhn=www.slideshare.net&utmt=event&utme=5(jsplayer*embed*player_initialized)8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&utmht=1473831876730&utmac=UA-2330466-1&utmni=1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=&utmu=6RCAACAAAAAAAAAAAAAAAAAE~",
+      "queryParams": "utmwv=5.6.7&utms=2&utmn=2074694580&utmhn=www.slideshare.net&utmt=event&utme=5(jsplayer*embed*player_initialized)8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&utmht=1473831876730&utmac=UA-2330466-1&utmni=1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=&utmu=6RCAACAAAAAAAAAAAAAAAAAE~",
+      "folderPathComponents": "",
+      "lastPathComponent": "__utm.gif"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": []
+      }
+    },
+    "_issueTime": 123361.388491,
+    "_startTime": 123361.390365,
+    "_endTime": 123361.570785,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:804::2008]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google-analytics.com",
+      "sanList": [
+        "*.google-analytics.com",
+        "app-measurement.com",
+        "google-analytics.com",
+        "googletagmanager.com",
+        "service.urchin.com",
+        "ssl.google-analytics.com",
+        "urchin.com",
+        "www.google-analytics.com",
+        "www.googletagmanager.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473292752,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Aviator' log",
+          "logId": "68F698F81F6482BE3A8CEEB9281D4CFC71515D6793D444D10A67ACBB4F4FFBC4",
+          "timestamp": 1473294457080,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022027A43B90AC9A6B5AA9CFA1AC575A22272BD590FC67F0B870825A210A3D6DF8E3022100BCAFA391F8FEC23ABE5F14084E2A3C43477F303AA270CC8682C801CE7BFE2728"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294457641,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502207E88D18CD758F452384AFA5DEF793172C0AAC8761D8788D62CD19A5DEABD9CC8022100E0501E846BE012C2A74ED719E251CB5B357E4BCF94DD133982E2C83CDCA72585"
+        }
+      ]
+    },
+    "connectionId": "1108",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/__utm.gif?utmwv=5.6.7&utms=2&utmn=2074694580&utmhn=www.slideshare.net&utmt=event&utme=5(jsplayer*embed*player_initialized)8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&utmht=1473831876730&utmac=UA-2330466-1&utmni=1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=&utmu=6RCAACAAAAAAAAAAAAAAAAAE~"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "ssl.google-analytics.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831876.73193,
+    "_responseReceivedTime": 123361.569925,
+    "_mimeType": "image/gif",
+    "_responseHeaders": [
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "date",
+        "value": "Tue, 13 Sep 2016 14:36:03 GMT"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Sun, 17 May 1998 03:00:00 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Golfe2"
+      },
+      {
+        "name": "age",
+        "value": "54513"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "content-type",
+        "value": "image/gif"
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache, no-store, must-revalidate"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "35"
+      },
+      {
+        "name": "expires",
+        "value": "Mon, 01 Jan 1990 00:00:00 GMT"
+      }
+    ],
+    "_transferSize": 192,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.390365,
+      "proxyStart": 0.75200000719633,
+      "proxyEnd": 1.52900000102818,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 2.11699999636039,
+      "sendEnd": 2.39799999690149,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 179.56000000413
+    },
+    "_resourceSize": 35,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.76._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.76._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.108",
+    "_url": "https://ssl.google-analytics.com/r/__utm.gif?utmwv=5.6.7&utms=1&utmn=970764202&utmhn=www.slideshare.net&utme=8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2FembedPlayerView&utmht=1473831876723&utmac=UA-2330466-1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=1522962769&utmredir=1&utmu=qRCAACAAAAAAAAAAAAAAAAAE~",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://ssl.google-analytics.com/r/__utm.gif?utmwv=5.6.7&utms=1&utmn=970764202&utmhn=www.slideshare.net&utme=8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2FembedPlayerView&utmht=1473831876723&utmac=UA-2330466-1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=1522962769&utmredir=1&utmu=qRCAACAAAAAAAAAAAAAAAAAE~",
+      "scheme": "https",
+      "host": "ssl.google-analytics.com",
+      "path": "/r/__utm.gif?utmwv=5.6.7&utms=1&utmn=970764202&utmhn=www.slideshare.net&utme=8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2FembedPlayerView&utmht=1473831876723&utmac=UA-2330466-1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=1522962769&utmredir=1&utmu=qRCAACAAAAAAAAAAAAAAAAAE~",
+      "queryParams": "utmwv=5.6.7&utms=1&utmn=970764202&utmhn=www.slideshare.net&utme=8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2FembedPlayerView&utmht=1473831876723&utmac=UA-2330466-1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=1522962769&utmredir=1&utmu=qRCAACAAAAAAAAAAAAAAAAAE~",
+      "folderPathComponents": "/r",
+      "lastPathComponent": "__utm.gif"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": []
+      }
+    },
+    "_issueTime": 123361.388109,
+    "_startTime": 123361.389976,
+    "_endTime": 123361.578459,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:804::2008]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google-analytics.com",
+      "sanList": [
+        "*.google-analytics.com",
+        "app-measurement.com",
+        "google-analytics.com",
+        "googletagmanager.com",
+        "service.urchin.com",
+        "ssl.google-analytics.com",
+        "urchin.com",
+        "www.google-analytics.com",
+        "www.googletagmanager.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473292752,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Aviator' log",
+          "logId": "68F698F81F6482BE3A8CEEB9281D4CFC71515D6793D444D10A67ACBB4F4FFBC4",
+          "timestamp": 1473294457080,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3045022027A43B90AC9A6B5AA9CFA1AC575A22272BD590FC67F0B870825A210A3D6DF8E3022100BCAFA391F8FEC23ABE5F14084E2A3C43477F303AA270CC8682C801CE7BFE2728"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294457641,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502207E88D18CD758F452384AFA5DEF793172C0AAC8761D8788D62CD19A5DEABD9CC8022100E0501E846BE012C2A74ED719E251CB5B357E4BCF94DD133982E2C83CDCA72585"
+        }
+      ]
+    },
+    "connectionId": "1108",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/r/__utm.gif?utmwv=5.6.7&utms=1&utmn=970764202&utmhn=www.slideshare.net&utme=8(2!document_referrer)9(2!https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F)&utmcs=UTF-8&utmsr=412x732&utmvp=300x485&utmsc=24-bit&utmul=en-us&utmje=0&utmfl=-&utmdt=HTTP%2F2%20and%20Java%3A%20Current%20Status&utmhid=151019478&utmr=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F&utmp=%2FembedPlayerView&utmht=1473831876723&utmac=UA-2330466-1&utmcc=__utma%3D186399478.1942588728.1473831877.1473831877.1473831877.1%3B%2B__utmz%3D186399478.1473831877.1.1.utmcsr%3Dwebtide.com%7Cutmccn%3D(referral)%7Cutmcmd%3Dreferral%7Cutmcct%3D%2Fhttp2-push-demo%2F%3B&utmjid=1522962769&utmredir=1&utmu=qRCAACAAAAAAAAAAAAAAAAAE~"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "ssl.google-analytics.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831876.73154,
+    "_responseReceivedTime": 123361.577608,
+    "_mimeType": "image/gif",
+    "_responseHeaders": [
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Sun, 17 May 1998 03:00:00 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Golfe2"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "content-type",
+        "value": "image/gif"
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache, no-store, must-revalidate"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "35"
+      },
+      {
+        "name": "expires",
+        "value": "Fri, 01 Jan 1990 00:00:00 GMT"
+      }
+    ],
+    "_transferSize": 111,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.389976,
+      "proxyStart": 0.906999994185753,
+      "proxyEnd": 1.60899999900721,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.74699998751748,
+      "sendEnd": 2.60699998761993,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 187.632000001031
+    },
+    "_resourceSize": 35,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.77._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.77._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.76",
+    "_url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/styles__ltr.css",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/styles__ltr.css",
+      "scheme": "https",
+      "host": "www.gstatic.com",
+      "path": "/recaptcha/api2/r20160908152041/styles__ltr.css",
+      "queryParams": "",
+      "folderPathComponents": "/recaptcha/api2/r20160908152041",
+      "lastPathComponent": "styles__ltr.css"
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+      "lineNumber": 23
+    },
+    "_issueTime": 123359.517636,
+    "_startTime": 123359.521886,
+    "_endTime": 123361.592165,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "stylesheet",
+      "_title": "Stylesheet",
+      "_category": {
+        "title": "Stylesheets",
+        "shortTitle": "CSS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:806::2003]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_ECDSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google.com",
+      "sanList": [
+        "*.google.com",
+        "*.android.com",
+        "*.appengine.google.com",
+        "*.cloud.google.com",
+        "*.google-analytics.com",
+        "*.google.ca",
+        "*.google.cl",
+        "*.google.co.in",
+        "*.google.co.jp",
+        "*.google.co.uk",
+        "*.google.com.ar",
+        "*.google.com.au",
+        "*.google.com.br",
+        "*.google.com.co",
+        "*.google.com.mx",
+        "*.google.com.tr",
+        "*.google.com.vn",
+        "*.google.de",
+        "*.google.es",
+        "*.google.fr",
+        "*.google.hu",
+        "*.google.it",
+        "*.google.nl",
+        "*.google.pl",
+        "*.google.pt",
+        "*.googleadapis.com",
+        "*.googleapis.cn",
+        "*.googlecommerce.com",
+        "*.googlevideo.com",
+        "*.gstatic.cn",
+        "*.gstatic.com",
+        "*.gvt1.com",
+        "*.gvt2.com",
+        "*.metric.gstatic.com",
+        "*.urchin.com",
+        "*.url.google.com",
+        "*.youtube-nocookie.com",
+        "*.youtube.com",
+        "*.youtubeeducation.com",
+        "*.ytimg.com",
+        "android.clients.google.com",
+        "android.com",
+        "g.co",
+        "goo.gl",
+        "google-analytics.com",
+        "google.com",
+        "googlecommerce.com",
+        "policy.mta-sts.google.com",
+        "urchin.com",
+        "www.goo.gl",
+        "youtu.be",
+        "youtube.com",
+        "youtubeeducation.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291668,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294157675,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450221009055A6D69C0CB2E407BE909674D95CC4AF2DA70F0227C59306FE478C7180AF9F022013374116DD952AA4B0CE6354EE179866A06014C15C6069A83F5CE6BF5971BC94"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294158314,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100E14BE9F27C6A8BBC0B3629205B8160CECAB700729222DE0C3058655338B45A9E0221008C902D61453456BFE66625FCE56ECFF15667097CAF2EB83C088BA636CA83119C"
+        }
+      ]
+    },
+    "connectionId": "537",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/recaptcha/api2/r20160908152041/styles__ltr.css"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "text/css,*/*;q=0.1"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.gstatic.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831874.86101,
+    "_responseReceivedTime": 123359.725539,
+    "_mimeType": "text/css",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Tue, 13 Sep 2016 17:59:15 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Thu, 08 Sep 2016 23:15:00 GMT"
+      },
+      {
+        "name": "server",
+        "value": "sffe"
+      },
+      {
+        "name": "age",
+        "value": "42319"
+      },
+      {
+        "name": "vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "content-type",
+        "value": "text/css"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=31536000"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "90524"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 13 Sep 2017 17:59:15 GMT"
+      }
+    ],
+    "_transferSize": 90664,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123359.521886,
+      "proxyStart": 1.19999999878928,
+      "proxyEnd": 1.8770000024233,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 3.33099999988917,
+      "sendEnd": 5.0479999918025,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 203.653000004124
+    },
+    "_resourceSize": 135549,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.78._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.78._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.110",
+    "_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFQAAANICAYAAABZl8i8AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAABUAAADSAC4K4y8AAA4oElEQVR42u2dCZRV1ZX3q5iE4IQIiKQQCKBt0JLEIUZwCCk7pBNFiRMajZrIl9aOLZ8sY4CWdkDbT2McooaAEmNixFhpaYE2dCiLScWiQHCgoGQoGQuhGArKKl7V+c5/n33fO/V4w733nVuheXuv9V/rrnvP2Xud3zvTPee+ewsKxMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExP4OdtlT6ztAbRWvvLy8A3QkwxzH6tBGMMexIo+nCgraaf2E1U6A5g60o9a9rI7S5N1APQaSzl1MTExMTExMTExMTExMTExMTExMTExMTExMTExMTOwIsMueWl8EtVW88vLyIqit4qmCguOgtoT5AKuojWA+wCpqA5i9tP6d1UuA5g70K1oPsL4iTd4N1DMh6dzFxMTExMTExMTExMTExMTExMTExMTExMTExMTExMT+l9tlT63/stbtrC9HHa+8vPzLWrezIo+nCgq6a41hdW8LoAD5COv2NgAKkI+wbm8DoHhf0yOsnwjQ3IHeaQG9U5p87kAHa01kDZZOXkxMTExMTExMTExMTExMTExMTExMTExMTExMTEysLe2yp9afoTWWdUbU8crLy8/QGsuKPJ4qKOirdRWrb1vAfDJJZ0QM88kknREhTLwR5wmtJ1lPRPpmHK6VT/5q3g4SAx0bIVDUyidXr15NYqBjIwT6YwI5cqSRgfpjARoe6E8J4vjxRgboT6XJhwf6Dau5e/qGDEq5Qb3I+mriRTINERMTExMTExMTExMTExMTExMTExMTExMTEzss7LKn1neB2ipeeXl5F+hIBHma1mStF1g4Pi1CkKdpTdZ6gYXjyOKpgoLeWndoPcPCce8oYU63YHqaHgVUhjndgulpehRQNbgiree0XkgSzhVFAZRq5pQ3t7+w+0CMhGOvpkYAlGrmhx9++EJTUxMJx15NjQDozwngN7/5gnr/fSMcG6g/j6LPJHgAqZQi4diqqV0c95kEDyC9eDi2amoXhzCP0ppO8DZsiMejYwMU144SoP6BHk3gCgtfUHv2JIDiGOcM1KOlyQeD+giB++lPX1AHDxrh2MB8RAal4EDPjg9Exx1nlBiYzpZpUzio39R6ygKJ42/KxD43qO14CgW1k9s4MTExMTExMTExMTExMTExMTExMTGxw894C+Q2rQdZt7XBFshtWg+ybot4C6Sn1hX8xZo7+bhnFCA78NdpStMI1zo4BNmBv05Tmka41sEhyEJ+C85rWqVJeo2vFboESjBHPb2+9Om/fV66pHo/Ccc450F1CJRgLliwoLSqqqp0x44dJBzjnAfVIdAxcYDf/napevxxIxwnwI5x2cwJXMX6A6VKqVbCOQvqaY6aOYHbuXPnIfFwzoJ6mgOYeE/T6wTtN785JB6dM0Bfd/IeJ+4nqTYeEoyFawz0NgdA0U9SbUwXD9cY6G0OgN5MwK66Km08umag3uwCKAYfauLpAuIaA33QAVAMPtTE08XDNQb6oAOg9xOsV15JDxTXDND7BWh2oA8TrFmz0gPFNQP0YWny2YHeQbDuuis9UFwzQO+QQSk70KEEq0uXUlVRcShMnMM1A3SoTJv8QZ1AwI4+ulQ9+GCpWrbMCMc4Z2BOkIm9f6Bf0pqcYlLvCde+JLeewe+WhvP3PKeyJvK5wgIxMTExMTExMTExMTExMTExMbHD2y57an03rRKtG1g47hZVvPLy8m5aJVo3sHAcWTxVUNBB6wytb7Nw3CEKkD20JmjN1ypL0ny+1sMhyB5aE7Tma5UlaT5f6+EQJBaYb9V6U6ssSW/ytS+5gnkar8qXXa41fuaWsmfnf07C8eUJsE73lDyAy5cvL1uzZg0JxxZYV3tKJ2v9Lg6wd+8y9Z3vGOE4ARZpTnZRMwnmna9sLlu3o7FMKdVKOIdrFtQeOdZMgrls2bKy+vr6Q+LhHK5ZUHvkAPMYrd8TsKKiMjVrVplqaUnEwzHO4ZqBirTH5AJ0ggezoan5kMJ5wjUL6oQcgE7wYMZisbTxcM2COiEHoD8jUKecUqa2bEkbj64hjYH6s1wGoPlo0qlqZqqaenmiT+0WcgCiPjNVzUxVU60+tVsImHhxyzyCpP1ki0dpDNB5oV7owiM49ZNZg7GQlmtpSQigJV6f6Tee1aeWhAB6MQE680zf8SitgXpxGKCYFtHg4zcg0jLQ60MAxbSIBh+/8ZCWgV4fAugYgnPbbf6BIq0BOqatgd7QxkBvCAH0RoLzz//sHyjSGqA3SpM/FOhIgnPJJf6BIq0BOlIGpUOB9iI4HTqUqU8/zQ4TaZDWAO0l06bUUB8hQCNGlKmDB9PDxDWkMTDDv2UsDyb2p2jNIVC4M0o1F8U5XDMwkfYUufXMDPU8rf8mYF27lqlrry1TjzxihGOcMzCR5jxZHPEHFd9EfjrFwoinpyP5RnLS8t31bbx8d30bLN+dpvVDrbu1/i8fR/Z0oZiYmJiYmJiYmJiYmJhYVKbv1wu1LuD31s/Sepc1i8/hmrN/m+n79UKtC/i99bO03mXN4nO45vTfbfqefYDWWK3nrb8kPs/nBriEOVDrZa3KLEKagQ5gDtR6Wasyi5BmoAOQPbT+n1ZlFiFNj1xhnqf1DoBd/dyGyt+W76z84LOGys/3xUg4xjlcY6hIe14OMM/TegfAFi1aVFldXV1ZV1dX+cUXX5BwjHO4xlCR9rwcYA7W+h8CVlhYqS6/vFJNn16ptH8SjnEO1wxUpB2cS80kmL94fWvlrvpYpVIqpXANaSyoA0PWTIK5YsWKysbGxrTxcA1pLKgDQ8A8SWs+gTrttEql/aWLR9eQxkBFnpPC9JkvezAPxlrSB2MhjQX15SB9KveZL3swW1qyx0MaC+rLQftUDeVZAjRkSKXavTtrPEqDtAbqs0GBXuA180w1M1VNtZr/BQGAXuA180w1M1VNtZr/BQFgnkVgOnasVFVVvuNRWuQxUM8KAhQjN/WPvoOxkIeBTg4AFCM39Y9B4yEPA50cAOjPCcottwSOR3kM0J8HAYrpEA06QQMiDwOdFQAopkM06ASNhzwMdFYAoKUEZc6c4ECRxwAtDQIUc0wayYMGRB4G+m4AoJhj0kgeNB7yMNB3AwBdTFA2bAgOFHkM0MUCNAH0PYKydWtwoMhjgL4nTT4BdDZBwVwzKFDkMUBny6CUAPofBGXChOBAkccA/Q+ZNiWAlhCU7t0rVZBWgbTIY4CWBAF6RE/sNYz2Wv9JYK6+ulL5iEdpkNbARN72cuvZGurXtCoI0JgxlerAgfQwcQ1pDEzk+ZosjqSG+k9xqH36VKonnqhUn35qaiOEY5zDtQTMf5Llu8xQz9ea22qpDreXiVtMT0hzviww+4N6FL+4Gq9ne9+C+D6fu8rpx6bzyfgdeN1Z8s47MTExMTExMbHDxPQE/li+e4KOjTqensAfy3dP0LFtUUY9/+wCRQmxn/c3Ra2qJJXxtX4OIfbz/qaoVZWkMr7WzyHAY7V+xK/AWKZVxVrG53DtWBcgO2tN0vrEhjjmNxtJSWA/4bSdcwDZWWuS1ic2xMWLF5OSwH7CaTvnALKd1i1ayy2I6bSc07YLC/MErb94wO77z21VS6r3VzU0NVcppUg4xjlcs8AizwkhYJ6g9RcP2MqVK6t27NhRFYvF4vFwjHO4ZoFFnhNCNuupcWCnn16lHn+8Sq1aVaX27DHCMc7hWgLs1MDdAddMgnnDb2uqlm04EC9UOiEN0lpQOwesmQRzyZIlVTt37swaD2mQ1oLaOQBMLDBPJ0BdulSp556rUtYPd4hwDWmQ1kCdHmiBmZsuAdqyuylr4TwhrQV1UgCgkzyYBw4c8B0PaS2okwIAvT0OU+f3G4/SJqDeHmQAoj7TT81MVVOtPrWfzwGI+kw/NTNVTbX61H4+YOLFA6sIyu9/Hzge5TFAV/l6EQGP2NQvBg7GsvrUCT6ATvD6zLDxrD51gg+gdxGQ886rUi0tweMhD/IaqHf5AUpTIww2YQuIvN6UygdQmhphsAkbD3m9KZUPoHND185Da+lcP5N2gmGP5kGFvNaof2yWSTvBiGUaFLIIea1R/9gMMLvGR+sQ3UtcyJsY9btmAjrQm2eGDsay5qkDMwAd6M0zc41nzVMHZgA6gCAcc0zO8ciHATogn4EOIgg9euQOFD4M0EH53ORPiDfVhobwMJE30eRPyPdBaTGBmDs3PFDkNTAXy7SpoOAhgnHtteGBIq8B+pBM7AsKvhpvrkuXBoeJPInm/lW59TRQf0lA+vevUrW1/mEiLfIYmL+UxZEE0OP4/0ZVatAgs6qUDSbSIK2BibzHyfJda6in8EuuqlT79lVq7NgqtWzZoSBxDteQxsAsC/26tjxYYO7Of5BN9Ivdu1epoUONcNx6kRlpu8sWSHaweALvufgqVGut4mvnF0RhR/ImHT+Fd7rWRazT5ak7MTExMbH8Mf7W/ImsDlHH42/Nn8jqcKRAHKQ1UWue1nqtGtZ6PodrgxxCHKQ1UWue1nqtGtZ6PodrzuLpqVE3ftzmRa13tNay3uFzuNbNBcieWs9aAElXPLOBlHye0/bMAWRPrWctgKQFCxaQks9z2p45gMSHqe7VWqNVk0VrOO2XwsI8R2s5QF2uNeXN7TVvr66v2bU/VqPvcUk4xjlcuzwBFXnOCQHzHK3lHqwPP/ywZvv27TWNjY3xeDjGOVyzoCLPOSFgfoXvyw2ws86qUQ8+WKPeeadGbd5shGOcw7UE2LLAL7hmmGsA6M4/bq5ZV5soVDohDdIy1DVBoDLMNQBUUVFRs2/fvqzxkAZpGeqaIFA1kIFaKwhQnz416o03ssajNEhroCLvwCDNnGrmv7+xreaLgy3Zg7GQFnmsmtrTZzOnmrlq1aqa5uZm3/GQFnmsmtrTB0x85WsRgTn77Bqla7zfeJQWeQzURb6+/uX1mahtQWDaUK2a+qwPoM96NTMITBuqVVOf9QH0IQLSr1+Nqq0NHI/yIK+B+pCf0Zz6Qz/NPFPzt/rUQVlGc4Lhp5lnav5WnzooA8w+WusJxvz5oeNRXgMUvvpkAorpDw0yoYOx4IOBTswAdKI3AOUazxqoJmYAOo5AjBiRczzyYaCOywQUc0oauXMNCB8MdF4GoJhT0sidazz4YKDzMgB9kyBMnZo7UPgwQN/MdAdEk3Z7ahRW8GFN/jukuQOiSbs9NQor+LAm/x1SwMRDtusIwoYNuQOFDwN0XcqHb/lWkibsOQdjWZP/E1MAPdGbtLuKZ03+T0yz3VGj2rd3Fo98Gajd8xFoTyr8UUe5AwpfBmjPfGzynbQ2EoCdO3OHCR8GJnx2ytdBqZwglJbmDhQ+DNDyfJ42TSEIN9yQO1D4MECn5PPE/iyC0LFjjfr00/AwkRc+DNCz8v3W848E4pJLalQsxFiBPMhrYP5RFkfMY+GrCcgttwSDirTIY2Cu9v069jxYvsNXZzcQmO98x6x9ZoOJNEhrYG4I/PXZPFhg/ife5qhRXbvWqH/91xq1aFGNslsIjnEO15DGwFwb+u1iebAFcqrWG622Orp0qVGDBhnhuPU2CNKeKpt0maHixVeX8JN1H6fYS/qYr10SyYuxjuRtZP7/fJHWUFZR6P/Hi4mJiYlF9ihOJ63vak3xPo1ufQJ9Cl/r5HAg6qT1Xa0p9qfR+XgKX+vksox68DlD66daT2q9xHqSz53hCiT+tDCen6WvzaIqTpvrnxbG87P0tVlUxWlz+dMCpkzXaC3Qqs2iBZy2MCzMYq2lHrBbXvis9rflO2vLq+prV21qIOEY53DNAos8xSFgFmst9YC9++67tdXV1bX6zqi2rq6OhGOcwzULLPIUh4D5Zd60M8C6dKlVl19eqx56qFa9+KIRjnEO1xJgkefLQWF+iyfutTdrWADX0qJq9e1YSuEa0tycAIu83woA81s8cSdYAJculiekscAi77cCwCzmxY1adfTRtWrKlFq1Z0/6eLiGNEhroCJvcZCaSTAnv7Gtdt8XzVkL5wlpkceCWuyzZhLMVatW1R48eNB3PKRFHgtqsQ+Y/eIwhw6tVevW+Y5HaZEnAbWfnz5zqQfzYKzFfzCvkDqPBXVppj6V+8ylHsyWluDxkMeCujRTn6oBdNCaR0C+/vVatXt34HiUB3kNVPjqkAnoeK+ZB6mZqWqq1fzHZwA63mvmQWpmqppqNf/xGYD+mEB061arPvssdDzKCx8G6o8zTY1oNEd/GDoYCz6s0b9TmqkRjeZ++kw/fao1+ndK86DDCoLw61/nHI98GKAr0j3o8F1vNM80APlvisoe/b+bAuh3vdqZc+FYVi39bgqglxCAE0+sVY2NuceDD/gyUC9JBRQTdJoGuSogfDHQKSmAYoJO0yBX8eCLgU5JAXQyFf6225zFI18G6ORUQEtdNfcUzb40BdBSV809RbMvTQF0JhV+xgx3QOHLAJ2ZCihuJWnC7iogfDHQshRAcStJE3ZX8eCLgZalAFpGhZ8/3x1Q+DJAy/IXaFmZO6DwlQHokd7kZ1HhX3vNHVD4MkBn5eOg9BgV/p573AGFLwP0sXycNo2mwp96qjug8GWAjs7Hif3R/IBCrZo7N3eY8GFgwufR+Xrr+QBB+Id/qFUNOQy+yAsfBugD+bw4cjzvs9eqm26qVSHiUR7kNTDh6/h8X767WGsbAbn11mC3oUiLPAYmfFwsC8wG6nVxqFjfXLIkO0ykSayFIu91sgXSGuql/JdtA+mCC2rVE0/UqsWLa9X69UY4xjlcS2yBIM+lskmXGmoPrae0NvvYpNvMaXvINnJ2sHi3/f/hD6ngY6jVrAo+9398vbNeTExMLH0/is/5Dtb6vtaNrO/zOecPovLnfAdrfV/rRtb3+VwkX4TlDwcU81z1Yj7u6hrkAK1H+Y8IdWm0htMMcABygNaj/EeEujRaw2kGOICIt93eofU3rZ1adUnaydfuCPxW2ySQXbUe0/rcA3f1cxvq7nltS93Ds7eTcIxzFtjPOU/XECC7aj2m9bkHbtGiRXXLly+v++ijj0g4xjkL7Oecp2sIkNgF/Rn/VzMBsE+fOvW1rxnhuDXcjZynfZhaudQD9cCs7XWVGw/UxZpb6vRdQyvhHK4hjQV2aZDayrVyqQdK307W7dq1q07fpx8SD+dwDWkssEuD1FYN5ESt2XFQZ5xRp55/vk5t3XpIPDqHa0iTAIu8JwaBWQ0wN79QU7eipuHQIGmEtMjDUKv9QGWY1QCj74DqYH7jwZCHoVb7gcowKwjM0UfXqWnT6lSKH+4QIQ3SIo+BWpEVKjdzqpn/8ofNdXX7Y74LFy+kzoO8Vk3tmqWZU82sqKioa2xsDBwPeZDXqqldM8DsyI/PmOb8ySeB41GeRFcAXx0zAX3Mq5lhYNpQrZr6WAagj3k1MwxMG6pVUx/LAPReAnH88XWqqip0PMoLHwbqvZmaOg1AQZp5puZvDVQD0jR1GoCCNPNMzd8aqAakub3cRhBeeSXneOTDAN2W8raUpz00uOQcjGUNVI+mAPqoNwC5imcNVI+mAPpvBGDYMGfxyJeB+m+pJu00z8SI7SogfFnz1MKkSTvNMzFiu4oHX9Y8tTAJ6Coq/J//7A4ofBmgq5KBDvbmmammRmEFX9Y8dbAFdLA3z2xpcRcPvqx56uCkh2zr1FFH1amGBndA4Qs+DdR+NlDcQtJE3VkwFnwy0O9bQHELSRN11/Hgk4F+3wI6kgp9zjnO45FPA3SkDRT35XT34zogfDLQGy2guC+nux/X8eCTgd5oAb2BCj1qlHug8GmA3pBPQH9Ehf7BD9wDhU8D9Ef51OSvoEJfdJF7oPBpgF6RT4PSECp0t251qrnZHUz4gk8DdEjeTJt4ZcmsKmngzoDCV2IVqn2+Tex/TYW//np3QOHLAP11Pt56nkmFb9euTi1bljtM+IAvA/TMfF0cmU4ATj+9Tu3bFx4m8sKHgTk9n5fvevBfCuvUJZfUqf37g8NEHuQ1MFdnffAhDxaYv661lYCceWad+vhj/zCRFnkMTPj4umyBGKjn8Aut6lTHjnXqjjvq1OrV6UHiGtIgrYGJvOcE3Vc60jfpTuL/LiX2ik491Yzc48YZ4RjnWm/UIc9Jso2cHuwwrT9p7UixhexpB6cZJg86+Ad7rNa3tW7Xmsi6nc9F/nVIMbHD67mm7lo3aT2vNV/rA9Z8Podr3R029+5aN2k9rzVf6wPWfD6Ha90dNveO/CzTL7Rm8L/uZvHxL/haR1fPNU3T2q1Vn0W7Oe2AHEBiQJqmtVurPot2c9oBOYDEp9Mm8X+N6rNoA6ftFgYkBqBxWjs9YOP+tKX+j+/W1b/z6f761Vu/IOEY53DNAruT8xYGAIkBaJzWTg9YZWVl/YYNG+o///zz+j179pBwjHO4ZoHdyXkLA8Ic3Qpkr1716qab6tUTT9SrV14xwjHO4VprsKODwMTj3y95gP7tL9vqq2sb6/UEN6OQBmktsC/5eUycH/9+yQO0cuXK+n379mWNhzRIa4F9yc9j4vzyqwfjgE4/vV69/nq9isXSx8M1pEHaBNgHs74Ui2smwbzimQ31c1ftzVqwZCEP8lpQC7PUTIK5YMGC+i1btgSOhzzIa0EtzAL0kTiUe+6pV01N/uMhLfIkoD6SDeg4D2bF+gOBC+cJeS2o4zIAHefB3LlzZ+h4yGtBHZcB5vVxGFOnho5HeRNQr880AFGfGaZmpqqpVp+abj2U+swwNTNVTbX61HSP4mwlCPfdl3M88mGAbk33KM40r8/MORjL6lOnpQA6zeszXcWz+tRpKYD+kgCcfXbm/tKv4AO+DNRfpppn0tTIzwDkV/BlTam6J80zaWrkZwDyK/iyplTdLZhH8/14vZo/31k88mWA7mj1F2+emNP0x1kwljWluskCepM3NXIdz5pS3WQBvZoKftppzuORTwP1ahso7nZoTuk6IHwy0OctoLjboTml63jwyUCft4A+FR/VXQNNjPpP2UBxC0kTddcB4ZOBzreA4haSJuqu48EnA51vAZ1HhX7tNfdA4dMAnWcDxX053f24DgifDPQDCyjuy+nux3U8+GSgH1hAl1OhFy92DxQ+DdDl+QR0FRX6vffcA4VPA3RVPjX5cir0f/2Xe6DwaYCW59Og9AIV+uGH3QOFTwP0hXyaNo2lQl94oXug8GmAjs2niT0+Mr1PFRbWqzVr3MGEL/iE7+SPTufBredMqknXXusOKHyZ2jkzHxdH8MXEvQSgtDR3mPBhYO5N++XEPFi+e5ggHHtsvaqoCA8TeeHDAH04bxeY+XO+/x2HOmdOcJjIk4D532k/45tHWyB4oOGv8QXin/ykXvn5IZEGaRMLy3/1/QDEkb5Jp0F01vpVHE6nTvXqBz+oVy++WK+WL69XW7ca4RjncA1pEjCRN/j7ovJgG/mb8YUTf0Lab8qDDtnBnsF77nO1PrUeEvuUz01y9k0lsegexzmJXzB4YZJw7iTX8XQNPIlfMHhhknDOeTz+BCXeL3pKko539ilKDep8ralaG7Uasmgjpz0/B4jna03V2qjVkEUbOe35OUDsqzWBv+aFJt6QRnWcBmn7hgHZX2uWDUzPLRtueeGzhjv/uLmVcA7XkuAib/8AIPtrzbKB6bllw7vvvttQUVHRSjiHa0lwkbd/AJCodU/zQNMa3nHHtdahcOs57/F+YV6qtd2D+PT/7GhYtamh4WCspUHPx1IK15AGaS248HGpD5iXam33IFZVVTXs3r27oaUlfTxcQxqkteDCx6U+YBbzM/IG0IgRDWrGjAa1bl2Dam4+NB7O4RrSIG0C7NqsX/1imHsB5J7XtjRs2d2UtlDphDzIy1D3ZoLKMPcCyPLlyxsOHDgQOB7yIC9D3ZsJKn+edzsBGTiwQek8QeNRHuQ1UOFraKZmTjXz0bm1GWtkNiEvfFg1tX+aZk418+OPP85YI7MJeeHDqqn9U8DEf5TWE4iLLmpQuoaHjUd54cNAXZ/yv0pen4nalQtMG6pVU2elADrLq5m5wLShWjV1VgqgMwjA6afnBtOGCl8G6oxUozn1f2Gaeabmb/Wp5yeN5tT/hWnmmZq/1aeeb8EcQgUvLGxQemBzFY98waeB2urv3Zju0KDiLBgLPhnoVAsopjs0qLiOB58MdKoF9FdU6Kuuch6PfBqgv7KB0jwTI7XrgPDpzVMtoDTP3O2i6SUJPr15qgW0igo9Z457oPBpgFbZd0DUNF30nan6UqvZn8R3QNQ0XfSdqfpSq9nj33InUIHbtWtQ+/e7Bwqf8G2gnuC9r54m6M6DseCbgRbzrSNN0KOKB98MtJj/J9+g+vSJLB75NkDPLOD7cbrriSogfDNQ736c7nqiigffDPRCXcjhVNgzzogOKHwboMPzAeiFVNji4uiAwrcBeqEAFaCHP9AjfVAaSoXt3z86oPBtgA7Nh2lTERW2U6cGFYu5hwmf8G2AFh3xE3v+59xWKvB777kHCp8G5tb4P+vy4NbzD1Tou+5yDxQ+DdA/5NPiyD9Sobt2bVBbt7qDCV/waYD+Y94s33GzX0gFv/zyBuWi74YP+DIwFx7yR9o8WGDGiL8n3vRzgYq8iaa+J+1WSB5sgfwwvid09dUNaufO4DCRB3kTe0s/zPdNuh/xE8cNqnv3BvXAAw1qw4bsIJEGaZHHgNzX6q22eb6NfK7Wslbbw337Nqjhw02/aAvncK31VjLynisPOrSG2kHrWq23Uu7Pp96Pf4vzdJBHcTLDxb+Vz9O6jPtZW5fxtaNzBdhXawx/q3OST43nPH1DAOyrNYa/1TnJp8Zznr4hIHbRukDrKq0bfeoqztMlCMhhWm9rNeUo+BjmA+Qwrbe1mnIUfAzzAXKA1u94utMUUnvYx4BsTy0/5AHRA03Tz/+8temZv33e9Nvynb6EtMiDvBbYh1I9zcxPLT/kAdEDTdOKFSua1qxZ01RdXe1LSIs8yGuBfSjd08wawG3cFxowRUVNqqSkSQ8+/oS0yJMAC1+3pQMahwkwu/bHmvR0IZSQFz5sqCmAxmECTGNjY+h4yAsfNtQUMG+Pg7j00iZVURE6HuWFjwTY21M1cyr8nJV7wwdKEnxZUIclNXMq/ObNm53Fgy8L6rCkJ5QPUOHvuadJ3+nkHg8+4MsAPdDqCWevz0StclU4T1ZNfdsC+rZXM13Hs2rq2xbQN6jgo0a5gWlDhU8D9Q17NKd+L5dmnqn5W31qXx7Nqd/LpZlnav5Wn9qXXy/UqAoLm5Tud13HI5/wjRh43RBPc2gwcR6MBd8MdAxPc2gwiSoefDPQMTzVaVLnnhtZPPJtaulVBTx3jKS5p2j243nuGElzT9Hsx+tCjqPC3nxzdEDh2wAdV8ATcpr2RBUQvhmoNyGnaU9U8eCbgU7iv8Q0qTvvjA4ofBugkwSoABWgAlSAClABKkAFqAAVoEcI0CP91vMeKuzYsdEBhW8D9J58WBy5kQqL1faogMK3AXpjPizfnUaF7dy5Se3e7R4mfMK3AXpaviwwL6cC33uve6DwaWAuz6ctkO9Rodu1a1KzZrmDCV/waYB+L9826V6kgrdv36QeeqhJHTgQHiTywgd8GZgv5t02Mr+m7Q/xncoePZrUD39owDzxhD8hLfIgb2LH8w8ZX9eWBw86jOH3MTXlKPgYI4/iFMS/5n0hf83rGf7Erx89w3kuPORr3RmeHinRelxrplZpSM1kHyU+3s5YovW41kyt0pCayT5KfHz+51Stn2k9yt8HCaNH2cepmWAO0npPK+ZY8DkoBcxBWu9pxRwLPgelAHkiv+U25ljweWIqmNsA4NrnN8Z+8/bO2Fsf7o39z8f7Qgl54QO+GOo2GyrD3AYAixYtiq1duza2ZcuW2LZt20IJeeEDvhjqNhsq781XEYD27WPqe9+LqV/8Iqbuuy+ckBc+4MtArYp/AoibOdXMcX/aEtNTnpieGjgRfMGnVVMLuZlTzaysrIzpKY+zePAFn1ZNLWSgc6ngAwbE1MqVzuKRL/g0UOd6QEu8mukSpg3Vqqkl3M9RbXIJ04Zq1dQSXdBvUIGPOiqmqqqcxyOf8G2gfqOABw9qos6DseCbgT7Ogwc10ajiwTcDfZzfuxxTN98cWTzybYA+XMAjMvV7UQWEbwY6k0dk6veiigffDHQmfyQ6pp5/Pjqg8G2A/qmApzk0mEQVEL4ZqDfNocEkqnjwzUBLdSFLqbAvvhgdUPg2QEsFqAAVoAJUgApQASpABagAFaACVIAKUAEqQPMe6JG+fPdnKuy0adEBhW8D9M/5sMD8NBV2/PjogMK3Afp0PmyBjKLC9uoVU3sjaIXwCd8G6KgjfpOO337zCRV45MiY2r/fHUz4gk8D85P423LyYBv5HH5xVUz16xdTjz0WU3/9a0yVlYUT8sIHfBmY8H1Ovj3ocL7WhggedIDP8/PyURx+tdBPtF7XWqpVGVJL2cdP0r5ySBf8eK17+am5NVrrctQa9gWfx6eAebzWvfzU3BqtdTlqDfuCz+PTvEnsOn49ED4nOT9HzWNf1x3ypjFd4KFam7SaIxJ8D7VgDtXapNUckeB7qAWzn9YKreaIBN/97JpJMP/595ua//bxvuY1275oXlfbmJPgA77g04J6PNdMgvn+++8360Glee/evc379u3LSfABX/BpQT2em/lHVPAePZrV5MnNaubMZvWXv+Qm+IAv+DRQP6Lmz02SCr6/sblZTwecCj4tqPdyk6SCHzx40Hk8+LSg3qsLeQcVuE+fZvXZZ87jkU/4NlDv8P4BQrXJeTAWfDPQt7mfo9oUVTz4ZqBvc1/XrH7968jikW8DdF4BDx7URKMKCN8MdA0PHtREo4oH3wx0jS7kairsu+9GBxS+DdDVBTwiU78XVUD4ZqDeiEz9XlTx4JuBrtOFXEeFXb48OqDwbYCuE6ACVIAKUAEqQAWoABWgAlSAClABKkAFqAAVoAJUgB7WQI/0BeZqKmxFRXRA4dsArc6HLZBFVNhXX40OKHwboIvyYZNuChX2vPOaVWME3Rp8wrcBOiUftpF7a9VRgS+6qFm9/Xazqq1tVnV1uQk+4As+DUzE6J0vDzqU8EelonrQAb5L8u1RnK9o/YYf7mpyALGJfcHnV5JhdtC6S2uZ1i6tOkfaxT7hu4MFs4PWXVrLtHZp1TnSLvYJ3x2SgF7BD3hV8tsaXaiSfV6RDHO2VkvEQowODHO2VkvEQowO/F1k1KKWiPUb+j4y156Wq57d0PLXD/e2bN19sGX7HjeCL/iEb4Z6F9eeloULF7Zs3bq1paGhwangE74Z6l26kDdRgdu3b1ETJrSov/2tRZWVuRF8wSd8G6g3FXCTpILraUAkgm8GuoybJBU8qnjwzUDxhdglVNhHHoksHvk2QJcUcD9HtSmyAmrfDHQX93NUm6KKB98MdJcu5OdU2LVrowMK3wbo5wU8eFATjSogfDNQb/BoK6B1PD9sUevXRwcUvg3QOgEqQAWoABWgAlSAClABKkAFqAAVoAJUgApQASpABagAFaACNDTQI30LpM2BHumbdB9SYWfOjA4ofBugH+bDNvJ9VNgePVrUvHktqrnZHUj4gk/4NkDvy4cHHbpqVbTBgw6I0TUvHsXRBT1G61daOyMAuZN9H2M/jtOfX161V0s51l723d8C2p9fXrVXSznWXvbd3wLajb8jt5If8HKpley7mw1zRwQgk4UY/RnmjghAJgsx+uuC9tBaq6UiFmL08F7Iqu56ZbNau/0LVf9Fs1PBJ3wzVO+FrGrZsmVq79696uDBg04Fn/DNUPFC1mlU4P79lXrtNaWWL3cr+IRvA3VagdfMUfCoDL695u81cxQ8KoNvr/nzozhKlZVFFo98G6D0KA4Vtp7+BBKNwbcXx2uSqE1RGXx7ceJNcteu6IDCN8fJH6B1ddEBhW8BKkAFqAAVoAJUgApQASpABagAFaACVIAKUAEqQAWoABWgAlSAHmZAj/RNugNU2I8+ig4ofBugB/JhG3kuFfbSS5WqrXUPEz7h2wCdmw8POpwVr6XQcce5VeJBB8Q4K18exTmXvyMX1VMj8H2u/WzTWVpvaTVFALSJfZ9lAT1L6y2tpgiANrHvsyygRfwaoDURPNu0hn0X2TAPtEGTR4yzGOaBNmjyiIHmjma/vQ2ebUKM/gVce9QvXt+qPtvV5LzPhk/4Zqhvce1RK1asUPv373ceDz7hm6G+xR+bVmrIEKXmzlVq/Xq3gk/4NlDpY9PUzKOAaUP1mr/XzKOAaUP1mn98QKqoiG7aBN/WtIkKG6Xh+enkiX3UdsjEvjm6GxeFz0kn3ylFbX93oFGbABWgAlSAClABKkAFqAAVoAJUgApQASpABagAFaACVIAKUAEqQA8zoEf6Jl2MCrtxY3Qw4dsAjR2yjdwSAcy/8zbyEirsVVcptW+fe5jwCd8G6JJ8eNDhEv7kmVLt2yvVt69Sp5ziTvBpYCLGJfnyKM5IraoInxqB75HJ36Ur0XqVX1y1wpGWsc+SFB/5K9F6lV9ctcKRlrHPkhQf+cOXE1/VwvvwVjjSMvZ5yBcT72+DJn+/BfP+Nmjy91sw72+DZ5vut2smFXpq+U61ouaAWrWpwYngCz4tqCVcM6nQ1dXVateuXaqurs6J4As+LaglXDNNof/lX5SaN8+8FsiF4As+E1BLCrhJUsGjMgvqq9wkqeBRmQX1VW6SpuBRWQLqq977Q6k2RWXwzUC994dSbYrK4JuBLuN+ztSmqAy+DdBlBTx4UBONyuCbgXqDBzXRqAy+Gag3eLTVm8VWCFABKkAFqAAVoAJUgApQASpABagAFaACVIAKUAEqQAWoABWgoYHKFkiulrQFIpt0uVrSJp1sI7vcRpYHHRw/6CCP4kTwKE4S2HZag7WGa10cUsPZR7uCLKYL305rsNZwrYtDajj7yBpPF76d1mCt4VoXh9Rw9tEuE8j2WuO0tjhs5lvYZ/sUINtrjdPa4rCZb2Gf7VOAbK81TmuLw2a+hX22TwWz1ANx7fMb1R0vb1J3/nFzKCEvfFhgS22oDLPUA7Fo0SL1/vvvq4qKilBCXviwwJbaUBlmaRzEsccq9dWvKlVcHE7ICx8JsKWtoHItUj94doP660f7VKw59+eY4QO+4JOhjrOAohaphQsXqq1bt6qWltzjwQd8wSdDHWcBHUcF79JFqWnT8ILR3KdK8AFf8GmgjrP7TGrmAODa4NNq/u24z6RmDgCuDT6t5t+O+0zTzAHAtcFnovm3K+DBg5qoi5qZqqZazX8wDx7URF3UzFQ11Wr+g3nwME00irfqwmei+Q8u4BGZ+r2oDL4Z6HAekanfi8rgm4EO5xHZ9HtRGXwboMMLeJpDg0lUBt8M1Jvm0GASlcE3A/WmOWYwicrg2wC9WIAKUAEqQAWoABWgAlSAClABKkAFqAAVoAI074HK8p3j5TtZYM7FUiwwyxZILpa8BSKbdDnUzFSbdLKNXOx+G1kedHD8oIM8ihPBozhiEZuuXYVaQ7RGao3yqZGcpzBoPF27CrWGaI3UGuVTIzlP4Hi6dhVqDeG3jo3yqZGcpzAIyM5ad2ttyqHv3MQ+OvsA2Vnrbq1NOfSdm9hHZx8gO2vdrbUph75zE/vonA1mT62l9mh/98wt9HZFP0LapNEdvnpmgNlTa6k92ldWVtLbFf0IaZNGd/jqmQFmz1bf98RIfd55Sl10kT8hbevRHb56ZqqZBHPM1I1q/ifh5qPIg7zwYUHtnKZmEszFixerbdu2hZqPIg/ywocFtXOammlgnnCCUi+9pFRTiHemIg/ywkcCaudUQO/2YG7ZnfvLWeHDgnp3CqB3ezAPHMj9HyjwYUG9OwXQu+Mw167NfWIPHwmod6cagKjPRO1yZfBl9amFSQMQ9ZmoXa4Mvqw+tTBpADJ9JmqXK4OvRJ9aaAMdEsUCSdLCyBAL6JAoFkiSFkaGWECHxPvMJoevRoavRJ86xAaK6Q4NKq4NPhnoSAsopjs0qLg2+GSgI5NeyGoGFdcGnwboSBvoKO89zK7Nev/yKAvoKO89zK7Nev/yKAvoKCo0RmrXBp8G6CgBKkAFqAAVoAJUgApQASpABegRBlRuPR3fesriiOPFEVm+c7l8JwvMjheYZQskYDP3swUim3QXud2kk23kCLaR5UGHCB50EBMTE0s8P1qk1S9JRame/8zV+PnRIq1+SSpK9fxnrsbPjxZp9UtSUcbnPwNC7KR1q1aZVmOGUb2R0yBtpxwgdtK6VatMqzHDqN7IaZC2Uw4QO2ndqlWm1ZhhVG/kNEjbKSzMYVrVNrhRT5u5qS2cS4KLPMNCwBymVW2DW7BgAU3YbeFcElzkGRYC5jCt6lbg8BXZ445rrcSXZT0hz7CgMK/zvkJ7w29r1Gvv71ab8N3kllR3KoquIQ3SWl+bvS4AzOu8r9AuWbJE1dTUZLwdxTWkQVrra7PXBYB5nVYTATrxRKWmTFFq9WqlmpsPDYZzuIY0SGugIu91QWomwXzoze1qf2Oz77sypEUeC+ownzWTYH744YcqFov5v83VaZHHgjrMZ800MC+/XKk9e/zfdiIt8iSgDvPTZ1Z7MMMsrCGPBbU6U5/KfWa1BzOsWVCrM/Wp3GdWx2GGWTpEngTU6ox9Kg8q1HSD1MxUNdVq/rdmAHqr18yD1MxUNdVq/rdmAHprvJkHqZmpamqi+d+aCShGauoPczX4YKBlGYBipKb+MFeDDwZalgFoGUFAf5irwYcBWpZpnklTIwwyuRp8WFOqdP9ToqmRq/VQa0qV7n9KZmqEQSZXg4/ElKp9KqBF3tTIxa4EfFhTqqIUQIu8qZErs6ZURSmAFsWnRs3NuQeDj8SUqigV0H7eGqgrs9ZG+6UA2s9bXHZl1iJzvxRA+1HhMbd0ZfBlgPYToAJUgOY9UBmUHA9KMm1yOW2Sib3jib3cekZz6+lkceTB/zrCF0cuu8zf4kjy8h3ABF2+s2Ae/st3ABN0+S4Bs8n3QrMsMDtcYJYtkAi2QGSTLoJNOtlGjmAbWUxMTExMTCwfTE+NemuN1ZquNZs1nc/1jmDa1FtrrNZ0rdms6XzOeTw9NeqtNVZrutZs1nQ+19slyJO1ZmjFMkzsY5zmZAcgT9aaoRXLMLGPcZqTHYA8WWuGVizDxD7GaU7OFSY+77vLAzfuT1vUH96pU/M+2kfCMc5ZYHel+mxvAJj4vO8uDxz+5bF+/Xp6cy2EY+uvh4rTluQAE5/33RUHd/bZSk2apNT06UY4xrkE2F0ZP9vrAyYtkPzrK5vVx1u+SLtYgWtIYy2MlISESQsky5YtU3syrALhGtJYCyMlIWGaBZKhQ5VatCj9KhOuIU1iYaQkTDOnmjnlze3qi4PZ1w2RZkriIbFdQZo/N/Nd3hJes489H6Sxlu52BWn+3MxNzRw1Sqn9+32sTe43aRM19eQgQGd4NdMPTBuqVVNnBAA6w6uZzQE20JDWqqkzAgCdEa+ZfmDaUBM1dUaQ0ZwGoEzNPFPztwaq3j5HcxqA9oTYlkAea6Dq7XM0NwNQpmaeqfknBqrefoCO9QagsGYNVGN9AB2b63/nrYFqrA+gY+MDUFhLDFRj/QDF3JJG8LCGvAx0ug+gmFvSCB7WkJeBTvcBdDrBwAge1pDXAJ3uBygm7DQtCmvzEl9XmO0D6Oxcv7pgfV1htg+gswkGpkVhDXkN0NkC9O8AVJq84yYvg5LjQUmmTS6nTTKxdzyxl1vPCG49ZXHE8eKILN9FsHwnC8wRLDDLFkgEWyBiYmJiYmJiYmJiYkeg8Wswe7Eif+0jvwazFyvyePwazF6swighjtaak/RvkEY+N9olXIY4WmtO0r9BGvncaJdwGeJorTlJ/wZp5HOjncHVoPpoLbQXQ654ZgMpaYEEafo4gNlHa2Hy/5VS/D8Jafo4gNlHa2GrxZCOHY1aL5AgTR8XMOnVwVc/t4GW6z6z/vqNY5zDNetVwX1yhLnJex8zluv2W4u/OMY5673Lm3KByjDNq4O7djXLdZ98klgHxTHO4VriVcF9cmnmVDPH/m6T2lyX/j/0uIY0Vk0N+8pgqplLly7N+tdEpLFqathXBpuaOXCgUmvWpF9gxjWkSdTUwjBAR3s1MxNMG6pVU0eHADraq5l+XkiANFZNHR0C6Oh4zcwE04aaqKmjwwCdE3R/3tqPnxMC6Jyg+/PWfvycEEDnBN6fT+zHzwnT3Gk0/yzA6zI+a/1ajMKAzZ1G8/0BdiGR1hr9CwM2dzOa231mNkPaxOgf6JPovbzRPKhZo3+vAEB7hX2hizX69woAtFd8NA9qidG/lwD9OwKVJu+yycug5HhQkmlTNNMmmdi7nNjLrafjW09ZHIlgcUSW7yJYvpMFZjExMTExMTExMTExMTExMTE2Xhgp1rqGVRzlAgkvjBRrXcMqjnKBhBdGirWuYRVHucp0pdbaFP+iw7krI4B5pdbaFP+iw7krI4B5pdbaFP+iw7krXcOc7AG85vmNatJftpKuSXyNBprsEOZkDyBW5z/44AOStVIPTXYIc3Ic4DHHKDVihBGOE2Anu6yZBO13i3epRuuv3jjGOQvqlY5qJkFbt25dq7964xjnLKhXOqqZBtrPf44NK3vzypxLQL3SRZ+51oOZziyoa3PpU7nPXOvBTGcW1LW59KncZ66Nw0xnCahrc+pTedChpt2Y4SUEuGY1/+IcgBZ7zTzTSwhwzWr+xTkALY4380xb17iWaP7FuQDFSE79ZdZnAHQaBnpNDkAxklN/mc2QhoFekwPQawgS+stshjQG6DUC9DACKk3ecZOXQcnloCTTJsfTJpnYRzCxl1vPCG49ZXFETExMTExMTExMTExMTExMTExMTEwsJ+MF5hFaE1kj2mCBeYTWRNaINlhgHqE1kTUiyqfveiT/K9n6F3KPCGD2SP5XsvUv5B4RwOxxyL+SE/9C7hFFzVzobdI9OW8HydqkWxjBv5EXept0VVVVJGuTbmEE/0ZeGN+ku/lmo8Qm3UKnNZWbNgG03+yAYwvqCIdAR6R6XUbSazFGOAQ6Ig5T/3Bxw3EC6giXQNFfUq1MNpxjoBMdAkV/SbUy2XCOgU50CHQiQUOtTDacM0AnCtDDGKg0ecdNXgYl19MnmTbJxP7wntiLiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJifm1y55af67WVNa5UccrLy8/V2sqK/J4qqDgXK2prHPbAmaTtYXcFCVUhtlkbSE3RQmVYTZZW8hNkULlWqnu+89tJIY6NUKgqJVq5cqVJIY6NUKgUwnkpZcaGahTBej/IqDS5GVQOowHJTExMTExMTExMTExMTGx4Pb/Ab7rit24eUF+AAAAAElFTkSuQmCC",
+    "_parsedURL": {
+      "isValid": false,
+      "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFQAAANICAYAAABZl8i8AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAABUAAADSAC4K4y8AAA4oElEQVR42u2dCZRV1ZX3q5iE4IQIiKQQCKBt0JLEIUZwCCk7pBNFiRMajZrIl9aOLZ8sY4CWdkDbT2McooaAEmNixFhpaYE2dCiLScWiQHCgoGQoGQuhGArKKl7V+c5/n33fO/V4w733nVuheXuv9V/rrnvP2Xud3zvTPee+ewsKxMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExP4OdtlT6ztAbRWvvLy8A3QkwxzH6tBGMMexIo+nCgraaf2E1U6A5g60o9a9rI7S5N1APQaSzl1MTExMTExMTExMTExMTExMTExMTExMTExMTExMTOwIsMueWl8EtVW88vLyIqit4qmCguOgtoT5AKuojWA+wCpqA5i9tP6d1UuA5g70K1oPsL4iTd4N1DMh6dzFxMTExMTExMTExMTExMTExMTExMTExMTExMTExMT+l9tlT63/stbtrC9HHa+8vPzLWrezIo+nCgq6a41hdW8LoAD5COv2NgAKkI+wbm8DoHhf0yOsnwjQ3IHeaQG9U5p87kAHa01kDZZOXkxMTExMTExMTExMTExMTExMTExMTExMTExMTEysLe2yp9afoTWWdUbU8crLy8/QGsuKPJ4qKOirdRWrb1vAfDJJZ0QM88kknREhTLwR5wmtJ1lPRPpmHK6VT/5q3g4SAx0bIVDUyidXr15NYqBjIwT6YwI5cqSRgfpjARoe6E8J4vjxRgboT6XJhwf6Dau5e/qGDEq5Qb3I+mriRTINERMTExMTExMTExMTExMTExMTExMTExMTEzss7LKn1neB2ipeeXl5F+hIBHma1mStF1g4Pi1CkKdpTdZ6gYXjyOKpgoLeWndoPcPCce8oYU63YHqaHgVUhjndgulpehRQNbgiree0XkgSzhVFAZRq5pQ3t7+w+0CMhGOvpkYAlGrmhx9++EJTUxMJx15NjQDozwngN7/5gnr/fSMcG6g/j6LPJHgAqZQi4diqqV0c95kEDyC9eDi2amoXhzCP0ppO8DZsiMejYwMU144SoP6BHk3gCgtfUHv2JIDiGOcM1KOlyQeD+giB++lPX1AHDxrh2MB8RAal4EDPjg9Exx1nlBiYzpZpUzio39R6ygKJ42/KxD43qO14CgW1k9s4MTExMTExMTExMTExMTExMTExMTGxw894C+Q2rQdZt7XBFshtWg+ybot4C6Sn1hX8xZo7+bhnFCA78NdpStMI1zo4BNmBv05Tmka41sEhyEJ+C85rWqVJeo2vFboESjBHPb2+9Om/fV66pHo/Ccc450F1CJRgLliwoLSqqqp0x44dJBzjnAfVIdAxcYDf/napevxxIxwnwI5x2cwJXMX6A6VKqVbCOQvqaY6aOYHbuXPnIfFwzoJ6mgOYeE/T6wTtN785JB6dM0Bfd/IeJ+4nqTYeEoyFawz0NgdA0U9SbUwXD9cY6G0OgN5MwK66Km08umag3uwCKAYfauLpAuIaA33QAVAMPtTE08XDNQb6oAOg9xOsV15JDxTXDND7BWh2oA8TrFmz0gPFNQP0YWny2YHeQbDuuis9UFwzQO+QQSk70KEEq0uXUlVRcShMnMM1A3SoTJv8QZ1AwI4+ulQ9+GCpWrbMCMc4Z2BOkIm9f6Bf0pqcYlLvCde+JLeewe+WhvP3PKeyJvK5wgIxMTExMTExMTExMTExMTExMbHD2y57an03rRKtG1g47hZVvPLy8m5aJVo3sHAcWTxVUNBB6wytb7Nw3CEKkD20JmjN1ypL0ny+1sMhyB5aE7Tma5UlaT5f6+EQJBaYb9V6U6ssSW/ytS+5gnkar8qXXa41fuaWsmfnf07C8eUJsE73lDyAy5cvL1uzZg0JxxZYV3tKJ2v9Lg6wd+8y9Z3vGOE4ARZpTnZRMwnmna9sLlu3o7FMKdVKOIdrFtQeOdZMgrls2bKy+vr6Q+LhHK5ZUHvkAPMYrd8TsKKiMjVrVplqaUnEwzHO4ZqBirTH5AJ0ggezoan5kMJ5wjUL6oQcgE7wYMZisbTxcM2COiEHoD8jUKecUqa2bEkbj64hjYH6s1wGoPlo0qlqZqqaenmiT+0WcgCiPjNVzUxVU60+tVsImHhxyzyCpP1ki0dpDNB5oV7owiM49ZNZg7GQlmtpSQigJV6f6Tee1aeWhAB6MQE680zf8SitgXpxGKCYFtHg4zcg0jLQ60MAxbSIBh+/8ZCWgV4fAugYgnPbbf6BIq0BOqatgd7QxkBvCAH0RoLzz//sHyjSGqA3SpM/FOhIgnPJJf6BIq0BOlIGpUOB9iI4HTqUqU8/zQ4TaZDWAO0l06bUUB8hQCNGlKmDB9PDxDWkMTDDv2UsDyb2p2jNIVC4M0o1F8U5XDMwkfYUufXMDPU8rf8mYF27lqlrry1TjzxihGOcMzCR5jxZHPEHFd9EfjrFwoinpyP5RnLS8t31bbx8d30bLN+dpvVDrbu1/i8fR/Z0oZiYmJiYmJiYmJiYmJhYVKbv1wu1LuD31s/Sepc1i8/hmrN/m+n79UKtC/i99bO03mXN4nO45vTfbfqefYDWWK3nrb8kPs/nBriEOVDrZa3KLEKagQ5gDtR6Wasyi5BmoAOQPbT+n1ZlFiFNj1xhnqf1DoBd/dyGyt+W76z84LOGys/3xUg4xjlcY6hIe14OMM/TegfAFi1aVFldXV1ZV1dX+cUXX5BwjHO4xlCR9rwcYA7W+h8CVlhYqS6/vFJNn16ptH8SjnEO1wxUpB2cS80kmL94fWvlrvpYpVIqpXANaSyoA0PWTIK5YsWKysbGxrTxcA1pLKgDQ8A8SWs+gTrttEql/aWLR9eQxkBFnpPC9JkvezAPxlrSB2MhjQX15SB9KveZL3swW1qyx0MaC+rLQftUDeVZAjRkSKXavTtrPEqDtAbqs0GBXuA180w1M1VNtZr/BQGAXuA180w1M1VNtZr/BQFgnkVgOnasVFVVvuNRWuQxUM8KAhQjN/WPvoOxkIeBTg4AFCM39Y9B4yEPA50cAOjPCcottwSOR3kM0J8HAYrpEA06QQMiDwOdFQAopkM06ASNhzwMdFYAoKUEZc6c4ECRxwAtDQIUc0wayYMGRB4G+m4AoJhj0kgeNB7yMNB3AwBdTFA2bAgOFHkM0MUCNAH0PYKydWtwoMhjgL4nTT4BdDZBwVwzKFDkMUBny6CUAPofBGXChOBAkccA/Q+ZNiWAlhCU7t0rVZBWgbTIY4CWBAF6RE/sNYz2Wv9JYK6+ulL5iEdpkNbARN72cuvZGurXtCoI0JgxlerAgfQwcQ1pDEzk+ZosjqSG+k9xqH36VKonnqhUn35qaiOEY5zDtQTMf5Llu8xQz9ea22qpDreXiVtMT0hzviww+4N6FL+4Gq9ne9+C+D6fu8rpx6bzyfgdeN1Z8s47MTExMTExMbHDxPQE/li+e4KOjTqensAfy3dP0LFtUUY9/+wCRQmxn/c3Ra2qJJXxtX4OIfbz/qaoVZWkMr7WzyHAY7V+xK/AWKZVxVrG53DtWBcgO2tN0vrEhjjmNxtJSWA/4bSdcwDZWWuS1ic2xMWLF5OSwH7CaTvnALKd1i1ayy2I6bSc07YLC/MErb94wO77z21VS6r3VzU0NVcppUg4xjlcs8AizwkhYJ6g9RcP2MqVK6t27NhRFYvF4vFwjHO4ZoFFnhNCNuupcWCnn16lHn+8Sq1aVaX27DHCMc7hWgLs1MDdAddMgnnDb2uqlm04EC9UOiEN0lpQOwesmQRzyZIlVTt37swaD2mQ1oLaOQBMLDBPJ0BdulSp556rUtYPd4hwDWmQ1kCdHmiBmZsuAdqyuylr4TwhrQV1UgCgkzyYBw4c8B0PaS2okwIAvT0OU+f3G4/SJqDeHmQAoj7TT81MVVOtPrWfzwGI+kw/NTNVTbX61H4+YOLFA6sIyu9/Hzge5TFAV/l6EQGP2NQvBg7GsvrUCT6ATvD6zLDxrD51gg+gdxGQ886rUi0tweMhD/IaqHf5AUpTIww2YQuIvN6UygdQmhphsAkbD3m9KZUPoHND185Da+lcP5N2gmGP5kGFvNaof2yWSTvBiGUaFLIIea1R/9gMMLvGR+sQ3UtcyJsY9btmAjrQm2eGDsay5qkDMwAd6M0zc41nzVMHZgA6gCAcc0zO8ciHATogn4EOIgg9euQOFD4M0EH53ORPiDfVhobwMJE30eRPyPdBaTGBmDs3PFDkNTAXy7SpoOAhgnHtteGBIq8B+pBM7AsKvhpvrkuXBoeJPInm/lW59TRQf0lA+vevUrW1/mEiLfIYmL+UxZEE0OP4/0ZVatAgs6qUDSbSIK2BibzHyfJda6in8EuuqlT79lVq7NgqtWzZoSBxDteQxsAsC/26tjxYYO7Of5BN9Ivdu1epoUONcNx6kRlpu8sWSHaweALvufgqVGut4mvnF0RhR/ImHT+Fd7rWRazT5ak7MTExMbH8Mf7W/ImsDlHH42/Nn8jqcKRAHKQ1UWue1nqtGtZ6PodrgxxCHKQ1UWue1nqtGtZ6PodrzuLpqVE3ftzmRa13tNay3uFzuNbNBcieWs9aAElXPLOBlHye0/bMAWRPrWctgKQFCxaQks9z2p45gMSHqe7VWqNVk0VrOO2XwsI8R2s5QF2uNeXN7TVvr66v2bU/VqPvcUk4xjlcuzwBFXnOCQHzHK3lHqwPP/ywZvv27TWNjY3xeDjGOVyzoCLPOSFgfoXvyw2ws86qUQ8+WKPeeadGbd5shGOcw7UE2LLAL7hmmGsA6M4/bq5ZV5soVDohDdIy1DVBoDLMNQBUUVFRs2/fvqzxkAZpGeqaIFA1kIFaKwhQnz416o03ssajNEhroCLvwCDNnGrmv7+xreaLgy3Zg7GQFnmsmtrTZzOnmrlq1aqa5uZm3/GQFnmsmtrTB0x85WsRgTn77Bqla7zfeJQWeQzURb6+/uX1mahtQWDaUK2a+qwPoM96NTMITBuqVVOf9QH0IQLSr1+Nqq0NHI/yIK+B+pCf0Zz6Qz/NPFPzt/rUQVlGc4Lhp5lnav5WnzooA8w+WusJxvz5oeNRXgMUvvpkAorpDw0yoYOx4IOBTswAdKI3AOUazxqoJmYAOo5AjBiRczzyYaCOywQUc0oauXMNCB8MdF4GoJhT0sidazz4YKDzMgB9kyBMnZo7UPgwQN/MdAdEk3Z7ahRW8GFN/jukuQOiSbs9NQor+LAm/x1SwMRDtusIwoYNuQOFDwN0XcqHb/lWkibsOQdjWZP/E1MAPdGbtLuKZ03+T0yz3VGj2rd3Fo98Gajd8xFoTyr8UUe5AwpfBmjPfGzynbQ2EoCdO3OHCR8GJnx2ytdBqZwglJbmDhQ+DNDyfJ42TSEIN9yQO1D4MECn5PPE/iyC0LFjjfr00/AwkRc+DNCz8v3W848E4pJLalQsxFiBPMhrYP5RFkfMY+GrCcgttwSDirTIY2Cu9v069jxYvsNXZzcQmO98x6x9ZoOJNEhrYG4I/PXZPFhg/ife5qhRXbvWqH/91xq1aFGNslsIjnEO15DGwFwb+u1iebAFcqrWG622Orp0qVGDBhnhuPU2CNKeKpt0maHixVeX8JN1H6fYS/qYr10SyYuxjuRtZP7/fJHWUFZR6P/Hi4mJiYlF9ihOJ63vak3xPo1ufQJ9Cl/r5HAg6qT1Xa0p9qfR+XgKX+vksox68DlD66daT2q9xHqSz53hCiT+tDCen6WvzaIqTpvrnxbG87P0tVlUxWlz+dMCpkzXaC3Qqs2iBZy2MCzMYq2lHrBbXvis9rflO2vLq+prV21qIOEY53DNAos8xSFgFmst9YC9++67tdXV1bX6zqi2rq6OhGOcwzULLPIUh4D5Zd60M8C6dKlVl19eqx56qFa9+KIRjnEO1xJgkefLQWF+iyfutTdrWADX0qJq9e1YSuEa0tycAIu83woA81s8cSdYAJculiekscAi77cCwCzmxY1adfTRtWrKlFq1Z0/6eLiGNEhroCJvcZCaSTAnv7Gtdt8XzVkL5wlpkceCWuyzZhLMVatW1R48eNB3PKRFHgtqsQ+Y/eIwhw6tVevW+Y5HaZEnAbWfnz5zqQfzYKzFfzCvkDqPBXVppj6V+8ylHsyWluDxkMeCujRTn6oBdNCaR0C+/vVatXt34HiUB3kNVPjqkAnoeK+ZB6mZqWqq1fzHZwA63mvmQWpmqppqNf/xGYD+mEB061arPvssdDzKCx8G6o8zTY1oNEd/GDoYCz6s0b9TmqkRjeZ++kw/fao1+ndK86DDCoLw61/nHI98GKAr0j3o8F1vNM80APlvisoe/b+bAuh3vdqZc+FYVi39bgqglxCAE0+sVY2NuceDD/gyUC9JBRQTdJoGuSogfDHQKSmAYoJO0yBX8eCLgU5JAXQyFf6225zFI18G6ORUQEtdNfcUzb40BdBSV809RbMvTQF0JhV+xgx3QOHLAJ2ZCihuJWnC7iogfDHQshRAcStJE3ZX8eCLgZalAFpGhZ8/3x1Q+DJAy/IXaFmZO6DwlQHokd7kZ1HhX3vNHVD4MkBn5eOg9BgV/p573AGFLwP0sXycNo2mwp96qjug8GWAjs7Hif3R/IBCrZo7N3eY8GFgwufR+Xrr+QBB+Id/qFUNOQy+yAsfBugD+bw4cjzvs9eqm26qVSHiUR7kNTDh6/h8X767WGsbAbn11mC3oUiLPAYmfFwsC8wG6nVxqFjfXLIkO0ykSayFIu91sgXSGuql/JdtA+mCC2rVE0/UqsWLa9X69UY4xjlcS2yBIM+lskmXGmoPrae0NvvYpNvMaXvINnJ2sHi3/f/hD6ngY6jVrAo+9398vbNeTExMLH0/is/5Dtb6vtaNrO/zOecPovLnfAdrfV/rRtb3+VwkX4TlDwcU81z1Yj7u6hrkAK1H+Y8IdWm0htMMcABygNaj/EeEujRaw2kGOICIt93eofU3rZ1adUnaydfuCPxW2ySQXbUe0/rcA3f1cxvq7nltS93Ds7eTcIxzFtjPOU/XECC7aj2m9bkHbtGiRXXLly+v++ijj0g4xjkL7Oecp2sIkNgF/Rn/VzMBsE+fOvW1rxnhuDXcjZynfZhaudQD9cCs7XWVGw/UxZpb6vRdQyvhHK4hjQV2aZDayrVyqQdK307W7dq1q07fpx8SD+dwDWkssEuD1FYN5ESt2XFQZ5xRp55/vk5t3XpIPDqHa0iTAIu8JwaBWQ0wN79QU7eipuHQIGmEtMjDUKv9QGWY1QCj74DqYH7jwZCHoVb7gcowKwjM0UfXqWnT6lSKH+4QIQ3SIo+BWpEVKjdzqpn/8ofNdXX7Y74LFy+kzoO8Vk3tmqWZU82sqKioa2xsDBwPeZDXqqldM8DsyI/PmOb8ySeB41GeRFcAXx0zAX3Mq5lhYNpQrZr6WAagj3k1MwxMG6pVUx/LAPReAnH88XWqqip0PMoLHwbqvZmaOg1AQZp5puZvDVQD0jR1GoCCNPNMzd8aqAakub3cRhBeeSXneOTDAN2W8raUpz00uOQcjGUNVI+mAPqoNwC5imcNVI+mAPpvBGDYMGfxyJeB+m+pJu00z8SI7SogfFnz1MKkSTvNMzFiu4oHX9Y8tTAJ6Coq/J//7A4ofBmgq5KBDvbmmammRmEFX9Y8dbAFdLA3z2xpcRcPvqx56uCkh2zr1FFH1amGBndA4Qs+DdR+NlDcQtJE3VkwFnwy0O9bQHELSRN11/Hgk4F+3wI6kgp9zjnO45FPA3SkDRT35XT34zogfDLQGy2guC+nux/X8eCTgd5oAb2BCj1qlHug8GmA3pBPQH9Ehf7BD9wDhU8D9Ef51OSvoEJfdJF7oPBpgF6RT4PSECp0t251qrnZHUz4gk8DdEjeTJt4ZcmsKmngzoDCV2IVqn2+Tex/TYW//np3QOHLAP11Pt56nkmFb9euTi1bljtM+IAvA/TMfF0cmU4ATj+9Tu3bFx4m8sKHgTk9n5fvevBfCuvUJZfUqf37g8NEHuQ1MFdnffAhDxaYv661lYCceWad+vhj/zCRFnkMTPj4umyBGKjn8Aut6lTHjnXqjjvq1OrV6UHiGtIgrYGJvOcE3Vc60jfpTuL/LiX2ik491Yzc48YZ4RjnWm/UIc9Jso2cHuwwrT9p7UixhexpB6cZJg86+Ad7rNa3tW7Xmsi6nc9F/nVIMbHD67mm7lo3aT2vNV/rA9Z8Podr3R029+5aN2k9rzVf6wPWfD6Ha90dNveO/CzTL7Rm8L/uZvHxL/haR1fPNU3T2q1Vn0W7Oe2AHEBiQJqmtVurPot2c9oBOYDEp9Mm8X+N6rNoA6ftFgYkBqBxWjs9YOP+tKX+j+/W1b/z6f761Vu/IOEY53DNAruT8xYGAIkBaJzWTg9YZWVl/YYNG+o///zz+j179pBwjHO4ZoHdyXkLA8Ic3Qpkr1716qab6tUTT9SrV14xwjHO4VprsKODwMTj3y95gP7tL9vqq2sb6/UEN6OQBmktsC/5eUycH/9+yQO0cuXK+n379mWNhzRIa4F9yc9j4vzyqwfjgE4/vV69/nq9isXSx8M1pEHaBNgHs74Ui2smwbzimQ31c1ftzVqwZCEP8lpQC7PUTIK5YMGC+i1btgSOhzzIa0EtzAL0kTiUe+6pV01N/uMhLfIkoD6SDeg4D2bF+gOBC+cJeS2o4zIAHefB3LlzZ+h4yGtBHZcB5vVxGFOnho5HeRNQr880AFGfGaZmpqqpVp+abj2U+swwNTNVTbX61HSP4mwlCPfdl3M88mGAbk33KM40r8/MORjL6lOnpQA6zeszXcWz+tRpKYD+kgCcfXbm/tKv4AO+DNRfpppn0tTIzwDkV/BlTam6J80zaWrkZwDyK/iyplTdLZhH8/14vZo/31k88mWA7mj1F2+emNP0x1kwljWluskCepM3NXIdz5pS3WQBvZoKftppzuORTwP1ahso7nZoTuk6IHwy0OctoLjboTml63jwyUCft4A+FR/VXQNNjPpP2UBxC0kTddcB4ZOBzreA4haSJuqu48EnA51vAZ1HhX7tNfdA4dMAnWcDxX053f24DgifDPQDCyjuy+nux3U8+GSgH1hAl1OhFy92DxQ+DdDl+QR0FRX6vffcA4VPA3RVPjX5cir0f/2Xe6DwaYCW59Og9AIV+uGH3QOFTwP0hXyaNo2lQl94oXug8GmAjs2niT0+Mr1PFRbWqzVr3MGEL/iE7+SPTufBredMqknXXusOKHyZ2jkzHxdH8MXEvQSgtDR3mPBhYO5N++XEPFi+e5ggHHtsvaqoCA8TeeHDAH04bxeY+XO+/x2HOmdOcJjIk4D532k/45tHWyB4oOGv8QXin/ykXvn5IZEGaRMLy3/1/QDEkb5Jp0F01vpVHE6nTvXqBz+oVy++WK+WL69XW7ca4RjncA1pEjCRN/j7ovJgG/mb8YUTf0Lab8qDDtnBnsF77nO1PrUeEvuUz01y9k0lsegexzmJXzB4YZJw7iTX8XQNPIlfMHhhknDOeTz+BCXeL3pKko539ilKDep8ralaG7Uasmgjpz0/B4jna03V2qjVkEUbOe35OUDsqzWBv+aFJt6QRnWcBmn7hgHZX2uWDUzPLRtueeGzhjv/uLmVcA7XkuAib/8AIPtrzbKB6bllw7vvvttQUVHRSjiHa0lwkbd/AJCodU/zQNMa3nHHtdahcOs57/F+YV6qtd2D+PT/7GhYtamh4WCspUHPx1IK15AGaS248HGpD5iXam33IFZVVTXs3r27oaUlfTxcQxqkteDCx6U+YBbzM/IG0IgRDWrGjAa1bl2Dam4+NB7O4RrSIG0C7NqsX/1imHsB5J7XtjRs2d2UtlDphDzIy1D3ZoLKMPcCyPLlyxsOHDgQOB7yIC9D3ZsJKn+edzsBGTiwQek8QeNRHuQ1UOFraKZmTjXz0bm1GWtkNiEvfFg1tX+aZk418+OPP85YI7MJeeHDqqn9U8DEf5TWE4iLLmpQuoaHjUd54cNAXZ/yv0pen4nalQtMG6pVU2elADrLq5m5wLShWjV1VgqgMwjA6afnBtOGCl8G6oxUozn1f2Gaeabmb/Wp5yeN5tT/hWnmmZq/1aeeb8EcQgUvLGxQemBzFY98waeB2urv3Zju0KDiLBgLPhnoVAsopjs0qLiOB58MdKoF9FdU6Kuuch6PfBqgv7KB0jwTI7XrgPDpzVMtoDTP3O2i6SUJPr15qgW0igo9Z457oPBpgFbZd0DUNF30nan6UqvZn8R3QNQ0XfSdqfpSq9nj33InUIHbtWtQ+/e7Bwqf8G2gnuC9r54m6M6DseCbgRbzrSNN0KOKB98MtJj/J9+g+vSJLB75NkDPLOD7cbrriSogfDNQ736c7nqiigffDPRCXcjhVNgzzogOKHwboMPzAeiFVNji4uiAwrcBeqEAFaCHP9AjfVAaSoXt3z86oPBtgA7Nh2lTERW2U6cGFYu5hwmf8G2AFh3xE3v+59xWKvB777kHCp8G5tb4P+vy4NbzD1Tou+5yDxQ+DdA/5NPiyD9Sobt2bVBbt7qDCV/waYD+Y94s33GzX0gFv/zyBuWi74YP+DIwFx7yR9o8WGDGiL8n3vRzgYq8iaa+J+1WSB5sgfwwvid09dUNaufO4DCRB3kTe0s/zPdNuh/xE8cNqnv3BvXAAw1qw4bsIJEGaZHHgNzX6q22eb6NfK7Wslbbw337Nqjhw02/aAvncK31VjLynisPOrSG2kHrWq23Uu7Pp96Pf4vzdJBHcTLDxb+Vz9O6jPtZW5fxtaNzBdhXawx/q3OST43nPH1DAOyrNYa/1TnJp8Zznr4hIHbRukDrKq0bfeoqztMlCMhhWm9rNeUo+BjmA+Qwrbe1mnIUfAzzAXKA1u94utMUUnvYx4BsTy0/5AHRA03Tz/+8temZv33e9Nvynb6EtMiDvBbYh1I9zcxPLT/kAdEDTdOKFSua1qxZ01RdXe1LSIs8yGuBfSjd08wawG3cFxowRUVNqqSkSQ8+/oS0yJMAC1+3pQMahwkwu/bHmvR0IZSQFz5sqCmAxmECTGNjY+h4yAsfNtQUMG+Pg7j00iZVURE6HuWFjwTY21M1cyr8nJV7wwdKEnxZUIclNXMq/ObNm53Fgy8L6rCkJ5QPUOHvuadJ3+nkHg8+4MsAPdDqCWevz0StclU4T1ZNfdsC+rZXM13Hs2rq2xbQN6jgo0a5gWlDhU8D9Q17NKd+L5dmnqn5W31qXx7Nqd/LpZlnav5Wn9qXXy/UqAoLm5Tud13HI5/wjRh43RBPc2gwcR6MBd8MdAxPc2gwiSoefDPQMTzVaVLnnhtZPPJtaulVBTx3jKS5p2j243nuGElzT9Hsx+tCjqPC3nxzdEDh2wAdV8ATcpr2RBUQvhmoNyGnaU9U8eCbgU7iv8Q0qTvvjA4ofBugkwSoABWgAlSAClABKkAFqAAVoEcI0CP91vMeKuzYsdEBhW8D9J58WBy5kQqL1faogMK3AXpjPizfnUaF7dy5Se3e7R4mfMK3AXpaviwwL6cC33uve6DwaWAuz6ctkO9Rodu1a1KzZrmDCV/waYB+L9826V6kgrdv36QeeqhJHTgQHiTywgd8GZgv5t02Mr+m7Q/xncoePZrUD39owDzxhD8hLfIgb2LH8w8ZX9eWBw86jOH3MTXlKPgYI4/iFMS/5n0hf83rGf7Erx89w3kuPORr3RmeHinRelxrplZpSM1kHyU+3s5YovW41kyt0pCayT5KfHz+51Stn2k9yt8HCaNH2cepmWAO0npPK+ZY8DkoBcxBWu9pxRwLPgelAHkiv+U25ljweWIqmNsA4NrnN8Z+8/bO2Fsf7o39z8f7Qgl54QO+GOo2GyrD3AYAixYtiq1duza2ZcuW2LZt20IJeeEDvhjqNhsq781XEYD27WPqe9+LqV/8Iqbuuy+ckBc+4MtArYp/AoibOdXMcX/aEtNTnpieGjgRfMGnVVMLuZlTzaysrIzpKY+zePAFn1ZNLWSgc6ngAwbE1MqVzuKRL/g0UOd6QEu8mukSpg3Vqqkl3M9RbXIJ04Zq1dQSXdBvUIGPOiqmqqqcxyOf8G2gfqOABw9qos6DseCbgT7Ogwc10ajiwTcDfZzfuxxTN98cWTzybYA+XMAjMvV7UQWEbwY6k0dk6veiigffDHQmfyQ6pp5/Pjqg8G2A/qmApzk0mEQVEL4ZqDfNocEkqnjwzUBLdSFLqbAvvhgdUPg2QEsFqAAVoAJUgApQASpABagAFaACVIAKUAEqQPMe6JG+fPdnKuy0adEBhW8D9M/5sMD8NBV2/PjogMK3Afp0PmyBjKLC9uoVU3sjaIXwCd8G6KgjfpOO337zCRV45MiY2r/fHUz4gk8D85P423LyYBv5HH5xVUz16xdTjz0WU3/9a0yVlYUT8sIHfBmY8H1Ovj3ocL7WhggedIDP8/PyURx+tdBPtF7XWqpVGVJL2cdP0r5ySBf8eK17+am5NVrrctQa9gWfx6eAebzWvfzU3BqtdTlqDfuCz+PTvEnsOn49ED4nOT9HzWNf1x3ypjFd4KFam7SaIxJ8D7VgDtXapNUckeB7qAWzn9YKreaIBN/97JpJMP/595ua//bxvuY1275oXlfbmJPgA77g04J6PNdMgvn+++8360Glee/evc379u3LSfABX/BpQT2em/lHVPAePZrV5MnNaubMZvWXv+Qm+IAv+DRQP6Lmz02SCr6/sblZTwecCj4tqPdyk6SCHzx40Hk8+LSg3qsLeQcVuE+fZvXZZ87jkU/4NlDv8P4BQrXJeTAWfDPQt7mfo9oUVTz4ZqBvc1/XrH7968jikW8DdF4BDx7URKMKCN8MdA0PHtREo4oH3wx0jS7kairsu+9GBxS+DdDVBTwiU78XVUD4ZqDeiEz9XlTx4JuBrtOFXEeFXb48OqDwbYCuE6ACVIAKUAEqQAWoABWgAlSAClABKkAFqAAVoAJUgB7WQI/0BeZqKmxFRXRA4dsArc6HLZBFVNhXX40OKHwboIvyYZNuChX2vPOaVWME3Rp8wrcBOiUftpF7a9VRgS+6qFm9/Xazqq1tVnV1uQk+4As+DUzE6J0vDzqU8EelonrQAb5L8u1RnK9o/YYf7mpyALGJfcHnV5JhdtC6S2uZ1i6tOkfaxT7hu4MFs4PWXVrLtHZp1TnSLvYJ3x2SgF7BD3hV8tsaXaiSfV6RDHO2VkvEQowODHO2VkvEQowO/F1k1KKWiPUb+j4y156Wq57d0PLXD/e2bN19sGX7HjeCL/iEb4Z6F9eeloULF7Zs3bq1paGhwangE74Z6l26kDdRgdu3b1ETJrSov/2tRZWVuRF8wSd8G6g3FXCTpILraUAkgm8GuoybJBU8qnjwzUDxhdglVNhHHoksHvk2QJcUcD9HtSmyAmrfDHQX93NUm6KKB98MdJcu5OdU2LVrowMK3wbo5wU8eFATjSogfDNQb/BoK6B1PD9sUevXRwcUvg3QOgEqQAWoABWgAlSAClABKkAFqAAVoAJUgApQASpABagAFaACNDTQI30LpM2BHumbdB9SYWfOjA4ofBugH+bDNvJ9VNgePVrUvHktqrnZHUj4gk/4NkDvy4cHHbpqVbTBgw6I0TUvHsXRBT1G61daOyMAuZN9H2M/jtOfX161V0s51l723d8C2p9fXrVXSznWXvbd3wLajb8jt5If8HKpley7mw1zRwQgk4UY/RnmjghAJgsx+uuC9tBaq6UiFmL08F7Iqu56ZbNau/0LVf9Fs1PBJ3wzVO+FrGrZsmVq79696uDBg04Fn/DNUPFC1mlU4P79lXrtNaWWL3cr+IRvA3VagdfMUfCoDL695u81cxQ8KoNvr/nzozhKlZVFFo98G6D0KA4Vtp7+BBKNwbcXx2uSqE1RGXx7ceJNcteu6IDCN8fJH6B1ddEBhW8BKkAFqAAVoAJUgApQASpABagAFaACVIAKUAEqQAWoABWgAlSAHmZAj/RNugNU2I8+ig4ofBugB/JhG3kuFfbSS5WqrXUPEz7h2wCdmw8POpwVr6XQcce5VeJBB8Q4K18exTmXvyMX1VMj8H2u/WzTWVpvaTVFALSJfZ9lAT1L6y2tpgiANrHvsyygRfwaoDURPNu0hn0X2TAPtEGTR4yzGOaBNmjyiIHmjma/vQ2ebUKM/gVce9QvXt+qPtvV5LzPhk/4Zqhvce1RK1asUPv373ceDz7hm6G+xR+bVmrIEKXmzlVq/Xq3gk/4NlDpY9PUzKOAaUP1mr/XzKOAaUP1mn98QKqoiG7aBN/WtIkKG6Xh+enkiX3UdsjEvjm6GxeFz0kn3ylFbX93oFGbABWgAlSAClABKkAFqAAVoAJUgApQASpABagAFaACVIAKUAEqQA8zoEf6Jl2MCrtxY3Qw4dsAjR2yjdwSAcy/8zbyEirsVVcptW+fe5jwCd8G6JJ8eNDhEv7kmVLt2yvVt69Sp5ziTvBpYCLGJfnyKM5IraoInxqB75HJ36Ur0XqVX1y1wpGWsc+SFB/5K9F6lV9ctcKRlrHPkhQf+cOXE1/VwvvwVjjSMvZ5yBcT72+DJn+/BfP+Nmjy91sw72+DZ5vut2smFXpq+U61ouaAWrWpwYngCz4tqCVcM6nQ1dXVateuXaqurs6J4As+LaglXDNNof/lX5SaN8+8FsiF4As+E1BLCrhJUsGjMgvqq9wkqeBRmQX1VW6SpuBRWQLqq977Q6k2RWXwzUC994dSbYrK4JuBLuN+ztSmqAy+DdBlBTx4UBONyuCbgXqDBzXRqAy+Gag3eLTVm8VWCFABKkAFqAAVoAJUgApQASpABagAFaACVIAKUAEqQAWoABWgoYHKFkiulrQFIpt0uVrSJp1sI7vcRpYHHRw/6CCP4kTwKE4S2HZag7WGa10cUsPZR7uCLKYL305rsNZwrYtDajj7yBpPF76d1mCt4VoXh9Rw9tEuE8j2WuO0tjhs5lvYZ/sUINtrjdPa4rCZb2Gf7VOAbK81TmuLw2a+hX22TwWz1ANx7fMb1R0vb1J3/nFzKCEvfFhgS22oDLPUA7Fo0SL1/vvvq4qKilBCXviwwJbaUBlmaRzEsccq9dWvKlVcHE7ICx8JsKWtoHItUj94doP660f7VKw59+eY4QO+4JOhjrOAohaphQsXqq1bt6qWltzjwQd8wSdDHWcBHUcF79JFqWnT8ILR3KdK8AFf8GmgjrP7TGrmAODa4NNq/u24z6RmDgCuDT6t5t+O+0zTzAHAtcFnovm3K+DBg5qoi5qZqqZazX8wDx7URF3UzFQ11Wr+g3nwME00irfqwmei+Q8u4BGZ+r2oDL4Z6HAekanfi8rgm4EO5xHZ9HtRGXwboMMLeJpDg0lUBt8M1Jvm0GASlcE3A/WmOWYwicrg2wC9WIAKUAEqQAWoABWgAlSAClABKkAFqAAVoAI074HK8p3j5TtZYM7FUiwwyxZILpa8BSKbdDnUzFSbdLKNXOx+G1kedHD8oIM8ihPBozhiEZuuXYVaQ7RGao3yqZGcpzBoPF27CrWGaI3UGuVTIzlP4Hi6dhVqDeG3jo3yqZGcpzAIyM5ad2ttyqHv3MQ+OvsA2Vnrbq1NOfSdm9hHZx8gO2vdrbUph75zE/vonA1mT62l9mh/98wt9HZFP0LapNEdvnpmgNlTa6k92ldWVtLbFf0IaZNGd/jqmQFmz1bf98RIfd55Sl10kT8hbevRHb56ZqqZBHPM1I1q/ifh5qPIg7zwYUHtnKZmEszFixerbdu2hZqPIg/ywocFtXOammlgnnCCUi+9pFRTiHemIg/ywkcCaudUQO/2YG7ZnfvLWeHDgnp3CqB3ezAPHMj9HyjwYUG9OwXQu+Mw167NfWIPHwmod6cagKjPRO1yZfBl9amFSQMQ9ZmoXa4Mvqw+tTBpADJ9JmqXK4OvRJ9aaAMdEsUCSdLCyBAL6JAoFkiSFkaGWECHxPvMJoevRoavRJ86xAaK6Q4NKq4NPhnoSAsopjs0qLg2+GSgI5NeyGoGFdcGnwboSBvoKO89zK7Nev/yKAvoKO89zK7Nev/yKAvoKCo0RmrXBp8G6CgBKkAFqAAVoAJUgApQASpABegRBlRuPR3fesriiOPFEVm+c7l8JwvMjheYZQskYDP3swUim3QXud2kk23kCLaR5UGHCB50EBMTE0s8P1qk1S9JRame/8zV+PnRIq1+SSpK9fxnrsbPjxZp9UtSUcbnPwNC7KR1q1aZVmOGUb2R0yBtpxwgdtK6VatMqzHDqN7IaZC2Uw4QO2ndqlWm1ZhhVG/kNEjbKSzMYVrVNrhRT5u5qS2cS4KLPMNCwBymVW2DW7BgAU3YbeFcElzkGRYC5jCt6lbg8BXZ445rrcSXZT0hz7CgMK/zvkJ7w29r1Gvv71ab8N3kllR3KoquIQ3SWl+bvS4AzOu8r9AuWbJE1dTUZLwdxTWkQVrra7PXBYB5nVYTATrxRKWmTFFq9WqlmpsPDYZzuIY0SGugIu91QWomwXzoze1qf2Oz77sypEUeC+ownzWTYH744YcqFov5v83VaZHHgjrMZ800MC+/XKk9e/zfdiIt8iSgDvPTZ1Z7MMMsrCGPBbU6U5/KfWa1BzOsWVCrM/Wp3GdWx2GGWTpEngTU6ox9Kg8q1HSD1MxUNdVq/rdmAHqr18yD1MxUNdVq/rdmAHprvJkHqZmpamqi+d+aCShGauoPczX4YKBlGYBipKb+MFeDDwZalgFoGUFAf5irwYcBWpZpnklTIwwyuRp8WFOqdP9ToqmRq/VQa0qV7n9KZmqEQSZXg4/ElKp9KqBF3tTIxa4EfFhTqqIUQIu8qZErs6ZURSmAFsWnRs3NuQeDj8SUqigV0H7eGqgrs9ZG+6UA2s9bXHZl1iJzvxRA+1HhMbd0ZfBlgPYToAJUgOY9UBmUHA9KMm1yOW2Sib3jib3cekZz6+lkceTB/zrCF0cuu8zf4kjy8h3ABF2+s2Ae/st3ABN0+S4Bs8n3QrMsMDtcYJYtkAi2QGSTLoJNOtlGjmAbWUxMTExMTCwfTE+NemuN1ZquNZs1nc/1jmDa1FtrrNZ0rdms6XzOeTw9NeqtNVZrutZs1nQ+19slyJO1ZmjFMkzsY5zmZAcgT9aaoRXLMLGPcZqTHYA8WWuGVizDxD7GaU7OFSY+77vLAzfuT1vUH96pU/M+2kfCMc5ZYHel+mxvAJj4vO8uDxz+5bF+/Xp6cy2EY+uvh4rTluQAE5/33RUHd/bZSk2apNT06UY4xrkE2F0ZP9vrAyYtkPzrK5vVx1u+SLtYgWtIYy2MlISESQsky5YtU3syrALhGtJYCyMlIWGaBZKhQ5VatCj9KhOuIU1iYaQkTDOnmjnlze3qi4PZ1w2RZkriIbFdQZo/N/Nd3hJes489H6Sxlu52BWn+3MxNzRw1Sqn9+32sTe43aRM19eQgQGd4NdMPTBuqVVNnBAA6w6uZzQE20JDWqqkzAgCdEa+ZfmDaUBM1dUaQ0ZwGoEzNPFPztwaq3j5HcxqA9oTYlkAea6Dq7XM0NwNQpmaeqfknBqrefoCO9QagsGYNVGN9AB2b63/nrYFqrA+gY+MDUFhLDFRj/QDF3JJG8LCGvAx0ug+gmFvSCB7WkJeBTvcBdDrBwAge1pDXAJ3uBygm7DQtCmvzEl9XmO0D6Oxcv7pgfV1htg+gswkGpkVhDXkN0NkC9O8AVJq84yYvg5LjQUmmTS6nTTKxdzyxl1vPCG49ZXHE8eKILN9FsHwnC8wRLDDLFkgEWyBiYmJiYmJiYmJiYkeg8Wswe7Eif+0jvwazFyvyePwazF6swighjtaak/RvkEY+N9olXIY4WmtO0r9BGvncaJdwGeJorTlJ/wZp5HOjncHVoPpoLbQXQ654ZgMpaYEEafo4gNlHa2Hy/5VS/D8Jafo4gNlHa2GrxZCOHY1aL5AgTR8XMOnVwVc/t4GW6z6z/vqNY5zDNetVwX1yhLnJex8zluv2W4u/OMY5673Lm3KByjDNq4O7djXLdZ98klgHxTHO4VriVcF9cmnmVDPH/m6T2lyX/j/0uIY0Vk0N+8pgqplLly7N+tdEpLFqathXBpuaOXCgUmvWpF9gxjWkSdTUwjBAR3s1MxNMG6pVU0eHADraq5l+XkiANFZNHR0C6Oh4zcwE04aaqKmjwwCdE3R/3tqPnxMC6Jyg+/PWfvycEEDnBN6fT+zHzwnT3Gk0/yzA6zI+a/1ajMKAzZ1G8/0BdiGR1hr9CwM2dzOa231mNkPaxOgf6JPovbzRPKhZo3+vAEB7hX2hizX69woAtFd8NA9qidG/lwD9OwKVJu+yycug5HhQkmlTNNMmmdi7nNjLrafjW09ZHIlgcUSW7yJYvpMFZjExMTExMTExMTExMTExMTE2Xhgp1rqGVRzlAgkvjBRrXcMqjnKBhBdGirWuYRVHucp0pdbaFP+iw7krI4B5pdbaFP+iw7krI4B5pdbaFP+iw7krXcOc7AG85vmNatJftpKuSXyNBprsEOZkDyBW5z/44AOStVIPTXYIc3Ic4DHHKDVihBGOE2Anu6yZBO13i3epRuuv3jjGOQvqlY5qJkFbt25dq7964xjnLKhXOqqZBtrPf44NK3vzypxLQL3SRZ+51oOZziyoa3PpU7nPXOvBTGcW1LW59KncZ66Nw0xnCahrc+pTedChpt2Y4SUEuGY1/+IcgBZ7zTzTSwhwzWr+xTkALY4380xb17iWaP7FuQDFSE79ZdZnAHQaBnpNDkAxklN/mc2QhoFekwPQawgS+stshjQG6DUC9DACKk3ecZOXQcnloCTTJsfTJpnYRzCxl1vPCG49ZXFETExMTExMTExMTExMTExMTExMTEwsJ+MF5hFaE1kj2mCBeYTWRNaINlhgHqE1kTUiyqfveiT/K9n6F3KPCGD2SP5XsvUv5B4RwOxxyL+SE/9C7hFFzVzobdI9OW8HydqkWxjBv5EXept0VVVVJGuTbmEE/0ZeGN+ku/lmo8Qm3UKnNZWbNgG03+yAYwvqCIdAR6R6XUbSazFGOAQ6Ig5T/3Bxw3EC6giXQNFfUq1MNpxjoBMdAkV/SbUy2XCOgU50CHQiQUOtTDacM0AnCtDDGKg0ecdNXgYl19MnmTbJxP7wntiLiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJifm1y55af67WVNa5UccrLy8/V2sqK/J4qqDgXK2prHPbAmaTtYXcFCVUhtlkbSE3RQmVYTZZW8hNkULlWqnu+89tJIY6NUKgqJVq5cqVJIY6NUKgUwnkpZcaGahTBej/IqDS5GVQOowHJTExMTExMTExMTExMTGx4Pb/Ab7rit24eUF+AAAAAElFTkSuQmCC",
+      "scheme": "data",
+      "host": "",
+      "port": "",
+      "path": "",
+      "queryParams": "",
+      "fragment": "",
+      "folderPathComponents": "",
+      "lastPathComponent": ""
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Ue",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 66,
+            "columnNumber": 8
+          },
+          {
+            "functionName": "Ve",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 66,
+            "columnNumber": 67
+          },
+          {
+            "functionName": "O.dj",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 83,
+            "columnNumber": 98
+          },
+          {
+            "functionName": "f.$i",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 91,
+            "columnNumber": 19
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 98,
+            "columnNumber": 273
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 144,
+            "columnNumber": 22
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 150,
+            "columnNumber": 185
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 81,
+            "columnNumber": 62
+          },
+          {
+            "functionName": "Array.forEach.d",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 12,
+            "columnNumber": 111
+          },
+          {
+            "functionName": "bg",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 83,
+            "columnNumber": 280
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 81,
+            "columnNumber": 26
+          },
+          {
+            "functionName": "ll.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 184,
+            "columnNumber": 360
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 199,
+            "columnNumber": 208
+          },
+          {
+            "functionName": "f.render",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 80,
+            "columnNumber": 182
+          },
+          {
+            "functionName": "Zm",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 512
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 795
+          },
+          {
+            "functionName": "",
+            "scriptId": "97",
+            "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+            "lineNumber": 63,
+            "columnNumber": 28
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.678983,
+    "_startTime": 123361.678983,
+    "_endTime": 123361.67975,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "data",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryLow",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "",
+    "_securityState": "unknown",
+    "_securityDetails": null,
+    "connectionId": "0",
+    "hasNetworkData": true,
+    "_requestHeaders": [],
+    "_wallIssueTime": 1473831877.02242,
+    "_fromMemoryCache": true,
+    "_responseReceivedTime": 123361.679551,
+    "_mimeType": "image/png",
+    "_responseHeaders": [],
+    "connectionReused": false,
+    "_resourceSize": 14613,
+    "_transferSize": 0,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.79._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.79._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.112",
+    "_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAscCAYAAAALLkmiAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAAAkAAALHABjzUiVAABgH0lEQVR42u2dCZwUxdn/mV1YrgUBD4QVTWK8o8b7gt2Zrh40xryeQTwS76hRAXOpSf7RHG+i7PQxsxwieKPxvo0STbzAC+/baIwxGmF3u3uGy4PrX9Vdg0PvUz09M91VrW89n099JNll5qG6qrrqW7/nefr1kyZNmjRp0qRJkyZNmjRp0qRJkyZNmjRp0qRJk/blNlV3mlXd/ilu83GblACHbA239RXtHGHOTDTtJuzAf3wOPSu6hx7wOfS4aIf2wu0j6szHuB0gfBwh3WnFjuyMNHugnObSpEmTJk2aNGnSpEmTJk2aNGn/90zV7Z/j9gpuD+G2o2hnvuNDeq8ebNpNIh36o88h0lSRDp0IOHSYMIcyBbsFO/BChTPv4jZC7Dgy7JHYibNw+wlum8tpLk2aNGnSpEmTJk2aNGnSpEmTFrtlC6Vm1bCHJMIZyoZ6cSvhdoloZ9pw+9SH9CaKdGhvgDFeIcwhxcN5a3wOvS36sS3wObRQtEPksf2XOrNE1Z39hM80RbOGYWd2ySZl6kuTJk2aNGnSpEmTJk2aNGnSpEVqWd0FVzsiw24R7gx25EjcVpSFlbiNFubMRNMi8fbv+wiaIcwhNKNIHCr6HHpT9CNb7HNojWI6I0Q6dDWAhncQ6dC5PmdW4baZuHGkO4OxA4/ito4y6wsSMPWd/tiRnXAbJ1dladKkSZMmTZo0adKkSZMmTVrDpur21rgdhds3kuBMO2VC66nI8kjRDj3oA1aLRTv0mM+htZmcM0SkQ9f6GSPS7V1FOpQDoOd4YQ7h3pjexyHDPkhkD/2vz6F1SDAWPhC31RUOvYhMp7/omabidhNuptDLF2nSpEmTJk2aNGnSpEmTJk1avWf7XXD7BW7fU41ik2hn9qyAnqTlRDs0w8eHVmYLvS0iHboSYIxCgVUn4NB4kQ5NB6DnBJEOXQX00G4iHXrWL85FhiDpaVa3h1aIu8vtv+mCoOy5SHM2pRrYSoduFb0OVZYMWyN0QLu9pNsjsBMX4zYPt6x8kUqTJk2aNGnSpEmTJk2atOQZPrHuT9Her1Td2US0M7vi9knF+f4h0Q5dDKj0xol0KAcQtH1FOjQdcChhjNFwdhfp0NOJYYz40Qz3XSuQ9pFiCrrvwF9+PMCoxTBGdGkpBeRrIO0EUb2jAM6U8IAeLsqhCwCHNJGzK+1j1L1ItDAXO3EKbs/T/MJ7y22GNGnSpEmTJk2aNGnSpAk7nx2K2z00TPkbop3ZHbfPK6viZDVngEiHLgKg57dEOtRXWKmJhZ6QjlEoY3yqj0OmM0qIMxkNZIwforwjjDGeAECrW4Q409FpN+EvfwZw6EQhDuGBOwlwpqiYNn/GiDRnrFf4qo9DOndnFN0eBiiE3d5BRnG0iIF8G+AMaefwf1SGM9z33iq3+7IFAVMdf3ELbkt9zryCDHukyJWZZOy2KaN+BDszRvj+J6vZg7AzW6ra0pTcDUqTJk2aNGnSpEmT9hU0vOE/gxyHaGWTfUU7M8En2/lY1ezBIh36rf8km9XFQk8ovH1HkQ496U8yqojSMWaM4jCfUthljMJ6B8GM8WYhzkyc+0mKwRh/IGrsHMvQMQ4T8aiSwxjVvEvRnoF7h7OOEenOGIYzpJ3Hz5G8k0IeOfuY4cx9SmdvE6/xshVBdwxHPMaoc2SM+AsfDnJG0e0t+a01hRIpureM4cxfkCmAvpIv9jlCHJyqaJagVBq6vQW9NSTqch0vfGPlllSaNGnSpEmTJk3aV8CyhkDt4saOuEorjZYEf4fU7hDqEHZgsu9UslTV7EEiHZoLQM+tRTq0yO+QotmtQpxJewInP2P8z753rRejmsGHyBOBI/ZNQpxRck4Kkp2KZIyTk8MYDVfHuDQRsdJIcwcyQ8fIkRXRQZwMxkidIYzxvwxn7lVmLoufFym6Q/K+Hg1csPBhjChnEYR3HM0D80gAztvgjGpYY+KcynOqOLAxY9RiZIxZ3WmlZQerOVLCbQrSe5vjXuiIztUKcIQ8vi6kWWN5rr4n+F6WPTTE5jTVcMQIcPGXj8KzZq8MXo0n5OzmftKkSZMmTZo0adKkNWwTDYdwxrFZwxkk3Jms4QbfPkrFlb0k1F2oQ0AKzQ+ynVazSIf8x+zPDs7bYgoZKZoN6Rj/Kax3EsUYJ3S5jHER4NAPRY0diDEuQ4YARq3ozFhpAYzRCNIxOnwZo2oG6hincHMkXegmA/iIAMZ4T3r2isauE5SclUK6NUI12YsYfgQEYh3FIPZfYD3NHtFY1+OXIP6g22lk+DLKE7twu4S2mfT9VJUxRhIrjT9oWg0skdUeUKOKIscfZjTgCGGM5yn5CEuC4Q88ELfVNTriMUY9JsZIM9+SdAcfMhwo72/uxe1UpHNijIpGZls3Wex2wy/LiaTkF/7vfvhNPma8boutGilNmjRp0qRJkyZNWmwkZKQbxG04myXBGVIsvbtclxw3JNqh+3ynlWeFOZPJu3Wl1/qP1yJ75wfAee5akQ4tBGLtxTBG5Cmx+lK0fLFVQM8kSMeo6C5jfBpwZjky7C3CPus0jcT8Y+i/BD+mIMY4Nawz433ohXT15FocyWpONcZ4d2ZGqSmsQ3+CPgT/ax8jEkE0cwWbMZqujvFIyhjXsbFeDagG/4WTqoAoosx7CLfZ9KqpzBgfD8EYX0VajYwx66nvbouAKfZhjHUrPDtmuWNgKpkJEThSwo6cly5EALPwsx5DgeeKOhwhj28GydcQ/cJm2MPwB59K7rbIhVsAY+z23ubOKUiz+GVUJl+GvOKMhC9OJFX+cG+24TUrGeE10qRJkyZNmjRp0qR9xQ3vxfdzA5pE1wyizlxQccwm5749hTmj5J1hwHF7nsjegRjjbOgXN6NFzG8kUZgxOvQE4NCx0C8+7DuBRu4UgqtulxTTafX/4qYAO+7B//+46JypQceINGcgIyvgcxnNarhijaK7A/kpWOXpbMF6tqczAALhg2310xOXMT5dM2NU/7eX8KC7GH9xKaqRMSrTu5tUI5Ax3qUYy1LVZsAmuL0YwHuILHBypuAMCeBJrRR2BukYX1bNkDpG/Mujqzi1nhazeoTGR5cZ4yw6pUtVGaPh1MYYkWkR0H1nDIzxL3UzxmyuVGaMK6JgjK6OMRdBIABJYUAZ4/I6HZkZC2NUPE00eQ9dg9u/GA6spbHS92MnTsKNI2MkPJFwRY8vEs64j5sdt1CUjFGaNGnSpEmTJk0aB2azM80jtF0SnDmlQprzeRKyR77CW1NIEijh9gvc/nejp4IuXZICjjSrlBglEuqMor9yMjk2jan09mZAuHRCjL3zw8D0h1QN5f+Fl9Kz4kkrR0VP/u87rIKeWcNo1Jy/lyZH7QyjIo6Nh0iL3+vLgF/sJnU3IjuKezVfIB1jDgIKm9Oavf5fXqwaziaNOpM1XMYIhbWvwEfy0axnewYDIDyNdKcBxugqtFg0bRr7X5F3eRALUpHHd1wtjhx85UpS8+XwgJovd4aZAYQxvhDAex4h8Bv/qwcH9Ah5PIcHkFd3FuPfGxFuWhouY3yhCogiSSD+RrWL5Vjp2VSaXKqej7FWxqi7jPGOeBhjcWQji9i0CBnjFLWr1BTFykpmid4AY5wRS+nvTM5qUXVrEv6C6+klyjoGY+ymVXF+wI0x7n3rajKlx5D4aMoXVdz2xhOiLWsUxaRckSZNmjRp0qQF7RA1awA+Nw1KhDN433Iwbu/T8M6rs5o9UJgz371mPTn6fOTbZJ0t8FHZOwC7vivFOUR2eX0dyotzyEieQ9Aj+7PIR0ZY32d+Kc34nC2m3Elad3nfBz6HVipGvMcXSu1ISOHVqr8aDv4/buHMGL/rO9O9jM/6/St/4QhgHL2Ie6k5Jof8sdJr1MqCs6qHT3oBp46LYcxCjPG/6qxSs9/r6SCk0qLTMSrsutJ/glbszRlFHJ7F/6qGK9YomiuUWwjpGBVW2DP+4ZkMgvGk0oBCSvHqSj9Zu44xb6cCINUSgvJqGi/T3ZJgQXWl76g+A0xX1vVCFR3jsZmZywYFDFwySf6nCmMks3h4yC62CGN8PqSOsZIxXk5ZdDXG+HLNAEsx3aUgjljp+1EjRUUi1DG6daXxbrTxxVbxdIydFZlMameMceRjROaSgbQ+0O0BjHENvZB7wGWMhsOHMe53w6oUXpva8IK6L7mjJblf8CtoTzdzRa5XMkZp0qRJi+d4otmD8Yq7RTKc0e0MzRe8hkZRjRLmTGa6W1TvTd9L8o8ie+eoRAEHEh/YxyHDPkekQ//wObRa0Wwx+e2UnFvI43O/6kAkH9ouWePHsPdKGNJzEuaQbm8PbNZvEuiQsylQS/OVjss+EsMYs0aRrNL/7nNM1uxN4/zeiaadQqxC6diBWwHGeHyME2kMBZ6Wlw/LGe7/hSNAHWPBiYsxPuD7roKPbtksxnh8DM5AsdKPQr8I6hhxd0anYzTsNoaO8f9B05/FGJ+Ooip2Ri8OZUhOlyusMFP8w7MYBGOh0oCOUfV0jAtrZowTZq5MUbIBxkrXyq2Vq1wd41EBjPH2MDhvWBWcR6SCx+MeG8LeQTjD8Mz9nyqx0i8gM6SkleoYnwuhY4QYI8G/xSp/9yX8hqg1Vjo2xngv/uwRjTLGlRHpGKchI4J8jIqX7eJ3dTLGZVTHGEOsdK53IPJSq9xOZ91aBmMkjj9IGKPC63yXNpxm5N3ukPhohCeCggfqnkiz2lSjJBmjNGlfHlN0N3KBpIH+UVJizWZUBoHgtpdIZ6DMSXMEHam7SbbldxKRf5z2zk8AZ1bi18H23J1pn/dJCiqQhnjWOPT1DnRQfFXkYL4ScOjHIh3y55pejQxLDEBHXrTUZ8mpDGG4jDE5wMq7Se4zfgoikd6eCWOMDvTIbhE4w5xREGNUOpeKYYzI7IUY40puEokaGOMJMX8nQTRbMd70DB2jWYwrVvpSer9Cxu68rOH7HsSXMUJVtw9keQ0wxuhipUncNUPHeDiLMUKx0k+RXIoNM0bDZjHGpQcbvQNZ3Xk2g2A8gRqgsaRYCCOPJ2nnVXvGtwfoGGuaeQdd7m78jg7Ix3hrmEHXWgXnEYw3OW2yY6XV/IZY6SDG+HxoHSN+4W5BNLAhdIyP0hyMv6WM8QrqRHXGWIeOsRUSfkfQ7sHjsWHG2BORjnGaOnNV4+9I1egmvfX7EOV3AnSMcTBGs0iu1E+liuLuAB0j4Y8L3FXZ4FTzJaM7zXjwj3UDVQxS/NpJI83ak/QEbuKCnaQlzrI5u38iHMno1gCSQoUGw5HLt4PEnUSM4hB6NVA5nf+lag7/2XPgzOVNwDV2eX0ZLWLDP4ex4j4lwpmjGc68hTdZ2/EexIQxvgU487qixfAeCtE7vwKc+Qy/Bnbj7sz+c1c0Ma6yxTBGBCfVenn3BevFnO9pNUm/Q2J0jHj2kJPBe/41B5nO5iIZ4+cJYozON4Gd380ikd4ewPjpkg5VOAQxxlsFOmSBjHG8JihWGnW5OsYP+l5L2UIZIyTLOUHkOAIZY0bvjosxfoOivYNY0HMYQ6F3QgzOHOYbs9NYvwjpGCOu+QLmY/wgawKKUpqP0QGcWtRuFIc26kxH3g1ieQy6uTxEL6ZYvfRjFmPEr5i6dYyKB8kfY3z2adWe8a0sxlhrXemOGa4u8pgAHeNt1f813gAPwnl/J8lH8e+xa754JXmq1Xx5Dn9GuALpimmHYYzL6WOYTRnjb2tgjC/UXPMFP/ehAY+vkXa30kjSUpp4dGkEjpAe/QnqjOBCB7+Aya5SaywfY/2zNGjAD6c6xrsoY4R0jKsrdYzI4PSSRmapP3auzYucIXzR7sAOfFsljDHvSMYo1hSjt5VeXRHRyslCnSGrMqAt+gl/xlgoDaAKcjhFhs5xz53J20NoGlXW2jKfmzN7X7OMoJn7gy7e8Mtza54b/jzDESKDn6rwrF3PiHcl7U3uJE0xncE0fZ3fmdcayd7dSO/8GmSMhrMHd2c6CsUWcJtpBMTtxEzRoIPiKxnWaYDD47o6MTpGpbAMYoyfK8J0jEZxBKBjFCc7xevLNxMlikPeLi85SA9vPyGHZoiEVd9MFGNUDTdWOjni3PaZIGNchc9im4p8bNCR+USRDkGvjhcyuiPm1aF4+RgtHr2EP3McWVbINjiwYBKDMfZGWfMFb2WIjvHdylcUbjvADpnOZgzGuDCoWEjog4NRGkQFdeGRHrlFZGxhH0Nm/Rt7fGTaMoAxonoZ439r5dbZQpHESgcxxuvC7K2H+upCgTpGZNpBdaWH0cSQTwZ8zuJM3hkacvV2GePTVUDUCionnU01jIQxzqWMsVo+xufwENiyxlOIyxivi4Ex3oV7cHgj68bpjNlXD2P8aVQor1zzZUWdgsou3CvR60cyeLBSxng35YhrqjDGH+ITDR/GqOi9A/DgH0sOkpQvthPGSHoik7P/j8ZK4z0SSaGp0EjP6zaqysaZMZIl4ALc/gOMmTTvU8lxUPxiRTM5MUY3RGd2iGl9Lg9WNLQK1ivvZa45bHbMoie8VSCM8Z4AR951s1PoFh+IpepWLiAoYGomb/HTxqpw/vEyY9yd79T2rrE/Apx5IxY9fZ2McTXCZ3/+K3DOHsi4xjy3nwhjiFFezeR7m4Q4lCzG2OXebbwHaGCF6RhHAJKv19MFQed6BmO8rZ8oU3VndyCkdKY4hzQQeopzCMHh7eIeGX67g/kYFa1H0KDWnETqGG8NrPMswKGjQSCQLzYJGthuujqbF4lVDWewYlS5i2PpGBXN3jo6R1x9261UEvYEXgN3Cpht1uYM7dhC1SgOaXzy2IMArPdItV46hx0r3UDNF8NVeD4KYUK8AWyu5tTNATrG2vIxFpYRxvj9AMbYFWKAu+TsqWo1XxSdzQeJjpEGrywM+JxFqmENDNnFbqz0whBE7Aka/vU72uZR0FmNMS5Wak32p3T2tjCy7jTa7myIMeKuPzeimi/kM36qdkWw8cP/oi0bqCu9nDLGGHSMmlOOlb4npI7xZGQU+bykVdMZQP7VSLO+TfniBBK04mobTYu/jjGtWSSdc6vrFD4oiNnMmS5jRHSqv0nHxxqqvrqII2N0AdaFDBhRGQf7jfjHiuGmb/4w5IzaNz7GaDj9QzLGDdpGNa4i6ZnO4oCQjJHgvQV4UF+CN3mbxfSIulMBb/z1tC7DNLx/asvqVvxb3AAd4yrcE9OyRqmZ22xi5GMsSwf5kjQ8tVsZSWdexz8bx33RI4nPwcdk2Px1jMgsJosx0tQ8fcaNUigKY4zXAIxITOVkJV9KJYoxKpoFMsaM1itKdupsW1f++hiR3u6JQnp4e/GlYIwCY6U1mDGmDVH5GDUbrPkimjFC6cV+KNKhY8AoS90R9OrwkrDZwOtDaC+xdIzbRPw9++B2QBigsBmDMT6e6Sq2NuoI3jkMobGNG0rxVt0Oqx56AZV5eL2qe9dIo8j/DnxuR5guZZ04PkY1MsZ0YTlhjJMCGGN1hzJejFAQY3yMfAkBDQE70FZ6O/BEwOc8dEhXKRW2i0fQ2lDVxG6LaHz0byljnBsyVvpZvO2pbeFFhZ6WmHSMd2TCRpEzxtTUOlEexBijCbakal+zIcaox6BjVA1nBGWM9wboGMs1Xx7Au9FT8FtgJJeVXTGLLW59F48rTqBtdzdW2rD46xgzWpEUum4lEnlSbQDvPHfAzrRlNY4v5IzpzryJNCC3zBjX0h3nOvq4yFIQb9ipkneGUB3jRyEH8g1x7gJqYYwbLlcid2T8DDfr4Kw615xoE7opxpIBISpzraYlER6kKzpp19d6yVf9De2V4721GmMkMyrdxUH9EJCP8VPCGAkuTgJjJDpGzozRS7zO0DFGV0uxlt75DVTnTkg+RrxfHsTIzi5Ix2g434Nw8HjzI2GM8VrAITGMsX261eQmofVPccMWVfPFGUmLNG70uNpNSxiO2RYAVneKJGgQY5wlziE9YdAzcfkYVVjH+HLHbEGDGr+9wVhpfIQZKbKXbk4aY5wEAYF0XlCaDUXvTSRjhGq+9OCxNE7M9DeczRnasYWoEXyygQvY/enZjsQ3nhW2l1g6xscbUUghLx+jP3B7WlinbmIxxnqOONiZYxnX74+HW5e6XN3H3wKOQaTUzveRyWaMqqcBOCYggpy0XA3Peyk5yz8cgjE+RbliJWMMo2N89GCzWJssrF1zSxvEkY/xjrRZHNTIcjAtIh3jyugYo+aWBjfrdCw+HSMy3Cv1k3G7j3LE1QwI0UMTu52K1zBOjDHX24J0ayzNwegyRvfPJH5aE8AY03oPucegjNHeHh8WdsDOjEM5a9hB5nI+L2XFLA7AX35wBWNcQbliJWNcTms2dGInW+NxxHADKi9kxEoHtfvj2HMfV4cjlUq+zSOaUb2pAIFc2PaRaliDophBA6pIB8tXCO/Skk7X07aA/n8r6X8bj8fPdLkKzyBR5dturLRht6WBapTItJqQURxO9j9R7RwvD4iVnjahy+aHaBCbMb6Bl36+Ba/JmsHYSL2K9z4J0jGKYIyK6QxkXGULi5U+DBo3qlFsFuIQ4/ZZDGNEWgmKlSbXCIIYY86GGOMbWUNUeQwjaYxRTxpjhGOlheZjTFZdaUW3RwH5GF8S5lCHvrQJzMfI6/hSA/E4SeRMOxZw6BlxDnnRUU7SSCykY+zGe6GviZltXs0XSDv2qJKP5sBHbg2yhjO0lr/AYoyP4uWhrYEh0UZZ02c0VedJtTh1XQBjnFxHrxwLXL/bqh6yp5DZTTRCfw04BhFt4jEooDw4mSQ0MeQjASfaLWpYBqzhVcSV5cIgT9H46HLNlzlU0FSNMdb+alK86tlxMMYbs4XelkYWzeQxRkri83XqGIkjBfxujF4/ohrulfpJlB8uraJjJHzgNH6MUbNb3BrShv1tyhcnkKAVvOEbq5glMfkY3VhpjzESDeP25LEg0x6W/ROnZErKjCKphHMIwBjXA4zxCvy7Kn4lRR9Zni449TLG9XTzF10iSeTpGP/d4JQnIL2xZCYobxHGOD2ixZDIU+vfxiiFInlEd4ZgjO/Qks/X+hijv/rpS6pZZyWUTM6uFrj9Nlm98fRuQ0BqMjzLmsjP6FZmgTcBGqgRE6BjXOPlY0xGrDTRMe7J+eThbjkgivY63vuM4b7qMhjjCtwzuwo4l7kL3xJAaiGMMR4KMca0aSeKMZ4lxBnlUlc/DTBGa7QYh/IwY0SitEN4/CSMMWoJY4xq0orQkCtu4JHdJK6HDCtZjFHtKkGMkUjfhTLGPwOvjZNEOjQZGNhPC3MoaxS/NIwx0povtZ7bN2XVfEnni4NE9RJbx9gAY1S9+sIkDvvnNR+HqNIOcqo7Isa4FD+N8NVMUMHNMhikP3wSH2uOJnVd2GTEZYyTAhhjbZOF1GMJUfOFxRgXhmCMah2oxX3ut8XAGOfWPcjbc+75fhpVdTYcK43CCnJDnNnKjLFUJ2PMx1LzBRlFst39YQjG2EO1jqcjXrHSqtbrMUaqY6Q5GfcgPYEbf8Y4ofBBChlWKwkXJIyRtq0Us9iKZnE6IOCTSH88+75Dk/69ScfHWoaOkSywiqLHUIVbKbi1xy6oE+2RsOYLo9D1l5f+I4CD5Po64ef+9ZNXvbeJlpCPclFcqGil2seXknfTqtwfUsf4F5pH7boAxrghYTKeBLWxxvHGsv5Vily/hWfT+QqeURP1vhFWmUuWEhUxyYQ6hcZVV/5dvZ4xcwXDEZKs7Sftl4ef0kpXkfzjjqMv4B/jZSJVqzMnMpx5nb+O0SyyGOMbCq+SPL7e+TXjDf0t/owoZw1OlI4Rf/F3oNmkdHEM9vc5dD3g0JlCnGmfbcM6RsMWwxjJJS3EGDsuLcpY6fL4SVxo8h6AQwWRPbQ94NCfxTlkujpG/3bhBWEOHdj57xTAGD/Fe+FNRD62GwHGeLJIh44DxtFTwhzKeBmY+ir0DLG99CdwD2w42whxSPFipS0wH6NZg/Yw4l46hR0r3VilQPwZrVmjDhkP/otXsY8w9iRlZm3nKgrln6fSnvtVo8blpN20W6pIBkno8VFBOsaMaQ2mjPHvkVQ3RV5d6WdCMMan6RHnd8hjjJfT4O4g4ragvqO05uoYb4+BMdZfZGu8bkfJGMln/Ciia4cNOsZ6HPvEY4wx3JkgzRpJFTQPBuRjXEsZ470uY+RV7QSfZltovlcSH034YgeeeXsR7TR+FfUXtLr3DnXjo3V7xzJjJPHTatcyPgeE8ZcXm6hwhST9e72CMVY+rkrGmMnocegYc84AqmOslzFegP8hw6J6vx1Oe6PRaf/fhjIRooIdtq50ra32I1aH6eoY/1Llg9dRHeN9tB7sNXQ5CGKM5XZU+JmjOS30g1kf9gZu52cMuy1zWd/tRMcsh+gYyXJwHnUY+oyf1TJm5gbIR88/4MZPUzV81gB617rcl2Ri97Bv+ROYsdIN5GPEn/sNWoL+BsKiQv4lZxMGRXuz0d1ilIxxOe6ZXfi/AjSHxRjPEbW5PwRijGRQinJoPnCUFsMYlRlFiDF+omqWoFhpjcEY5ywTVPPFAOtK3yHyTJ8s2SD+8j0Bh/LiHDJAHeMNwhzCm3WIMT4vroeuXZkCQmw+TevOCJHj6AZgHJ0iEp4fD1WkFeeQaQ/hWVc67GO7FNYxCsrHqOZ6hzKS2ZASzsIY40kBdaXHiHLqJnZdaef7ma5irYxRxe33RM+I6imMpObdTDtBksGnSM1o1Mk+GqeN4hCa5eBvkbwjFd1N5rc4pI5xboWOcTYVZS5n/p16gygJZSXbkIiP0f9Q8w2kEMKPL0VrvpQicIao+rIRreQOYYyFBnSMpqpb0ddDQ5o1CnkKmgfpv3g1A0L00vyvZyCzyIkxmo7HGA33EpnwxTT+s8sYFUMQY0RGcSjSLcIVd1I9xjiOqPGQ3sPngLDPg+tTFYzxNZo9bl3FjrMPY0S5GKpwq/mlRLpFNGXv18kYfxF0WVPrq2QyhVSNTvsP65HQfzFoc8VGar4ECryRUWOCAHyaHUJjoKsFZL9DS8tfRTljWMb4kKLZ4UIz8JRtoQLJwHyM+PfAy5SOTqvJLSkfzBjD58kKYIyr8DpTU5qMdM69nTyX8bIlQeCpejb7Ddd8wTNsJ2BiXF2Nom3C2MK+GcVuEXkFAubT6wnCtIfXwxiX4Q/aOdJXTq5UfdeIOntZjPHHooADyBg7pluJYow/EuJMx6UOyBjxOiNKxwjWfHnjgNySRMVKC6wrDcsGBTJGA2SMpkA2ZO0IPLL54hzyxLmrYy+qF/qRdbkbMf/19+qMIVbHCDHGk0U6lEgdo5O0XoJKzvUoui2GMSq5JYMZG7SFiiGIMeLXyFnMMCwRGXaqMEZCO45RzGVNNX4eqeg9soFecnOdB0kGn3aj8vLso3Haq009iZZpWUNFlRc08ugIY3yuRsZ4CT3pPsLITri2ocKzqqd0uDPCIzR5XzYmSqCvlakR6Rgfw8MhGpCFNDdWuitEiW9WBYI/TjSKLXEsC6NolN6CgFjpSsZ4umJySmiCSD5GwxUu4R2nyxcV7PA+LmM0i4J0jIXiYJcr6tZO2Lmd3D9rVmt2VonPASGju3lmDqXipFcrGGP5Ua2lXPptF0wRxpiPQceYyblln86pE+1RxhiRjpEimvejYIxEhV63I+mcWzYsDh3jPGTW+BjxDGqtIh0svwreptP7SsoZHwjJGB8O/QhRwamW7JgArJ+yktxktN4mGit9bhXG+PAEI8TyQEX/LOX4tO1eXR96SmdMq8wYWa8erdoAnhwQQb573RPDsHekKRWgnNfNjJ5hMsa3lGgY45aA6vhl5sUw/uGvQB0jXoEjfBd+nUbBrKF1iA+Cn3WXzY0x4t4msugtAwsd0RJgfR5V2kiWjvEMMc4Uismq+UKOKFBdaZEEDdIx3pY0pCcuNBnv9vYGHDJEUo8dAYeuF/jInFHA6UEcY0x3lVIAY1yDjKJQxng9sDCeKtIh6GrzCWEOKZpbpvC/kQY4RtBL0PajBwljjJo1jKH2XIQ3/cNE9dK5TGVeHJneQjp1c0C6p6NJRTi+ED1ntVaRDBL+eESQ/EbR3B3oZLqc3FtXukMf+CSM8YWQjHEO5YukzaQB2yuBBFx7NOaUaW9CT6VRHaEbzwh+sFlMUWVVKQLguW+UA73MGOtxrFeNKjEkcAL16xjXMJywKFI+Q9EtPjllEclcQApA6M6elC+quO2L/7yVkrcEpbM3iwMRiZU2nF2IltGt+aLbrYrRk+K5cCI6vV8GTiuVjJFknFNUM4Y0wIp3mfJTKqasjzHmomWM/45gHSLpfL9f/9ZWd7MOXh4LY9TtQTVOb/fObEGIDydj5S5K3a6kORzDMMa/o2oatA2DNl8cSC/emPkYSZUtZMJ1XDJ6TxOe+m1qCMZI4rIbYYxuXen2fPgrTqS7uWODGOO8as5MAs75ZRHkbg1MjB1pz64HTjcnsvYwLMb4dhQ6RsXb0kBXE4/Uxhj1SBnjToAMdTH0XgIZI4qhcjL+XBJC/2lF7P0R0C+BOkakxaNjVD3d2ySmipRxlBajY1RNi8UYBdV80a0RFc80EYwxWUWK8aPZO1mhyWTbmSTGSC5XgBl2nTg2ZLri3LU+p57tJ9LoVdFGOkalIJYxzk9WNRPNPipROkYlt6Q/PR34B7fQmi+/A2OlGSE3PKb/Zgy155NBxULEMUbdFsYYWYWJP8ZOHZX+I2fGiHRnOL3KZusYDftwNeAxdswuEUXDRMoZ2yIYT9Zot6Bn8GGvSJNFXl5mjOgLxlipYyTj8ttRbEtG0Oi6KI7P0URBZP+0tIlG0jXKGC+NeKA3pGN8TY0rBxYN2zmRCpeCGGM3hRAnfscs8ZEQqlrvALduPYmP9vhiFjuwXyyZKUNfQ+SdwdiprbETO7uc0bDHKYY1VClw0jGizt6UalgkO2WOMsbPAxgjuXJQUBxYOOMdtS+gMKoexvhz1UweYySOHdPAidYNmo2DMV6JTKdGxmgWh1WRDpYvVN6kVwhlxnhfWMaI34XDw641g4AEIhvnYzTsnyqMRNqZgpttt1o+Rg98muEY45VBjDGT7w29/choxRYq6mUxxiurOfN9JmM06q9sQskZizGeDG/08w6bMRoR6BgNNzQDFFcqOlAGCsGMkcRK7xgh2NiB8fimbvyLOa6M8WzAoU7/L4E1Xzr0YuSMsT3vpjl71Jd09ICqjFGNkTHizx5BS4+TMJ5DNt6QF0rJYozIdHWM/hK8r3UYHwqLlYYY480iz/T7JCo0mWw7gemeOMZ4rUBO7YwATg/iChQzGaPBKZ08w6G5icrHiE+m30tUPkYl5+oYu5OmY4TyMXajKPhOnef2TRkw4Sm89x0uxik2Y3xGiI6xw1ieqsIYj1RmLWviPZaGVZEMUh0j+2iseIfMLbNB0S01rt5kQ/5iCB3jIhqlR/jixTSY8mF6ZFpLhQPbRbmruzeCo/Ot0T0+042KObdOlLfhEcexJIyhj6Mex06Kc1ko13x5IKDmyzpa84XURPsez4V0AN5Ltbnx0R5fnIj/uz/hjvvetV7MflwpFAcpXg7Gb2FHCGd0GSOavYKPQwfdtD6lam7i2Utp7obVwONaSc/wcxDRPJp29IwxbbgFRRqp+fKLyO7caF6ZDyNijEfV7Ugm7y7/cyLmi+tcxlizjtF7nz0c4sMJj74DeVvgufT26J0QjPGR0DpGAroZhdAqdYzTWIwxa9op/Blh8jE+opghoHpAyTmPMRZKobXSKGcTHWMQY7wqDGMEkxQ3Uj2Z6hjfrunVghe44QzG+I9I8jFqbqw0xBiXpDVgPKl8GOP2jMd3ie+9VOTJGM8CSWyX01z5S4eCYe2GEzljxO+6JmA3SpaQb1Q6dC3PutJECtQnEYBGy2tmZrlBk//qWzo+3pov+Dt+SV8n5NDQUdmFI4CV9bVs1/LYtxB429IMnTASVqTYcPZNVvpDw94fcEgX2EP2zoBD14hjQ4abdSlxOsY3+tSVNsUyxtlJyzQI6RifVAqWoPNV3n25FpNW8+UykDGKigDOaPbmjF56Gq9Vw0X1EpsxCtQx3s6u+WIfmcn18B3oBAFXkQw+7dZ8MZxWnqhlyxA6RsIYF9IcjJWM8W/0PHa3qjvRQXd8ShhB1S6NHJ0XRLs+mXaZMdarY3SyMdz9k+NLvbHSd8d99TCSbtDvpxxxLQNC/JsG547gORtbCE8k8dHI44sH4/+9P9ExKtMFvQMzWnGAq2PUCWN0OePWGbM4JFNw+Di0133rU/RQqdMpXwIe1ydlxkgKFyG9N/p8jCjnkOJWFwLF+8LXlU4gY/yoIcaIz/UDaYh61DrGq/AKPrg2Z3IuY/xbiA9/i8qU51LOeDd9bayu8vceDR8rrduDaH7gICfOxz04LuAzyHIwpYp29lElDFSn1W1YVbam1lK7XjGtxhgjCmKMRv2VTShj/EdNjBGxY6X/gXSr8VhpzdUxvgUmydGc0IyxFCljNFwdYwlAh5f4nWHlY4ycojEYYzfKVwh1sYffBbObatEzxvGFnhRjN3pMIGNE8TLGM5lMakLe1T+/15cxOpvHdlLWXVXXKt93/ry8oYcY4yscjlunVgQ1kcueTcpIbwdRjJEmp9wWzajYP+GpmCzZoJo0xoh7YxfAoWsFOuTeIPoVCk+KZoyv+GN8MqJkXtSheVxFJCEcOj5pNV8GM6KATxA521iMUVCsNJsxPosMJ3GMcTHeighjjHcwGaNhH1lXbejGHHJjhF6swhiPUrkyRs3akgZFVmOMTxAOhLxY6YspEyJK0em4bR5xT7l3sfc3cGSOPq9selaxCTXEGJ0tYxpXVj2M8SM8CeJNfahqZIfnnExxcS+DMa6nk2IC19moGMUBtJDsfjSt/cH4vwcqurWZsNeNoi/pjzrt0Xht2pVs9PCKvk2mUBzCzYEOs9gffVHz5VlG6t9V9A73clf9aRRjYIyGM5TqGD+omzFGVvPFsI9NhI5RMew4GOM6D4jVyBhp7o+/15CP8QqqY7yLgqkQjDHklkb1YqUfqeLE+YrGDkDBnzGWZtx9J9ApLURPBTBGkpRvKl5n+odf4Z1qjPHqbL6YCnImSMdYdzG0KjrGH7D+EkvH+E4kOkbD3dJATi0Fr+EZdaUjZYyqp2MsVdUxZgwmYzwr8kWWwRjbjQrGSKILQGIfh44xZzUzdqMbMcZrOOsYIcZ4Nd0VrgB1jHhzFRtjxENkU0iq6D1TszgcWFlf5nDcWuT7zpfKL88dAaR3AweH1AroSYLHDy//YD9ROkb8PeOIwAVvjb9ZOQ0PqLmMV8xI75uJ0jGi/JJBQJJR4TpG/z3Wp5kyWRfk0PykMcbjQMrRaYvRcKQNB9QxIpGMkSIUiDEKipXWnc0YjHEx0ixhjPEcxjbzWWQI0DEe7NUAvjNAx3iUqnEWK6GcXY0xkrIqRyPTGcpxPLn5GKsxxuVUVDJT/YIxkoRt5zdUaTvgTN8IY3wOv8Gjr9mRybs6xnPqDEneP8ZHuEHHGLbgNdmBbsNhbLm3yKfQsPceRkYwsvv7Cf/XjWn3pzrG/WmG00PwZNgja9aIWiIdY532gKzRS+JCtsOTYFeiukI8HVJ0ZwBljOWaLysYlXFJKZbL8e8eophWDIzRdAuKNKJjvBA/zsjyMU6KUMd4dP0vWqM4iGK6dcJ1jPh9NrwK1tsgeqqoK30FfTG/HZCetdweU3Mh9+yK5uoYHw34MMINz2cluRk/3SnnY6zGGB/LGuF0jNcEMcZ0DdlOMnpvtbrSV2dmBjNGVs2Xd5i1NcIzRpaOkVHzRQ/SMUZSV3oMQ8e4FNTF0mR7fRmjEXk+xmL1WOm8O5CXAL/IK1a6B3VW3Bphzw+HprQSprp6jdahl5oBeRA5Ax5Tjd6fFdc7keR6DCQu+H/8s6+O0Y5Txwgxxne9tcJ0hgGXuS9xOAM+67+6yuSsFvIDSMc4n4NDc/tkydSc1n50x8ddNkhS1fvKPs2hP7D2EKVjVL1smT93E/yXj02q0btNsmKlc72DgPdX4vIxfoZnn2SMla8OSMf4TLsoxohXziGMt/DxSWOMSwXWfLFYOsbFqiZogOMv/zFLx6iKYIwZw83EfBe7rrR9lNJV5F3zxd1bB+E8UlblGPwiHMLz0W0ZkjE+QsVNF9M9+WmxxbYiVwBXF2Mkp9l4VKCq4d6x16Nj/H7c44qcqQo1MEbEZ2x5NV9OpQnYLMYp91pkcp6J7uumy2kicdFUx0hKZ3ZkK9M+CXkH5p1Bbjoxo/fryOWMzjYduj2Q3xqluTrG7yAvLcIrQF3p9fRCmTDG2e7vGr0tMYydUiut+fJRnYzxIhTVUkCOuHU6Em1dadWLGZobg47xKpIIrtbBGkbHuJbyxHLNl3k0wCAUYwwdmqHqVXWMhKZNC9q4KZ6seWoVxvg40qxQOsarAl6mU/CiF1oGltFsQv7PC1jhrznItAIZ47EBOsb6GaMRqGM8gbWFZTNGzY4iVnoMwymy8RsRljHGkY+xOmNUDIsnYzyTofYcVPlLR0AVlDKdduSMUZlRJHusV4HvO7razOLKGFEVxvi5EiNjpHU//WVd3iv/cDgAIHkwRn81y9XYl5FgARFOjLFvSL1mb0deot8WoWOE6sficfR14tC3qpZeiufgsIPvEnkh7qEm8oNvioqVpiTWIOLyDas1Mp1RwHbhmX4iDTvwfh+IbTgjRDp0Q7LqSsOM8VmUd5rEOOQpF6BY6eOSxxh1QdVHs4a9BaOXnsMDXBhjPJsZK60LiJXO6G7u6LsDar4c3T69l7OO0atkEpT68EmSOCmtW0N4OhWGMa6oYIy/JXwxq9ubxgmn6snHSARPY2JzSjHt5jrqSv+Uw7WDU2aMK0I4dCa/seU9xtPoTOwFGOPjeBwNFbJmtc8ukdD3NrwFJoEqHbjtns3ZYt59X4yx4mDs1NZ4p4d3fy5n3CJTKLZwdMAhhdcOoalXX2Uwxs8pf5xFNI+ZfAwO4seCdwPOBXXKBz/Ejl2kmFZk+RiPjlDHOKl+R/KujnFexDrGdVRiOLjWRzQshI5xjY8xzqV/fjPEP+JRNeyWhuZjrKZjnKboVht71+DqGKcGKPM8caVhh2KMrLrSBF5NRTkn9KwhPFINZozXVnNmcgB53bmBiRGkYzyOtdEfzogGfieSutLelgZmjEZtjHGHCLfI2zF2Dhf7V2CSDmEp8Is/5kHPvOJsFZJmFmNEXdEHiyidro7xdeD7jqrGGM+O652Ih8EZwPddV+mQfwasTut2bClXkFcBw48R32vXnVQ567s/VvpFAYxxDXZ0ExIp9bXEMEbD3oWF9HIcHNIA6LkP+cGegEMGB4cuAr53JzLAdhGhYyRf7ttxvowPEc0kD/VIgDFyiZXG3zOejiVzo3TBQBqfz0Lnj47J0xuTxhihWOnnOgxHkI7RsEDGiBLIGLuRJkzH6GzOYIyLkWkLY4xnMWOlRdR8mZjrbqLqKZAxErmgOnMZZ8ZoVGWMC0lUXtpweDJGJyxj/BsNoJwWe6AtpbG16BjJ5n23eLm11ttEI+nCygVn8BpXYRnjnziv6BsY4120rnQlVCCQarSwlb39Cx0juTfdDbcB/URbu1kauKHmC7llzvWOwqeV/vyWA3NZC+6Vg2mJutcBucR6OgFeocvBd5VC9EFz5GRCdgO/qJcxkv2zYvRGo2N0MyjVF7Ttb0S9Nbn+Nch04mCMpM3DW5oa60proRjjanoEL+djvJL++Y0wjBGFzW+EnRlYxRlSx2UquVZoL3SnGHsrkjphaoAyz2WMeF1riDEuJ5rEjG6HZowTDbs/ffUsZ3zmddWcOZ6tY3R2amCW7sTorXXMga7oFosxEh3j2Ijeh28zLpdBxvgbxmPaIbr1zGHpGH2MMV8cyNAx8mKMS9XK9BwILg76eocWffRBWnf6MxjjkYEzC8XIGNU6GOO6jO7Edgev6EWIMb6PtFIK/7B7IPDD5zmcAV/wr/wZzR5JAm/HAd13PQeHrgOGyS5kQO8pSMeYA773wH70mpt7PkYQeur2PsShnUXoGPF3/L7v91pb98OzCdIxLubg0D6+ybSo8of+HeEnpBwTB6e+g9tNVO25ReUP/hw6KzInLjQZFMOJCFxzHTLcRBI2MOoni+wlRqy0Larmi7UFIxH/YlKwT1QvncnOxyhAx6hobu68ewMY46QJXf/lyxiV6rHSj7uM0eTKGO3RNTBG3X0pcnCqFh3jmg3pnOO0DnNZEyWsYRjjgzzZNTlT5aswRv5V4ZBRJAP+dBoc2VN5QlFJkIhIU2aUUnj/MiqrO1urutO/n2hTjFIKr+CD8TZlHD6Rkqv2XfFqP0bpXNqf5xpFGGOWMsY3aFy0nwWRK65nyjpGpSuG3kOauxuolzH+x2OMTuIY40cNXZkSDkiP2JEzxppLQOFBGpYxvkOlzHMpZ7y7CsYrt0fAGh3wI6oaK+0xRsNum2jAYcXIqytdlTGqphMqH2MgY0Q1MMa04UropwSs8NeqhYArU5LTnKljNOwGGKO9U0BvTWbcYzB1jG9HcSOtetemb8MbPyc0Y1wWcV1pFmP8zcbXCPliC6N34mCMZzCitIb4Fz//L72azpciPygqWm9/+trxf98RlQ5dxZkxnh4IyYAMkmtI3vwYN3ybARUw/qXkS6l+an7pQFq7vvKHL3A4A/rVE5/j19VIcvuzrSDGeL3/exWi2UaCyjgjgDEilzGKSxDZCXzvQWQXuHPN91jROATN7B1JD0GM8TkODgE5PbtbsENuMja/jvGTuGOl8XdkfB1xZeUPbwqdFTlap7I0xpFkEhtY+QMoRcvzmVxvcz8RhsziMAY9m9RPlDGm4VK8IRdT80XVbDZj1MUxxh8lSseYvrS3mo5x0v7kjcy5l6rpGB/DvXVshmustBE6H+NDRK6aNez4lwe8QRsR8Pj87fd8xlShmKJVbpZXceg9zijPKTPGlQyHHhCzonupgU6jwZEf0JcjCanZrl8SbKLpDMzqxVS/pJii2UMJY8RtF1LzhcRNd+QcfgJLkqWd5OukNaPfpDWk1wHLwSJ6DX7YgVesiv5WEmnWMJqLvB7G+IHLGAsRXdYg75gdVV3p4xtwxCrrGNdH3OaGIme+91mYfIxlxngP3bDPpVcOb4UApX/H/+BwjDGbd0NM/x5Cxzg2k7dZOsZxNFb6zUAdox6u5su8gJfpufjoHZ4xmlZzFR1j1VjpEwPyMdbNGFVP8MJijMfCf8kstjKUem9HESut6BabMWrhY6WXqw3QV2AJ2SEUY9zvihVNvHSMCN63L9mIMTJ0jK+kY9gJqloPizH+T+XjmpGAWOn5lQ49509Cq+SdLWLcHkOM8f2Mbjf165je0wLoGHlIvl7uk1GFEBeB+Rj7VsDQ8IxWxSE9iDEeIJIxQg4dVL46EoGFrwLC23cl+rNRQAIAHuC8z61lRrNbSdBtE3DrvBJvIUbG7NCjzIrx+H/cHDorcnQOHVlRYor897TKH04CHHpB1ZzmmJ0iwuCfkFz7G28Ncr1fHsaIl3lBOkadzRiVsAnSY3CKpWN8RhWRjxHNWhbIGBFr/xszctmkCmMk68exHbNKLTwH+JZVnCoXeSAZKbbkRc1GBKTT3Ci6/GCTU26HjhlOGMaIe4qjDJVuOccG6BifErZ4koINVARwA03ud49w/WJiDc1clsJLxFC8No1DmrOLotu74D9vo/CsK42/eCD+UqUKY/yUVpG8jPDIA/GpOHraatplxliPfPAD/I+4UMnbg6NaJKPSMZJEkfVv+vAbPq660nPxZ9dWW0jxGOPfQjDGd2lQwTwfY1xblTGG3dJkDIswxoeDGCMqx0rrcKy04kqaqzLGRxU9XKz03CDGmKmBMe7etSKFgnWM11Rz5gexMEbdTdwFlXBez9xjKXlnKJMx6rHmY/wYDPVhMcZGMlUC37EDIx/jxoxxj/mrU5COETtzDid6tlSp3MLQ0Lw+jHGfP0V/OZfWLRZjPKzSIZMnY2ToGOcH4jX8Jo+v5otubw4kSn5fmbG8ieTz3ERQPkZ/J3xGiv6V60KJAFZ9K2AYzg6k+/YTlP4Qysd4AMshUYzxwHJexGQwRt3elZQJgyqp82CMT/VRKJskAYDpNDMY44i4nMlo7k2j/5rqH5Xe3gJ0X2wVk1XNTd7uTx08s3KhOgZijOkYa77Q2iDrKuKGtq043rjKBavvuhAvY6T7JKL2HBmeMQqLlWYzxmcVUQlHA3SMT0VRKbBmy3qx0ncH1JXmH39P9rchGONkkvWbJwcaHYIxklIFB/OmsXdVcerjmsP7GlriCyvKjHEFM2jbsEeJYNdjaW6OVT6H7hFLzTwd4/EUgOKes1r7SWMx7C4nhcxiK+61ceTcj5eLXTxNY5EjY+x0hXIkHmMORS0rfUBrHT3evOKNOatD0WOg/Mh0huFe+FmdaI8I5y7KREVnVU/KE0msdEMXy8iIpa40aVfgN0FLjY+IlOUJzRjvp9HD86isOUw+xoeV0LHSmtMSgjFOwbvMtmwB1jEqpr0Nvf5+PVhcaTfMGM/L5MO/5fe96vMU1TGurJcx/jCWutK6/a0AIsuMlW5l1JV+k4RVRPDaGc1kjAYcKw0xxpVRMkakW+EYY1braQYqlsbCGBn79iVqriKSRvVSZ/h/6aWD5n0S+bKvGDBjxP/471Z6PZOHyrPi+04Dvu+Gyl/w52Nci1fqGBmjBTNG3WoqV+JazTMfY9boTQEB4x5jVNz6dUJ0jDcmjTHqfb/X2Y/8YN/EMEYXesJYmMcjuxoIb/8W0TFuCqQG5wHOF/WZ2To+4yn5ZTBjhCBSVIuj6R6n/AHjH1R6eyvPismq5mar9H/f1f59s/8XXlQuX9YU0+P6BtBD36v4BTcVNJSPcVKMY+h31CmyKF8eljF2473KVjE6tRmzQq5qMBnjM6ooHWNAzZcnFV0AY0x79TmC6koLYIxeerognPd3/HiP5s2ByKX/i8KrI2+8iXJ76s7AmEPT5pvTQckXgxjjawJRnpt/yqwoBVXaKIGRKFO67AG0nMqm/aRVY4ydFhErtZKITRJf5HFGZ1xaL/HTxaYLdpkxXkHhwQqAMX66oeaLZk+Ma/9Cjko/qzNEmTCinyiFUmSMMaq60v9BjSTIUb2is3EwxjlKreXBaVmeh6p88OeUMf6FqhTm0dujN0M49VDo0uB4A04Y41+rMEaSBrEtbSyFGSPe1NEV/q1gcaUVKlb6isB8jLXESs9ZVi43torxmVfXyxjfbkTHqHiM8Y2a6kpn2IzxjSjKgKmae236JkjPGDVffgHloFY0e5cIt8ggY0R9GGO+p4lRqjsOxngmXH3b2ShW+jBIx9gxZ0X0jJEdK31opddQXekz49uNgozxz0GMcZ1iOnHqGLeAGGPGKDaTsjmbAArxWCVfmU47RQNVNo52MJxRRFqxQyCije9Q6s9Ot45UXioX8kgEY8SPcl9yBttbkENQEZr9CWSAHtmNHBy6BoCeu5AjDqRjfImDQ310jGnCGDOdPQwdY3wik7Sn//enSPgAb31SZW9vAxR6x8XYO5MDhwkjle8LGa3YHJNDlwWmbEFe6I3Fq+YL0EPvIa27fzjGqEevY6T62zIreAMsrxGgY3yG5MmPpacMewB+XTQFdeXZrFhWRXf4Z65U8subAoRwS1UxjNFV5wXhvHtU3Wnl7JQLqF4IcOqXonrqjrpqaMa3olpQrPQ6obkcaG+1YSd+SwvpHSZx3ZfSJly6PKVolqdjNJwdXc6I/6zkeJaAyrux0mlKSN6ijNF/YiHHm9fKdaU7tO6mGGabK5KrNx8jdtw6V+mMqFQ4/sDvR8QY/9WQjjGj9wwMgFeNtMuRWWPeT/wXhlbBemXG+E+SE5aygSsrar5U0zEuwEf1cO9DxXQTiS6opmNUNLutvQu+RicaR+St8G8Eiyt7QjHGOQGMcQrSrZYax+AUACyU21XV/vIPmDPFqJ+kkUC2gN46gTGIe1uAfPkuY0S607COUfG2yCzGCMZKT2PoGL8V4Xq2YygdY7vhRsT9k1M+xjPhbPMbx0pDYpRYhHFZr4B6VcZ4JQ8CW9FLpzIZ4765lSngca3Fg3CzGB0CdYzpzlJTP5Rzs75zjZVun10EGaMr+cJ/2F4QsLoF+N7tWUjP5OCQAXzvPuQHohgjVFd6P3Io3AF4O/+Zg0PXAh2xcz+8L94MYIwvc3Do6T6x0qSQUcarwuZnjCuQFh9jzHipp/xizg93nlHawBhv58kY8Vg5qRpjPAqOlS7GpWN8MLDojeJ1IcQYI++lrObiPP9V6pL2nDXA7zVUV7pbjYGcAYWwLqyFMT6V0e1IGWNWt4dQ6LmQaNnwezPF8vzHjG3mE4qImi+oUGwKEMKRZDcZ/uDTCx19ge2Uwz+UlOoYnwMcIq+YHcRQMy8rvH/BfE+tNZwvhin6I5oHmKQX21WSMWlRWfqypaSudCu5viIVAihnHKfwLAGV0dy0dn4dYyVjXEuPN69jJ2eTILb0jBgyOOMvaCgfI7kNmGh2R8YYj42IMb6hNpIKWDXdiOBYGCN+PdVWHpwyxgUhdYwP0kioq2ha1lCMEeVDvhOzXpTlg1Xi56dgp8eq03ubGO/CsTQfY5CO8SH8ehoYZsywGCOZUVMU06mVMZ4fECt9ZbW/fDzjL76Jp3ADjNHZLSCy/ETGuFnSwlDqva7oTgQ1X+wxDFC1BD/iEVDv/BwOaXeiY4yam+JsGfA9F2+8AncVBzDqSp8XwyILxR8t2eiVwzgoxnK+z5i9rFjpjRjj1YBDZ8W46WPrGDvM5TBjJBK++PbsIGPMdtpN5Vzmn/NkjNk/uIzxtb6MkegYvYrq6wQwxluBcbQd+cFeghgjlEd0b/wDZ09BDkGMcZ+y9NT/yG4WwRhdmT3SLChW+uX233+aitmhZ/qkfjGczfAP3IWqj45RLcQ37Skg8+sYPzpU/4zNGJEeK2P8QTWBN8gYOzQnLsa4KHAbQnWMED2LPGslfuPvDnzPMsW0hvq9ZukY2yLunQnA9/wO+EVni4qgyMq2KB1htQmqI6nca7+R1btbWL98TkD076AInSL/+Atp0iR24Tb1Kjd3HksId5IYcmY4wxg471fCyAbNx/isL13ULv1EGi0Seh5uvxYGOqVJ42njr12RQjk3/HQrssmjnHErlHeG8lsO8qVKxvgWXQ7W0B1nua2i/NFljBmz2D9yR1TDvWb4RZ1o799uXenpEVXkRro1OSLGSASWR9S/MM5wdT5zYmCMs9N5p7bHqJjOEKpPDKNjXEBPEIQP3EcZ05oqf/cBJSxjxBvw/jQgO5gx6lbbhLkrWXWl26imLSgf419RV6n6uKJVk6APIJxwSjoXXmR7wFz3ynRaQI/Nq+KMdSQLejei1qOM8TVGzZcfwpcpXu16KF/ia5lIGKO7pXkN1DEy8jH+Bhq4eDxEdotIcjsyqsVd7AdILYxI8sirmjAY48Y6RgQHvL243/zV0dd88ZJRQrPvu4GMEfGv+eIdpbMzSykqT/ePHe46RiVfbCaC7hG8JV/puStBxqhqno5xO6D7bhLAGL1Yadx9ewAO5Tk4lAfG7V4E6e0pyCEdhJ7Ie2R+xngLB4eu71tX2tnAGD8VoGN8FpzZiunqGD/oI33POTHmY3QZ4yd9sobp9I6fwRiPj3Ed+mHgzGYyRpI4Np7H9QTQASdWvlzhmi9xMEa44E0JGdbgcIzRcMZE7BCUPHA6tA/eAiguVP0qu3aH7utzvZkDAk3oL58LjaWJ+d5UhA7tXxFssiowRFWZuSoFvGN+H/1J2CZrX4caBjmreVeE8kc6E36lmlZTP2nSpEnr1y8zu5TK5J1WvDEnWeE8xkhqTJsc5c34i1uqMMa1PsZ46Hh9WfQ6RsVwaesFdaI98ncu3CitWIO9clxEjJHAz6PqP8x1lZoD4FUjTevIl5prfERu7s4HQuoYy4zxGlr/5Z0wjDFthCzb05F3q7w9UJ0x2m2IkfdF0a22EHWlF6B8CKjOOMBtYIz4Q0IzxgNvd8/w0wApR1jGCO53XcaoNKDHxz25JxAkWW4wY1Ty7l0rJE9+BUXAGGn6l9fAislG+LrSK/AH7R7ZeuYxxhVVGeMEvTSAUXU7Dh3j2YyKloOrHRRjOd+TmRWGMV7DU8fIqL7tCfHaZ1owY4wxVlrVHYgx/guZxeZ+WcMZCawTr8S6dTGWQozxE7x1GcUCVjxEcbcBkVnbEaQHMcYCB4cKAAHZk/xgT0EOQcHbe5XD20UwxvnAI9uRPDJQx5jRuuPWMT4PMMZN+6VNG9Qx4hEfH2PUrE2AjMwfonwwYzwhxt6BdIw3V/7C0cAvPHfozGWpmBxaFJiyBZ+tIB0jPtJY23AisKW0ZvfRMU7vUzw24ujfTG5FM/Caghmj6qk9F1YErl0Ww6PaAyawNpzHGHWVmmhxrB1jGjtbAUvM6UKZABVv9lBV6SWJABV4YBMd0pB+0qRJ+zIZutRKkWrK+Bi8Fa0QsAPeW22Fj92tygwnxcWJjOHegyAqlmMxxhX0Z5fj9eYQpBcHRO4I/vChVLJeF2NERMdoRscYj4+q5ovaSM0XvJ3sHxNjzCGjxv067t5BVaSDlXWlF1CVwnX077wLZA3ztzsz+ZBF1ZHpHnPvDMMYM0A6oEzBSbn8sTpjfLCjywmlY9QCGaMWXmS7z00b6krXp2NE7Jovr+Gf7dbAdmMPluoTseJFFHbNl9eQWYyKMb7CiJUeDv0rfsOA45HFcyihdYy6G8OxhEc+RkaOo6XIKG7EGI+AcHAcr5+sl+YMGk+VxUHBrG1xxkr/iFm0JFtw7zb8h7fPFD2+mi8Ko650RuttJqN/JCD5ir0kYRBj/KYgYHVbXx2jFysNHW+7RDBGghdZwkoeDuVB6InEMcYbYcZouGVw+zBGpVDkzhhJSd5+yKv54tcx9qiGHVs2L5qPsQ9jzBZKTWVvu/x7lZh750Rg3N5SuZwPJislxXokxdi2MTu0KJREETs2MMvK/BcdijkBipXGGz/+KfFojupuYLp3iqJnhZoYIweHngUcmiKSL/4yThVpzUaK0tK0Qgtc56b3pPpJkybty2ITC8u8fIxuzRd7e6pj3Arp1rBszHupL95FhhvHqFKQ9SbAGNdQxkh+Ngc7eHDGsKJnjIqX7I8wxo/qIGbk71yUNoqRMsaPIkB5HzRU82X8PPcyb1YMjHEmPqHWJqtHes8Ampg2rI6xzBgfDMkYb8F7o3BjSzV6yAvw5oAPI8HZU/EMa1PMvoxRNZwUKZ5FGePbAZ9znzIrhOKTVkSCPuATt/iMET7DgDqj1EQdY+VjvKKaM6yaL6+SeOf6cZ57On6tppw0GY3JGF9SjMZzENHy4K8wdIzDod75DViaJ0IdI+GVjMd3sX8gDqRlCWOvaoJgxtiNzI1jpSHG+Or+s6OPlVZyrk4bGk+HJ5Mx4hMjxBg/xWMnzrrSmwMY8X2VCJoUvRdkjGkjvmvKiZoDx0qTmi94/wLpGG8TyRh3ARzKcXCoq28ksL0H0aVCC+IhIhijCz29dcit/PcEfXFO43Ss/jPwyLb38SGHW/gfUD7hc7yD2KyfCCO5hCHGqHY5zWIcghnjrUKcSc9wk1Y8CTh0XJJ6p4hf8MO4O4P3RFszdhX8GWP7ZctSjETuyzJBKRBjnOYHMbaw5wkZOzSUcD3voltMy5Ky394tQdmZv2Q6e8RWR6EVAg8hoigl78igcGnSqs2YFD7vD1M1exzlizu4Am7Nbk2bvXwYI/LWkok+HeNaho6RMMasUoihEhPKu/XG6mWMRHJ4EeqMKJOl6l1JRqFj/Ag1omNUchY50c6OIx/jfnNrLPanmksHMIp3snSM19G2gP5/n1fTMWZnhGSMB3mx0ncEfNjbbhy04YxVZnzWZzZ15HoJxivXfPlHwOfc2jG9JxRjZKXNJPVWp3QY4U8Gac3NMD8lgDHOrbbfZesYGyBptK40Kx/jyfAg1txY6aWwM/bohvfTut3GipXG/9jQjDHSutLks4ADYl/GqJjWIIaOMQ7GeDacCcraSMcIlch4TcnbkR9tacYDKPb+iEqHoIoUZ3BmjPP9v2RUXMbFKvlSYVXX+3joNPud+rrqZzTx9RLAGOOrgBHGoVurAivODnWBskGBDhWS5tBNiSk8Sh160a9QxoNaEGPUHZAxKpotjDFCSr3bRD6upwGHJotyBuqdIhLBGJG3J+pOBGPEGzQib30c1DFqjhDGeDljC8tfx0gvmXsCFcJcwYTp0nt/8avHMobAeGkaNv8iBRQ3Z/Vu8cHbqmbhQyTH8hnSpNX0GvCmsltXWqU1X/BqPA7vaYZN1DnFSiumW9X0ELrqvuWrK11mjMvpz67ATqqo4AyMfrqazmDKGP9TL2PEvRcZYzweiIyplzGe0KgzegyMcU56VrG2rWqHZtfCGB+ogzE+kNZCMsasl4T9L8Hldlx+2JbJ9Y2SIWnI6UZsShXGeDsylqTCPKZTWIyRfMl4LXx3I83uj4IZYz6MQzkorx4y7G83sHXdLSAf40nVHJroY0XPI9NpXMdISofDTn1cVURAFHOUTlymGoz84/UdEHcPpWPkvFE7G1Z7OoOEODS+s5cwxpcBp44U2UtnAg5dL9AhZzNIx4jMYpPIXnq1r5jTFsoYbwHzMSYJ6ZG4bZEO5YESK0IZ483AIxOKhQHGKErHqNsjgVfIhxP1Un9RvQNRtNtFPq5nAIeOTRKBdcBrTg5YbysGY8xxdybdVSRnu0chxog3aHwZY/tly8iW46+MLewUEYP4PJa6QdSs6gKceQaZghgjDbRcW1laXBG1Klc4laZv+Klqrru5nzRpSbP2LjuF3z8kambchnyM+NWQIf+fwYkxts8uElTznYpY6RUVOsb1Ph0jYYyKosfAGCfeuz5FGeMHar01X0w7mswnJDwHKIJWL2M8PooFbSdAytMQY8wYxeZGHPq6b9mvzF/9DsV/19bKGBWjgVshWrBvbUUF5alId8bCGM9qwm1sCMb4FzS9t6Ge+gaJ1ssWwgMBxXQGVGGMuph9tMHWMaoxVrQMdkqztmQxxkzYGkLR95TLGD9PGmME8zEqZlFMFIwyw63V+BLg1NHCegnBjPE6cQ5psI4R6b1CGaM/O8FnSLCO8eak6RjZocnSIfYjE6pjfKnPoDYcoYxxRZ8M3zVkXYm6d44Hxs8dIh/XYsCh74t6XFDv2CqUroXDRq0tMbHSipdr/3FQ5ck7Vhp5F3aPJiJWWtVdic+TDGduEzGj9mY484wiQpDLOPk+HUUAVCNOXUY3ZERRM69dExxFTp0ajWfTlpKsSduIrJl2EzI21JXeXvVqvgxLG3ZKxCDdnV7krgXyMRLGOBc3BRnWwNidUaa7CWefqCEf44XILMaXXRk/muY64qc/ihW9ACXqQjPGjs4YyoOjgpup63SaaelqyhnDMsYFimbzYULjtSKZeWPpLeI7geDzlvV8Z2PGU4wGMcaZovbR32LVfFF1SwwXwusRq+bL+5l8cZAgp1zFJzTgfyOSnkFX5j0o74jZI6l5V8v/YtIY41mAQ9cKc0gx7FHAWHpfxbsHkVval/viGLE6xj8njTGaSUN6JlhXOkGMcb1kjF+sQxbEGD9UcrYwxnhcYhhjxiw2QYwRj59jksUYtWQxRgE6RsPNg/U4I5KcLyuiJVYfSQhjdPPSsA6Vt2XMZfxOHplOd0a9wHBmcUbnPJBVL8a+BDjzLB7gY0QtgvN9ztyomAKkymUj9axIFCd17Lh+0qR92YzGUhNeNIMkp81q9kCRzuwPlNv9D37DX4DXHSEXLX8MZozOZN4OnR6CMV6h6JzES2jGyhTl01UZY0Yv8ivChzR7LJULvhNYV3r2cr5SeORVYjoPOGGEq/kS4z6alE94g+GUoCAlvE1l6BjfQXpvi6ie+hYDEf9aJD07F9IxTsg74mI9EscYGbHSAhmjp2P0L57/OmjWqlSSHtvneN0SyhhvBEqsCAVWANJz9hY5/RPHGBOXj/Gl5MRK5+BY6bQpiDGiJDHGtOmKEJ5PzKuDQWBtpAsAEDTVeDJ0jHiDRnSMC6FIcqK+4t0zYwJ0jOfyHjPHMMohujOLVJjj6cz3AoLlnlN4D+SAXFiLM5ozWsQUvwJCwcIYI/7yrStkYYRVnymeFxkOUciQO47+/aRJkxbf9D+dBu8qSXCm4NvIz1V1q0WUM+R6ygJW64cUjSNjLNvBplv3jpVl8K/teQGhpPiLDyWF9+qq+RLjBm1nmlIBcupkMQjGsLdkiCv/pQpmjJ8ATv1UJGQ4B0o0se8VyRLEETGKUMYI6RivEeaQYhQhxvheesbyRDHGNYrhjBDp0A19x5G1o0iHDGBg75Moh0hwnEiH+khPVcMW+she6gvOxdWVBmOls7olTMd4bGIYIyksmzTGOBlwxsKPSwRjdMYkp+aL4cZKL4IJrM1bx+hm736csYU9h/Njcrk0kzEqM0qcar/qbs60qwOkFs+rhrMJz9l0RIAzzyGNc1Qw/tKfsRL2pwVGkS+vXGtwO180aCBOXYLbNKRZw/tJkyZNmrS+ltWdTemeej/hzmAntnUrmHzxOimIduiPwPH5JJEO/Q7Mx5i3xMRK4w3Z1xh1pX8mspegmi/vKrqgSqV73/Z5ilHzRWisNERirxLokAPFSr8negnwR1WtQWZxpEiH5gNr0k4iHQIYo7WvSId0oIeEOnQDMNOEPrI+4lxVGGPULFDHqGqOMB3j5OToGAsWK7Lz6CT1jo3+z8dKK7ozDH/xUwyV5xa8e2ZMQBKuH/MeM8cGMMa7SNZ4Xo6QROsPBWC9F5DJiTHivfMI33EHAp782DT+woMCi4Jq/KPIt6bJIP3FRaeJfHkSYP5P2v5AtB/Cj854fWnqJ02aNGnSpH1Fjd7J3obbbBJEINqZvXzJJhZP7OwWKoi7CNi4fUekQycCDl0pzCHFLI6G0LDocfRcHx1jXqyOcT5QNVkosAKQnrN/whwSeIcGPLJ1SLCOEWCMgvIx4i8fBTJGsyjmRohB0W4T0zuX2izGKCwf4yRIxyikrnRArLTG//2l24QxPs2IlRbCGBcxeNHZImYUi6bdnTGKTbzWmiNJueYAkvaiovNijF5JlaCkWi8iXgBL9SpvrQpw5k78GLkqPFuBCoCkfYIdOX+C7gip5XFRBfTsJVsNYSkzK5wihWn3zxrd4kvySJMmTZo0adKkfWFZw2nJGpb4vDJ4r0SS3FxOo2NIAa20aIdO8W1x/63kBfYU7R1/PkZxjBEBSE81nANE9pAGMEahDl0PKD2FYmE/tFqt6PamQpxRdFjHmM2XmkX1DpRx8FYhzkyYtTxxjPH7IGMUEyudIB0jyZNP6nTAjJGzjhFP5y0DSjmfxXtGHRvAGO9pzxXj50WKZg/Aj+i4KozxZfx7m/DokT2r5Mcn7SVkONwY4+IqzhDGOIKPM6ZN4n4+YDhC0mqcP8EspXgP4j/4HCFE1sAzTVBZHs1No0Gg+Z9wm9RhCir8KU2aNGnSpEmTJk1aLPtvkpb11wTPIHyWE+3M7j5odZVoh+b0ycdocsz6BTjUNwGALqhYuuLFSvsVNB9m8oLCv1CSGGOHZjUzGOMkUb0zCYwGNgTESiuJYoy6PZzFGJEhhjE+BWIag3PJDDpmmIxx4v/2xj/VMzOKg2jQdiBjVOMmaarhkArJ+SqywfU0a278jBGgZ2BIu8orD3VAsaL19Pb5fFQocq0TdDEDdhqKZo/l/wb3Cs78mkqVr8UD+2RkWPzTZUqTJk2aNGnSpEmTJk0aUUCQE8pRbnYLwxoi1hnDacGOPFZxdns2q1viODVDx3i4EGeUrhKr5suhQhxi6BgdVUhBCC1R+RjtTRiMkdR84R4rPZYRuM1Xx6gYVqoKY7w33cWBF2VMeyBljEEA62WkWyPiXl+OorWkV1bBei/HzhjxF0yk5ZqrMcZ7kM6BMUJxGgBjnJYuONzi66cxHFmFx5OJeOsY8Re30GvLIk0KeStupwm55dlozRGV3USaNGnSpEmTJk2aNGnSpNVyqDySJjouqLwLFDOcWVdx1F6UzRfFJDpmxEpj5xz+vaQYLmOEQk6XqobNN46R5mN8hkFH+OkYFW1FinLpJSzGqOa5MMZSmTE+Foj1jBh1jLSs5R+pmPKT6owxxlhp/AXb0DLN60O0e5XYFZ66fX4IR5YR7Ddh9ooUj8XuhABHiI4xT2rb81t9Nbs/Tb1STjVPKindQRhjWhfIGEk+T6T1Dp9g2OJy3kuTJk2aNGnSpEmTJk2aNGl1GzLtwfh0ewatxbCtWGc8HWNlCkQbt2+IcUZzdYyQqPICro5kdIfk1jsmgDGezmmsOIOooPKJwPBkwxkaiwOqF0v/I9xm4fa3ELHSr8SmY0SGPZR+wfqQ7b5YdYz4C74X0hHCGKeqnTHDLJIKvIojHmPkVfNFMd2ZdKVPdtpNU2WehnRB6Vcoq95FMZzR7bMdyRilSZMmTZo0adKkSZMmTZq0r5CRgsQ0oJJAz/+n6kUxdcqUgs1ijHxhp2LaQ6igciGDGT0Q25dnjQ3ZKUhivxlUx7i8CsT6fSzOqIZbLOT+Gviiq2NEekxpNfCH71qDI4QxTsnmnfgCc6ncdG0IR/gxRlrbxe9UNyKpMnX7NFXnlC7T59TXcDsAO7E3MpyxyLRkvLQ0adKkSZMmTZo0adKkSZMmLXo7JF9MUUkYiYPdT5gjSNvAGCulpiTk9Lh4vzhnE6R3GBXbXoLbTNweoUI4CF49FatD+AuuqJEvPhCnM6NwW12DMyS4e5/4HDLsIQGPpg9jVHkwRqp//bxvUgi7V/UY46nIsEfynVG6vRn+4gPxfxGZ2tiBtr1mFKWOUZo0adKkSZMmTZo0adKkSZP2FbaM7hB2dDhuv8Ity+VLJxrFJreylle6+XfI0zHOooVnlvt4UfxpMvGXXFYDznslZmesVA0JIUl7OF6HDIs8rjdDOrM0VthZ8cjSjEwDZMz0kHI8uJ2CTI6x0qrWSxJD7oIHtErqBuH/7pfR7bGqUZI6RmnSpEmTJk2aNGnSpEmTJk2atOgsq7nA6iTcrqFc8RLaZtHCM//C7abYa0eXzYuZDxcXzcuhl0I69DEvh24L6dB8Xg610dydkBNraT7GeWrc5Xj6OmZtggx7H0LrEWmavS/SnTZVc/rLqS9NmjRp0qRJkyZNmjRp0qRJkxaJZT394i9xe46o70gORqTbv1W9puP2Y9VwWrg5hL/wpyHI2e3ItFK8HLojhEMkOngzXg6dF8KhIspzymyaNZ1mon3F7d2AYO0ThQxwxbDHEO0iooyRKDqzOudgbWnSpEmTJk2aNGnSpEmTJk2atMgN6fZQRbPFq6iyultShdT/XYlbidZ3KesYT83q9kCuDtHK60Hk7ClkcHSKkrNqOG8CT4d2x+2zKg4dwPuxHUQ1sB8BMdJXCRvgB860U3i8jMUzbl8aK70zmmHJPIzSpEmTJk2aNGnSpEmTJk2atC+xqYZNSjbvp2r2+ExXcbBoZ0iGwQUVPOgzyhh1IRVvaLEZFjUjpVbG83ZIrYLyrubrkGa14C99KMChS7k/NjT9YzKOJuF2C42HXkcbwcGjxA7yQrFJNZwx2Jlt1IIj8y9KkyZNmjRp0qRJkyZNmjRp0r7kpur25jT8eCbS7WMzeWegMGeUnFvB5BkfoCIFiv+M29dF9M72AeTsdWTYA3g7NIpG+K5nVDBpE9FLk0nCR8Chdw/OFZuEjCWkWQPxgD6ZhK/j9gEthr5nImbdIV2rpGZRmjRp0qRJkyZNmjRp0qRJk1a/qV3LmlTNHpwMZ3R7L9xepeWZFyDdPk6ZUWwW6dAzAKgiDn5NhDODcHMYOO9KUT10JcOhO4U4pHSVSMpDUurbrnBmDW5HCh3c6bxNiqCfiNsFiWGL0qRJkyZNmjRp0qRJkyZNmjRpDRsVxf0AtwOT4Mz3fPnzHsWtXaRD9wDkjGgYtxHl0M0MnHe8KId2ooo8v0MiH1tPK3bgMtws3Hpx+1VCZpszQDWswXLdkSZNmjRp0qRJkyZNmjRp0qQ1ZCiXoBoKqm5Pxe1tivKOFe3MIQCominSIahkMxHDbSvKoX1wWws4tbPIXjoJt54KZ+4QPrCVvBu8TeSCh6qaM0CuO9KkSZMmTZo0adKkSZMmTZq0r4apmk2KEreTWh2ZnN0i3iHdnl/Bhf6N23dEOrMtTdxXSc4IuBomyqGtKU/0ZxbcXmQv6T6H/okMgZkqqVOn4raQKj53k1NdmjRp0qRJkyZNmjRp0qRJk/bVMqTZ/RPhiKrbY3G7l1aguEbVrRGiHbrDB6sezxhWkyhnmoFgW+E4r8vnEAngHi3OIa2b9NIVuH2CWwm385IxuA17JBKFgqVJkyZNmjRp0qRJkyZNmjRp0mIzmmHwfJUUC9GcJtHO7IzbqsoyGBO1UkqkQ78Ggm0zIh06A3BInKgyk+shktO/VDizKGsKlgtOnOMWt56I23eRbg2S01yaNGnSpEmTJk2aNGnSpEmT9tUyVbc3UXVndFKcIRkGV+K2mkQDI623SaQzm/r44nqh+jP85eOAhH6zRD+yu3wOHSrUoYl5V1j5S9yuw+0IOcWlSZMmTZo0adKkSZMmTZo0adJiM0VzlVW/we1ZkikO6bbY2grYiQt8sOoq0Q793efQEtVw+ot06Dc+h+4X2kMH6z1kDJm4ve8FcDttiRjceDA3yykuTZo0adKkSZMmTZo0adKkSfvq2UTN6q/q9g9puVSx+c+Q7gygxYjLsGqxmrOE0rM9gIDbrEiHtgOqmOwj9LFhB/6A26e0msmsRAxskuaQZKyUU1yatK+i/X9jsJ4YiehNDAAAAABJRU5ErkJggg==",
+    "_parsedURL": {
+      "isValid": false,
+      "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAscCAYAAAALLkmiAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAAAkAAALHABjzUiVAABgH0lEQVR42u2dCZwUxdn/mV1YrgUBD4QVTWK8o8b7gt2Zrh40xryeQTwS76hRAXOpSf7RHG+i7PQxsxwieKPxvo0STbzAC+/baIwxGmF3u3uGy4PrX9Vdg0PvUz09M91VrW89n099JNll5qG6qrrqW7/nefr1kyZNmjRp0qRJkyZNmjRp0qRJkyZNmjRp0qRJk/blNlV3mlXd/ilu83GblACHbA239RXtHGHOTDTtJuzAf3wOPSu6hx7wOfS4aIf2wu0j6szHuB0gfBwh3WnFjuyMNHugnObSpEmTJk2aNGnSpEmTJk2aNGn/90zV7Z/j9gpuD+G2o2hnvuNDeq8ebNpNIh36o88h0lSRDp0IOHSYMIcyBbsFO/BChTPv4jZC7Dgy7JHYibNw+wlum8tpLk2aNGnSpEmTJk2aNGnSpEmTFrtlC6Vm1bCHJMIZyoZ6cSvhdoloZ9pw+9SH9CaKdGhvgDFeIcwhxcN5a3wOvS36sS3wObRQtEPksf2XOrNE1Z39hM80RbOGYWd2ySZl6kuTJk2aNGnSpEmTJk2aNGnSpEVqWd0FVzsiw24R7gx25EjcVpSFlbiNFubMRNMi8fbv+wiaIcwhNKNIHCr6HHpT9CNb7HNojWI6I0Q6dDWAhncQ6dC5PmdW4baZuHGkO4OxA4/ito4y6wsSMPWd/tiRnXAbJ1dladKkSZMmTZo0adKkSZMmTVrDpur21rgdhds3kuBMO2VC66nI8kjRDj3oA1aLRTv0mM+htZmcM0SkQ9f6GSPS7V1FOpQDoOd4YQ7h3pjexyHDPkhkD/2vz6F1SDAWPhC31RUOvYhMp7/omabidhNuptDLF2nSpEmTJk2aNGnSpEmTJk1avWf7XXD7BW7fU41ik2hn9qyAnqTlRDs0w8eHVmYLvS0iHboSYIxCgVUn4NB4kQ5NB6DnBJEOXQX00G4iHXrWL85FhiDpaVa3h1aIu8vtv+mCoOy5SHM2pRrYSoduFb0OVZYMWyN0QLu9pNsjsBMX4zYPt6x8kUqTJk2aNGnSpEmTJk2atOQZPrHuT9Her1Td2US0M7vi9knF+f4h0Q5dDKj0xol0KAcQtH1FOjQdcChhjNFwdhfp0NOJYYz40Qz3XSuQ9pFiCrrvwF9+PMCoxTBGdGkpBeRrIO0EUb2jAM6U8IAeLsqhCwCHNJGzK+1j1L1ItDAXO3EKbs/T/MJ7y22GNGnSpEmTJk2aNGnSpAk7nx2K2z00TPkbop3ZHbfPK6viZDVngEiHLgKg57dEOtRXWKmJhZ6QjlEoY3yqj0OmM0qIMxkNZIwforwjjDGeAECrW4Q409FpN+EvfwZw6EQhDuGBOwlwpqiYNn/GiDRnrFf4qo9DOndnFN0eBiiE3d5BRnG0iIF8G+AMaefwf1SGM9z33iq3+7IFAVMdf3ELbkt9zryCDHukyJWZZOy2KaN+BDszRvj+J6vZg7AzW6ra0pTcDUqTJk2aNGnSpEmT9hU0vOE/gxyHaGWTfUU7M8En2/lY1ezBIh36rf8km9XFQk8ovH1HkQ496U8yqojSMWaM4jCfUthljMJ6B8GM8WYhzkyc+0mKwRh/IGrsHMvQMQ4T8aiSwxjVvEvRnoF7h7OOEenOGIYzpJ3Hz5G8k0IeOfuY4cx9SmdvE6/xshVBdwxHPMaoc2SM+AsfDnJG0e0t+a01hRIpureM4cxfkCmAvpIv9jlCHJyqaJagVBq6vQW9NSTqch0vfGPlllSaNGnSpEmTJk3aV8CyhkDt4saOuEorjZYEf4fU7hDqEHZgsu9UslTV7EEiHZoLQM+tRTq0yO+QotmtQpxJewInP2P8z753rRejmsGHyBOBI/ZNQpxRck4Kkp2KZIyTk8MYDVfHuDQRsdJIcwcyQ8fIkRXRQZwMxkidIYzxvwxn7lVmLoufFym6Q/K+Hg1csPBhjChnEYR3HM0D80gAztvgjGpYY+KcynOqOLAxY9RiZIxZ3WmlZQerOVLCbQrSe5vjXuiIztUKcIQ8vi6kWWN5rr4n+F6WPTTE5jTVcMQIcPGXj8KzZq8MXo0n5OzmftKkSZMmTZo0adKkNWwTDYdwxrFZwxkk3Jms4QbfPkrFlb0k1F2oQ0AKzQ+ynVazSIf8x+zPDs7bYgoZKZoN6Rj/Kax3EsUYJ3S5jHER4NAPRY0diDEuQ4YARq3ozFhpAYzRCNIxOnwZo2oG6hincHMkXegmA/iIAMZ4T3r2isauE5SclUK6NUI12YsYfgQEYh3FIPZfYD3NHtFY1+OXIP6g22lk+DLKE7twu4S2mfT9VJUxRhIrjT9oWg0skdUeUKOKIscfZjTgCGGM5yn5CEuC4Q88ELfVNTriMUY9JsZIM9+SdAcfMhwo72/uxe1UpHNijIpGZls3Wex2wy/LiaTkF/7vfvhNPma8boutGilNmjRp0qRJkyZNWmwkZKQbxG04myXBGVIsvbtclxw3JNqh+3ynlWeFOZPJu3Wl1/qP1yJ75wfAee5akQ4tBGLtxTBG5Cmx+lK0fLFVQM8kSMeo6C5jfBpwZjky7C3CPus0jcT8Y+i/BD+mIMY4Nawz433ohXT15FocyWpONcZ4d2ZGqSmsQ3+CPgT/ax8jEkE0cwWbMZqujvFIyhjXsbFeDagG/4WTqoAoosx7CLfZ9KqpzBgfD8EYX0VajYwx66nvbouAKfZhjHUrPDtmuWNgKpkJEThSwo6cly5EALPwsx5DgeeKOhwhj28GydcQ/cJm2MPwB59K7rbIhVsAY+z23ubOKUiz+GVUJl+GvOKMhC9OJFX+cG+24TUrGeE10qRJkyZNmjRp0qR9xQ3vxfdzA5pE1wyizlxQccwm5749hTmj5J1hwHF7nsjegRjjbOgXN6NFzG8kUZgxOvQE4NCx0C8+7DuBRu4UgqtulxTTafX/4qYAO+7B//+46JypQceINGcgIyvgcxnNarhijaK7A/kpWOXpbMF6tqczAALhg2310xOXMT5dM2NU/7eX8KC7GH9xKaqRMSrTu5tUI5Ax3qUYy1LVZsAmuL0YwHuILHBypuAMCeBJrRR2BukYX1bNkDpG/Mujqzi1nhazeoTGR5cZ4yw6pUtVGaPh1MYYkWkR0H1nDIzxL3UzxmyuVGaMK6JgjK6OMRdBIABJYUAZ4/I6HZkZC2NUPE00eQ9dg9u/GA6spbHS92MnTsKNI2MkPJFwRY8vEs64j5sdt1CUjFGaNGnSpEmTJk0aB2azM80jtF0SnDmlQprzeRKyR77CW1NIEijh9gvc/nejp4IuXZICjjSrlBglEuqMor9yMjk2jan09mZAuHRCjL3zw8D0h1QN5f+Fl9Kz4kkrR0VP/u87rIKeWcNo1Jy/lyZH7QyjIo6Nh0iL3+vLgF/sJnU3IjuKezVfIB1jDgIKm9Oavf5fXqwaziaNOpM1XMYIhbWvwEfy0axnewYDIDyNdKcBxugqtFg0bRr7X5F3eRALUpHHd1wtjhx85UpS8+XwgJovd4aZAYQxvhDAex4h8Bv/qwcH9Ah5PIcHkFd3FuPfGxFuWhouY3yhCogiSSD+RrWL5Vjp2VSaXKqej7FWxqi7jPGOeBhjcWQji9i0CBnjFLWr1BTFykpmid4AY5wRS+nvTM5qUXVrEv6C6+klyjoGY+ymVXF+wI0x7n3rajKlx5D4aMoXVdz2xhOiLWsUxaRckSZNmjRp0qQF7RA1awA+Nw1KhDN433Iwbu/T8M6rs5o9UJgz371mPTn6fOTbZJ0t8FHZOwC7vivFOUR2eX0dyotzyEieQ9Aj+7PIR0ZY32d+Kc34nC2m3Elad3nfBz6HVipGvMcXSu1ISOHVqr8aDv4/buHMGL/rO9O9jM/6/St/4QhgHL2Ie6k5Jof8sdJr1MqCs6qHT3oBp46LYcxCjPG/6qxSs9/r6SCk0qLTMSrsutJ/glbszRlFHJ7F/6qGK9YomiuUWwjpGBVW2DP+4ZkMgvGk0oBCSvHqSj9Zu44xb6cCINUSgvJqGi/T3ZJgQXWl76g+A0xX1vVCFR3jsZmZywYFDFwySf6nCmMks3h4yC62CGN8PqSOsZIxXk5ZdDXG+HLNAEsx3aUgjljp+1EjRUUi1DG6daXxbrTxxVbxdIydFZlMameMceRjROaSgbQ+0O0BjHENvZB7wGWMhsOHMe53w6oUXpva8IK6L7mjJblf8CtoTzdzRa5XMkZp0qRJi+d4otmD8Yq7RTKc0e0MzRe8hkZRjRLmTGa6W1TvTd9L8o8ie+eoRAEHEh/YxyHDPkekQ//wObRa0Wwx+e2UnFvI43O/6kAkH9ouWePHsPdKGNJzEuaQbm8PbNZvEuiQsylQS/OVjss+EsMYs0aRrNL/7nNM1uxN4/zeiaadQqxC6diBWwHGeHyME2kMBZ6Wlw/LGe7/hSNAHWPBiYsxPuD7roKPbtksxnh8DM5AsdKPQr8I6hhxd0anYzTsNoaO8f9B05/FGJ+Ooip2Ri8OZUhOlyusMFP8w7MYBGOh0oCOUfV0jAtrZowTZq5MUbIBxkrXyq2Vq1wd41EBjPH2MDhvWBWcR6SCx+MeG8LeQTjD8Mz9nyqx0i8gM6SkleoYnwuhY4QYI8G/xSp/9yX8hqg1Vjo2xngv/uwRjTLGlRHpGKchI4J8jIqX7eJ3dTLGZVTHGEOsdK53IPJSq9xOZ91aBmMkjj9IGKPC63yXNpxm5N3ukPhohCeCggfqnkiz2lSjJBmjNGlfHlN0N3KBpIH+UVJizWZUBoHgtpdIZ6DMSXMEHam7SbbldxKRf5z2zk8AZ1bi18H23J1pn/dJCiqQhnjWOPT1DnRQfFXkYL4ScOjHIh3y55pejQxLDEBHXrTUZ8mpDGG4jDE5wMq7Se4zfgoikd6eCWOMDvTIbhE4w5xREGNUOpeKYYzI7IUY40puEokaGOMJMX8nQTRbMd70DB2jWYwrVvpSer9Cxu68rOH7HsSXMUJVtw9keQ0wxuhipUncNUPHeDiLMUKx0k+RXIoNM0bDZjHGpQcbvQNZ3Xk2g2A8gRqgsaRYCCOPJ2nnVXvGtwfoGGuaeQdd7m78jg7Ix3hrmEHXWgXnEYw3OW2yY6XV/IZY6SDG+HxoHSN+4W5BNLAhdIyP0hyMv6WM8QrqRHXGWIeOsRUSfkfQ7sHjsWHG2BORjnGaOnNV4+9I1egmvfX7EOV3AnSMcTBGs0iu1E+liuLuAB0j4Y8L3FXZ4FTzJaM7zXjwj3UDVQxS/NpJI83ak/QEbuKCnaQlzrI5u38iHMno1gCSQoUGw5HLt4PEnUSM4hB6NVA5nf+lag7/2XPgzOVNwDV2eX0ZLWLDP4ex4j4lwpmjGc68hTdZ2/EexIQxvgU487qixfAeCtE7vwKc+Qy/Bnbj7sz+c1c0Ma6yxTBGBCfVenn3BevFnO9pNUm/Q2J0jHj2kJPBe/41B5nO5iIZ4+cJYozON4Gd380ikd4ewPjpkg5VOAQxxlsFOmSBjHG8JihWGnW5OsYP+l5L2UIZIyTLOUHkOAIZY0bvjosxfoOivYNY0HMYQ6F3QgzOHOYbs9NYvwjpGCOu+QLmY/wgawKKUpqP0QGcWtRuFIc26kxH3g1ieQy6uTxEL6ZYvfRjFmPEr5i6dYyKB8kfY3z2adWe8a0sxlhrXemOGa4u8pgAHeNt1f813gAPwnl/J8lH8e+xa754JXmq1Xx5Dn9GuALpimmHYYzL6WOYTRnjb2tgjC/UXPMFP/ehAY+vkXa30kjSUpp4dGkEjpAe/QnqjOBCB7+Aya5SaywfY/2zNGjAD6c6xrsoY4R0jKsrdYzI4PSSRmapP3auzYucIXzR7sAOfFsljDHvSMYo1hSjt5VeXRHRyslCnSGrMqAt+gl/xlgoDaAKcjhFhs5xz53J20NoGlXW2jKfmzN7X7OMoJn7gy7e8Mtza54b/jzDESKDn6rwrF3PiHcl7U3uJE0xncE0fZ3fmdcayd7dSO/8GmSMhrMHd2c6CsUWcJtpBMTtxEzRoIPiKxnWaYDD47o6MTpGpbAMYoyfK8J0jEZxBKBjFCc7xevLNxMlikPeLi85SA9vPyGHZoiEVd9MFGNUDTdWOjni3PaZIGNchc9im4p8bNCR+USRDkGvjhcyuiPm1aF4+RgtHr2EP3McWVbINjiwYBKDMfZGWfMFb2WIjvHdylcUbjvADpnOZgzGuDCoWEjog4NRGkQFdeGRHrlFZGxhH0Nm/Rt7fGTaMoAxonoZ439r5dbZQpHESgcxxuvC7K2H+upCgTpGZNpBdaWH0cSQTwZ8zuJM3hkacvV2GePTVUDUCionnU01jIQxzqWMsVo+xufwENiyxlOIyxivi4Ex3oV7cHgj68bpjNlXD2P8aVQor1zzZUWdgsou3CvR60cyeLBSxng35YhrqjDGH+ITDR/GqOi9A/DgH0sOkpQvthPGSHoik7P/j8ZK4z0SSaGp0EjP6zaqysaZMZIl4ALc/gOMmTTvU8lxUPxiRTM5MUY3RGd2iGl9Lg9WNLQK1ivvZa45bHbMoie8VSCM8Z4AR951s1PoFh+IpepWLiAoYGomb/HTxqpw/vEyY9yd79T2rrE/Apx5IxY9fZ2McTXCZ3/+K3DOHsi4xjy3nwhjiFFezeR7m4Q4lCzG2OXebbwHaGCF6RhHAJKv19MFQed6BmO8rZ8oU3VndyCkdKY4hzQQeopzCMHh7eIeGX67g/kYFa1H0KDWnETqGG8NrPMswKGjQSCQLzYJGthuujqbF4lVDWewYlS5i2PpGBXN3jo6R1x9261UEvYEXgN3Cpht1uYM7dhC1SgOaXzy2IMArPdItV46hx0r3UDNF8NVeD4KYUK8AWyu5tTNATrG2vIxFpYRxvj9AMbYFWKAu+TsqWo1XxSdzQeJjpEGrywM+JxFqmENDNnFbqz0whBE7Aka/vU72uZR0FmNMS5Wak32p3T2tjCy7jTa7myIMeKuPzeimi/kM36qdkWw8cP/oi0bqCu9nDLGGHSMmlOOlb4npI7xZGQU+bykVdMZQP7VSLO+TfniBBK04mobTYu/jjGtWSSdc6vrFD4oiNnMmS5jRHSqv0nHxxqqvrqII2N0AdaFDBhRGQf7jfjHiuGmb/4w5IzaNz7GaDj9QzLGDdpGNa4i6ZnO4oCQjJHgvQV4UF+CN3mbxfSIulMBb/z1tC7DNLx/asvqVvxb3AAd4yrcE9OyRqmZ22xi5GMsSwf5kjQ8tVsZSWdexz8bx33RI4nPwcdk2Px1jMgsJosx0tQ8fcaNUigKY4zXAIxITOVkJV9KJYoxKpoFMsaM1itKdupsW1f++hiR3u6JQnp4e/GlYIwCY6U1mDGmDVH5GDUbrPkimjFC6cV+KNKhY8AoS90R9OrwkrDZwOtDaC+xdIzbRPw9++B2QBigsBmDMT6e6Sq2NuoI3jkMobGNG0rxVt0Oqx56AZV5eL2qe9dIo8j/DnxuR5guZZ04PkY1MsZ0YTlhjJMCGGN1hzJejFAQY3yMfAkBDQE70FZ6O/BEwOc8dEhXKRW2i0fQ2lDVxG6LaHz0byljnBsyVvpZvO2pbeFFhZ6WmHSMd2TCRpEzxtTUOlEexBijCbakal+zIcaox6BjVA1nBGWM9wboGMs1Xx7Au9FT8FtgJJeVXTGLLW59F48rTqBtdzdW2rD46xgzWpEUum4lEnlSbQDvPHfAzrRlNY4v5IzpzryJNCC3zBjX0h3nOvq4yFIQb9ipkneGUB3jRyEH8g1x7gJqYYwbLlcid2T8DDfr4Kw615xoE7opxpIBISpzraYlER6kKzpp19d6yVf9De2V4721GmMkMyrdxUH9EJCP8VPCGAkuTgJjJDpGzozRS7zO0DFGV0uxlt75DVTnTkg+RrxfHsTIzi5Ix2g434Nw8HjzI2GM8VrAITGMsX261eQmofVPccMWVfPFGUmLNG70uNpNSxiO2RYAVneKJGgQY5wlziE9YdAzcfkYVVjH+HLHbEGDGr+9wVhpfIQZKbKXbk4aY5wEAYF0XlCaDUXvTSRjhGq+9OCxNE7M9DeczRnasYWoEXyygQvY/enZjsQ3nhW2l1g6xscbUUghLx+jP3B7WlinbmIxxnqOONiZYxnX74+HW5e6XN3H3wKOQaTUzveRyWaMqqcBOCYggpy0XA3Peyk5yz8cgjE+RbliJWMMo2N89GCzWJssrF1zSxvEkY/xjrRZHNTIcjAtIh3jyugYo+aWBjfrdCw+HSMy3Cv1k3G7j3LE1QwI0UMTu52K1zBOjDHX24J0ayzNwegyRvfPJH5aE8AY03oPucegjNHeHh8WdsDOjEM5a9hB5nI+L2XFLA7AX35wBWNcQbliJWNcTms2dGInW+NxxHADKi9kxEoHtfvj2HMfV4cjlUq+zSOaUb2pAIFc2PaRaliDophBA6pIB8tXCO/Skk7X07aA/n8r6X8bj8fPdLkKzyBR5dturLRht6WBapTItJqQURxO9j9R7RwvD4iVnjahy+aHaBCbMb6Bl36+Ba/JmsHYSL2K9z4J0jGKYIyK6QxkXGULi5U+DBo3qlFsFuIQ4/ZZDGNEWgmKlSbXCIIYY86GGOMbWUNUeQwjaYxRTxpjhGOlheZjTFZdaUW3RwH5GF8S5lCHvrQJzMfI6/hSA/E4SeRMOxZw6BlxDnnRUU7SSCykY+zGe6GviZltXs0XSDv2qJKP5sBHbg2yhjO0lr/AYoyP4uWhrYEh0UZZ02c0VedJtTh1XQBjnFxHrxwLXL/bqh6yp5DZTTRCfw04BhFt4jEooDw4mSQ0MeQjASfaLWpYBqzhVcSV5cIgT9H46HLNlzlU0FSNMdb+alK86tlxMMYbs4XelkYWzeQxRkri83XqGIkjBfxujF4/ohrulfpJlB8uraJjJHzgNH6MUbNb3BrShv1tyhcnkKAVvOEbq5glMfkY3VhpjzESDeP25LEg0x6W/ROnZErKjCKphHMIwBjXA4zxCvy7Kn4lRR9Zni449TLG9XTzF10iSeTpGP/d4JQnIL2xZCYobxHGOD2ixZDIU+vfxiiFInlEd4ZgjO/Qks/X+hijv/rpS6pZZyWUTM6uFrj9Nlm98fRuQ0BqMjzLmsjP6FZmgTcBGqgRE6BjXOPlY0xGrDTRMe7J+eThbjkgivY63vuM4b7qMhjjCtwzuwo4l7kL3xJAaiGMMR4KMca0aSeKMZ4lxBnlUlc/DTBGa7QYh/IwY0SitEN4/CSMMWoJY4xq0orQkCtu4JHdJK6HDCtZjFHtKkGMkUjfhTLGPwOvjZNEOjQZGNhPC3MoaxS/NIwx0povtZ7bN2XVfEnni4NE9RJbx9gAY1S9+sIkDvvnNR+HqNIOcqo7Isa4FD+N8NVMUMHNMhikP3wSH2uOJnVd2GTEZYyTAhhjbZOF1GMJUfOFxRgXhmCMah2oxX3ut8XAGOfWPcjbc+75fhpVdTYcK43CCnJDnNnKjLFUJ2PMx1LzBRlFst39YQjG2EO1jqcjXrHSqtbrMUaqY6Q5GfcgPYEbf8Y4ofBBChlWKwkXJIyRtq0Us9iKZnE6IOCTSH88+75Dk/69ScfHWoaOkSywiqLHUIVbKbi1xy6oE+2RsOYLo9D1l5f+I4CD5Po64ef+9ZNXvbeJlpCPclFcqGil2seXknfTqtwfUsf4F5pH7boAxrghYTKeBLWxxvHGsv5Vily/hWfT+QqeURP1vhFWmUuWEhUxyYQ6hcZVV/5dvZ4xcwXDEZKs7Sftl4ef0kpXkfzjjqMv4B/jZSJVqzMnMpx5nb+O0SyyGOMbCq+SPL7e+TXjDf0t/owoZw1OlI4Rf/F3oNmkdHEM9vc5dD3g0JlCnGmfbcM6RsMWwxjJJS3EGDsuLcpY6fL4SVxo8h6AQwWRPbQ94NCfxTlkujpG/3bhBWEOHdj57xTAGD/Fe+FNRD62GwHGeLJIh44DxtFTwhzKeBmY+ir0DLG99CdwD2w42whxSPFipS0wH6NZg/Yw4l46hR0r3VilQPwZrVmjDhkP/otXsY8w9iRlZm3nKgrln6fSnvtVo8blpN20W6pIBkno8VFBOsaMaQ2mjPHvkVQ3RV5d6WdCMMan6RHnd8hjjJfT4O4g4ragvqO05uoYb4+BMdZfZGu8bkfJGMln/Ciia4cNOsZ6HPvEY4wx3JkgzRpJFTQPBuRjXEsZ470uY+RV7QSfZltovlcSH034YgeeeXsR7TR+FfUXtLr3DnXjo3V7xzJjJPHTatcyPgeE8ZcXm6hwhST9e72CMVY+rkrGmMnocegYc84AqmOslzFegP8hw6J6vx1Oe6PRaf/fhjIRooIdtq50ra32I1aH6eoY/1Llg9dRHeN9tB7sNXQ5CGKM5XZU+JmjOS30g1kf9gZu52cMuy1zWd/tRMcsh+gYyXJwHnUY+oyf1TJm5gbIR88/4MZPUzV81gB617rcl2Ri97Bv+ROYsdIN5GPEn/sNWoL+BsKiQv4lZxMGRXuz0d1ilIxxOe6ZXfi/AjSHxRjPEbW5PwRijGRQinJoPnCUFsMYlRlFiDF+omqWoFhpjcEY5ywTVPPFAOtK3yHyTJ8s2SD+8j0Bh/LiHDJAHeMNwhzCm3WIMT4vroeuXZkCQmw+TevOCJHj6AZgHJ0iEp4fD1WkFeeQaQ/hWVc67GO7FNYxCsrHqOZ6hzKS2ZASzsIY40kBdaXHiHLqJnZdaef7ma5irYxRxe33RM+I6imMpObdTDtBksGnSM1o1Mk+GqeN4hCa5eBvkbwjFd1N5rc4pI5xboWOcTYVZS5n/p16gygJZSXbkIiP0f9Q8w2kEMKPL0VrvpQicIao+rIRreQOYYyFBnSMpqpb0ddDQ5o1CnkKmgfpv3g1A0L00vyvZyCzyIkxmo7HGA33EpnwxTT+s8sYFUMQY0RGcSjSLcIVd1I9xjiOqPGQ3sPngLDPg+tTFYzxNZo9bl3FjrMPY0S5GKpwq/mlRLpFNGXv18kYfxF0WVPrq2QyhVSNTvsP65HQfzFoc8VGar4ECryRUWOCAHyaHUJjoKsFZL9DS8tfRTljWMb4kKLZ4UIz8JRtoQLJwHyM+PfAy5SOTqvJLSkfzBjD58kKYIyr8DpTU5qMdM69nTyX8bIlQeCpejb7Ddd8wTNsJ2BiXF2Nom3C2MK+GcVuEXkFAubT6wnCtIfXwxiX4Q/aOdJXTq5UfdeIOntZjPHHooADyBg7pluJYow/EuJMx6UOyBjxOiNKxwjWfHnjgNySRMVKC6wrDcsGBTJGA2SMpkA2ZO0IPLL54hzyxLmrYy+qF/qRdbkbMf/19+qMIVbHCDHGk0U6lEgdo5O0XoJKzvUoui2GMSq5JYMZG7SFiiGIMeLXyFnMMCwRGXaqMEZCO45RzGVNNX4eqeg9soFecnOdB0kGn3aj8vLso3Haq009iZZpWUNFlRc08ugIY3yuRsZ4CT3pPsLITri2ocKzqqd0uDPCIzR5XzYmSqCvlakR6Rgfw8MhGpCFNDdWuitEiW9WBYI/TjSKLXEsC6NolN6CgFjpSsZ4umJySmiCSD5GwxUu4R2nyxcV7PA+LmM0i4J0jIXiYJcr6tZO2Lmd3D9rVmt2VonPASGju3lmDqXipFcrGGP5Ua2lXPptF0wRxpiPQceYyblln86pE+1RxhiRjpEimvejYIxEhV63I+mcWzYsDh3jPGTW+BjxDGqtIh0svwreptP7SsoZHwjJGB8O/QhRwamW7JgArJ+yktxktN4mGit9bhXG+PAEI8TyQEX/LOX4tO1eXR96SmdMq8wYWa8erdoAnhwQQb573RPDsHekKRWgnNfNjJ5hMsa3lGgY45aA6vhl5sUw/uGvQB0jXoEjfBd+nUbBrKF1iA+Cn3WXzY0x4t4msugtAwsd0RJgfR5V2kiWjvEMMc4Uismq+UKOKFBdaZEEDdIx3pY0pCcuNBnv9vYGHDJEUo8dAYeuF/jInFHA6UEcY0x3lVIAY1yDjKJQxng9sDCeKtIh6GrzCWEOKZpbpvC/kQY4RtBL0PajBwljjJo1jKH2XIQ3/cNE9dK5TGVeHJneQjp1c0C6p6NJRTi+ED1ntVaRDBL+eESQ/EbR3B3oZLqc3FtXukMf+CSM8YWQjHEO5YukzaQB2yuBBFx7NOaUaW9CT6VRHaEbzwh+sFlMUWVVKQLguW+UA73MGOtxrFeNKjEkcAL16xjXMJywKFI+Q9EtPjllEclcQApA6M6elC+quO2L/7yVkrcEpbM3iwMRiZU2nF2IltGt+aLbrYrRk+K5cCI6vV8GTiuVjJFknFNUM4Y0wIp3mfJTKqasjzHmomWM/45gHSLpfL9f/9ZWd7MOXh4LY9TtQTVOb/fObEGIDydj5S5K3a6kORzDMMa/o2oatA2DNl8cSC/emPkYSZUtZMJ1XDJ6TxOe+m1qCMZI4rIbYYxuXen2fPgrTqS7uWODGOO8as5MAs75ZRHkbg1MjB1pz64HTjcnsvYwLMb4dhQ6RsXb0kBXE4/Uxhj1SBnjToAMdTH0XgIZI4qhcjL+XBJC/2lF7P0R0C+BOkakxaNjVD3d2ySmipRxlBajY1RNi8UYBdV80a0RFc80EYwxWUWK8aPZO1mhyWTbmSTGSC5XgBl2nTg2ZLri3LU+p57tJ9LoVdFGOkalIJYxzk9WNRPNPipROkYlt6Q/PR34B7fQmi+/A2OlGSE3PKb/Zgy155NBxULEMUbdFsYYWYWJP8ZOHZX+I2fGiHRnOL3KZusYDftwNeAxdswuEUXDRMoZ2yIYT9Zot6Bn8GGvSJNFXl5mjOgLxlipYyTj8ttRbEtG0Oi6KI7P0URBZP+0tIlG0jXKGC+NeKA3pGN8TY0rBxYN2zmRCpeCGGM3hRAnfscs8ZEQqlrvALduPYmP9vhiFjuwXyyZKUNfQ+SdwdiprbETO7uc0bDHKYY1VClw0jGizt6UalgkO2WOMsbPAxgjuXJQUBxYOOMdtS+gMKoexvhz1UweYySOHdPAidYNmo2DMV6JTKdGxmgWh1WRDpYvVN6kVwhlxnhfWMaI34XDw641g4AEIhvnYzTsnyqMRNqZgpttt1o+Rg98muEY45VBjDGT7w29/choxRYq6mUxxiurOfN9JmM06q9sQskZizGeDG/08w6bMRoR6BgNNzQDFFcqOlAGCsGMkcRK7xgh2NiB8fimbvyLOa6M8WzAoU7/L4E1Xzr0YuSMsT3vpjl71Jd09ICqjFGNkTHizx5BS4+TMJ5DNt6QF0rJYozIdHWM/hK8r3UYHwqLlYYY480iz/T7JCo0mWw7gemeOMZ4rUBO7YwATg/iChQzGaPBKZ08w6G5icrHiE+m30tUPkYl5+oYu5OmY4TyMXajKPhOnef2TRkw4Sm89x0uxik2Y3xGiI6xw1ieqsIYj1RmLWviPZaGVZEMUh0j+2iseIfMLbNB0S01rt5kQ/5iCB3jIhqlR/jixTSY8mF6ZFpLhQPbRbmruzeCo/Ot0T0+042KObdOlLfhEcexJIyhj6Mex06Kc1ko13x5IKDmyzpa84XURPsez4V0AN5Ltbnx0R5fnIj/uz/hjvvetV7MflwpFAcpXg7Gb2FHCGd0GSOavYKPQwfdtD6lam7i2Utp7obVwONaSc/wcxDRPJp29IwxbbgFRRqp+fKLyO7caF6ZDyNijEfV7Ugm7y7/cyLmi+tcxlizjtF7nz0c4sMJj74DeVvgufT26J0QjPGR0DpGAroZhdAqdYzTWIwxa9op/Blh8jE+opghoHpAyTmPMRZKobXSKGcTHWMQY7wqDGMEkxQ3Uj2Z6hjfrunVghe44QzG+I9I8jFqbqw0xBiXpDVgPKl8GOP2jMd3ie+9VOTJGM8CSWyX01z5S4eCYe2GEzljxO+6JmA3SpaQb1Q6dC3PutJECtQnEYBGy2tmZrlBk//qWzo+3pov+Dt+SV8n5NDQUdmFI4CV9bVs1/LYtxB429IMnTASVqTYcPZNVvpDw94fcEgX2EP2zoBD14hjQ4abdSlxOsY3+tSVNsUyxtlJyzQI6RifVAqWoPNV3n25FpNW8+UykDGKigDOaPbmjF56Gq9Vw0X1EpsxCtQx3s6u+WIfmcn18B3oBAFXkQw+7dZ8MZxWnqhlyxA6RsIYF9IcjJWM8W/0PHa3qjvRQXd8ShhB1S6NHJ0XRLs+mXaZMdarY3SyMdz9k+NLvbHSd8d99TCSbtDvpxxxLQNC/JsG547gORtbCE8k8dHI44sH4/+9P9ExKtMFvQMzWnGAq2PUCWN0OePWGbM4JFNw+Di0133rU/RQqdMpXwIe1ydlxkgKFyG9N/p8jCjnkOJWFwLF+8LXlU4gY/yoIcaIz/UDaYh61DrGq/AKPrg2Z3IuY/xbiA9/i8qU51LOeDd9bayu8vceDR8rrduDaH7gICfOxz04LuAzyHIwpYp29lElDFSn1W1YVbam1lK7XjGtxhgjCmKMRv2VTShj/EdNjBGxY6X/gXSr8VhpzdUxvgUmydGc0IyxFCljNFwdYwlAh5f4nWHlY4ycojEYYzfKVwh1sYffBbObatEzxvGFnhRjN3pMIGNE8TLGM5lMakLe1T+/15cxOpvHdlLWXVXXKt93/ry8oYcY4yscjlunVgQ1kcueTcpIbwdRjJEmp9wWzajYP+GpmCzZoJo0xoh7YxfAoWsFOuTeIPoVCk+KZoyv+GN8MqJkXtSheVxFJCEcOj5pNV8GM6KATxA521iMUVCsNJsxPosMJ3GMcTHeighjjHcwGaNhH1lXbejGHHJjhF6swhiPUrkyRs3akgZFVmOMTxAOhLxY6YspEyJK0em4bR5xT7l3sfc3cGSOPq9selaxCTXEGJ0tYxpXVj2M8SM8CeJNfahqZIfnnExxcS+DMa6nk2IC19moGMUBtJDsfjSt/cH4vwcqurWZsNeNoi/pjzrt0Xht2pVs9PCKvk2mUBzCzYEOs9gffVHz5VlG6t9V9A73clf9aRRjYIyGM5TqGD+omzFGVvPFsI9NhI5RMew4GOM6D4jVyBhp7o+/15CP8QqqY7yLgqkQjDHklkb1YqUfqeLE+YrGDkDBnzGWZtx9J9ApLURPBTBGkpRvKl5n+odf4Z1qjPHqbL6YCnImSMdYdzG0KjrGH7D+EkvH+E4kOkbD3dJATi0Fr+EZdaUjZYyqp2MsVdUxZgwmYzwr8kWWwRjbjQrGSKILQGIfh44xZzUzdqMbMcZrOOsYIcZ4Nd0VrgB1jHhzFRtjxENkU0iq6D1TszgcWFlf5nDcWuT7zpfKL88dAaR3AweH1AroSYLHDy//YD9ROkb8PeOIwAVvjb9ZOQ0PqLmMV8xI75uJ0jGi/JJBQJJR4TpG/z3Wp5kyWRfk0PykMcbjQMrRaYvRcKQNB9QxIpGMkSIUiDEKipXWnc0YjHEx0ixhjPEcxjbzWWQI0DEe7NUAvjNAx3iUqnEWK6GcXY0xkrIqRyPTGcpxPLn5GKsxxuVUVDJT/YIxkoRt5zdUaTvgTN8IY3wOv8Gjr9mRybs6xnPqDEneP8ZHuEHHGLbgNdmBbsNhbLm3yKfQsPceRkYwsvv7Cf/XjWn3pzrG/WmG00PwZNgja9aIWiIdY532gKzRS+JCtsOTYFeiukI8HVJ0ZwBljOWaLysYlXFJKZbL8e8eophWDIzRdAuKNKJjvBA/zsjyMU6KUMd4dP0vWqM4iGK6dcJ1jPh9NrwK1tsgeqqoK30FfTG/HZCetdweU3Mh9+yK5uoYHw34MMINz2cluRk/3SnnY6zGGB/LGuF0jNcEMcZ0DdlOMnpvtbrSV2dmBjNGVs2Xd5i1NcIzRpaOkVHzRQ/SMUZSV3oMQ8e4FNTF0mR7fRmjEXk+xmL1WOm8O5CXAL/IK1a6B3VW3Bphzw+HprQSprp6jdahl5oBeRA5Ax5Tjd6fFdc7keR6DCQu+H/8s6+O0Y5Txwgxxne9tcJ0hgGXuS9xOAM+67+6yuSsFvIDSMc4n4NDc/tkydSc1n50x8ddNkhS1fvKPs2hP7D2EKVjVL1smT93E/yXj02q0btNsmKlc72DgPdX4vIxfoZnn2SMla8OSMf4TLsoxohXziGMt/DxSWOMSwXWfLFYOsbFqiZogOMv/zFLx6iKYIwZw83EfBe7rrR9lNJV5F3zxd1bB+E8UlblGPwiHMLz0W0ZkjE+QsVNF9M9+WmxxbYiVwBXF2Mkp9l4VKCq4d6x16Nj/H7c44qcqQo1MEbEZ2x5NV9OpQnYLMYp91pkcp6J7uumy2kicdFUx0hKZ3ZkK9M+CXkH5p1Bbjoxo/fryOWMzjYduj2Q3xqluTrG7yAvLcIrQF3p9fRCmTDG2e7vGr0tMYydUiut+fJRnYzxIhTVUkCOuHU6Em1dadWLGZobg47xKpIIrtbBGkbHuJbyxHLNl3k0wCAUYwwdmqHqVXWMhKZNC9q4KZ6seWoVxvg40qxQOsarAl6mU/CiF1oGltFsQv7PC1jhrznItAIZ47EBOsb6GaMRqGM8gbWFZTNGzY4iVnoMwymy8RsRljHGkY+xOmNUDIsnYzyTofYcVPlLR0AVlDKdduSMUZlRJHusV4HvO7razOLKGFEVxvi5EiNjpHU//WVd3iv/cDgAIHkwRn81y9XYl5FgARFOjLFvSL1mb0deot8WoWOE6sficfR14tC3qpZeiufgsIPvEnkh7qEm8oNvioqVpiTWIOLyDas1Mp1RwHbhmX4iDTvwfh+IbTgjRDp0Q7LqSsOM8VmUd5rEOOQpF6BY6eOSxxh1QdVHs4a9BaOXnsMDXBhjPJsZK60LiJXO6G7u6LsDar4c3T69l7OO0atkEpT68EmSOCmtW0N4OhWGMa6oYIy/JXwxq9ubxgmn6snHSARPY2JzSjHt5jrqSv+Uw7WDU2aMK0I4dCa/seU9xtPoTOwFGOPjeBwNFbJmtc8ukdD3NrwFJoEqHbjtns3ZYt59X4yx4mDs1NZ4p4d3fy5n3CJTKLZwdMAhhdcOoalXX2Uwxs8pf5xFNI+ZfAwO4seCdwPOBXXKBz/Ejl2kmFZk+RiPjlDHOKl+R/KujnFexDrGdVRiOLjWRzQshI5xjY8xzqV/fjPEP+JRNeyWhuZjrKZjnKboVht71+DqGKcGKPM8caVhh2KMrLrSBF5NRTkn9KwhPFINZozXVnNmcgB53bmBiRGkYzyOtdEfzogGfieSutLelgZmjEZtjHGHCLfI2zF2Dhf7V2CSDmEp8Is/5kHPvOJsFZJmFmNEXdEHiyidro7xdeD7jqrGGM+O652Ih8EZwPddV+mQfwasTut2bClXkFcBw48R32vXnVQ567s/VvpFAYxxDXZ0ExIp9bXEMEbD3oWF9HIcHNIA6LkP+cGegEMGB4cuAr53JzLAdhGhYyRf7ttxvowPEc0kD/VIgDFyiZXG3zOejiVzo3TBQBqfz0Lnj47J0xuTxhihWOnnOgxHkI7RsEDGiBLIGLuRJkzH6GzOYIyLkWkLY4xnMWOlRdR8mZjrbqLqKZAxErmgOnMZZ8ZoVGWMC0lUXtpweDJGJyxj/BsNoJwWe6AtpbG16BjJ5n23eLm11ttEI+nCygVn8BpXYRnjnziv6BsY4120rnQlVCCQarSwlb39Cx0juTfdDbcB/URbu1kauKHmC7llzvWOwqeV/vyWA3NZC+6Vg2mJutcBucR6OgFeocvBd5VC9EFz5GRCdgO/qJcxkv2zYvRGo2N0MyjVF7Ttb0S9Nbn+Nch04mCMpM3DW5oa60proRjjanoEL+djvJL++Y0wjBGFzW+EnRlYxRlSx2UquVZoL3SnGHsrkjphaoAyz2WMeF1riDEuJ5rEjG6HZowTDbs/ffUsZ3zmddWcOZ6tY3R2amCW7sTorXXMga7oFosxEh3j2Ijeh28zLpdBxvgbxmPaIbr1zGHpGH2MMV8cyNAx8mKMS9XK9BwILg76eocWffRBWnf6MxjjkYEzC8XIGNU6GOO6jO7Edgev6EWIMb6PtFIK/7B7IPDD5zmcAV/wr/wZzR5JAm/HAd13PQeHrgOGyS5kQO8pSMeYA773wH70mpt7PkYQeur2PsShnUXoGPF3/L7v91pb98OzCdIxLubg0D6+ybSo8of+HeEnpBwTB6e+g9tNVO25ReUP/hw6KzInLjQZFMOJCFxzHTLcRBI2MOoni+wlRqy0Larmi7UFIxH/YlKwT1QvncnOxyhAx6hobu68ewMY46QJXf/lyxiV6rHSj7uM0eTKGO3RNTBG3X0pcnCqFh3jmg3pnOO0DnNZEyWsYRjjgzzZNTlT5aswRv5V4ZBRJAP+dBoc2VN5QlFJkIhIU2aUUnj/MiqrO1urutO/n2hTjFIKr+CD8TZlHD6Rkqv2XfFqP0bpXNqf5xpFGGOWMsY3aFy0nwWRK65nyjpGpSuG3kOauxuolzH+x2OMTuIY40cNXZkSDkiP2JEzxppLQOFBGpYxvkOlzHMpZ7y7CsYrt0fAGh3wI6oaK+0xRsNum2jAYcXIqytdlTGqphMqH2MgY0Q1MMa04UropwSs8NeqhYArU5LTnKljNOwGGKO9U0BvTWbcYzB1jG9HcSOtetemb8MbPyc0Y1wWcV1pFmP8zcbXCPliC6N34mCMZzCitIb4Fz//L72azpciPygqWm9/+trxf98RlQ5dxZkxnh4IyYAMkmtI3vwYN3ybARUw/qXkS6l+an7pQFq7vvKHL3A4A/rVE5/j19VIcvuzrSDGeL3/exWi2UaCyjgjgDEilzGKSxDZCXzvQWQXuHPN91jROATN7B1JD0GM8TkODgE5PbtbsENuMja/jvGTuGOl8XdkfB1xZeUPbwqdFTlap7I0xpFkEhtY+QMoRcvzmVxvcz8RhsziMAY9m9RPlDGm4VK8IRdT80XVbDZj1MUxxh8lSseYvrS3mo5x0v7kjcy5l6rpGB/DvXVshmustBE6H+NDRK6aNez4lwe8QRsR8Pj87fd8xlShmKJVbpZXceg9zijPKTPGlQyHHhCzonupgU6jwZEf0JcjCanZrl8SbKLpDMzqxVS/pJii2UMJY8RtF1LzhcRNd+QcfgJLkqWd5OukNaPfpDWk1wHLwSJ6DX7YgVesiv5WEmnWMJqLvB7G+IHLGAsRXdYg75gdVV3p4xtwxCrrGNdH3OaGIme+91mYfIxlxngP3bDPpVcOb4UApX/H/+BwjDGbd0NM/x5Cxzg2k7dZOsZxNFb6zUAdox6u5su8gJfpufjoHZ4xmlZzFR1j1VjpEwPyMdbNGFVP8MJijMfCf8kstjKUem9HESut6BabMWrhY6WXqw3QV2AJ2SEUY9zvihVNvHSMCN63L9mIMTJ0jK+kY9gJqloPizH+T+XjmpGAWOn5lQ49509Cq+SdLWLcHkOM8f2Mbjf165je0wLoGHlIvl7uk1GFEBeB+Rj7VsDQ8IxWxSE9iDEeIJIxQg4dVL46EoGFrwLC23cl+rNRQAIAHuC8z61lRrNbSdBtE3DrvBJvIUbG7NCjzIrx+H/cHDorcnQOHVlRYor897TKH04CHHpB1ZzmmJ0iwuCfkFz7G28Ncr1fHsaIl3lBOkadzRiVsAnSY3CKpWN8RhWRjxHNWhbIGBFr/xszctmkCmMk68exHbNKLTwH+JZVnCoXeSAZKbbkRc1GBKTT3Ci6/GCTU26HjhlOGMaIe4qjDJVuOccG6BifErZ4koINVARwA03ud49w/WJiDc1clsJLxFC8No1DmrOLotu74D9vo/CsK42/eCD+UqUKY/yUVpG8jPDIA/GpOHraatplxliPfPAD/I+4UMnbg6NaJKPSMZJEkfVv+vAbPq660nPxZ9dWW0jxGOPfQjDGd2lQwTwfY1xblTGG3dJkDIswxoeDGCMqx0rrcKy04kqaqzLGRxU9XKz03CDGmKmBMe7etSKFgnWM11Rz5gexMEbdTdwFlXBez9xjKXlnKJMx6rHmY/wYDPVhMcZGMlUC37EDIx/jxoxxj/mrU5COETtzDid6tlSp3MLQ0Lw+jHGfP0V/OZfWLRZjPKzSIZMnY2ToGOcH4jX8Jo+v5otubw4kSn5fmbG8ieTz3ERQPkZ/J3xGiv6V60KJAFZ9K2AYzg6k+/YTlP4Qysd4AMshUYzxwHJexGQwRt3elZQJgyqp82CMT/VRKJskAYDpNDMY44i4nMlo7k2j/5rqH5Xe3gJ0X2wVk1XNTd7uTx08s3KhOgZijOkYa77Q2iDrKuKGtq043rjKBavvuhAvY6T7JKL2HBmeMQqLlWYzxmcVUQlHA3SMT0VRKbBmy3qx0ncH1JXmH39P9rchGONkkvWbJwcaHYIxklIFB/OmsXdVcerjmsP7GlriCyvKjHEFM2jbsEeJYNdjaW6OVT6H7hFLzTwd4/EUgOKes1r7SWMx7C4nhcxiK+61ceTcj5eLXTxNY5EjY+x0hXIkHmMORS0rfUBrHT3evOKNOatD0WOg/Mh0huFe+FmdaI8I5y7KREVnVU/KE0msdEMXy8iIpa40aVfgN0FLjY+IlOUJzRjvp9HD86isOUw+xoeV0LHSmtMSgjFOwbvMtmwB1jEqpr0Nvf5+PVhcaTfMGM/L5MO/5fe96vMU1TGurJcx/jCWutK6/a0AIsuMlW5l1JV+k4RVRPDaGc1kjAYcKw0xxpVRMkakW+EYY1braQYqlsbCGBn79iVqriKSRvVSZ/h/6aWD5n0S+bKvGDBjxP/471Z6PZOHyrPi+04Dvu+Gyl/w52Nci1fqGBmjBTNG3WoqV+JazTMfY9boTQEB4x5jVNz6dUJ0jDcmjTHqfb/X2Y/8YN/EMEYXesJYmMcjuxoIb/8W0TFuCqQG5wHOF/WZ2To+4yn5ZTBjhCBSVIuj6R6n/AHjH1R6eyvPismq5mar9H/f1f59s/8XXlQuX9YU0+P6BtBD36v4BTcVNJSPcVKMY+h31CmyKF8eljF2473KVjE6tRmzQq5qMBnjM6ooHWNAzZcnFV0AY0x79TmC6koLYIxeerognPd3/HiP5s2ByKX/i8KrI2+8iXJ76s7AmEPT5pvTQckXgxjjawJRnpt/yqwoBVXaKIGRKFO67AG0nMqm/aRVY4ydFhErtZKITRJf5HFGZ1xaL/HTxaYLdpkxXkHhwQqAMX66oeaLZk+Ma/9Cjko/qzNEmTCinyiFUmSMMaq60v9BjSTIUb2is3EwxjlKreXBaVmeh6p88OeUMf6FqhTm0dujN0M49VDo0uB4A04Y41+rMEaSBrEtbSyFGSPe1NEV/q1gcaUVKlb6isB8jLXESs9ZVi43torxmVfXyxjfbkTHqHiM8Y2a6kpn2IzxjSjKgKmae236JkjPGDVffgHloFY0e5cIt8ggY0R9GGO+p4lRqjsOxngmXH3b2ShW+jBIx9gxZ0X0jJEdK31opddQXekz49uNgozxz0GMcZ1iOnHqGLeAGGPGKDaTsjmbAArxWCVfmU47RQNVNo52MJxRRFqxQyCije9Q6s9Ot45UXioX8kgEY8SPcl9yBttbkENQEZr9CWSAHtmNHBy6BoCeu5AjDqRjfImDQ310jGnCGDOdPQwdY3wik7Sn//enSPgAb31SZW9vAxR6x8XYO5MDhwkjle8LGa3YHJNDlwWmbEFe6I3Fq+YL0EPvIa27fzjGqEevY6T62zIreAMsrxGgY3yG5MmPpacMewB+XTQFdeXZrFhWRXf4Z65U8subAoRwS1UxjNFV5wXhvHtU3Wnl7JQLqF4IcOqXonrqjrpqaMa3olpQrPQ6obkcaG+1YSd+SwvpHSZx3ZfSJly6PKVolqdjNJwdXc6I/6zkeJaAyrux0mlKSN6ijNF/YiHHm9fKdaU7tO6mGGabK5KrNx8jdtw6V+mMqFQ4/sDvR8QY/9WQjjGj9wwMgFeNtMuRWWPeT/wXhlbBemXG+E+SE5aygSsrar5U0zEuwEf1cO9DxXQTiS6opmNUNLutvQu+RicaR+St8G8Eiyt7QjHGOQGMcQrSrZYax+AUACyU21XV/vIPmDPFqJ+kkUC2gN46gTGIe1uAfPkuY0S607COUfG2yCzGCMZKT2PoGL8V4Xq2YygdY7vhRsT9k1M+xjPhbPMbx0pDYpRYhHFZr4B6VcZ4JQ8CW9FLpzIZ4765lSngca3Fg3CzGB0CdYzpzlJTP5Rzs75zjZVun10EGaMr+cJ/2F4QsLoF+N7tWUjP5OCQAXzvPuQHohgjVFd6P3Io3AF4O/+Zg0PXAh2xcz+8L94MYIwvc3Do6T6x0qSQUcarwuZnjCuQFh9jzHipp/xizg93nlHawBhv58kY8Vg5qRpjPAqOlS7GpWN8MLDojeJ1IcQYI++lrObiPP9V6pL2nDXA7zVUV7pbjYGcAYWwLqyFMT6V0e1IGWNWt4dQ6LmQaNnwezPF8vzHjG3mE4qImi+oUGwKEMKRZDcZ/uDTCx19ge2Uwz+UlOoYnwMcIq+YHcRQMy8rvH/BfE+tNZwvhin6I5oHmKQX21WSMWlRWfqypaSudCu5viIVAihnHKfwLAGV0dy0dn4dYyVjXEuPN69jJ2eTILb0jBgyOOMvaCgfI7kNmGh2R8YYj42IMb6hNpIKWDXdiOBYGCN+PdVWHpwyxgUhdYwP0kioq2ha1lCMEeVDvhOzXpTlg1Xi56dgp8eq03ubGO/CsTQfY5CO8SH8ehoYZsywGCOZUVMU06mVMZ4fECt9ZbW/fDzjL76Jp3ADjNHZLSCy/ETGuFnSwlDqva7oTgQ1X+wxDFC1BD/iEVDv/BwOaXeiY4yam+JsGfA9F2+8AncVBzDqSp8XwyILxR8t2eiVwzgoxnK+z5i9rFjpjRjj1YBDZ8W46WPrGDvM5TBjJBK++PbsIGPMdtpN5Vzmn/NkjNk/uIzxtb6MkegYvYrq6wQwxluBcbQd+cFeghgjlEd0b/wDZ09BDkGMcZ+y9NT/yG4WwRhdmT3SLChW+uX233+aitmhZ/qkfjGczfAP3IWqj45RLcQ37Skg8+sYPzpU/4zNGJEeK2P8QTWBN8gYOzQnLsa4KHAbQnWMED2LPGslfuPvDnzPMsW0hvq9ZukY2yLunQnA9/wO+EVni4qgyMq2KB1htQmqI6nca7+R1btbWL98TkD076AInSL/+Atp0iR24Tb1Kjd3HksId5IYcmY4wxg471fCyAbNx/isL13ULv1EGi0Seh5uvxYGOqVJ42njr12RQjk3/HQrssmjnHErlHeG8lsO8qVKxvgWXQ7W0B1nua2i/NFljBmz2D9yR1TDvWb4RZ1o799uXenpEVXkRro1OSLGSASWR9S/MM5wdT5zYmCMs9N5p7bHqJjOEKpPDKNjXEBPEIQP3EcZ05oqf/cBJSxjxBvw/jQgO5gx6lbbhLkrWXWl26imLSgf419RV6n6uKJVk6APIJxwSjoXXmR7wFz3ynRaQI/Nq+KMdSQLejei1qOM8TVGzZcfwpcpXu16KF/ia5lIGKO7pXkN1DEy8jH+Bhq4eDxEdotIcjsyqsVd7AdILYxI8sirmjAY48Y6RgQHvL243/zV0dd88ZJRQrPvu4GMEfGv+eIdpbMzSykqT/ePHe46RiVfbCaC7hG8JV/puStBxqhqno5xO6D7bhLAGL1Yadx9ewAO5Tk4lAfG7V4E6e0pyCEdhJ7Ie2R+xngLB4eu71tX2tnAGD8VoGN8FpzZiunqGD/oI33POTHmY3QZ4yd9sobp9I6fwRiPj3Ed+mHgzGYyRpI4Np7H9QTQASdWvlzhmi9xMEa44E0JGdbgcIzRcMZE7BCUPHA6tA/eAiguVP0qu3aH7utzvZkDAk3oL58LjaWJ+d5UhA7tXxFssiowRFWZuSoFvGN+H/1J2CZrX4caBjmreVeE8kc6E36lmlZTP2nSpEnr1y8zu5TK5J1WvDEnWeE8xkhqTJsc5c34i1uqMMa1PsZ46Hh9WfQ6RsVwaesFdaI98ncu3CitWIO9clxEjJHAz6PqP8x1lZoD4FUjTevIl5prfERu7s4HQuoYy4zxGlr/5Z0wjDFthCzb05F3q7w9UJ0x2m2IkfdF0a22EHWlF6B8CKjOOMBtYIz4Q0IzxgNvd8/w0wApR1jGCO53XcaoNKDHxz25JxAkWW4wY1Ty7l0rJE9+BUXAGGn6l9fAislG+LrSK/AH7R7ZeuYxxhVVGeMEvTSAUXU7Dh3j2YyKloOrHRRjOd+TmRWGMV7DU8fIqL7tCfHaZ1owY4wxVlrVHYgx/guZxeZ+WcMZCawTr8S6dTGWQozxE7x1GcUCVjxEcbcBkVnbEaQHMcYCB4cKAAHZk/xgT0EOQcHbe5XD20UwxvnAI9uRPDJQx5jRuuPWMT4PMMZN+6VNG9Qx4hEfH2PUrE2AjMwfonwwYzwhxt6BdIw3V/7C0cAvPHfozGWpmBxaFJiyBZ+tIB0jPtJY23AisKW0ZvfRMU7vUzw24ujfTG5FM/Caghmj6qk9F1YErl0Ww6PaAyawNpzHGHWVmmhxrB1jGjtbAUvM6UKZABVv9lBV6SWJABV4YBMd0pB+0qRJ+zIZutRKkWrK+Bi8Fa0QsAPeW22Fj92tygwnxcWJjOHegyAqlmMxxhX0Z5fj9eYQpBcHRO4I/vChVLJeF2NERMdoRscYj4+q5ovaSM0XvJ3sHxNjzCGjxv067t5BVaSDlXWlF1CVwnX077wLZA3ztzsz+ZBF1ZHpHnPvDMMYM0A6oEzBSbn8sTpjfLCjywmlY9QCGaMWXmS7z00b6krXp2NE7Jovr+Gf7dbAdmMPluoTseJFFHbNl9eQWYyKMb7CiJUeDv0rfsOA45HFcyihdYy6G8OxhEc+RkaOo6XIKG7EGI+AcHAcr5+sl+YMGk+VxUHBrG1xxkr/iFm0JFtw7zb8h7fPFD2+mi8Ko650RuttJqN/JCD5ir0kYRBj/KYgYHVbXx2jFysNHW+7RDBGghdZwkoeDuVB6InEMcYbYcZouGVw+zBGpVDkzhhJSd5+yKv54tcx9qiGHVs2L5qPsQ9jzBZKTWVvu/x7lZh750Rg3N5SuZwPJislxXokxdi2MTu0KJREETs2MMvK/BcdijkBipXGGz/+KfFojupuYLp3iqJnhZoYIweHngUcmiKSL/4yThVpzUaK0tK0Qgtc56b3pPpJkybty2ITC8u8fIxuzRd7e6pj3Arp1rBszHupL95FhhvHqFKQ9SbAGNdQxkh+Ngc7eHDGsKJnjIqX7I8wxo/qIGbk71yUNoqRMsaPIkB5HzRU82X8PPcyb1YMjHEmPqHWJqtHes8Ampg2rI6xzBgfDMkYb8F7o3BjSzV6yAvw5oAPI8HZU/EMa1PMvoxRNZwUKZ5FGePbAZ9znzIrhOKTVkSCPuATt/iMET7DgDqj1EQdY+VjvKKaM6yaL6+SeOf6cZ57On6tppw0GY3JGF9SjMZzENHy4K8wdIzDod75DViaJ0IdI+GVjMd3sX8gDqRlCWOvaoJgxtiNzI1jpSHG+Or+s6OPlVZyrk4bGk+HJ5Mx4hMjxBg/xWMnzrrSmwMY8X2VCJoUvRdkjGkjvmvKiZoDx0qTmi94/wLpGG8TyRh3ARzKcXCoq28ksL0H0aVCC+IhIhijCz29dcit/PcEfXFO43Ss/jPwyLb38SGHW/gfUD7hc7yD2KyfCCO5hCHGqHY5zWIcghnjrUKcSc9wk1Y8CTh0XJJ6p4hf8MO4O4P3RFszdhX8GWP7ZctSjETuyzJBKRBjnOYHMbaw5wkZOzSUcD3voltMy5Ky394tQdmZv2Q6e8RWR6EVAg8hoigl78igcGnSqs2YFD7vD1M1exzlizu4Am7Nbk2bvXwYI/LWkok+HeNaho6RMMasUoihEhPKu/XG6mWMRHJ4EeqMKJOl6l1JRqFj/Ag1omNUchY50c6OIx/jfnNrLPanmksHMIp3snSM19G2gP5/n1fTMWZnhGSMB3mx0ncEfNjbbhy04YxVZnzWZzZ15HoJxivXfPlHwOfc2jG9JxRjZKXNJPVWp3QY4U8Gac3NMD8lgDHOrbbfZesYGyBptK40Kx/jyfAg1txY6aWwM/bohvfTut3GipXG/9jQjDHSutLks4ADYl/GqJjWIIaOMQ7GeDacCcraSMcIlch4TcnbkR9tacYDKPb+iEqHoIoUZ3BmjPP9v2RUXMbFKvlSYVXX+3joNPud+rrqZzTx9RLAGOOrgBHGoVurAivODnWBskGBDhWS5tBNiSk8Sh160a9QxoNaEGPUHZAxKpotjDFCSr3bRD6upwGHJotyBuqdIhLBGJG3J+pOBGPEGzQib30c1DFqjhDGeDljC8tfx0gvmXsCFcJcwYTp0nt/8avHMobAeGkaNv8iBRQ3Z/Vu8cHbqmbhQyTH8hnSpNX0GvCmsltXWqU1X/BqPA7vaYZN1DnFSiumW9X0ELrqvuWrK11mjMvpz67ATqqo4AyMfrqazmDKGP9TL2PEvRcZYzweiIyplzGe0KgzegyMcU56VrG2rWqHZtfCGB+ogzE+kNZCMsasl4T9L8Hldlx+2JbJ9Y2SIWnI6UZsShXGeDsylqTCPKZTWIyRfMl4LXx3I83uj4IZYz6MQzkorx4y7G83sHXdLSAf40nVHJroY0XPI9NpXMdISofDTn1cVURAFHOUTlymGoz84/UdEHcPpWPkvFE7G1Z7OoOEODS+s5cwxpcBp44U2UtnAg5dL9AhZzNIx4jMYpPIXnq1r5jTFsoYbwHzMSYJ6ZG4bZEO5YESK0IZ483AIxOKhQHGKErHqNsjgVfIhxP1Un9RvQNRtNtFPq5nAIeOTRKBdcBrTg5YbysGY8xxdybdVSRnu0chxog3aHwZY/tly8iW46+MLewUEYP4PJa6QdSs6gKceQaZghgjDbRcW1laXBG1Klc4laZv+Klqrru5nzRpSbP2LjuF3z8kambchnyM+NWQIf+fwYkxts8uElTznYpY6RUVOsb1Ph0jYYyKosfAGCfeuz5FGeMHar01X0w7mswnJDwHKIJWL2M8PooFbSdAytMQY8wYxeZGHPq6b9mvzF/9DsV/19bKGBWjgVshWrBvbUUF5alId8bCGM9qwm1sCMb4FzS9t6Ge+gaJ1ssWwgMBxXQGVGGMuph9tMHWMaoxVrQMdkqztmQxxkzYGkLR95TLGD9PGmME8zEqZlFMFIwyw63V+BLg1NHCegnBjPE6cQ5psI4R6b1CGaM/O8FnSLCO8eak6RjZocnSIfYjE6pjfKnPoDYcoYxxRZ8M3zVkXYm6d44Hxs8dIh/XYsCh74t6XFDv2CqUroXDRq0tMbHSipdr/3FQ5ck7Vhp5F3aPJiJWWtVdic+TDGduEzGj9mY484wiQpDLOPk+HUUAVCNOXUY3ZERRM69dExxFTp0ajWfTlpKsSduIrJl2EzI21JXeXvVqvgxLG3ZKxCDdnV7krgXyMRLGOBc3BRnWwNidUaa7CWefqCEf44XILMaXXRk/muY64qc/ihW9ACXqQjPGjs4YyoOjgpup63SaaelqyhnDMsYFimbzYULjtSKZeWPpLeI7geDzlvV8Z2PGU4wGMcaZovbR32LVfFF1SwwXwusRq+bL+5l8cZAgp1zFJzTgfyOSnkFX5j0o74jZI6l5V8v/YtIY41mAQ9cKc0gx7FHAWHpfxbsHkVval/viGLE6xj8njTGaSUN6JlhXOkGMcb1kjF+sQxbEGD9UcrYwxnhcYhhjxiw2QYwRj59jksUYtWQxRgE6RsPNg/U4I5KcLyuiJVYfSQhjdPPSsA6Vt2XMZfxOHplOd0a9wHBmcUbnPJBVL8a+BDjzLB7gY0QtgvN9ztyomAKkymUj9axIFCd17Lh+0qR92YzGUhNeNIMkp81q9kCRzuwPlNv9D37DX4DXHSEXLX8MZozOZN4OnR6CMV6h6JzES2jGyhTl01UZY0Yv8ivChzR7LJULvhNYV3r2cr5SeORVYjoPOGGEq/kS4z6alE94g+GUoCAlvE1l6BjfQXpvi6ie+hYDEf9aJD07F9IxTsg74mI9EscYGbHSAhmjp2P0L57/OmjWqlSSHtvneN0SyhhvBEqsCAVWANJz9hY5/RPHGBOXj/Gl5MRK5+BY6bQpiDGiJDHGtOmKEJ5PzKuDQWBtpAsAEDTVeDJ0jHiDRnSMC6FIcqK+4t0zYwJ0jOfyHjPHMMohujOLVJjj6cz3AoLlnlN4D+SAXFiLM5ozWsQUvwJCwcIYI/7yrStkYYRVnymeFxkOUciQO47+/aRJkxbf9D+dBu8qSXCm4NvIz1V1q0WUM+R6ygJW64cUjSNjLNvBplv3jpVl8K/teQGhpPiLDyWF9+qq+RLjBm1nmlIBcupkMQjGsLdkiCv/pQpmjJ8ATv1UJGQ4B0o0se8VyRLEETGKUMYI6RivEeaQYhQhxvheesbyRDHGNYrhjBDp0A19x5G1o0iHDGBg75Moh0hwnEiH+khPVcMW+she6gvOxdWVBmOls7olTMd4bGIYIyksmzTGOBlwxsKPSwRjdMYkp+aL4cZKL4IJrM1bx+hm736csYU9h/Njcrk0kzEqM0qcar/qbs60qwOkFs+rhrMJz9l0RIAzzyGNc1Qw/tKfsRL2pwVGkS+vXGtwO180aCBOXYLbNKRZw/tJkyZNmrS+ltWdTemeej/hzmAntnUrmHzxOimIduiPwPH5JJEO/Q7Mx5i3xMRK4w3Z1xh1pX8mspegmi/vKrqgSqV73/Z5ilHzRWisNERirxLokAPFSr8negnwR1WtQWZxpEiH5gNr0k4iHQIYo7WvSId0oIeEOnQDMNOEPrI+4lxVGGPULFDHqGqOMB3j5OToGAsWK7Lz6CT1jo3+z8dKK7ozDH/xUwyV5xa8e2ZMQBKuH/MeM8cGMMa7SNZ4Xo6QROsPBWC9F5DJiTHivfMI33EHAp782DT+woMCi4Jq/KPIt6bJIP3FRaeJfHkSYP5P2v5AtB/Cj854fWnqJ02aNGnSpH1Fjd7J3obbbBJEINqZvXzJJhZP7OwWKoi7CNi4fUekQycCDl0pzCHFLI6G0LDocfRcHx1jXqyOcT5QNVkosAKQnrN/whwSeIcGPLJ1SLCOEWCMgvIx4i8fBTJGsyjmRohB0W4T0zuX2izGKCwf4yRIxyikrnRArLTG//2l24QxPs2IlRbCGBcxeNHZImYUi6bdnTGKTbzWmiNJueYAkvaiovNijF5JlaCkWi8iXgBL9SpvrQpw5k78GLkqPFuBCoCkfYIdOX+C7gip5XFRBfTsJVsNYSkzK5wihWn3zxrd4kvySJMmTZo0adKkfWFZw2nJGpb4vDJ4r0SS3FxOo2NIAa20aIdO8W1x/63kBfYU7R1/PkZxjBEBSE81nANE9pAGMEahDl0PKD2FYmE/tFqt6PamQpxRdFjHmM2XmkX1DpRx8FYhzkyYtTxxjPH7IGMUEyudIB0jyZNP6nTAjJGzjhFP5y0DSjmfxXtGHRvAGO9pzxXj50WKZg/Aj+i4KozxZfx7m/DokT2r5Mcn7SVkONwY4+IqzhDGOIKPM6ZN4n4+YDhC0mqcP8EspXgP4j/4HCFE1sAzTVBZHs1No0Gg+Z9wm9RhCir8KU2aNGnSpEmTJk1aLPtvkpb11wTPIHyWE+3M7j5odZVoh+b0ycdocsz6BTjUNwGALqhYuuLFSvsVNB9m8oLCv1CSGGOHZjUzGOMkUb0zCYwGNgTESiuJYoy6PZzFGJEhhjE+BWIag3PJDDpmmIxx4v/2xj/VMzOKg2jQdiBjVOMmaarhkArJ+SqywfU0a278jBGgZ2BIu8orD3VAsaL19Pb5fFQocq0TdDEDdhqKZo/l/wb3Cs78mkqVr8UD+2RkWPzTZUqTJk2aNGnSpEmTJk0aUUCQE8pRbnYLwxoi1hnDacGOPFZxdns2q1viODVDx3i4EGeUrhKr5suhQhxi6BgdVUhBCC1R+RjtTRiMkdR84R4rPZYRuM1Xx6gYVqoKY7w33cWBF2VMeyBljEEA62WkWyPiXl+OorWkV1bBei/HzhjxF0yk5ZqrMcZ7kM6BMUJxGgBjnJYuONzi66cxHFmFx5OJeOsY8Re30GvLIk0KeStupwm55dlozRGV3USaNGnSpEmTJk2aNGnSpNVyqDySJjouqLwLFDOcWVdx1F6UzRfFJDpmxEpj5xz+vaQYLmOEQk6XqobNN46R5mN8hkFH+OkYFW1FinLpJSzGqOa5MMZSmTE+Foj1jBh1jLSs5R+pmPKT6owxxlhp/AXb0DLN60O0e5XYFZ66fX4IR5YR7Ddh9ooUj8XuhABHiI4xT2rb81t9Nbs/Tb1STjVPKindQRhjWhfIGEk+T6T1Dp9g2OJy3kuTJk2aNGnSpEmTJk2aNGl1GzLtwfh0ewatxbCtWGc8HWNlCkQbt2+IcUZzdYyQqPICro5kdIfk1jsmgDGezmmsOIOooPKJwPBkwxkaiwOqF0v/I9xm4fa3ELHSr8SmY0SGPZR+wfqQ7b5YdYz4C74X0hHCGKeqnTHDLJIKvIojHmPkVfNFMd2ZdKVPdtpNU2WehnRB6Vcoq95FMZzR7bMdyRilSZMmTZo0adKkSZMmTZq0r5CRgsQ0oJJAz/+n6kUxdcqUgs1ijHxhp2LaQ6igciGDGT0Q25dnjQ3ZKUhivxlUx7i8CsT6fSzOqIZbLOT+Gviiq2NEekxpNfCH71qDI4QxTsnmnfgCc6ncdG0IR/gxRlrbxe9UNyKpMnX7NFXnlC7T59TXcDsAO7E3MpyxyLRkvLQ0adKkSZMmTZo0adKkSZMmLXo7JF9MUUkYiYPdT5gjSNvAGCulpiTk9Lh4vzhnE6R3GBXbXoLbTNweoUI4CF49FatD+AuuqJEvPhCnM6NwW12DMyS4e5/4HDLsIQGPpg9jVHkwRqp//bxvUgi7V/UY46nIsEfynVG6vRn+4gPxfxGZ2tiBtr1mFKWOUZo0adKkSZMmTZo0adKkSZP2FbaM7hB2dDhuv8Ity+VLJxrFJreylle6+XfI0zHOooVnlvt4UfxpMvGXXFYDznslZmesVA0JIUl7OF6HDIs8rjdDOrM0VthZ8cjSjEwDZMz0kHI8uJ2CTI6x0qrWSxJD7oIHtErqBuH/7pfR7bGqUZI6RmnSpEmTJk2aNGnSpEmTJk2atOgsq7nA6iTcrqFc8RLaZtHCM//C7abYa0eXzYuZDxcXzcuhl0I69DEvh24L6dB8Xg610dydkBNraT7GeWrc5Xj6OmZtggx7H0LrEWmavS/SnTZVc/rLqS9NmjRp0qRJkyZNmjRp0qRJkxaJZT394i9xe46o70gORqTbv1W9puP2Y9VwWrg5hL/wpyHI2e3ItFK8HLojhEMkOngzXg6dF8KhIspzymyaNZ1mon3F7d2AYO0ThQxwxbDHEO0iooyRKDqzOudgbWnSpEmTJk2aNGnSpEmTJk2atMgN6fZQRbPFq6iyultShdT/XYlbidZ3KesYT83q9kCuDtHK60Hk7ClkcHSKkrNqOG8CT4d2x+2zKg4dwPuxHUQ1sB8BMdJXCRvgB860U3i8jMUzbl8aK70zmmHJPIzSpEmTJk2aNGnSpEmTJk2atC+xqYZNSjbvp2r2+ExXcbBoZ0iGwQUVPOgzyhh1IRVvaLEZFjUjpVbG83ZIrYLyrubrkGa14C99KMChS7k/NjT9YzKOJuF2C42HXkcbwcGjxA7yQrFJNZwx2Jlt1IIj8y9KkyZNmjRp0qRJkyZNmjRp0r7kpur25jT8eCbS7WMzeWegMGeUnFvB5BkfoCIFiv+M29dF9M72AeTsdWTYA3g7NIpG+K5nVDBpE9FLk0nCR8Chdw/OFZuEjCWkWQPxgD6ZhK/j9gEthr5nImbdIV2rpGZRmjRp0qRJkyZNmjRp0qRJk1a/qV3LmlTNHpwMZ3R7L9xepeWZFyDdPk6ZUWwW6dAzAKgiDn5NhDODcHMYOO9KUT10JcOhO4U4pHSVSMpDUurbrnBmDW5HCh3c6bxNiqCfiNsFiWGL0qRJkyZNmjRp0qRJkyZNmjRpDRsVxf0AtwOT4Mz3fPnzHsWtXaRD9wDkjGgYtxHl0M0MnHe8KId2ooo8v0MiH1tPK3bgMtws3Hpx+1VCZpszQDWswXLdkSZNmjRp0qRJkyZNmjRp0qQ1ZCiXoBoKqm5Pxe1tivKOFe3MIQCominSIahkMxHDbSvKoX1wWws4tbPIXjoJt54KZ+4QPrCVvBu8TeSCh6qaM0CuO9KkSZMmTZo0adKkSZMmTZq0r4apmk2KEreTWh2ZnN0i3iHdnl/Bhf6N23dEOrMtTdxXSc4IuBomyqGtKU/0ZxbcXmQv6T6H/okMgZkqqVOn4raQKj53k1NdmjRp0qRJkyZNmjRp0qRJk/bVMqTZ/RPhiKrbY3G7l1aguEbVrRGiHbrDB6sezxhWkyhnmoFgW+E4r8vnEAngHi3OIa2b9NIVuH2CWwm385IxuA17JBKFgqVJkyZNmjRp0qRJkyZNmjRp0mIzmmHwfJUUC9GcJtHO7IzbqsoyGBO1UkqkQ78Ggm0zIh06A3BInKgyk+shktO/VDizKGsKlgtOnOMWt56I23eRbg2S01yaNGnSpEmTJk2aNGnSpEmT9tUyVbc3UXVndFKcIRkGV+K2mkQDI623SaQzm/r44nqh+jP85eOAhH6zRD+yu3wOHSrUoYl5V1j5S9yuw+0IOcWlSZMmTZo0adKkSZMmTZo0adJiM0VzlVW/we1ZkikO6bbY2grYiQt8sOoq0Q793efQEtVw+ot06Dc+h+4X2kMH6z1kDJm4ve8FcDttiRjceDA3yykuTZo0adKkSZMmTZo0adKkSfvq2UTN6q/q9g9puVSx+c+Q7gygxYjLsGqxmrOE0rM9gIDbrEiHtgOqmOwj9LFhB/6A26e0msmsRAxskuaQZKyUU1yatK+i/X9jsJ4YiehNDAAAAABJRU5ErkJggg==",
+      "scheme": "data",
+      "host": "",
+      "port": "",
+      "path": "",
+      "queryParams": "",
+      "fragment": "",
+      "folderPathComponents": "",
+      "lastPathComponent": ""
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Ue",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 66,
+            "columnNumber": 8
+          },
+          {
+            "functionName": "Ve",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 66,
+            "columnNumber": 67
+          },
+          {
+            "functionName": "O.dj",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 83,
+            "columnNumber": 98
+          },
+          {
+            "functionName": "f.$i",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 91,
+            "columnNumber": 19
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 98,
+            "columnNumber": 273
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 144,
+            "columnNumber": 22
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 150,
+            "columnNumber": 185
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 81,
+            "columnNumber": 62
+          },
+          {
+            "functionName": "Array.forEach.d",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 12,
+            "columnNumber": 111
+          },
+          {
+            "functionName": "bg",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 83,
+            "columnNumber": 280
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 81,
+            "columnNumber": 26
+          },
+          {
+            "functionName": "ll.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 184,
+            "columnNumber": 360
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 199,
+            "columnNumber": 208
+          },
+          {
+            "functionName": "f.render",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 80,
+            "columnNumber": 182
+          },
+          {
+            "functionName": "Zm",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 512
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 795
+          },
+          {
+            "functionName": "",
+            "scriptId": "97",
+            "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+            "lineNumber": 63,
+            "columnNumber": 28
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.681119,
+    "_startTime": 123361.681119,
+    "_endTime": 123361.682399,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "data",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryLow",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "",
+    "_securityState": "unknown",
+    "_securityDetails": null,
+    "connectionId": "0",
+    "hasNetworkData": true,
+    "_requestHeaders": [],
+    "_wallIssueTime": 1473831877.02455,
+    "_fromMemoryCache": true,
+    "_responseReceivedTime": 123361.682015,
+    "_mimeType": "image/png",
+    "_responseHeaders": [],
+    "connectionReused": false,
+    "_resourceSize": 24724,
+    "_transferSize": 0,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.80._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.80._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.114",
+    "_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAATsCAYAAADsAfBvAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAAAmAAAE7AAx5U8eAAAGSElEQVR42u3dMWicZQDG8dRo0FIrgqFFVCxWQaFD6VDnqiBCJ3NK1UVQsaOQQsAiKIoF7eLSwfLh0lXaKmZTEBQLgkNXRxHUqUvX+l6+7/guSQOXL5fLk9zvB++iwz0kl1zeP+llZgYAAAAAAGBHVb3T5TycNuqFcp5KG3VPOc94ygAAAADRqt7Zcs6ljXqrnH/LeTppVL/2XCvnmKcNAAAAEKuuPZ+ljerXnjvNOZ8yql97fm1G3cqqPlXvoXJ+KOek5zQAAABMt11Qe74oZ1/CqOHaMziXUsb1a88va8a9kfLp3F/Oj82oyxkfsdXjPihn1ncDAAAA9ga1Z/RRu672fJPRMFbXnsG5Us59KeO+WzPuejlzCePmyrk6NOz3cg6mfJXONp/Gm+XMp30Lmc17PzIAAIAJ3orUnlFHqT1dx6k9XcetrT39s1zOws4/79racyfvi6Ied/ku4xYTPq37mo/SYNTPK1/BQd+ALzRfsfsTX7LmZgAAgBF+dFZ7Rh21h2pP1ft85VM/oXGj1Z76jjn4/xMdt3HtWT2qf36bXEPbuPZ8uea/3Zh8Lti49uzgqNXjLmeNasepPVv7ogAAAEb40blb7al6H5dzartGdas97c389vjHda0963PBT9vxEdts7bkwuUtwt9ozoZv55mvPBHOB2rO1cWpP14FqDwAAW/qZ7YHEUUt5b0NR9T4auheMeVz32rP2EvzH+IZtvfZsw9VufLVnG+6bao/ao/aoPWoPAMAUhpWllZ/fAkcNftq9kDhqEFcOJNWeMRcftUftUXvUHrVH7VF7AICsF/3jqWFlgm870a1hnEkNK/NGqT1qj9qj9qg9ao/ao/YAwIReXxfyXmPbm/n1nHHrc8FFYcUotUftUXvUHrVH7VF71B4Apj2sPJ84anAJXkocNTjvCCtGqT1qj9qj9qg9ao/ao/YAMO1h5f7UsBL3PrFLWRdgucAotUftUXvUHrVH7VF71B4AuOurxvvlPJZYe/o/APyZM279Jfiq2mOUUWqP2qP2qD1qj9qj9qg9ANMeVmYTRy3lvaStvm+GjLv7JfgRN3OjjFJ71B61R+1Re9QetUftAZjm2nMstfbE//2k11Jrj5u5UUapPWqP2qP2qD1qj9qj9gBMde15Ne+Vo73aBb2srb9vXlJ7jDJK7VF71B61R+1Re9QetQeAwG/Qb3uLnI73zatqj1FGqT1qj9qj9qg9ao/ao/YAEPgN+r28f83VXu3+Kedoau1ZVnuMMkrtUXvUHrVH7VF71B61BwC1R+1xMzfKKLVH7VF71B61R+1Re9QeANQetcfN3Cijpqr2HCvnw7Ta82w5/2XVnvoBvlV71B61R+1Re9QeANQetccoo4yKrj31AxzOqj31Axxtik9U7TlSzl9qj9qj9qg9ao/aA4Dao/YYZZRR0bWn+31gG2tP+0CHcmpP+0CPN9UnpPbUD/Ro8xcH1B61R+1Re9QeANQetcfN3Cij1J7c2rO1URFXux0aVfVez6g9qx/4k6zaUz/wgtqj9qg9ag8Aao/a42ZulFFqj9pjlFGTH/NKOdcyak876lQ5t/PCStX7Su1RewBQe9QeN3OjjFJ71B6jjNolo17OG7X+I3Yjq2HU487mjQKAPUDt6X7fVHuMMmqqR6k9csG4R802/14pMhfMNeMic0F/3EE/0wEADP+IpPZ0vW+qPUYZNdWjImvPgWZIUO1px8034yJzwbzfLgAAYA9Re7rfN9Ueo/bkqMW8UfWw4behuJnTMNpxN7JGteP2zQAAANNF7el+M1d7jBrHsEt5owaJoB53M69h1OP8sw0AAICNbk1qT9dcoPZsNGohNazMDb0nRtwvh/THXcz85RAAAAB2FbVn86Oias/xzLBSjzubGVbqcWeEFQAAAPYmtWf0Uafzak89rP9XXK6k/sZKf9ynwgoAAABM8DYeWXsW82pPPWz4fWKX0z5q3icWAAAASK09h8u5lVd76nEnm3HLiZ/OE36NBgAAAKZb1Xs3r/bUw94s5++82tOO+z71U3qv5zUAAABMr6r3Umrt6f+Joq9Ta09/3DlPHwAAACBO1XuinOdSx71YzpHUcSc8fQAAAIA4Ve/BleITOu7J3HehqXqHPH0AAAAAAAAAALr5H72AWmG4R73sAAAAAElFTkSuQmCC",
+    "_parsedURL": {
+      "isValid": false,
+      "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAATsCAYAAADsAfBvAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAABIAAAASABGyWs+AAAACXZwQWcAAAAmAAAE7AAx5U8eAAAGSElEQVR42u3dMWicZQDG8dRo0FIrgqFFVCxWQaFD6VDnqiBCJ3NK1UVQsaOQQsAiKIoF7eLSwfLh0lXaKmZTEBQLgkNXRxHUqUvX+l6+7/guSQOXL5fLk9zvB++iwz0kl1zeP+llZgYAAAAAAGBHVb3T5TycNuqFcp5KG3VPOc94ygAAAADRqt7Zcs6ljXqrnH/LeTppVL/2XCvnmKcNAAAAEKuuPZ+ljerXnjvNOZ8yql97fm1G3cqqPlXvoXJ+KOek5zQAAABMt11Qe74oZ1/CqOHaMziXUsb1a88va8a9kfLp3F/Oj82oyxkfsdXjPihn1ncDAAAA9ga1Z/RRu672fJPRMFbXnsG5Us59KeO+WzPuejlzCePmyrk6NOz3cg6mfJXONp/Gm+XMp30Lmc17PzIAAIAJ3orUnlFHqT1dx6k9XcetrT39s1zOws4/79racyfvi6Ied/ku4xYTPq37mo/SYNTPK1/BQd+ALzRfsfsTX7LmZgAAgBF+dFZ7Rh21h2pP1ft85VM/oXGj1Z76jjn4/xMdt3HtWT2qf36bXEPbuPZ8uea/3Zh8Lti49uzgqNXjLmeNasepPVv7ogAAAEb40blb7al6H5dzartGdas97c389vjHda0963PBT9vxEdts7bkwuUtwt9ozoZv55mvPBHOB2rO1cWpP14FqDwAAW/qZ7YHEUUt5b0NR9T4auheMeVz32rP2EvzH+IZtvfZsw9VufLVnG+6bao/ao/aoPWoPAMAUhpWllZ/fAkcNftq9kDhqEFcOJNWeMRcftUftUXvUHrVH7VF7AICsF/3jqWFlgm870a1hnEkNK/NGqT1qj9qj9qg9ao/ao/YAwIReXxfyXmPbm/n1nHHrc8FFYcUotUftUXvUHrVH7VF71B4Apj2sPJ84anAJXkocNTjvCCtGqT1qj9qj9qg9ao/ao/YAMO1h5f7UsBL3PrFLWRdgucAotUftUXvUHrVH7VF71B4AuOurxvvlPJZYe/o/APyZM279Jfiq2mOUUWqP2qP2qD1qj9qj9qg9ANMeVmYTRy3lvaStvm+GjLv7JfgRN3OjjFJ71B61R+1Re9QetUftAZjm2nMstfbE//2k11Jrj5u5UUapPWqP2qP2qD1qj9qj9gBMde15Ne+Vo73aBb2srb9vXlJ7jDJK7VF71B61R+1Re9QetQeAwG/Qb3uLnI73zatqj1FGqT1qj9qj9qg9ao/ao/YAEPgN+r28f83VXu3+Kedoau1ZVnuMMkrtUXvUHrVH7VF71B61BwC1R+1xMzfKKLVH7VF71B61R+1Re9QeANQetcfN3Cijpqr2HCvnw7Ta82w5/2XVnvoBvlV71B61R+1Re9QeANQetccoo4yKrj31AxzOqj31Axxtik9U7TlSzl9qj9qj9qg9ao/aA4Dao/YYZZRR0bWn+31gG2tP+0CHcmpP+0CPN9UnpPbUD/Ro8xcH1B61R+1Re9QeANQetcfN3Cij1J7c2rO1URFXux0aVfVez6g9qx/4k6zaUz/wgtqj9qg9ag8Aao/a42ZulFFqj9pjlFGTH/NKOdcyak876lQ5t/PCStX7Su1RewBQe9QeN3OjjFJ71B6jjNolo17OG7X+I3Yjq2HU487mjQKAPUDt6X7fVHuMMmqqR6k9csG4R802/14pMhfMNeMic0F/3EE/0wEADP+IpPZ0vW+qPUYZNdWjImvPgWZIUO1px8034yJzwbzfLgAAYA9Re7rfN9Ueo/bkqMW8UfWw4behuJnTMNpxN7JGteP2zQAAANNF7el+M1d7jBrHsEt5owaJoB53M69h1OP8sw0AAICNbk1qT9dcoPZsNGohNazMDb0nRtwvh/THXcz85RAAAAB2FbVn86Oias/xzLBSjzubGVbqcWeEFQAAAPYmtWf0Uafzak89rP9XXK6k/sZKf9ynwgoAAABM8DYeWXsW82pPPWz4fWKX0z5q3icWAAAASK09h8u5lVd76nEnm3HLiZ/OE36NBgAAAKZb1Xs3r/bUw94s5++82tOO+z71U3qv5zUAAABMr6r3Umrt6f+Joq9Ta09/3DlPHwAAACBO1XuinOdSx71YzpHUcSc8fQAAAIA4Ve/BleITOu7J3HehqXqHPH0AAAAAAAAAALr5H72AWmG4R73sAAAAAElFTkSuQmCC",
+      "scheme": "data",
+      "host": "",
+      "port": "",
+      "path": "",
+      "queryParams": "",
+      "fragment": "",
+      "folderPathComponents": "",
+      "lastPathComponent": ""
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Ue",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 66,
+            "columnNumber": 8
+          },
+          {
+            "functionName": "Ve",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 66,
+            "columnNumber": 67
+          },
+          {
+            "functionName": "O.dj",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 83,
+            "columnNumber": 98
+          },
+          {
+            "functionName": "f.$i",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 91,
+            "columnNumber": 19
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 98,
+            "columnNumber": 273
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 144,
+            "columnNumber": 22
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 150,
+            "columnNumber": 185
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 81,
+            "columnNumber": 62
+          },
+          {
+            "functionName": "Array.forEach.d",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 12,
+            "columnNumber": 111
+          },
+          {
+            "functionName": "bg",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 83,
+            "columnNumber": 280
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 81,
+            "columnNumber": 26
+          },
+          {
+            "functionName": "ll.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 184,
+            "columnNumber": 360
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 199,
+            "columnNumber": 208
+          },
+          {
+            "functionName": "f.render",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 80,
+            "columnNumber": 182
+          },
+          {
+            "functionName": "Zm",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 512
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 795
+          },
+          {
+            "functionName": "",
+            "scriptId": "97",
+            "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+            "lineNumber": 63,
+            "columnNumber": 28
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.682795,
+    "_startTime": 123361.682795,
+    "_endTime": 123361.683038,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "data",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryLow",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "",
+    "_securityState": "unknown",
+    "_securityDetails": null,
+    "connectionId": "0",
+    "hasNetworkData": true,
+    "_requestHeaders": [],
+    "_wallIssueTime": 1473831877.02623,
+    "_fromMemoryCache": true,
+    "_responseReceivedTime": 123361.682984,
+    "_mimeType": "image/png",
+    "_responseHeaders": [],
+    "connectionReused": false,
+    "_resourceSize": 1725,
+    "_transferSize": 0,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.81._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.81._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.107",
+    "_url": "https://sb.scorecardresearch.com/b2?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://sb.scorecardresearch.com/b2?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+      "scheme": "https",
+      "host": "sb.scorecardresearch.com",
+      "path": "/b2?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+      "queryParams": "c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+      "folderPathComponents": "",
+      "lastPathComponent": "b2"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": []
+      }
+    },
+    "_issueTime": 123361.479015,
+    "_startTime": 123361.479387,
+    "_endTime": 123361.649229,
+    "statusCode": 204,
+    "statusText": "No Content",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.34.168.146:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.scorecardresearch.com",
+      "sanList": [
+        "*.scorecardresearch.com",
+        "scorecardresearch.com"
+      ],
+      "issuer": "Symantec Class 3 Secure Server CA - G4",
+      "validFrom": 1468540800,
+      "validTo": 1500163199,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Symantec log",
+          "logId": "DDEB1D2B7A0D4FA6208B81AD8168707E2E8E9D01D55C888D3D11C4CDB6ECBECC",
+          "timestamp": 1468601402062,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304402205602EF7560924EE5A61F65A6EE7398EAAE4D0CDF682AB1870CB4BE74F7D8EA3502207ADC953A6D21A45212B9340BE0355480463290CFE5CD0E646FCB753374EFCC50"
+        },
+        {
+          "status": "Verified",
+          "origin": "Embedded in certificate",
+          "logDescription": "Google 'Pilot' log",
+          "logId": "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+          "timestamp": 1468601402099,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "304502200AA6DE589387048B571CB45068A48882DF8BF66D9A0D4AF607C2ED4AB84A7E3C022100E1824357CF5F45E785F4A5CE9010DCEFA04EDD62D40211E81BA91EF30F51EB84"
+        }
+      ]
+    },
+    "connectionId": "1110",
+    "redirects": [
+      {
+        "_target": {
+          "_modelByConstructor": {},
+          "consoleModel": {},
+          "networkManager": {
+            "_target": "[Circular ~.networkRecords.defaultPass.81.redirects.0._target]",
+            "_dispatcher": {
+              "_manager": "[Circular ~.networkRecords.defaultPass.81.redirects.0._target.networkManager]",
+              "_inflightRequestsById": {},
+              "_inflightRequestsByURL": {}
+            },
+            "_networkAgent": {},
+            "_certificateDetailsCache": {},
+            "_bypassServiceWorkerSetting": {},
+            "_listeners": {}
+          },
+          "networkLog": {
+            "_requests": {}
+          }
+        },
+        "_requestId": "19748.107:redirected.0",
+        "_url": "https://sb.scorecardresearch.com/b?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+        "_parsedURL": {
+          "isValid": true,
+          "url": "https://sb.scorecardresearch.com/b?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+          "scheme": "https",
+          "host": "sb.scorecardresearch.com",
+          "path": "/b?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+          "queryParams": "c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F",
+          "folderPathComponents": "",
+          "lastPathComponent": "b"
+        },
+        "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+        "_frameId": "19748.2",
+        "_loaderId": "19748.3",
+        "_initiator": {
+          "type": "script",
+          "stack": {
+            "callFrames": []
+          }
+        },
+        "_issueTime": 123361.303716,
+        "_startTime": 123361.304172,
+        "_endTime": 123361.479015,
+        "statusCode": 302,
+        "statusText": "Moved Temporarily",
+        "requestMethod": "GET",
+        "requestTime": 0,
+        "protocol": "http/1.1",
+        "mixedContentType": "none",
+        "_initialPriority": "Low",
+        "_currentPriority": null,
+        "_contentEncoded": false,
+        "_pendingContentCallbacks": [],
+        "_frames": [],
+        "_eventSourceMessages": [],
+        "_responseHeaderValues": {},
+        "_remoteAddress": "23.34.168.146:443",
+        "_securityState": "secure",
+        "_securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "*.scorecardresearch.com",
+          "sanList": [
+            "*.scorecardresearch.com",
+            "scorecardresearch.com"
+          ],
+          "issuer": "Symantec Class 3 Secure Server CA - G4",
+          "validFrom": 1468540800,
+          "validTo": 1500163199,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Symantec log",
+              "logId": "DDEB1D2B7A0D4FA6208B81AD8168707E2E8E9D01D55C888D3D11C4CDB6ECBECC",
+              "timestamp": 1468601402062,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "304402205602EF7560924EE5A61F65A6EE7398EAAE4D0CDF682AB1870CB4BE74F7D8EA3502207ADC953A6D21A45212B9340BE0355480463290CFE5CD0E646FCB753374EFCC50"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Pilot' log",
+              "logId": "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+              "timestamp": 1468601402099,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "304502200AA6DE589387048B571CB45068A48882DF8BF66D9A0D4AF607C2ED4AB84A7E3C022100E1824357CF5F45E785F4A5CE9010DCEFA04EDD62D40211E81BA91EF30F51EB84"
+            }
+          ]
+        },
+        "connectionId": "1110",
+        "hasNetworkData": true,
+        "_requestHeaders": [
+          {
+            "name": "Pragma",
+            "value": "no-cache"
+          },
+          {
+            "name": "Accept-Encoding",
+            "value": "gzip, deflate, sdch, br"
+          },
+          {
+            "name": "Host",
+            "value": "sb.scorecardresearch.com"
+          },
+          {
+            "name": "Accept-Language",
+            "value": "en-US,en;q=0.8"
+          },
+          {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+          },
+          {
+            "name": "Accept",
+            "value": "image/webp,image/*,*/*;q=0.8"
+          },
+          {
+            "name": "Referer",
+            "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+          },
+          {
+            "name": "Connection",
+            "value": "keep-alive"
+          },
+          {
+            "name": "Cache-Control",
+            "value": "no-cache"
+          }
+        ],
+        "_wallIssueTime": 1473831876.64715,
+        "_responseReceivedTime": 123361.476963,
+        "_mimeType": "",
+        "_responseHeaders": [
+          {
+            "name": "Pragma",
+            "value": "no-cache"
+          },
+          {
+            "name": "Date",
+            "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+          },
+          {
+            "name": "Location",
+            "value": "https://sb.scorecardresearch.com/b2?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F"
+          },
+          {
+            "name": "Set-Cookie",
+            "value": "UID=14020910720713a3c809abg1473831876; expires=Tue, 04-Sep-2018 05:44:36 GMT; path=/; domain=.scorecardresearch.com"
+          },
+          {
+            "name": "Set-Cookie",
+            "value": "UIDR=1473831876; expires=Tue, 04-Sep-2018 05:44:36 GMT; path=/; domain=.scorecardresearch.com"
+          },
+          {
+            "name": "Cache-Control",
+            "value": "private, no-cache, no-cache=Set-Cookie, no-store, proxy-revalidate"
+          },
+          {
+            "name": "Connection",
+            "value": "keep-alive"
+          },
+          {
+            "name": "Content-Length",
+            "value": "0"
+          },
+          {
+            "name": "Expires",
+            "value": "Mon, 01 Jan 1990 00:00:00 GMT"
+          }
+        ],
+        "_transferSize": 796,
+        "_responseHeadersText": "HTTP/1.1 302 Moved Temporarily\r\nContent-Length: 0\r\nLocation: https://sb.scorecardresearch.com/b2?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nConnection: keep-alive\r\nSet-Cookie: UID=14020910720713a3c809abg1473831876; expires=Tue, 04-Sep-2018 05:44:36 GMT; path=/; domain=.scorecardresearch.com\r\nSet-Cookie: UIDR=1473831876; expires=Tue, 04-Sep-2018 05:44:36 GMT; path=/; domain=.scorecardresearch.com\r\nPragma: no-cache\r\nExpires: Mon, 01 Jan 1990 00:00:00 GMT\r\nCache-Control: private, no-cache, no-cache=Set-Cookie, no-store, proxy-revalidate\r\n\r\n",
+        "_requestHeadersText": "GET /b?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F HTTP/1.1\r\nHost: sb.scorecardresearch.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: image/webp,image/*,*/*;q=0.8\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+        "connectionReused": true,
+        "_timing": {
+          "requestTime": 123361.304172,
+          "proxyStart": 1.26900000032038,
+          "proxyEnd": 1.97399999888148,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 2.20000000263099,
+          "sendEnd": 2.31099998927675,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 172.790999989957
+        },
+        "_finished": true
+      }
+    ],
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "sb.scorecardresearch.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Cookie",
+        "value": "UID=14020910720713a3c809abg1473831876; UIDR=1473831876"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.82245,
+    "_responseReceivedTime": 123361.648549,
+    "_mimeType": "text/plain",
+    "_responseHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "private, no-cache, no-cache=Set-Cookie, no-store, proxy-revalidate"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "0"
+      },
+      {
+        "name": "Expires",
+        "value": "Mon, 01 Jan 1990 00:00:00 GMT"
+      }
+    ],
+    "_transferSize": 248,
+    "_responseHeadersText": "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nConnection: keep-alive\r\nPragma: no-cache\r\nExpires: Mon, 01 Jan 1990 00:00:00 GMT\r\nCache-Control: private, no-cache, no-cache=Set-Cookie, no-store, proxy-revalidate\r\n\r\n",
+    "_requestHeadersText": "GET /b2?c1=7&c2=6402952&c3=1&ns__t=1473831876646&ns_c=UTF-8&ns_if=1&cv=3.1m&c8=HTTP%2F2%20and%20Java%3A%20Current%20Status&c7=https%3A%2F%2Fwww.slideshare.net%2Fmobile%2Fslideshow%2Fembed_code%2Fkey%2F2bcPOKkYBQ6WnM&c9=https%3A%2F%2Fwebtide.com%2Fhttp2-push-demo%2F HTTP/1.1\r\nHost: sb.scorecardresearch.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: image/webp,image/*,*/*;q=0.8\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\nCookie: UID=14020910720713a3c809abg1473831876; UIDR=1473831876\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.479387,
+      "proxyStart": 0.40600000647828,
+      "proxyEnd": 0.778999994508922,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 0.939000005018897,
+      "sendEnd": 1.03200000012293,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 169.162000005599
+    },
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.82._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.82._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.104",
+    "_url": "https://public.slidesharecdn.com/images/mobile/ssmobilesprite.png?cb=d28b628c55079803085be32c69e936f8cd24eedf",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/images/mobile/ssmobilesprite.png?cb=d28b628c55079803085be32c69e936f8cd24eedf",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/images/mobile/ssmobilesprite.png?cb=d28b628c55079803085be32c69e936f8cd24eedf",
+      "queryParams": "cb=d28b628c55079803085be32c69e936f8cd24eedf",
+      "folderPathComponents": "/images/mobile",
+      "lastPathComponent": "ssmobilesprite.png"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "w",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 0,
+            "columnNumber": 2990
+          },
+          {
+            "functionName": "css",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 27275
+          },
+          {
+            "functionName": "Ce",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 10325
+          },
+          {
+            "functionName": "S",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 0,
+            "columnNumber": 4464
+          },
+          {
+            "functionName": "hide",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 28343
+          },
+          {
+            "functionName": "Z.fn.(anonymous function)",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 2,
+            "columnNumber": 216
+          },
+          {
+            "functionName": "SSToolbar.deactivateProgressTooltip",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 2,
+            "columnNumber": 24478
+          },
+          {
+            "functionName": "SSToolbar.activateProgressTooltip",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 2,
+            "columnNumber": 24680
+          },
+          {
+            "functionName": "SSToolbar.activate",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 2,
+            "columnNumber": 19501
+          },
+          {
+            "functionName": "",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 3,
+            "columnNumber": 26422
+          },
+          {
+            "functionName": "each",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 0,
+            "columnNumber": 12106
+          },
+          {
+            "functionName": "SSPlayerController._activateComponentSet",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 3,
+            "columnNumber": 26399
+          },
+          {
+            "functionName": "SSPlayerController.postInitialize",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 3,
+            "columnNumber": 249
+          },
+          {
+            "functionName": "SSPlayerController._init",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 2,
+            "columnNumber": 25618
+          },
+          {
+            "functionName": "SSPlayerController",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 0,
+            "columnNumber": 4151
+          },
+          {
+            "functionName": "SSPlayer._init",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 4,
+            "columnNumber": 5718
+          },
+          {
+            "functionName": "SSPlayer",
+            "scriptId": "88",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_player_presentation.js?b194f6aec5",
+            "lineNumber": 0,
+            "columnNumber": 4390
+          },
+          {
+            "functionName": "",
+            "scriptId": "89",
+            "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+            "lineNumber": 92,
+            "columnNumber": 19
+          },
+          {
+            "functionName": "c",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 3464
+          },
+          {
+            "functionName": "fireWith",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 4276
+          },
+          {
+            "functionName": "ready",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 1,
+            "columnNumber": 6072
+          },
+          {
+            "functionName": "s",
+            "scriptId": "83",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_jquery.js?8f7e6ae431",
+            "lineNumber": 0,
+            "columnNumber": 961
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.223784,
+    "_startTime": 123361.224406,
+    "_endTime": 123361.713511,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1055",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "Referer",
+        "value": "https://public.slidesharecdn.com/b/stylesheets/ssplayer/combined_presentation.css?9692d09516"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.56722,
+    "_responseReceivedTime": 123361.392131,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "25991"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "jk2NgAUmchRg78fLtCoAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "8e4d8d800526721460efc7cbb42a0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 06 Sep 2016 21:07:43 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "\"57cf301f-6ca5\""
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "196245191 145253358"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31536000"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "image/png"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      }
+    ],
+    "_transferSize": 26553,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: image/png\r\nLast-Modified: Tue, 06 Sep 2016 21:07:43 GMT\r\nETag: \"57cf301f-6ca5\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nX-Varnish: 196245191 145253358\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 8e4d8d800526721460efc7cbb42a0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: jk2NgAUmchRg78fLtCoAAA==\r\nVary: Accept-Encoding\r\nContent-Encoding: gzip\r\nCache-Control: max-age=31536000\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nContent-Length: 25991\r\nConnection: keep-alive\r\n\r\n",
+    "_requestHeadersText": "GET /images/mobile/ssmobilesprite.png?cb=d28b628c55079803085be32c69e936f8cd24eedf HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: image/webp,image/*,*/*;q=0.8\r\nReferer: https://public.slidesharecdn.com/b/stylesheets/ssplayer/combined_presentation.css?9692d09516\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.224406,
+      "proxyStart": 0.805000003310852,
+      "proxyEnd": 1.2470000074245,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.44800000998657,
+      "sendEnd": 1.58900000678841,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 167.725000006612
+    },
+    "_resourceSize": 27813,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.83._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.83._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.118",
+    "_url": "https://www.google.com/recaptcha/api2/webworker.js?hl=en&v=r20160908152041",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.google.com/recaptcha/api2/webworker.js?hl=en&v=r20160908152041",
+      "scheme": "https",
+      "host": "www.google.com",
+      "path": "/recaptcha/api2/webworker.js?hl=en&v=r20160908152041",
+      "queryParams": "hl=en&v=r20160908152041",
+      "folderPathComponents": "/recaptcha/api2",
+      "lastPathComponent": "webworker.js"
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Dk",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 177,
+            "columnNumber": 588
+          },
+          {
+            "functionName": "Zm",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 701
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 795
+          },
+          {
+            "functionName": "",
+            "scriptId": "97",
+            "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+            "lineNumber": 63,
+            "columnNumber": 28
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.702465,
+    "_startTime": 123361.703075,
+    "_endTime": 123361.886399,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "other",
+      "_title": "Other",
+      "_category": {
+        "title": "Other",
+        "shortTitle": "Other"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:807::2004]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "www.google.com",
+      "sanList": [
+        "www.google.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291496,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294117382,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3044022100A688267D1A44644516F7DB1383E6586CEB8C23F83F6CBC4AB6DCC281AB5A81BC021F73BB3CDAC5CFBCA95DF32CE9564B3674EC70C84D6F66FD58F0A67AB3941E5D"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294117951,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100CF0010B0CC6D5F757ED9E601DC52F8C170FDEE752868276ECB2E0FDF34F2BA12022100A58876BD1B7ECFAB6C7B1A1ACD9A33285A400669EFD2336F32CBCE61FCD3EBB7"
+        }
+      ]
+    },
+    "connectionId": "183",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/recaptcha/api2/webworker.js?hl=en&v=r20160908152041"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.google.com"
+      },
+      {
+        "name": "cookie",
+        "value": "NID=86=UA8sn8EjVDzbV-HK1jEfVtIxu23pgQVxnPSTwXX6I_cs_YMMDZAX6vbDYXVioIkClO7zKrZTg9GrGiEBO8Cav_otesPIsOKM7a8mHmtVuObzblXoRXK24Wl82e6RQrqo; S=sso=oeb1g7nauNo"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831877.0459,
+    "_responseReceivedTime": 123361.885346,
+    "_mimeType": "text/javascript",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Wed, 14 Sep 2016 05:44:37 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "server",
+        "value": "GSE"
+      },
+      {
+        "name": "x-frame-options",
+        "value": "SAMEORIGIN"
+      },
+      {
+        "name": "content-type",
+        "value": "text/javascript; charset=UTF-8"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "private, max-age=0"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "99"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 14 Sep 2016 05:44:37 GMT"
+      }
+    ],
+    "_transferSize": 178,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.703075,
+      "proxyStart": 0.671000001602806,
+      "proxyEnd": 1.35099999897648,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.45999999949709,
+      "sendEnd": 1.76900000951719,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 182.270999997854
+    },
+    "_resourceSize": 89,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.84._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.84._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.116",
+    "_url": "https://www.gstatic.com/recaptcha/api2/logo_48.png",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.gstatic.com/recaptcha/api2/logo_48.png",
+      "scheme": "https",
+      "host": "www.gstatic.com",
+      "path": "/recaptcha/api2/logo_48.png",
+      "queryParams": "",
+      "folderPathComponents": "/recaptcha/api2",
+      "lastPathComponent": "logo_48.png"
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Ue",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 66,
+            "columnNumber": 8
+          },
+          {
+            "functionName": "Ve",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 66,
+            "columnNumber": 67
+          },
+          {
+            "functionName": "O.dj",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 83,
+            "columnNumber": 98
+          },
+          {
+            "functionName": "f.$i",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 91,
+            "columnNumber": 19
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 98,
+            "columnNumber": 273
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 144,
+            "columnNumber": 22
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 150,
+            "columnNumber": 185
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 81,
+            "columnNumber": 62
+          },
+          {
+            "functionName": "Array.forEach.d",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 12,
+            "columnNumber": 111
+          },
+          {
+            "functionName": "bg",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 83,
+            "columnNumber": 280
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 81,
+            "columnNumber": 26
+          },
+          {
+            "functionName": "ll.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 184,
+            "columnNumber": 360
+          },
+          {
+            "functionName": "f.J",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 199,
+            "columnNumber": 208
+          },
+          {
+            "functionName": "f.render",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 80,
+            "columnNumber": 182
+          },
+          {
+            "functionName": "Zm",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 512
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 795
+          },
+          {
+            "functionName": "",
+            "scriptId": "97",
+            "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+            "lineNumber": 63,
+            "columnNumber": 28
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.684106,
+    "_startTime": 123361.684623,
+    "_endTime": 123361.892175,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": "High",
+    "_resourceType": {
+      "_name": "image",
+      "_title": "Image",
+      "_category": {
+        "title": "Images",
+        "shortTitle": "Img"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:806::2003]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_ECDSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google.com",
+      "sanList": [
+        "*.google.com",
+        "*.android.com",
+        "*.appengine.google.com",
+        "*.cloud.google.com",
+        "*.google-analytics.com",
+        "*.google.ca",
+        "*.google.cl",
+        "*.google.co.in",
+        "*.google.co.jp",
+        "*.google.co.uk",
+        "*.google.com.ar",
+        "*.google.com.au",
+        "*.google.com.br",
+        "*.google.com.co",
+        "*.google.com.mx",
+        "*.google.com.tr",
+        "*.google.com.vn",
+        "*.google.de",
+        "*.google.es",
+        "*.google.fr",
+        "*.google.hu",
+        "*.google.it",
+        "*.google.nl",
+        "*.google.pl",
+        "*.google.pt",
+        "*.googleadapis.com",
+        "*.googleapis.cn",
+        "*.googlecommerce.com",
+        "*.googlevideo.com",
+        "*.gstatic.cn",
+        "*.gstatic.com",
+        "*.gvt1.com",
+        "*.gvt2.com",
+        "*.metric.gstatic.com",
+        "*.urchin.com",
+        "*.url.google.com",
+        "*.youtube-nocookie.com",
+        "*.youtube.com",
+        "*.youtubeeducation.com",
+        "*.ytimg.com",
+        "android.clients.google.com",
+        "android.com",
+        "g.co",
+        "goo.gl",
+        "google-analytics.com",
+        "google.com",
+        "googlecommerce.com",
+        "policy.mta-sts.google.com",
+        "urchin.com",
+        "www.goo.gl",
+        "youtu.be",
+        "youtube.com",
+        "youtubeeducation.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291668,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294157675,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450221009055A6D69C0CB2E407BE909674D95CC4AF2DA70F0227C59306FE478C7180AF9F022013374116DD952AA4B0CE6354EE179866A06014C15C6069A83F5CE6BF5971BC94"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294158314,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100E14BE9F27C6A8BBC0B3629205B8160CECAB700729222DE0C3058655338B45A9E0221008C902D61453456BFE66625FCE56ECFF15667097CAF2EB83C088BA636CA83119C"
+        }
+      ]
+    },
+    "connectionId": "537",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/recaptcha/api2/logo_48.png"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.gstatic.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.gstatic.com/recaptcha/api2/r20160908152041/styles__ltr.css"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831877.02754,
+    "_responseReceivedTime": 123361.856137,
+    "_mimeType": "image/png",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Tue, 13 Sep 2016 05:26:20 GMT"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Thu, 21 Apr 2016 03:17:22 GMT"
+      },
+      {
+        "name": "server",
+        "value": "sffe"
+      },
+      {
+        "name": "age",
+        "value": "87497"
+      },
+      {
+        "name": "content-type",
+        "value": "image/png"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=604800"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "2228"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Tue, 20 Sep 2016 05:26:20 GMT"
+      }
+    ],
+    "_transferSize": 2361,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.684623,
+      "proxyStart": 0.382000012905337,
+      "proxyEnd": 0.750999999581836,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 0.833000012789853,
+      "sendEnd": 1.03900000976864,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 171.51400000148
+    },
+    "_resourceSize": 2228,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.85._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.85._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.106",
+    "_url": "https://public.slidesharecdn.com/b/images/artdeco/icons.svg?43e81fd2ef",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/b/images/artdeco/icons.svg?43e81fd2ef",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/b/images/artdeco/icons.svg?43e81fd2ef",
+      "queryParams": "43e81fd2ef",
+      "folderPathComponents": "/b/images/artdeco",
+      "lastPathComponent": "icons.svg"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "o",
+            "scriptId": "92",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+            "lineNumber": 0,
+            "columnNumber": 10746
+          },
+          {
+            "functionName": "i",
+            "scriptId": "92",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+            "lineNumber": 0,
+            "columnNumber": 10844
+          },
+          {
+            "functionName": "",
+            "scriptId": "92",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+            "lineNumber": 0,
+            "columnNumber": 3772
+          },
+          {
+            "functionName": "s",
+            "scriptId": "92",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+            "lineNumber": 0,
+            "columnNumber": 3734
+          },
+          {
+            "functionName": "",
+            "scriptId": "92",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+            "lineNumber": 0,
+            "columnNumber": 4228
+          },
+          {
+            "functionName": "r",
+            "scriptId": "92",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+            "lineNumber": 0,
+            "columnNumber": 5301
+          },
+          {
+            "functionName": "o.run",
+            "scriptId": "92",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+            "lineNumber": 0,
+            "columnNumber": 6631
+          },
+          {
+            "functionName": "r",
+            "scriptId": "92",
+            "url": "https://public.slidesharecdn.com/b/ss_foundation/combined_old_embed.js?34356cb730",
+            "lineNumber": 0,
+            "columnNumber": 6087
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.271914,
+    "_startTime": 123361.272667,
+    "_endTime": 123361.943204,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "xhr",
+      "_title": "XHR",
+      "_category": {
+        "title": "XHR and Fetch",
+        "shortTitle": "XHR"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1162",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Origin",
+        "value": "https://www.slideshare.net"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.61535,
+    "_responseReceivedTime": 123361.521303,
+    "_mimeType": "image/svg+xml",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "Content-Encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "Content-Length",
+        "value": "32963"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "ff42hAUmchTATNkxtSoAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "7dfe368405267214c04cd931b52a0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Tue, 06 Sep 2016 21:07:43 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "W/\"57cf301f-1ab9a\""
+      },
+      {
+        "name": "access-control-max-age",
+        "value": "86400"
+      },
+      {
+        "name": "access-control-allow-methods",
+        "value": "GET"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "180742885 72607038"
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=30913865"
+      },
+      {
+        "name": "access-control-allow-credentials",
+        "value": "false"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "image/svg+xml"
+      },
+      {
+        "name": "access-control-allow-headers",
+        "value": "*"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      },
+      {
+        "name": "Expires",
+        "value": "Thu, 07 Sep 2017 00:55:41 GMT"
+      }
+    ],
+    "_transferSize": 33743,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: image/svg+xml\r\nLast-Modified: Tue, 06 Sep 2016 21:07:43 GMT\r\nETag: W/\"57cf301f-1ab9a\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nContent-Encoding: gzip\r\nX-Varnish: 180742885 72607038\r\nContent-Length: 32963\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 7dfe368405267214c04cd931b52a0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: ff42hAUmchTATNkxtSoAAA==\r\nVary: Accept-Encoding\r\nCache-Control: max-age=30913865\r\nExpires: Thu, 07 Sep 2017 00:55:41 GMT\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nConnection: keep-alive\r\naccess-control-allow-origin: *\r\naccess-control-max-age: 86400\r\naccess-control-allow-credentials: false\r\naccess-control-allow-headers: *\r\naccess-control-allow-methods: GET\r\n\r\n",
+    "_requestHeadersText": "GET /b/images/artdeco/icons.svg?43e81fd2ef HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nOrigin: https://www.slideshare.net\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123361.272667,
+      "proxyStart": 0.58300000091549,
+      "proxyEnd": 1.3020000042161,
+      "dnsStart": 1.45999999949709,
+      "dnsEnd": 33.2020000059856,
+      "connectStart": 33.2020000059856,
+      "connectEnd": 76.123999999254,
+      "sslStart": 53.7239999976009,
+      "sslEnd": 76.0640000080457,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 76.5990000072634,
+      "sendEnd": 77.0179999963148,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 248.636000003899
+    },
+    "_resourceSize": 109466,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.86._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.86._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.117",
+    "_url": "https://www.google.com/js/bg/N_dga_2qRRDPwlgGjfhfA3VGUpIa0MSIiwhsrl5R2OQ.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.google.com/js/bg/N_dga_2qRRDPwlgGjfhfA3VGUpIa0MSIiwhsrl5R2OQ.js",
+      "scheme": "https",
+      "host": "www.google.com",
+      "path": "/js/bg/N_dga_2qRRDPwlgGjfhfA3VGUpIa0MSIiwhsrl5R2OQ.js",
+      "queryParams": "",
+      "folderPathComponents": "/js/bg",
+      "lastPathComponent": "N_dga_2qRRDPwlgGjfhfA3VGUpIa0MSIiwhsrl5R2OQ.js"
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "script",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "Bm",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 234,
+            "columnNumber": 135
+          },
+          {
+            "functionName": "Cm",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 233,
+            "columnNumber": 541
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 236,
+            "columnNumber": 215
+          },
+          {
+            "functionName": "bd",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 37,
+            "columnNumber": 651
+          },
+          {
+            "functionName": "Hm.load",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 236,
+            "columnNumber": 167
+          },
+          {
+            "functionName": "Zm",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 572
+          },
+          {
+            "functionName": "",
+            "scriptId": "95",
+            "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+            "lineNumber": 249,
+            "columnNumber": 795
+          },
+          {
+            "functionName": "",
+            "scriptId": "97",
+            "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+            "lineNumber": 63,
+            "columnNumber": 28
+          }
+        ]
+      }
+    },
+    "_issueTime": 123361.69823,
+    "_startTime": 123361.698842,
+    "_endTime": 123361.956679,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "Low",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "script",
+      "_title": "Script",
+      "_category": {
+        "title": "Scripts",
+        "shortTitle": "JS"
+      },
+      "_isTextType": true
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:807::2004]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "www.google.com",
+      "sanList": [
+        "www.google.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291496,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294117382,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3044022100A688267D1A44644516F7DB1383E6586CEB8C23F83F6CBC4AB6DCC281AB5A81BC021F73BB3CDAC5CFBCA95DF32CE9564B3674EC70C84D6F66FD58F0A67AB3941E5D"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294117951,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100CF0010B0CC6D5F757ED9E601DC52F8C170FDEE752868276ECB2E0FDF34F2BA12022100A58876BD1B7ECFAB6C7B1A1ACD9A33285A400669EFD2336F32CBCE61FCD3EBB7"
+        }
+      ]
+    },
+    "connectionId": "183",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/js/bg/N_dga_2qRRDPwlgGjfhfA3VGUpIa0MSIiwhsrl5R2OQ.js"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.google.com"
+      },
+      {
+        "name": "cookie",
+        "value": "NID=86=UA8sn8EjVDzbV-HK1jEfVtIxu23pgQVxnPSTwXX6I_cs_YMMDZAX6vbDYXVioIkClO7zKrZTg9GrGiEBO8Cav_otesPIsOKM7a8mHmtVuObzblXoRXK24Wl82e6RQrqo; S=sso=oeb1g7nauNo"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831877.04166,
+    "_responseReceivedTime": 123361.877869,
+    "_mimeType": "text/javascript",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Sat, 03 Sep 2016 14:53:30 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Wed, 24 Aug 2016 11:03:23 GMT"
+      },
+      {
+        "name": "server",
+        "value": "sffe"
+      },
+      {
+        "name": "age",
+        "value": "917467"
+      },
+      {
+        "name": "vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "content-type",
+        "value": "text/javascript"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=31536000"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "4783"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Sun, 03 Sep 2017 14:53:30 GMT"
+      }
+    ],
+    "_transferSize": 4906,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.698842,
+      "proxyStart": 0.551000004634261,
+      "proxyEnd": 1.22000000556,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.34000000252854,
+      "sendEnd": 1.51600000390317,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 179.02700000559
+    },
+    "_resourceSize": 11713,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.87._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.87._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.96",
+    "_url": "https://public.slidesharecdn.com/fonts/fontawesome-webfont.woff?v=4.3.0?cb=1473813487",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://public.slidesharecdn.com/fonts/fontawesome-webfont.woff?v=4.3.0?cb=1473813487",
+      "scheme": "https",
+      "host": "public.slidesharecdn.com",
+      "path": "/fonts/fontawesome-webfont.woff?v=4.3.0?cb=1473813487",
+      "queryParams": "v=4.3.0?cb=1473813487",
+      "folderPathComponents": "/fonts",
+      "lastPathComponent": "fontawesome-webfont.woff"
+    },
+    "_documentURL": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+    "_frameId": "19748.2",
+    "_loaderId": "19748.3",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.slideshare.net/mobile/slideshow/embed_code/key/2bcPOKkYBQ6WnM",
+      "lineNumber": 0
+    },
+    "_issueTime": 123361.395761,
+    "_startTime": 123361.396452,
+    "_endTime": 123362.32832,
+    "statusCode": 200,
+    "statusText": "OK",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "http/1.1",
+    "mixedContentType": "none",
+    "_initialPriority": "VeryHigh",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "font",
+      "_title": "Font",
+      "_category": {
+        "title": "Fonts",
+        "shortTitle": "Font"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "23.209.177.70:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_256_GCM",
+      "certificateId": 0,
+      "subjectName": "*.slidesharecdn.com",
+      "sanList": [
+        "*.slidesharecdn.com",
+        "slidesharecdn.com"
+      ],
+      "issuer": "DigiCert SHA2 Secure Server CA",
+      "validFrom": 1458864000,
+      "validTo": 1501329600,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "1181",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": "Pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "Origin",
+        "value": "https://www.slideshare.net"
+      },
+      {
+        "name": "Accept-Encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "Host",
+        "value": "public.slidesharecdn.com"
+      },
+      {
+        "name": "Accept-Language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "Accept",
+        "value": "*/*"
+      },
+      {
+        "name": "Referer",
+        "value": "https://public.slidesharecdn.com/b/stylesheets/font-awesome.css?8e2051b24c"
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "no-cache"
+      }
+    ],
+    "_wallIssueTime": 1473831876.73919,
+    "_responseReceivedTime": 123361.677397,
+    "_mimeType": "application/font-woff",
+    "_responseHeaders": [
+      {
+        "name": "Date",
+        "value": "Wed, 14 Sep 2016 05:44:36 GMT"
+      },
+      {
+        "name": "X-Content-Type-Options",
+        "value": "nosniff"
+      },
+      {
+        "name": "P3P",
+        "value": "CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\""
+      },
+      {
+        "name": "Connection",
+        "value": "keep-alive"
+      },
+      {
+        "name": "Content-Length",
+        "value": "71508"
+      },
+      {
+        "name": "X-LI-UUID",
+        "value": "iqKyqNwKdBQA5YNgcSsAAA=="
+      },
+      {
+        "name": "Server",
+        "value": "nginx"
+      },
+      {
+        "name": "X-FS-UUID",
+        "value": "8aa2b2a8dc0a741400e58360712b0000"
+      },
+      {
+        "name": "Last-Modified",
+        "value": "Wed, 14 Sep 2016 00:30:42 GMT"
+      },
+      {
+        "name": "X-Li-Pop",
+        "value": "PROD-ELA4"
+      },
+      {
+        "name": "ETag",
+        "value": "\"57d89a32-11754\""
+      },
+      {
+        "name": "access-control-max-age",
+        "value": "86400"
+      },
+      {
+        "name": "access-control-allow-methods",
+        "value": "GET"
+      },
+      {
+        "name": "X-Varnish",
+        "value": "1069420944 1014574368"
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*"
+      },
+      {
+        "name": "Cache-Control",
+        "value": "max-age=31518984"
+      },
+      {
+        "name": "access-control-allow-credentials",
+        "value": "false"
+      },
+      {
+        "name": "Accept-Ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "Content-Type",
+        "value": "application/font-woff"
+      },
+      {
+        "name": "access-control-allow-headers",
+        "value": "*"
+      },
+      {
+        "name": "X-Li-Fabric",
+        "value": "prod-lva1"
+      },
+      {
+        "name": "Expires",
+        "value": "Thu, 14 Sep 2017 01:01:00 GMT"
+      }
+    ],
+    "_transferSize": 72250,
+    "_responseHeadersText": "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: application/font-woff\r\nLast-Modified: Wed, 14 Sep 2016 00:30:42 GMT\r\nETag: \"57d89a32-11754\"\r\nP3P: CP=\"OTI DSP COR CUR ADM DEV PSD IVD CONo OUR IND\"\r\nX-Content-Type-Options: nosniff\r\nX-Varnish: 1069420944 1014574368\r\nContent-Length: 71508\r\nAccept-Ranges: bytes\r\nX-FS-UUID: 8aa2b2a8dc0a741400e58360712b0000\r\nX-Li-Fabric: prod-lva1\r\nX-Li-Pop: PROD-ELA4\r\nX-LI-UUID: iqKyqNwKdBQA5YNgcSsAAA==\r\nCache-Control: max-age=31518984\r\nExpires: Thu, 14 Sep 2017 01:01:00 GMT\r\nDate: Wed, 14 Sep 2016 05:44:36 GMT\r\nConnection: keep-alive\r\naccess-control-allow-origin: *\r\naccess-control-max-age: 86400\r\naccess-control-allow-credentials: false\r\naccess-control-allow-headers: *\r\naccess-control-allow-methods: GET\r\n\r\n",
+    "_requestHeadersText": "GET /fonts/fontawesome-webfont.woff?v=4.3.0?cb=1473813487 HTTP/1.1\r\nHost: public.slidesharecdn.com\r\nConnection: keep-alive\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nOrigin: https://www.slideshare.net\r\nUser-Agent: Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36\r\nAccept: */*\r\nReferer: https://public.slidesharecdn.com/b/stylesheets/font-awesome.css?8e2051b24c\r\nAccept-Encoding: gzip, deflate, sdch, br\r\nAccept-Language: en-US,en;q=0.8\r\n\r\n",
+    "connectionReused": false,
+    "_timing": {
+      "requestTime": 123361.396452,
+      "proxyStart": 0.535999992280267,
+      "proxyEnd": 0.975999995716848,
+      "dnsStart": 1.09700000029989,
+      "dnsEnd": 52.8570000024047,
+      "connectStart": 52.8570000024047,
+      "connectEnd": 109.591000000364,
+      "sslStart": 75.0509999925271,
+      "sslEnd": 109.570000000531,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 109.744999994291,
+      "sendEnd": 109.876999995322,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 280.945000005886
+    },
+    "_resourceSize": 71508,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.88._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.88._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.120",
+    "_url": "https://webtide.com/wp-content/uploads/2014/03/icon.jpg",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://webtide.com/wp-content/uploads/2014/03/icon.jpg",
+      "scheme": "https",
+      "host": "webtide.com",
+      "path": "/wp-content/uploads/2014/03/icon.jpg",
+      "queryParams": "",
+      "folderPathComponents": "/wp-content/uploads/2014/03",
+      "lastPathComponent": "icon.jpg"
+    },
+    "_documentURL": "https://webtide.com/http2-push-demo/",
+    "_frameId": "19748.1",
+    "_loaderId": "19748.2",
+    "_initiator": {
+      "type": "other"
+    },
+    "_issueTime": 123362.352326,
+    "_startTime": 123362.352705,
+    "_endTime": 123362.529548,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "other",
+      "_title": "Other",
+      "_category": {
+        "title": "Other",
+        "shortTitle": "Other"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "107.22.210.238:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_RSA",
+      "keyExchangeGroup": "P-256",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.webtide.com",
+      "sanList": [
+        "*.webtide.com",
+        "webtide.com"
+      ],
+      "issuer": "COMODO RSA Domain Validation Secure Server CA",
+      "validFrom": 1450310400,
+      "validTo": 1483919999,
+      "signedCertificateTimestampList": []
+    },
+    "connectionId": "208",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/wp-content/uploads/2014/03/icon.jpg"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "accept",
+        "value": "image/webp,image/*,*/*;q=0.8"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "webtide.com"
+      },
+      {
+        "name": "cookie",
+        "value": "PHPSESSID=oc67hr6khr2u9oourjc42p36m3; wordpress_google_apps_login=fb1990922aa58dda9eb2400d9c842822; NCS_INENTIM=1473831869; 9b7fd567f916008bfc13d93e0fbb6c78=23b32aa08b1f65e52de30d78f670b3ca; SJECT16=CKON16; JCS_INENREF=; JCS_INENTIM=1473831873532; __utmt=1; __utma=124097164.1115498836.1473831874.1473831874.1473831874.1; __utmb=124097164.1.10.1473831874; __utmc=124097164; __utmz=124097164.1473831874.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none)"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": "referer",
+        "value": "https://webtide.com/http2-push-demo/"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831877.69582,
+    "_responseReceivedTime": 123362.514421,
+    "_mimeType": "image/jpeg",
+    "_responseHeaders": [
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "last-modified",
+        "value": "Tue, 11 Mar 2014 15:07:51 GMT"
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.3.11.v20160721)"
+      },
+      {
+        "name": "accept-ranges",
+        "value": "bytes"
+      },
+      {
+        "name": "content-length",
+        "value": "2290"
+      },
+      {
+        "name": "content-type",
+        "value": "image/jpeg"
+      }
+    ],
+    "_transferSize": 2352,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123362.352705,
+      "proxyStart": 0.544000009540469,
+      "proxyEnd": 0.987999999779277,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.07700000808109,
+      "sendEnd": 1.40900000405964,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 161.716000002343
+    },
+    "_resourceSize": 2290,
+    "_finished": true
+  },
+  {
+    "_target": {
+      "_modelByConstructor": {},
+      "consoleModel": {},
+      "networkManager": {
+        "_target": "[Circular ~.networkRecords.defaultPass.89._target]",
+        "_dispatcher": {
+          "_manager": "[Circular ~.networkRecords.defaultPass.89._target.networkManager]",
+          "_inflightRequestsById": {},
+          "_inflightRequestsByURL": {}
+        },
+        "_networkAgent": {},
+        "_certificateDetailsCache": {},
+        "_bypassServiceWorkerSetting": {},
+        "_listeners": {}
+      },
+      "networkLog": {
+        "_requests": {}
+      }
+    },
+    "_requestId": "19748.119",
+    "_url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+    "_parsedURL": {
+      "isValid": true,
+      "url": "https://www.gstatic.com/recaptcha/api2/r20160908152041/recaptcha__en.js",
+      "scheme": "https",
+      "host": "www.gstatic.com",
+      "path": "/recaptcha/api2/r20160908152041/recaptcha__en.js",
+      "queryParams": "",
+      "folderPathComponents": "/recaptcha/api2/r20160908152041",
+      "lastPathComponent": "recaptcha__en.js"
+    },
+    "_documentURL": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+    "_frameId": "19748.3",
+    "_loaderId": "19748.4",
+    "_initiator": {
+      "type": "parser",
+      "url": "https://www.google.com/recaptcha/api2/anchor?k=6LfoKAwTAAAAAKXxYecPROqRxwuS0tt7I_7hiURh&co=aHR0cHM6Ly93ZWJ0aWRlLmNvbTo0NDM.&hl=en&v=r20160908152041&size=normal&cb=fa9c9ludn0bz",
+      "lineNumber": 0
+    },
+    "_issueTime": 123361.901708,
+    "_startTime": 123361.902195,
+    "_endTime": 123362.550558,
+    "statusCode": 200,
+    "statusText": "",
+    "requestMethod": "GET",
+    "requestTime": 0,
+    "protocol": "h2",
+    "mixedContentType": "none",
+    "_initialPriority": "High",
+    "_currentPriority": null,
+    "_resourceType": {
+      "_name": "other",
+      "_title": "Other",
+      "_category": {
+        "title": "Other",
+        "shortTitle": "Other"
+      },
+      "_isTextType": false
+    },
+    "_contentEncoded": false,
+    "_pendingContentCallbacks": [],
+    "_frames": [],
+    "_eventSourceMessages": [],
+    "_responseHeaderValues": {},
+    "_remoteAddress": "[2607:f8b0:4005:806::2003]:443",
+    "_securityState": "secure",
+    "_securityDetails": {
+      "protocol": "TLS 1.2",
+      "keyExchange": "ECDHE_ECDSA",
+      "keyExchangeGroup": "X25519",
+      "cipher": "AES_128_GCM",
+      "certificateId": 0,
+      "subjectName": "*.google.com",
+      "sanList": [
+        "*.google.com",
+        "*.android.com",
+        "*.appengine.google.com",
+        "*.cloud.google.com",
+        "*.google-analytics.com",
+        "*.google.ca",
+        "*.google.cl",
+        "*.google.co.in",
+        "*.google.co.jp",
+        "*.google.co.uk",
+        "*.google.com.ar",
+        "*.google.com.au",
+        "*.google.com.br",
+        "*.google.com.co",
+        "*.google.com.mx",
+        "*.google.com.tr",
+        "*.google.com.vn",
+        "*.google.de",
+        "*.google.es",
+        "*.google.fr",
+        "*.google.hu",
+        "*.google.it",
+        "*.google.nl",
+        "*.google.pl",
+        "*.google.pt",
+        "*.googleadapis.com",
+        "*.googleapis.cn",
+        "*.googlecommerce.com",
+        "*.googlevideo.com",
+        "*.gstatic.cn",
+        "*.gstatic.com",
+        "*.gvt1.com",
+        "*.gvt2.com",
+        "*.metric.gstatic.com",
+        "*.urchin.com",
+        "*.url.google.com",
+        "*.youtube-nocookie.com",
+        "*.youtube.com",
+        "*.youtubeeducation.com",
+        "*.ytimg.com",
+        "android.clients.google.com",
+        "android.com",
+        "g.co",
+        "goo.gl",
+        "google-analytics.com",
+        "google.com",
+        "googlecommerce.com",
+        "policy.mta-sts.google.com",
+        "urchin.com",
+        "www.goo.gl",
+        "youtu.be",
+        "youtube.com",
+        "youtubeeducation.com"
+      ],
+      "issuer": "Google Internet Authority G2",
+      "validFrom": 1473291668,
+      "validTo": 1480548660,
+      "signedCertificateTimestampList": [
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "Google 'Rocketeer' log",
+          "logId": "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+          "timestamp": 1473294157675,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "30450221009055A6D69C0CB2E407BE909674D95CC4AF2DA70F0227C59306FE478C7180AF9F022013374116DD952AA4B0CE6354EE179866A06014C15C6069A83F5CE6BF5971BC94"
+        },
+        {
+          "status": "Verified",
+          "origin": "TLS extension",
+          "logDescription": "DigiCert Log Server",
+          "logId": "5614069A2FD7C2ECD3F5E1BD44B23EC74676B9BC99115CC0EF949855D689D0DD",
+          "timestamp": 1473294158314,
+          "hashAlgorithm": "SHA-256",
+          "signatureAlgorithm": "ECDSA",
+          "signatureData": "3046022100E14BE9F27C6A8BBC0B3629205B8160CECAB700729222DE0C3058655338B45A9E0221008C902D61453456BFE66625FCE56ECFF15667097CAF2EB83C088BA636CA83119C"
+        }
+      ]
+    },
+    "connectionId": "537",
+    "hasNetworkData": true,
+    "_requestHeaders": [
+      {
+        "name": ":path",
+        "value": "/recaptcha/api2/r20160908152041/recaptcha__en.js"
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache"
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, sdch, br"
+      },
+      {
+        "name": "accept-language",
+        "value": "en-US,en;q=0.8"
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/52.0.2743.8 Mobile Safari/537.36"
+      },
+      {
+        "name": "x-chrome-uma-enabled",
+        "value": "1"
+      },
+      {
+        "name": "accept",
+        "value": "*/*"
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache"
+      },
+      {
+        "name": ":authority",
+        "value": "www.gstatic.com"
+      },
+      {
+        "name": "referer",
+        "value": "https://www.google.com/recaptcha/api2/webworker.js?hl=en&v=r20160908152041"
+      },
+      {
+        "name": ":scheme",
+        "value": "https"
+      },
+      {
+        "name": ":method",
+        "value": "GET"
+      }
+    ],
+    "_wallIssueTime": 1473831877.24514,
+    "_responseReceivedTime": 123362.06547,
+    "_mimeType": "text/javascript",
+    "_responseHeaders": [
+      {
+        "name": "date",
+        "value": "Tue, 13 Sep 2016 18:09:55 GMT"
+      },
+      {
+        "name": "content-encoding",
+        "value": "gzip"
+      },
+      {
+        "name": "x-content-type-options",
+        "value": "nosniff"
+      },
+      {
+        "name": "last-modified",
+        "value": "Thu, 08 Sep 2016 23:15:00 GMT"
+      },
+      {
+        "name": "server",
+        "value": "sffe"
+      },
+      {
+        "name": "age",
+        "value": "41682"
+      },
+      {
+        "name": "vary",
+        "value": "Accept-Encoding"
+      },
+      {
+        "name": "content-type",
+        "value": "text/javascript"
+      },
+      {
+        "name": "status",
+        "value": "200"
+      },
+      {
+        "name": "cache-control",
+        "value": "public, max-age=31536000"
+      },
+      {
+        "name": "alt-svc",
+        "value": "quic=\":443\"; ma=2592000; v=\"36,35,34,33,32\""
+      },
+      {
+        "name": "content-length",
+        "value": "71283"
+      },
+      {
+        "name": "x-xss-protection",
+        "value": "1; mode=block"
+      },
+      {
+        "name": "expires",
+        "value": "Wed, 13 Sep 2017 18:09:55 GMT"
+      }
+    ],
+    "_transferSize": 71356,
+    "_requestHeadersText": "",
+    "connectionReused": true,
+    "_timing": {
+      "requestTime": 123361.902195,
+      "proxyStart": 0.939999998081476,
+      "proxyEnd": 1.40799999644514,
+      "dnsStart": -1,
+      "dnsEnd": -1,
+      "connectStart": -1,
+      "connectEnd": -1,
+      "sslStart": -1,
+      "sslEnd": -1,
+      "workerStart": -1,
+      "workerReady": -1,
+      "sendStart": 1.49599999713246,
+      "sendEnd": 1.74199999310076,
+      "pushStart": 0,
+      "pushEnd": 0,
+      "receiveHeadersEnd": 163.274999998976
+    },
+    "_resourceSize": 223052,
+    "_finished": true
+  }
+]

--- a/lighthouse-core/test/gather/computed/pushed-requests-test.js
+++ b/lighthouse-core/test/gather/computed/pushed-requests-test.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* eslint-env mocha */
+
+const GathererClass = require('../../../gather/computed/pushed-requests');
+const mockNetworkRecords = require('../../fixtures/networkRecords-h2push.json');
+
+const assert = require('assert');
+const Gatherer = new GathererClass();
+
+describe('PushedRequests computed artifact', () => {
+  it('filters networkRecords down to the pushed ones', () => {
+    return Gatherer.request(mockNetworkRecords).then(records => {
+      assert.ok(records.length < mockNetworkRecords.length, 'We filtered out the non-push records');
+      assert.equal(records.length, 3, 'There are 3 pushed responses in the recording');
+      return;
+    });
+  });
+});


### PR DESCRIPTION
fixes #652 

Usage in an audit looks something like..

```js
const networkRecords = artifacts.networkRecords[Audit.DEFAULT_PASS];
return artifacts.requestPushedRequests(networkRecords).then(records => {
    const record = records[0];
    // ...
    record._url
    record._startTime
    record._endTime
    record._duration
    record._timing.pushStart
    record._timing.pushEnd
    record._resourceSize
```

The record object looks like this: 
![image](https://cloud.githubusercontent.com/assets/39191/18501019/12402dee-7a02-11e6-991e-2083887059b7.png)


Also FWIW, devtools has some [fancy handling of endTime](https://github.com/ChromeDevTools/devtools-frontend/blob/42cfb581ea5b9f2c35db3f2a606148be79d11d4f/front_end/network/RequestTimingView.js#L188-L194) that we could also do if neccessary.

R=@samccone 