### PR TITLE
make manifest parser return empty array when icons missing or erroneous

### DIFF
--- a/lighthouse-core/closure/typedefs/Manifest.js
+++ b/lighthouse-core/closure/typedefs/Manifest.js
@@ -100,7 +100,7 @@ Manifest.prototype.display;
 /** @type {!ManifestNode<(string|undefined)>} */
 Manifest.prototype.orientation;
 
-/** @type {!ManifestNode<(!Array<!ManifestImageNode>|undefined)>} */
+/** @type {!ManifestNode<!Array<!ManifestImageNode>>} */
 Manifest.prototype.icons;
 
 /** @type {!ManifestNode<(!Array<!ManifestApplicationNode>|undefined)>} */

--- a/lighthouse-core/lib/icons.js
+++ b/lighthouse-core/lib/icons.js
@@ -24,9 +24,6 @@ function doExist(manifest) {
   if (!manifest || !manifest.icons) {
     return false;
   }
-  if (!manifest.icons.value) {
-    return false;
-  }
   if (manifest.icons.value.length === 0) {
     return false;
   }
@@ -41,7 +38,7 @@ function doExist(manifest) {
 function sizeAtLeast(sizeRequirement, manifest) {
   // An icon can be provided for a single size, or for multiple sizes.
   // To handle both, we flatten all found sizes into a single array.
-  const iconValues = /** @type {!Array<!ManifestImageNode>} */ (manifest.icons.value);
+  const iconValues = manifest.icons.value;
   const nestedSizes = iconValues.map(icon => icon.value.sizes.value);
   const flattenedSizes = [].concat.apply([], nestedSizes);
 

--- a/lighthouse-core/lib/manifest-parser.js
+++ b/lighthouse-core/lib/manifest-parser.js
@@ -233,12 +233,11 @@ function parseIcon(raw, manifestUrl) {
 
 function parseIcons(jsonInput, manifestUrl) {
   const raw = jsonInput.icons;
-  let value;
 
   if (raw === undefined) {
     return {
       raw,
-      value,
+      value: [],
       debugString: undefined
     };
   }
@@ -246,14 +245,14 @@ function parseIcons(jsonInput, manifestUrl) {
   if (!Array.isArray(raw)) {
     return {
       raw,
-      value,
+      value: [],
       debugString: 'ERROR: \'icons\' expected to be an array but is not.'
     };
   }
 
   // TODO(bckenny): spec says to skip icons missing `src`, so debug messages on
   // individual icons are lost. Warn instead?
-  value = raw
+  const value = raw
     // 9.6(3)(1)
     .filter(icon => icon.src !== undefined)
     // 9.6(3)(2)(1)

--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -50,13 +50,35 @@ describe('Manifest Parser', function() {
     assert.equal(parsedManifest.value.orientation.value, undefined);
     assert.equal(parsedManifest.value.theme_color.value, undefined);
     assert.equal(parsedManifest.value.background_color.value, undefined);
+    assert.ok(Array.isArray(parsedManifest.value.icons.value));
+    assert.ok(parsedManifest.value.icons.value.length === 0);
     // TODO:
-    // icons
     // related_applications
     // prefer_related_applications
   });
 
   describe('icon parsing', function() {
+    // 9.7
+    it('gives an empty array and an error for erroneous icons entry', () => {
+      let parsedManifest = manifestParser('{"icons": {"16": "img/icons/icon16.png"}}',
+          EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
+      assert.ok(!parsedManifest.debugString);
+      const icons = parsedManifest.value.icons;
+      assert.ok(Array.isArray(icons.value));
+      assert.equal(icons.value.length, 0);
+      assert.ok(icons.debugString);
+    });
+
+    it('gives an empty array and no error for missing icons entry', () => {
+      let parsedManifest = manifestParser('{}',
+          EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
+      assert.ok(!parsedManifest.debugString);
+      const icons = parsedManifest.value.icons;
+      assert.ok(Array.isArray(icons.value));
+      assert.equal(icons.value.length, 0);
+      assert.ok(!icons.debugString);
+    });
+
     it('parses basic string', function() {
       let parsedManifest = manifestParser('{"icons": [{"src": "192.png", "sizes": "192x192"}]}',
           EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);


### PR DESCRIPTION
Noticed a small spec violation in our current impl.

When parsing the manifest `icons` member, [a list of icons is *always* generated](https://w3c.github.io/manifest/#dfn-steps-for-processing-an-array-of-images), it's just empty if the `icons` entry is missing or erroneous.