### PR TITLE
When fail css parse that not working no-old-flexbox.

### DIFF
--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -32,16 +32,16 @@ const Gatherer = require('./gatherer');
  */
 function getCSSPropsInStyleSheet(parseTree) {
   const results = [];
-
-  parseTree.traverseByType('declaration', function(node, index, parent) {
-    const keyVal = node.toString().split(':').map(item => item.trim());
-    results.push({
-      property: {name: keyVal[0], val: keyVal[1]},
-      declarationRange: node.declarationRange,
-      selector: parent.selectors.toString()
+  try{
+    parseTree.traverseByType('declaration', function(node, index, parent) {
+      const keyVal = node.toString().split(':').map(item => item.trim());
+      results.push({
+        property: {name: keyVal[0], val: keyVal[1]},
+        declarationRange: node.declarationRange,
+        selector: parent.selectors.toString()
+      });
     });
-  });
-
+  }catch(e){}
   return results;
 }
 


### PR DESCRIPTION
When css parser fail parsing that css parser returned [empty array](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/lib/web-inspector.js#L283-L285).  `parseTree` has not `traverseByType` function since `parseTree` is empty array. So, `getCSSPropsInStyleSheet` is not wokring.
![image](https://cloud.githubusercontent.com/assets/22300/20014755/a281ff00-a2fb-11e6-9031-4800c1203e31.png)

You can check this issue when you run below command.
```
node lighthouse-cli --config-path=lighthouse-core/config/dobetterweb.json  https://m.naver.com
```
