### PR TITLE
move helpText toggle to pure CSS

### DIFF
--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -19,40 +19,9 @@
 
 'use strict';
 
-/* Using ES5 to broaden support */
-function LighthouseReport() {
-  this.printButton = document.querySelector('.js-print');
-  this.viewUserFeature = document.querySelector('.js-report-by-user-feature');
-  this.viewTechnology = document.querySelector('.js-report-by-technology');
-  this.reportItems = document.querySelectorAll('.report-section__item');
-  this.helpToggles = document.querySelectorAll('.subitem__help-toggle');
-
-  this.toggleHelpText = this.toggleHelpText.bind(this);
-
-  this.addEventListeners();
-}
-
-LighthouseReport.prototype = {
-
-  onPrint: function() {
-    window.print();
-  },
-
-  toggleHelpText: function(e) {
-    const item = e.currentTarget.closest('.subitem');
-    item.classList.toggle('--show-help');
-  },
-
-  addEventListeners: function() {
-    this.printButton.addEventListener('click', this.onPrint);
-    [...this.helpToggles].forEach(node => {
-      node.addEventListener('click', this.toggleHelpText);
-    });
-  }
-};
-
 window.addEventListener('DOMContentLoaded', _ => {
-  // TODO: remove these two comments when we upgrade to latest eslint
-  // eslint-disable-next-line no-new
-  new LighthouseReport();
+  const printButton = document.querySelector('.js-print');
+  printButton.addEventListener('click', _ => {
+    window.print();
+  });
 });

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -24,7 +24,6 @@ span, div, p, section, header, h1, h2, li, ul {
   line-height: inherit;
 }
 
-
 :root {
   --text-font-family: "Roboto", -apple-system, BlinkMacSystemFont,  "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   --text-color: #212121;
@@ -723,7 +722,7 @@ body {
   margin-left: var(--subitem-indent);
 }
 
-.subitem.--show-help .subitem__help {
+.subitem__help-toggle:checked + .subitem__help {
   display: block;
 }
 

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -116,14 +116,11 @@ limitations under the License.
 
                     {{#if subItem.helpText }}
                       <input type="checkbox" class="subitem__help-toggle" title="Toggle help text"  {{#if (shouldShowHelpText subItem.score)}}checked{{/if}}>
+                      <span class="subitem__help">
+                        {{{ subItem.helpText }}}
+                      </span>
                     {{/if}}
                   </p>
-
-                  {{#if subItem.helpText }}
-                    <div class="subitem__help">
-                      {{{ subItem.helpText }}}
-                    </div>
-                  {{/if}}
 
                   {{#if subItem.debugString }}
                     <div class="subitem__debug">

--- a/lighthouse-core/test/report/report-test.js
+++ b/lighthouse-core/test/report/report-test.js
@@ -49,7 +49,7 @@ describe('Report', () => {
 
     assert.ok(html.includes('self.lhresults = {'), 'results object was not added');
     assert.ok(html.includes('<footer'), 'no footer tag found');
-    assert.ok(html.includes('function LighthouseReport'), 'lighthouse-report.js was not inlined');
+    assert.ok(html.includes('printButton = document.querySelector'), 'lighthouse-report.js was not inlined');
     assert.ok(html.includes('.report-body {'), 'report.css was not inlined');
     assert.ok(!html.includes('&quot;lighthouseVersion'), 'lhresults were not escaped');
     assert.ok(/Version: x\.x\.x/g.test(html), 'Version doesn\'t appear in report');


### PR DESCRIPTION
In the DevTools panel we can't run inline script in our iframe, so I'm moving this critical functionality to CSS. :)

That means we can simplify lighthouse-report.js considerably, and only do the `print()`.