### PR TITLE
remove tab targetId dependency from multiple tab check

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -230,8 +230,6 @@ function showRuntimeError(err: LightHouseError) {
 function handleError(err: LightHouseError) {
   if (err.code === 'ECONNREFUSED') {
     showConnectionError();
-  } else if (err.message.toLowerCase().includes('multiple tabs')) {
-    console.error(err.message);
   } else {
     showRuntimeError(err);
   }

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -30,7 +30,6 @@ class CriConnection extends Connection {
   connect() {
     return this._runJsonCommand('new').then(response => {
       const url = response.webSocketDebuggerUrl;
-      this._tabId = response.id;
 
       return new Promise((resolve, reject) => {
         const ws = new WebSocket(url);
@@ -89,10 +88,6 @@ class CriConnection extends Connection {
    */
   sendRawMessage(message) {
     this._ws.send(message);
-  }
-
-  getCurrentTabId() {
-    return Promise.resolve(this._tabId);
   }
 }
 

--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -153,22 +153,6 @@ class ExtensionConnection extends Connection {
   getCurrentTabURL() {
     return this._queryCurrentTab().then(tab => tab.url);
   }
-
-  getCurrentTabId() {
-    return this._queryCurrentTab().then(currentTab => {
-      return new Promise((resolve, reject) => {
-        chrome.debugger.getTargets(targets => {
-          const target = targets.find(target => target.tabId === currentTab.id);
-
-          if (!target) {
-            reject(new Error('We can\'t find a target id.'));
-          }
-
-          resolve(target.id);
-        });
-      });
-    });
-  }
 }
 
 module.exports = ExtensionConnection;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -28,7 +28,7 @@ const path = require('path');
  *   A. navigate to about:blank
  *   B. driver.connect()
  *   C. GatherRunner.setupDriver()
- *     i. checkForMultipleTabsAttached
+ *     i. assertNoSameOriginServiceWorkerClients
  *     ii. beginEmulation
  *     iii. cleanAndDisableBrowserCaches
  *     iiii. clearDataForOrigin
@@ -87,7 +87,7 @@ class GatherRunner {
   static setupDriver(driver, options) {
     log.log('status', 'Initializing…');
     // Enable emulation based on flags
-    return driver.checkForMultipleTabsAttached(options.url)
+    return driver.assertNoSameOriginServiceWorkerClients(options.url)
       .then(_ => driver.beginEmulation(options.flags))
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cleanAndDisableBrowserCaches())

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -17,10 +17,10 @@
 
 'use strict';
 
-const Driver = require('../../../gather/driver.js');
-const Connection = require('../../../gather/connections/connection.js');
-const Element = require('../../../lib/element.js');
-const NetworkRecorder = require('../../../lib/network-recorder');
+const Driver = require('../../gather/driver.js');
+const Connection = require('../../gather/connections/connection.js');
+const Element = require('../../lib/element.js');
+const NetworkRecorder = require('../../lib/network-recorder');
 const assert = require('assert');
 
 const connection = new Connection();
@@ -114,17 +114,32 @@ describe('Browser Driver', () => {
 });
 
 describe('Multiple tab check', () => {
-  it('will fail when multiple tabs are found with the same active serviceworker', () => {
+  it('will pass if there are no current service workers', () => {
     const pageUrl = 'https://example.com/';
-    const swUrl = `${pageUrl}sw.js`;
+    driverStub.once = createOnceStub({
+      'ServiceWorker.workerRegistrationUpdated': {
+        registrations: []
+      },
+      'ServiceWorker.workerVersionUpdated': {
+        versions: []
+      }
+    });
+
+    return driverStub.assertNoSameOriginServiceWorkerClients(pageUrl);
+  });
+
+  it('will pass if there is an active service worker for a different origin', () => {
+    const pageUrl = 'https://example.com/';
+    const secondUrl = 'https://example.edu';
+    const swUrl = `${secondUrl}sw.js`;
+
     const registrations = [
-      createSWRegistration(1, pageUrl),
+      createSWRegistration(1, secondUrl),
     ];
     const versions = [
-      createActiveWorker(1, swUrl, ['unique'])
+      createActiveWorker(1, swUrl, ['uniqueId'])
     ];
 
-    driverStub.getCurrentTabId = () => Promise.resolve('unique2');
     driverStub.once = createOnceStub({
       'ServiceWorker.workerRegistrationUpdated': {
         registrations
@@ -134,21 +149,19 @@ describe('Multiple tab check', () => {
       }
     });
 
-    return driverStub.checkForMultipleTabsAttached(pageUrl)
-      .then(_ => assert.ok(false), _ => assert.ok(true));
+    return driverStub.assertNoSameOriginServiceWorkerClients(pageUrl);
   });
 
-  it('will succeed when service worker is already registered on current tab', () => {
+  it('will fail if a service worker with a matching origin has a controlled client', () => {
     const pageUrl = 'https://example.com/';
     const swUrl = `${pageUrl}sw.js`;
     const registrations = [
       createSWRegistration(1, pageUrl),
     ];
     const versions = [
-      createActiveWorker(1, swUrl, ['unique'])
+      createActiveWorker(1, swUrl, ['uniqueId'])
     ];
 
-    driverStub.getCurrentTabId = () => Promise.resolve('unique');
     driverStub.once = createOnceStub({
       'ServiceWorker.workerRegistrationUpdated': {
         registrations
@@ -158,17 +171,19 @@ describe('Multiple tab check', () => {
       }
     });
 
-    return driverStub.checkForMultipleTabsAttached(pageUrl)
-      .then(_ => assert.ok(true), _ => assert.ok(false));
+    return driverStub.assertNoSameOriginServiceWorkerClients(pageUrl)
+      .then(_ => assert.ok(false),
+          err => {
+            assert.ok(err.message.toLowerCase().includes('multiple tabs'));
+          });
   });
 
-  it('will succeed when only one service worker loaded', () => {
+  it('will succeed if a service worker with a matching origin has no controlled clients', () => {
     const pageUrl = 'https://example.com/';
     const swUrl = `${pageUrl}sw.js`;
     const registrations = [createSWRegistration(1, pageUrl)];
     const versions = [createActiveWorker(1, swUrl, [])];
 
-    driverStub.getCurrentTabId = () => Promise.resolve('unique');
     driverStub.once = createOnceStub({
       'ServiceWorker.workerRegistrationUpdated': {
         registrations
@@ -178,7 +193,6 @@ describe('Multiple tab check', () => {
       }
     });
 
-    return driverStub.checkForMultipleTabsAttached(pageUrl)
-      .then(_ => assert.ok(true), _ => assert.ok(false));
+    return driverStub.assertNoSameOriginServiceWorkerClients(pageUrl);
   });
 });

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -29,7 +29,7 @@ module.exports = {
   beginEmulation() {
     return Promise.resolve();
   },
-  checkForMultipleTabsAttached() {
+  assertNoSameOriginServiceWorkerClients() {
     return Promise.resolve();
   },
   reloadForCleanStateIfNeeded() {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -54,7 +54,7 @@ function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn) {
     enableRuntimeEvents() {
       return Promise.resolve();
     }
-    checkForMultipleTabsAttached() {
+    assertNoSameOriginServiceWorkerClients() {
       return Promise.resolve();
     }
     cleanAndDisableBrowserCaches() {}


### PR DESCRIPTION
Followup to #639. Unfortunately we don't necessarily have a tab ID (particularly in the case of the `raw` connection where Lighthouse doesn't establish the debugger connection), so we can't use the id to check against `controlledClients` of any active service workers.

However, with the change to first navigate to `about:blank` in #850, we know the current tab _can't_ be controlled by a service worker for the target URL, so we can simplify the multiple tab check to just find any service worker for the target URL with any controlled clients at all.
