### PR TITLE
fix(audit/without-javascript): non-string error handling

### DIFF
--- a/lighthouse-core/audits/without-javascript.js
+++ b/lighthouse-core/audits/without-javascript.js
@@ -38,10 +38,11 @@ class WithoutJavaScript extends Audit {
    */
   static audit(artifacts) {
     const artifact = artifacts.HTMLWithoutJavaScript;
-    if (artifact.value === -1) {
+    if (!artifact || typeof artifact.value !== 'string') {
       return WithoutJavaScript.generateAuditResult({
         rawValue: -1,
-        debugString: artifact.debugString
+        debugString: (artifact && artifact.debugString) ||
+          'HTMLWithoutJavaScript gatherer did not complete successfully'
       });
     }
 

--- a/lighthouse-core/gather/gatherers/html-without-javascript.js
+++ b/lighthouse-core/gather/gatherers/html-without-javascript.js
@@ -43,6 +43,10 @@ class HTMLWithoutJavaScript extends Gatherer {
 
     return options.driver.evaluateAsync(`(${getBodyText.toString()}())`)
       .then(result => {
+        if (typeof result !== 'string') {
+          throw new Error('result was not a string');
+        }
+
         this.artifact = {
           value: result
         };

--- a/lighthouse-core/test/audits/without-javascript-test.js
+++ b/lighthouse-core/test/audits/without-javascript-test.js
@@ -35,6 +35,18 @@ describe('Progressive Enhancement: without javascript audit', () => {
     assert.equal(result.debugString, debugString);
   });
 
+  it('does not error on non-string input', () => {
+    const artifacts = {
+      HTMLWithoutJavaScript: {
+        value: {}
+      }
+    };
+
+    const result = withoutJsAudit.audit(artifacts);
+    assert.equal(result.score, -1);
+    assert.ok(result.debugString);
+  });
+
   it('fails when the js-less body is empty', () => {
     const artifacts = {
       HTMLWithoutJavaScript: {

--- a/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
+++ b/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
@@ -63,6 +63,19 @@ describe('HTML without JavaScript gatherer', () => {
     });
   });
 
+  it('handles driver returning non-string', () => {
+    return htmlWithoutJavaScriptGather.afterPass({
+      driver: {
+        evaluateAsync() {
+          return Promise.resolve(null);
+        }
+      }
+    }).then(_ => {
+      assert.equal(htmlWithoutJavaScriptGather.artifact.value, -1);
+      assert.ok(htmlWithoutJavaScriptGather.artifact.debugString);
+    });
+  });
+
   it('handles driver failure', () => {
     return htmlWithoutJavaScriptGather.afterPass({
       driver: {


### PR DESCRIPTION
Handles the issue with a two-pronged solution.

1. Ensure if `innerText` returns something other than a string to surface the error in the gatherer
2. Ensure the type of the resulting artifact is a string before calling `.trim`

Addresses #967