### PR TITLE
only create a manifest display debugString when there is an error

### DIFF
--- a/lighthouse-core/audits/manifest-display.js
+++ b/lighthouse-core/audits/manifest-display.js
@@ -50,11 +50,14 @@ class ManifestDisplay extends Audit {
 
     const hasRecommendedValue = ManifestDisplay.hasRecommendedValue(displayValue);
 
-    return ManifestDisplay.generateAuditResult({
+    const auditResult = {
       rawValue: hasRecommendedValue,
-      displayValue,
-      debugString: 'Manifest display property should be set.'
-    });
+      displayValue
+    };
+    if (!hasRecommendedValue) {
+      auditResult.debugString = 'Manifest display property should be set.';
+    }
+    return ManifestDisplay.generateAuditResult(auditResult);
   }
 }
 

--- a/lighthouse-core/test/audits/display-test.js
+++ b/lighthouse-core/test/audits/display-test.js
@@ -35,9 +35,9 @@ describe('Mobile-friendly: display audit', () => {
   });
 
   it('fails when no manifest artifact present', () => {
-    return assert.equal(Audit.audit({Manifest: {
-      value: undefined
-    }}).rawValue, false);
+    const output = Audit.audit({Manifest: {value: undefined}});
+    assert.equal(output.rawValue, false);
+    assert.equal(output.debugString && output.debugString.length > 0, true);
   });
 
   it('falls back to the successful default when there is no manifest display property', () => {
@@ -49,6 +49,7 @@ describe('Mobile-friendly: display audit', () => {
     assert.equal(output.score, true);
     assert.equal(output.displayValue, 'browser');
     assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
 
   it('succeeds when a manifest has a display property', () => {
@@ -61,6 +62,7 @@ describe('Mobile-friendly: display audit', () => {
     assert.equal(output.score, true);
     assert.equal(output.displayValue, 'standalone');
     assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
 
   it('succeeds when a complete manifest contains a display property', () => {


### PR DESCRIPTION
fixes #933

(taking over for #950 with @ebidel's feedback incorporated)