### PR TITLE
Slight refactor of event listener label/code formatting. Also Fixes #951

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -24,6 +24,7 @@
 
 const url = require('url');
 const Audit = require('../audit');
+const EventHelpers = require('../../lib/event-helpers');
 const Formatter = require('../../formatters/formatter');
 
 class NoMutationEventsAudit extends Audit {
@@ -78,13 +79,7 @@ class NoMutationEventsAudit extends Audit {
       const isMutationEvent = this.MUTATION_EVENTS.indexOf(loc.type) !== -1;
       const sameHost = loc.url ? url.parse(loc.url).host === pageHost : true;
       return sameHost && isMutationEvent;
-    }).map(loc => {
-      const handler = loc.handler ? loc.handler.description : '...';
-      return Object.assign({
-        label: `line: ${loc.line}, col: ${loc.col}`,
-        code: `${loc.objectId}.addEventListener('${loc.type}', ${handler})`
-      }, loc);
-    });
+    }).map(loc => EventHelpers.addFormattedCodeSnippet(loc));
 
     return NoMutationEventsAudit.generateAuditResult({
       rawValue: results.length === 0,

--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -79,7 +79,7 @@ class NoMutationEventsAudit extends Audit {
       const isMutationEvent = this.MUTATION_EVENTS.indexOf(loc.type) !== -1;
       const sameHost = loc.url ? url.parse(loc.url).host === pageHost : true;
       return sameHost && isMutationEvent;
-    }).map(loc => EventHelpers.addFormattedCodeSnippet(loc));
+    }).map(EventHelpers.addFormattedCodeSnippet);
 
     return NoMutationEventsAudit.generateAuditResult({
       rawValue: results.length === 0,

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -24,6 +24,7 @@
 
 const url = require('url');
 const Audit = require('../audit');
+const EventHelpers = require('../../lib/event-helpers');
 const Formatter = require('../../formatters/formatter');
 
 class PassiveEventsAudit extends Audit {
@@ -74,13 +75,7 @@ class PassiveEventsAudit extends Audit {
       const sameHost = loc.url ? url.parse(loc.url).host === pageHost : true;
       return sameHost && isScrollBlocking && !loc.passive &&
              !mentionsPreventDefault;
-    }).map(loc => {
-      const handler = loc.handler ? loc.handler.description : '...';
-      return Object.assign({
-        label: `line: ${loc.line}, col: ${loc.col}`,
-        code: `${loc.objectName}.addEventListener('${loc.type}', ${handler})`
-      }, loc);
-    });
+    }).map(loc => EventHelpers.addFormattedCodeSnippet(loc));
 
     return PassiveEventsAudit.generateAuditResult({
       rawValue: results.length === 0,

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -75,7 +75,7 @@ class PassiveEventsAudit extends Audit {
       const sameHost = loc.url ? url.parse(loc.url).host === pageHost : true;
       return sameHost && isScrollBlocking && !loc.passive &&
              !mentionsPreventDefault;
-    }).map(loc => EventHelpers.addFormattedCodeSnippet(loc));
+    }).map(EventHelpers.addFormattedCodeSnippet);
 
     return PassiveEventsAudit.generateAuditResult({
       rawValue: results.length === 0,

--- a/lighthouse-core/closure/closure-type-checking.js
+++ b/lighthouse-core/closure/closure-type-checking.js
@@ -29,6 +29,7 @@ gulp.task('js-compile', function() {
     'closure/third_party/*.js',
     'audits/**/*.js',
     'lib/icons.js',
+    'lib/event-helpers.js',
     'lib/styles-helpers.js',
     'aggregator/**/*.js'
   ])

--- a/lighthouse-core/lib/event-helpers.js
+++ b/lighthouse-core/lib/event-helpers.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Adds line/col information to an event listener object along with a formatted
+ * code snippet of violation.
+ *
+ * @param {!EventListener} listener A modified EventListener object as returned
+ *     by the events gatherer.
+ * @return {!Object} A copy of the original listener object with the added
+ *     properties.
+ */
+function addFormattedCodeSnippet(listener) {
+  const handler = listener.handler ? listener.handler.description : '...';
+  const objectName = listener.objectName.toLowerCase().replace('#document', 'document');
+  return Object.assign({
+    label: `line: ${listener.line}, col: ${listener.col}`,
+    code: `${objectName}.addEventListener('${listener.type}', ${handler})`
+  }, listener);
+}
+
+module.exports = {
+  addFormattedCodeSnippet
+};

--- a/lighthouse-core/lib/event-helpers.js
+++ b/lighthouse-core/lib/event-helpers.js
@@ -20,8 +20,8 @@
  * Adds line/col information to an event listener object along with a formatted
  * code snippet of violation.
  *
- * @param {!EventListener} listener A modified EventListener object as returned
- *     by the events gatherer.
+ * @param {!Object} listener A modified EventListener object as returned
+ *     by the driver in the all events gatherer.
  * @return {!Object} A copy of the original listener object with the added
  *     properties.
  */

--- a/lighthouse-core/test/fixtures/page-level-event-listeners.json
+++ b/lighthouse-core/test/fixtures/page-level-event-listeners.json
@@ -38,7 +38,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"window",
+    "objectName":"Window",
     "line":112,
     "col":54
   },
@@ -81,7 +81,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"window",
+    "objectName":"Window",
     "line":117,
     "col":55
   },
@@ -124,7 +124,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"window",
+    "objectName":"Window",
     "line":127,
     "col":44
   },
@@ -166,7 +166,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"window",
+    "objectName":"Window",
     "line":132,
     "col":49
   },
@@ -209,7 +209,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"window",
+    "objectName":"Window",
     "line":165,
     "col":49
   },
@@ -252,7 +252,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"window",
+    "objectName":"Window",
     "line":137,
     "col":49
   },
@@ -295,7 +295,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"window",
+    "objectName":"Window",
     "line":170,
     "col":45
   },
@@ -338,7 +338,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"document",
+    "objectName":"#document",
     "line":11,
     "col":36
   },
@@ -380,7 +380,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"document",
+    "objectName":"#document",
     "line":97,
     "col":56
   },
@@ -423,7 +423,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"document",
+    "objectName":"#document",
     "line":102,
     "col":55
   },
@@ -466,7 +466,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"document",
+    "objectName":"#document",
     "line":142,
     "col":51
   },
@@ -509,7 +509,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"document",
+    "objectName":"#document",
     "line":152,
     "col":51
   },
@@ -552,7 +552,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"document.body",
+    "objectName":"document.body",
     "line":107,
     "col":61
   },
@@ -595,7 +595,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"document.body",
+    "objectName":"body",
     "line":147,
     "col":55
   },
@@ -638,7 +638,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"document.body",
+    "objectName":"body",
     "line":160,
     "col":56
   },
@@ -681,7 +681,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"section#touchmove-section",
+    "objectName":"section#touchmove-section",
     "line":141,
     "col":50
   },
@@ -724,7 +724,7 @@
     "isLiveEdit":false,
     "sourceMapURL":"",
     "hasSourceURL":false,
-    "objectId":"section#touchmove-section",
+    "objectName":"section#touchmove-section",
     "line":184,
     "col":44
   }

--- a/lighthouse-core/test/lib/event-helpers-test.js
+++ b/lighthouse-core/test/lib/event-helpers-test.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const EventHelpers = require('../../lib/event-helpers');
+const assert = require('assert');
+
+const eventListeners = require('../fixtures/page-level-event-listeners.json');
+
+/* eslint-env mocha */
+
+describe('event helpers', () => {
+  describe('addFormattedCodeSnippet()', function() {
+    it('adds label and code snippet and returns new object', () => {
+      eventListeners.forEach(listener => {
+        const obj = EventHelpers.addFormattedCodeSnippet(listener);
+        assert.ok('label' in obj, 'helper adds a label property');
+        assert.ok('code' in obj, 'helper adds a code property');
+        assert.ok(obj.label.match(/line: (?:\d+), col: (?:\d+)/),
+                  'label is not formatted correctly');
+        const regEx = new RegExp(`.addEventListener\\('${listener.type}', `);
+        assert.ok(obj.code.match(regEx), 'code snippet is not formatted correctly');
+      });
+    });
+
+    it('normalizes document and window objects', () => {
+      eventListeners.forEach(listener => {
+        const obj = EventHelpers.addFormattedCodeSnippet(listener);
+        assert.ok(obj.code.indexOf('Window') !== 0, 'Window was not lowercase');
+        assert.ok(obj.code.indexOf('#document') !== 0,
+                    '#document was not replaced with document');
+      });
+    });
+  });
+});


### PR DESCRIPTION
R: @brendankenny @GoogleChrome/lighthouse 

- Fixes #951 
- Adds a slight refactor, removing duplicated code into lib/event-helpers.js. The single use event listener will also use this 👍 
- normals `Window` -> `window` and `#document` -> `document`. These are cleaner and more intuitive names than what the driver returns.

Before:

![screen shot 2016-11-16 at 1 48 36 pm](https://cloud.githubusercontent.com/assets/238208/20368303/4f4551e6-ac08-11e6-98c1-e5f8f0dac315.png)

After:

![screen shot 2016-11-16 at 2 23 22 pm](https://cloud.githubusercontent.com/assets/238208/20368293/462984d8-ac08-11e6-907d-7ed3e55a8b19.png)
