### PR TITLE
user timing CLI formatter: more concise output.

### DIFF
--- a/lighthouse-core/formatters/user-timings.js
+++ b/lighthouse-core/formatters/user-timings.js
@@ -31,19 +31,16 @@ class UserTimings extends Formatter {
             return '';
           }
 
-          const output = `    - performance.measure events created by the site\n` +
-          events.reduce((prev, event) => {
-            let output = prev + `      - ${event.isMark ? 'Mark' : 'Measure'}: ${event.name}\n` +
-            '        - Start Time: ' + event.startTime.toFixed(2) + 'ms\n';
-            if (!event.isMark) {
-              output += '        - End Time: ' + event.endTime.toFixed(2) + '\n' +
-              '        - Duration: ' + event.duration.toFixed(2) + 'ms\n';
-            }
-
-            return output;
+          const measuresStr = events.filter(e => !e.isMark).reduce((prev, event) => {
+            let output = prev + `    - measure ${event.name}: \t`;
+            output += `duration: ${event.duration.toFixed(1)}ms,\t`;
+            output += `start: ${event.startTime.toFixed(1)}ms,\tend: ${event.endTime.toFixed(1)}`;
+            return output + '\n';
           }, '');
-
-          return output;
+          const marksStr = events.filter(e => e.isMark).reduce((prev, event) => {
+            return prev + `    - mark ${event.name}: \t time: ${event.startTime.toFixed(1)}ms\n`;
+          }, '');
+          return measuresStr + marksStr;
         };
 
       case 'html':

--- a/lighthouse-core/test/formatter/user-timings-test.js
+++ b/lighthouse-core/test/formatter/user-timings-test.js
@@ -43,9 +43,9 @@ describe('Formatter', () => {
       endTime: 2500,
       duration: 1500
     }]);
-    assert.ok(/Mark/.test(output));
-    assert.ok(/Start Time: 10/.test(output));
-    assert.ok(/Measure/.test(output));
-    assert.ok(/Duration: 1500/.test(output));
+    assert.ok(/mark/.test(output));
+    assert.ok(/start: 10/.test(output));
+    assert.ok(/measure/.test(output));
+    assert.ok(/duration: 1500/.test(output));
   });
 });


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/39191/18573724/0cb4a632-7b7b-11e6-8547-70f96f787241.png)

After: 
![image](https://cloud.githubusercontent.com/assets/39191/18573722/0789386c-7b7b-11e6-89ce-1a39c3b6706c.png)

URL to test: `lighthouse --perf "http://output.jsbin.com/goyoridice/1/quiet"`