### PR TITLE
Remove "tabs" extension permission

### DIFF
--- a/lighthouse-extension/app/manifest.json
+++ b/lighthouse-extension/app/manifest.json
@@ -18,8 +18,7 @@
   "permissions": [
     "activeTab",
     "debugger",
-    "storage",
-    "tabs"
+    "storage"
   ],
   "browser_action": {
     "default_icon": {


### PR DESCRIPTION
I believe the "tabs" permission is not mandatory as we already have access to the "activeTab" permission. Please consider removing it.

I've run locally Lighthouse extension without the "tabs" permission and it worked fine.