### PR TITLE
fix Travis test timeouts

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -20,6 +20,7 @@
 const _SIGINT = 'SIGINT';
 const _ERROR_EXIT_CODE = 130;
 const _RUNTIME_ERROR_CODE = 1;
+const _PROTOCOL_TIMEOUT_EXIT_CODE = 67;
 
 interface LightHouseError extends Error {
   code?: string
@@ -254,9 +255,16 @@ function showRuntimeError(err: LightHouseError) {
   process.exit(_RUNTIME_ERROR_CODE);
 }
 
+function showProtocolTimeoutError() {
+  console.error('Debugger protocol timed out while connecting to Chrome.');
+  process.exit(_PROTOCOL_TIMEOUT_EXIT_CODE);
+}
+
 function handleError(err: LightHouseError) {
   if (err.code === 'ECONNREFUSED') {
     showConnectionError();
+  } else if (err.code === 'CRI_TIMEOUT') {
+    showProtocolTimeoutError();
   } else {
     showRuntimeError(err);
   }

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -42,12 +42,14 @@ class ChromeLauncher {
   startingUrl: string
   additionalFlags: Array<string>
   chrome: childProcess.ChildProcess
+  port: number
 
   // We can not use default args here due to support node pre 6.
   constructor(opts?: {
       startingUrl?: string,
       additionalFlags?: Array<string>,
-      autoSelectChrome?: Boolean}) {
+      autoSelectChrome?: Boolean,
+      port?: number}) {
 
         opts = opts || {};
 
@@ -55,11 +57,12 @@ class ChromeLauncher {
         this.autoSelectChrome = defaults(opts.autoSelectChrome, true);
         this.startingUrl = defaults(opts.startingUrl, 'about:blank');
         this.additionalFlags = defaults(opts.additionalFlags, []);
+        this.port = defaults(opts.port, 9222);
   }
 
   flags() {
     const flags = [
-      '--remote-debugging-port=9222',
+      `--remote-debugging-port=${this.port}`,
       '--disable-extensions',
       '--disable-translate',
       '--disable-default-apps',
@@ -138,7 +141,7 @@ class ChromeLauncher {
 
       fs.writeFileSync(this.pidFile, chrome.pid.toString());
 
-      log.verbose('ChromeLauncher', 'Chrome running with pid =', chrome.pid);
+      log.verbose('ChromeLauncher', `Chrome running with pid ${chrome.pid} on port ${this.port}.`);
       resolve(chrome.pid);
     })
     .then(pid => Promise.all([pid, this.waitUntilReady()]));
@@ -156,7 +159,7 @@ class ChromeLauncher {
   // resolves if ready, rejects otherwise
   isDebuggerReady(): Promise<undefined> {
     return new Promise((resolve, reject) => {
-      const client = net.createConnection(9222);
+      const client = net.createConnection(this.port);
       client.once('error', err => {
         this.cleanup(client);
         reject(err);

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -20,9 +20,18 @@ const Connection = require('./connection.js');
 const WebSocket = require('ws');
 const http = require('http');
 const hostname = 'localhost';
-const port = process.env.PORT || 9222;
 
 class CriConnection extends Connection {
+  /**
+   * @param {number=} port Optional port number. Defaults to 9222;
+   * @constructor
+   */
+  constructor(port) {
+    super();
+
+    this.port = port;
+  }
+
   /**
    * @override
    * @return {!Promise}
@@ -51,7 +60,7 @@ class CriConnection extends Connection {
     return new Promise((resolve, reject) => {
       http.get({
         hostname: hostname,
-        port: port,
+        port: this.port,
         path: '/json/' + command
       }, response => {
         var data = '';

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -58,7 +58,7 @@ module.exports = function(url, flags, configJSON) {
     // Use ConfigParser to generate a valid config file
     const config = new Config(configJSON, flags.configPath);
 
-    const connection = new ChromeProtocol();
+    const connection = new ChromeProtocol(flags.port);
 
     // kick off a lighthouse run
     resolve(Runner.run(connection, {url, flags, config}));


### PR DESCRIPTION
fixes #833 

- commit 2fed833: as described in #833, the issue on Travis is that the initial HTTP GET request to Chrome for debugger connection information sometimes never responds. This PR adds a 10 second timeout to that request, at which point it exits the process on a special exit code
- commit 227487a: add the ability to specify a port for the debugger protocol with a `--port` flag (defaulting to the current 9222). If you specify port 0, it will pick a random open port (via the [behavior of `server.listen`](https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback))

With these changes in place, smokehouse now always uses a random port for the protocol and retries launching Chrome and running Lighthouse up to three times when LH fails with that specific exit code.

Both changes are necessary: when the GET request fails, the port appears to be out of commission, even after killing Chrome, so a new port must be used for the next attempt or it will continue to fail. Using a random port is also not sufficient on its own; even if using a random port on every Lighthouse run, it will still occasionally fail on our Travis setup and so will need to be re-run.

*Why* Chrome sometimes fails like this isn't clear, but I'm reasonably happy with this solution until (if) we figure this out.

The retries look like this in the smokehouse logs:
<img width="598" alt="screen shot 2016-11-07 at 22 26 15" src="https://cloud.githubusercontent.com/assets/316891/20089381/666141d8-a53b-11e6-95d6-18b9864718bc.png">
