### PR TITLE
Lighthouse Report Style Refresh

### DIFF
--- a/lighthouse-core/formatters/partials/accessibility.html
+++ b/lighthouse-core/formatters/partials/accessibility.html
@@ -1,25 +1,3 @@
-{{!--
-<style>
-.axe-violation {
-  color: #D0021B;
-}
-
-.axe-violation__help {
-  color: #76B530;
-}
-
-.axe-violation__help-minor,
-.axe-violation__help-moderate {
-  color: #F5A623;
-}
-
-.axe-violation__help-serious,
-.axe-violation__help--critical {
-  color: #D0021B;
-}
-</style>
---}}
-
 <details class="subitem__details">
   <summary class="subitem__detail">
     {{#if (gt this.nodes.length 1)}}

--- a/lighthouse-core/formatters/partials/accessibility.html
+++ b/lighthouse-core/formatters/partials/accessibility.html
@@ -1,3 +1,4 @@
+{{!--
 <style>
 .axe-violation {
   color: #D0021B;
@@ -17,15 +18,20 @@
   color: #D0021B;
 }
 </style>
-<div class="axe-violation">
-  <details>
-    <summary>
-      <a class="axe-violation__help--{{ this.impact }}" href="{{ this.helpUrl }}" target="_blank">{{ this.help }}</a>
-    </summary>
-    <ul>
-    {{#each this.nodes}}
-      <li><code>{{ this.target }}</code></li>
-    {{/each}}
-    </ul>
-  </details>
-</div>
+--}}
+
+<details class="subitem__details">
+  <summary class="subitem__detail">
+    {{#if (gt this.nodes.length 1)}}
+      {{this.nodes.length}} elements fail this test
+    {{else}}
+      {{this.nodes.length}} element fails this test
+    {{/if}}
+    <a href="{{ this.helpUrl }}" target="_blank"><small>learn more</small></a>
+  </summary>
+  <ul class="subitem__details">
+  {{#each this.nodes}}
+    <li class="subitem__detail"><code>{{ this.target }}</code></li>
+  {{/each}}
+  </ul>
+</details>

--- a/lighthouse-core/formatters/partials/critical-request-chains.html
+++ b/lighthouse-core/formatters/partials/critical-request-chains.html
@@ -102,11 +102,11 @@
   {{/each}}
 {{/inline}}
 
-<div class="cnc-tree">
-  <div>Longest request chain (shorter is better): <strong>{{longestChain this}}</strong></div>
-  <div>Longest chain duration (shorter is better): <strong>{{formatTime (longestDuration this)}}ms</strong></div>
-  <div>Longest chain transfer size (smaller is better): <strong>{{formatTransferSize (longestChainTransferSize this)}}KB</strong></div>
-  <div>
+<ul class="subitem__details">
+  <li class="subitem__detail">Longest request chain (shorter is better): <strong>{{longestChain this}}</strong></li>
+  <li class="subitem__detail">Longest chain duration (shorter is better): <strong>{{formatTime (longestDuration this)}}ms</strong></li>
+  <li class="subitem__detail">Longest chain transfer size (smaller is better): <strong>{{formatTransferSize (longestChainTransferSize this)}}KB</strong></li>
+  <li class="subitem__detail">
     <div>Initial navigation</div>
     {{#createTreeRenderContext this}}
       {{#each this.tree }}
@@ -115,5 +115,5 @@
         {{/createContextFor}}
       {{/each}}
     {{/createTreeRenderContext}}
-  </div>
-</div>
+  </li>
+</ul>

--- a/lighthouse-core/formatters/partials/speedline.html
+++ b/lighthouse-core/formatters/partials/speedline.html
@@ -4,9 +4,7 @@
   }
 </style>
 
-<div>
-  <div class="speedline-measures">
-    <div>First Visual Change: <strong>{{this.first}}ms</strong></div>
-    <div>Last Visual Change: <strong>{{this.complete}}ms</strong></div>
-  </div>
-</div>
+<ul class="subitem__details">
+    <li class="subitem__detail">First Visual Change: <strong>{{this.first}}ms</strong></li>
+    <li class="subitem__detail">Last Visual Change: <strong>{{this.complete}}ms</strong></li>
+</ul>

--- a/lighthouse-core/formatters/partials/speedline.html
+++ b/lighthouse-core/formatters/partials/speedline.html
@@ -5,6 +5,6 @@
 </style>
 
 <ul class="subitem__details">
-    <li class="subitem__detail">First Visual Change: <strong>{{this.first}}ms</strong></li>
-    <li class="subitem__detail">Last Visual Change: <strong>{{this.complete}}ms</strong></li>
+  <li class="subitem__detail">First Visual Change: <strong>{{this.first}}ms</strong></li>
+  <li class="subitem__detail">Last Visual Change: <strong>{{this.complete}}ms</strong></li>
 </ul>

--- a/lighthouse-core/formatters/partials/url-list.html
+++ b/lighthouse-core/formatters/partials/url-list.html
@@ -1,13 +1,7 @@
 <style>
-  .http-resources {
-    font-size: 14px;
-  }
-  .http-resource__url {
-    margin-right: 8px;
-  }
   .http-resource__protocol,
   .http-resource__code {
-    color: #999;
+    color: var(--secondary-text-color);
   }
   .http-resource__code {
     text-overflow: ellipsis;
@@ -15,19 +9,19 @@
   }
 </style>
 
-<div>
-  <details class="http-resources">
-    <summary>URLs</summary>
-    {{#each this}}
-      <div class="http-resource">
-        <span class="http-resource__url">{{this.url}}</span>
-        {{#if this.label}}
-          <span class="http-resource__protocol">({{this.label}})</span>
-        {{/if}}
-        {{#if this.code}}
-          <pre class="http-resource__code">{{this.code}}</pre>
-        {{/if}}
-      </div>
-    {{/each}}
-  </details>
-</div>
+<details class="subitem__details">
+  <summary class="subitem__detail">URLs</summary>
+  <ul class="subitem__details">
+  {{#each this}}
+    <li class="subitem__detail http-resource">
+      <span class="http-resource__url">{{this.url}}</span>
+      {{#if this.label}}
+        <span class="http-resource__protocol">({{this.label}})</span>
+      {{/if}}
+      {{#if this.code}}
+        <pre class="http-resource__code">{{this.code}}</pre>
+      {{/if}}
+    </li>
+  {{/each}}
+  </ul>
+</details>

--- a/lighthouse-core/formatters/partials/user-timings.html
+++ b/lighthouse-core/formatters/partials/user-timings.html
@@ -1,23 +1,17 @@
 <style>
-  .ut-measures {
-    font-size: 14px
-  }
-
   .ut-measure_listing-duration {
     font-weight: bold
   }
 </style>
 
-<div>
-  <div class="ut-measures">
-    {{#each this}}
-      <div>
-        {{#if this.isMark}}
-          <span class="ut-measure_listing-duration">Mark: {{ decimal this.startTime }}ms</span> - {{ this.name }}
-        {{else}}
-          <span class="ut-measure_listing-duration">Measure {{ decimal this.duration }}ms</span> - {{ this.name }}
-        {{/if}}
-      </div>
-    {{/each}}
-  </div>
-</div>
+<ul class="subitem__details">
+  {{#each this}}
+    <li class="subitem__detail">
+      {{#if this.isMark}}
+        <strong class="ut-measure_listing-duration">Mark: {{ decimal this.startTime }}ms</strong> - {{ this.name }}
+      {{else}}
+        <strong class="ut-measure_listing-duration">Measure {{ decimal this.duration }}ms</strong> - {{ this.name }}
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -93,9 +93,7 @@ class ReportGenerator {
     // for color styling.
     Handlebars.registerHelper('getItemRating', getItemRating);
 
-    Handlebars.registerHelper('showHelpText', value => {
-      return getItemRating(value) === RATINGS.GOOD.label ? 'hidden' : '';
-    });
+    Handlebars.registerHelper('shouldShowHelpText', value => (getItemRating(value) !== RATINGS.GOOD.label));
 
     // Convert numbers to fixed point decimals
     Handlebars.registerHelper('decimal', number => {

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -116,7 +116,7 @@ class ReportGenerator {
     // arg1 && arg2 && ... && argn
     Handlebars.registerHelper('and', () => {
       let arg = false;
-      for (let i = 0, n = arguments.length-1; i < n; i++) {
+      for (let i = 0, n = arguments.length - 1; i < n; i++) {
         arg = arguments[i];
         if (!arg) {
           break;

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -104,19 +104,19 @@ class ReportGenerator {
       }
       return number;
     });
-    
+
     // Is a value is boolean?
-    Handlebars.registerHelper('is-bool', (value) => (typeof value === 'boolean'));
-    
+    Handlebars.registerHelper('is-bool', value => (typeof value === 'boolean'));
+
     // a > b
     Handlebars.registerHelper('gt', (a, b) => (a > b));
-    
+
     // !value
-    Handlebars.registerHelper('not', (value) => !value);
-    
+    Handlebars.registerHelper('not', value => !value);
+
     // arg1 && arg2 && ... && argn
     Handlebars.registerHelper('and', (...args) => {
-      const options = args.pop();
+      args.pop();
       let arg;
       for (arg of args) {
         if (!arg) {
@@ -124,7 +124,7 @@ class ReportGenerator {
         }
       }
       return arg;
-    })
+    });
   }
 
   /**

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -104,6 +104,27 @@ class ReportGenerator {
       }
       return number;
     });
+    
+    // Is a value is boolean?
+    Handlebars.registerHelper('is-bool', (value) => (typeof value === 'boolean'));
+    
+    // a > b
+    Handlebars.registerHelper('gt', (a, b) => (a > b));
+    
+    // !value
+    Handlebars.registerHelper('not', (value) => !value);
+    
+    // arg1 && arg2 && ... && argn
+    Handlebars.registerHelper('and', (...args) => {
+      const options = args.pop();
+      let arg;
+      for (arg of args) {
+        if (!arg) {
+          break;
+        }
+      }
+      return arg;
+    })
   }
 
   /**
@@ -222,6 +243,7 @@ class ReportGenerator {
       lighthouseVersion: results.lighthouseVersion,
       generatedTime: this._formatTime(results.generatedTime),
       css: this.getReportCSS(inline),
+      reportContext: 'extension', // devtools, extension, cli
       script: this.getReportJS(inline),
       aggregations: results.aggregations,
       auditsByCategory: this._createPWAAuditsByCategory(results.aggregations)

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -93,7 +93,8 @@ class ReportGenerator {
     // for color styling.
     Handlebars.registerHelper('getItemRating', getItemRating);
 
-    Handlebars.registerHelper('shouldShowHelpText', value => (getItemRating(value) !== RATINGS.GOOD.label));
+    Handlebars.registerHelper('shouldShowHelpText',
+      value => (getItemRating(value) !== RATINGS.GOOD.label));
 
     // Convert numbers to fixed point decimals
     Handlebars.registerHelper('decimal', number => {
@@ -103,7 +104,7 @@ class ReportGenerator {
       return number;
     });
 
-    // Is a value is boolean?
+    // value is boolean?
     Handlebars.registerHelper('is-bool', value => (typeof value === 'boolean'));
 
     // a > b

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -114,10 +114,10 @@ class ReportGenerator {
     Handlebars.registerHelper('not', value => !value);
 
     // arg1 && arg2 && ... && argn
-    Handlebars.registerHelper('and', (...args) => {
-      args.pop();
-      let arg;
-      for (arg of args) {
+    Handlebars.registerHelper('and', () => {
+      let arg = false;
+      for (let i = 0, n = arguments.length-1; i < n; i++) {
+        arg = arguments[i];
         if (!arg) {
           break;
         }

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -22,13 +22,11 @@
 /* Using ES5 to broaden support */
 function LighthouseReport() {
   this.printButton = document.querySelector('.js-print');
-  this.checkboxToggleView = document.querySelector('.js-toggle-view');
   this.viewUserFeature = document.querySelector('.js-report-by-user-feature');
   this.viewTechnology = document.querySelector('.js-report-by-technology');
   this.reportItems = document.querySelectorAll('.report-section__item');
   this.helpToggles = document.querySelectorAll('.subitem__help-toggle');
 
-  this.updateView = this.updateView.bind(this);
   this.toggleHelpText = this.toggleHelpText.bind(this);
 
   this.addEventListeners();
@@ -40,16 +38,6 @@ LighthouseReport.prototype = {
     window.print();
   },
 
-  updateView: function() {
-    if (this.checkboxToggleView.checked) {
-      this.viewUserFeature.setAttribute('hidden', 'hidden');
-      this.viewTechnology.removeAttribute('hidden');
-    } else {
-      this.viewUserFeature.removeAttribute('hidden');
-      this.viewTechnology.setAttribute('hidden', 'hidden');
-    }
-  },
-
   toggleHelpText: function(e) {
     const item = e.currentTarget.closest('.subitem');
     item.classList.toggle('--show-help');
@@ -57,7 +45,6 @@ LighthouseReport.prototype = {
 
   addEventListeners: function() {
     this.printButton.addEventListener('click', this.onPrint);
-    this.checkboxToggleView.addEventListener('change', this.updateView);
     [...this.helpToggles].forEach(node => {
       node.addEventListener('click', this.toggleHelpText);
     });

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -26,6 +26,7 @@ function LighthouseReport() {
   this.viewUserFeature = document.querySelector('.js-report-by-user-feature');
   this.viewTechnology = document.querySelector('.js-report-by-technology');
   this.reportItems = document.querySelectorAll('.report-section__item');
+  this.helpToggles = document.querySelectorAll('.subitem__help-toggle');
 
   this.updateView = this.updateView.bind(this);
   this.toggleHelpText = this.toggleHelpText.bind(this);
@@ -50,18 +51,14 @@ LighthouseReport.prototype = {
   },
 
   toggleHelpText: function(e) {
-    if (e.target.classList.contains('report-section__item-help-toggle')) {
-      const el = e.currentTarget.querySelector('.report-section__item-helptext');
-      if (el) {
-        el.hidden = !el.hidden;
-      }
-    }
+    const item = e.currentTarget.closest('.subitem');
+    item.classList.toggle('--show-help');
   },
 
   addEventListeners: function() {
     this.printButton.addEventListener('click', this.onPrint);
     this.checkboxToggleView.addEventListener('change', this.updateView);
-    [...this.reportItems].forEach(node => {
+    [...this.helpToggles].forEach(node => {
       node.addEventListener('click', this.toggleHelpText);
     });
   }

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -91,8 +91,6 @@ body {
   background: #f5f5f5;
 }
 
-
-/* have to deal with  */
 .report {
   width: 100%;
   margin: 0 auto;
@@ -581,9 +579,6 @@ body {
   font-size: 70%;
 }
 
-
-
-
 .devtabs {
   flex: 0 1 auto;
   background: right 0 / auto 27px no-repeat url(tabs_right.png),
@@ -591,12 +586,6 @@ body {
               0 0 / auto 27px repeat-x url(tabs_center.png);
   height: 27px;
 }
-/*
-.report {
-  flex: 1 1 0;
-  overflow: auto;
-}*/
-
 
 .header1 {
 }
@@ -664,7 +653,6 @@ body {
   border-top: 1px solid #fff;
   padding-top: 4px;
 }
-
 
 .header2 {
   max-width: var(--max-line-length);
@@ -756,20 +744,6 @@ body {
 .subitem-result__unknown { background-color: var(--unknown-color); }
 .subitem-result__unknown::after { -webkit-mask-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><title>neutral</title><path d="M2 5h8v2H2z" fill="#FFF" fill-rule="evenodd"/></svg>'); }
 
-/*
-.subitem-result__good, .subitem-result__poor, .subitem-result__unknown {
-  color: #fff;
-  font-size: var(--body-font-size);
-  text-transform: uppercase;
-  padding: 2px 4px;
-  border-radius: 2px;
-  margin-top: calc((var(--subitem-line-height) - var(--body-font-size) - 4px) / 2);
-}
-
-.subitem-result__good { background-color: var(--good-color); }
-.subitem-result__poor { background-color: var(--poor-color); }
-.subitem-result__unknown { background-color: var(--unknown-color); }
-*/
 .subitem-result__points {
   margin-top: calc((var(--subitem-line-height) - var(--subitem-font-size) - 4px) / 2);
   background: #000;
@@ -821,11 +795,7 @@ body {
   background-color: var(--secondary-text-color);
   cursor: pointer;
 }
-/*
-.test:hover .test__help-toggle, .test__help-toggle:focus, .test__help-toggle:checked {
-  opacity: 1;
-}
-*/
+
 .subitem__help-toggle:hover {
   border-color: var(--secondary-text-color);
 }
@@ -859,9 +829,6 @@ body {
   color: var(--poor-color);
 }
 
-
-
-
 @media print {
   .report {
     box-shadow: none;
@@ -872,7 +839,6 @@ body {
     display: none;
   }
 }
-
 
 :root[data-report-context="devtools"] .report {
   margin: 0;
@@ -895,6 +861,3 @@ body {
 :root[data-report-context="devtools"] .footer {
   display: none;
 }
-
-
-

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -105,25 +105,7 @@ body {
   background: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjNDQ0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik0xOSA4SDVjLTEuNjYgMC0zIDEuMzQtMyAzdjZoNHY0aDEydi00aDR2LTZjMC0xLjY2LTEuMzQtMy0zLTN6bS0zIDExSDh2LTVoOHY1em0zLTdjLS41NSAwLTEtLjQ1LTEtMXMuNDUtMSAxLTEgMSAuNDUgMSAxLS40NSAxLTEgMXptLTEtOUg2djRoMTJWM3oiLz4KICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4KPC9zdmc+Cg==');
   border: none;
   cursor: pointer;
-}
-
-.toggle {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px;
-  margin-right: 26px;
-}
-
-.toggle__label {
-  padding: 0 10px 0 20px;
-}
-
-.toggle__title {
-  margin: 0;
-  font-weight: bold;
-  font-size: 13px;
+  flex: 0 0 auto;
 }
 
 .score-container__overall-score {
@@ -480,97 +462,6 @@ body {
   color: #999;
 }
 
-.toggle__label {
-  width: 120px;
-  height: 24px;
-  position: relative;
-  margin-left: 20px;
-}
-
-.toggle-view {
-  position: absolute;
-  left: 50%;
-  top: 40%;
-  transform: translate(-50%, -50%);
-  z-index: 0;
-}
-
-.toggle__display {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1;
-}
-
-.toggle__display::before,
-.toggle__display::after,
-.toggle__focus-ring {
-  display: block;
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  text-align: center;
-  line-height: 24px;
-  font-size: 13px;
-  color: #333;
-  transition: opacity 0.2s cubic-bezier(0,0,0.3,1);
-}
-
-.toggle__display::before {
-  content: attr(data-on);
-  opacity: 0;
-  background: #57A0A8;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.5);
-  border-radius: 12px;
-  color: #FFF;
-}
-
-.toggle__display::after {
-  content: attr(data-off);
-  opacity: 1;
-  background: #E7E7E8;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.5);
-  border-radius: 12px;
-}
-
-.toggle__focus-ring {
-  border-radius: 12px;
-}
-
-.toggle__slider {
-  position: absolute;
-  left: 4px;
-  top: 4px;
-  border-radius: 50%;
-  background: #FFF;
-  width: 16px;
-  height: 16px;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.5);
-  transition: transform 0.1s cubic-bezier(0,0,0.3,1);
-  z-index: 2;
-}
-
-.toggle-view:focus ~ .toggle__focus-ring,
-.toggle__label:active .toggle__focus-ring {
-  box-shadow: 0 0 5px 2px #83BFFC;
-}
-
-.toggle-view:checked ~ .toggle__display::before {
-  opacity: 1;
-}
-
-.toggle-view:checked ~ .toggle__display::after {
-  opacity: 0;
-}
-
-.toggle-view:checked ~ .toggle__display .toggle__slider {
-  transform: translateX(96px);
-}
-
 .coming-soon, .coming-soon * {
   color: #AAA;
 }
@@ -587,26 +478,26 @@ body {
   height: 27px;
 }
 
-.header1 {
+.aggregations__header {
 }
 
-.header1 > h1 {
+.aggregations__header > h1 {
   font-size: var(--heading-font-size);
   font-weight: normal;
   line-height: var(--heading-line-height);
 }
 
-.section1 {
+.aggregations {
   position: relative;
   padding: var(--heading-line-height);
   padding-left: calc(var(--heading-line-height) + var(--gutter-width) + var(--gutter-gap));
 }
 
-.section1:not(:first-child) {
+.aggregations:not(:first-child) {
   border-top: 1px solid #ccc;
 }
 
-.section1__desc {
+.aggregations__desc {
   font-size: var(--body-font-size);
   line-height: var(--body-line-height);
   margin-top: calc(var(--body-line-height) / 2);
@@ -654,23 +545,23 @@ body {
   padding-top: 4px;
 }
 
-.header2 {
+.aggregation__header {
   max-width: var(--max-line-length);
 }
 
-.header2 > h2 {
+.aggregation__header > h2 {
   font-size: var(--subheading-font-size);
   font-weight: normal;
   line-height: var(--subheading-line-height);
   color: var(--subheading-color);
 }
 
-.section2 {
+.aggregation {
   margin-top: var(--subheading-line-height);
   max-width: var(--max-line-length);
 }
 
-.section2__desc {
+.aggregation__desc {
   font-size: var(--body-font-size);
   line-height: var(--body-line-height);
   margin-top: calc(var(--body-line-height) / 2);

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -851,6 +851,14 @@ body {
   display: block;
 }
 
+.subitem__debug {
+  font-size: var(--body-font-size);
+  line-height: var(--body-line-height);
+  margin-top: calc(var(--body-line-height) / 2);
+  margin-left: var(--subitem-indent);
+  color: var(--poor-color);
+}
+
 
 
 

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -14,50 +14,88 @@
  * limitations under the License.
  */
 
-@font-face {
-  font-family: 'Roboto';
-  font-style: normal;
-  font-weight: 100;
-  src: local('Roboto Thin'), local('Roboto-Thin') format('woff');
-}
-@font-face {
-  font-family: 'Roboto';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular') format('woff');
-}
-@font-face {
-  font-family: 'Roboto';
-  font-style: normal;
-  font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium') format('woff');
-}
-
 * {
   box-sizing: border-box;
 }
 
-html, body {
-  padding: 0;
+span, div, p, section, header, h1, h2, li, ul {
   margin: 0;
-  background: #F0F0F0;
-  color: #444;
-  font-family: Arial, sans-serif;
-  font-size: 15px;
+  padding: 0;
+  line-height: inherit;
 }
 
-body {
-  min-width: 845px;
+
+:root {
+  --text-font-family: "Roboto", -apple-system, BlinkMacSystemFont,  "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  --text-color: #212121;
+  --secondary-text-color: #757575;
+  --accent-color: #719EA8;
+  --poor-color: #eb211e;
+  --good-color: #1ac123;
+  --average-color: #ffae00;
+  --unknown-color: #b3b3b3;
+  --gutter-gap: 12px;
+  --gutter-width: 40px;
+  --body-font-size: 14px;
+  --body-line-height: 20px;
+  --subitem-font-size: 14px;
+  --subitem-line-height: 20px;
+  --subheading-font-size: 16px;
+  --subheading-line-height: 24px;
+  --subheading-color: var(--accent-color);
+  --heading-font-size: 24px;
+  --heading-line-height: 32px;
+  --subitem-indent: 24px;
+  --max-line-length: none;
+}
+
+:root[data-report-context="devtools"] {
+  --text-font-family: '.SFNSDisplay-Regular', 'Helvetica Neue', 'Lucida Grande', sans-serif;
+  --text-color: #222;
+  --secondary-text-color: #606060;
+  --accent-color: #3879d9;
+  --body-font-size: 13px;
+  --body-line-height: 17px;
+  --subitem-font-size: 14px;
+  --subitem-line-height: 18px;
+  --subheading-font-size: 16px;
+  --subheading-line-height: 20px;
+  --subheading-color: inherit;
+  --heading-font-size: 20px;
+  --heading-line-height: 24px;
+  --subitem-indent: 24px;
+  --max-line-length: calc(60 * var(--body-font-size));
+}
+
+html {
+  font-family: var(--text-font-family);
+  font-size: var(--body-font-size);
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
 }
 
 a {
-  color: #57A0A8;
+  color: #15c;
 }
 
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  margin: 0;
+  background: #f5f5f5;
+}
+
+
+/* have to deal with  */
 .report {
   width: 100%;
   margin: 0 auto;
-  border-radius: 0 0 4px 4px;
   max-width: 1280px;
   background: #FFF;
   box-shadow: 0 0 6px 0 rgba(0,0,0,0.26);
@@ -123,7 +161,6 @@ a {
 }
 
 .report-body__content {
-  padding: 0 4% 0 4%;
   margin-left: 22%;
   position: relative;
 }
@@ -157,7 +194,7 @@ a {
   height: 115px;
   line-height: 54px;
   color: #FFF;
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: var(--text-font-family);
   font-size: 18px;
   position: relative;
   display: flex;
@@ -178,7 +215,7 @@ a {
 }
 
 .menu__header-title {
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: var(--text-font-family);
   font-size: 22px;
   font-weight: 400;
   color: #fff;
@@ -190,7 +227,7 @@ a {
 .menu__header-version {
   opacity: 0.4;
   color: #fff;
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: var(--text-font-family);
   font-size: 14px;
   line-height: 1.5;
 }
@@ -258,14 +295,22 @@ a {
   color: #FFF;
 }
 
+
+.report-body__metadata {
+  flex: 1 1 0;
+  margin-right: 40px;
+  white-space: nowrap;
+}
+
 .report-body__url {
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: var(--text-font-family);
   white-space: nowrap;
   font-size: 13px;
-  font-style: italic;
   font-weight: 400;
-  color: #aaa;
-  padding: 20px 0 10px;
+  color: #757575;
+  line-height: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .report-body__url a {
@@ -289,16 +334,17 @@ a {
   height: 58px;
   border-bottom: 1px solid #EBEBEB;
   background: #FAFAFA;
+  margin-left: 22%;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-end;
-  padding: 0 4%;
+  padding: 0 var(--heading-line-height);
 }
 
 .report-section__title {
   -webkit-font-smoothing: antialiased;
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: var(--text-font-family);
   font-size: 28px;
   font-weight: 500;
   color: #49525F;
@@ -322,7 +368,7 @@ a {
 
 .report-section__subtitle {
   -webkit-font-smoothing: antialiased;
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: var(--text-font-family);
   font-size: 18px;
   font-weight: 500;
   color: #719EA8;
@@ -427,13 +473,13 @@ a {
 
 .footer {
   margin-top: 40px;
+  margin-left: 22%;
   height: 130px;
   line-height: 90px;
   text-align: center;
   font-size: 12px;
   border-top: 1px solid #EBEBEB;
   color: #999;
-  margin-left: 22%;
 }
 
 .toggle__label {
@@ -535,6 +581,279 @@ a {
   font-size: 70%;
 }
 
+
+
+
+.devtabs {
+  flex: 0 1 auto;
+  background: right 0 / auto 27px no-repeat url(tabs_right.png),
+              0 0 / auto 27px no-repeat url(tabs_left.png),
+              0 0 / auto 27px repeat-x url(tabs_center.png);
+  height: 27px;
+}
+/*
+.report {
+  flex: 1 1 0;
+  overflow: auto;
+}*/
+
+
+.header1 {
+}
+
+.header1 > h1 {
+  font-size: var(--heading-font-size);
+  font-weight: normal;
+  line-height: var(--heading-line-height);
+}
+
+.section1 {
+  position: relative;
+  padding: var(--heading-line-height);
+  padding-left: calc(var(--heading-line-height) + var(--gutter-width) + var(--gutter-gap));
+}
+
+.section1:not(:first-child) {
+  border-top: 1px solid #ccc;
+}
+
+.section1__desc {
+  font-size: var(--body-font-size);
+  line-height: var(--body-line-height);
+  margin-top: calc(var(--body-line-height) / 2);
+}
+
+.section-result {
+  position: absolute;
+  top: var(--heading-line-height);
+  left: var(--heading-line-height);
+  width: var(--gutter-width);
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.section-result__score {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  background: #000;
+  color: #fff;
+  text-align: center;
+  padding: 4px 8px;
+  border-radius: 2px;
+  margin-top: calc((var(--heading-line-height) - var(--heading-font-size) - 6px) / 2);
+}
+
+.section-result__score.--good { background-color: var(--good-color); }
+.section-result__score.--poor { background-color: var(--poor-color); }
+.section-result__score.--average { background-color: var(--average-color); }
+
+.section-result__points {
+  font-size: var(--heading-font-size);
+}
+
+.section-result__divider {
+  display: none;
+}
+
+.section-result__total {
+  font-size: var(--body-font-size);
+  margin-top: 2px;
+  border-top: 1px solid #fff;
+  padding-top: 4px;
+}
+
+
+.header2 {
+  max-width: var(--max-line-length);
+}
+
+.header2 > h2 {
+  font-size: var(--subheading-font-size);
+  font-weight: normal;
+  line-height: var(--subheading-line-height);
+  color: var(--subheading-color);
+}
+
+.section2 {
+  margin-top: var(--subheading-line-height);
+  max-width: var(--max-line-length);
+}
+
+.section2__desc {
+  font-size: var(--body-font-size);
+  line-height: var(--body-line-height);
+  margin-top: calc(var(--body-line-height) / 2);
+}
+
+.subitems {
+  list-style: none;
+  margin-top: var(--subitem-line-height);
+}
+
+.subitem {
+  position: relative;
+  font-size: var(--subitem-font-size);
+  padding-left: calc(var(--subitem-indent) + var(--gutter-width) + var(--gutter-gap));
+  margin-top: calc(var(--subitem-line-height) / 2);
+}
+
+.subitem.--coming-soon {
+  color: var(--secondary-text-color);
+}
+
+.subitem strong {
+  font-weight: bold;
+}
+
+.subitem small {
+  font-size: var(--body-font-size);
+}
+
+.subitem__desc {
+  line-height: var(--subitem-line-height);
+}
+
+.subitem-result {
+  position: absolute;
+  top: 0;
+  left: var(--subitem-indent);
+  width: var(--gutter-width);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.subitem-result__good, .subitem-result__poor, .subitem-result__unknown {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  margin-top: calc((var(--subitem-line-height) - 16px) / 2);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  color: transparent;
+  background-color: #000;
+}
+
+.subitem-result__good::after, .subitem-result__poor::after, .subitem-result__unknown::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  -webkit-mask: center center / 12px 12px no-repeat;
+  background-color: #fff;
+}
+
+.subitem-result__good { background-color: var(--good-color); }
+.subitem-result__good::after { -webkit-mask-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><title>good</title><path d="M9.17 2.33L4.5 7 2.83 5.33 1.5 6.66l3 3 6-6z" fill="#FFF" fill-rule="evenodd"/></svg>'); }
+.subitem-result__poor { background-color: var(--poor-color); }
+.subitem-result__poor::after { -webkit-mask-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><title>poor</title><path d="M8.33 2.33l1.33 1.33-2.335 2.335L9.66 8.33 8.33 9.66 5.995 7.325 3.66 9.66 2.33 8.33l2.335-2.335L2.33 3.66l1.33-1.33 2.335 2.335z" fill="#FFF" fill-rule="evenodd"/></svg>'); }
+.subitem-result__unknown { background-color: var(--unknown-color); }
+.subitem-result__unknown::after { -webkit-mask-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><title>neutral</title><path d="M2 5h8v2H2z" fill="#FFF" fill-rule="evenodd"/></svg>'); }
+
+/*
+.subitem-result__good, .subitem-result__poor, .subitem-result__unknown {
+  color: #fff;
+  font-size: var(--body-font-size);
+  text-transform: uppercase;
+  padding: 2px 4px;
+  border-radius: 2px;
+  margin-top: calc((var(--subitem-line-height) - var(--body-font-size) - 4px) / 2);
+}
+
+.subitem-result__good { background-color: var(--good-color); }
+.subitem-result__poor { background-color: var(--poor-color); }
+.subitem-result__unknown { background-color: var(--unknown-color); }
+*/
+.subitem-result__points {
+  margin-top: calc((var(--subitem-line-height) - var(--subitem-font-size) - 4px) / 2);
+  background: #000;
+  padding: 2px 4px;
+  border-radius: 1px;
+  color: #fff;
+  border-radius: 2px;
+}
+
+.subitem-result__points.--good { background-color: var(--good-color); }
+.subitem-result__points.--poor { background-color: var(--poor-color); }
+.subitem-result__points.--average { background-color: var(--average-color); }
+
+.subitem__details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  margin-left: var(--subitem-indent);
+}
+
+.subitem__detail {
+  font-size: var(--body-font-size);
+  line-height: var(--body-line-height);
+  margin-top: calc(var(--body-line-height) / 2);
+}
+
+.subitem__help-toggle {
+  -webkit-appearance: none;
+  position: relative;
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid #ccc;
+  vertical-align: middle;
+  margin-left: .5em;
+  outline: 0;
+}
+
+.subitem__help-toggle::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  -webkit-mask: 1px 1px / 12px 12px no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><title>help</title><path d="M5.216 7.457c0-.237.011-.452.033-.645.021-.194.058-.372.11-.535a1.918 1.918 0 0 1 .55-.847 3.65 3.65 0 0 0 .545-.597c.133-.19.2-.398.2-.623 0-.28-.053-.485-.16-.616-.107-.13-.268-.196-.482-.196a.583.583 0 0 0-.457.207.834.834 0 0 0-.15.271c-.04.111-.062.244-.065.398H3.67c.003-.401.067-.745.19-1.032a1.96 1.96 0 0 1 .5-.707c.208-.185.455-.32.738-.406A3.13 3.13 0 0 1 6.012 2c.359 0 .682.046.968.137.287.091.53.227.729.406.2.18.352.401.457.667.105.265.158.571.158.919 0 .233-.03.44-.091.624-.061.182-.145.353-.252.51-.107.158-.233.311-.378.46-.145.149-.3.306-.465.47a2.084 2.084 0 0 0-.24.275c-.063.09-.115.183-.152.282a1.57 1.57 0 0 0-.084.323 2.966 2.966 0 0 0-.033.384H5.216zm-.202 1.634a.96.96 0 0 1 .067-.36.828.828 0 0 1 .19-.287.913.913 0 0 1 .291-.191.969.969 0 0 1 .376-.07c.138 0 .263.023.375.07.112.046.21.11.292.19.082.081.146.177.19.288a.96.96 0 0 1 .067.36.96.96 0 0 1-.067.36.828.828 0 0 1-.19.288.913.913 0 0 1-.292.191.969.969 0 0 1-.375.07.969.969 0 0 1-.376-.07.913.913 0 0 1-.291-.19.828.828 0 0 1-.19-.288.96.96 0 0 1-.067-.36z" fill="#000" fill-rule="evenodd"/></svg>');
+  background-color: var(--secondary-text-color);
+  cursor: pointer;
+}
+/*
+.test:hover .test__help-toggle, .test__help-toggle:focus, .test__help-toggle:checked {
+  opacity: 1;
+}
+*/
+.subitem__help-toggle:hover {
+  border-color: var(--secondary-text-color);
+}
+
+.subitem__help-toggle:checked {
+  background-color: var(--accent-color);
+  border-color: var(--accent-color);
+}
+
+.subitem__help-toggle:checked::after {
+  background-color: #fff;
+}
+
+.subitem__help {
+  display: none;
+  font-size: var(--body-font-size);
+  line-height: var(--body-line-height);
+  margin-top: calc(var(--body-line-height) / 2);
+  margin-left: var(--subitem-indent);
+}
+
+.subitem.--show-help .subitem__help {
+  display: block;
+}
+
+
+
+
 @media print {
   .report {
     box-shadow: none;
@@ -545,3 +864,29 @@ a {
     display: none;
   }
 }
+
+
+:root[data-report-context="devtools"] .report {
+  margin: 0;
+  box-shadow: none;
+  max-width: none;
+}
+
+:root[data-report-context="devtools"] .report-body__menu-container {
+  display: none;
+}
+
+:root[data-report-context="devtools"] .report-body__header {
+  display: none;
+}
+
+:root[data-report-context="devtools"] .report-body__content {
+  margin-left: 0;
+}
+
+:root[data-report-context="devtools"] .footer {
+  display: none;
+}
+
+
+

--- a/lighthouse-core/report/templates/report.html
+++ b/lighthouse-core/report/templates/report.html
@@ -34,18 +34,6 @@ limitations under the License.
         <div class="report-body__url">Results for: <a href="{{ url }}" target="_blank">{{ url }}</a></div>
         <div class="report-body__url">Generated on: {{generatedTime}}</div>
       </div>
-      <div class="toggle">
-        <h1 class="toggle__title">View:</h1>
-
-        <label class="toggle__label" for="user-feature" aria-label="User feature">
-          <input name="view-toggle" class="js-toggle-view toggle-view" id="user-feature" type="checkbox" value="toggle">
-          <div role="presentation" class="toggle__display" data-on="Technology" data-off="User feature">
-            <div aria-hidden class="toggle__slider"></div>
-          </div>
-          <div role="presentation" class="toggle__focus-ring"></div>
-        </label>
-      </div>
-
       <button class="print js-print"></button>
     </div>
     <div class="report-body__content">
@@ -67,13 +55,13 @@ limitations under the License.
         </div>
       </div>
 
-      <div class="aggregations">
+      <div>
       {{#each aggregations}}
-      <section class="js-breakdown section1">
-        <header class="header1" id="{{nameToLink this.name}}">
+      <section class="js-breakdown aggregations">
+        <header class="aggregations__header" id="{{nameToLink this.name}}">
           <h1>{{ this.name }}</h1>
         </header>
-        <p class="section1__desc">{{ this.description }}</p>
+        <p class="aggregations__desc">{{ this.description }}</p>
         {{#if this.scored}}
         <div class="section-result">
           <span class="section-result__score --{{ getTotalScoreRating this }}">
@@ -86,16 +74,16 @@ limitations under the License.
 
         <div class="js-report-by-user-feature">
           {{#each this.score as |aggregation|}}
-            <section class="section2">
+            <section class="aggregation">
 
             {{#if aggregation.name }}
-            <header class="header2">
+            <header class="aggregation__header">
               <h2>{{ aggregation.name }}</h2>
             </header>
             {{/if}}
 
             {{#if aggregation.description }}
-            <p class="section2__desc">{{{ aggregation.description }}}</p>
+            <p class="aggregation__desc">{{{ aggregation.description }}}</p>
             {{/if}}
 
             <ul class="subitems">
@@ -165,57 +153,6 @@ limitations under the License.
           </section>
           {{/each}}
         </div>
-
-        {{#if this.categorizable}}
-        <div class="js-report-by-technology" hidden>
-           {{#each ../auditsByCategory }}
-            <section class="section2">
-              <header class="header2"><h2>{{ @key }}</h2></header>
-
-              <ul class="subitems">
-                {{#each this as |subItem| }}
-                  <li class="subitem {{#if subItem.comingSoon}}--coming-soon{{/if}}">
-                    <div class="subitem__desc">
-                      {{ subItem.description }}
-                      {{~#if (and subItem.rawValue (not (is-bool subItem.rawValue)))~}}
-                        : <strong class="subitem__raw-value">{{ subItem.rawValue }}</strong>
-                      {{/if }}
-                      {{#if subItem.optimalValue }}
-                        (target: {{ subItem.optimalValue }})
-                      {{/if}}
-                      {{#if subItem.comingSoon}}
-                        (Coming soon)
-                      {{/if}}
-                    </div>
-                    
-                    <div class="subitem-result">
-                      {{#if subItem.comingSoon}}
-                            <span class="subitem-result__unknown">N/A</span>
-                      {{else}}
-                        {{#if (is-bool subItem.score)}}
-                          {{#if subItem.score}}
-                            <span class="subitem-result__good">Pass</span>
-                          {{else}}
-                            <span class="subitem-result__poor">Fail</span>
-                          {{/if}}
-                        {{else}}
-                          <span class="subitem-result__points --{{ getItemRating subItem.score }}">
-                            {{{ getItemValue subItem.score }}}
-                          </span>
-                        {{/if}}
-                      {{/if}}
-                    </div>
-
-                    {{#if subItem.extendedInfo.value}}
-                      {{> (lookup . 'name') subItem.extendedInfo.value }}
-                    {{/if}}
-                  </li>
-                {{/each}}
-              </ul>
-            </section>
-          {{/each}}
-        </div>
-        {{/if}}
       </section>
       {{/each}}
       </div>

--- a/lighthouse-core/report/templates/report.html
+++ b/lighthouse-core/report/templates/report.html
@@ -16,11 +16,14 @@ limitations under the License.
 
 -->
 <!doctype html>
-<html>
+<html data-report-context="{{reportContext}}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>Lighthouse report: {{ url }}</title>
+  {{!--
+  <link rel="stylesheet" href="lighthouse-core/report/styles/report.css">
+  --}}
   <style>
   {{{ css }}}
   </style>
@@ -30,6 +33,10 @@ limitations under the License.
 
   <section class="report-body">
     <div class="report-body__header">
+      <div class="report-body__metadata">
+        <div class="report-body__url">Results for: <a href="{{ url }}" target="_blank">{{ url }}</a></div>
+        <div class="report-body__url">Generated on: {{generatedTime}}</div>
+      </div>
       <div class="toggle">
         <h1 class="toggle__title">View:</h1>
 
@@ -63,73 +70,91 @@ limitations under the License.
         </div>
       </div>
 
-      <div class="report-body__url">Results for <a href="{{ url }}" target="_blank">{{ url }}</a></div>
-
+      <div class="aggregations">
       {{#each aggregations}}
-      <div class="js-breakdown report-body__breakdown">
-        <h1 class="report-section__title" id="{{nameToLink this.name}}">
-          <span class="report-section__title-main">{{ this.name }}</span>
-          {{#if this.scored}}
-          <span class="report-section__title-score">
-            <span class="report-section__title-score-total report-section__title-score-total--{{ getTotalScoreRating this }}">{{ getTotalScore this }}</span>
-            <span class="report-section__title-score-max"> / 100</span>
+      <section class="js-breakdown section1">
+        <header class="header1" id="{{nameToLink this.name}}">
+          <h1>{{ this.name }}</h1>
+        </header>
+        <p class="section1__desc">{{ this.description }}</p>
+        {{#if this.scored}}
+        <div class="section-result">
+          <span class="section-result__score --{{ getTotalScoreRating this }}">
+            <span class="section-result__points">{{ getTotalScore this }}</span>
+            <span class="section-result__divider">/</span>
+            <span class="section-result__total">100</span>
           </span>
-          {{/if}}
-        </h1>
-        <p class="report-section__description">{{ this.description }}</p>
+        </div>
+        {{/if}}
 
         <div class="js-report-by-user-feature">
           {{#each this.score as |aggregation|}}
-            <section class="report-body__breakdown-item">
+            <section class="section2">
 
             {{#if aggregation.name }}
-            <h1 class="report-section__subtitle">{{ aggregation.name }}</h1>
+            <header class="header2">
+              <h2>{{ aggregation.name }}</h2>
+              </header>
             {{/if}}
 
             {{#if aggregation.description }}
-            <p class="report-section__aggregation-description">{{{ aggregation.description }}}</p>
+            <p class="section2__desc">{{{ aggregation.description }}}</p>
             {{/if}}
 
-            <ul class="report-section__individual-results">
+            <ul class="subitems">
               {{#each aggregation.subItems as |subItem| }}
-                <li class="report-section__item {{#if subItem.comingSoon}}coming-soon{{/if}}">
-                  <div class="report-section__item-details">
-                    <span class="report-section__item-description">
-                      {{#unless ../../scored }}
-                        <span class="report-section__item-category">
-                          {{ subItem.category }}:
-                        </span>
-                      {{/unless}}
+                <li class="subitem {{#if subItem.comingSoon}}--coming-soon{{/if}}">
 
-                      {{ subItem.description }}
-                      {{#if subItem.optimalValue }}
-                        <small>
-                          (target: {{ subItem.optimalValue }})
-                        </small>
-                      {{/if}}
-                      {{#if subItem.comingSoon}}
-                      (Coming soon)
-                      {{/if}}
+                  <p class="subitem__desc">
+                    {{#unless ../../scored }}
+                      <strong class="subitem__category">{{ subItem.category }}:</strong>
+                    {{/unless}}
+                    
+                    {{ subItem.description }}
 
-                      {{#if subItem.helpText }}
-                        <span class="report-section__item-help-toggle">?</span>
-                      {{/if}}
-                    </span>
+                    {{~#if (and subItem.displayValue (not (is-bool subItem.displayValue))) ~}}
+                      <strong class="subitem__raw-value">: {{ subItem.displayValue }}</strong>
+                    {{/if}}
 
-                    {{#if subItem.displayValue }}
-                    <span class="report-section__item-raw-value">({{ subItem.displayValue }})&nbsp;</span>
-                    {{/if }}
-                    <span class="report-section__item-value report-section__item-value--{{ getItemRating subItem.score }}">{{{ getItemValue subItem.score }}}</span>
-                  </div>
+                    {{#if subItem.optimalValue }}
+                      <small>(target: {{ subItem.optimalValue }})</small>
+                    {{/if}}
+
+                    {{#if subItem.comingSoon}}
+                      <small class="subitem__tease">(Coming soon)</small>
+                    {{/if}}
+
+                    {{#if subItem.helpText }}
+                      <input type="checkbox" class="subitem__help-toggle" title="Toggle help text">
+                    {{/if}}
+                  </p>
 
                   {{#if subItem.helpText }}
-                    <div class="report-section__item-helptext" {{showHelpText subItem.score}}>
+                    <div class="subitem__help" {{showHelpText subItem.score}}>
                       {{{ subItem.helpText }}}
                     </div>
                   {{/if}}
 
+                  <div class="subitem-result">
+                    {{#if subItem.comingSoon}}
+                          <span class="subitem-result__unknown">N/A</span>
+                    {{else}}
+                      {{#if (is-bool subItem.score)}}
+                        {{#if subItem.score}}
+                          <span class="subitem-result__good">Pass</span>
+                        {{else}}
+                          <span class="subitem-result__poor">Fail</span>
+                        {{/if}}
+                      {{else}}
+                        <span class="subitem-result__points --{{ getItemRating subItem.score }}">
+                          {{{ getItemValue subItem.score }}}
+                        </span>
+                      {{/if}}
+                    {{/if}}
+                  </div>
+
                   {{#if subItem.extendedInfo.value}}
-                    <div class="report-section__item-extended-info">{{> (lookup . 'name') subItem.extendedInfo.value }}</div>
+                    {{> (lookup . 'name') subItem.extendedInfo.value }}
                   {{/if}}
                 </li>
               {{/each}}
@@ -139,32 +164,47 @@ limitations under the License.
         </div>
 
         {{#if this.categorizable}}
-        <div class="js-report-by-technology" hidden="hidden">
+        <div class="js-report-by-technology">
            {{#each ../auditsByCategory }}
-            <section class="report-body__breakdown-item">
-              <h1 class="report-section__subtitle">{{ @key }}</h1>
+            <section class="section2">
+              <header class="header2"><h2>{{ @key }}</h2></header>
 
-              <ul class="report-section__individual-results">
+              <ul class="subitems">
                 {{#each this as |subItem| }}
-                  <li class="report-section__item {{#if subItem.comingSoon}}coming-soon{{/if}}">
-                    <div class="report-section__item-details">
-                      <span class="report-section__item-description">
-                        {{ subItem.description }}
-                        {{#if subItem.optimalValue }}
-                          (target: {{ subItem.optimalValue }})
-                        {{/if}}
-                        {{#if subItem.comingSoon}}
-                        (Coming soon)
-                        {{/if}}
-                      </span>
-                      {{#if subItem.rawValue }}
-                      <span class="report-section__item-raw-value">({{ subItem.rawValue }})&nbsp;</span>
+                  <li class="subitem {{#if subItem.comingSoon}}--coming-soon{{/if}}">
+                    <div class="subitem__desc">
+                      {{ subItem.description }}
+                      {{~#if (and subItem.rawValue (not (is-bool subItem.rawValue)))~}}
+                        : <strong class="subitem__raw-value">{{ subItem.rawValue }}</strong>
                       {{/if }}
-                      <span class="report-section__item-value report-section__item-value--{{ getItemRating subItem.value }}">{{{ getItemValue subItem.value }}}</span>
+                      {{#if subItem.optimalValue }}
+                        (target: {{ subItem.optimalValue }})
+                      {{/if}}
+                      {{#if subItem.comingSoon}}
+                        (Coming soon)
+                      {{/if}}
+                    </div>
+                    
+                    <div class="subitem-result">
+                      {{#if subItem.comingSoon}}
+                            <span class="subitem-result__unknown">N/A</span>
+                      {{else}}
+                        {{#if (is-bool subItem.score)}}
+                          {{#if subItem.score}}
+                            <span class="subitem-result__good">Pass</span>
+                          {{else}}
+                            <span class="subitem-result__poor">Fail</span>
+                          {{/if}}
+                        {{else}}
+                          <span class="subitem-result__points --{{ getItemRating subItem.score }}">
+                            {{{ getItemValue subItem.score }}}
+                          </span>
+                        {{/if}}
+                      {{/if}}
                     </div>
 
                     {{#if subItem.extendedInfo.value}}
-                      <div class="report-section__item-extended-info">{{> (lookup . 'name') subItem.extendedInfo.value }}</div>
+                      {{> (lookup . 'name') subItem.extendedInfo.value }}
                     {{/if}}
                   </li>
                 {{/each}}
@@ -173,8 +213,9 @@ limitations under the License.
           {{/each}}
         </div>
         {{/if}}
-      </div>
+      </section>
       {{/each}}
+      </div>
     </div>
 
     <footer class="footer">

--- a/lighthouse-core/report/templates/report.html
+++ b/lighthouse-core/report/templates/report.html
@@ -21,9 +21,6 @@ limitations under the License.
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>Lighthouse report: {{ url }}</title>
-  {{!--
-  <link rel="stylesheet" href="lighthouse-core/report/styles/report.css">
-  --}}
   <style>
   {{{ css }}}
   </style>

--- a/lighthouse-core/report/templates/report.html
+++ b/lighthouse-core/report/templates/report.html
@@ -164,7 +164,7 @@ limitations under the License.
         </div>
 
         {{#if this.categorizable}}
-        <div class="js-report-by-technology">
+        <div class="js-report-by-technology" hidden>
            {{#each ../auditsByCategory }}
             <section class="section2">
               <header class="header2"><h2>{{ @key }}</h2></header>

--- a/lighthouse-core/report/templates/report.html
+++ b/lighthouse-core/report/templates/report.html
@@ -94,7 +94,7 @@ limitations under the License.
             {{#if aggregation.name }}
             <header class="header2">
               <h2>{{ aggregation.name }}</h2>
-              </header>
+            </header>
             {{/if}}
 
             {{#if aggregation.description }}
@@ -137,7 +137,7 @@ limitations under the License.
 
                   {{#if subItem.debugString }}
                     <div class="subitem__debug">
-                      {{{ subItem.helpText }}}
+                      {{{ subItem.debugString }}}
                     </div>
                   {{/if}}
 

--- a/lighthouse-core/report/templates/report.html
+++ b/lighthouse-core/report/templates/report.html
@@ -103,7 +103,7 @@ limitations under the License.
 
             <ul class="subitems">
               {{#each aggregation.subItems as |subItem| }}
-                <li class="subitem {{#if subItem.comingSoon}}--coming-soon{{/if}}">
+                <li class="subitem {{#if subItem.comingSoon}}--coming-soon{{/if}} {{#if (shouldShowHelpText subItem.score)}}--show-help{{/if}}">
 
                   <p class="subitem__desc">
                     {{#unless ../../scored }}
@@ -125,12 +125,18 @@ limitations under the License.
                     {{/if}}
 
                     {{#if subItem.helpText }}
-                      <input type="checkbox" class="subitem__help-toggle" title="Toggle help text">
+                      <input type="checkbox" class="subitem__help-toggle" title="Toggle help text"  {{#if (shouldShowHelpText subItem.score)}}checked{{/if}}>
                     {{/if}}
                   </p>
 
                   {{#if subItem.helpText }}
-                    <div class="subitem__help" {{showHelpText subItem.score}}>
+                    <div class="subitem__help">
+                      {{{ subItem.helpText }}}
+                    </div>
+                  {{/if}}
+
+                  {{#if subItem.debugString }}
+                    <div class="subitem__debug">
                       {{{ subItem.helpText }}}
                     </div>
                   {{/if}}


### PR DESCRIPTION
- Moved pass/fail/score from the right side to the left for better readability
- Added icons for pass/fail/help
- Added chromeless styling (based on data-report-context) for future integrations.
- Various other visual cleanups and consolidations.

**Old report:**
![image](https://cloud.githubusercontent.com/assets/291485/20147536/5bda948a-a65d-11e6-87ff-6cae7ec1c00b.png)

**New report:**
![image](https://cloud.githubusercontent.com/assets/291485/20147560/731a4884-a65d-11e6-9303-203cd16380f0.png)

**Chromeless report:**
![image](https://cloud.githubusercontent.com/assets/291485/20147580/86f36494-a65d-11e6-99a0-d72f3b162006.png)





