### PR TITLE
add a timeout to gotoURL to handle sites that never reach `load`

### DIFF
--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -23,7 +23,7 @@ const parseURL = require('url').parse;
 
 const log = require('../../lib/log.js');
 
-const LOAD_TIMEOUT = 25000;
+const MAX_WAIT_FOR_LOAD_EVENT = 25 * 1000;
 const PAUSE_AFTER_LOAD = 500;
 
 class Driver {
@@ -266,12 +266,12 @@ class Driver {
         };
         this.once('Page.loadEventFired', loadListener);
 
-        // ...or LOAD_TIMEOUT ms from now in case the page load times out.
+        // ...or MAX_WAIT_FOR_LOAD_EVENT ms from now in case the page load times out.
         loadTimeout = setTimeout(_ => {
-          console.warn('Driver', 'Timed out waiting for page load. Moving on...');
+          log.warn('Driver', 'Timed out waiting for page load. Moving on...');
           this.off('Page.loadEventFired', loadListener);
           resolve();
-        }, LOAD_TIMEOUT);
+        }, MAX_WAIT_FOR_LOAD_EVENT);
       });
     });
   }

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -23,10 +23,12 @@ const parseURL = require('url').parse;
 
 const log = require('../../lib/log.js');
 
+const LOAD_TIMEOUT = 25000;
+const PAUSE_AFTER_LOAD = 500;
+
 class Driver {
 
   constructor() {
-    this.PAUSE_AFTER_LOAD = 500;
     this._traceEvents = [];
     this._traceCategories = Driver.traceCategories;
     this._eventEmitter = null;
@@ -252,11 +254,24 @@ class Driver {
           return resolve();
         }
 
-        this.once('Page.loadEventFired', response => {
+        // Resolve PAUSE_AFTER_LOAD milliseconds after onload...
+        let loadTimeout;
+        const loadListener = function() {
           setTimeout(_ => {
-            resolve(response);
-          }, this.PAUSE_AFTER_LOAD);
-        });
+            if (loadTimeout) {
+              clearTimeout(loadTimeout);
+            }
+            resolve();
+          }, PAUSE_AFTER_LOAD);
+        };
+        this.once('Page.loadEventFired', loadListener);
+
+        // ...or LOAD_TIMEOUT ms from now in case the page load times out.
+        loadTimeout = setTimeout(_ => {
+          console.warn('Driver', 'Timed out waiting for page load. Moving on...');
+          this.off('Page.loadEventFired', loadListener);
+          resolve();
+        }, LOAD_TIMEOUT);
       });
     });
   }


### PR DESCRIPTION
fixes #647

cuts off load time at 25 seconds. Fixes aliexpress, which currently never reaches load and so just hangs Lighthouse indefinitely. One step to fixing #627 