### PR TITLE
DBW: add console.time -> performance.mark() suggestion

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -58,8 +58,9 @@ class NoConsoleTimeAudit extends Audit {
     const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
       return url.parse(err.url).host === pageHost;
     }).map(err => {
-      err.misc = `(line: ${err.line}, col: ${err.col})`;
-      return err;
+      return Object.assign({
+        misc: `(line: ${err.line}, col: ${err.col})`
+      }, err);
     });
 
     return NoConsoleTimeAudit.generateAuditResult({

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -55,13 +55,13 @@ class NoConsoleTimeAudit extends Audit {
 
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts.
-    const results = artifacts.ConsoleTimeUsage.usage.reduce((prev, err) => {
-      if (url.parse(err.url).host === pageHost) {
-        err.misc = `(line: ${err.line}, col: ${err.col})`;
-        prev.push(err);
-      }
-      return prev;
-    }, []);
+    // Filter usage from other hosts.
+    const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
+      return url.parse(err.url).host === pageHost;
+    }).map(err => {
+      err.misc = `(line: ${err.line}, col: ${err.col})`;
+      return err;
+    });
 
     return NoConsoleTimeAudit.generateAuditResult({
       rawValue: results.length === 0,

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -16,8 +16,7 @@
  */
 
 /**
- * @fileoverview Audit a page to see if it's using Date.now() (instead of a
- * newer API like performance.now()).
+ * @fileoverview Audit a page to see if it's using console.time()/console.timeEnd.
  */
 
 'use strict';
@@ -26,7 +25,7 @@ const url = require('url');
 const Audit = require('../audit');
 const Formatter = require('../../formatters/formatter');
 
-class NoDateNowAudit extends Audit {
+class NoConsoleTimeAudit extends Audit {
 
   /**
    * @return {!AuditMeta}
@@ -34,10 +33,10 @@ class NoDateNowAudit extends Audit {
   static get meta() {
     return {
       category: 'JavaScript',
-      name: 'no-datenow',
-      description: 'Site does not use Date.now() in its own scripts',
-      helpText: 'Consider using <a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/now" target="_blank">performance.now()</a>, which as better precision than <code>Date.now()</code> and always increases at a constant rate, independent of the system clock.',
-      requiredArtifacts: ['URL', 'DateNowUse']
+      name: 'no-console-time',
+      description: 'Site does not use console.time() in its own scripts',
+      helpText: 'Consider using the <a href="https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API" target="_blank">User Timine API</a> (<a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark" target="_blank">performance.mark()</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure" target="_blank">performance.measure()</a>), which is a standard, uses high resolution timestamps, and has the added benefit of integrating with the DevTools timeline.',
+      requiredArtifacts: ['URL', 'ConsoleTimeUsage']
     };
   }
 
@@ -46,17 +45,17 @@ class NoDateNowAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (typeof artifacts.DateNowUse === 'undefined' ||
-        artifacts.DateNowUse === -1) {
-      return NoDateNowAudit.generateAuditResult({
+    if (typeof artifacts.ConsoleTimeUsage === 'undefined' ||
+        artifacts.ConsoleTimeUsage === -1) {
+      return NoConsoleTimeAudit.generateAuditResult({
         rawValue: -1,
-        debugString: 'DateNowUse gatherer did not run'
+        debugString: 'ConsoleTimeUsage gatherer did not run'
       });
     }
 
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts.
-    const results = artifacts.DateNowUse.usage.reduce((prev, err) => {
+    const results = artifacts.ConsoleTimeUsage.usage.reduce((prev, err) => {
       if (url.parse(err.url).host === pageHost) {
         err.misc = `(line: ${err.line}, col: ${err.col})`;
         prev.push(err);
@@ -64,7 +63,7 @@ class NoDateNowAudit extends Audit {
       return prev;
     }, []);
 
-    return NoDateNowAudit.generateAuditResult({
+    return NoConsoleTimeAudit.generateAuditResult({
       rawValue: results.length === 0,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
@@ -74,4 +73,4 @@ class NoDateNowAudit extends Audit {
   }
 }
 
-module.exports = NoDateNowAudit;
+module.exports = NoConsoleTimeAudit;

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -55,7 +55,6 @@ class NoConsoleTimeAudit extends Audit {
 
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts.
-    // Filter usage from other hosts.
     const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
       return url.parse(err.url).host === pageHost;
     }).map(err => {

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -56,13 +56,12 @@ class NoDateNowAudit extends Audit {
 
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts.
-    const results = artifacts.DateNowUse.usage.reduce((prev, err) => {
-      if (url.parse(err.url).host === pageHost) {
-        err.misc = `(line: ${err.line}, col: ${err.col})`;
-        prev.push(err);
-      }
-      return prev;
-    }, []);
+    const results = artifacts.DateNowUse.usage.filter(err => {
+      return url.parse(err.url).host === pageHost;
+    }).map(err => {
+      err.misc = `(line: ${err.line}, col: ${err.col})`;
+      return err;
+    });
 
     return NoDateNowAudit.generateAuditResult({
       rawValue: results.length === 0,

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -59,8 +59,9 @@ class NoDateNowAudit extends Audit {
     const results = artifacts.DateNowUse.usage.filter(err => {
       return url.parse(err.url).host === pageHost;
     }).map(err => {
-      err.misc = `(line: ${err.line}, col: ${err.col})`;
-      return err;
+      return Object.assign({
+        misc: `(line: ${err.line}, col: ${err.col})`
+      }, err);
     });
 
     return NoDateNowAudit.generateAuditResult({

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -6,6 +6,7 @@
       "../gather/gatherers/https",
       "../gather/gatherers/url",
       "../gather/gatherers/dobetterweb/appcache",
+      "../gather/gatherers/dobetterweb/console-time-usage",
       "../gather/gatherers/dobetterweb/datenow",
       "../gather/gatherers/dobetterweb/websql"
     ]
@@ -13,6 +14,7 @@
 
   "audits": [
     "../audits/dobetterweb/appcache-manifest",
+    "../audits/dobetterweb/no-console-time",
     "../audits/dobetterweb/no-datenow",
     "../audits/dobetterweb/no-websql",
     "../audits/dobetterweb/uses-http2",
@@ -49,6 +51,9 @@
       "name": "Using modern JavaScript features",
       "criteria": {
         "no-datenow": {
+          "rawValue": false
+        },
+        "no-console-time": {
           "rawValue": false
         }
       }

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -485,7 +485,7 @@ class Driver {
    * @param {string} funcName The function name to track ('Date.now', 'console.time').
    * @param {string} globalVarToPopulate The variable name to populate with stack traces.
    *     This should unique and on the global object ('window.__dateNowStackTraces').
-   * @return {function(): !Promise<!Array<!{url: string, line: number, col: number}>>}
+   * @return {function(): !Promise<!Array<{url: string, line: number, col: number}>>}
    *     Call this method when you want results.
    */
   captureFunctionCallSites(funcName, globalVarToPopulate) {

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -485,7 +485,7 @@ class Driver {
    * @param {string} funcName The function name to track ('Date.now', 'console.time').
    * @param {string} globalVarToPopulate The variable name to populate with stack traces.
    *     This should unique and on the global object ('window.__dateNowStackTraces').
-   * @return {function(): !Promise<!Array<{url: string, line: number, col: number}>>}
+   * @return {function(): !Promise<!Array<!{url: string, line: number, col: number}>>}
    *     Call this method when you want results.
    */
   captureFunctionCallSites(funcName, globalVarToPopulate) {

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -460,7 +460,7 @@ class Driver {
     const originalFunc = func;
     const originalPrepareStackTrace = Error.prepareStackTrace;
 
-    return function(...args) {
+    return function() {
       // See v8's Stack Trace API https://github.com/v8/v8/wiki/Stack-Trace-API#customizing-stack-traces
       Error.prepareStackTrace = function(error, structStackTrace) {
         const lastCallFrame = structStackTrace[structStackTrace.length - 1];
@@ -476,7 +476,7 @@ class Driver {
       // our custom one.
       Error.prepareStackTrace = originalPrepareStackTrace;
 
-      return originalFunc(...args);
+      return originalFunc.apply(this, arguments);
     };
   }
 }

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -483,12 +483,11 @@ class Driver {
    * Keeps track of calls to a JS function and returns a list of {url, line, col}
    * of the usage. Should be called before page load (in beforePass).
    * @param {string} funcName The function name to track ('Date.now', 'console.time').
-   * @param {string} globalVarToPopulate The variable name to populate with stack traces.
-   *     This should unique and on the global object ('window.__dateNowStackTraces').
    * @return {function(): !Promise<!Array<{url: string, line: number, col: number}>>}
    *     Call this method when you want results.
    */
-  captureFunctionCallSites(funcName, globalVarToPopulate) {
+  captureFunctionCallSites(funcName) {
+    const globalVarToPopulate = `window['__${funcName}StackTraces']`;
     const collectUsage = () => {
       return this.evaluateAsync(
           `__returnResults(Array.from(${globalVarToPopulate}).map(item => JSON.parse(item)))`);

--- a/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
@@ -26,7 +26,7 @@ const Gatherer = require('../gatherer');
 class ConsoleTimeUsage extends Gatherer {
 
   beforePass(options) {
-    this.collectUsage = options.driver.captureJSCalls(
+    this.collectUsage = options.driver.captureFunctionCallSites(
         'console.time', 'window.__consoleTimeStackTraces');
   }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview Tests whether the page is using Date.now().
+ * @fileoverview Tests whether the page is using console.time().
  */
 
 /* global window, __returnResults */
@@ -28,23 +28,23 @@ const Gatherer = require('../gatherer');
 
 function collectUsage() {
   __returnResults(Array.from(
-      window.__dateNowStackTraces).map(item => JSON.parse(item)));
+      window.__consoleTimeStackTraces).map(item => JSON.parse(item)));
 }
 
-class DateNowUse extends Gatherer {
+class ConsoleTimeUsage extends Gatherer {
 
   beforePass(options) {
     const driver = options.driver;
     return driver.evaluateScriptOnLoad(`
-        window.__dateNowStackTraces = new Set();
-        (Date.now = function ${Driver.captureAPIUsage.toString()}(
-            Date.now, window.__dateNowStackTraces))`);
+        window.__consoleTimeStackTraces = new Set();
+        (console.time = function ${Driver.captureAPIUsage.toString()}(
+            console.time, window.__consoleTimeStackTraces))`);
   }
 
   afterPass(options) {
     return options.driver.evaluateAsync(`(${collectUsage.toString()}())`)
-        .then(dateNowUses => {
-          this.artifact.usage = dateNowUses;
+        .then(consoleTimeUsage => {
+          this.artifact.usage = consoleTimeUsage;
         }, _ => {
           this.artifact = -1;
           return;
@@ -52,4 +52,4 @@ class DateNowUse extends Gatherer {
   }
 }
 
-module.exports = DateNowUse;
+module.exports = ConsoleTimeUsage;

--- a/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
@@ -26,8 +26,7 @@ const Gatherer = require('../gatherer');
 class ConsoleTimeUsage extends Gatherer {
 
   beforePass(options) {
-    this.collectUsage = options.driver.captureFunctionCallSites(
-        'console.time', 'window.__consoleTimeStackTraces');
+    this.collectUsage = options.driver.captureFunctionCallSites('console.time');
   }
 
   afterPass() {

--- a/lighthouse-core/gather/gatherers/dobetterweb/datenow.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/datenow.js
@@ -26,7 +26,7 @@ const Gatherer = require('../gatherer');
 class DateNowUse extends Gatherer {
 
   beforePass(options) {
-    this.collectUsage = options.driver.captureJSCalls(
+    this.collectUsage = options.driver.captureFunctionCallSites(
         'Date.now', 'window.__dateNowStackTraces');
   }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/datenow.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/datenow.js
@@ -26,8 +26,7 @@ const Gatherer = require('../gatherer');
 class DateNowUse extends Gatherer {
 
   beforePass(options) {
-    this.collectUsage = options.driver.captureFunctionCallSites(
-        'Date.now', 'window.__dateNowStackTraces');
+    this.collectUsage = options.driver.captureFunctionCallSites('Date.now');
   }
 
   afterPass() {

--- a/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
@@ -15,32 +15,32 @@
  */
 'use strict';
 
-const DateNowUseAudit = require('../../../audits/dobetterweb/no-datenow.js');
+const NoConsoleTimeAudit = require('../../../audits/dobetterweb/no-console-time.js');
 const assert = require('assert');
 
 const URL = 'https://example.com';
 
 /* eslint-env mocha */
 
-describe('Page does not use Date.now()', () => {
+describe('Page does not use console.time()', () => {
   it('fails when no input present', () => {
-    const auditResult = DateNowUseAudit.audit({});
+    const auditResult = NoConsoleTimeAudit.audit({});
     assert.equal(auditResult.rawValue, -1);
     assert.ok(auditResult.debugString);
   });
 
-  it('passes when Date.now() is not used', () => {
-    const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {usage: []},
+  it('passes when console.time() is not used', () => {
+    const auditResult = NoConsoleTimeAudit.audit({
+      ConsoleTimeUsage: {usage: []},
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);
   });
 
-  it('passes when Date.now() is used on a different origin', () => {
-    const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {
+  it('passes when console.time() is used on a different origin', () => {
+    const auditResult = NoConsoleTimeAudit.audit({
+      ConsoleTimeUsage: {
         usage: [
           {url: 'http://different.com/two', line: 2, col: 2},
           {url: 'http://example2.com/two', line: 2, col: 22}
@@ -52,9 +52,9 @@ describe('Page does not use Date.now()', () => {
     assert.equal(auditResult.extendedInfo.value.length, 0);
   });
 
-  it('fails when Date.now() is used on the origin', () => {
-    const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {
+  it('fails when console.time() is used on the origin', () => {
+    const auditResult = NoConsoleTimeAudit.audit({
+      ConsoleTimeUsage: {
         usage: [
           {url: 'http://example.com/one', line: 1, col: 1},
           {url: 'http://example.com/two', line: 10, col: 1},

--- a/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
+++ b/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
@@ -34,13 +34,6 @@ describe('HTML without JavaScript gatherer', () => {
     return assert.equal(opts.disableJavaScript, true);
   });
 
-  it('updates the options', () => {
-    const opts = {disableJavaScript: false};
-    htmlWithoutJavaScriptGather.beforePass(opts);
-
-    return assert.equal(opts.disableJavaScript, true);
-  });
-
   it('resets the options', () => {
     const opts = {
       disableJavaScript: true,


### PR DESCRIPTION
R: @brendankenny @paulirish @GoogleChrome/lighthouse 

- Makes article naming consistent across similar audits
- Also refactors some common code for recording function calls into driver.

![screen shot 2016-09-28 at 11 24 21 am](https://cloud.githubusercontent.com/assets/238208/18926803/1e27412a-856e-11e6-9a7c-6a64feba0b43.png)

Usage is much simpler now to record API calls:

```javascript
class DateNowUse extends Gatherer {
  beforePass(options) {
    this.collectUsage = options.driver.captureJSCalls(
        'Date.now', 'window.__dateNowStackTraces');
  }
  afterPass() {
    return this.collectUsage().then(dateNowUses => {
      this.artifact.usage = dateNowUses;
    }, _ => {
      this.artifact = -1;
      return;
    });
  }
}
```