### PR TITLE
Add config for CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,22 @@
+machine:
+  node:
+    version: 4.4
+  environment:
+    LIGHTHOUSE_CHROMIUM_PATH: $(pwd)/lighthouse/chrome-linux/chrome
+    __node_harmony: $(if [[ $(node -v) =~ ^v4.* ]]; then echo --harmony; fi)
+dependencies:
+   cache_directories:
+     - node_modules
+     - chrome-linux
+     - lighthouse-extension/node_modules
+dependencies:
+  pre:
+    - npm --prefix ./lighthouse-extension install ./lighthouse-extension
+    - ./lighthouse-core/scripts/download-chrome.sh
+test:
+  override:
+    - npm run lint
+    - npm run unit
+    - npm run closure
+    - npm run smoke
+    - cd lighthouse-extension && gulp build


### PR DESCRIPTION
Two big advantages of having Circle in our CI setup:

* CircleCI typically starts builds a little faster than Travis. (For this commit, Circle started immediately at push, and Travis took ~50 seconds before it begain.)
* You can SSH into circleCI to debug. Yeah. it's amazing.


![image](https://cloud.githubusercontent.com/assets/39191/19000457/8bb45644-86f7-11e6-999c-66fdfd68f482.png)

![image](https://cloud.githubusercontent.com/assets/39191/19000658/8c01e5f2-86f8-11e6-89d7-276d19878d21.png)


Only bad news is our smoketest that's 10% flaky on travis is also flaky on circleci.