### PR TITLE
Handle CSS parse errors in stylesheet gatherer

### DIFF
--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -25,6 +25,7 @@
 
 const WebInspector = require('../../lib/web-inspector');
 const Gatherer = require('./gatherer');
+const log = require('../../lib/log.js');
 
 /**
  * @param {!gonzales.AST} parseTree
@@ -98,9 +99,15 @@ class Styles extends Gatherer {
         }).then(content => {
           const styleHeader = this._activeStyleHeaders[sheetId];
           styleHeader.content = content.text;
+
           const parsedContent = parser.parse(styleHeader.content);
-          styleHeader.parsedContent = parsedContent.error ?
-              [] : getCSSPropsInStyleSheet(parsedContent);
+          if (parsedContent.error) {
+            log.warn('Styles Gatherer', '....${parsedContent.error}');
+            styleHeader.parsedContent = [];
+          } else {
+            styleHeader.parsedContent = getCSSPropsInStyleSheet(parsedContent);
+          }
+
           return styleHeader;
         });
       });

--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -102,7 +102,7 @@ class Styles extends Gatherer {
 
           const parsedContent = parser.parse(styleHeader.content);
           if (parsedContent.error) {
-            log.warn('Styles Gatherer', '....${parsedContent.error}');
+            log.warn('Styles Gatherer', `Could not parse content: ${parsedContent.error}`);
             styleHeader.parsedContent = [];
           } else {
             styleHeader.parsedContent = getCSSPropsInStyleSheet(parsedContent);

--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -98,8 +98,9 @@ class Styles extends Gatherer {
         }).then(content => {
           const styleHeader = this._activeStyleHeaders[sheetId];
           styleHeader.content = content.text;
-          styleHeader.parsedContent = getCSSPropsInStyleSheet(
-              parser.parse(styleHeader.content));
+          const parsedContent = parser.parse(styleHeader.content);
+          styleHeader.parsedContent = parsedContent.error ?
+              [] : getCSSPropsInStyleSheet(parsedContent);
           return styleHeader;
         });
       });

--- a/lighthouse-core/lib/web-inspector.js
+++ b/lighthouse-core/lib/web-inspector.js
@@ -281,7 +281,7 @@ module.exports = (function() {
     try {
       ast = gonzales.parse(content, {syntax: 'css'});
     } catch (e) {
-      return [];
+      return {error: e};
     }
 
     /** @type {!{properties: !Array<!Gonzales.Node>, node: !Gonzales.Node}} */


### PR DESCRIPTION
R: @paulirish @brendankenny @samccone 

This is a better fix for the bug found in #902. Stylesheets that can't be parsed now return an error.  Future audits may want to use this information somehow.