### PR TITLE
Migrate tracingmodel to computed artifact

### DIFF
--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -95,7 +95,7 @@ Example: --output-path=./lighthouse-results.html`
     'help'
   ])
 
-  .choices('output', Object.values(Printer.OUTPUT_MODE))
+  .choices('output', Object.keys(Printer.OUTPUT_MODE))
 
   // default values
   .default('mobile', true)

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -77,23 +77,28 @@ class EstimatedInputLatency extends Audit {
    * @return {!Promise<!AuditResult>} The score from the audit, ranging from 0-100.
    */
   static audit(artifacts) {
-    const trace = artifacts.traces[this.DEFAULT_PASS];
+    return new Promise((resolve, reject) => {
+      const trace = artifacts.traces[this.DEFAULT_PASS];
 
-    const pendingSpeedline = artifacts.requestSpeedline(trace);
-    const pendingTracingModel = artifacts.requestTracingModel(trace);
+      const pendingSpeedline = artifacts.requestSpeedline(trace);
+      const pendingTracingModel = artifacts.requestTracingModel(trace);
 
-    return Promise.all([pendingSpeedline, pendingTracingModel]).then(results => {
-      const speedline = results[0];
-      const model = results[1];
+      const computedP = Promise.all([pendingSpeedline, pendingTracingModel]).then(results => {
+        const speedline = results[0];
+        const model = results[1];
 
-      return EstimatedInputLatency.calculate(speedline, trace, model);
-    }).catch(err => {
-      return EstimatedInputLatency.generateAuditResult({
-        rawValue: -1,
-        debugString: 'Speedline unable to parse trace contents: ' + err.message
+        return EstimatedInputLatency.calculate(speedline, trace, model);
       });
-    });
+      resolve(computedP);
+    }).catch(generateError);
   }
+}
+
+function generateError(err) {
+  return EstimatedInputLatency.generateAuditResult({
+    rawValue: -1,
+    debugString: 'EIL audit unable continue. Bad trace contents: ' + err.message
+  });
 }
 
 module.exports = EstimatedInputLatency;

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -77,20 +77,19 @@ class EstimatedInputLatency extends Audit {
    * @return {!Promise<!AuditResult>} The score from the audit, ranging from 0-100.
    */
   static audit(artifacts) {
-    return new Promise((resolve, reject) => {
-      const trace = artifacts.traces[this.DEFAULT_PASS];
+    const trace = artifacts.traces[this.DEFAULT_PASS];
 
-      const pendingSpeedline = artifacts.requestSpeedline(trace);
-      const pendingTracingModel = artifacts.requestTracingModel(trace);
+    const pendingSpeedline = artifacts.requestSpeedline(trace);
+    const pendingTracingModel = artifacts.requestTracingModel(trace);
 
-      const computedP = Promise.all([pendingSpeedline, pendingTracingModel]).then(results => {
-        const speedline = results[0];
-        const model = results[1];
+    const computedP = Promise.all([pendingSpeedline, pendingTracingModel]).then(results => {
+      const speedline = results[0];
+      const model = results[1];
 
-        return EstimatedInputLatency.calculate(speedline, trace, model);
-      });
-      resolve(computedP);
-    }).catch(generateError);
+      return EstimatedInputLatency.calculate(speedline, trace, model);
+    });
+    computedP.catch(generateError);
+    return computedP;
   }
 }
 

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -59,12 +59,14 @@ class TTIMetric extends Audit {
   static audit(artifacts) {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const pendingSpeedline = artifacts.requestSpeedline(trace);
+    const pendingTracingModel = artifacts.requestTracingModel(trace);
     const pendingFMP = FMPMetric.audit(artifacts);
 
     // We start looking at Math.Max(FMPMetric, visProgress[0.85])
-    return Promise.all([pendingSpeedline, pendingFMP]).then(results => {
+    return Promise.all([pendingSpeedline, pendingTracingModel, pendingFMP]).then(results => {
       const speedline = results[0];
-      const fmpResult = results[1];
+      const model = results[1];
+      const fmpResult = results[2];
       if (fmpResult.rawValue === -1) {
         return generateError(fmpResult.debugString);
       }
@@ -73,9 +75,6 @@ class TTIMetric extends Audit {
           fmpResult.extendedInfo.value.timings;
 
       // Process the trace
-      const tracingProcessor = new TracingProcessor();
-      const trace = artifacts.traces[Audit.DEFAULT_PASS];
-      const model = tracingProcessor.init(trace);
       const endOfTraceTime = model.bounds.max;
 
       // TODO: Wait for DOMContentLoadedEndEvent

--- a/lighthouse-core/gather/computed/tracing-model.js
+++ b/lighthouse-core/gather/computed/tracing-model.js
@@ -29,7 +29,7 @@ class TracingModel extends ComputedArtifact {
   /**
    * Return catapult traceviewer model
    * @param {{traceEvents: !Array}} trace
-   * @return {!Promise}
+   * @return {!Promise<{!TracingProcessorModel}>}
    */
   compute_(trace) {
     const tracingProcessor = new TracingProcessor();

--- a/lighthouse-core/gather/computed/tracing-model.js
+++ b/lighthouse-core/gather/computed/tracing-model.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ComputedArtifact = require('./computed-artifact');
+const TracingProcessor = require('../../lib/traces/tracing-processor');
+
+class TracingModel extends ComputedArtifact {
+
+  get name() {
+    return 'TracingModel';
+  }
+
+  /**
+   * Return catapult traceviewer model
+   * @param {{traceEvents: !Array}} trace
+   * @return {!Promise}
+   */
+  compute_(trace) {
+    const tracingProcessor = new TracingProcessor();
+    return tracingProcessor.init(trace);
+  }
+
+}
+
+module.exports = TracingModel;

--- a/lighthouse-core/test/audits/time-to-interactive-test.js
+++ b/lighthouse-core/test/audits/time-to-interactive-test.js
@@ -41,7 +41,7 @@ describe('Performance: time-to-interactive audit', () => {
   });
 
   it('evaluates valid input correctly', done => {
-    let artifacts = computedArtifacts;
+    const artifacts = computedArtifacts;
     artifacts.traces = {
       [Audit.DEFAULT_PASS]: {
         traceEvents: pwaTrace


### PR DESCRIPTION
Followup from introducing computed artifacts (#583, #542)...

This moves the catapult tracing model into a computed artifact. Creating this model can take 1-3seconds, and we've been doing it twice each run. Now, just once. :)

_Driveby: change the `object.values` in the CLI to use `keys()` instead. Same result, and not relying on the accidental polyfill of o.values coming from devtools frontend._