### PR TITLE
speed index: allow speedline results even if <3 frames

### DIFF
--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -64,13 +64,6 @@ class SpeedIndexMetric extends Audit {
         });
       }
 
-      if (speedline.frames.length < 3) {
-        return SpeedIndexMetric.generateAuditResult({
-          rawValue: -1,
-          debugString: 'Trace unable to find sufficient frames to evaluate Speed Index.'
-        });
-      }
-
       if (speedline.speedIndex === 0) {
         return SpeedIndexMetric.generateAuditResult({
           rawValue: -1,

--- a/lighthouse-core/test/audits/speed-index-metric-test.js
+++ b/lighthouse-core/test/audits/speed-index-metric-test.js
@@ -63,14 +63,6 @@ describe('Performance: speed-index-metric audit', () => {
     });
   });
 
-  it('gives error string if too few frames to determine speed index', () => {
-    const artifacts = mockArtifactsWithSpeedlineResult({frames: [frame()]});
-    return Audit.audit(artifacts).then(response => {
-      assert.equal(response.rawValue, -1);
-      assert(response.debugString);
-    });
-  });
-
   it('gives error string if speed index of 0', () => {
     const SpeedlineResult = {
       frames: [frame(), frame(), frame()],


### PR DESCRIPTION
Speedline was handling 3 frame traces incorrectly.
Since we fixed it and bumped to 1.0.2 (in #728) we don't need this any longer.