### PR TITLE
Don't include disabled links in link-blocking-first-paint audit

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_disabled.css
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_disabled.css
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+body {
+  display: box; /* PASS: in disabled stylesheet */
+}

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_disabled.css
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_disabled.css
@@ -15,6 +15,13 @@
  * limitations under the License.
  */
 
+/**
+ * Note: although this stylesheet uses rules that violate certain style audits
+ * (e.g. old CSS flexbox), those rules will not show up as violations. This is
+ * because this stylsheet is loaded using the `disabled` attribute, meaning it
+ * won't be collected by the style gatherer as an "active stylesheet".
+ */
+
 body {
-  display: box; /* PASS: in disabled stylesheet */
+  display: box; /* PASS - see note above. */
 }

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -22,10 +22,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 
 <script src="./dbw_tester.js"></script>
-<link rel="stylesheet" type="text/css" href="./dbw_tester.css">
+<link rel="stylesheet" href="./dbw_tester.css">
+<link rel="stylesheet" href="./dbw_disabled.css" disabled>
 <style>
   body {
-    color: red;
+    color: white;
   }
   p, div {
     background: red, green;

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -33,8 +33,8 @@ class LinkBlockingFirstPaintAudit extends Audit {
     return {
       category: 'Performance',
       name: 'link-blocking-first-paint',
-      description: 'Site does not use <link> that block first paint',
-      helpText: '&lt;link elements are <a href="https://developers.google.com/web/fundamentals/performance/critical-rendering-path/analyzing-crp" target="_blank">blocking the first paint</a> of your page. Consider inline critical CSS/HTML Imports or using the <code>disabled</code> or <code>media</code> attributes to <a href="https://developers.google.com/web/fundamentals/performance/critical-rendering-path/render-blocking-css"  target="_blank">make the resource(s) non-render blocking.</a>',
+      description: 'Site does not use <link> that delay first paint',
+      helpText: '&lt;link> elements are <a href="https://developers.google.com/web/fundamentals/performance/critical-rendering-path/analyzing-crp" target="_blank">delaying the first paint</a> of your page! For stylesheets, consider inlining or using the <code>disabled</code> and <code>media</code> attributes. For HTML Imports, use the <code>async</code> attribute. These techniques will <a href="https://developers.google.com/web/fundamentals/performance/critical-rendering-path/render-blocking-css" target="_blank">make the resource(s) non-render blocking</a>.',
       requiredArtifacts: ['LinksBlockingFirstPaint']
     };
   }
@@ -55,14 +55,16 @@ class LinkBlockingFirstPaintAudit extends Audit {
     const results = artifacts.LinksBlockingFirstPaint.items.map(link => {
       return {
         url: link.url,
-        label: `blocked first paint by ${link.spendTime}ms`
+        label: `delayed first paint by ${link.spendTime}ms`
       };
     });
 
     let displayValue = '';
     const totalSpendTime = artifacts.LinksBlockingFirstPaint.total.spendTime;
-    if (results.length > 0) {
-      displayValue = `${results.length} resources blocked first paint by ${totalSpendTime}ms`;
+    if (results.length > 1) {
+      displayValue = `${results.length} resources delayed first paint by ${totalSpendTime}ms`;
+    } else if (results.length === 1) {
+      displayValue = `${results.length} resource delayed first paint by ${totalSpendTime}ms`;
     }
 
     return LinkBlockingFirstPaintAudit.generateAuditResult({

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -52,10 +52,10 @@ class LinkBlockingFirstPaintAudit extends Audit {
       });
     }
 
-    const results = artifacts.LinksBlockingFirstPaint.items.map(link => {
+    const results = artifacts.LinksBlockingFirstPaint.items.map(item => {
       return {
-        url: link.url,
-        label: `delayed first paint by ${link.spendTime}ms`
+        url: item.link.href,
+        label: `delayed first paint by ${item.spendTime}ms`
       };
     });
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/links-blocking-first-paint.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/links-blocking-first-paint.js
@@ -34,7 +34,14 @@ function collectLinksThatBlockFirstPaint() {
           const blockingImport = link.rel === 'import' && link.hasAttribute('async');
           return blockingStylesheet || blockingImport;
         })
-        .map(link => link.href);
+        .map(link => {
+          return {
+            href: link.href,
+            rel: link.rel,
+            media: link.media,
+            disabled: link.disabled
+          };
+        });
       resolve(linkList);
     } catch (e) {
       reject('Unable to get Stylesheets/HTML Imports on page');
@@ -70,12 +77,12 @@ class LinksBlockingFirstPaint extends Gatherer {
       let totalTransferSize = 0;
       let totalSpendTime = 0;
 
-      const blockingLinks = links.reduce((prev, url) => {
-        if (linkInfo[url]) {
+      const blockingLinks = links.reduce((prev, link) => {
+        if (linkInfo[link.href]) {
           const data = {
-            url,
-            transferSize: linkInfo[url].transferSize,
-            spendTime: this._formatMS(linkInfo[url])
+            link,
+            transferSize: linkInfo[link.href].transferSize,
+            spendTime: this._formatMS(linkInfo[link.href])
           };
           totalTransferSize += data.transferSize;
           totalSpendTime += data.spendTime;

--- a/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
@@ -59,6 +59,7 @@ describe('Block First Paint audit', () => {
       }
     });
     assert.equal(auditResult.rawValue, false);
+    assert.ok(auditResult.displayValue.match('1 resource delayed first paint by 100ms'));
     assert.ok(auditResult.extendedInfo.value.length, 1);
     assert.ok(auditResult.extendedInfo.value[0].url.match(linkDetails.href));
     assert.ok(auditResult.extendedInfo.value[0].label.match('delayed first paint'));

--- a/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
@@ -39,10 +39,16 @@ describe('Block First Paint audit', () => {
   });
 
   it('fails when there are links found which block first paint', () => {
+    const linkDetails = {
+      href: 'http://google.com/css/style.css',
+      disabled: false,
+      media: '',
+      rel: 'stylesheet'
+    };
     const auditResult = LinkBlockingFirstPaintAudit.audit({
       LinksBlockingFirstPaint: {
         items: [{
-          url: 'http://google.com/style.css',
+          link: linkDetails,
           transferSize: 100,
           spendTime: 100
         }],
@@ -53,7 +59,9 @@ describe('Block First Paint audit', () => {
       }
     });
     assert.equal(auditResult.rawValue, false);
-    assert.ok(auditResult.extendedInfo.value.length > 0);
+    assert.ok(auditResult.extendedInfo.value.length, 1);
+    assert.ok(auditResult.extendedInfo.value[0].url.match(linkDetails.href));
+    assert.ok(auditResult.extendedInfo.value[0].label.match('delayed first paint'));
   });
 
   it('passes when there are no links found which block first paint', () => {

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/links-blocking-first-paint-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/links-blocking-first-paint-test.js
@@ -47,7 +47,7 @@ const traceData = {
   ]
 };
 
-describe('Link in head', () => {
+describe('First paint blocking links', () => {
   // Reset the Gatherer before each test.
   beforeEach(() => {
     linksBlockingFirstPaint = new LinksBlockingFirstPaint();
@@ -76,16 +76,23 @@ describe('Link in head', () => {
   });
 
   it('returns an artifact', () => {
+    const linkDetails = {
+      href: 'http://google.com/css/style.css',
+      disabled: false,
+      media: '',
+      rel: 'stylesheet'
+    };
+
     return linksBlockingFirstPaint.afterPass({
       driver: {
         evaluateAsync() {
-          return Promise.resolve(['http://google.com/css/style.css']);
+          return Promise.resolve([linkDetails]);
         }
       }
     }, traceData).then(_ => {
       const expected = {
         items: [{
-          url: 'http://google.com/css/style.css',
+          link: linkDetails,
           transferSize: 10,
           spendTime: 0
         }],


### PR DESCRIPTION
R: @paulirish @brendankenny @samccone @GoogleChrome/lighthouse 

Disabled stylesheets do not block first render, so we should leave them out. Also some renames, spacing adjustments, and code legibility changes.