### PR TITLE
clean up and unification of custom audit/gatherer loading

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -153,6 +153,52 @@ class Runner {
         .readdirSync(path.join(__dirname, './gather/gatherers'))
         .filter(f => /\.js$/.test(f));
   }
+
+  /**
+   * Resolves the location of the specified plugin and returns an absolute
+   * string path to the file. Used for loading custom audits and gatherers.
+   * Throws an error if no plugin is found.
+   * @param {string} plugin
+   * @param {string=} configDir The absolute path to the directory of the config file, if there is one.
+   * @param {string=} category Optional plugin category (e.g. 'audit') for better error messages.
+   * @return {string}
+   * @throws {Error}
+   */
+  static resolvePlugin(plugin, configDir, category) {
+    // First try straight `require()`. Unlikely to be specified relative to this
+    // file, but adds support for Lighthouse plugins in npm modules as
+    // `require()` walks up parent directories looking inside any node_modules/
+    // present. Also handles absolute paths.
+    try {
+      return require.resolve(plugin);
+    } catch (e) {}
+
+    // See if the plugin resolves relative to the current working directory.
+    // Most useful to handle the case of invoking Lighthouse as a module, since
+    // then the config is an object and so has no path.
+    const cwdPath = path.resolve(process.cwd(), plugin);
+    try {
+      return require.resolve(cwdPath);
+    } catch (e) {}
+
+    const errorString = 'Unable to locate ' +
+        (category ? `${category}: ` : '') +
+        `${plugin} (tried to require() from '${__dirname}' and load from '${cwdPath}'`;
+
+    if (!configDir) {
+      throw new Error(errorString + ')');
+    }
+
+    // Finally, try looking up relative to the config file path. Just like the
+    // relative path passed to `require()` is found relative to the file it's
+    // in, this allows plugin paths to be specified relative to the config file.
+    const relativePath = path.resolve(configDir, plugin);
+    try {
+      return require.resolve(relativePath);
+    } catch (requireError) {}
+
+    throw new Error(errorString + ` and '${relativePath}')`);
+  }
 }
 
 module.exports = Runner;

--- a/lighthouse-core/test/fixtures/invalid-gatherers/require-error.js
+++ b/lighthouse-core/test/fixtures/invalid-gatherers/require-error.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+// NOTE: this require path does not resolve correctly.
+const LighthouseGatherer = require('../terrible/path/no/seriously/gatherer');
+
+class CustomGatherer extends LighthouseGatherer {}
+
+module.exports = CustomGatherer;


### PR DESCRIPTION
cleans up custom gatherer loading as #679 cleaned up custom audit loading. Made a single method `resolvePlugin()` on `Runner` to handle this, which should also work if we have custom anything else in the future.

The only awkward part of combining the two is passing in a `category` string (right now either 'audit' or 'gatherer') which doesn't affect it functionally but it does give a nicer error message, but I think it's worth it to give the error message context of what kind of thing it was trying to load.