### PR TITLE
[Proposal] Report downloaded but offscreen images

### DIFF
--- a/lighthouse-core/audits/invisible-image.js
+++ b/lighthouse-core/audits/invisible-image.js
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Audit = require('./audit');
+const Formatter = require('../formatters/formatter');
+
+class InvisibleImage extends Audit {
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return {
+      category: 'Performance',
+      name: 'invisible-image',
+      description: 'Invisible images',
+      optimalValue: 0,
+      requiredArtifacts: ['InvisibleImage']
+    };
+  }
+
+  static audit(artifacts) {
+    const info = artifacts.InvisibleImage;
+
+    return InvisibleImage.generateAuditResult({
+      rawValue: info.length,
+      optimalValue: this.meta.optimalValue,
+      extendedInfo: {
+        formatter: Formatter.SUPPORTED_FORMATS.INVISIBLE_IMAGE,
+        value: info
+      }
+    });
+  }
+}
+
+module.exports = InvisibleImage;

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -3,8 +3,24 @@
     "recordNetwork": true,
     "recordTrace": true,
     "gatherers": []
+  },
+  {
+    "passName": "invisibleImage",
+    "recordNetwork": true,
+    "gatherers": [
+      "invisible-image"
+    ],
+    "size":{
+      "width" : 70,
+      "height" : 70
+    },
+    "range":{
+      "left" : 200,
+      "right" : "device-width",
+      "top" : 0,
+      "bottom" : "device-height/2"
+    }
   }],
-
   "audits": [
     "first-meaningful-paint",
     "speed-index-metric",
@@ -12,7 +28,8 @@
     "time-to-interactive",
     "user-timings",
     "screenshots",
-    "critical-request-chains"
+    "critical-request-chains",
+    "invisible-image"
   ],
 
   "aggregations": [{
@@ -55,6 +72,10 @@
         },
         "user-timings": {
           "expectedValue": 0,
+          "weight": 1
+        },
+        "invisible-image": {
+          "expectedValue": 100,
           "weight": 1
         }
       }

--- a/lighthouse-core/formatters/formatter.js
+++ b/lighthouse-core/formatters/formatter.js
@@ -45,7 +45,8 @@ class Formatter {
       urllist: require('./url-list'),
       null: require('./null-formatter'),
       speedline: require('./speedline-formatter'),
-      userTimings: require('./user-timings')
+      userTimings: require('./user-timings'),
+      invisibleImage: require('./invisible-image'),
     };
   }
 

--- a/lighthouse-core/formatters/invisible-image.js
+++ b/lighthouse-core/formatters/invisible-image.js
@@ -47,7 +47,7 @@ class InvisibleImage extends Formatter {
         };
 
       case 'html':
-        throw new Error('Unsupport html format');
+        '';
 
       default:
         throw new Error('Unknown formatter type');

--- a/lighthouse-core/formatters/invisible-image.js
+++ b/lighthouse-core/formatters/invisible-image.js
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Formatter = require('./formatter');
+
+class InvisibleImage extends Formatter {
+
+  /**
+   * gets the formatter for the CLI Printer and the HTML report.
+   */
+  static getFormatter(type) {
+    switch (type) {
+      case 'pretty':
+        return function(info) {
+          if (info === null ||
+              typeof info === 'undefined') {
+            return '';
+          }
+
+          const count = InvisibleImage._count(info);
+          const duration = InvisibleImage._duration(info);
+          const transferSize = InvisibleImage._transferSize(info);
+          const listup = InvisibleImage._listup(info);
+
+          const output = `    - Count: ${count}\n` +
+          `    - Duration: ${duration}ms\n` +
+          `    - Transfer Size: ${transferSize}KB\n` +
+          '    - List' +
+              '      ' + listup.replace(/\n/g, '\n      ') + '\n';
+          return output;
+        };
+
+      case 'html':
+        throw new Error('Unsupport html format');
+
+      default:
+        throw new Error('Unknown formatter type');
+    }
+  }
+
+  static _count(info) {
+    return info.length;
+  }
+
+  static _formatMS(ms) {
+    return Math.round(ms * 100) / 100;
+  }
+
+  static _formatSize(ms) {
+    return Math.round(ms / 10) / 100;
+  }
+
+  static _duration(info) {
+    return InvisibleImage._formatMS(info.reduce((prev, next) => {
+      return prev + next.perf.spendTime;
+    }, 0));
+  }
+
+  static _transferSize(info) {
+    return InvisibleImage._formatSize(info.reduce((prev, next) => {
+      return prev + next.perf.transferSize;
+    }, 0));
+  }
+
+  static _listup(info) {
+    const totalCount = info.length;
+    return info.reduce((prev, next, i) => {
+      let delimiter;
+      if (i === 0) {
+        delimiter = '┏━';
+      } else if (i === (totalCount - 1)) {
+        delimiter = '┗━';
+      } else {
+        delimiter = '┣━';
+      }
+      return `${prev}\n${delimiter} ${next.filename} - ` +
+              `${InvisibleImage._formatMS(next.perf.spendTime)}ms, ` +
+              `${InvisibleImage._formatSize(next.perf.transferSize)}KB`;
+    }, '');
+  }
+}
+
+module.exports = InvisibleImage;

--- a/lighthouse-core/formatters/invisible-image.js
+++ b/lighthouse-core/formatters/invisible-image.js
@@ -47,7 +47,7 @@ class InvisibleImage extends Formatter {
         };
 
       case 'html':
-        '';
+        return '';
 
       default:
         throw new Error('Unknown formatter type');

--- a/lighthouse-core/formatters/invisible-image.js
+++ b/lighthouse-core/formatters/invisible-image.js
@@ -28,8 +28,7 @@ class InvisibleImage extends Formatter {
     switch (type) {
       case 'pretty':
         return function(info) {
-          if (info === null ||
-              typeof info === 'undefined') {
+          if (!Array.isArray(info)) {
             return '';
           }
 

--- a/lighthouse-core/gather/gatherers/invisible-image.js
+++ b/lighthouse-core/gather/gatherers/invisible-image.js
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const Gatherer = require('./gatherer');
+/* global document */
+
+// This is run in the page, not Lighthouse itself.
+/* istanbul ignore next */
+function getInVisibleImages(range, size) {
+  const invisibleImages = [... document.querySelectorAll('img')].map(img => {
+    return [img.getBoundingClientRect(), img];
+  }).reduce((prev, data) => {
+    const info = data[0];
+    const img = data[1];
+    if (
+      img.src !== '' &&
+      info.width > size.width && info.height > size.height &&
+      (info.top < range.top * -1 ||
+      info.top > document.documentElement.clientHeight + range.bottom ||
+      info.left < range.left * -1 ||
+      info.left > document.documentElement.clientWidth + range.right)
+    ) {
+      prev[img.src] = {
+        url: img.src,
+        box: {
+          top: info.top,
+          bottom: info.bottom,
+          left: info.left,
+          right: info.right,
+          width: info.width,
+          height: info.height
+        }
+      };
+    }
+    return prev;
+  }, {});
+
+  return Promise.resolve(invisibleImages);
+}
+
+function reviseRange(param) {
+  return JSON.stringify(['left', 'right', 'top', 'bottom'].reduce((prev, current) => {
+    if (typeof param[current] === 'string') {
+      if (current === 'left' || current === 'right' ||
+         current === 'top' || current === 'bottom') {
+        prev[current] = param[current].replace(/(device\-)(w|h)/, (_, a, b) => {
+          return 'document.documentElement.client' + b.toUpperCase();
+        });
+      }
+    } else {
+      prev[current] = param[current] || 0;
+    }
+    return prev;
+  }, {})).replace(/"/g, '');
+}
+
+function reviseSize(param) {
+  param.width = param.width || 70;
+  param.height = param.height || 70;
+  return JSON.stringify(param);
+}
+
+class InvisibleImage extends Gatherer {
+
+  afterPass(options, tracingData) {
+    const driver = options.driver;
+    const navigationRecord = tracingData.networkRecords.reduce((prev, record) => {
+      if (/image/.test(record._mimeType)) {
+        prev[record._url] = {
+          transferSize: record._transferSize,
+          filename: record._parsedURL.lastPathComponent,
+          startTime: record._startTime,
+          endTime: record._endTime,
+          timing: record._timing
+        };
+      }
+      return prev;
+    }, {});
+
+    const range = reviseRange(options.config.range || {});
+    const size = reviseSize(options.config.size || {});
+    return driver.evaluateAsync(`(${getInVisibleImages.toString()})(${range},${size})`)
+      .then(data => {
+        const filteredData = Object.keys(data).reduce((prev, url) => {
+          if (navigationRecord[url]) {
+            data[url].filename = navigationRecord[url].filename;
+            data[url].perf = navigationRecord[url];
+            data[url].perf.spendTime = data[url].perf.endTime - data[url].perf.startTime;
+            prev.push(data[url]);
+          }
+          return prev;
+        }, []);
+
+        this.artifact = filteredData;
+        return;
+      }, _ => {
+        this.artifact = [];
+        return;
+      });
+  }
+}
+
+module.exports = InvisibleImage;


### PR DESCRIPTION
## Motivation

When I have analyzed load performance using devtools Almost performance bottleneck was network(images...). So, I have checked invisible image and applied lazy load image. I think that This practice is common sense.
## How to make it?

I have filtered image that checked size, position. So, I think that LH(LightHouse) have to support options size and position of image. If I ran LH that I think LH have to suggest perf enhance point. So. LH support 2 features.
- support option (size, position)
- perf enhance point

I have made prototype. What do you think about this feature?

![image](https://cloud.githubusercontent.com/assets/22300/19653449/8cfa7d4c-9a4f-11e6-981a-4d0e89f9f65e.png)

reference)
- [AMP Prioritize resource loading](https://www.ampproject.org/learn/how-amp-works/#prioritize-resource-loading)
- [Lazy loading image library in github](https://github.com/search?l=JavaScript&q=lazy+image+loading&ref=searchresults&type=Repositories&utf8=%E2%9C%93)
- [Lazy loading image article in google](https://www.google.co.kr/search?q=Lazy+loading+image&oq=Lazy+loading+image&aqs=chrome..69i57j0l5.1281j0j4&sourceid=chrome&ie=UTF-8)
