### PR TITLE
Open about:blank as initial URL.

### DIFF
--- a/lighthouse-cli/chrome-launcher.js
+++ b/lighthouse-cli/chrome-launcher.js
@@ -50,7 +50,8 @@ module.exports = class Launcher {
     if (process.platform === 'linux') {
       flags.push('--disable-setuid-sandbox');
     }
-
+    // open about:blank as starting page rather than NTP
+    flags.push('about:blank');
     return flags;
   }
 


### PR DESCRIPTION
[Just like the bash script](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/scripts/launch-chrome.sh#L13) we want the initial URL for our chrome instance to be "about:blank"

The chrome new tab page (NTP) uses a serviceworker and has a decent amount of network traffic and CPU load that we'd prefer doesn't interfere with our tests.