### PR TITLE
log: force red color on errors, yellow on warnings.

### DIFF
--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -60,7 +60,7 @@ class Log {
   static _logToStdErr(title, argsArray) {
     const args = [...argsArray];
     const log = Log.loggerfn(title);
-    return log(...args);
+    log(...args);
   }
 
   static loggerfn(title) {

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -17,7 +17,10 @@
 'use strict';
 
 const debug = require('debug');
+const debugNode = require('debug/node');
 const EventEmitter = require('events').EventEmitter;
+
+debugNode.colors = [6, 2, 4, 5];
 
 class Emitter extends EventEmitter {
   /**
@@ -46,10 +49,19 @@ class Log {
 
   static _logToStdErr(title, argsArray) {
     const args = [...argsArray];
-    if (!loggersByTitle[title]) {
-      loggersByTitle[title] = debug(title);
+    const log = Log.loggerfn(title);
+    return log(...args);
+  }
+
+  static loggerfn(title) {
+    let log = loggersByTitle[title];
+    if (!log) {
+      log = loggersByTitle[title] = debug(title);
+      // errors with red, warnings with yellow.
+      // eslint-disable-next-line no-nested-ternary
+      log.color = title.includes('error') ? 1 : title.includes('warn') ? 3 : undefined;
     }
-    return loggersByTitle[title](...args);
+    return log;
   }
 
   static setLevel(level) {

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -20,7 +20,17 @@ const debug = require('debug');
 const debugNode = require('debug/node');
 const EventEmitter = require('events').EventEmitter;
 
-debugNode.colors = [6, 2, 4, 5];
+const colors = {
+  red: 1,
+  yellow: 3,
+  cyan: 6,
+  green: 2,
+  blue: 4,
+  magenta: 5
+};
+
+// whitelist non-red/yellow colors for debug()
+debugNode.colors = [colors.cyan, colors.green, colors.blue, colors.magenta];
 
 class Emitter extends EventEmitter {
   /**
@@ -56,10 +66,12 @@ class Log {
   static loggerfn(title) {
     let log = loggersByTitle[title];
     if (!log) {
-      log = loggersByTitle[title] = debug(title);
+      log = debug(title);
+      loggersByTitle[title] = log;
       // errors with red, warnings with yellow.
       // eslint-disable-next-line no-nested-ternary
-      log.color = title.includes('error') ? 1 : title.includes('warn') ? 3 : undefined;
+      log.color = title.endsWith('error') ? colors.red :
+          title.endsWith('warn') ? colors.yellow : undefined;
     }
     return log;
   }


### PR DESCRIPTION
Small followup from #835, from @wardpeet's suggestion..

Errors are red, warnings are yellow. And the other logs will never use those colors

![image](https://cloud.githubusercontent.com/assets/39191/19867549/7a12d546-9f61-11e6-98c1-9ffacb26b95e.png)
![image](https://cloud.githubusercontent.com/assets/39191/19867555/7d8eff2e-9f61-11e6-9d9f-4008c0938463.png)
