### PR TITLE
Report: show the displayValue of perf metrics

### DIFF
--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -99,10 +99,10 @@ limitations under the License.
                     {{#unless ../../scored }}
                       <strong class="subitem__category">{{ subItem.category }}:</strong>
                     {{/unless}}
-                    
+
                     {{ subItem.description }}
 
-                    {{~#if (and subItem.displayValue (not (is-bool subItem.displayValue))) ~}}
+                    {{#if subItem.displayValue }}
                       <strong class="subitem__raw-value">: {{ subItem.displayValue }}</strong>
                     {{/if}}
 


### PR DESCRIPTION
Before and after:
![image](https://cloud.githubusercontent.com/assets/39191/20242510/38ad5472-a8e5-11e6-81ee-13464237a502.png)


@chowse can you review? I couldn't understand the ` {{~#if (and subItem.displayValue (not (is-bool subItem.displayValue))) ~}}` line, and removing it didn't seem to introduce any problems, but you probably know better.