### PR TITLE
always handle async sendCommand rejections

### DIFF
--- a/lighthouse-core/gather/drivers/cri.js
+++ b/lighthouse-core/gather/drivers/cri.js
@@ -101,7 +101,7 @@ class CriDriver extends Driver {
    */
   sendCommand(command, params) {
     if (this._cri === null) {
-      throw new Error('connect() must be called before attempting to send a command.');
+      return Promise.reject('connect() must be called before attempting to send a command.');
     }
 
     return new Promise((resolve, reject) => {

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -181,7 +181,7 @@ class Driver {
       this.sendCommand('Runtime.evaluate', {
         expression,
         includeCommandLineAPI: true
-      });
+      }).catch(reject);
 
       // If this gets to 60s and it hasn't been resolved, reject the Promise.
       asyncTimeout = setTimeout(
@@ -194,22 +194,22 @@ class Driver {
   getSecurityState() {
     return new Promise((resolve, reject) => {
       this.once('Security.securityStateChanged', data => {
-        this.sendCommand('Security.disable');
-        resolve(data);
+        this.sendCommand('Security.disable')
+          .then(_ => resolve(data), reject);
       });
 
-      this.sendCommand('Security.enable');
+      this.sendCommand('Security.enable').catch(reject);
     });
   }
 
   getServiceWorkerVersions() {
     return new Promise((resolve, reject) => {
       this.once('ServiceWorker.workerVersionUpdated', data => {
-        this.sendCommand('ServiceWorker.disable');
-        resolve(data);
+        this.sendCommand('ServiceWorker.disable')
+          .then(_ => resolve(data), reject);
       });
 
-      this.sendCommand('ServiceWorker.enable');
+      this.sendCommand('ServiceWorker.enable').catch(reject);
     });
   }
 
@@ -315,11 +315,11 @@ class Driver {
       // When the tracing has ended this will fire with a stream handle.
       this.once('Tracing.tracingComplete', streamHandle => {
         this._readTraceFromStream(streamHandle)
-            .then(traceContents => resolve(traceContents));
+            .then(traceContents => resolve(traceContents), reject);
       });
 
       // Issue the command to stop tracing.
-      this.sendCommand('Tracing.end');
+      this.sendCommand('Tracing.end').catch(reject);
     });
   }
 
@@ -350,7 +350,7 @@ class Driver {
         return this.sendCommand('IO.read', readArguments).then(onChunkRead);
       };
 
-      this.sendCommand('IO.read', readArguments).then(onChunkRead);
+      this.sendCommand('IO.read', readArguments).then(onChunkRead).catch(reject);
     });
   }
 
@@ -368,9 +368,7 @@ class Driver {
       this.on('Network.loadingFailed', this._networkRecorder.onLoadingFailed);
       this.on('Network.resourceChangedPriority', this._networkRecorder.onResourceChangedPriority);
 
-      this.sendCommand('Network.enable').then(_ => {
-        resolve();
-      });
+      this.sendCommand('Network.enable').then(resolve, reject);
     });
   }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/websql.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/websql.js
@@ -29,10 +29,10 @@ class WebSQL extends Gatherer {
     return new Promise((resolve, reject) => {
       driver.once('Database.addDatabase', db => {
         clearTimeout(timeout);
-        driver.sendCommand('Database.disable').then(_ => resolve(db));
+        driver.sendCommand('Database.disable').then(_ => resolve(db), reject);
       });
 
-      driver.sendCommand('Database.enable');
+      driver.sendCommand('Database.enable').catch(reject);
 
       // Wait for a websql db to be opened. Reject the Promise no dbs were created.
       // TODO(ericbidelman): this assumes dbs are opened on page load.


### PR DESCRIPTION
I was looking at the promise+event and promise+timeout async patterns we use in a few places with `driver.sendCommand()` and noticed that we were dropping possible promise rejections in several places (and even leaving promise chains behind completely a couple of times).

In practice, the debugger interface serializes our commands for us, so the dropped promise chains likely aren't a problem, and I have yet to see a failure on any domain enabling (though I suppose it might be hard to recognize on master when it does happen without an unhandled rejection warning), but better to have these locked down, especially since they serve as the copy/paste examples for how to use the protocol in audits, like in [#691](https://github.com/GoogleChrome/lighthouse/pull/691/files#diff-436df3e05730abbf26b5005b3e2f7775R29).