### PR TITLE
Send console.errors from devtools-frontend to --verbose

### DIFF
--- a/lighthouse-core/gather/computed/screenshots.js
+++ b/lighthouse-core/gather/computed/screenshots.js
@@ -33,7 +33,7 @@ class ScreenshotFilmstrip extends ComputedArtifact {
   }
 
   /**
-   * @param {!Array<!Object>} trace
+   * @param {{traceEvents: !Array}} trace
    * @return {!Promise}
   */
   getScreenshots(trace) {

--- a/lighthouse-core/gather/computed/screenshots.js
+++ b/lighthouse-core/gather/computed/screenshots.js
@@ -33,11 +33,11 @@ class ScreenshotFilmstrip extends ComputedArtifact {
   }
 
   /**
-   * @param {!Array<!Object>} traceData
+   * @param {!Array<!Object>} trace
    * @return {!Promise}
   */
-  getScreenshots(traceData) {
-    const model = new DevtoolsTimelineModel(traceData);
+  getScreenshots(trace) {
+    const model = new DevtoolsTimelineModel(trace.traceEvents);
     const filmStripFrames = model.filmStripModel().frames();
 
     const frameFetches = filmStripFrames.map(frame => this.fetchScreenshot(frame));

--- a/lighthouse-core/gather/computed/speedline.js
+++ b/lighthouse-core/gather/computed/speedline.js
@@ -18,6 +18,7 @@
 
 const ComputedArtifact = require('./computed-artifact');
 const speedline = require('speedline');
+const ConsoleQuieter = require('../../lib/console-quieter');
 
 class Speedline extends ComputedArtifact {
 
@@ -35,12 +36,14 @@ class Speedline extends ComputedArtifact {
 
     // speedline() may throw without a promise, so we resolve immediately
     // to get in a promise chain.
-    return Promise.resolve()
-        .then(_ => speedline(trace.traceEvents))
-        .then(speedlineResults => {
-          this.cache.set(trace, speedlineResults);
-          return speedlineResults;
-        });
+    return Promise.resolve().then(_ => {
+      ConsoleQuieter.mute({prefix: 'speedline'});
+      return speedline(trace.traceEvents);
+    }).then(speedlineResults => {
+      ConsoleQuieter.unmuteAndFlush();
+      this.cache.set(trace, speedlineResults);
+      return speedlineResults;
+    });
   }
 }
 

--- a/lighthouse-core/lib/console-quieter.js
+++ b/lighthouse-core/lib/console-quieter.js
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const log = require('./log.js');
+
+class ConsoleQuieter {
+
+  static mute(opts) {
+    ConsoleQuieter._logs = ConsoleQuieter._logs || [];
+
+    console.log = function() {
+      ConsoleQuieter._logs.push({type: 'log', args: arguments, prefix: opts.prefix});
+    };
+    console.warn = function() {
+      ConsoleQuieter._logs.push({type: 'warn', args: arguments, prefix: opts.prefix});
+    };
+    console.error = function() {
+      ConsoleQuieter._logs.push({type: 'error', args: arguments, prefix: opts.prefix});
+    };
+  }
+
+  static unmuteAndFlush() {
+    console.log = ConsoleQuieter._consolelog;
+    console.warn = ConsoleQuieter._consolewarn;
+    console.error = ConsoleQuieter._consoleerror;
+
+    ConsoleQuieter._logs.forEach(entry => {
+      log.verbose(`${entry.prefix}-${entry.type}`, ...entry.args);
+    });
+    ConsoleQuieter._logs = [];
+  }
+}
+
+ConsoleQuieter._consolelog = console.log.bind(console);
+ConsoleQuieter._consolewarn = console.warn.bind(console);
+ConsoleQuieter._consoleerror = console.error.bind(console);
+
+module.exports = ConsoleQuieter;

--- a/lighthouse-core/lib/traces/devtools-timeline-model.js
+++ b/lighthouse-core/lib/traces/devtools-timeline-model.js
@@ -18,6 +18,7 @@
 'use strict';
 
 const WebInspector = require('../web-inspector');
+const ConsoleQuieter = require('../console-quieter');
 
 // Polyfill the bottom-up and topdown tree sorting.
 const TimelineModelTreeView =
@@ -37,11 +38,21 @@ class TimelineModel {
     this._timelineModel =
         new WebInspector.TimelineModel(WebInspector.TimelineUIUtils.visibleEventsFilter());
 
+    if (typeof events === 'string') {
+      events = JSON.parse(events);
+    }
+    if (events.hasOwnProperty('traceEvents')) {
+      events = events.traceEvents;
+    }
+
     // populate with events
     this._tracingModel.reset();
-    this._tracingModel.addEvents(typeof events === 'string' ? JSON.parse(events) : events);
+
+    ConsoleQuieter.mute({prefix: 'timelineModel'});
+    this._tracingModel.addEvents(events);
     this._tracingModel.tracingComplete();
     this._timelineModel.setEvents(this._tracingModel);
+    ConsoleQuieter.unmuteAndFlush();
 
     return this;
   }

--- a/lighthouse-core/test/gather/computed/screenshots-test.js
+++ b/lighthouse-core/test/gather/computed/screenshots-test.js
@@ -25,7 +25,7 @@ let screenshotsGather = new ScreenshotsGather();
 
 describe('Screenshot gatherer', () => {
   it('returns an artifact for a real trace', () => {
-    return screenshotsGather.request(pwaTrace).then(screenshots => {
+    return screenshotsGather.request({traceEvents: pwaTrace}).then(screenshots => {
       assert.ok(Array.isArray(screenshots));
       assert.equal(screenshots.length, 7);
 


### PR DESCRIPTION
When our dependencies are spitting into console.log it gets pretty ugly. In particular the "tracingstartedinpage not found" and "MSG_LOOP_STARTED already began" logs that we see.

This PR will mute the console while we're doing work inside of devtoolstimelinemodel (ours or speedlines).

If you've set `--verbose` then you'll get the messages.

Also, a driveby fix to handle `.traceEvents` as expected in our timelinemodel.

fixes #617