### PR TITLE
Close outfile & errfile in chrome launcher before cleaning the directory

### DIFF
--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -229,7 +229,16 @@ class ChromeLauncher {
   destroyTmp() {
     if (this.TMP_PROFILE_DIR) {
       log.verbose('ChromeLauncher', `Removing ${this.TMP_PROFILE_DIR}`);
-      rimraf.sync(this.TMP_PROFILE_DIR);
+
+      if (this.outFile) {
+        fs.closeSync(this.outFile);
+      }
+
+      if (this.errFile) {
+        fs.closeSync(this.errFile);
+      }
+
+      rimraf.sync(path.normalize(this.TMP_PROFILE_DIR));
     }
   }
 };

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -238,7 +238,7 @@ class ChromeLauncher {
         fs.closeSync(this.errFile);
       }
 
-      rimraf.sync(path.normalize(this.TMP_PROFILE_DIR));
+      rimraf.sync(this.TMP_PROFILE_DIR);
     }
   }
 };


### PR DESCRIPTION
Windows can't remove the temp directory because the node process still has the 2 log files open. By closing them right before removal we close the files.

Fixes [#1001](https://github.com/GoogleChrome/lighthouse/issues/1001)