### PR TITLE
Add support for collecting event listeners across all DOM nodes.

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -69,7 +69,12 @@
 </head>
 <body>
 
-Hi there!
+<div>
+  <h2>Do better web tester page</h2>
+  <span>Hi there!</span>
+</div>
+
+<section id="touchmove-section">touchmove section</section>
 
 <template id="noopener-links-tmpl">
   <!-- FAIL - does not use rel="noopener" to open external link -->
@@ -132,6 +137,12 @@ function mutationEvenTest() {
   });
 
   // FAIL
+  const el = document.querySelector('#touchmove-section');
+  el.addEventListener('DOMNodeInserted', function(e) {
+    console.log('DOMNodeInserted on element');
+  });
+
+  // FAIL
   window.addEventListener('DOMNodeInserted', function(e) {
     console.log('DOMNodeInserted');
   });
@@ -165,6 +176,12 @@ function passiveEventsListenerTest() {
 
   // FAIL
   document.body.addEventListener('touchmove', function(e) {
+    console.log('touchmove');
+  });
+
+  // FAIL
+  const el = document.querySelector('#touchmove-section');
+  el.addEventListener('touchmove', function(e) {
     console.log('touchmove');
   });
 

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
@@ -21,22 +21,22 @@
 
 const params = new URLSearchParams(location.search);
 
-if (params.has('dateNow')) {
+if (location.search === '' || params.has('dateNow')) {
   // FAIL - Date.now() usage in another file.
   const d = Date.now();
 }
 
-if (params.has('mutationEvents')) {
+if (location.search === '' || params.has('mutationEvents')) {
   // FAIL - MutationEvent usage in another file.
   document.addEventListener('DOMNodeInserted', function(e) {
     console.log('DOMNodeInserted');
   });
 }
 
-if (params.has('passiveEvents')) {
+if (location.search === '' || params.has('passiveEvents')) {
   // FAIL - non-passive listener usage in another file.
   document.addEventListener('wheel', e => {
-    console.log('whee: arrow function');
+    console.log('wheel: arrow function');
   });
 }
 

--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -49,9 +49,9 @@ class NoMutationEventsAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-mutation-events',
-      description: 'Site does not use Mutation Events (at the page level) in its own scripts',
+      description: 'Site does not use Mutation Events in its own scripts',
       helpText: 'Using <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Mutation_events" target="_blank">Mutation events</a> degrades application performance. They are deprecated in the DOM events spec, replaced by <a href="https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver" target="_blank">MutationObservers</a>.',
-      requiredArtifacts: ['URL', 'PageLevelEventListeners']
+      requiredArtifacts: ['URL', 'EventListeners']
     };
   }
 
@@ -60,17 +60,17 @@ class NoMutationEventsAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (typeof artifacts.PageLevelEventListeners === 'undefined' ||
-        artifacts.PageLevelEventListeners === -1) {
+    if (typeof artifacts.EventListeners === 'undefined' ||
+        artifacts.EventListeners === -1) {
       return NoMutationEventsAudit.generateAuditResult({
         rawValue: -1,
-        debugString: 'PageLevelEventListeners gatherer did not run'
+        debugString: 'EventListeners gatherer did not run'
       });
-    } else if (artifacts.PageLevelEventListeners.rawValue === -1) {
-      return NoMutationEventsAudit.generateAuditResult(artifacts.PageLevelEventListeners);
+    } else if (artifacts.EventListeners.rawValue === -1) {
+      return NoMutationEventsAudit.generateAuditResult(artifacts.EventListeners);
     }
 
-    const listeners = artifacts.PageLevelEventListeners;
+    const listeners = artifacts.EventListeners;
 
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
 

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -78,7 +78,7 @@ class PassiveEventsAudit extends Audit {
       const handler = loc.handler ? loc.handler.description : '...';
       return Object.assign({
         label: `line: ${loc.line}, col: ${loc.col}`,
-        code: `${loc.objectId}.addEventListener('${loc.type}', ${handler})`
+        code: `${loc.objectName}.addEventListener('${loc.type}', ${handler})`
       }, loc);
     });
 

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -43,7 +43,7 @@ class PassiveEventsAudit extends Audit {
       description: 'Site is using passive listeners (at the page level) ' +
                    'to improve scrolling performance',
       helpText: `<a href="https://www.chromestatus.com/features/5745543795965952" target="_blank">Passive event listeners</a> enable better scrolling performance. If you don't call <code>preventDefault()</code> in your <code>${this.SCROLL_BLOCKING_EVENTS.toString()}</code> event listeners, make them passive: <code>addEventListener('touchstart', ..., {passive: true})</code>.`,
-      requiredArtifacts: ['URL', 'PageLevelEventListeners']
+      requiredArtifacts: ['URL', 'EventListeners']
     };
   }
 
@@ -52,17 +52,17 @@ class PassiveEventsAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (typeof artifacts.PageLevelEventListeners === 'undefined' ||
-        artifacts.PageLevelEventListeners === -1) {
+    if (typeof artifacts.EventListeners === 'undefined' ||
+        artifacts.EventListeners === -1) {
       return PassiveEventsAudit.generateAuditResult({
         rawValue: -1,
-        debugString: 'PageLevelEventListeners gatherer did not run'
+        debugString: 'EventListeners gatherer did not run'
       });
-    } else if (artifacts.PageLevelEventListeners.rawValue === -1) {
-      return PassiveEventsAudit.generateAuditResult(artifacts.PageLevelEventListeners);
+    } else if (artifacts.EventListeners.rawValue === -1) {
+      return PassiveEventsAudit.generateAuditResult(artifacts.EventListeners);
     }
 
-    const listeners = artifacts.PageLevelEventListeners;
+    const listeners = artifacts.EventListeners;
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
 
     // Filter out non-passive window/document/document.body listeners that do

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -30,11 +30,11 @@
     "passName": "dbw",
     "gatherers": [
       "styles",
+      "dobetterweb/all-event-listeners",
       "dobetterweb/anchors-with-no-rel-noopener",
       "dobetterweb/appcache",
       "dobetterweb/console-time-usage",
       "dobetterweb/datenow",
-      "dobetterweb/document-event-listeners",
       "dobetterweb/document-write",
       "dobetterweb/geolocation-on-start",
       "dobetterweb/links-blocking-first-paint",

--- a/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
@@ -131,16 +131,13 @@ class EventListeners extends Gatherer {
     const driver = options.driver;
 
     return this.unlistenForScriptParsedEvents(options.driver)
-        .then(_ => driver.sendCommand('DOM.enable'))
         .then(_ => driver.querySelectorAll('body, body /deep/ *')) // drills into shadow trees
         .then(nodes => {
           nodes.push('document', 'window');
           return this.collectListeners(nodes);
         })
         .then(listeners => {
-          return driver.sendCommand('DOM.disable').then(_ => {
-            this.artifact = listeners;
-          });
+          this.artifact = listeners;
         }).catch(_ => {
           this.artifact = {
             usage: -1,

--- a/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
@@ -59,7 +59,7 @@ class PageLevelEventListeners extends Gatherer {
     }
 
     return promise.then(result => {
-      let obj = result.object || result.result;
+      const obj = result.object || result.result;
       return this.driver.sendCommand('DOMDebugger.getEventListeners', {
         objectId: obj.objectId
       }).then(listeners => {
@@ -137,7 +137,7 @@ class PageLevelEventListeners extends Gatherer {
         })
         .then(listeners => {
           this.artifact = listeners;
-        }).catch(e => {
+        }).catch(_ => {
           this.artifact = {
             usage: -1,
             debugString: 'Unable to collect passive events listener usage.'

--- a/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
@@ -130,7 +130,7 @@ class EventListeners extends Gatherer {
 
     return this.unlistenForScriptParsedEvents(options.driver)
         .then(_ => driver.sendCommand('DOM.enable'))
-        .then(_ => driver.querySelectorAll('body, body *'))
+        .then(_ => driver.querySelectorAll('body, body /deep/ *')) // drills into shadow trees
         .then(nodes => {
           nodes.push('document', 'window');
           return this.collectListeners(nodes);

--- a/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
@@ -49,12 +49,12 @@ class PageLevelEventListeners extends Gatherer {
     if (typeof nodeId === 'string') {
       promise = this.driver.sendCommand('Runtime.evaluate', {
         expression: nodeId,
-        objectGroup: 'event-listeners-gatherer' // needed to populate event handler info.
+        objectGroup: 'event-listeners-gatherer' // populates event handler info.
       });
     } else {
       promise = this.driver.sendCommand('DOM.resolveNode', {
         nodeId: nodeId,
-        objectGroup: 'event-listeners-gatherer' // needed to populate event handler info.
+        objectGroup: 'event-listeners-gatherer' // populates event handler info.
       });
     }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
@@ -39,21 +39,22 @@ class EventListeners extends Gatherer {
   }
 
   /**
-   * @param {number|string} node The node id of the element, 'document', or 'window'.
+   * @param {number|string} nodeIdOrObject The node id of the element or the
+   *     string of and object ('document', 'window').
    * @return {!Promise<!Array.<EventListener>>}
    * @private
    */
-  _listEventListeners(nodeId) {
+  _listEventListeners(nodeIdOrObject) {
     let promise;
 
-    if (typeof nodeId === 'string') {
+    if (typeof nodeIdOrObject === 'string') {
       promise = this.driver.sendCommand('Runtime.evaluate', {
-        expression: nodeId,
+        expression: nodeIdOrObject,
         objectGroup: 'event-listeners-gatherer' // populates event handler info.
       });
     } else {
       promise = this.driver.sendCommand('DOM.resolveNode', {
-        nodeId: nodeId,
+        nodeId: nodeIdOrObject,
         objectGroup: 'event-listeners-gatherer' // populates event handler info.
       });
     }

--- a/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/document-event-listeners.js
@@ -23,7 +23,7 @@
 
 const Gatherer = require('../gatherer');
 
-class PageLevelEventListeners extends Gatherer {
+class EventListeners extends Gatherer {
 
   listenForScriptParsedEvents() {
     return this.driver.sendCommand('Debugger.enable').then(_ => {
@@ -146,4 +146,4 @@ class PageLevelEventListeners extends Gatherer {
   }
 }
 
-module.exports = PageLevelEventListeners;
+module.exports = EventListeners;

--- a/lighthouse-core/test/audits/dobetterweb/no-mutation-events-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-mutation-events-test.js
@@ -33,7 +33,7 @@ describe('Page does not use mutation events', () => {
 
   it('passes when mutation events are not used', () => {
     const auditResult = NoMutationEventsAudit.audit({
-      PageLevelEventListeners: [],
+      EventListeners: [],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, true);
@@ -42,20 +42,20 @@ describe('Page does not use mutation events', () => {
 
   it('fails when mutation events are used on the origin', () => {
     const auditResult = NoMutationEventsAudit.audit({
-      PageLevelEventListeners: fixtureData,
+      EventListeners: fixtureData,
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);
-    assert.equal(auditResult.extendedInfo.value.length, 3);
+    assert.equal(auditResult.extendedInfo.value.length, 4);
   });
 
   it('fails when listener is missing a url property', () => {
     const auditResult = NoMutationEventsAudit.audit({
-      PageLevelEventListeners: fixtureData,
+      EventListeners: fixtureData,
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);
     assert.ok(auditResult.extendedInfo.value[1].url === undefined);
-    assert.equal(auditResult.extendedInfo.value.length, 3);
+    assert.equal(auditResult.extendedInfo.value.length, 4);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
@@ -33,7 +33,7 @@ describe('Page uses passive events listeners where applicable', () => {
   it('debugString is present if gatherer fails', () => {
     const debugString = 'Unable to gather passive event listeners usage.';
     const auditResult = PassiveEventsAudit.audit({
-      PageLevelEventListeners: {
+      EventListeners: {
         rawValue: -1,
         debugString: debugString
       },
@@ -45,7 +45,7 @@ describe('Page uses passive events listeners where applicable', () => {
 
   it('fails when scroll blocking listeners should be passive', () => {
     const auditResult = PassiveEventsAudit.audit({
-      PageLevelEventListeners: fixtureData,
+      EventListeners: fixtureData,
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, false);
@@ -63,7 +63,7 @@ describe('Page uses passive events listeners where applicable', () => {
 
   it('passes scroll blocking listeners should be passive', () => {
     const auditResult = PassiveEventsAudit.audit({
-      PageLevelEventListeners: [],
+      EventListeners: [],
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, true);
@@ -72,7 +72,7 @@ describe('Page uses passive events listeners where applicable', () => {
 
   it('fails when listener is missing a url property', () => {
     const auditResult = PassiveEventsAudit.audit({
-      PageLevelEventListeners: fixtureData,
+      EventListeners: fixtureData,
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);

--- a/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
@@ -31,7 +31,7 @@ describe('Page uses passive events listeners where applicable', () => {
   });
 
   it('debugString is present if gatherer fails', () => {
-    const debugString = 'Unable to gather passive events listeners usage.';
+    const debugString = 'Unable to gather passive event listeners usage.';
     const auditResult = PassiveEventsAudit.audit({
       PageLevelEventListeners: {
         rawValue: -1,
@@ -43,7 +43,7 @@ describe('Page uses passive events listeners where applicable', () => {
     assert.equal(auditResult.debugString, debugString);
   });
 
-  it('fails when page-level scroll blocking listeners should be passive', () => {
+  it('fails when scroll blocking listeners should be passive', () => {
     const auditResult = PassiveEventsAudit.audit({
       PageLevelEventListeners: fixtureData,
       URL: {finalUrl: URL}
@@ -56,12 +56,12 @@ describe('Page uses passive events listeners where applicable', () => {
       assert.notEqual(PassiveEventsAudit.SCROLL_BLOCKING_EVENTS.indexOf(val.type), -1,
           'results should not contain other types of events');
     }
-    assert.equal(auditResult.extendedInfo.value.length, 5);
+    assert.equal(auditResult.extendedInfo.value.length, 6);
     assert.equal(auditResult.extendedInfo.value[0].url, fixtureData[0].url);
     assert.ok(auditResult.extendedInfo.value[0].code.match(/addEventListener/));
   });
 
-  it('passes page-level scroll blocking listeners should be passive', () => {
+  it('passes scroll blocking listeners should be passive', () => {
     const auditResult = PassiveEventsAudit.audit({
       PageLevelEventListeners: [],
       URL: {finalUrl: URL}
@@ -77,6 +77,6 @@ describe('Page uses passive events listeners where applicable', () => {
     });
     assert.equal(auditResult.rawValue, false);
     assert.ok(auditResult.extendedInfo.value[1].url === undefined);
-    assert.equal(auditResult.extendedInfo.value.length, 5);
+    assert.equal(auditResult.extendedInfo.value.length, 6);
   });
 });

--- a/lighthouse-core/test/fixtures/page-level-event-listeners.json
+++ b/lighthouse-core/test/fixtures/page-level-event-listeners.json
@@ -641,5 +641,91 @@
     "objectId":"document.body",
     "line":160,
     "col":56
+  },
+  {
+    "type":"DOMNodeInserted",
+    "useCapture":false,
+    "passive":false,
+    "scriptId":"74",
+    "lineNumber":140,
+    "columnNumber":49,
+    "handler":{
+      "type":"function",
+      "className":"Function",
+      "description":"function (e) {\n    console.log('DOMNodeInserted on element');\n  }",
+      "objectId":"{\"injectedScriptId\":9,\"id\":50}"
+    },
+    "originalHandler":{
+      "type":"function",
+      "className":"Function",
+      "description":"function (e) {\n    console.log('DOMNodeInserted on element');\n  }",
+      "objectId":"{\"injectedScriptId\":9,\"id\":51}"
+    },
+    "removeFunction":{
+      "type":"function",
+      "className":"Function",
+      "description":"function remove() { [Command Line API] }",
+      "objectId":"{\"injectedScriptId\":9,\"id\":52}"
+    },
+    "url":"http://example.com/dbw_tester.html",
+    "startLine":87,
+    "startColumn":8,
+    "endLine":279,
+    "endColumn":0,
+    "executionContextId":9,
+    "hash":"D30491F357534D373A3E60171730B9C871495595",
+    "executionContextAuxData":{
+      "isDefault":true,
+      "frameId":"36427.1"
+    },
+    "isLiveEdit":false,
+    "sourceMapURL":"",
+    "hasSourceURL":false,
+    "objectId":"section#touchmove-section",
+    "line":141,
+    "col":50
+  },
+  {
+    "type":"touchmove",
+    "useCapture":false,
+    "passive":false,
+    "scriptId":"74",
+    "lineNumber":183,
+    "columnNumber":43,
+    "handler":{
+      "type":"function",
+      "className":"Function",
+      "description":"function (e) {\n    console.log('touchmove');\n  }",
+      "objectId":"{\"injectedScriptId\":9,\"id\":53}"
+    },
+    "originalHandler":{
+      "type":"function",
+      "className":"Function",
+      "description":"function (e) {\n    console.log('touchmove');\n  }",
+      "objectId":"{\"injectedScriptId\":9,\"id\":54}"
+    },
+    "removeFunction":{
+      "type":"function",
+      "className":"Function",
+      "description":"function remove() { [Command Line API] }",
+      "objectId":"{\"injectedScriptId\":9,\"id\":55}"
+    },
+    "url":"http://example.com/dbw_tester.html",
+    "startLine":87,
+    "startColumn":8,
+    "endLine":279,
+    "endColumn":0,
+    "executionContextId":9,
+    "hash":"D30491F357534D373A3E60171730B9C871495595",
+    "executionContextAuxData":{
+      "isDefault":true,
+      "frameId":"36427.1"
+    },
+    "isLiveEdit":false,
+    "sourceMapURL":"",
+    "hasSourceURL":false,
+    "objectId":"section#touchmove-section",
+    "line":184,
+    "col":44
   }
 ]


### PR DESCRIPTION
R: all

Fixes #858. This adds support for looking up event listeners on all DOM nodes. Previously the gatherer just returned listeners at the page level.