### PR TITLE
clean up of extensible audit loading and error handling

### DIFF
--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -138,8 +138,8 @@ const flags = cli;
 let config = null;
 if (cli.configPath) {
   // Resolve the config file path relative to where cli was called.
-  const configPath = path.resolve(process.cwd(), cli.configPath);
-  config = require(configPath);
+  cli.configPath = path.resolve(process.cwd(), cli.configPath);
+  config = require(cli.configPath);
 } else if (cli.perf) {
   config = perfOnlyConfig;
 }

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -155,6 +155,51 @@ function getGatherersNeededByAudits(audits) {
   }, new Set());
 }
 
+/**
+ * Resolves the location of the specified audit and returns a string path that
+ * can then be loaded via `require()`. Throws an error if no audit is found.
+ * @param {string} audit
+ * @param {string=} configPath The absolute path to the config file, if there is one.
+ * @return {string}
+ * @throws {Error}
+ */
+function resolveAudit(audit, configPath) {
+  // First try straight `require()`. Unlikely to be specified relative to this
+  // file, but adds support for Lighthouse audits in npm modules as `require()`
+  // walks up parent directories looking inside any node_modules/ present. Also
+  // handles absolute paths.
+  try {
+    require.resolve(audit);
+    return audit;
+  } catch (e) {}
+
+  // See if the audit resolves relative to the current working directory. Most
+  // useful to handle the case of invoking Lighthouse as a module, since then
+  // the config is an object and so has no path.
+  const cwdPath = path.resolve(process.cwd(), audit);
+  try {
+    require.resolve(cwdPath);
+    return cwdPath;
+  } catch (e) {}
+
+  const errorString = `Unable to locate audit: ${audit} (tried to require() ` +
+      `from '${__dirname}' and load from '${cwdPath}'`;
+  if (!configPath) {
+    throw new Error(errorString + ')');
+  }
+
+  // Finally, try looking up relative to the config file path. Just like the
+  // relative path passed to `require()` is found relative to the file it's in,
+  // this allows audit paths to be specified relative to the config file.
+  const relativePath = path.resolve(configPath, audit);
+  try {
+    require.resolve(relativePath);
+    return relativePath;
+  } catch (requireError) {}
+
+  throw new Error(errorString + ` and '${relativePath}')`);
+}
+
 function requireAudits(audits, configPath) {
   if (!audits) {
     return null;
@@ -165,34 +210,13 @@ function requireAudits(audits, configPath) {
   return audits.map(audit => {
     let requirePath;
 
-    // First, see if the audit is in Lighthouse itself.
+    // First, see if the audit is a Lighthouse core audit.
     const coreAudit = coreList.find(a => a === `${audit}.js`);
     if (coreAudit) {
       requirePath = `../audits/${audit}`;
     } else {
-      // If not, see if it can be found another way:
-      // See if the audit resolves relative to the current working directory.
-      const cwdPath = path.resolve(process.cwd(), audit);
-      try {
-        // If resolving this path works, update the path to be used.
-        require.resolve(cwdPath);
-        requirePath = cwdPath;
-      } catch (requireError) {
-        // Also try relative to the config path, if provided.
-        if (!configPath) {
-          throw new Error(`Unable to locate audit: ${audit} (tried at '${cwdPath}')`);
-        }
-
-        const relativePath = path.resolve(configPath, audit);
-        try {
-          // If resolving this path works, update the path to be used.
-          require.resolve(relativePath);
-          requirePath = relativePath;
-        } catch (requireError) {
-          throw new Error(`Unable to locate audit: ${audit} ` +
-              `(tried at '${cwdPath}' and '${relativePath}')`);
-        }
-      }
+      // Otherwise, attempt to find it elsewhere.
+      requirePath = resolveAudit(audit, configPath);
     }
 
     const AuditClass = require(requirePath);

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -181,6 +181,16 @@ describe('Config', () => {
     }, configPath));
   });
 
+  it('loads an audit from node_modules/', () => {
+    return assert.throws(_ => new Config({
+      // Use a lighthouse dep as a stand in for a module.
+      audits: ['chrome-remote-interface']
+    }), function(err) {
+      // Should throw an audit validation error, but *not* an audit not found error.
+      return !/locate audit/.test(err) && /audit\(\) method/.test(err);
+    });
+  });
+
   it('loads an audit relative to the working directory', () => {
     // Construct an audit URL relative to current working directory, regardless
     // of where test was started from.

--- a/lighthouse-core/test/fixtures/invalid-audits/require-error.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/require-error.js
@@ -1,0 +1,35 @@
+/**
+ *
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// NOTE: this require path does not resolve correctly.
+const LighthouseAudit = require('../terrible/path/come/on/audit');
+
+class ValidCustomAudit extends LighthouseAudit {
+  static get meta() {
+    return {
+      name: 'valid-audit',
+      category: 'Custom',
+      description: 'Valid Audit',
+      requiredArtifacts: ['HTML']
+    };
+  }
+
+  static audit() {}
+}
+
+module.exports = ValidCustomAudit;

--- a/lighthouse-core/test/fixtures/invalid-audits/require-error.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/require-error.js
@@ -19,12 +19,12 @@
 // NOTE: this require path does not resolve correctly.
 const LighthouseAudit = require('../terrible/path/come/on/audit');
 
-class ValidCustomAudit extends LighthouseAudit {
+class RequireErrorAudit extends LighthouseAudit {
   static get meta() {
     return {
-      name: 'valid-audit',
+      name: 'require-error',
       category: 'Custom',
-      description: 'Valid Audit',
+      description: 'Require Error',
       requiredArtifacts: ['HTML']
     };
   }
@@ -32,4 +32,4 @@ class ValidCustomAudit extends LighthouseAudit {
   static audit() {}
 }
 
-module.exports = ValidCustomAudit;
+module.exports = RequireErrorAudit;


### PR DESCRIPTION
This came from @ebidel making his own custom audits. Any errors in a custom audit (e.g. syntax error or transitive dependencies not being found) were being absorbed and reemitted as "Unable to locate audit", which is not true and confusing.

In fixing this, however, it also became clear that our audit resolution was being done in a really fragile way, so this PR changes a few things:
- Only assume we can use a core audit path to load an audit if the audit is in fact a core audit. Using this path as the default value makes for confusing error messages if the audit is never found.
- Next, attempt to `require()` in place. No one is going to specify their paths relative to `lighthouse-core/config/config.js`, but this handles the audit-in-an-npm module case by walking up and down the path looking for audits in `node_modules/` directories.
- Next, look for the audit relative to `process.cwd()`. Resolving relative to the working directory is mostly to handle the case of using Lighthouse as a module since then you're passing in a config object, not a file, so there is no config file path.
- Next, as before, look for the audit relative to the config file path, if there is one. We need to make sure the config path is an absolute one by this point, however, as it's unlikely for the config file to be specified relative to `config.js`, and we won't always be able to locate it ourselves by this point. I've put in an assertion in the `Config` constructor to make sure the path is absolute by that point and made sure the CLI handles that properly.
- Finally, only emit an 'Unable to locate audit' error in the case of a not found audit. For all other errors, let the normal error flow handle it.