### PR TITLE
Adopt Perceptual Speed Index

### DIFF
--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -79,27 +79,28 @@ class SpeedIndexMetric extends Audit {
       //  95th Percentile = 17,400
       const distribution = TracingProcessor.getLogNormalDistribution(SCORING_MEDIAN,
         SCORING_POINT_OF_DIMINISHING_RETURNS);
-      let score = 100 * distribution.computeComplementaryPercentile(speedline.speedIndex);
+      let score = 100 * distribution.computeComplementaryPercentile(speedline.perceptualSpeedIndex);
 
       // Clamp the score to 0 <= x <= 100.
       score = Math.min(100, score);
       score = Math.max(0, score);
 
       const extendedInfo = {
+        speedline,
         first: speedline.first,
         complete: speedline.complete,
         duration: speedline.duration,
         frames: speedline.frames.map(frame => {
           return {
             timestamp: frame.getTimeStamp(),
-            progress: frame.getProgress()
+            progress: frame.getPerceptualProgress()
           };
         })
       };
 
       return SpeedIndexMetric.generateAuditResult({
         score: Math.round(score),
-        rawValue: Math.round(speedline.speedIndex),
+        rawValue: Math.round(speedline.perceptualSpeedIndex),
         optimalValue: this.meta.optimalValue,
         extendedInfo: {
           formatter: Formatter.SUPPORTED_FORMATS.SPEEDLINE,

--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -34,7 +34,7 @@ class SpeedIndexMetric extends Audit {
     return {
       category: 'Performance',
       name: 'speed-index-metric',
-      description: 'Speed Index',
+      description: 'Perceptual Speed Index',
       optimalValue: SCORING_POINT_OF_DIMINISHING_RETURNS.toLocaleString(),
       requiredArtifacts: ['traceContents']
     };
@@ -86,7 +86,6 @@ class SpeedIndexMetric extends Audit {
       score = Math.max(0, score);
 
       const extendedInfo = {
-        speedline,
         first: speedline.first,
         complete: speedline.complete,
         duration: speedline.duration,

--- a/lighthouse-core/test/audits/speed-index-metric-test.js
+++ b/lighthouse-core/test/audits/speed-index-metric-test.js
@@ -42,7 +42,8 @@ describe('Performance: speed-index-metric audit', () => {
 
     return {
       getTimeStamp: () => timestamp,
-      getProgress: () => progress
+      getProgress: () => progress,
+      getPerceptualProgress: () => progress
     };
   }
 
@@ -79,13 +80,14 @@ describe('Performance: speed-index-metric audit', () => {
   it('scores speed index of 831 as 100', () => {
     const SpeedlineResult = {
       frames: [frame(), frame(), frame()],
-      speedIndex: 831
+      speedIndex: 831,
+      perceptualSpeedIndex: 845
     };
     const artifacts = mockArtifactsWithSpeedlineResult(SpeedlineResult);
 
     return Audit.audit(artifacts).then(response => {
-      assert.equal(response.displayValue, '831');
-      assert.equal(response.rawValue, 831);
+      assert.equal(response.displayValue, '845');
+      assert.equal(response.rawValue, 845);
       assert.equal(response.score, 100);
     });
   });

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mkdirp": "^0.5.1",
     "rimraf": "^2.2.8",
     "semver": ">=4.3.3",
-    "speedline": "1.0.2",
+    "speedline": "1.0.3",
     "yargs": "3.30.0"
   },
   "repository": "googlechrome/lighthouse",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2638,9 +2638,9 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-speedline@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/speedline/-/speedline-1.0.2.tgz#acd8d8ee096cac48f2071a62bd635045ef887341"
+speedline@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/speedline/-/speedline-1.0.3.tgz#ee1d98c18d583a2d8488aaded2db9334b943dbbd"
   dependencies:
     babar "0.0.3"
     image-ssim "^0.2.0"


### PR DESCRIPTION
Our speed index metric has been using the classic speed index.
This PR updates us to use pSI: [Perceptual Speed Index (PSI) for measuring above-fold visual performance of webpages](http://www.parvez-ahammad.org/blog/perceptual-speed-index-psi-for-measuring-above-fold-visual-performance-of-webpages)

It also bumps speedline to 1.0.3 which includes bckenny's very nice perf upgrade: https://github.com/pmdartus/speedline/pull/35