### PR TITLE
remove old auditWhitelist argument

### DIFF
--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -56,7 +56,7 @@ module.exports = function(url, flags, configJSON) {
     log.setLevel(flags.logLevel);
 
     // Use ConfigParser to generate a valid config file
-    const config = new Config(configJSON, flags.auditWhitelist, flags.configPath);
+    const config = new Config(configJSON, flags.configPath);
 
     const driver = new ChromeProtocol();
 


### PR DESCRIPTION
somehow missed this when removing the `auditWhitelist`. Causing the `configPath` to be `undefined` when trying to resolve external audits (and so not finding them)