### PR TITLE
Change NetworkManager.events into NetworkManager.EventTypes

### DIFF
--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -45,7 +45,7 @@ class NetworkRecorder extends EventEmitter {
   }
 
   get EventTypes() {
-    return NetworkManager.Events;
+    return NetworkManager.EventTypes;
   }
 
   activeRequestCount() {

--- a/lighthouse-core/lib/web-inspector.js
+++ b/lighthouse-core/lib/web-inspector.js
@@ -211,7 +211,7 @@ module.exports = (function() {
   WebInspector.NetworkLog = function(target) {
     this._requests = new Map();
     target.networkManager.addEventListener(
-      WebInspector.NetworkManager.Events.RequestStarted, this._onRequestStarted, this);
+      WebInspector.NetworkManager.EventTypes.RequestStarted, this._onRequestStarted, this);
   };
 
   WebInspector.NetworkLog.prototype = {


### PR DESCRIPTION
Can't run npm start <url>.
I get the following error
`Runtime error encountered: [TypeError: Cannot read property 'RequestStarted' of undefined]
TypeError: Cannot read property 'RequestStarted' of undefined`