### PR TITLE
initial rename of config properties

### DIFF
--- a/lighthouse-cli/test/fixtures/smoketest-offline-config.json
+++ b/lighthouse-cli/test/fixtures/smoketest-offline-config.json
@@ -26,7 +26,7 @@
     "items": [{
       "name": "App can load on offline/flaky connections",
       "description": "Ensuring your web app can respond when the network connection is unavailable or flaky is critical to providing your users a good experience. This is achieved through use of a <a href=\"https://developers.google.com/web/fundamentals/primers/service-worker/\">Service Worker</a>.",
-      "criteria": {
+      "audits": {
         "service-worker": {
           "rawValue": true,
           "weight": 1
@@ -39,7 +39,7 @@
     }, {
       "name": "Design is mobile-friendly",
       "description": "Users increasingly experience your app on mobile devices, so it's important to ensure that the experience can adapt to smaller screens.",
-      "criteria": {
+      "audits": {
         "viewport": {
           "rawValue": true,
           "weight": 1

--- a/lighthouse-cli/test/fixtures/smoketest-offline-config.json
+++ b/lighthouse-cli/test/fixtures/smoketest-offline-config.json
@@ -28,11 +28,11 @@
       "description": "Ensuring your web app can respond when the network connection is unavailable or flaky is critical to providing your users a good experience. This is achieved through use of a <a href=\"https://developers.google.com/web/fundamentals/primers/service-worker/\">Service Worker</a>.",
       "audits": {
         "service-worker": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "works-offline": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -41,7 +41,7 @@
       "description": "Users increasingly experience your app on mobile devices, so it's important to ensure that the experience can adapt to smaller screens.",
       "audits": {
         "viewport": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }

--- a/lighthouse-cli/test/fixtures/smoketest-offline-config.json
+++ b/lighthouse-cli/test/fixtures/smoketest-offline-config.json
@@ -5,7 +5,7 @@
       "url"
     ]
   },{
-    "network": true,
+    "recordNetwork": true,
     "gatherers": [
       "service-worker",
       "offline"

--- a/lighthouse-cli/test/fixtures/smoketest-offline-config.json
+++ b/lighthouse-cli/test/fixtures/smoketest-offline-config.json
@@ -1,12 +1,10 @@
 {
   "passes": [{
-    "loadPage": true,
     "gatherers": [
       "viewport",
       "url"
     ]
   },{
-    "loadPage": true,
     "network": true,
     "gatherers": [
       "service-worker",

--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -77,7 +77,7 @@ class Aggregate {
         typeof expected.rawValue === 'undefined' ||
         typeof expected.weight === 'undefined') {
       const msg =
-          `aggregations: ${name} criteria does not contain expected rawValue or weight properties`;
+          `aggregations: ${name} audit does not contain expected rawValue or weight properties`;
       throw new Error(msg);
     }
 
@@ -148,15 +148,15 @@ class Aggregate {
    */
   static compare(results, items, aggregationIsScored) {
     return items.map(item => {
-      const expectedNames = Object.keys(item.criteria);
+      const expectedNames = Object.keys(item.audits);
 
       // Filter down and remap the results to something more comparable to
       // the expected set of results.
       const filteredAndRemappedResults =
           Aggregate._remapResultsByName(
-            Aggregate._filterResultsByAuditNames(results, item.criteria)
+            Aggregate._filterResultsByAuditNames(results, item.audits)
           );
-      const maxScore = Aggregate._getTotalWeight(item.criteria);
+      const maxScore = Aggregate._getTotalWeight(item.audits);
       const subItems = [];
       let overallScore = 0;
 
@@ -165,12 +165,12 @@ class Aggregate {
       expectedNames.forEach(e => {
         /* istanbul ignore if */
         // TODO(paullewis): Remove once coming soon audits have landed.
-        if (item.criteria[e].comingSoon) {
+        if (item.audits[e].comingSoon) {
           subItems.push({
             score: '¯\\_(ツ)_/¯', // TODO(samthor): Patch going to Closure, String.raw is badly typed
             name: 'coming-soon',
-            category: item.criteria[e].category,
-            description: item.criteria[e].description,
+            category: item.audits[e].category,
+            description: item.audits[e].description,
             comingSoon: true
           });
 
@@ -191,7 +191,7 @@ class Aggregate {
 
         overallScore += Aggregate._convertToWeight(
             filteredAndRemappedResults[e],
-            item.criteria[e],
+            item.audits[e],
             e);
       });
 

--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -74,10 +74,10 @@ class Aggregate {
     let weight = 0;
 
     if (typeof expected === 'undefined' ||
-        typeof expected.rawValue === 'undefined' ||
+        typeof expected.expectedValue === 'undefined' ||
         typeof expected.weight === 'undefined') {
       const msg =
-          `aggregations: ${name} audit does not contain expected rawValue or weight properties`;
+          `aggregations: ${name} audit does not contain expectedValue or weight properties`;
       throw new Error(msg);
     }
 
@@ -91,22 +91,24 @@ class Aggregate {
       throw new Error(msg);
     }
 
-    if (typeof result.score !== typeof expected.rawValue) {
-      let msg =
-          `Expected rawValue of type ${typeof expected.rawValue}, got ${typeof result.rawValue}`;
+    if (typeof result.score !== typeof expected.expectedValue) {
+      const expectedType = typeof expected.expectedValue;
+      const resultType = typeof result.rawValue;
+      let msg = `Expected expectedValue of type ${expectedType}, got ${resultType}`;
       if (result.debugString) {
         msg += ': ' + result.debugString;
       }
       throw new Error(msg);
     }
 
-    switch (typeof expected.rawValue) {
+    switch (typeof expected.expectedValue) {
       case 'boolean':
-        weight = this._convertBooleanToWeight(result.score, expected.rawValue, expected.weight);
+        weight = this._convertBooleanToWeight(result.score,
+            expected.expectedValue, expected.weight);
         break;
 
       case 'number':
-        weight = this._convertNumberToWeight(result.score, expected.rawValue, expected.weight);
+        weight = this._convertNumberToWeight(result.score, expected.expectedValue, expected.weight);
         break;
 
       default:

--- a/lighthouse-core/closure/typedefs/Aggregation.js
+++ b/lighthouse-core/closure/typedefs/Aggregation.js
@@ -53,7 +53,7 @@ var AggregationCriteria;
 function AggregationItem() {}
 
 /** @type {!Object<!AggregationCriterion>} */
-AggregationItem.prototype.criteria;
+AggregationItem.prototype.audits;
 
 /** @type {string} */
 AggregationItem.prototype.name;

--- a/lighthouse-core/closure/typedefs/Config.js
+++ b/lighthouse-core/closure/typedefs/Config.js
@@ -35,9 +35,6 @@ PassConfig.prototype.trace;
 /** type {string} */
 PassConfig.prototype.loadDataName;
 
-/** type {!boolean} */
-PassConfig.prototype.loadPage;
-
 /** type {!Array<!string>} */
 PassConfig.prototype.gatherers;
 

--- a/lighthouse-core/closure/typedefs/Config.js
+++ b/lighthouse-core/closure/typedefs/Config.js
@@ -27,10 +27,10 @@
 var PassConfig = function() {};
 
 /** type {boolean} */
-PassConfig.prototype.network;
+PassConfig.prototype.recordNetwork;
 
 /** type {boolean} */
-PassConfig.prototype.trace;
+PassConfig.prototype.recordTrace;
 
 /** type {string} */
 PassConfig.prototype.loadDataName;

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -126,10 +126,10 @@ function validatePasses(passes, audits, rootPath) {
     });
   });
 
-  // Log if multiple passes require trace or network data and could overwrite one another.
+  // Log if multiple passes require trace or network recording and could overwrite one another.
   const usedNames = new Set();
   passes.forEach((pass, index) => {
-    if (!pass.network && !pass.trace) {
+    if (!pass.recordNetwork && !pass.recordTrace) {
       return;
     }
 

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -1,7 +1,7 @@
 {
   "passes": [{
-    "network": true,
-    "trace": true,
+    "recordNetwork": true,
+    "recordTrace": true,
     "gatherers": [
       "url",
       "https",
@@ -16,7 +16,7 @@
   },
   {
     "passName": "offlinePass",
-    "network": true,
+    "recordNetwork": true,
     "gatherers": [
       "service-worker",
       "offline"

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -75,15 +75,15 @@
       "description": "Ensuring your web app can respond when the network connection is unavailable or flaky is critical to providing your users a good experience. This is achieved through use of a <a href=\"https://developers.google.com/web/fundamentals/primers/service-worker/\">Service Worker</a>.",
       "audits": {
         "service-worker": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "works-offline": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "cache-start-url": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -92,37 +92,37 @@
       "description": "Users notice if sites and apps don't perform well. These top-level metrics capture the most important perceived performance concerns.",
       "audits": {
         "first-meaningful-paint": {
-          "rawValue": 100,
+          "expectedValue": 100,
           "weight": 1
         },
         "speed-index-metric": {
-          "rawValue": 100,
+          "expectedValue": 100,
           "weight": 1
         },
         "estimated-input-latency": {
-          "rawValue": 100,
+          "expectedValue": 100,
           "weight": 1
         },
         "time-to-interactive": {
-          "rawValue": 100,
+          "expectedValue": 100,
           "weight": 1
         },
         "scrolling-60fps": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Content scrolls at 60fps",
           "category": "UX"
         },
         "touch-150ms": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Touch input gets a response in < 150ms",
           "category": "UX"
         },
         "fmp-no-jank": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "App is interactive without jank after the first meaningful paint",
@@ -134,7 +134,7 @@
       "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but not unfunctioning experience.",
       "audits": {
         "without-javascript": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -143,11 +143,11 @@
       "description": "Security is an important part of the web for both developers and users. Moving forward, Transport Layer Security (TLS) support will be required for many APIs.",
       "audits": {
         "is-on-https": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "redirects-http": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -157,23 +157,23 @@
       "see": "https://github.com/GoogleChrome/lighthouse/issues/23",
       "audits": {
         "service-worker": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-exists": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-start-url": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-icons-min-144": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-short-name": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -183,23 +183,23 @@
       "see": "https://github.com/GoogleChrome/lighthouse/issues/24",
       "audits": {
         "manifest-exists": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-name": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-background-color": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-theme-color": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-icons-min-192": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -208,15 +208,15 @@
       "description": "The browser address bar can be themed to match your site. A theme-color <a href=\"https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android\">meta tag</a> will upgrade the address bar when a user browses the site, and the <a href=\"https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color\">manifest theme-color</a> will apply the same theme site-wide once it's been added to homescreen.",
       "audits": {
         "manifest-exists": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "theme-color-meta": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-theme-color": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -225,11 +225,11 @@
       "description": "Users increasingly experience your app on mobile devices, so it's important to ensure that the experience can adapt to smaller screens.",
       "audits": {
         "viewport": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "content-width": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -242,71 +242,71 @@
     "items": [{
       "audits": {
         "aria-allowed-attr": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "aria-valid-attr": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "color-contrast": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "image-alt": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "label": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "tabindex": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-short-name-length": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "manifest-display": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "geolocation-on-start": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 1
         },
         "serviceworker-push": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Service worker makes use of push notifications, if appropriate",
           "category": "UX"
         },
         "tap-targets": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Tap targets are appropriately sized for touch",
           "category": "UX"
         },
         "payments-autocomplete": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Payment forms marked up with [autocomplete] attributes",
           "category": "UX"
         },
         "login-autocomplete": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Login forms marked up with [autocomplete] attributes",
           "category": "UX"
         },
         "input-type": {
-          "rawValue": true,
+          "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
           "description": "Input fields use appropriate [type] attributes for custom keyboards",
@@ -322,11 +322,11 @@
     "items": [{
       "audits": {
         "critical-request-chains": {
-          "rawValue": 0,
+          "expectedValue": 0,
           "weight": 1
         },
         "user-timings": {
-          "rawValue": 0,
+          "expectedValue": 0,
           "weight": 1
         }
       }

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -73,7 +73,7 @@
     "items": [{
       "name": "App can load on offline/flaky connections",
       "description": "Ensuring your web app can respond when the network connection is unavailable or flaky is critical to providing your users a good experience. This is achieved through use of a <a href=\"https://developers.google.com/web/fundamentals/primers/service-worker/\">Service Worker</a>.",
-      "criteria": {
+      "audits": {
         "service-worker": {
           "rawValue": true,
           "weight": 1
@@ -90,7 +90,7 @@
     },{
       "name": "Page load performance is fast",
       "description": "Users notice if sites and apps don't perform well. These top-level metrics capture the most important perceived performance concerns.",
-      "criteria": {
+      "audits": {
         "first-meaningful-paint": {
           "rawValue": 100,
           "weight": 1
@@ -132,7 +132,7 @@
     }, {
       "name": "Site is progressively enhanced",
       "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but not unfunctioning experience.",
-      "criteria": {
+      "audits": {
         "without-javascript": {
           "rawValue": true,
           "weight": 1
@@ -141,7 +141,7 @@
     }, {
       "name": "Network connection is secure",
       "description": "Security is an important part of the web for both developers and users. Moving forward, Transport Layer Security (TLS) support will be required for many APIs.",
-      "criteria": {
+      "audits": {
         "is-on-https": {
           "rawValue": true,
           "weight": 1
@@ -155,7 +155,7 @@
       "name": "User can be prompted to Add to Homescreen",
       "description": "While users can manually add your site to their homescreen in the browser menu, the <a href=\"https://developers.google.com/web/updates/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android?hl=en\">prompt (aka app install banner)</a> will proactively prompt the user to install the app if the below requirements are met and the user has visited your site at least twice (with at least five minutes between visits).",
       "see": "https://github.com/GoogleChrome/lighthouse/issues/23",
-      "criteria": {
+      "audits": {
         "service-worker": {
           "rawValue": true,
           "weight": 1
@@ -181,7 +181,7 @@
       "name": "Installed web app will launch with custom splash screen",
       "description": "A default splash screen will be constructed, but meeting these requirements guarantee a high-quality and customizable <a href=\"https://developers.google.com/web/updates/2015/10/splashscreen?hl=en\">splash screen</a> the user sees between tapping the home screen icon and your app’s first paint.",
       "see": "https://github.com/GoogleChrome/lighthouse/issues/24",
-      "criteria": {
+      "audits": {
         "manifest-exists": {
           "rawValue": true,
           "weight": 1
@@ -206,7 +206,7 @@
     }, {
       "name": "Address bar matches brand colors",
       "description": "The browser address bar can be themed to match your site. A theme-color <a href=\"https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android\">meta tag</a> will upgrade the address bar when a user browses the site, and the <a href=\"https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color\">manifest theme-color</a> will apply the same theme site-wide once it's been added to homescreen.",
-      "criteria": {
+      "audits": {
         "manifest-exists": {
           "rawValue": true,
           "weight": 1
@@ -223,7 +223,7 @@
     }, {
       "name": "Design is mobile-friendly",
       "description": "Users increasingly experience your app on mobile devices, so it's important to ensure that the experience can adapt to smaller screens.",
-      "criteria": {
+      "audits": {
         "viewport": {
           "rawValue": true,
           "weight": 1
@@ -240,7 +240,7 @@
     "scored": false,
     "categorizable": false,
     "items": [{
-      "criteria": {
+      "audits": {
         "aria-allowed-attr": {
           "rawValue": true,
           "weight": 1
@@ -320,7 +320,7 @@
     "scored": false,
     "categorizable": false,
     "items": [{
-      "criteria": {
+      "audits": {
         "critical-request-chains": {
           "rawValue": 0,
           "weight": 1

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -2,7 +2,6 @@
   "passes": [{
     "network": true,
     "trace": true,
-    "loadPage": true,
     "gatherers": [
       "url",
       "https",
@@ -17,7 +16,6 @@
   },
   {
     "passName": "offlinePass",
-    "loadPage": true,
     "network": true,
     "gatherers": [
       "service-worker",
@@ -25,7 +23,6 @@
     ]
   },
   {
-    "loadPage": true,
     "gatherers": [
       "http-redirect",
       "html-without-javascript"

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -31,20 +31,20 @@
       "name": "Using modern offline features",
       "audits": {
         "appcache-manifest": {
-          "rawValue": false
+          "expectedValue": false
         },
         "no-websql": {
-          "rawValue": false
+          "expectedValue": false
         }
       }
     }, {
       "name": "Using modern protocols",
       "audits": {
         "is-on-https": {
-          "rawValue": false
+          "expectedValue": false
         },
         "uses-http2": {
-          "rawValue": false,
+          "expectedValue": false,
           "description": "Resources made by this application should be severed over HTTP/2 for improved performance."
         }
       }
@@ -52,17 +52,17 @@
       "name": "Using modern JavaScript features",
       "audits": {
         "no-datenow": {
-          "rawValue": false
+          "expectedValue": false
         },
         "no-console-time": {
-          "rawValue": false
+          "expectedValue": false
         }
       }
     }, {
       "name": "Avoiding APIs that harm the user experience",
       "audits": {
         "no-document-write": {
-          "rawValue": false
+          "expectedValue": false
         }
       }
     }]

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -29,7 +29,7 @@
     "categorizable": true,
     "items": [{
       "name": "Using modern offline features",
-      "criteria": {
+      "audits": {
         "appcache-manifest": {
           "rawValue": false
         },
@@ -39,7 +39,7 @@
       }
     }, {
       "name": "Using modern protocols",
-      "criteria": {
+      "audits": {
         "is-on-https": {
           "rawValue": false
         },
@@ -50,7 +50,7 @@
       }
     }, {
       "name": "Using modern JavaScript features",
-      "criteria": {
+      "audits": {
         "no-datenow": {
           "rawValue": false
         },
@@ -60,7 +60,7 @@
       }
     }, {
       "name": "Avoiding APIs that harm the user experience",
-      "criteria": {
+      "audits": {
         "no-document-write": {
           "rawValue": false
         }

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -1,6 +1,6 @@
 {
   "passes": [{
-    "network": true,
+    "recordNetwork": true,
     "gatherers": [
       "../gather/gatherers/https",
       "../gather/gatherers/url",

--- a/lighthouse-core/config/dobetterweb.json
+++ b/lighthouse-core/config/dobetterweb.json
@@ -1,7 +1,6 @@
 {
   "passes": [{
     "network": true,
-    "loadPage": true,
     "gatherers": [
       "../gather/gatherers/https",
       "../gather/gatherers/url",

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -23,7 +23,7 @@
     "items": [{
       "name": "Page load performance is fast",
       "description": "",
-      "criteria": {
+      "audits": {
         "first-meaningful-paint": {
           "rawValue": 100,
           "weight": 1
@@ -48,7 +48,7 @@
     "scored": false,
     "categorizable": false,
     "items": [{
-      "criteria": {
+      "audits": {
         "critical-request-chains": {
           "rawValue": 0,
           "weight": 1

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -25,19 +25,19 @@
       "description": "",
       "audits": {
         "first-meaningful-paint": {
-          "rawValue": 100,
+          "expectedValue": 100,
           "weight": 1
         },
         "speed-index-metric": {
-          "rawValue": 100,
+          "expectedValue": 100,
           "weight": 1
         },
         "estimated-input-latency": {
-          "rawValue": 100,
+          "expectedValue": 100,
           "weight": 1
         },
         "time-to-interactive": {
-          "rawValue": 100,
+          "expectedValue": 100,
           "weight": 1
         }
       }
@@ -50,11 +50,11 @@
     "items": [{
       "audits": {
         "critical-request-chains": {
-          "rawValue": 0,
+          "expectedValue": 0,
           "weight": 1
         },
         "user-timings": {
-          "rawValue": 0,
+          "expectedValue": 0,
           "weight": 1
         }
       }

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -1,7 +1,7 @@
 {
   "passes": [{
-    "network": true,
-    "trace": true,
+    "recordNetwork": true,
+    "recordTrace": true,
     "gatherers": []
   }],
 

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -2,7 +2,6 @@
   "passes": [{
     "network": true,
     "trace": true,
-    "loadPage": true,
     "gatherers": []
   }],
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -72,7 +72,7 @@ class GatherRunner {
   static loadPage(driver, options) {
     return Promise.resolve()
       // Begin tracing only if requested by config.
-      .then(_ => options.config.trace && driver.beginTrace())
+      .then(_ => options.config.recordTrace && driver.beginTrace())
       // Network is always recorded for internal use, even if not saved as artifact.
       .then(_ => driver.beginNetworkCollect(options))
       // Navigate.
@@ -150,7 +150,7 @@ class GatherRunner {
 
     let pass = Promise.resolve();
 
-    if (config.trace) {
+    if (config.recordTrace) {
       pass = pass.then(_ => {
         log.log('status', 'Retrieving trace');
         return driver.endTrace();
@@ -170,7 +170,7 @@ class GatherRunner {
       return driver.endNetworkCollect();
     }).then(networkRecords => {
       // Network records only given to gatherers if requested by config.
-      config.network && (passData.networkRecords = networkRecords);
+      config.recordNetwork && (passData.networkRecords = networkRecords);
       log.verbose('statusEnd', status);
     });
 
@@ -233,8 +233,9 @@ class GatherRunner {
               // If requested by config, merge trace and network data for this
               // pass into tracingData.
               const passName = config.passName || Audit.DEFAULT_PASS;
-              config.trace && (tracingData.traces[passName] = passData.trace);
-              config.network && (tracingData.networkRecords[passName] = passData.networkRecords);
+              config.recordTrace && (tracingData.traces[passName] = passData.trace);
+              config.recordNetwork &&
+                  (tracingData.networkRecords[passName] = passData.networkRecords);
 
               if (passIndex === 0) {
                 urlAfterRedirects = runOptions.url;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -121,18 +121,14 @@ class GatherRunner {
     const driver = options.driver;
     const config = options.config;
     const gatherers = config.gatherers;
-    let pass = Promise.resolve();
 
-    if (config.loadPage) {
-      pass = pass.then(_ => {
-        const status = 'Loading page & waiting for onload';
-        const gatherernames = gatherers.map(g => g.name).join(', ');
-        log.log('status', status, gatherernames);
-        return GatherRunner.loadPage(driver, options).then(_ => {
-          log.log('statusEnd', status);
-        });
-      });
-    }
+    const gatherernames = gatherers.map(g => g.name).join(', ');
+    const status = 'Loading page & waiting for onload';
+    log.log('status', status, gatherernames);
+
+    const pass = GatherRunner.loadPage(driver, options).then(_ => {
+      log.log('statusEnd', status);
+    });
 
     return gatherers.reduce((chain, gatherer) => {
       return chain.then(_ => gatherer.pass(options));

--- a/lighthouse-core/test/aggregator/aggregate-test.js
+++ b/lighthouse-core/test/aggregator/aggregate-test.js
@@ -133,7 +133,7 @@ describe('Aggregate', () => {
 
   it('throws for undefined results', () => {
     const expected = {
-      rawValue: true,
+      expectedValue: true,
       weight: 10
     };
     return assert.throws(_ => Aggregate._convertToWeight(undefined, expected));
@@ -150,7 +150,7 @@ describe('Aggregate', () => {
 
   it('returns the correct weight for a boolean result', () => {
     const expected = {
-      rawValue: true,
+      expectedValue: true,
       weight: 10
     };
 
@@ -165,7 +165,7 @@ describe('Aggregate', () => {
 
   it('returns the correct weight for a numeric result', () => {
     const expected = {
-      rawValue: 100,
+      expectedValue: 100,
       weight: 10
     };
 
@@ -180,7 +180,7 @@ describe('Aggregate', () => {
 
   it('throws if weight is missing from the expected', () => {
     const expected = {
-      rawValue: 100
+      expectedValue: 100
     };
 
     const result = {
@@ -194,7 +194,7 @@ describe('Aggregate', () => {
 
   it('returns a weight of zero for other inputs', () => {
     const expected = {
-      rawValue: [],
+      expectedValue: [],
       weight: 10
     };
 
@@ -209,7 +209,7 @@ describe('Aggregate', () => {
 
   it('throws if types do not match', () => {
     const expected = {
-      rawValue: true,
+      expectedValue: true,
       weight: 10
     };
 
@@ -226,11 +226,11 @@ describe('Aggregate', () => {
     const items = [{
       audits: {
         'test': {
-          rawValue: true,
+          expectedValue: true,
           weight: 1
         },
         'alternate-test': {
-          rawValue: 100,
+          expectedValue: 100,
           weight: 3
         }
       }
@@ -264,11 +264,11 @@ describe('Aggregate', () => {
     const items = [{
       audits: {
         'test': {
-          rawValue: true,
+          expectedValue: true,
           weight: 1
         },
         'alternate-test': {
-          rawValue: 100,
+          expectedValue: 100,
           weight: 3
         }
       }
@@ -302,7 +302,7 @@ describe('Aggregate', () => {
     const items = [{
       audits: {
         test: {
-          rawValue: true,
+          expectedValue: true,
           weight: 1
         }
       }
@@ -318,7 +318,7 @@ describe('Aggregate', () => {
     return assert.throws(_ => Aggregate.compare(results, items, scored));
   });
 
-  it('throws when given a criterion containing no rawValue property', () => {
+  it('throws when given an audit containing no expectedValue property', () => {
     const items = [{
       audits: {
         test: {
@@ -341,7 +341,7 @@ describe('Aggregate', () => {
     const items = [{
       audits: {
         test: {
-          rawValue: true,
+          expectedValue: true,
           weight: 1
         }
       }
@@ -369,7 +369,7 @@ describe('Aggregate', () => {
     const items = [{
       audits: {
         test: {
-          rawValue: true,
+          expectedValue: true,
           weight: 1
         }
       }
@@ -389,7 +389,7 @@ describe('Aggregate', () => {
     const items = [{
       audits: {
         test: {
-          rawValue: true,
+          expectedValue: true,
           weight: 1
         }
       }
@@ -416,7 +416,7 @@ describe('Aggregate', () => {
       items: [{
         audits: {
           test: {
-            rawValue: true,
+            expectedValue: true,
             weight: 1
           }
         }

--- a/lighthouse-core/test/aggregator/aggregate-test.js
+++ b/lighthouse-core/test/aggregator/aggregate-test.js
@@ -224,7 +224,7 @@ describe('Aggregate', () => {
 
   it('scores a set correctly (contributesToScore: true)', () => {
     const items = [{
-      criteria: {
+      audits: {
         'test': {
           rawValue: true,
           weight: 1
@@ -262,7 +262,7 @@ describe('Aggregate', () => {
 
   it('scores a set correctly (contributesToScore: false)', () => {
     const items = [{
-      criteria: {
+      audits: {
         'test': {
           rawValue: true,
           weight: 1
@@ -300,7 +300,7 @@ describe('Aggregate', () => {
 
   it('throws when given a result containing no score property', () => {
     const items = [{
-      criteria: {
+      audits: {
         test: {
           rawValue: true,
           weight: 1
@@ -320,7 +320,7 @@ describe('Aggregate', () => {
 
   it('throws when given a criterion containing no rawValue property', () => {
     const items = [{
-      criteria: {
+      audits: {
         test: {
           weight: 1
         }
@@ -339,7 +339,7 @@ describe('Aggregate', () => {
 
   it('filters a set correctly', () => {
     const items = [{
-      criteria: {
+      audits: {
         test: {
           rawValue: true,
           weight: 1
@@ -367,7 +367,7 @@ describe('Aggregate', () => {
 
   it('outputs a score', () => {
     const items = [{
-      criteria: {
+      audits: {
         test: {
           rawValue: true,
           weight: 1
@@ -387,7 +387,7 @@ describe('Aggregate', () => {
 
   it('outputs subitems', () => {
     const items = [{
-      criteria: {
+      audits: {
         test: {
           rawValue: true,
           weight: 1
@@ -414,7 +414,7 @@ describe('Aggregate', () => {
       scored: true,
       categorizable: true,
       items: [{
-        criteria: {
+        audits: {
           test: {
             rawValue: true,
             weight: 1

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -43,11 +43,11 @@ describe('Config', () => {
     const unlikelyPassName = 'unlikelyPassName';
     const configJson = {
       passes: [{
-        network: true,
+        recordNetwork: true,
         passName: unlikelyPassName,
         gatherers: []
       }, {
-        network: true,
+        recordNetwork: true,
         passName: unlikelyPassName,
         gatherers: []
       }],
@@ -71,10 +71,10 @@ describe('Config', () => {
   it('warns when traced twice with no passNames specified', () => {
     const configJson = {
       passes: [{
-        network: true,
+        recordNetwork: true,
         gatherers: []
       }, {
-        network: true,
+        recordNetwork: true,
         gatherers: []
       }],
       audits: []

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -233,12 +233,10 @@ describe('GatherRunner', function() {
       network: true,
       trace: true,
       passName: 'firstPass',
-      loadPage: true,
       gatherers: [
         t1
       ]
     }, {
-      loadPage: true,
       passName: 'secondPass',
       gatherers: [
         t2
@@ -263,13 +261,11 @@ describe('GatherRunner', function() {
       network: true,
       trace: true,
       passName: 'firstPass',
-      loadPage: true,
       gatherers: [new TestGatherer()]
     }, {
       network: true,
       trace: true,
       passName: 'secondPass',
-      loadPage: true,
       gatherers: [new TestGatherer()]
     }];
     const options = {driver: fakeDriver, url: 'https://example.com', flags: {}, config: {}};
@@ -292,7 +288,6 @@ describe('GatherRunner', function() {
       network: true,
       trace: true,
       passName: 'firstPass',
-      loadPage: true,
       gatherers: [
         t1
       ]
@@ -385,7 +380,6 @@ describe('GatherRunner', function() {
       network: true,
       trace: true,
       passName: 'firstPass',
-      loadPage: true,
       gatherers: [new TestGatherer()]
     }];
     const options = {driver: fakeDriver, url: 'https://example.com', flags: {}, config: {}};

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -129,7 +129,7 @@ describe('GatherRunner', function() {
     };
 
     const config = {
-      trace: true,
+      recordTrace: true,
       gatherers: [{}]
     };
 
@@ -152,7 +152,7 @@ describe('GatherRunner', function() {
     };
 
     const config = {
-      trace: true,
+      recordTrace: true,
       gatherers: [{
         afterPass() {}
       }]
@@ -177,7 +177,7 @@ describe('GatherRunner', function() {
     };
 
     const config = {
-      network: true,
+      recordNetwork: true,
       gatherers: [{}]
     };
 
@@ -196,7 +196,7 @@ describe('GatherRunner', function() {
     };
 
     const config = {
-      network: true,
+      recordNetwork: true,
       gatherers: [{
         afterPass() {}
       }]
@@ -230,8 +230,8 @@ describe('GatherRunner', function() {
     const flags = {};
 
     const passes = [{
-      network: true,
-      trace: true,
+      recordNetwork: true,
+      recordTrace: true,
       passName: 'firstPass',
       gatherers: [
         t1
@@ -258,13 +258,13 @@ describe('GatherRunner', function() {
 
   it('respects trace names', () => {
     const passes = [{
-      network: true,
-      trace: true,
+      recordNetwork: true,
+      recordTrace: true,
       passName: 'firstPass',
       gatherers: [new TestGatherer()]
     }, {
-      network: true,
-      trace: true,
+      recordNetwork: true,
+      recordTrace: true,
       passName: 'secondPass',
       gatherers: [new TestGatherer()]
     }];
@@ -285,8 +285,8 @@ describe('GatherRunner', function() {
     const flags = {};
 
     const passes = [{
-      network: true,
-      trace: true,
+      recordNetwork: true,
+      recordTrace: true,
       passName: 'firstPass',
       gatherers: [
         t1
@@ -377,8 +377,8 @@ describe('GatherRunner', function() {
 
   it('will instantiate computed artifacts during a run', () => {
     const passes = [{
-      network: true,
-      trace: true,
+      recordNetwork: true,
+      recordTrace: true,
       passName: 'firstPass',
       gatherers: [new TestGatherer()]
     }];

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -153,7 +153,7 @@ describe('Runner', () => {
         items: [{
           name: 'name',
           description: 'description',
-          criteria: {
+          audits: {
             'is-on-https': {
               value: true,
               weight: 1
@@ -184,7 +184,7 @@ describe('Runner', () => {
         items: [{
           name: 'name',
           description: 'description',
-          criteria: {
+          audits: {
             'is-on-https': {
               rawValue: true,
               weight: 1

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -186,7 +186,7 @@ describe('Runner', () => {
           description: 'description',
           audits: {
             'is-on-https': {
-              rawValue: true,
+              expectedValue: true,
               weight: 1
             }
           }

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -81,7 +81,7 @@ window.getDefaultAggregations = function() {
       if (aggregation.items.length === 1) {
         return {
           name: aggregation.name,
-          criteria: aggregation.items[0].criteria,
+          audits: aggregation.items[0].audits,
         };
       }
 
@@ -90,7 +90,7 @@ window.getDefaultAggregations = function() {
   ).map(aggregation => {
     return {
       name: aggregation.name,
-      audits: Object.keys(aggregation.criteria)
+      audits: Object.keys(aggregation.audits)
     };
   });
 };

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Lighthouse can be used to analyze trace and performance data collected from othe
     "scored": false,
     "categorizable": false,
     "items": [{
-      "criteria": {
+      "audits": {
         "user-timings": { "rawValue": 0, "weight": 1 },
         "critical-request-chains": { "rawValue": 0, "weight": 1}
       }

--- a/readme.md
+++ b/readme.md
@@ -81,8 +81,8 @@ Lighthouse can be used to analyze trace and performance data collected from othe
     "categorizable": false,
     "items": [{
       "audits": {
-        "user-timings": { "rawValue": 0, "weight": 1 },
-        "critical-request-chains": { "rawValue": 0, "weight": 1}
+        "user-timings": { "expectedValue": 0, "weight": 1 },
+        "critical-request-chains": { "expectedValue": 0, "weight": 1}
       }
     }]
   }]


### PR DESCRIPTION
Since we possibly have more dependents incoming, seems like the time to do the rename in #688. I started with some of the easier ones, separated into commits for easy review and possible cherry picking if there are objections to any particular one :)

Note that any existing config files (pwmetrics? smokehouse) will have to change

- `network` -> `recordNetwork`
- `trace` -> `recordTrace`
- `loadPage` -> 💥
- `criteria` -> `audits`
- `rawValue` -> `expectedValue`

Unit tests look good, as do runs of smokehouse, `--perf` and `npm run dbw`

#688 still open for comments on remaining possible renames