### PR TITLE
restore log's status-event payload

### DIFF
--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -81,7 +81,7 @@ class Log {
   }
 
   static log(title) {
-    Log.events.issueStatus(title);
+    Log.events.issueStatus(title, arguments);
     return Log._logToStdErr(title, Array.from(arguments).slice(1));
   }
 


### PR DESCRIPTION
currently breaks extension because extension then [attempts to destructure](https://github.com/GoogleChrome/lighthouse/blob/09ec5b6bd4d3361e923a867f947ce97b6642a96b/lighthouse-extension/app/src/popup.js#L58) `undefined`