### PR TITLE
Fixes #1071 - handles eval'd script in callsite collector

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -99,6 +99,7 @@ function dateNowTest() {
     return Date.now();
   }
   helloDate();
+  eval('Date.now()'); // FAIL
 }
 
 function consoleTimeTest() {
@@ -110,6 +111,8 @@ function consoleTimeTest() {
   }
   console.timeEnd('arg1');
   console.timeEnd('arg2');
+
+  eval("console.time('arg3')"); // FAIL
 }
 
 function documentWriteTest() {

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -63,7 +63,10 @@ class NoConsoleTimeAudit extends Audit {
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts.
     const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
-      return url.parse(err.url).host === pageHost;
+      if (!err.url) {
+        return false;
+      }
+      return err.isEval ? err.url : url.parse(err.url).host === pageHost;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -61,11 +61,8 @@ class NoConsoleTimeAudit extends Audit {
     }
 
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
-    // Filter usage from other hosts.
+    // Filter usage from other hosts and keep eval'd code.
     const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
-      if (!err.url) {
-        return false;
-      }
       return err.isEval ? err.url : url.parse(err.url).host === pageHost;
     }).map(err => {
       return Object.assign({

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -62,11 +62,8 @@ class NoDateNowAudit extends Audit {
     }
 
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
-    // Filter usage from other hosts.
+    // Filter usage from other hosts and keep eval'd code.
     const results = artifacts.DateNowUse.usage.filter(err => {
-      if (!err.url) {
-        return false;
-      }
       return err.isEval ? err.url : url.parse(err.url).host === pageHost;
     }).map(err => {
       return Object.assign({

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -64,7 +64,10 @@ class NoDateNowAudit extends Audit {
     const pageHost = url.parse(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts.
     const results = artifacts.DateNowUse.usage.filter(err => {
-      return err.url ? url.parse(err.url).host === pageHost : false;
+      if (!err.url) {
+        return false;
+      }
+      return err.isEval ? err.url : url.parse(err.url).host === pageHost;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`,

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -709,7 +709,8 @@ function captureJSCallUsage(funcRef, set) {
       const stackTrace = structStackTrace.slice(1).map(callsite => callsite.toString());
 
       // If we don't have an URL, (e.g. eval'd code), use the last entry in the
-      // stack trace to give some context. See https://crbug.com/646849.
+      // stack trace to give some context: eval(<context>):<line>:<col>
+      // See https://crbug.com/646849.
       if (!url) {
         url = stackTrace[0];
       }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -702,13 +702,23 @@ function captureJSCallUsage(funcRef, set) {
       // First frame is the function we injected (the one that just threw).
       // Second, is the actual callsite of the funcRef we're after.
       const callFrame = structStackTrace[1];
-      const file = callFrame.getFileName();
+      let url = callFrame.getFileName();
       const line = callFrame.getLineNumber();
       const col = callFrame.getColumnNumber();
-      // TODO: add back when we want stack traces. See https://github.com/GoogleChrome/lighthouse/issues/957
-      // const stackTrace = structStackTrace.slice(1).map(
-      //    callsite => callsite.toString());
-      return {url: file, args, line, col}; // return value is e.stack
+      const isEval = callFrame.isEval();
+      const stackTrace = structStackTrace.slice(1).map(callsite => callsite.toString());
+
+      // If we don't have an URL, (e.g. eval'd code), use the last entry in the
+      // stack trace to give some context. See https://crbug.com/646849.
+      if (!url) {
+        url = stackTrace[0];
+      }
+
+      // TODO: add back when we want stack traces.
+      // Stack traces were removed from the return object in
+      // https://github.com/GoogleChrome/lighthouse/issues/957 so callsites
+      // would be unique.
+      return {url, args, line, col, isEval}; // return value is e.stack
     };
     const e = new Error(`__called ${funcRef.name}__`);
     set.add(JSON.stringify(e.stack));

--- a/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
@@ -76,17 +76,6 @@ describe('Page does not use console.time()', () => {
     assert.equal(auditResult.extendedInfo.value.length, 2);
   });
 
-  it('passes when url property is missing', () => {
-    const auditResult = NoConsoleTimeAudit.audit({
-      ConsoleTimeUsage: {
-        usage: [{line: 1, col: 1}]
-      },
-      URL: {finalUrl: URL}
-    });
-    assert.equal(auditResult.rawValue, true);
-    assert.equal(auditResult.extendedInfo.value.length, 0);
-  });
-
   it('fails when console.time() is used in eval()', () => {
     const auditResult = NoConsoleTimeAudit.audit({
       ConsoleTimeUsage: {

--- a/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
@@ -41,7 +41,7 @@ describe('Page does not use console.time()', () => {
   it('passes when console.time() is not used', () => {
     const auditResult = NoConsoleTimeAudit.audit({
       ConsoleTimeUsage: {usage: []},
-      URL: {finalUrl: URL},
+      URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);
@@ -55,7 +55,7 @@ describe('Page does not use console.time()', () => {
           {url: 'http://example2.com/two', line: 2, col: 22}
         ]
       },
-      URL: {finalUrl: URL},
+      URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);
@@ -70,7 +70,33 @@ describe('Page does not use console.time()', () => {
           {url: 'http://example2.com/two', line: 2, col: 22}
         ]
       },
-      URL: {finalUrl: URL},
+      URL: {finalUrl: URL}
+    });
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.extendedInfo.value.length, 2);
+  });
+
+  it('passes when url property is missing', () => {
+    const auditResult = NoConsoleTimeAudit.audit({
+      ConsoleTimeUsage: {
+        usage: [{line: 1, col: 1}]
+      },
+      URL: {finalUrl: URL}
+    });
+    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.extendedInfo.value.length, 0);
+  });
+
+  it('fails when console.time() is used in eval()', () => {
+    const auditResult = NoConsoleTimeAudit.audit({
+      ConsoleTimeUsage: {
+        usage: [
+          {url: 'http://example.com/one', line: 1, col: 1, isEval: false},
+          {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: true},
+          {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: false}
+        ]
+      },
+      URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 2);

--- a/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
@@ -80,7 +80,6 @@ describe('Page does not use Date.now()', () => {
     const auditResult = DateNowUseAudit.audit({
       DateNowUse: {
         usage: [
-          {line: 1, col: 1},
           {url: 'http://example.com/two', line: 10, col: 1},
           {url: 'http://example2.com/two', line: 2, col: 22}
         ]
@@ -90,17 +89,6 @@ describe('Page does not use Date.now()', () => {
 
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 1);
-  });
-
-  it('passes when url property is missing', () => {
-    const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {
-        usage: [{line: 1, col: 1}]
-      },
-      URL: {finalUrl: URL}
-    });
-    assert.equal(auditResult.rawValue, true);
-    assert.equal(auditResult.extendedInfo.value.length, 0);
   });
 
   it('fails when console.time() is used in eval()', () => {

--- a/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
@@ -91,4 +91,30 @@ describe('Page does not use Date.now()', () => {
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 1);
   });
+
+  it('passes when url property is missing', () => {
+    const auditResult = DateNowUseAudit.audit({
+      DateNowUse: {
+        usage: [{line: 1, col: 1}]
+      },
+      URL: {finalUrl: URL}
+    });
+    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.extendedInfo.value.length, 0);
+  });
+
+  it('fails when console.time() is used in eval()', () => {
+    const auditResult = DateNowUseAudit.audit({
+      DateNowUse: {
+        usage: [
+          {url: 'http://example.com/one', line: 1, col: 1, isEval: false},
+          {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: true},
+          {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: false}
+        ]
+      },
+      URL: {finalUrl: URL}
+    });
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.extendedInfo.value.length, 2);
+  });
 });


### PR DESCRIPTION
R: @brendankenny @patrickhulce @paulirish 

According to  https://crbug.com/646849, eval'd script does not include the url context where the script was run. So for our callsite collector, we were throwing an error trying to parse a `.url` property that did not exist. This PR handles eval'd scripts and sets the .url to be the last entry of the stacktrace.

Example run: http://onset.github.io/lighthouse-test/

![screen shot 2016-11-28 at 4 59 41 pm](https://cloud.githubusercontent.com/assets/238208/20692352/2b0fcbde-b58c-11e6-86e9-dc02b7fcd660.png)