### PR TITLE
bump speedline to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mkdirp": "^0.5.1",
     "rimraf": "^2.2.8",
     "semver": ">=4.3.3",
-    "speedline": "0.2.2",
+    "speedline": "1.0.0",
     "yargs": "3.30.0"
   },
   "repository": "googlechrome/lighthouse",


### PR DESCRIPTION
[speedline 1.0.0](https://github.com/pmdartus/speedline)  doesn't depend on `chrome-devtools-frontend` any longer, which really simplifies things, since we depend on it, and so does our `devtools-timeline-model`. 

Landing this will also resolve the issues in #724