### PR TITLE
Use sourcemaps to revert stacktrace in extension

### DIFF
--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -73,9 +73,10 @@ document.addEventListener('DOMContentLoaded', _ => {
       titleError = `${titleError.substring(0, MAX_ISSUE_ERROR_LENGTH - 3)}...`;
     }
     const title = encodeURI('title=Extension Error: ' + titleError);
+    const labels = '&' + encodeURI('labels=extension');
     const body = '&body=' + encodeURI(qsBody);
 
-    reportErrorEl.href = base + title + body;
+    reportErrorEl.href = base + title + labels + body;
     reportErrorEl.textContent = 'Report Error';
     reportErrorEl.target = '_blank';
     return reportErrorEl;

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -67,7 +67,7 @@ document.addEventListener('DOMContentLoaded', _ => {
     let qsBody = '**Lighthouse Version**: ' + getLighthouseVersion() + '\n';
     qsBody += '**Chrome Version**: ' + getChromeVersion() + '\n';
     qsBody += '**Error Message**: ' + err.message + '\n';
-    qsBody += '**Stack Trace**:\n ```' + err.stack.join('\n') + '```';
+    qsBody += '**Stack Trace**:\n ```' + err.stack + '\n```';
 
     const base = 'https://github.com/googlechrome/lighthouse/issues/new?';
     let titleError = err.message;
@@ -123,7 +123,7 @@ document.addEventListener('DOMContentLoaded', _ => {
     }).catch(err => Promise.resolve(err.stack));
 
     stackTracePromise.then(stack => {
-      err.stack = stack;
+      err.stack = stack.join('\n');
 
       feedbackEl.textContent = message;
 
@@ -132,7 +132,7 @@ document.addEventListener('DOMContentLoaded', _ => {
         feedbackEl.appendChild(buildReportErrorLink(err));
       }
 
-      background.console.error(err);
+      background.console.error(err.message + '\n' + err.stack);
     });
   }
 

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -116,8 +116,14 @@ document.addEventListener('DOMContentLoaded', _ => {
   }
 
   function showError(err, message, includeReportLink) {
-    sourcemapStacktrace.mapStackTrace(err.stack, stackWithSourcemaps => {
-      err.stack = stackWithSourcemaps;
+    const stackTracePromise = new Promise(function(resolve) {
+      sourcemapStacktrace.mapStackTrace(err.stack, stackWithSourcemaps => {
+        resolve(stackWithSourcemaps);
+      });
+    }).catch(err => Promise.resolve(err.stack));
+
+    stackTracePromise.then(stack => {
+      err.stack = stack;
 
       feedbackEl.textContent = message;
 

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -100,7 +100,7 @@ gulp.task('browserify-lighthouse', () => {
     'app/src/lighthouse-background.js'
   ], {read: false})
     .pipe(tap(file => {
-      let bundle = browserify(file.path); // , {debug: true})
+      let bundle = browserify(file.path, {debug: true});
       bundle = applyBrowserifyTransforms(bundle);
 
       // lighthouse-background will need some additional transforms, ignores and requires…

--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -22,5 +22,8 @@
     "gulp-zip": "^3.2.0",
     "run-sequence": "^1.1.5",
     "through2": "^2.0.1"
+  },
+  "dependencies": {
+    "sourcemapped-stacktrace": "^1.1.3"
   }
 }

--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -24,6 +24,6 @@
     "through2": "^2.0.1"
   },
   "dependencies": {
-    "sourcemapped-stacktrace": "^1.1.3"
+    "sourcemapped-stacktrace": "^1.1.4"
   }
 }


### PR DESCRIPTION
Should fix #972, downside is that I had to fix an issue with browserify sourcemaps inside https://github.com/novocaine/sourcemapped-stacktrace/pull/19

perhaps you know of another library? (didn't want to write it myself)