### PR TITLE
Override travis install method to use npm for older versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ cache:
      - chrome-linux
      - lighthouse-extension/node_modules
 install:
-  - if [[ $(node -v) =~ ^v4.* ]]; then npm install; fi
-  - if [[ $(node -v) =~ ^v5.* ]]; then npm install; fi
-  - if [[ $(node -v) =~ ^v6.* ]]; then npm install yarn -g && yarn install; fi
-  - if [[ $(node -v) =~ ^v7.* ]]; then npm install yarn -g && yarn install; fi
+  - npm install
 before_script:
   - npm i -g typescript@2.0
   - npm --prefix ./lighthouse-extension install ./lighthouse-extension

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ cache:
      - chrome-linux
      - lighthouse-extension/node_modules
 install:
-  - if [[ $(node -v) =~ ^v4.* ]]; then npm install fi
-  - if [[ $(node -v) >= ^v6.* ]]; then yarn install fi
+  - if [[ $(node -v) =~ ^v4.* ]]; then npm install; fi
+  - if [[ $(node -v) =~ ^v5.* ]]; then npm install; fi
+  - if [[ $(node -v) =~ ^v6.* ]]; then npm install yarn -g && yarn install; fi
+  - if [[ $(node -v) =~ ^v7.* ]]; then npm install yarn -g && yarn install; fi
 before_script:
   - npm i -g typescript@2.0
   - npm --prefix ./lighthouse-extension install ./lighthouse-extension

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ cache:
      - node_modules
      - chrome-linux
      - lighthouse-extension/node_modules
+install:
+  - if [[ $(node -v) =~ ^v4.* ]]; then npm install fi
+  - if [[ $(node -v) >= ^v6.* ]]; then yarn install fi
 before_script:
   - npm i -g typescript@2.0
   - npm --prefix ./lighthouse-extension install ./lighthouse-extension


### PR DESCRIPTION
I noticed that [my PR](https://github.com/GoogleChrome/lighthouse/pull/992) was failing on node v4.xx.x on Travis CI, so I decided to look into it briefly. 

Travis-CI introduced support for Yarn recently. Unfortunately, Yarn doesn't officially support node [versions < v6.xx.x](https://github.com/yarnpkg/yarn/issues/1944#issuecomment-261696213)

**Purposed fix**
Override Travis install method to use `npm install` for node versions < v6.xx.x


