### PR TITLE
Disable cache contains start_url audit in config

### DIFF
--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -61,7 +61,6 @@
     "label",
     "tabindex",
     "content-width",
-    "cache-start-url",
     "geolocation-on-start"
   ],
 


### PR DESCRIPTION
I’ve had a few reports from Googlers of this audit incorrectly flagging when their manifest does have a valid `start_url` that’s definitely being cached in the Cache API.

After talking it over with Brendan, it appears there are known issues with this audit not being quite ready just yet. He’s happy with it being disabled in the config, so here’s that change for now ✂️ 🐐 