### PR TITLE
log.js: fix spread strings

### DIFF
--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -105,8 +105,8 @@ class Connection {
       callback.resolve(object.result);
       return;
     }
-    log.formatProtocol('method <= browser EVENT',
-        {method: object.method, params: object.result}, 'verbose');
+    log.formatProtocol('<= event',
+        {method: object.method, params: object.params}, 'verbose');
     this.emitNotification(object.method, object.params);
   }
 

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -86,7 +86,7 @@ class Log {
   }
 
   static warn(title) {
-    Log.events.issueWarning(title);
+    Log.events.issueWarning(arguments);
     return Log._logToStdErr(`${title}:warn`, Array.from(arguments).slice(1));
   }
 


### PR DESCRIPTION
Verbose logging regressed a bit ago:
![image](https://cloud.githubusercontent.com/assets/39191/19750154/b5fdd964-9ba3-11e6-8abd-ac91ddea07b8.png)

Strings were being spread into arrays. :)

This PR swaps out usage of `arguments` for spread args, along with some minor cleanup of the log module.
