### PR TITLE
Fix formatting nit in found sizes

### DIFF
--- a/lighthouse-core/audits/manifest-icons-min-144.js
+++ b/lighthouse-core/audits/manifest-icons-min-144.js
@@ -49,7 +49,7 @@ class ManifestIconsMin144 extends Audit {
 
     const matchingIcons = icons.sizeAtLeast(144, /** @type {!Manifest} */ (manifest));
     const foundSizesDebug = matchingIcons.length ?
-        `Found icons of sizes: ${matchingIcons}` : undefined;
+        `Found icons of sizes: ${matchingIcons.join(', ')}` : undefined;
     return ManifestIconsMin144.generateAuditResult({
       rawValue: !!matchingIcons.length,
       debugString: foundSizesDebug

--- a/lighthouse-core/audits/manifest-icons-min-192.js
+++ b/lighthouse-core/audits/manifest-icons-min-192.js
@@ -50,7 +50,7 @@ class ManifestIconsMin192 extends Audit {
     const matchingIcons = icons.sizeAtLeast(192, /** @type {!Manifest} */ (manifest));
 
     const foundSizesDebug = matchingIcons.length ?
-        `Found icons of sizes: ${matchingIcons}` : undefined;
+        `Found icons of sizes: ${matchingIcons.join(', ')}` : undefined;
     return ManifestIconsMin192.generateAuditResult({
       rawValue: !!matchingIcons.length,
       debugString: foundSizesDebug


### PR DESCRIPTION
This simple patch makes reading icons of sizes easier:

```diff
- Found icons of sizes: 152x152,144x144,192x192,256x256,512x512
+ Found icons of sizes: 152x152, 144x144, 192x192, 256x256, 512x512
```