### PR TITLE
fix tests which were unconditionally passing failed assertions

### DIFF
--- a/lighthouse-core/gather/gatherers/html-without-javascript.js
+++ b/lighthouse-core/gather/gatherers/html-without-javascript.js
@@ -44,15 +44,15 @@ class HTMLWithoutJavaScript extends Gatherer {
 
     this.artifact = {};
     return driver.evaluateAsync(`(${getBodyText.toString()}())`)
-    .then(result => {
-      this.artifact = result;
-    })
-    .catch(_ => {
-      this.artifact = {
-        value: -1,
-        debugString: 'Unable to get document body innerText'
-      };
-    });
+      .then(result => {
+        this.artifact = result;
+      })
+      .catch(_ => {
+        this.artifact = {
+          value: -1,
+          debugString: 'Unable to get document body innerText'
+        };
+      });
   }
 }
 

--- a/lighthouse-core/test/gather/gatherers/accessibility-test.js
+++ b/lighthouse-core/test/gather/gatherers/accessibility-test.js
@@ -21,10 +21,6 @@ const AccessibilityGather = require('../../../gather/gatherers/accessibility');
 const assert = require('assert');
 let accessibilityGather;
 
-const isExpectedOutput = artifact => {
-  return 'raw' in artifact && 'value' in artifact;
-};
-
 describe('Accessibility gatherer', () => {
   // Reset the Gatherer before each test.
   beforeEach(() => {
@@ -51,9 +47,7 @@ describe('Accessibility gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
-      assert.ok(isExpectedOutput(accessibilityGather.artifact));
+      assert.ok(accessibilityGather.artifact.debugString);
     });
   });
 

--- a/lighthouse-core/test/gather/gatherers/cache-contents-test.js
+++ b/lighthouse-core/test/gather/gatherers/cache-contents-test.js
@@ -21,10 +21,6 @@ const CacheContentGather = require('../../../gather/gatherers/cache-contents');
 const assert = require('assert');
 let cacheContentGather;
 
-const isExpectedOutput = artifact => {
-  return 'raw' in artifact && 'value' in artifact;
-};
-
 describe('Cache Contents gatherer', () => {
   // Reset the Gatherer before each test.
   beforeEach(() => {
@@ -51,9 +47,7 @@ describe('Cache Contents gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
-      assert.ok(isExpectedOutput(cacheContentGather.artifact));
+      assert.ok(cacheContentGather.artifact.debugString);
     });
   });
 

--- a/lighthouse-core/test/gather/gatherers/content-width-test.js
+++ b/lighthouse-core/test/gather/gatherers/content-width-test.js
@@ -21,7 +21,7 @@ const ContentWidthGatherer = require('../../../gather/gatherers/content-width');
 const assert = require('assert');
 let contentWidthGatherer;
 
-describe('Viewport gatherer', () => {
+describe('Content Width gatherer', () => {
   // Reset the Gatherer before each test.
   beforeEach(() => {
     contentWidthGatherer = new ContentWidthGatherer();
@@ -51,8 +51,6 @@ describe('Viewport gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
       assert.equal(contentWidthGatherer.artifact.scrollWidth, -1);
     });
   });

--- a/lighthouse-core/test/gather/gatherers/geolocation-on-start-test.js
+++ b/lighthouse-core/test/gather/gatherers/geolocation-on-start-test.js
@@ -41,8 +41,7 @@ describe('Geolocation gatherer', () => {
         }
       }
     })).then(_ => {
-      assert.ok(typeof geolocationGatherer.artifact === 'boolean');
-      assert.equal(geolocationGatherer.artifact, true);
+      assert.strictEqual(geolocationGatherer.artifact, true);
     });
   });
 
@@ -60,8 +59,6 @@ describe('Geolocation gatherer', () => {
         }
       }
     })).then(_ => {
-      assert(false);
-    }).catch(_ => {
       assert.equal(geolocationGatherer.artifact, -1);
     });
   });

--- a/lighthouse-core/test/gather/gatherers/html-test.js
+++ b/lighthouse-core/test/gather/gatherers/html-test.js
@@ -70,10 +70,8 @@ describe('HTML gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
-      assert.ok('value' in htmlGather.artifact);
-      assert.ok('debugString' in htmlGather.artifact);
+      assert.equal(htmlGather.artifact.value, -1);
+      assert.ok(htmlGather.artifact.debugString);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
+++ b/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
@@ -71,10 +71,8 @@ describe('HTML without JavaScript gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
-      assert.ok('value' in htmlWithoutJavaScriptGather.artifact);
-      assert.ok('debugString' in htmlWithoutJavaScriptGather.artifact);
+      assert.equal(htmlWithoutJavaScriptGather.artifact.value, -1);
+      assert.ok(htmlWithoutJavaScriptGather.artifact.debugString);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/https-test.js
+++ b/lighthouse-core/test/gather/gatherers/https-test.js
@@ -49,9 +49,8 @@ describe('HTTPS gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
       assert.equal(httpsGather.artifact.value, false);
+      assert.ok(httpsGather.artifact.debugString);
     });
   });
 
@@ -68,10 +67,8 @@ describe('HTTPS gatherer', () => {
 
       timeout: 250
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
       assert.equal(httpsGather.artifact.value, false);
-      assert.ok(typeof httpsGather.artifact.debugString === 'string');
+      assert.ok(httpsGather.artifact.debugString);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -24,10 +24,6 @@ let manifestGather;
 const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 
-const isExpectedOutput = artifact => {
-  return 'raw' in artifact && 'value' in artifact;
-};
-
 describe('Manifest gatherer', () => {
   // Reset the Gatherer before each test.
   beforeEach(() => {
@@ -59,9 +55,7 @@ describe('Manifest gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
-      assert.ok(isExpectedOutput(manifestGather.artifact));
+      assert.ok(manifestGather.artifact.debugString);
     });
   });
 

--- a/lighthouse-core/test/gather/gatherers/theme-color-test.js
+++ b/lighthouse-core/test/gather/gatherers/theme-color-test.js
@@ -51,8 +51,6 @@ describe('Theme Color gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
       assert.equal(themeColorGather.artifact, -1);
     });
   });

--- a/lighthouse-core/test/gather/gatherers/viewport-test.js
+++ b/lighthouse-core/test/gather/gatherers/viewport-test.js
@@ -50,8 +50,6 @@ describe('Viewport gatherer', () => {
         }
       }
     }).then(_ => {
-      assert(false);
-    }).catch(_ => {
       assert.equal(viewportGather.artifact, -1);
     });
   });


### PR DESCRIPTION
Found a set of tests that weren't testing anything since anything caught by the `assert(false)` path was immediately handled by a `catch`. In most cases I just got rid of the `catch` since most of the gatherers here don't intentionally throw and so any that do *should* be caught by mocha.

No bugs caught here, just making them do what they say on the tin :)