### PR TITLE
filter unneeded aggregations from config before extension runs

### DIFF
--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -16,8 +16,6 @@
  */
 'use strict';
 
-const _flatten = arr => [].concat.apply([], arr);
-
 document.addEventListener('DOMContentLoaded', _ => {
   const background = chrome.extension.getBackgroundPage();
   const defaultAggregations = background.getDefaultAggregations();
@@ -121,22 +119,6 @@ document.addEventListener('DOMContentLoaded', _ => {
     return frag;
   }
 
-  /**
-   * Returns an array of names of audits from the selected aggregation
-   * categories.
-   * @param {!Object<boolean>} selectedAggregations
-   * @return {!Array<string>}
-   */
-  function getAuditsFromSelected(selectedAggregations) {
-    const auditLists = defaultAggregations.filter(aggregation => {
-      return selectedAggregations[aggregation.name];
-    }).map(selectedAggregation => {
-      return selectedAggregation.audits;
-    });
-
-    return _flatten(auditLists);
-  }
-
   background.listenForStatus(logstatus);
   background.loadSelectedAggregations().then(aggregations => {
     const frag = generateOptionsList(optionsList, aggregations);
@@ -148,14 +130,13 @@ document.addEventListener('DOMContentLoaded', _ => {
     feedbackEl.textContent = '';
 
     background.loadSelectedAggregations()
-    .then(getAuditsFromSelected)
-    .then(selectedAudits => {
+    .then(selectedAggregations => {
       return background.runLighthouseInExtension({
         flags: {
           disableCpuThrottling: true
         },
         restoreCleanState: true
-      }, selectedAudits);
+      }, selectedAggregations);
     })
     .catch(err => {
       let message = err.message;


### PR DESCRIPTION
fixes #921 (but for real this time)

The issue was that we were correctly filtering out audits from running based on what aggregation categories were selected in the extension, but we weren't filtering out the aggregations themselves. When report time comes along, the unselected aggregations were looking for results in audits that had been filtered out, causing the error.

@pavelfeldman: This needs to happen for both the extension and worker (DevTools) versions, though, which means it needs to happen in `lighthouse-background.js`. This means a (hopefully minor) breaking change for DevTools, as it will now need to pass in a set of aggregations to run, not a set of audits.