### PR TITLE
Handle error messages from remote protocol correctly.

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -221,7 +221,9 @@ function showConnectionError() {
 
 function showRuntimeError(err: LightHouseError) {
   console.error('Runtime error encountered:', err);
-  console.error(err.stack);
+  if (err.stack) {
+    console.error(err.stack);
+  }
   process.exit(_RUNTIME_ERROR_CODE);
 }
 

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -96,8 +96,8 @@ class Connection {
       this._callbacks.delete(object.id);
       if (object.error) {
         log.formatProtocol('method <= browser ERR',
-            {method: callback.method, params: object.result}, 'error');
-        callback.reject(object.result);
+            {method: callback.method}, 'error');
+        callback.reject(object.error);
         return;
       }
       log.formatProtocol('method <= browser OK',


### PR DESCRIPTION
If the result of parsing the incoming message from `json` => `pojo` contains an error, the
 `result` property will not exist. This means error handling later in the program will fail since
 you will not be able to access `error.code`, `error.stack` etc.

Before: (current master branch)
<img width="1109" alt="screen shot 2016-10-29 at 10 53 50" src="https://cloud.githubusercontent.com/assets/1643522/19828735/3cca65ec-9dc6-11e6-9fc0-9eb419e1457e.png">

After: 
<img width="1116" alt="screen shot 2016-10-29 at 11 08 56" src="https://cloud.githubusercontent.com/assets/1643522/19828806/2c78de6a-9dc8-11e6-96c5-871061440f92.png">
