### PR TITLE
Recover if protocol DOM agent throws error about domain not being enabled

### DIFF
--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -94,11 +94,9 @@ class Connection {
     if (object.id) {
       const callback = this._callbacks.get(object.id);
       this._callbacks.delete(object.id);
+
       if (object.error) {
-        log.formatProtocol('method <= browser ERR',
-            {method: callback.method}, 'error');
-        callback.reject(object.error);
-        return;
+        return this._handleRawError(object, callback);
       }
       log.formatProtocol('method <= browser OK',
           {method: callback.method, params: object.result}, 'verbose');
@@ -108,6 +106,18 @@ class Connection {
     log.formatProtocol('<= event',
         {method: object.method, params: object.params}, 'verbose');
     this.emitNotification(object.method, object.params);
+  }
+
+  _handleRawError(object, callback) {
+    // We proactively disable a few domains. Ignore any errors
+    if (object.error.message && object.error.message.includes('DOM agent hasn\'t been enabled')) {
+      callback.resolve();
+      return;
+    }
+    log.formatProtocol('method <= browser ERR',
+        {method: callback.method}, 'error');
+    callback.reject(object.error);
+    return;
   }
 
   /**

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -109,15 +109,9 @@ class Connection {
   }
 
   _handleRawError(object, callback) {
-    // We proactively disable a few domains. Ignore any errors
-    if (object.error.message && object.error.message.includes('DOM agent hasn\'t been enabled')) {
-      callback.resolve();
-      return;
-    }
     log.formatProtocol('method <= browser ERR',
         {method: callback.method}, 'error');
     callback.reject(object.error);
-    return;
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -440,9 +440,11 @@ class Driver {
       options: 'sampling-frequency=10000'  // 1000 is default and too slow.
     };
 
+    // Disable any domains that could interfere or add overhead to the trace
     return this.sendCommand('Debugger.disable')
       .then(_ => this.sendCommand('DOM.disable'))
       .then(_ => this.sendCommand('CSS.disable'))
+      // Enable Page domain to wait for Page.loadEventFired
       .then(_ => this.sendCommand('Page.enable'))
       .then(_ => this.sendCommand('Tracing.start', tracingOpts));
   }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -442,8 +442,12 @@ class Driver {
 
     // Disable any domains that could interfere or add overhead to the trace
     return this.sendCommand('Debugger.disable')
-      .then(_ => this.sendCommand('DOM.disable'))
       .then(_ => this.sendCommand('CSS.disable'))
+      .then(_ => {
+        return this.sendCommand('DOM.disable')
+          // If it wasn't already enabled, it will throw; ignore these. See #861
+          .catch(_ => {});
+      })
       // Enable Page domain to wait for Page.loadEventFired
       .then(_ => this.sendCommand('Page.enable'))
       .then(_ => this.sendCommand('Tracing.start', tracingOpts));


### PR DESCRIPTION
This fixes a regression we introduced in #830 

DOM agent the only domain which complains if you attempt to disable when it was never enabled.

https://cs.chromium.org/search/?q=if.*!enabled+file:%5Esrc/third_party/WebKit/Source/core/inspector/+case:yes&sq=package:chromium&type=cs

This PR permits us to ignore these errors. And it should unbreak the `master` build.