### PR TITLE
Report: Replace 'not unfunctioning' with 'still functional'

### DIFF
--- a/lighthouse-cli/test/fixtures/sample.json
+++ b/lighthouse-cli/test/fixtures/sample.json
@@ -482,7 +482,7 @@
         {
           "overall": 1,
           "name": "Site is progressively enhanced",
-          "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but not unfunctioning experience.",
+          "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but still functional experience.",
           "subItems": [
             "without-javascript"
           ]

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -131,7 +131,7 @@
       }
     }, {
       "name": "Site is progressively enhanced",
-      "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but not unfunctioning experience.",
+      "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but still functional experience.",
       "audits": {
         "without-javascript": {
           "expectedValue": true,

--- a/lighthouse-core/test/results/sample.json
+++ b/lighthouse-core/test/results/sample.json
@@ -473,7 +473,7 @@
         {
           "overall": 1,
           "name": "Site is progressively enhanced",
-          "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but not unfunctioning experience.",
+          "description": "Progressive enhancement means that everyone can access the basic content and functionality of a page in any browser, and those without certain browser features may receive a reduced but still functional experience.",
           "subItems": [
             "without-javascript"
           ]


### PR DESCRIPTION
Unfunctioning is not a real word :) Came across this today while writing up an article on the LH PE tests. "still functional" flowed better than "not non-functioning".