### PR TITLE
Help text toggle

### DIFF
--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -101,7 +101,7 @@ class ReportGenerator {
     Handlebars.registerHelper('getItemRating', getItemRating);
 
     Handlebars.registerHelper('showHelpText', value => {
-      return getItemRating(value) === 'good' ? 'hidden': '';
+      return getItemRating(value) === 'good' ? 'hidden' : '';
     });
 
     // Convert numbers to fixed point decimals

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -34,6 +34,23 @@ class ReportGenerator {
       return Math.round(totalScore * 100);
     };
 
+    const getItemRating = (value, aggregatorScored) => {
+      if (typeof value === 'boolean') {
+        return value ? 'good' : 'poor';
+      }
+
+      // Limit the rating to average if this is a rating for Best Practices.
+      let rating = aggregatorScored ? 'average' : 'poor';
+      if (value > 0.33) {
+        rating = 'average';
+      }
+      if (value > 0.66) {
+        rating = 'good';
+      }
+
+      return rating;
+    };
+
     // Converts a name to a link.
     Handlebars.registerHelper('nameToLink', name => {
       return name.toLowerCase().replace(/\s/, '-');
@@ -79,22 +96,12 @@ class ReportGenerator {
       return rating;
     });
 
-    // Converts a value to a rating string, which can be used inside the report for color styling.
-    Handlebars.registerHelper('getItemRating', (value, aggregatorScored) => {
-      if (typeof value === 'boolean') {
-        return value ? 'good' : 'poor';
-      }
+    // Converts a value to a rating string, which can be used inside the report
+    // for color styling.
+    Handlebars.registerHelper('getItemRating', getItemRating);
 
-      // Limit the rating to average if this is a rating for Best Practices.
-      let rating = aggregatorScored ? 'average' : 'poor';
-      if (value > 0.33) {
-        rating = 'average';
-      }
-      if (value > 0.66) {
-        rating = 'good';
-      }
-
-      return rating;
+    Handlebars.registerHelper('showHelpText', value => {
+      return getItemRating(value) === 'good' ? 'hidden': '';
     });
 
     // Convert numbers to fixed point decimals

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -40,18 +40,17 @@ class ReportGenerator {
       return Math.round(totalScore * 100);
     };
 
-    const getItemRating = (value, aggregatorScored) => {
+    const getItemRating = value => {
       if (typeof value === 'boolean') {
         return value ? RATINGS.GOOD.label : RATINGS.POOR.label;
       }
 
       // Limit the rating to average if this is a rating for Best Practices.
-      let rating = aggregatorScored ? RATINGS.AVERAGE.label : RATINGS.POOR.label;
-      if (value > RATINGS.AVERAGE.minValue) {
-        rating = RATINGS.AVERAGE.label;
-      }
+      let rating = RATINGS.POOR.label;
       if (value > RATINGS.GOOD.minValue) {
         rating = RATINGS.GOOD.label;
+      } else if (value > RATINGS.AVERAGE.minValue) {
+        rating = RATINGS.AVERAGE.label;
       }
 
       return rating;

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -23,6 +23,12 @@ const Handlebars = require('handlebars');
 const fs = require('fs');
 const path = require('path');
 
+const RATINGS = {
+  GOOD: 'good',
+  AVERAGE: 'average',
+  POOR: 'poor'
+};
+
 class ReportGenerator {
 
   constructor() {
@@ -36,16 +42,16 @@ class ReportGenerator {
 
     const getItemRating = (value, aggregatorScored) => {
       if (typeof value === 'boolean') {
-        return value ? 'good' : 'poor';
+        return value ? RATINGS.GOOD : RATINGS.POOR;
       }
 
       // Limit the rating to average if this is a rating for Best Practices.
-      let rating = aggregatorScored ? 'average' : 'poor';
+      let rating = aggregatorScored ? RATINGS.AVERAGE : RATINGS.POOR;
       if (value > 0.33) {
-        rating = 'average';
+        rating = RATINGS.AVERAGE;
       }
       if (value > 0.66) {
-        rating = 'good';
+        rating = RATINGS.GOOD;
       }
 
       return rating;
@@ -85,12 +91,12 @@ class ReportGenerator {
     Handlebars.registerHelper('getTotalScoreRating', aggregation => {
       const totalScore = getTotalScore(aggregation);
 
-      let rating = 'poor';
+      let rating = RATINGS.POOR;
       if (totalScore > 45) {
-        rating = 'average';
+        rating = RATINGS.AVERAGE;
       }
       if (totalScore > 75) {
-        rating = 'good';
+        rating = RATINGS.GOOD;
       }
 
       return rating;
@@ -101,7 +107,7 @@ class ReportGenerator {
     Handlebars.registerHelper('getItemRating', getItemRating);
 
     Handlebars.registerHelper('showHelpText', value => {
-      return getItemRating(value) === 'good' ? 'hidden' : '';
+      return getItemRating(value) === RATINGS.GOOD ? 'hidden' : '';
     });
 
     // Convert numbers to fixed point decimals

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -24,9 +24,9 @@ const fs = require('fs');
 const path = require('path');
 
 const RATINGS = {
-  GOOD: 'good',
-  AVERAGE: 'average',
-  POOR: 'poor'
+  GOOD: {label: 'good', minValue: 0.66, minScore: 75},
+  AVERAGE: {label: 'average', minValue: 0.33},
+  POOR: {label: 'poor', minScore: 45}
 };
 
 class ReportGenerator {
@@ -42,16 +42,16 @@ class ReportGenerator {
 
     const getItemRating = (value, aggregatorScored) => {
       if (typeof value === 'boolean') {
-        return value ? RATINGS.GOOD : RATINGS.POOR;
+        return value ? RATINGS.GOOD.label : RATINGS.POOR.label;
       }
 
       // Limit the rating to average if this is a rating for Best Practices.
-      let rating = aggregatorScored ? RATINGS.AVERAGE : RATINGS.POOR;
-      if (value > 0.33) {
-        rating = RATINGS.AVERAGE;
+      let rating = aggregatorScored ? RATINGS.AVERAGE.label : RATINGS.POOR.label;
+      if (value > RATINGS.AVERAGE.minValue) {
+        rating = RATINGS.AVERAGE.label;
       }
-      if (value > 0.66) {
-        rating = RATINGS.GOOD;
+      if (value > RATINGS.GOOD.minValue) {
+        rating = RATINGS.GOOD.label;
       }
 
       return rating;
@@ -91,12 +91,12 @@ class ReportGenerator {
     Handlebars.registerHelper('getTotalScoreRating', aggregation => {
       const totalScore = getTotalScore(aggregation);
 
-      let rating = RATINGS.POOR;
-      if (totalScore > 45) {
-        rating = RATINGS.AVERAGE;
+      let rating = RATINGS.POOR.label;
+      if (totalScore > RATINGS.POOR.minScore) {
+        rating = RATINGS.AVERAGE.label;
       }
-      if (totalScore > 75) {
-        rating = RATINGS.GOOD;
+      if (totalScore > RATINGS.GOOD.minScore) {
+        rating = RATINGS.GOOD.label;
       }
 
       return rating;
@@ -107,7 +107,7 @@ class ReportGenerator {
     Handlebars.registerHelper('getItemRating', getItemRating);
 
     Handlebars.registerHelper('showHelpText', value => {
-      return getItemRating(value) === RATINGS.GOOD ? 'hidden' : '';
+      return getItemRating(value) === RATINGS.GOOD.label ? 'hidden' : '';
     });
 
     // Convert numbers to fixed point decimals

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -25,8 +25,10 @@ function LighthouseReport() {
   this.checkboxToggleView = document.querySelector('.js-toggle-view');
   this.viewUserFeature = document.querySelector('.js-report-by-user-feature');
   this.viewTechnology = document.querySelector('.js-report-by-technology');
+  this.itemDetails = document.querySelectorAll('.report-section__item-details');
 
   this.updateView = this.updateView.bind(this);
+  this.toggleHelpText = this.toggleHelpText.bind(this);
 
   this.addEventListeners();
 }
@@ -47,9 +49,19 @@ LighthouseReport.prototype = {
     }
   },
 
+  toggleHelpText: function(e) {
+    if (e.target.classList.contains('report-section__item-help-toggle')) {
+      const el = e.currentTarget.parentNode.querySelector('.report-section__item-helptext')
+      el.hidden = !el.hidden;
+    }
+  },
+
   addEventListeners: function() {
     this.printButton.addEventListener('click', this.onPrint);
     this.checkboxToggleView.addEventListener('change', this.updateView);
+    Array.from(this.itemDetails).forEach(node => {
+      node.addEventListener('click', this.toggleHelpText);
+    });
   }
 };
 

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -51,7 +51,7 @@ LighthouseReport.prototype = {
 
   toggleHelpText: function(e) {
     if (e.target.classList.contains('report-section__item-help-toggle')) {
-      const el = e.currentTarget.parentNode.querySelector('.report-section__item-helptext')
+      const el = e.currentTarget.parentNode.querySelector('.report-section__item-helptext');
       el.hidden = !el.hidden;
     }
   },

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -25,7 +25,7 @@ function LighthouseReport() {
   this.checkboxToggleView = document.querySelector('.js-toggle-view');
   this.viewUserFeature = document.querySelector('.js-report-by-user-feature');
   this.viewTechnology = document.querySelector('.js-report-by-technology');
-  this.itemDetails = document.querySelectorAll('.report-section__item-details');
+  this.reportItems = document.querySelectorAll('.report-section__item');
 
   this.updateView = this.updateView.bind(this);
   this.toggleHelpText = this.toggleHelpText.bind(this);
@@ -51,15 +51,17 @@ LighthouseReport.prototype = {
 
   toggleHelpText: function(e) {
     if (e.target.classList.contains('report-section__item-help-toggle')) {
-      const el = e.currentTarget.parentNode.querySelector('.report-section__item-helptext');
-      el.hidden = !el.hidden;
+      const el = e.currentTarget.querySelector('.report-section__item-helptext');
+      if (el) {
+        el.hidden = !el.hidden;
+      }
     }
   },
 
   addEventListeners: function() {
     this.printButton.addEventListener('click', this.onPrint);
     this.checkboxToggleView.addEventListener('change', this.updateView);
-    Array.from(this.itemDetails).forEach(node => {
+    [...this.reportItems].forEach(node => {
       node.addEventListener('click', this.toggleHelpText);
     });
   }

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -386,6 +386,29 @@ a {
   max-width: 90%;
 }
 
+.report-section__item-help-toggle {
+  color: currentColor;
+  border-radius: 50%;
+  width: 21px;
+  height: 21px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0,0,0.3,1);
+  font-size: 90%;
+  font-weight: 600;
+  margin-left: 8px;
+  vertical-align: top;
+  opacity: 0.6;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.5);
+}
+
+.report-section__item-help-toggle:hover {
+  opacity: 1;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.7);
+}
+
 .report-section__item-raw-value {
   color: #777;
 }

--- a/lighthouse-core/report/templates/report.html
+++ b/lighthouse-core/report/templates/report.html
@@ -112,7 +112,12 @@ limitations under the License.
                       {{#if subItem.comingSoon}}
                       (Coming soon)
                       {{/if}}
+
+                      {{#if subItem.helpText }}
+                        <span class="report-section__item-help-toggle">?</span>
+                      {{/if}}
                     </span>
+
                     {{#if subItem.displayValue }}
                     <span class="report-section__item-raw-value">({{ subItem.displayValue }})&nbsp;</span>
                     {{/if }}
@@ -120,7 +125,7 @@ limitations under the License.
                   </div>
 
                   {{#if subItem.helpText }}
-                    <div class="report-section__item-helptext">
+                    <div class="report-section__item-helptext" {{showHelpText subItem.score}}>
                       {{{ subItem.helpText }}}
                     </div>
                   {{/if}}


### PR DESCRIPTION
R: @paullewis @paulirish @brendankenny 

- Hides `helpText` by default when the audit rating is "good". Shows it otherwise.
- Adds a ? button to toggle help text
- Note: the HTTPs audit here does not have `helpText`, which is why nothing is showing for that failed audit :)

<img width="863" alt="screen shot 2016-10-05 at 8 10 18 pm" src="https://cloud.githubusercontent.com/assets/238208/19139253/cb48346c-8b37-11e6-9f0d-b5d2602df81d.png">
