### PR TITLE
stop interpreting driver manifest errors as failure to fetch manifest

### DIFF
--- a/lighthouse-core/gather/gatherers/manifest.js
+++ b/lighthouse-core/gather/gatherers/manifest.js
@@ -19,6 +19,12 @@
 const Gatherer = require('./gatherer');
 const manifestParser = require('../../lib/manifest-parser');
 
+/**
+ * Uses the debugger protocol to fetch the manifest from within the context of
+ * the target page, reusing any credentials, emulation, etc, already established
+ * there. The artifact produced is the fetched string, if any, passed through
+ * the manifest parser.
+ */
 class Manifest extends Gatherer {
 
   static _errorManifest(errorString) {
@@ -30,34 +36,25 @@ class Manifest extends Gatherer {
   }
 
   afterPass(options) {
-    const driver = options.driver;
-    /**
-     * This re-fetches the manifest separately, which could
-     * potentially lead to a different asset. Using the original manifest
-     * resource is tracked in issue #83
-     */
-    return driver.sendCommand('Page.getAppManifest')
+    return options.driver.sendCommand('Page.getAppManifest')
       .then(response => {
-        if (response.errors.length) {
+        if (!response.data) {
           let errorString;
           if (response.url) {
-            errorString = `Unable to retrieve manifest at ${response.url}: `;
+            errorString = `Unable to retrieve manifest at ${response.url}`;
+          } else {
+            // The driver will return an empty string for url and the data if
+            // the page has no manifest.
+            errorString = 'No manifest found.';
           }
-          this.artifact = Manifest._errorManifest(errorString + response.errors.join(', '));
-          return;
-        }
 
-        // The driver will return an empty string for url and the data if the
-        // page has no manifest.
-        if (!response.data.length && !response.data.url) {
-          this.artifact = Manifest._errorManifest('No manifest found.');
+          this.artifact = Manifest._errorManifest(errorString);
           return;
         }
 
         this.artifact = manifestParser(response.data, response.url, options.url);
-      }, _ => {
-        this.artifact = Manifest._errorManifest('Unable to retrieve manifest');
-        return;
+      }, err => {
+        this.artifact = Manifest._errorManifest('Unable to retrieve manifest: ' + err);
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/manifest.js
+++ b/lighthouse-core/gather/gatherers/manifest.js
@@ -38,6 +38,9 @@ class Manifest extends Gatherer {
   afterPass(options) {
     return options.driver.sendCommand('Page.getAppManifest')
       .then(response => {
+        // We're not reading `response.errors` however it may contain critical and noncritical
+        // errors from Blink's manifest parser: 
+        //   https://chromedevtools.github.io/debugger-protocol-viewer/tot/Page/#type-AppManifestError
         if (!response.data) {
           let errorString;
           if (response.url) {

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -47,30 +47,32 @@ describe('Manifest gatherer', () => {
     });
   });
 
-  it('handles driver failure', () => {
-    return manifestGather.afterPass({
-      driver: {
-        sendCommand() {
-          return Promise.reject('such a fail');
-        }
-      }
-    }).then(_ => {
-      assert.ok(manifestGather.artifact.debugString);
-    });
-  });
-
-  it('propagates error retrieving the manifest', () => {
+  it('propagates error from driver failure', () => {
     const error = 'There was an error.';
     return manifestGather.afterPass({
       driver: {
         sendCommand() {
+          return Promise.reject(error);
+        }
+      }
+    }).then(_ => {
+      assert.ok(manifestGather.artifact.debugString);
+      assert.notStrictEqual(manifestGather.artifact.debugString.indexOf(error), -1);
+    });
+  });
+
+  it('emits an error when unable to retrieve the manifest', () => {
+    return manifestGather.afterPass({
+      driver: {
+        sendCommand() {
           return Promise.resolve({
-            errors: [error]
+            errors: [],
+            url: EXAMPLE_MANIFEST_URL
           });
         }
       }
     }).then(_ => {
-      assert.notStrictEqual(manifestGather.artifact.debugString.indexOf(error), -1);
+      assert.ok(manifestGather.artifact.debugString);
     });
   });
 


### PR DESCRIPTION
fixes #819 

currently any entries in `response.errors` are treated as a failure to fetch the manifest, even though they entires in `response.errors` are parsing errors. There are some caveats here: for instance, the debugger protocol will try to `JSON.parse()` a 404 message from a missing manifest and so will report a syntax error instead of the actual 404 error.

This PR works around this by ignoring the `errors` array and looking directly at the raw `data` and `url` returned.

This isn't perfect, however. Malformed JSON, for instance, will show up as `'Unable to retrieve manifest at ${response.url}`, but there's not really any signal we can use to get around that. The debugger protocol simply won't return anything on `response.data` in that case, and so is indistinguishable from e.g. a 404 page.