### PR TITLE
fix: remove `paintNonDefaultBackgroundColor` from user timings

### DIFF
--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -48,7 +48,9 @@ function filterTrace(traceData) {
     if (ut.hasCategory('blink.user_timing')) {
       // reject these "userTiming" events that aren't really UserTiming, by nuking ones with frame data (or requestStart)
       // https://cs.chromium.org/search/?q=trace_event.*?user_timing&sq=package:chromium&type=cs
-      return !(ut.name === 'requestStart' || ut.args.frame !== undefined);
+      return ut.name !== 'requestStart' &&
+          ut.name !== 'paintNonDefaultBackgroundColor' &&
+          ut.args.frame === undefined;
     }
 
     return false;

--- a/lighthouse-core/test/fixtures/traces/trace-user-timings.json
+++ b/lighthouse-core/test/fixtures/traces/trace-user-timings.json
@@ -1,5 +1,6 @@
 [{"pid":41904,"tid":1295,"ts":1676836141,"ph":"I","cat":"disabled-by-default-devtools.timeline","name":"TracingStartedInPage","args":{"data":{"page":"0xf5fc2501e08","sessionId":"9331.8"}},"tts":314881,"s":"t"},
 {"pid":41904,"tid":1295,"ts":506085991145,"ph":"R","cat":"blink.user_timing","name":"navigationStart","args":{"frame": 0},"tts":314882},
+{"pid":41904,"tid":1295,"ts":506085991146,"ph":"R","cat":"blink.user_timing","name":"paintNonDefaultBackgroundColor","args":{},"tts":314883},
 {"pid":41904,"tid":1295,"ts":506086992099,"ph":"R","cat":"blink.user_timing","name":"mark_test","args":{},"tts":331149},
 {"pid":41904,"tid":1295,"ts":506085991147,"ph":"b","cat":"blink.user_timing","name":"measure_test","args":{},"tts":331184,"id":"0x73b016"},
 {"pid":41904,"tid":1295,"ts":506086992112,"ph":"e","cat":"blink.user_timing","name":"measure_test","args":{},"tts":331186,"id":"0x73b016"}]


### PR DESCRIPTION
Don't show paintNonDefaultBackgroundColor with user timings

Fixes #934