### PR TITLE
return promise in CRC test

### DIFF
--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -61,8 +61,8 @@ const mockArtifacts = {
 /* eslint-env mocha */
 describe('Performance: critical-request-chains audit', () => {
   it('calculates the correct chain length', () => {
-    Audit.audit(mockArtifacts).then(output => {
-      assert.equal(output.score, 2);
+    return Audit.audit(mockArtifacts).then(output => {
+      assert.equal(output.score, false);
     });
   });
 });


### PR DESCRIPTION
fixes #1099 

just needed to return the promise in the test. Another leftover failure from #1072 when perf metric scoring was changed to pass/fail, so no bug here except the need for the expectation to be updated