### PR TITLE
fix: disable extension system in launched Chrome instance

### DIFF
--- a/lighthouse-cli/chrome-launcher.js
+++ b/lighthouse-cli/chrome-launcher.js
@@ -43,6 +43,7 @@ module.exports = class Launcher {
   flags() {
     const flags = [
       '--remote-debugging-port=9222',
+      '--disable-extensions',
       '--no-first-run',
       `--user-data-dir=${this.TMP_PROFILE_DIR}`
     ];

--- a/lighthouse-core/scripts/launch-chrome.sh
+++ b/lighthouse-core/scripts/launch-chrome.sh
@@ -12,7 +12,7 @@ CHROME_ARGS=$@
 
 INITIAL_URL="about:blank"
 TMP_PROFILE_DIR=$(mktemp -d -t lighthouse.XXXXXXXXXX)
-CHROME_FLAGS="--remote-debugging-port=9222 --user-data-dir=$TMP_PROFILE_DIR --no-first-run $CHROME_ARGS"
+CHROME_FLAGS="--remote-debugging-port=9222 --disable-extensions --user-data-dir=$TMP_PROFILE_DIR --no-first-run $CHROME_ARGS"
 CHROME_PATH=""
 
 log_warning() {


### PR DESCRIPTION
Brendan and I were looking at some traces today and background pages were busy instantiating while we were tracing the page load. 

(This would add some CPU contention, but probably not anything too significant)

This PR disables Chrome extensions completely via chrome-launcher. 