### PR TITLE
Chrome extension runtime fixes

### DIFF
--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -103,7 +103,10 @@ class ReportGenerator {
 
     // Convert numbers to fixed point decimals
     Handlebars.registerHelper('decimal', number => {
-      return number.toFixed(2);
+      if (number && number.toFixed) {
+        return number.toFixed(2);
+      }
+      return number;
     });
   }
 

--- a/lighthouse-core/scripts/build-traceviewer-module.js
+++ b/lighthouse-core/scripts/build-traceviewer-module.js
@@ -70,6 +70,8 @@ function convertImport(src) {
 
       // node4 compat
       scriptsContent = polyfillNode4Support(dest, scriptsContent);
+      // browser compat
+      scriptsContent = adjustForBrowserCompat(scriptsContent);
 
       writeNewFile(dest, scriptsContent);
 
@@ -131,6 +133,12 @@ function convertImport(src) {
           plugins: ['transform-es2015-destructuring']
         }).code;
         return transformed;
+      }
+
+      function adjustForBrowserCompat(scriptsContent) {
+        return scriptsContent
+            // early exit in tracing/base.ui and avoid currentScript from breaking us.
+            .replace('var THIS_DOC = document.currentScript.ownerDocument;', 'return;');
       }
 
       function writeNewFile(dest, scriptsContent) {

--- a/lighthouse-core/third_party/traceviewer-js/ui/base/overlay.js
+++ b/lighthouse-core/third_party/traceviewer-js/ui/base/overlay.js
@@ -24,7 +24,7 @@ require("./utils.js");
 global.tr.exportTo('tr.ui.b', function () {
   if (tr.isHeadless) return {};
 
-  var THIS_DOC = document.currentScript.ownerDocument;
+  return;
 
   /**
    * Creates a new overlay element. It will not be visible until shown.


### PR DESCRIPTION
Two fixes in here that bring our chrome extension back into working order :)

1. With the new traceviewer build, their `base/overlay.html` has a `document.currentScript.ownerDocument` line, that throws in a background page. We're not interested in that, so we `return;` instead. (Unfortunately we've never used the `tr.isHeadless` boolean they have, because their headless involves a custom HTML parser. :)
2. Bugs about `toFixed()` have come up a few times when rendering our report. While we still want to resolve the core bugs, tanking the report seems suboptimal. So we add a safety check first.

wdyt yall?