### PR TITLE
TTI: Update scoring PODR

### DIFF
--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -15,7 +15,7 @@ const Formatter = require('../formatters/formatter');
 
 // Parameters (in ms) for log-normal CDF scoring. To see the curve:
 //   https://www.desmos.com/calculator/jlrx14q4w8
-const SCORING_POINT_OF_DIMINISHING_RETURNS = 1700;
+const SCORING_POINT_OF_DIMINISHING_RETURNS = 4500;
 const SCORING_MEDIAN = 5000;
 
 class TTIMetric extends Audit {


### PR DESCRIPTION
For #780. This will probably require some discussion. Alex's latest post on PWAs sets the bar for TTI to <5s. The current point of diminishing returns we use is 1700. I propose we raise this closer to 5000ms (here I use 4500) which has the following impact on the curve:

![screen shot 2016-10-16 at 6 47 39 pm](https://cloud.githubusercontent.com/assets/110953/19423039/26908d5a-93d1-11e6-98bc-3494198e6ae9.jpg)

For a site like housing.com, this takes the TTI score from:

**66** Time To Interactive (alpha) (3940.8ms)

to

**100** Time To Interactive (alpha) (3564.1ms)

cc @paulirish and @brendankenny as I believe they wrote a lot of the original code for the TTI implem.
