### PR TITLE
Disable installing default apps on clean chrome install.

### DIFF
--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -62,6 +62,7 @@ class ChromeLauncher {
       '--remote-debugging-port=9222',
       '--disable-extensions',
       '--disable-translate',
+      '--disable-default-apps',
       '--no-first-run',
       `--user-data-dir=${this.TMP_PROFILE_DIR}`
     ];


### PR DESCRIPTION


"Disables installation of default apps on first run. This is used during automated testing" via http://peter.sh flags page.

Discovered during #897 