### PR TITLE
set extension's minimum supported Chrome to m54

### DIFF
--- a/lighthouse-extension/app/manifest.json
+++ b/lighthouse-extension/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "version": "1.2.1",
-  "minimum_chrome_version": "52",
+  "minimum_chrome_version": "54",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "icons": {


### PR DESCRIPTION
Chrome 54 is the latest stable version and is required for e.g. `evaluateAsync` as of #793 