### PR TITLE
Ensure HTML is written to disk when outputMode=pretty.

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -201,8 +201,8 @@ function lighthouseRun(addresses: Array<string>, config: Object) {
   return lighthouse(address, flags, config)
     .then((results: Results) => Printer.write(results, outputMode, outputPath))
     .then((results: Results) => {
-      if (outputMode === Printer.OutputMode.pretty) {
-        const filename = `./${assetSaver.getFilenamePrefix({url: address})}.report.html`
+      if (outputMode === Printer.OutputMode[Printer.OutputMode.pretty]) {
+        const filename = `./${assetSaver.getFilenamePrefix({url: address})}.report.html`;
         Printer.write(results, 'html', filename);
       }
 


### PR DESCRIPTION
`outputMode` in this case is derived from the CLI options and ends up being a regular string.
Then it's being compared to an enum value, which in Typscript is a number by default.

This PR ensures that we compare string against string and correctly write the HTML output to disk.

Note: there are cleaner ways to deal with enums in TS which I'd be happy to help with, but for now this fixes the issue.