### PR TITLE
Run coveralls only after build success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ script:
   - npm run lint
   - npm run unit
   - npm run closure
-  - npm run coveralls
   - npm run smoke
   - cd lighthouse-extension
   - gulp build
+  - cd ..
+after_success:
+  - npm run coveralls


### PR DESCRIPTION
This is generally the [recommended](https://www.andreagrandi.it/2014/03/02/travis-ci-org-and-coveralls-io-qa-made-easy/) [config](https://github.com/benbria/coffee-coverage/blob/master/docs/HOWTO-travisci-and-coveralls.md), anyway.

Two advantages:

1. Coveralls bugging out with `Bad response: 422 {"message":"Couldn't find a repository matching this job.","error":true}` [doesnt break our build](https://travis-ci.org/GoogleChrome/lighthouse/jobs/164491870#L926).
1. We don't really want coveralls data unless the build is successful.