### PR TITLE
move `gt` handlebars helper to accessibility formatter

### DIFF
--- a/lighthouse-core/formatters/accessibility.js
+++ b/lighthouse-core/formatters/accessibility.js
@@ -50,6 +50,14 @@ class Accessibilty extends Formatter {
         throw new Error('Unknown formatter type');
     }
   }
+
+  static getHelpers() {
+    return {
+      gt(a, b) {
+        return a > b;
+      }
+    };
+  }
 }
 
 module.exports = Accessibilty;

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -106,9 +106,6 @@ class ReportGenerator {
     // value is boolean?
     Handlebars.registerHelper('is-bool', value => (typeof value === 'boolean'));
 
-    // a > b
-    Handlebars.registerHelper('gt', (a, b) => (a > b));
-
     // !value
     Handlebars.registerHelper('not', value => !value);
 


### PR DESCRIPTION
#926 started causing an error in the [html formatters test](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/test/formatter/formatters-test.js#L62) when the accessibility formatter tried to use the `gt` handlebars helper but no such helper existed (in #926 that helper was put in `report-generator.js`, which doesn't run in this test). This PR moves that helper into the accessibility formatter class, which is the only place it's currently used anyways.

There are other formatters that use helpers defined in `report-generator.js`; the key difference is that the accessibility formatter calls on that helper even when run on empty input (as the test does), while the other formatters do not.

Interestingly Travis does *not* report this error in the tests. I suspect it has something to do with the global nature of the Handlebars helper registration (so perhaps other tests have already registered the `report-generator.js` helpers) but I haven't been able to track that down.