### PR TITLE
create single path for handling errors from the protocol

### DIFF
--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -96,8 +96,9 @@ class Connection {
       this._callbacks.delete(object.id);
 
       if (object.error) {
-        return this._handleRawError(object, callback);
+        return this.handleRawError(object.error, callback);
       }
+
       log.formatProtocol('method <= browser OK',
           {method: callback.method, params: object.result}, 'verbose');
       callback.resolve(object.result);
@@ -109,19 +110,19 @@ class Connection {
   }
 
   /**
-   * @param {{error: {message: string}}} object
-   * @param {{reject: function(*), method: string}} callback
-   * @private
+   * @param {{message: string}} error
+   * @param {{resolve: function(*), reject: function(*), method: string}} callback
+   * @protected
    */
-  _handleRawError(object, callback) {
-    // We proactively disable a few domains. Ignore any errors
-    if (object.error.message && object.error.message.includes('DOM agent hasn\'t been enabled')) {
+  handleRawError(error, callback) {
+    // We proactively disable the DOM domain. Ignore any errors.
+    if (error.message && error.message.includes('DOM agent hasn\'t been enabled')) {
       callback.resolve();
       return;
     }
-    log.formatProtocol('method <= browser ERR',
-        {method: callback.method}, 'error');
-    callback.reject(new Error(`Raw Protocol (${callback.method}) ${object.error.message}`));
+
+    log.formatProtocol('method <= browser ERR', {method: callback.method}, 'error');
+    callback.reject(new Error(`Protocol error (${callback.method}): ${error.message}`));
   }
 
   /**

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -95,14 +95,16 @@ class Connection {
       const callback = this._callbacks.get(object.id);
       this._callbacks.delete(object.id);
 
-      if (object.error) {
-        return this.handleRawError(object.error, callback);
-      }
+      // handleRawError returns or throws synchronously; wrap to put into promise chain.
+      return callback.resolve(Promise.resolve().then(_ => {
+        if (object.error) {
+          return this.handleRawError(object.error, callback.method);
+        }
 
-      log.formatProtocol('method <= browser OK',
+        log.formatProtocol('method <= browser OK',
           {method: callback.method, params: object.result}, 'verbose');
-      callback.resolve(object.result);
-      return;
+        return object.result;
+      }));
     }
     log.formatProtocol('<= event',
         {method: object.method, params: object.params}, 'verbose');
@@ -110,19 +112,24 @@ class Connection {
   }
 
   /**
+   * Handles error responses from the protocol, absorbing errors we don't care
+   * about and throwing on the rest.
+   *
+   * Currently the only error ignored is from defensive calls of `DOM.disable`
+   * when already disabled.
    * @param {{message: string}} error
-   * @param {{resolve: function(*), reject: function(*), method: string}} callback
+   * @param {string} method Protocol method that received the error response.
+   * @throws {Error}
    * @protected
    */
-  handleRawError(error, callback) {
+  handleRawError(error, method) {
     // We proactively disable the DOM domain. Ignore any errors.
     if (error.message && error.message.includes('DOM agent hasn\'t been enabled')) {
-      callback.resolve();
       return;
     }
 
-    log.formatProtocol('method <= browser ERR', {method: callback.method}, 'error');
-    callback.reject(new Error(`Protocol error (${callback.method}): ${error.message}`));
+    log.formatProtocol('method <= browser ERR', {method}, 'error');
+    throw new Error(`Protocol error (${method}): ${error.message}`);
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -475,11 +475,7 @@ class Driver {
     // Disable any domains that could interfere or add overhead to the trace
     return this.sendCommand('Debugger.disable')
       .then(_ => this.sendCommand('CSS.disable'))
-      .then(_ => {
-        return this.sendCommand('DOM.disable')
-          // If it wasn't already enabled, it will throw; ignore these. See #861
-          .catch(_ => {});
-      })
+      .then(_ => this.sendCommand('DOM.disable'))
       // Enable Page domain to wait for Page.loadEventFired
       .then(_ => this.sendCommand('Page.enable'))
       .then(_ => this.sendCommand('Tracing.start', tracingOpts));

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -155,7 +155,10 @@ class Driver {
         } else {
           resolve(result.result.value);
         }
-      }).catch(reject);
+      }).catch(err => {
+        clearTimeout(asyncTimeout);
+        reject(err);
+      });
     });
   }
 


### PR DESCRIPTION
starts addressing #976
also gives slightly more context for errors like #966 (as well as a real stack trace)

Moves the extension and the raw connection to use the same error handler for messages coming back from the debugging protocol, as well as normalizing the error object fed into it. This should aid debugging. Happens to unify catching of `DOM.disable` error, instead of in separate spots for extension and CLI.

Also removes old `result.wasThrown` from extension `sendCommand`, which as discussed in #976 was doing nothing but confusing us.