### PR TITLE
Reduce eslint warnings.

### DIFF
--- a/lighthouse-cli/test/fixtures/offline-ready-sw.js
+++ b/lighthouse-cli/test/fixtures/offline-ready-sw.js
@@ -17,6 +17,7 @@
 'use strict';
 
 /* eslint-env worker, serviceworker */
+/* eslint max-nested-callbacks: ["error", 5] */
 
 // This service-worker courtesy of googlechrome.github.io/samples/service-worker/basic/index.html
 

--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -163,10 +163,10 @@ class Aggregate {
       // to the overall score and add each to the subItems list.
       expectedNames.forEach(e => {
         /* istanbul ignore if */
-        // TODO(paullewis): Remove once coming soon audits have landed.
+        // TODO(paullewis): Remove once coming soon audits have landed
         if (item.audits[e].comingSoon) {
           subItems.push({
-            score: '¯\\_(ツ)_/¯', // TODO(samthor): Patch going to Closure, String.raw is badly typed
+            score: '¯\\_(ツ)_/¯',
             name: 'coming-soon',
             category: item.audits[e].category,
             description: item.audits[e].description,

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -79,9 +79,6 @@ class TTIMetric extends Audit {
       const endOfTraceTime = model.bounds.max;
 
       // TODO: Wait for DOMContentLoadedEndEvent
-      // TODO: Wait for UA loading indicator to be done
-
-      // TODO CHECK these units are the same
       const fMPts = timings.fMPfull + timings.navStart;
 
       // look at speedline results for 85% starting at FMP
@@ -93,7 +90,6 @@ class TTIMetric extends Audit {
         });
 
         if (eightyFivePctVC) {
-          // TODO CHECK these units are the same
           visuallyReadyTiming = eightyFivePctVC.getTimeStamp() - timings.navStart;
         }
       }

--- a/lighthouse-core/closure/closure-type-checking.js
+++ b/lighthouse-core/closure/closure-type-checking.js
@@ -32,7 +32,7 @@ gulp.task('js-compile', function() {
     'lib/styles-helpers.js',
     'aggregator/**/*.js'
   ])
-    // TODO: hack to remove `require`s that Closure currently can't resolve.
+    // Hack to remove `require`s that Closure currently can't resolve.
     .pipe(replace('require(\'../lib/web-inspector\').Color.parse;',
         'WebInspector.Color.parse;'))
     .pipe(replace('require(\'../lib/traces/tracing-processor\');', '/** @type {?} */ (null);'))

--- a/lighthouse-core/test/formatter/formatters-test.js
+++ b/lighthouse-core/test/formatter/formatters-test.js
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+/* eslint max-nested-callbacks: ["error", 5] */
+
 const assert = require('assert');
 const walk = require('walk');
 const path = require('path');


### PR DESCRIPTION
The eslint results are pretty big and unwieldy.

I've +1'd the max nested callback depth in two tests and nuked a few TODOs that won't be happening for various reasons.

Still plenty of TODO warnings kept, but they're all quite reasonable, so I'm comfortable allowing them to keep bugging us. :)

![image](https://cloud.githubusercontent.com/assets/39191/19735548/e3b1d48e-9b60-11e6-8988-df5caeb47384.png)
