### PR TITLE
Improved currentTab impl

### DIFF
--- a/lighthouse-core/gather/drivers/extension.js
+++ b/lighthouse-core/gather/drivers/extension.js
@@ -130,19 +130,23 @@ class ExtensionDriver extends Driver {
   }
 
   queryCurrentTab_() {
-    const currentTab = {
-      active: true,
-      windowId: chrome.windows.WINDOW_ID_CURRENT
-    };
-
     return new Promise((resolve, reject) => {
-      chrome.tabs.query(currentTab, tabs => {
+      const queryOpts = {
+        active: true,
+        lastFocusedWindow: true,
+        windowType: 'normal'
+      };
+
+      chrome.tabs.query(queryOpts, (tabs => {
         if (chrome.runtime.lastError) {
           return reject(chrome.runtime.lastError);
         }
-
+        if (tabs.length === 0) {
+          const message = 'Couldn\'t resolve current tab. Please file a bug.';
+          return reject(new Error(message));
+        }
         resolve(tabs[0]);
-      });
+      }));
     });
   }
 


### PR DESCRIPTION
Our current `chrome.windows.WINDOW_ID_CURRENT` is pretty flaky with devtools open. 

Also, `currentWindow: true` isn't ideal:

> The current window is the window that contains the code that is currently executing. It's important to realize that this can be different from the topmost or focused window.

The `lastFocusedWindow` property is what we want, plus `windowType` lets us make sure we're not selecting a chrome app/extension. https://developer.chrome.com/extensions/tabs#method-query

R=@wardpeet 