### PR TITLE
Remove html gatherer from default.

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -119,7 +119,8 @@ function validatePasses(passes, audits, rootPath) {
       const GathererClass = GatherRunner.getGathererClass(gatherer, rootPath);
       const isGatherRequiredByAudits = requiredGatherers.has(GathererClass.name);
       if (isGatherRequiredByAudits === false) {
-        log.warn('config', `${GathererClass.name} is included, however no audit requires it.`);
+        const msg = `${GathererClass.name} gatherer requested, however no audit requires it.`;
+        log.warn('config', msg);
       }
     });
   });

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -8,7 +8,6 @@
       "https",
       "viewport",
       "theme-color",
-      "html",
       "manifest",
       "accessibility",
       "content-width",


### PR DESCRIPTION
No audits require our HTML gatherer any longer 

So we're logging this warning all the time:

![image](https://cloud.githubusercontent.com/assets/39191/18572901/153810a2-7b74-11e6-8030-3b29050a64bf.png)

This PR removes it from the default config.