### PR TITLE
DBW: add audit for no-websql

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -19,7 +19,7 @@
 
 const Audit = require('../audit');
 
-class AppCacheManifestAttr extends Audit {
+class NoWebSQLAudit extends Audit {
 
   /**
    * @return {!AuditMeta}
@@ -27,9 +27,9 @@ class AppCacheManifestAttr extends Audit {
   static get meta() {
     return {
       category: 'Offline',
-      name: 'appcache-manifest',
-      description: 'Site is not using Application Cache',
-      requiredArtifacts: ['AppCacheManifest']
+      name: 'no-websql',
+      description: 'Site is not using WebSQL DB.',
+      requiredArtifacts: ['WebSQL']
     };
   }
 
@@ -38,22 +38,22 @@ class AppCacheManifestAttr extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (typeof artifacts.AppCacheManifest === 'undefined' ||
-        artifacts.AppCacheManifest === -1) {
-      return AppCacheManifestAttr.generateAuditResult({
-        rawValue: false,
-        debugString: 'Unable to determine if you\'re using AppCache.'
+    if (typeof artifacts.WebSQL === 'undefined' ||
+        artifacts.WebSQL === -1) {
+      return NoWebSQLAudit.generateAuditResult({
+        rawValue: -1,
+        debugString: artifacts.WebSQL ? artifacts.WebSQL.debugString : ''
       });
     }
 
-    const usingAppcache = artifacts.AppCacheManifest !== null;
-    const displayValue = usingAppcache ? `<html manifest="${artifacts.AppCacheManifest}">` : '';
+    const db = artifacts.WebSQL.database;
+    const displayValue = db ? `db name: ${db.name}, version: ${db.version}` : '';
 
-    return AppCacheManifestAttr.generateAuditResult({
-      rawValue: !usingAppcache,
+    return NoWebSQLAudit.generateAuditResult({
+      rawValue: !db,
       displayValue: displayValue
     });
   }
 }
 
-module.exports = AppCacheManifestAttr;
+module.exports = NoWebSQLAudit;

--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -15,6 +15,11 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview Audit a page to ensure that it does not open a database using =
+ * the WebSQL API.
+ */
+
 'use strict';
 
 const Audit = require('../audit');
@@ -39,15 +44,17 @@ class NoWebSQLAudit extends Audit {
    */
   static audit(artifacts) {
     if (typeof artifacts.WebSQL === 'undefined' ||
-        artifacts.WebSQL === -1) {
+        artifacts.WebSQL.database === -1) {
       return NoWebSQLAudit.generateAuditResult({
         rawValue: -1,
-        debugString: artifacts.WebSQL ? artifacts.WebSQL.debugString : ''
+        debugString: (artifacts.WebSQL ?
+            artifacts.WebSQL.debugString : 'WebSQL gatherer did not run')
       });
     }
 
     const db = artifacts.WebSQL.database;
-    const displayValue = db ? `db name: ${db.name}, version: ${db.version}` : '';
+    const displayValue = (db && db.database ?
+        `db name: ${db.database.name}, version: ${db.database.version}` : '');
 
     return NoWebSQLAudit.generateAuditResult({
       rawValue: !db,

--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview Audit a page to ensure that it does not open a database using =
+ * @fileoverview Audit a page to ensure that it does not open a database using
  * the WebSQL API.
  */
 

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -3,12 +3,14 @@
     "network": false,
     "loadPage": true,
     "gatherers": [
-      "../gather/gatherers/dobetterweb/appcache"
+      "../gather/gatherers/dobetterweb/appcache",
+      "../gather/gatherers/dobetterweb/websql"
     ]
   }],
 
   "audits": [
-    "../audits/dobetterweb/appcache-manifest"
+    "../audits/dobetterweb/appcache-manifest",
+    "../audits/dobetterweb/no-websql"
   ],
 
   "aggregations": [{
@@ -17,11 +19,15 @@
     "scored": false,
     "categorizable": true,
     "items": [{
-      "name": "Using modern offline web platform features",
-      "description": "Application Cache is <a href='https://html.spec.whatwg.org/multipage/browsers.html#offline' target='_blank'>deprecated</a> by <a href='https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers' target='_blank'>Service Workers</a>. Consider implementing an offline solution using the <a href='https://developer.mozilla.org/en-US/docs/Web/API/Cache' target='blank'>Cache Storage API</a>.",
+      "name": "Using modern offline features",
       "criteria": {
         "appcache-manifest": {
-          "rawValue": false
+          "rawValue": false,
+          "description": "Application Cache is <a href='https://html.spec.whatwg.org/multipage/browsers.html#offline' target='_blank'>deprecated</a> by <a href='https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers' target='_blank'>Service Workers</a>. Consider implementing an offline solution using the <a href='https://developer.mozilla.org/en-US/docs/Web/API/Cache' target='blank'>Cache Storage API</a>."
+        },
+        "no-websql": {
+          "rawValue": false,
+          "description": "WebSQL DB is <a href='https://dev.w3.org/html5/webdatabase/' target='_blank'>deprecated</a>. Consider implementing an offline solution using <a href='https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB' target='blank'>IndexedDB</a>."
         }
       }
     }]

--- a/lighthouse-core/gather/gatherers/dobetterweb/websql.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/websql.js
@@ -19,7 +19,7 @@
 
 const Gatherer = require('../gatherer');
 
-const MAX_WAIT_TIMEOUT = 10 * 1000;
+const MAX_WAIT_TIMEOUT = 500;
 
 class WebSQL extends Gatherer {
 
@@ -32,17 +32,15 @@ class WebSQL extends Gatherer {
 
     return new Promise((resolve, reject) => {
       driver.once('Database.addDatabase', db => {
-        if (timeout) {
-          clearTimeout(timeout);
-        }
+        clearTimeout(timeout);
         driver.sendCommand('Database.disable');
         resolve(db);
       });
 
       driver.sendCommand('Database.enable');
 
-      // Wait for a websql db to be opened. Reject the Promise if none were.
-      // TODO(ericbidelman): this assumes dbs are only opened 10s within page
+      // Wait for a websql db to be opened. Reject the Promise no dbs were created.
+      // TODO(ericbidelman): this assumes dbs are opened on page load.
       // load. Figure out a better strategy (code greping, user interaction) later.
       timeout = setTimeout(function() {
         reject('No WebSQL databases were opened');
@@ -61,7 +59,10 @@ class WebSQL extends Gatherer {
         };
       })
       .catch(_ => {
-        this.artifact = -1;
+        this.artifact = {
+          value: -1,
+          debugString: 'Unable to gather WebSQL database state'
+        };
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/websql.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/websql.js
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Gatherer = require('../gatherer');
+
+const MAX_WAIT_TIMEOUT = 10 * 1000;
+
+class WebSQL extends Gatherer {
+
+  static get MAX_WAIT_TIMEOUT() {
+    return MAX_WAIT_TIMEOUT;
+  }
+
+  listenForDatabaseEvents(driver) {
+    let timeout;
+
+    return new Promise((resolve, reject) => {
+      driver.once('Database.addDatabase', db => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        driver.sendCommand('Database.disable');
+        resolve(db);
+      });
+
+      driver.sendCommand('Database.enable');
+
+      // Wait for a websql db to be opened. Reject the Promise if none were.
+      // TODO(ericbidelman): this assumes dbs are only opened 10s within page
+      // load. Figure out a better strategy (code greping, user interaction) later.
+      timeout = setTimeout(function() {
+        reject('No WebSQL databases were opened');
+      }, WebSQL.MAX_WAIT_TIMEOUT);
+    });
+  }
+
+  afterPass(options) {
+    return this.listenForDatabaseEvents(options.driver)
+      .then(database => {
+        this.artifact = database;
+      }, reason => {
+        this.artifact = {
+          database: null,
+          debugString: reason
+        };
+      })
+      .catch(_ => {
+        this.artifact = -1;
+      });
+  }
+}
+
+module.exports = WebSQL;

--- a/lighthouse-core/test/audits/dobetterweb/websql-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/websql-test.js
@@ -21,19 +21,27 @@ const assert = require('assert');
 /* eslint-env mocha */
 
 describe('No websql audit', () => {
-  it('fails gracefully', () => {
+  it('fails gracefully when gatherer does not run', () => {
     const auditResult = NoWebSQLAudit.audit({});
     assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, '');
+    assert.equal(auditResult.debugString, 'WebSQL gatherer did not run');
   });
 
   it('passes when no database is created', () => {
-    assert.equal(NoWebSQLAudit.audit({WebSQL: {database: null}}).rawValue, true);
+    assert.equal(NoWebSQLAudit.audit({
+      WebSQL: {
+        database: null
+      }
+    }).rawValue, true);
   });
 
   it('fails when database is created', () => {
     const auditResult = NoWebSQLAudit.audit({
-      WebSQL: {database: 'db-name', version: 1.0}
+      WebSQL: {
+        database: {
+          database: 'db-name', version: 1.0
+        }
+      }
     });
 
     assert.equal(auditResult.rawValue, false);

--- a/lighthouse-core/test/audits/dobetterweb/websql-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/websql-test.js
@@ -13,24 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const Audit = require('../../../audits/dobetterweb/no-websql.js');
+'use strict';
+
+const NoWebSQLAudit = require('../../../audits/dobetterweb/no-websql.js');
 const assert = require('assert');
 
 /* eslint-env mocha */
 
 describe('No websql audit', () => {
   it('fails gracefully', () => {
-    const auditResult = Audit.audit({});
+    const auditResult = NoWebSQLAudit.audit({});
     assert.equal(auditResult.rawValue, -1);
     assert.equal(auditResult.debugString, '');
   });
 
   it('passes when no database is created', () => {
-    assert.equal(Audit.audit({WebSQL: {database: null}}).rawValue, true);
+    assert.equal(NoWebSQLAudit.audit({WebSQL: {database: null}}).rawValue, true);
   });
 
   it('fails when database is created', () => {
-    const auditResult = Audit.audit({
+    const auditResult = NoWebSQLAudit.audit({
       WebSQL: {database: 'db-name', version: 1.0}
     });
 

--- a/lighthouse-core/test/audits/dobetterweb/websql-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/websql-test.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const Audit = require('../../../audits/dobetterweb/no-websql.js');
+const assert = require('assert');
+
+/* eslint-env mocha */
+
+describe('No websql audit', () => {
+  it('fails gracefully', () => {
+    const auditResult = Audit.audit({});
+    assert.equal(auditResult.rawValue, -1);
+    assert.equal(auditResult.debugString, '');
+  });
+
+  it('passes when no database is created', () => {
+    assert.equal(Audit.audit({WebSQL: {database: null}}).rawValue, true);
+  });
+
+  it('fails when database is created', () => {
+    const auditResult = Audit.audit({
+      WebSQL: {database: 'db-name', version: 1.0}
+    });
+
+    assert.equal(auditResult.rawValue, false);
+    assert.ok(auditResult.displayValue.match(/db name: (.*), version: (.*)/));
+  });
+});


### PR DESCRIPTION
R: @brendankenny @paulirish @GoogleChrome/lighthouse 

![screen shot 2016-09-22 at 11 13 48 am](https://cloud.githubusercontent.com/assets/238208/18760548/64d9f322-80b6-11e6-8053-37d9b125522f.png)

I'm not stoked on the 10s timeout for WebSQL db creation, but we need a better framework solution for https://github.com/GoogleChrome/lighthouse/issues/627.