### PR TITLE
fix unhandled promise rejections in runner testing

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -294,6 +294,10 @@ class Config {
 
     this._passes = configJSON.passes || null;
     this._auditResults = configJSON.auditResults || null;
+    if (this._auditResults && !Array.isArray(this._auditResults)) {
+      throw new Error('config.auditResults must be an array');
+    }
+
     this._aggregations = configJSON.aggregations || null;
 
     this._audits = requireAudits(configJSON.audits, this._configDir);

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -110,8 +110,9 @@ class Runner {
       // If there are existing audit results, surface those here.
       run = run.then(_ => config.auditResults);
     } else {
-      throw new Error(
+      const err = Error(
           'The config must provide passes and audits, artifacts and audits, or auditResults');
+      return Promise.reject(err);
     }
 
     // Format and aggregate results before returning.

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -41,7 +41,7 @@ describe('Runner', () => {
     });
   });
 
-  it('throws when given neither passes nor artifacts', () => {
+  it('rejects when given neither passes nor artifacts', () => {
     const url = 'https://example.com';
     const config = new Config({
       audits: [
@@ -49,8 +49,12 @@ describe('Runner', () => {
       ]
     });
 
-    return assert.throws(_ => Runner.run(fakeDriver, {url, config}),
-        /The config must provide passes/);
+    return Runner.run(fakeDriver, {url, config})
+      .then(_ => {
+        assert.ok(false);
+      }, err => {
+        assert.ok(/The config must provide passes/.test(err.message));
+      });
   });
 
   it('accepts existing artifacts', () => {
@@ -61,11 +65,17 @@ describe('Runner', () => {
       ],
 
       artifacts: {
-        HTTPS: true
+        HTTPS: {
+          value: true
+        }
       }
     });
 
-    return assert.doesNotThrow(_ => Runner.run({}, {url, config}));
+    return Runner.run({}, {url, config}).then(results => {
+      // Mostly checking that this did not throw, but check representative values.
+      assert.equal(results.initialUrl, url);
+      assert.strictEqual(results.audits['is-on-https'].rawValue, true);
+    });
   });
 
   it('accepts trace artifacts as paths and outputs appropriate data', () => {
@@ -126,7 +136,7 @@ describe('Runner', () => {
     });
   });
 
-  it('throws when given neither audits nor auditResults', () => {
+  it('rejects when given neither audits nor auditResults', () => {
     const url = 'https://example.com';
     const config = new Config({
       passes: [{
@@ -134,16 +144,23 @@ describe('Runner', () => {
       }]
     });
 
-    return assert.throws(_ => Runner.run(fakeDriver, {url, config}),
-        /The config must provide passes/);
+    return Runner.run(fakeDriver, {url, config})
+      .then(_ => {
+        assert.ok(false);
+      }, err => {
+        assert.ok(/The config must provide passes/.test(err.message));
+      });
   });
 
   it('accepts existing auditResults', () => {
     const url = 'https://example.com';
     const config = new Config({
-      auditResults: {
-        HTTPS: true
-      },
+      auditResults: [{
+        name: 'is-on-https',
+        rawValue: true,
+        score: true,
+        displayValue: ''
+      }],
 
       aggregations: [{
         name: 'Aggregation',
@@ -155,7 +172,7 @@ describe('Runner', () => {
           description: 'description',
           audits: {
             'is-on-https': {
-              value: true,
+              expectedValue: true,
               weight: 1
             }
           }
@@ -163,7 +180,11 @@ describe('Runner', () => {
       }]
     });
 
-    return assert.doesNotThrow(_ => Runner.run(fakeDriver, {url, config}));
+    return Runner.run(fakeDriver, {url, config}).then(results => {
+      // Mostly checking that this did not throw, but check representative values.
+      assert.equal(results.initialUrl, url);
+      assert.strictEqual(results.audits['is-on-https'].rawValue, true);
+    });
   });
 
   it('returns an aggregation', () => {


### PR DESCRIPTION
Last two unhandled rejections in our unit tests :) We were checking `doesNotThrow` on `Runner.run` when it *should* always be returning a promise (it wasn't quite, but it does now).

Also added an `Array.isArray(config.auditResults)` assertion on `Config` construction because if it's not an array (as it wasn't for one of the tests), the error manifests quite deep into the pipeline and it isn't clear what's causing it.