### PR TITLE
Update TTI scoring label to 5000ms (matches guidance)

### DIFF
--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -17,6 +17,8 @@ const Formatter = require('../formatters/formatter');
 //   https://www.desmos.com/calculator/jlrx14q4w8
 const SCORING_POINT_OF_DIMINISHING_RETURNS = 1700;
 const SCORING_MEDIAN = 5000;
+// This aligns with the external TTI targets in https://goo.gl/yXqxpL
+const SCORING_TARGET = 5000;
 
 class TTIMetric extends Audit {
   /**
@@ -27,7 +29,7 @@ class TTIMetric extends Audit {
       category: 'Performance',
       name: 'time-to-interactive',
       description: 'Time To Interactive (alpha)',
-      optimalValue: SCORING_POINT_OF_DIMINISHING_RETURNS.toLocaleString(),
+      optimalValue: SCORING_TARGET.toLocaleString(),
       requiredArtifacts: ['traceContents']
     };
   }

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -29,7 +29,7 @@ class TTIMetric extends Audit {
       category: 'Performance',
       name: 'time-to-interactive',
       description: 'Time To Interactive (alpha)',
-      optimalValue: SCORING_TARGET.toLocaleString(),
+      optimalValue: SCORING_TARGET.toLocaleString() + 'ms',
       requiredArtifacts: ['traceContents']
     };
   }


### PR DESCRIPTION
The current TTI uses our point of diminishing returns as a label, however this number (1700) currently doesn't align with the external guidance on TTI targets (5s on 3G). This PR updates the TTI target to 5000 as discussed with sir @brendankenny. 

![screen shot 2016-11-15 at 6 11 27 pm](https://cloud.githubusercontent.com/assets/110953/20332217/243e9e02-ab5f-11e6-963a-49df72b35200.jpg)

A separate commit also adds the missing `ms` units to the report that are used in other performance metrics but not included in TTI for some reason. Two fixes for the price of one 🐦 🐦 

![screen shot 2016-11-15 at 6 14 33 pm](https://cloud.githubusercontent.com/assets/110953/20332291/96e74134-ab5f-11e6-997b-ea1ad2fcc260.jpg)
