### PR TITLE
Address inconsistencies with errors raised within Promise flows.

### DIFF
--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -111,7 +111,7 @@ class Connection {
   _handleRawError(object, callback) {
     log.formatProtocol('method <= browser ERR',
         {method: callback.method}, 'error');
-    callback.reject(object.error);
+    callback.reject(new Error(`Raw Protocol (${callback.method}) ${object.error.message}`));
   }
 
   /**

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -64,7 +64,7 @@ class CriConnection extends Connection {
             resolve(JSON.parse(data));
             return;
           }
-          reject('Unable to fetch webSocketDebuggerUrl, status: ' + response.statusCode);
+          reject(new Error(`Unable to fetch webSocketDebuggerUrl, status: ${response.statusCode}`));
         });
       });
     });
@@ -75,7 +75,7 @@ class CriConnection extends Connection {
    */
   disconnect() {
     if (!this._ws) {
-      return Promise.reject('connect() must be called before attempting to disconnect.');
+      return Promise.reject(new Error('connect() must be called before attempting to disconnect.'));
     }
     this._ws.removeAllListeners();
     this._ws.close();

--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -85,7 +85,7 @@ class Styles extends Gatherer {
   endStylesCollect(driver) {
     return new Promise((resolve, reject) => {
       if (!this._activeStyleSheetIds.length) {
-        reject('No active stylesheets were collected.');
+        reject(new Error('No active stylesheets were collected.'));
         return;
       }
 

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Better docs coming soon, but in the meantime look at [PR #593](https://github.co
 Lighthouse can be used to analyze trace and performance data collected from other tools (like WebPageTest and ChromeDriver). The `traces` and `performanceLog` artifact items can be provided using a string for the absolute path on disk. The perf log is captured from the Network domain (a la ChromeDriver's [`enableNetwork` option](https://sites.google.com/a/chromium.org/chromedriver/capabilities#TOC-perfLoggingPrefs-object)) and reformatted slightly. As an example, here's a trace-only run that's reporting on user timings and critical request chains:
 
 ##### `config.json`
-```js
+```json
 {
   "audits": [
     "user-timings",
@@ -168,7 +168,7 @@ $ lighthouse --disable-device-emulation --disable-cpu-throttling https://mysite.
 
 Some basic unit tests forked are in `/test` and run via mocha. eslint is also checked for style violations.
 
-```js
+```sh
 # lint and test all files
 npm test
 
@@ -242,7 +242,7 @@ Promise.resolve({
   rawValue: {},
   // debugString: Some *specific* error string for helping the user figure out why they failed here.
   //   The reporter can handle *general* feedback on how to fix, e.g. links to the docs
-  debugString: 'Your manifest 404ed'
+  debugString: 'Your manifest 404ed',
   // fault:  Optional argument when the audit doesn't cover whatever it is you're doing,
   //   e.g. we can't parse your particular corner case out of a trace yet.
   //   Whatever is in `rawValue` and `score` would be N/A in these cases


### PR DESCRIPTION
Where possible, avoid using anything other than Error objects when rejecting promises.
This is especially important when a receiver expects properties that only exist on
native Error objects to be present.