### PR TITLE
add `main` field in package.json (cli)

### DIFF
--- a/lighthouse-cli/package.json
+++ b/lighthouse-cli/package.json
@@ -1,4 +1,5 @@
 {
+  "main": "index.js",
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w"


### PR DESCRIPTION
without it, npm will not automatically bundle non top-level
index.js files in a mono-repo setup such as this

re: https://github.com/GoogleChrome/lighthouse/issues/854