### PR TITLE
Fixes #1069 - remove scores from perf metrics. Change to pass/fail.

### DIFF
--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -61,7 +61,8 @@ class CriticalRequestChains extends Audit {
       walk(chains, 0);
 
       return CriticalRequestChains.generateAuditResult({
-        rawValue: chainCount,
+        rawValue: chainCount.length <= this.meta.optimalValue,
+        displayValue: chainCount,
         optimalValue: this.meta.optimalValue,
         extendedInfo: {
           formatter: Formatter.SUPPORTED_FORMATS.CRITICAL_REQUEST_CHAINS,

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -21,8 +21,6 @@ const Audit = require('./audit');
 const Formatter = require('../formatters/formatter');
 const TimelineModel = require('../lib/traces/devtools-timeline-model');
 
-const FAILURE_MESSAGE = 'Trace data not found.';
-
 /**
  * @param {!Array<!Object>} traceData
  * @return {!Array<!UserTimingsExtendedInfo>}
@@ -127,27 +125,24 @@ class UserTimings extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    return new Promise((resolve, reject) => {
-      const traceContents =
-        artifacts.traces[this.DEFAULT_PASS] &&
-        artifacts.traces[this.DEFAULT_PASS].traceEvents;
-      if (!traceContents || !Array.isArray(traceContents)) {
-        throw new Error(FAILURE_MESSAGE);
-      }
-
-      const userTimings = filterTrace(traceContents);
-      resolve(UserTimings.generateAuditResult({
-        rawValue: userTimings.length,
-        extendedInfo: {
-          formatter: Formatter.SUPPORTED_FORMATS.USER_TIMINGS,
-          value: userTimings
-        }
-      }));
-    }).catch(err => {
+    if (!artifacts.traces || !artifacts.traces[Audit.DEFAULT_PASS] ||
+        !Array.isArray(artifacts.traces[Audit.DEFAULT_PASS].traceEvents)) {
       return UserTimings.generateAuditResult({
         rawValue: -1,
-        debugString: err.message
+        debugString: 'Trace data not found.'
       });
+    }
+
+    const traceContents = artifacts.traces[Audit.DEFAULT_PASS].traceEvents;
+    const userTimings = filterTrace(traceContents);
+
+    return UserTimings.generateAuditResult({
+      rawValue: true,
+      displayValue: userTimings.length,
+      extendedInfo: {
+        formatter: Formatter.SUPPORTED_FORMATS.USER_TIMINGS,
+        value: userTimings
+      }
     });
   }
 }

--- a/lighthouse-core/test/audits/user-timing-test.js
+++ b/lighthouse-core/test/audits/user-timing-test.js
@@ -22,27 +22,33 @@ const traceEvents = require('../fixtures/traces/trace-user-timings.json');
 /* eslint-env mocha */
 
 describe('Performance: user-timings audit', () => {
-  it('fails gracefully', () => {
-    return Audit.audit({}).then(response => {
-      assert.equal(response.score, -1);
-      assert.ok(response.debugString.length);
-    });
+  it('fails when there is no trace data', () => {
+    const auditResult = Audit.audit({});
+    assert.equal(auditResult.score, -1);
+    assert.ok(auditResult.debugString.length);
+  });
+
+  it('fails when trace data is not an array', () => {
+    const auditResult = Audit.audit({traces: 'not-an-array'});
+    assert.equal(auditResult.score, -1);
+    assert.ok(auditResult.debugString);
   });
 
   it('evaluates valid input correctly', () => {
-    return Audit.audit({traces: {[Audit.DEFAULT_PASS]: {traceEvents}}})
-      .then(response => {
-        assert.equal(response.score, 2);
+    const auditResult = Audit.audit({
+      traces: {[Audit.DEFAULT_PASS]: {traceEvents}}
+    });
+    assert.equal(auditResult.score, true);
+    assert.equal(auditResult.displayValue, 2);
 
-        assert.equal(response.extendedInfo.value[0].isMark, true);
-        assert.equal(Math.floor(response.extendedInfo.value[0].startTime), 1000);
-        assert.equal(typeof response.extendedInfo.value[0].endTime, 'undefined');
-        assert.equal(typeof response.extendedInfo.value[0].duration, 'undefined');
+    assert.equal(auditResult.extendedInfo.value[0].isMark, true);
+    assert.equal(Math.floor(auditResult.extendedInfo.value[0].startTime), 1000);
+    assert.equal(typeof auditResult.extendedInfo.value[0].endTime, 'undefined');
+    assert.equal(typeof auditResult.extendedInfo.value[0].duration, 'undefined');
 
-        assert.equal(response.extendedInfo.value[1].isMark, false);
-        assert.equal(Math.floor(response.extendedInfo.value[1].startTime), 0);
-        assert.equal(Math.floor(response.extendedInfo.value[1].endTime), 1000);
-        assert.equal(Math.floor(response.extendedInfo.value[1].duration), 1000);
-      });
+    assert.equal(auditResult.extendedInfo.value[1].isMark, false);
+    assert.equal(Math.floor(auditResult.extendedInfo.value[1].startTime), 0);
+    assert.equal(Math.floor(auditResult.extendedInfo.value[1].endTime), 1000);
+    assert.equal(Math.floor(auditResult.extendedInfo.value[1].duration), 1000);
   });
 });

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -95,7 +95,8 @@ describe('Runner', () => {
 
     return Runner.run({}, {url, config}).then(results => {
       const audits = results.audits;
-      assert.equal(audits['user-timings'].rawValue, 2);
+      assert.equal(audits['user-timings'].displayValue, 2);
+      assert.equal(audits['user-timings'].rawValue, true);
     });
   });
 
@@ -132,7 +133,8 @@ describe('Runner', () => {
 
     return Runner.run({}, {url, config}).then(results => {
       const audits = results.audits;
-      assert.equal(audits['critical-request-chains'].rawValue, 9);
+      assert.equal(audits['critical-request-chains'].displayValue, 9);
+      assert.equal(audits['critical-request-chains'].rawValue, false);
     });
   });
 


### PR DESCRIPTION
R: @brendankenny @paulirish @patrickhulce 

Per #1069, this removes the scoring labels from the performance metrics section. 

Notes:
- The user timing metrics will always be a green checkbox.
- For critical requests, if you have more than 0, you'll always get a red x. We don't have a good story there for what to display.

![screen shot 2016-11-28 at 2 42 49 pm](https://cloud.githubusercontent.com/assets/238208/20690054/3bc3a3d8-b57d-11e6-958d-c605e80eab1e.png)
