### PR TITLE
Catch DOM.disable exception so it doesn't interrupt the extension.

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -423,7 +423,11 @@ class Driver {
     // Disable any domains that could interfere or add overhead to the trace
     return this.sendCommand('Debugger.disable')
       .then(_ => this.sendCommand('CSS.disable'))
-      .then(_ => this.sendCommand('DOM.disable'))
+      .then(_ => {
+        return this.sendCommand('DOM.disable')
+          // If it wasn't already enabled, it will throw; ignore these. See #861
+          .catch(_ => {});
+      })
       // Enable Page domain to wait for Page.loadEventFired
       .then(_ => this.sendCommand('Page.enable'))
       .then(_ => this.sendCommand('Tracing.start', tracingOpts));


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/39191/20026849/9b0e4fde-a2c0-11e6-94d1-1dedbcd750e5.png)
