### PR TITLE
remove stack trace from function call site entries

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -694,9 +694,10 @@ function captureJSCallUsage(funcRef, set) {
       const file = callFrame.getFileName();
       const line = callFrame.getLineNumber();
       const col = callFrame.getColumnNumber();
-      const stackTrace = structStackTrace.slice(1).map(
-          callsite => callsite.toString());
-      return {url: file, args, line, col, stackTrace}; // return value is e.stack
+      // TODO: add back when we want stack traces. See https://github.com/GoogleChrome/lighthouse/issues/957
+      // const stackTrace = structStackTrace.slice(1).map(
+      //    callsite => callsite.toString());
+      return {url: file, args, line, col}; // return value is e.stack
     };
     const e = new Error(`__called ${funcRef.name}__`);
     set.add(JSON.stringify(e.stack));


### PR DESCRIPTION
we were getting multiple call sites per instrumented function (e.g. `Date.now`) since we were counting every call stack as a unique entry, instead of just every call site location. This removes the stack traces for now to work around this; #957 tracks adding them back later if they end up being needed.