### PR TITLE
travis: Test node 6 and 7 explicitly 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: node_js
 matrix:
   include:
     - node_js: "4.3.2"
-    - node_js: "5.0"
-    - node_js: "node"
+    - node_js: "5"
+    - node_js: "6"
+    - node_js: "7"
 sudo: required
 dist: trusty
 cache:


### PR DESCRIPTION
* 6.0 currently isn't being tested, since `node` alias is now v7.x. This PR includes 6
* The `node` alias is dropped in exchange for `"7"`. While we'll have to manually update this as node stable bumps, I think the improvements for readability are worth it:
![image](https://cloud.githubusercontent.com/assets/39191/19738656/247d1c38-9b6d-11e6-850a-5abd95e43252.png)
