### PR TITLE
log errors as red in browser as well.

### DIFF
--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -17,20 +17,28 @@
 'use strict';
 
 const debug = require('debug');
-const debugNode = require('debug/node');
 const EventEmitter = require('events').EventEmitter;
 
+// process.browser is set when browserify'd via the `process` npm module
+const isBrowser = process.browser;
+
 const colors = {
-  red: 1,
-  yellow: 3,
-  cyan: 6,
-  green: 2,
-  blue: 4,
-  magenta: 5
+  red: isBrowser ? 'crimson' : 1,
+  yellow: isBrowser ? 'gold' : 3,
+  cyan: isBrowser ? 'darkturquoise' : 6,
+  green: isBrowser ? 'forestgreen' : 2,
+  blue: isBrowser ? 'steelblue' : 4,
+  magenta: isBrowser ? 'palevioletred' : 5
 };
 
 // whitelist non-red/yellow colors for debug()
-debugNode.colors = [colors.cyan, colors.green, colors.blue, colors.magenta];
+if (isBrowser) {
+  const debugBrowser = require('debug/browser');
+  debugBrowser.colors = [colors.cyan, colors.green, colors.blue, colors.magenta];
+} else {
+  const debugNode = require('debug/node');
+  debugNode.colors = [colors.cyan, colors.green, colors.blue, colors.magenta];
+}
 
 class Emitter extends EventEmitter {
   /**


### PR DESCRIPTION
The red-error-logging PR #860 broke the extension as requiring `debug/node` overrode debug's choice of log function, setting it to stderr even in the browserify build.

Interestingly the regression is rather flaky. I _think_ the order of modules in lighthouse-background hasn't been the same on every build, and when `debug/browser` and `debug/node` swapped places it went from broken to fixed.  

![image](https://cloud.githubusercontent.com/assets/39191/20035301/9bee5990-a39b-11e6-866f-391273789d36.png)

Anyhow, the fix is sniffing before we require, and we'll apply the same color changes to the browser while we're at it.

![image](https://cloud.githubusercontent.com/assets/39191/20035320/3af7aea6-a39c-11e6-863e-533c7709edb8.png)
![image](https://cloud.githubusercontent.com/assets/39191/20035321/4168ed72-a39c-11e6-9b3f-d1cb6ad0f5ed.png)

