### PR TITLE
fix arguments in handlebars `and` helper

### DIFF
--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -110,7 +110,7 @@ class ReportGenerator {
     Handlebars.registerHelper('not', value => !value);
 
     // arg1 && arg2 && ... && argn
-    Handlebars.registerHelper('and', () => {
+    Handlebars.registerHelper('and', function() {
       let arg = false;
       for (let i = 0, n = arguments.length - 1; i < n; i++) {
         arg = arguments[i];


### PR DESCRIPTION
alternate to #936 

the issue was arrow functions don't get an `arguments` of their own. The `and` helper always skipped the loop, returned false, and so never displayed the `displayValue`.