### PR TITLE
clarify description of --select-chrome command line flag

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -72,8 +72,8 @@ const cli = yargs
     'list-trace-categories': 'Prints a list of all required trace categories and exits',
     'config-path': 'The path to the config JSON.',
     'perf': 'Use a performance-test-only configuration',
-    'skip-autolaunch': 'Skip autolaunch of chrome when accessing port 9222 fails',
-    'select-chrome': 'Choose chrome location to use when multiple installations are found',
+    'skip-autolaunch': 'Skip autolaunch of Chrome when accessing port 9222 fails',
+    'select-chrome': 'Interactively choose version of Chrome to use when multiple installations are found',
   })
 
   .group([

--- a/readme.md
+++ b/readme.md
@@ -138,7 +138,8 @@ Options:
   --help             Show help                                                        [boolean]
   --version          Show version number                                              [boolean]
   --skip-autolaunch  Skip autolaunch of Chrome when accessing port 9222 fails         [boolean]
-  --select-chrome    Choose Chrome location when multiple installations are found     [boolean]
+  --select-chrome    Interactively choose version of Chrome to use when multiple
+                     installations are found                                          [boolean]
 ```
 
 ## Lighthouse w/ mobile devices


### PR DESCRIPTION
helps address situations like #827, since `--select-chrome` can sound like specifying the path directly.

Choosing a different flag name and/or being able to specify a `LIGHTHOUSE_CHROMIUM_PATH` on any platform can come later if demand warrants them.