### PR TITLE
Do Better Web: initial commit

### DIFF
--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Audit = require('../audit');
+
+class AppCacheManifestAttr extends Audit {
+
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return {
+      category: 'Offline',
+      name: 'appcache-manifest',
+      description: 'Site isn\'t using Application Cache',
+      requiredArtifacts: ['AppCacheManifest']
+    };
+  }
+
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    if (typeof artifacts.AppCacheManifest === 'undefined' ||
+        artifacts.AppCacheManifest === -1) {
+      return AppCacheManifestAttr.generateAuditResult({
+        rawValue: false,
+        debugString: 'Unable to determine if you\'re using AppCache.'
+      });
+    }
+
+    const usingAppcache = artifacts.AppCacheManifest !== null;
+    const displayValue = usingAppcache ? `<html manifest="${artifacts.AppCacheManifest}">` : '';
+
+    return AppCacheManifestAttr.generateAuditResult({
+      rawValue: !usingAppcache,
+      displayValue: displayValue
+    });
+  }
+}
+
+module.exports = AppCacheManifestAttr;

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -1,0 +1,29 @@
+{
+  "passes": [{
+    "network": false,
+    "loadPage": true,
+    "gatherers": [
+      "../gather/gatherers/dobetterweb/appcache"
+    ]
+  }],
+
+  "audits": [
+    "../audits/dobetterweb/appcache-manifest"
+  ],
+
+  "aggregations": [{
+    "name": "Do Better Web",
+    "description": "Here are some recommendations to modernize your web app.",
+    "scored": false,
+    "categorizable": true,
+    "items": [{
+      "name": "Using modern offline web platform features",
+      "description": "Application Cache is <a href='https://html.spec.whatwg.org/multipage/browsers.html#offline' target='_blank'>deprecated</a> by <a href='https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers' target='_blank'>Service Workers</a>. Consider implementing an offline solution using the <a href='https://developer.mozilla.org/en-US/docs/Web/API/Cache' target='blank'>Cache Storage API</a>.",
+      "criteria": {
+        "appcache-manifest": {
+          "rawValue": false
+        }
+      }
+    }]
+  }]
+}

--- a/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Gatherer = require('../gatherer');
+
+class AppCacheManifest extends Gatherer {
+
+  afterPass(options) {
+    const driver = options.driver;
+
+    return driver.querySelector('html')
+      .then(node => node && node.getAttribute('manifest'))
+      .then(manifest => {
+        this.artifact = manifest;
+      })
+      .catch(_ => {
+        this.artifact = -1;
+      });
+  }
+}
+
+module.exports = AppCacheManifest;


### PR DESCRIPTION
R: @brendankenny @paulirish @paullewis @GoogleChrome/accessibility-admin 

Adds an initial setup for DBW®️ and a first test...which is suggesting Service Worker/Cache API over manifest.

Run: `node lighthouse-cli --config-path=lighthouse-core/config/dobetterweb.json --output=html --output-path=results.html http://webdbg.com/test/appcache/`

<img width="875" alt="screen shot 2016-09-20 at 6 57 51 pm" src="https://cloud.githubusercontent.com/assets/238208/18695084/25ddecbc-7f64-11e6-8a80-e3a46d8821c5.png">
  