### PR TITLE
test: add TracingProcessor tests for getLogNormalDistribution and getRiskToResponsiveness

### DIFF
--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -193,6 +193,21 @@ class TraceProcessor {
       percentiles = [0.5, 0.75, 0.9, 0.99, 1];
     }
 
+    const ret = TraceProcessor.getMainThreadTopLevelEventDurations(model, trace, startTime,
+        endTime);
+    return TraceProcessor._riskPercentiles(ret.durations, totalTime, percentiles,
+        ret.clippedLength);
+  }
+
+  /**
+   * Provides durations of all main thread top-level events
+   * @param {!traceviewer.Model} model
+   * @param {{traceEvents: !Array<!Object>}} trace
+   * @param {number} startTime Optional start time (in ms) of range of interest. Defaults to trace start.
+   * @param {number} endTime Optional end time (in ms) of range of interest. Defaults to trace end.
+   * @return {{durations: !Array<number>, clippedLength: number}}
+   */
+  static getMainThreadTopLevelEventDurations(model, trace, startTime, endTime) {
     // Find the main thread via the first TracingStartedInPage event in the trace
     const startEvent = trace.traceEvents.find(event => {
       return event.name === 'TracingStartedInPage';
@@ -227,8 +242,10 @@ class TraceProcessor {
     });
     durations.sort((a, b) => a - b);
 
-    // Actual calculation of percentiles done in _riskPercentiles.
-    return TraceProcessor._riskPercentiles(durations, totalTime, percentiles, clippedLength);
+    return {
+      durations,
+      clippedLength
+    };
   }
 
   /**

--- a/lighthouse-core/test/lib/traces/tracing-processor-test.js
+++ b/lighthouse-core/test/lib/traces/tracing-processor-test.js
@@ -170,51 +170,43 @@ describe('TracingProcessor lib', () => {
       const distribution = TracingProcessor.getLogNormalDistribution(median, pODM);
 
       function getPct(distribution, value) {
-        return distribution.computeComplementaryPercentile(value).toFixed(2);
+        return Number(distribution.computeComplementaryPercentile(value).toFixed(2));
       }
       assert.equal(typeof distribution.computeComplementaryPercentile, 'function');
-      assert.equal(getPct(distribution, 2000), '1.00', 'pct for 2000 does not match');
-      assert.equal(getPct(distribution, 3000), '0.98', 'pct for 3000 does not match');
-      assert.equal(getPct(distribution, 3500), '0.92', 'pct for 3500 does not match');
-      assert.equal(getPct(distribution, 4000), '0.81', 'pct for 4000 does not match');
-      assert.equal(getPct(distribution, 5000), '0.50', 'pct for 5000 does not match');
-      assert.equal(getPct(distribution, 6000), '0.24', 'pct for 6000 does not match');
-      assert.equal(getPct(distribution, 7000), '0.09', 'pct for 7000 does not match');
-      assert.equal(getPct(distribution, 8000), '0.03', 'pct for 8000 does not match');
-      assert.equal(getPct(distribution, 9000), '0.01', 'pct for 9000 does not match');
-      assert.equal(getPct(distribution, 10000), '0.00', 'pct for 10000 does not match');
+      assert.equal(getPct(distribution, 2000), 1.00, 'pct for 2000 does not match');
+      assert.equal(getPct(distribution, 3000), 0.98, 'pct for 3000 does not match');
+      assert.equal(getPct(distribution, 3500), 0.92, 'pct for 3500 does not match');
+      assert.equal(getPct(distribution, 4000), 0.81, 'pct for 4000 does not match');
+      assert.equal(getPct(distribution, 5000), 0.50, 'pct for 5000 does not match');
+      assert.equal(getPct(distribution, 6000), 0.24, 'pct for 6000 does not match');
+      assert.equal(getPct(distribution, 7000), 0.09, 'pct for 7000 does not match');
+      assert.equal(getPct(distribution, 8000), 0.03, 'pct for 8000 does not match');
+      assert.equal(getPct(distribution, 9000), 0.01, 'pct for 9000 does not match');
+      assert.equal(getPct(distribution, 10000), 0.00, 'pct for 10000 does not match');
     });
   });
 
   describe('risk to responsiveness', () => {
-    let oldFn;
-    // monkeypatch _riskPercentiles to deal with gRtR solo
-    beforeEach(() => {
-      oldFn = TracingProcessor._riskPercentiles;
-      TracingProcessor._riskPercentiles = (durations, totalTime, percentiles, clippedLength) => {
-        return {
-          durations, totalTime, percentiles, clippedLength
-        };
-      };
-    });
-    afterEach(() => {
-      TracingProcessor._riskPercentiles = oldFn;
-    });
-
     it('gets durations of top-level tasks', () => {
       const tracingProcessor = new TracingProcessor();
       const model = tracingProcessor.init(pwaTrace);
-      const ret = TracingProcessor.getRiskToResponsiveness(model, {traceEvents: pwaTrace});
+      const trace = {traceEvents: pwaTrace};
+      const ret = TracingProcessor.getMainThreadTopLevelEventDurations(model, trace);
       const durations = ret.durations;
+
+      function getDurationFromIndex(index) {
+        return Number(durations[index].toFixed(2));
+      }
 
       assert.equal(durations.filter(dur => isNaN(dur)).length, 0, 'NaN found');
       assert.equal(durations.length, 309);
-      assert.equal(durations[50], 0.012);
-      assert.equal(durations[100], 0.053);
-      assert.equal(durations[200], 0.558);
-      assert.equal(durations[durations.length - 3].toFixed(2), '26.32');
-      assert.equal(durations[durations.length - 2].toFixed(2), '37.61');
-      assert.equal(durations[durations.length - 1].toFixed(2), '40.10');
+
+      assert.equal(getDurationFromIndex(50), 0.01);
+      assert.equal(getDurationFromIndex(100), 0.05);
+      assert.equal(getDurationFromIndex(200), 0.56);
+      assert.equal(getDurationFromIndex(durations.length - 3), 26.32);
+      assert.equal(getDurationFromIndex(durations.length - 2), 37.61);
+      assert.equal(getDurationFromIndex(durations.length - 1), 40.10);
     });
   });
 });

--- a/lighthouse-core/test/lib/traces/tracing-processor-test.js
+++ b/lighthouse-core/test/lib/traces/tracing-processor-test.js
@@ -158,5 +158,29 @@ describe('TracingProcessor lib', () => {
       const expected = createRiskPercentiles([1], [16 + duration2]);
       assert.deepEqual(results, expected);
     });
+
+    it('creates a log normal distribution', () => {
+      // This curve plotted with the below percentile assertions
+      // https://www.desmos.com/calculator/vjk2rwd17y
+
+      const median = 5000;
+      const pODM = 3500;
+      const distribution = TracingProcessor.getLogNormalDistribution(median, pODM);
+
+      function getPct(distribution, value) {
+        return distribution.computeComplementaryPercentile(value).toFixed(2);
+      }
+      assert.equal(typeof distribution.computeComplementaryPercentile, 'function');
+      assert.equal(getPct(distribution, 2000), '1.00', 'pct for 2000 does not match');
+      assert.equal(getPct(distribution, 3000), '0.98', 'pct for 3000 does not match');
+      assert.equal(getPct(distribution, 3500), '0.92', 'pct for 3500 does not match');
+      assert.equal(getPct(distribution, 4000), '0.81', 'pct for 4000 does not match');
+      assert.equal(getPct(distribution, 5000), '0.50', 'pct for 5000 does not match');
+      assert.equal(getPct(distribution, 6000), '0.24', 'pct for 6000 does not match');
+      assert.equal(getPct(distribution, 7000), '0.09', 'pct for 7000 does not match');
+      assert.equal(getPct(distribution, 8000), '0.03', 'pct for 8000 does not match');
+      assert.equal(getPct(distribution, 9000), '0.01', 'pct for 9000 does not match');
+      assert.equal(getPct(distribution, 10000), '0.00', 'pct for 10000 does not match');
+    });
   });
 });


### PR DESCRIPTION
We didn't have test coverage for this method. The assertions test the shape of the curve and that our percentiles are correct.

![image](https://cloud.githubusercontent.com/assets/39191/19611817/4fefddb6-9798-11e6-9404-b27cf6e1c4b8.png)
https://www.desmos.com/calculator/0izses21rf