### PR TITLE
Improve github issue title

### DIFF
--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -56,7 +56,7 @@ document.addEventListener('DOMContentLoaded', _ => {
 
     const base = 'https://github.com/googlechrome/lighthouse/issues/new?';
     let titleError = err.message;
-    if (titleError.length > MAX_ISSUE_ERROR_LENGTH) {;
+    if (titleError.length > MAX_ISSUE_ERROR_LENGTH) {
       titleError = `${titleError.substring(0, MAX_ISSUE_ERROR_LENGTH - 3)}...`;
     }
     const title = encodeURI('title=Extension Error: ' + titleError);

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -35,6 +35,8 @@ document.addEventListener('DOMContentLoaded', _ => {
   const optionsList = document.body.querySelector('.options__list');
   const okButton = document.getElementById('ok');
 
+  const MAX_ISSUE_ERROR_LENGTH = 60;
+
   function getLighthouseVersion() {
     return chrome.runtime.getManifest().version;
   }
@@ -53,7 +55,11 @@ document.addEventListener('DOMContentLoaded', _ => {
     qsBody += '**Stack Trace**:\n ```' + err.stack + '```';
 
     const base = 'https://github.com/googlechrome/lighthouse/issues/new?';
-    const title = encodeURI('title=Extension Error: ' + err.message);
+    let titleError = err.message;
+    if (titleError.length > MAX_ISSUE_ERROR_LENGTH) {
+      titleError = err.message.substring(0, MAX_ISSUE_ERROR_LENGTH - 3) + '...';
+    }
+    const title = encodeURI('title=Extension Error: ' + titleError);
     const body = '&body=' + encodeURI(qsBody);
 
     reportErrorEl.href = base + title + body;

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', _ => {
     qsBody += '**Stack Trace**:\n ```' + err.stack + '```';
 
     const base = 'https://github.com/googlechrome/lighthouse/issues/new?';
-    const title = encodeURI('title=Lighthouse Extension Error');
+    const title = encodeURI('title=Extension Error: ' + err.message);
     const body = '&body=' + encodeURI(qsBody);
 
     reportErrorEl.href = base + title + body;

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -56,8 +56,8 @@ document.addEventListener('DOMContentLoaded', _ => {
 
     const base = 'https://github.com/googlechrome/lighthouse/issues/new?';
     let titleError = err.message;
-    if (titleError.length > MAX_ISSUE_ERROR_LENGTH) {
-      titleError = err.message.substring(0, MAX_ISSUE_ERROR_LENGTH - 3) + '...';
+    if (titleError.length > MAX_ISSUE_ERROR_LENGTH) {;
+      titleError = `${titleError.substring(0, MAX_ISSUE_ERROR_LENGTH - 3)}...`;
     }
     const title = encodeURI('title=Extension Error: ' + titleError);
     const body = '&body=' + encodeURI(qsBody);


### PR DESCRIPTION
Currently the Lighthouse Extension Errors create a generic title that is too ambiguous to differentiate duplicates without actually clicking on the issue.

<img width="645" alt="screen shot 2016-11-21 at 9 58 12 am" src="https://cloud.githubusercontent.com/assets/1470297/20487425/3c885efa-afd1-11e6-91b4-5cc178dda75f.png">


This PR appends the JS error to the title.