### PR TITLE
Migrate off chrome-remote-interface

### DIFF
--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -209,7 +209,7 @@ describe('Config', () => {
   it('loads an audit from node_modules/', () => {
     return assert.throws(_ => new Config({
       // Use a lighthouse dep as a stand in for a module.
-      audits: ['chrome-remote-interface']
+      audits: ['ws']
     }), function(err) {
       // Should throw an audit validation error, but *not* an audit not found error.
       return !/locate audit/.test(err) && /audit\(\) method/.test(err);

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -327,7 +327,7 @@ describe('GatherRunner', function() {
   it('loads a gatherer from node_modules/', () => {
     return assert.throws(_ => GatherRunner.getGathererClass(
         // Use a lighthouse dep as a stand in for a module.
-        'chrome-remote-interface'
+        'mocha'
     ), function(err) {
       // Should throw a gatherer validation error, but *not* a gatherer not found error.
       return !/locate gatherer/.test(err) && /beforePass\(\) method/.test(err);

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -120,7 +120,6 @@ gulp.task('browserify', () => {
           global: true
         })
         .ignore('../lighthouse-core/lib/asset-saver.js') // relative from gulpfile location
-        .ignore('chrome-remote-interface')
         .ignore('source-map');
 
         // Expose the audits, gatherers, and computed artifacts so they can be dynamically loaded.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "axe-core": "^1.1.1",
     "chrome-devtools-frontend": "1.0.422034",
-    "chrome-remote-interface": "^0.11.0",
     "debug": "^2.2.0",
     "devtools-timeline-model": "1.1.6",
     "gl-matrix": "2.3.2",
@@ -56,6 +55,7 @@
     "rimraf": "^2.2.8",
     "semver": ">=4.3.3",
     "speedline": "1.0.3",
+    "ws": "^1.1.1",
     "yargs": "3.30.0"
   },
   "repository": "googlechrome/lighthouse",

--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ _Some incomplete notes_
 
 ### Protocol
 
-* _Interacting with Chrome:_ The Chrome protocol connection maintained via  [chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface) for the CLI and [`chrome.debuggger` API](https://developer.chrome.com/extensions/debugger) when in the Chrome extension.
+* _Interacting with Chrome:_ The Chrome protocol connection maintained via [WebSocket](https://github.com/websockets/ws) for the CLI [`chrome.debuggger` API](https://developer.chrome.com/extensions/debugger) when in the Chrome extension.
 * _Event binding & domains_: Some domains must be `enable()`d so they issue events. Once enabled, they flush any events that represent state. As such, network events will only issue after the domain is enabled. All the protocol agents resolve their `Domain.enable()` callback _after_ they have flushed any pending events. See example:
 
 ```js

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,13 +392,6 @@ chrome-devtools-frontend@1.0.422034:
   version "1.0.422034"
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.422034.tgz#071c8ce14466b7653032fcd1ad1a4a68d5e3cbd9"
 
-chrome-remote-interface@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.11.1.tgz#d1818a6bc37ffa7039fa26c6d9801eaef8bb22c1"
-  dependencies:
-    commander "2.1.x"
-    ws "1.x.x"
-
 circular-json@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"


### PR DESCRIPTION
Lighthouse does not use generated SDK classes from remote-interface, it only uses raw messaging. This change is prerequisite to extracting connection abstraction from the driver. The next step is to inherit CriConnection, RawConnection and ExtensionConnection from the Connection and pass that abstract connection into the Driver.