### PR TITLE
make Chrome Launcher respect --quiet

### DIFF
--- a/lighthouse-cli/chrome-launcher.js
+++ b/lighthouse-cli/chrome-launcher.js
@@ -153,16 +153,24 @@ module.exports = class Launcher {
 
     return new Promise((resolve, reject) => {
       let retries = 0;
+      let waitStatus = 'Waiting for browser.';
       (function poll() {
+        const green = '\x1B[32m';
+        const reset = '\x1B[0m';
+
         if (retries === 0) {
-          log.log('ChromeLauncher', 'Waiting for browser...');
+          log.log('ChromeLauncher', waitStatus);
         }
         retries++;
-        log.verbose('ChromeLauncher', 'Waiting for browser...');
+        waitStatus += '..';
+        log.verbose('ChromeLauncher', waitStatus);
 
         launcher
           .isDebuggerReady()
-          .then(resolve)
+          .then(() => {
+            log.verbose('ChromeLauncher', waitStatus + `${green}✓${reset}`);
+            resolve();
+          })
           .catch(err => {
             if (retries > 10) {
               return reject(err);

--- a/lighthouse-cli/chrome-launcher.js
+++ b/lighthouse-cli/chrome-launcher.js
@@ -78,7 +78,7 @@ module.exports = class Launcher {
     // you can't pass a fd to fs.writeFileSync
     this.pidFile = `${this.TMP_PROFILE_DIR}/chrome.pid`;
 
-    log.log('ChromeLauncher', `created ${this.TMP_PROFILE_DIR}`);
+    log.verbose('ChromeLauncher', `created ${this.TMP_PROFILE_DIR}`);
 
     this.prepared = true;
   }
@@ -117,7 +117,7 @@ module.exports = class Launcher {
 
       fs.writeFileSync(this.pidFile, chrome.pid.toString());
 
-      log.log('ChromeLauncher', 'Chrome running with pid =', chrome.pid);
+      log.verbose('ChromeLauncher', 'Chrome running with pid =', chrome.pid);
       resolve(chrome.pid);
     })
     .then(pid => Promise.all([pid, this.waitUntilReady()]));
@@ -163,12 +163,12 @@ module.exports = class Launcher {
         }
         retries++;
         waitStatus += '..';
-        log.verbose('ChromeLauncher', waitStatus);
+        log.log('ChromeLauncher', waitStatus);
 
         launcher
           .isDebuggerReady()
           .then(() => {
-            log.verbose('ChromeLauncher', waitStatus + `${green}✓${reset}`);
+            log.log('ChromeLauncher', waitStatus + `${green}✓${reset}`);
             resolve();
           })
           .catch(err => {
@@ -204,7 +204,7 @@ module.exports = class Launcher {
 
   destroyTmp() {
     if (this.TMP_PROFILE_DIR) {
-      log.log('ChromeLauncher', `Removing ${this.TMP_PROFILE_DIR}`);
+      log.verbose('ChromeLauncher', `Removing ${this.TMP_PROFILE_DIR}`);
       rimraf.sync(this.TMP_PROFILE_DIR);
     }
   }

--- a/lighthouse-cli/index.js
+++ b/lighthouse-cli/index.js
@@ -30,6 +30,7 @@ const Printer = require('./printer');
 const lighthouse = require('../lighthouse-core');
 const assetSaver = require('../lighthouse-core/lib/asset-saver.js');
 const ChromeLauncher = require('./chrome-launcher');
+const log = require('../lighthouse-core/lib/log');
 
 const perfOnlyConfig = require('../lighthouse-core/config/perf.json');
 
@@ -152,6 +153,7 @@ if (cli.verbose) {
 } else if (cli.quiet) {
   flags.logLevel = 'error';
 }
+log.setLevel(flags.logLevel);
 
 const cleanup = {
   fns: [],
@@ -173,7 +175,7 @@ function launchChromeAndRun(addresses) {
   return launcher
     .isDebuggerReady()
     .catch(() => {
-      console.log('Launching Chrome...');
+      log.log('Lighthouse CLI', 'Launching Chrome...');
       return launcher.run();
     })
     .then(() => lighthouseRun(addresses))


### PR DESCRIPTION
this moves the chrome launcher class to using `log` for logging instead of a combo of `console.log` and `process.stdout.write`.

We lose the nice `Waiting for browser.....✓` animation, but it goes so fast I don't think much is lost there. In exchange, `--quiet` works again to silence all Lighthouse output but the results. This fixes piping the output and also makes things like smokehouse reporting a lot easier to read without the launcher repeatedly interrupting.

One possible issue: if you *do* want logging from `Launcher`, you have to first set `log.setLevel('info')` or whatever, otherwise nothing is logged. Lighthouse itself handles this internally, but downstream users of the launcher (like smokehouse) will also have to manually set it if they want log messages. It does seem like the default should be quiet like this, but others may disagree.