### PR TITLE
don't clear cookies for site at start of lighthouse run

### DIFF
--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -474,7 +474,8 @@ class Driver {
       (parsedURL.port ? `:${parsedURL.port}` : '');
 
     // Clear all types of storage except cookies, so the user isn't logged out.
-    const storageTypes = [
+    //   https://chromedevtools.github.io/debugger-protocol-viewer/tot/Storage/#type-StorageType
+    const typesToClear = [
       'appcache',
       // 'cookies',
       'file_systems',
@@ -487,8 +488,8 @@ class Driver {
     ].join(',');
 
     return this.sendCommand('Storage.clearDataForOrigin', {
-      origin,
-      storageTypes,
+      origin: origin,
+      storageTypes: typesToClear
     });
   }
 

--- a/lighthouse-core/gather/drivers/driver.js
+++ b/lighthouse-core/gather/drivers/driver.js
@@ -473,9 +473,22 @@ class Driver {
     const origin = `${parsedURL.protocol}//${parsedURL.hostname}` +
       (parsedURL.port ? `:${parsedURL.port}` : '');
 
+    // Clear all types of storage except cookies, so the user isn't logged out.
+    const storageTypes = [
+      'appcache',
+      // 'cookies',
+      'file_systems',
+      'indexeddb',
+      'local_storage',
+      'shader_cache',
+      'websql',
+      'service_workers',
+      'cache_storage'
+    ].join(',');
+
     return this.sendCommand('Storage.clearDataForOrigin', {
       origin,
-      storageTypes: 'all',
+      storageTypes,
     });
   }
 


### PR DESCRIPTION
when we started using `Storage.clearDataForOrigin` we inadvertently started clearing cookies as well. This means if you were testing in a Chrome where you're already logged into a site it would log you out -- annoying for afterwards, but also means you can't test pages that require you to be logged in.

This makes us now clear everything but cookies.