### PR TITLE
WIP (TS): Partially refactor outputmode into real enum

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
     "//": "to run: tsc -p ./jsconfig.json ",
 
-    "//": "good docs here: https://github.com/Microsoft/vscode-docs/blob/vnext/docs/languages/javascript.md#javascript-projects-jsconfigjson ",
+    "///": "good docs here: https://github.com/Microsoft/vscode-docs/blob/vnext/docs/languages/javascript.md#javascript-projects-jsconfigjson ",
 
     "compilerOptions": {
         "target": "ES6",
@@ -12,6 +12,7 @@
         "node_modules",
         "lighthouse-extension",
         "lighthouse-core/closure",
+        "lighthouse-cli",
 
         "third_party",
         "lighthouse-core/third_party",

--- a/lighthouse-cli/index.ts
+++ b/lighthouse-cli/index.ts
@@ -25,7 +25,7 @@ if (!environment.checkNodeCompatibility()) {
   process.exit(1);
 }
 
-const path = require('path');
+import * as path from 'path';
 const yargs = require('yargs');
 import * as Printer from './printer';
 const lighthouse = require('../lighthouse-core');
@@ -96,11 +96,11 @@ Example: --output-path=./lighthouse-results.html`
     'help'
   ])
 
-  .choices('output', Object.keys(Printer.OUTPUT_MODE).map(k => Printer.OUTPUT_MODE[k]))
+  .choices('output', Object.keys(Printer.OutputMode).map(k => Printer.OutputMode[k]))
 
   // default values
   .default('mobile', true)
-  .default('output', Printer.OUTPUT_MODE.pretty)
+  .default('output', Printer.OutputMode.pretty)
   .default('output-path', 'stdout')
   .check(argv => {
     // Make sure lighthouse has been passed a url, or at least one of --list-all-audits

--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -19,7 +19,15 @@
 
 'use strict';
 
+/**
+ * An enumeration of acceptable output modes:
+ *   'pretty': Pretty print the results
+ *   'json': JSON formatted results
+ *   'html': An HTML report
+ */
+enum OutputMode { pretty, json, html };
 type Mode = 'pretty' | 'json' | 'html';
+
 interface Results {
   url: string;
   aggregations: any[];
@@ -32,30 +40,17 @@ const Formatter = require('../lighthouse-core/formatters/formatter');
 const log = require('../lighthouse-core/lib/log');
 
 /**
- * An enumeration of acceptable output modes:
- * <ul>
- *   <li>'pretty': Pretty print the results</li>
- *   <li>'json': JSON formatted results</li>
- *   <li>'html': An HTML report</li>
- * </ul>
- * @enum {string}
- */
-const OUTPUT_MODE = {
-  pretty: 'pretty',
-  json: 'json',
-  html: 'html'
-};
-
-/**
  * Verify output mode.
  */
-function checkOutputMode(mode: string): Mode {
-  if (!OUTPUT_MODE.hasOwnProperty(mode)) {
-    log.warn('Printer', `Unknown output mode ${mode}; using pretty`);
-    return OUTPUT_MODE.pretty as Mode;
+function checkOutputMode(mode: Mode): OutputMode {
+  switch (mode) {
+    case 'json': return OutputMode.json;
+    case 'html': return OutputMode.html;
+    case 'pretty': return OutputMode.pretty;
+    default:
+      log.warn('Printer', `Unknown output mode ${mode}. using pretty`);
+      return OutputMode.pretty;
   }
-
-  return OUTPUT_MODE[mode];
 }
 
 /**
@@ -101,16 +96,16 @@ function formatScore(score, suffix?: string) {
 /**
  * Creates the results output in a format based on the `mode`.
  */
-function createOutput(results: Results, outputMode: Mode): string {
+function createOutput(results: Results, outputMode: OutputMode): string {
   const reportGenerator = new ReportGenerator();
 
   // HTML report.
-  if (outputMode === 'html') {
+  if (outputMode === OutputMode.html) {
     return reportGenerator.generateHTML(results, {inline: true});
   }
 
   // JSON report.
-  if (outputMode === 'json') {
+  if (outputMode === OutputMode.json) {
     return JSON.stringify(results, null, 2);
   }
 
@@ -178,17 +173,14 @@ function writeToStdout(output: string): Promise<undefined> {
 /**
  * Writes the output to a file.
  */
-function writeFile(
-  filePath: string,
-  output: string,
-  outputMode: Mode): Promise<undefined> {
+function writeFile(filePath: string, output: string, outputMode: OutputMode): Promise<undefined> {
   return new Promise((resolve, reject) => {
     // TODO: make this mkdir to the filePath.
     fs.writeFile(filePath, output, 'utf8', err => {
       if (err) {
         return reject(err);
       }
-      log.log('Printer', `${outputMode} output written to ${filePath}`);
+      log.log('Printer', `${OutputMode[outputMode]} output written to ${filePath}`);
       resolve();
     });
   });
@@ -222,5 +214,5 @@ export {
   checkOutputPath,
   createOutput,
   write,
-  OUTPUT_MODE
+  OutputMode
 }

--- a/lighthouse-cli/test/cli/printer-test.js
+++ b/lighthouse-cli/test/cli/printer-test.js
@@ -26,7 +26,7 @@ const sampleResults = require('../fixtures/sample.json');
 describe('Printer', () => {
   it('accepts valid output modes', () => {
     const mode = 'json';
-    assert.equal(Printer.checkOutputMode(mode), mode);
+    assert.equal(Printer.checkOutputMode(mode), Printer.OutputMode.json);
   });
 
   it('rejects invalid output modes', () => {
@@ -45,13 +45,13 @@ describe('Printer', () => {
   });
 
   it('creates JSON for results', () => {
-    const mode = 'json';
+    const mode = Printer.OutputMode.json;
     const jsonOutput = Printer.createOutput(sampleResults, mode);
     assert.doesNotThrow(_ => JSON.parse(jsonOutput));
   });
 
   it('creates Pretty Printed results', () => {
-    const mode = 'pretty';
+    const mode = Printer.OutputMode.pretty;
     const prettyOutput = Printer.createOutput(sampleResults, mode);
 
     // Just check there's no HTML / JSON there.
@@ -60,7 +60,7 @@ describe('Printer', () => {
   });
 
   it('creates HTML for results', () => {
-    const mode = 'html';
+    const mode = Printer.OutputMode.html;
     const htmlOutput = Printer.createOutput(sampleResults, mode);
     assert.ok(/<!doctype/gim.test(htmlOutput));
   });


### PR DESCRIPTION
R=@samccone

Just a small PR for me to get a better feel of the CLI in TS.

![image](https://cloud.githubusercontent.com/assets/39191/18874765/d509b60e-8477-11e6-9a33-0d40f5630a4b.png)

It was definitely quite nice that once the compilation succeeded everything worked. Plus, the inline errors  meant I didn't need to cmd-s that often.

@samccone question for you in this one. We have both the type alias for the strings, and then also an enum. Can we get rid of one of them?

And please feel free to go to town on this PR (or push to the branch).