### PR TITLE
add 'use strict'; to files missing it and enforce usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,16 @@
     "quotes": [2, "single"],
     "require-jsdoc": 0,
     "valid-jsdoc": 0,
-    "comma-dangle": 0
+    "comma-dangle": 0,
+    "strict": [2, "global"]
+  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "globalReturn": true,
+      "jsx": false,
+      "experimentalObjectRestSpread": false
+    },
+    "sourceType": "script"
   }
 }

--- a/lighthouse-cli/test/fixtures/offline-ready-sw.js
+++ b/lighthouse-cli/test/fixtures/offline-ready-sw.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
 /* eslint-env worker, serviceworker */
 

--- a/lighthouse-core/test/aggregator/aggregate-test.js
+++ b/lighthouse-core/test/aggregator/aggregate-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Aggregate = require('../../aggregator/aggregate');
 const assert = require('assert');
 
@@ -405,8 +407,6 @@ describe('Aggregate', () => {
   });
 
   it('aggregates', () => {
-    'use strict';
-
     // Make a fake aggregation and test it.
     const aggregation = {
       name: 'name',

--- a/lighthouse-core/test/audits/aria-allowed-attr-test.js
+++ b/lighthouse-core/test/audits/aria-allowed-attr-test.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/aria-allowed-attr.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/aria-valid-attr-test.js
+++ b/lighthouse-core/test/audits/aria-valid-attr-test.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/aria-valid-attr.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/background-color-test.js
+++ b/lighthouse-core/test/audits/background-color-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/manifest-background-color.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));

--- a/lighthouse-core/test/audits/cache-start-url-test.js
+++ b/lighthouse-core/test/audits/cache-start-url-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/cache-start-url.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));

--- a/lighthouse-core/test/audits/color-contrast-test.js
+++ b/lighthouse-core/test/audits/color-contrast-test.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/color-contrast.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/content-width-test.js
+++ b/lighthouse-core/test/audits/content-width-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/content-width.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/display-test.js
+++ b/lighthouse-core/test/audits/display-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/manifest-display.js');
 const manifestParser = require('../../lib/manifest-parser');
 const assert = require('assert');

--- a/lighthouse-core/test/audits/exists-test.js
+++ b/lighthouse-core/test/audits/exists-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/manifest-exists.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/geolocation-on-start-test.js
+++ b/lighthouse-core/test/audits/geolocation-on-start-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/geolocation-on-start.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/icons-test.js
+++ b/lighthouse-core/test/audits/icons-test.js
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
 const Audit144 = require('../../audits/manifest-icons-min-144.js');
 const Audit192 = require('../../audits/manifest-icons-min-192.js');

--- a/lighthouse-core/test/audits/image-alt-test.js
+++ b/lighthouse-core/test/audits/image-alt-test.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/image-alt.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/label-test.js
+++ b/lighthouse-core/test/audits/label-test.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/label.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/name-test.js
+++ b/lighthouse-core/test/audits/name-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/manifest-name.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));

--- a/lighthouse-core/test/audits/redirects-http-test.js
+++ b/lighthouse-core/test/audits/redirects-http-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/redirects-http.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/short-name-length-test.js
+++ b/lighthouse-core/test/audits/short-name-length-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/manifest-short-name-length.js');
 const assert = require('assert');
 const manifestParser = require('../../lib/manifest-parser');

--- a/lighthouse-core/test/audits/short-name-test.js
+++ b/lighthouse-core/test/audits/short-name-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/manifest-short-name.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));

--- a/lighthouse-core/test/audits/start-url-test.js
+++ b/lighthouse-core/test/audits/start-url-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/manifest-start-url.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));

--- a/lighthouse-core/test/audits/tabindex-test.js
+++ b/lighthouse-core/test/audits/tabindex-test.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/tabindex.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/theme-color-test.js
+++ b/lighthouse-core/test/audits/theme-color-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/manifest-theme-color.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));

--- a/lighthouse-core/test/audits/theme-colors-test.js
+++ b/lighthouse-core/test/audits/theme-colors-test.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/meta-theme-color.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/viewport.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/without-javascript-test.js
+++ b/lighthouse-core/test/audits/without-javascript-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/without-javascript.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/audits/works-offline-test.js
+++ b/lighthouse-core/test/audits/works-offline-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Audit = require('../../audits/works-offline.js');
 const assert = require('assert');
 

--- a/lighthouse-core/test/formatter/formatters-test.js
+++ b/lighthouse-core/test/formatter/formatters-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const assert = require('assert');
 const walk = require('walk');
 const path = require('path');

--- a/lighthouse-core/test/report/report-test.js
+++ b/lighthouse-core/test/report/report-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const ReportGenerator = require('../../report/report-generator.js');
 const sampleResults = require('../results/sample.json');
 const assert = require('assert');

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const Runner = require('../runner');
 const fakeDriver = require('./gather/fake-driver');
 const Config = require('../config/config');

--- a/lighthouse-extension/app/src/report-loader.js
+++ b/lighthouse-extension/app/src/report-loader.js
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
+
 const ReportGenerator = require('../../../lighthouse-core/report/report-generator.js');
 
 class ReportLoader {


### PR DESCRIPTION
for some reason a bunch of the tests, and only the tests, were missing `'use strict';`. Added here and tweaked the .eslintrc to enforce it.