### PR TITLE
Extension: Print errors thrown from handlebars

### DIFF
--- a/lighthouse-extension/app/pages/styles/report.css
+++ b/lighthouse-extension/app/pages/styles/report.css
@@ -55,3 +55,18 @@ a {
   background-size: 34px 34px;
   will-change: transform;
 }
+
+.report-error {
+  font-family: consolas, monospace;
+}
+
+.error-stack {
+  white-space: pre-wrap;
+}
+
+.error-results {
+  background: #dedede;
+  max-height: 600px;
+  overflow: auto;
+  border-radius: 2px;
+}

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -64,6 +64,8 @@ window.runLighthouse = function(options, requestedAudits) {
 
       // Run Lighthouse.
       return Runner.run(driver, runOptions);
+    }).then(results => {
+      window.createPageAndPopulate(results);
     }).catch(e => {
       console.error(e);
       throw e;

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -129,9 +129,6 @@ document.addEventListener('DOMContentLoaded', _ => {
         }
       }, selectedAudits);
     })
-    .then(results => {
-      background.createPageAndPopulate(results);
-    })
     .catch(err => {
       let {message} = err;
       if (err.message.toLowerCase().startsWith('another debugger')) {

--- a/lighthouse-extension/app/src/report-loader.js
+++ b/lighthouse-extension/app/src/report-loader.js
@@ -61,7 +61,7 @@ class ReportLoader {
       <div class="report-error">
         <h1 class="error-message">⚠️ Error: <span></span></h1>
         <p class="error-stack"><span></span></p>
-        <big>➡ <a target="_blank" href="httbigs://github.com/GoogleChrome/lighthouse/issues">Please report this bug</a></big>
+        <big>➡ <a target="_blank" href="https://github.com/GoogleChrome/lighthouse/issues">Please report this bug</a></big>
         <div class="error-results"><pre><span></span></pre></div>
       </div>
     `;

--- a/lighthouse-extension/app/src/report-loader.js
+++ b/lighthouse-extension/app/src/report-loader.js
@@ -42,16 +42,34 @@ class ReportLoader {
 
   write(results) {
     const reportGenerator = new ReportGenerator();
-    const html = reportGenerator.generateHTML(results);
-
-    this.stopSpinner();
-    document.documentElement.innerHTML = html;
+    try {
+      const html = reportGenerator.generateHTML(results);
+      this.stopSpinner();
+      document.documentElement.innerHTML = html;
+    } catch (err) {
+      this.stopSpinner();
+      this.displayException(err, results);
+    }
 
     // Find and replace all the scripts that have been injected so that they get evaluated.
     const scripts = document.querySelectorAll('script');
     scripts.forEach(this.replaceScript);
   }
 
+  displayException(err, results) {
+    const html = `
+      <div class="report-error">
+        <h1 class="error-message">⚠️ Error: <span></span></h1>
+        <p class="error-stack"><span></span></p>
+        <big>➡ <a target="_blank" href="httbigs://github.com/GoogleChrome/lighthouse/issues">Please report this bug</a></big>
+        <div class="error-results"><pre><span></span></pre></div>
+      </div>
+    `;
+    document.body.innerHTML = html;
+    document.querySelector('.error-message span').textContent = err.message;
+    document.querySelector('.error-stack span').textContent = err.stack;
+    document.querySelector('.error-results span').textContent = JSON.stringify(results, null, 2);
+  }
   /**
    * Replaces the script injected by innerHTML so that it actually gets evaluated and executed.
    */


### PR DESCRIPTION
While handlebars is generating HTML, it sometimes throws an exception. Currently that results in the spinner just spinning, though there is an error in the report.html page's console.

This PR will print the error to the screen, along with the existing results.

![image](https://cloud.githubusercontent.com/assets/39191/19023575/5f06169a-88a6-11e6-931b-4e4d254b0e33.png)

The results are also rendered, which is probably valuable to the user as well as to the developer for debugging the root cause.