### PR TITLE
add support for `silent` log level

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -54,11 +54,13 @@ const cli = yargs
   // List of options
   .group([
     'verbose',
-    'quiet'
+    'quiet',
+    'silent'
   ], 'Logging:')
   .describe({
     verbose: 'Displays verbose logging',
-    quiet: 'Displays no progress or debug logs'
+    quiet: 'Displays no progress or debug logs (only errors + results)',
+    silent: 'Displays no debugging information (only results)'
   })
 
   .group([
@@ -157,6 +159,8 @@ if (cli.verbose) {
   flags.logLevel = 'verbose';
 } else if (cli.quiet) {
   flags.logLevel = 'error';
+} else if (cli.silent) {
+  flags.logLevel = 'silent';
 }
 
 log.setLevel(flags.logLevel);

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -51,7 +51,7 @@ module.exports = function(url, flags, configJSON) {
 
     flags = flags || {};
 
-    // set logging preferences, assume quiet
+    // set logging preferences, assume quiet/silent
     flags.logLevel = flags.logLevel || 'error';
     log.setLevel(flags.logLevel);
 

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -51,7 +51,7 @@ module.exports = function(url, flags, configJSON) {
 
     flags = flags || {};
 
-    // set logging preferences, assume quiet/silent
+    // set logging preferences, assume quiet
     flags.logLevel = flags.logLevel || 'error';
     log.setLevel(flags.logLevel);
 

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -54,6 +54,8 @@ class Log {
 
   static setLevel(level) {
     switch (level) {
+      case 'silent':
+        break;
       case 'verbose':
         debug.enable('*');
         break;


### PR DESCRIPTION
This is essential for users of the api.

Before: no control over terminal output
![untitled](https://cloud.githubusercontent.com/assets/1643522/19875127/17aec8ea-9fc2-11e6-84f8-fc52215d5bde.gif)

After: ahhhh feel the fresh air
![untitled2](https://cloud.githubusercontent.com/assets/1643522/19875131/2056472a-9fc2-11e6-9d97-818d7182b8e7.gif)


