### PR TITLE
Add `chrome-debug` binary to launch the debuggable standalone chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.1.3",
   "description": "Lighthouse",
   "main": "./lighthouse-core/index.js",
-  "bin": "./lighthouse-cli/index.js",
+  "bin": {
+    "lighthouse": "./lighthouse-cli/index.js",
+    "chrome-debug": "lighthouse-core/scripts/launch-chrome.sh"
+  },
   "engines": {
     "node": ">=5"
   },


### PR DESCRIPTION
### Usage options:
```sh
chrome-debug

chrome-debug --show-paint-rects

chrome-debug --show-paint-rects http://goat.com
```

fixes #655 