### PR TITLE
DBW: Add test for usage of document.write()

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -31,10 +31,10 @@ class NoDocWriteAudit extends Audit {
    */
   static get meta() {
     return {
-      category: 'JavaScript',
+      category: 'Performance',
       name: 'no-document-write',
       description: 'Site does not use document.write()',
-      helpText: '',
+      helpText: 'Consider using <code>&lt;script async></code> to load scripts. <code>document.write()</code> is considered <a href="https://developers.google.com/web/updates/2016/08/removing-document-write" target="_blank">harmful for performance</a>.',
       requiredArtifacts: ['URL', 'DocWriteUse']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Audit a page to see if it's using document.write()
+ */
+
+'use strict';
+
+const Audit = require('../audit');
+const Formatter = require('../../formatters/formatter');
+
+class NoDocWriteAudit extends Audit {
+
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return {
+      category: 'JavaScript',
+      name: 'no-document-write',
+      description: 'Site does not use document.write()',
+      helpText: '',
+      requiredArtifacts: ['URL', 'DocWriteUse']
+    };
+  }
+
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    if (typeof artifacts.DocWriteUse === 'undefined' ||
+        artifacts.DocWriteUse === -1) {
+      return NoDocWriteAudit.generateAuditResult({
+        rawValue: -1,
+        debugString: 'DocWriteUse gatherer did not run'
+      });
+    }
+
+    const results = artifacts.DocWriteUse.usage.map(err => {
+      return Object.assign({
+        misc: `(line: ${err.line}, col: ${err.col})`
+      }, err);
+    });
+
+    return NoDocWriteAudit.generateAuditResult({
+      rawValue: results.length === 0,
+      extendedInfo: {
+        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
+        value: results
+      }
+    });
+  }
+}
+
+module.exports = NoDocWriteAudit;

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -8,6 +8,7 @@
       "../gather/gatherers/dobetterweb/appcache",
       "../gather/gatherers/dobetterweb/console-time-usage",
       "../gather/gatherers/dobetterweb/datenow",
+      "../gather/gatherers/dobetterweb/document-write",
       "../gather/gatherers/dobetterweb/websql"
     ]
   }],
@@ -16,6 +17,7 @@
     "../audits/dobetterweb/appcache-manifest",
     "../audits/dobetterweb/no-console-time",
     "../audits/dobetterweb/no-datenow",
+    "../audits/dobetterweb/no-document-write",
     "../audits/dobetterweb/no-websql",
     "../audits/dobetterweb/uses-http2",
     "../audits/is-on-https"
@@ -54,6 +56,14 @@
           "rawValue": false
         },
         "no-console-time": {
+          "rawValue": false
+        }
+      }
+    },
+    {
+      "name": "Avoiding APIs that are detrimental to the user experience",
+      "criteria": {
+        "no-document-write": {
           "rawValue": false
         }
       }

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -59,9 +59,8 @@
           "rawValue": false
         }
       }
-    },
-    {
-      "name": "Avoiding APIs that are detrimental to the user experience",
+    }, {
+      "name": "Avoiding APIs that harm the user experience",
       "criteria": {
         "no-document-write": {
           "rawValue": false

--- a/lighthouse-core/gather/gatherers/dobetterweb/document-write.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/document-write.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests whether the page is using document.write().
+ */
+
+'use strict';
+
+const Gatherer = require('../gatherer');
+
+class DocWriteUse extends Gatherer {
+
+  beforePass(options) {
+    this.collectUsage = options.driver.captureFunctionCallSites('document.write');
+  }
+
+  afterPass() {
+    return this.collectUsage().then(DocWriteUses => {
+      this.artifact.usage = DocWriteUses;
+    }, _ => {
+      this.artifact = -1;
+      return;
+    });
+  }
+}
+
+module.exports = DocWriteUse;

--- a/lighthouse-core/test/audits/dobetterweb/no-document-write-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-document-write-test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const DocWriteUseAudit = require('../../../audits/dobetterweb/no-document-write.js');
+const assert = require('assert');
+
+const URL = 'https://example.com';
+
+/* eslint-env mocha */
+
+describe('Page does not use document.write()', () => {
+  it('fails when no input present', () => {
+    const auditResult = DocWriteUseAudit.audit({});
+    assert.equal(auditResult.rawValue, -1);
+    assert.ok(auditResult.debugString);
+  });
+
+  it('passes when document.write() is not used', () => {
+    const auditResult = DocWriteUseAudit.audit({
+      DocWriteUse: {usage: []},
+      URL: {finalUrl: URL},
+    });
+    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.extendedInfo.value.length, 0);
+  });
+
+  it('fails when document.write() is used', () => {
+    const auditResult = DocWriteUseAudit.audit({
+      DocWriteUse: {
+        usage: [
+          {url: 'http://example.com/one', line: 1, col: 1},
+          {url: 'http://example.com/two', line: 10, col: 1},
+          {url: 'http://example2.com/two', line: 2, col: 22}
+        ]
+      },
+      URL: {finalUrl: URL},
+    });
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.extendedInfo.value.length, 3);
+  });
+});


### PR DESCRIPTION
This PR introduces and audit that reports if `document.write()` is used anywhere on the page during the capture.

It reports the script position where document.write() was invoked.

The results when running `npm run dbw http://output.jsbin.com/cajuhoricu/1/quiet`. Peep those line numbers:
![image](https://cloud.githubusercontent.com/assets/39191/18974350/5db9427c-8657-11e6-860c-d9247ef98b65.png)

In situ: 
![image](https://cloud.githubusercontent.com/assets/39191/18974768/3ecec60e-865a-11e6-9eb2-dae5e71c1f12.png)
