### PR TITLE
navigate to about:blank before driver setup

### DIFF
--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -155,7 +155,7 @@ class ExtensionConnection extends Connection {
   }
 
   getCurrentTabId() {
-    return this.queryCurrentTab_().then(currentTab => {
+    return this._queryCurrentTab().then(currentTab => {
       return new Promise((resolve, reject) => {
         chrome.debugger.getTargets(targets => {
           const target = targets.find(target => target.tabId === currentTab.id);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -25,8 +25,9 @@ const path = require('path');
  * Execution sequence when GatherRunner.run() is called:
  *
  * 1. Setup
- *   A. driver.connect()
- *   B. GatherRunner.setupDriver()
+ *   A. navigate to about:blank
+ *   B. driver.connect()
+ *   C. GatherRunner.setupDriver()
  *     i. checkForMultipleTabsAttached
  *     ii. beginEmulation
  *     iii. cleanAndDisableBrowserCaches
@@ -46,7 +47,7 @@ const path = require('path');
  *     ii. all gatherer's afterPass()
  *
  * 3. Teardown
- *   A. driver.disconnect()
+ *   A. GatherRunner.disposeDriver()
  *   B. collect all artifacts and return them
  */
 class GatherRunner {
@@ -221,6 +222,7 @@ class GatherRunner {
     passes = this.instantiateGatherers(passes, options.config.configDir);
 
     return driver.connect()
+      .then(_ => GatherRunner.loadBlank(driver))
       .then(_ => GatherRunner.setupDriver(driver, options))
 
       // Run each pass


### PR DESCRIPTION
this is especially important for the extension, so we aren't still on the site while trying to clear state, turn on mobile emulation (which might trigger the page to do work), etc.

separate commit to fix a typo I missed in #639 that makes the new check throw in the extension :)