### PR TITLE
don't emit script tags in devtools report.

### DIFF
--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -173,7 +173,8 @@ class ReportGenerator {
    * @return {string}
    */
   getReportJS() {
-    return fs.readFileSync(path.join(__dirname, './scripts/lighthouse-report.js'), 'utf8');
+    const scriptSrc = fs.readFileSync(path.join(__dirname, './scripts/lighthouse-report.js'), 'utf8');
+    return `<script>${scriptSrc}</script>`;
   }
 
   /**
@@ -261,14 +262,16 @@ class ReportGenerator {
     });
 
     const template = Handlebars.compile(this.getReportTemplate());
+    reportContext = reportContext || 'extension'; // could be: devtools, extension
+
     return template({
       url: results.url,
       lighthouseVersion: results.lighthouseVersion,
       generatedTime: this._formatTime(results.generatedTime),
       lhresults: this._escapeScriptTags(JSON.stringify(results, null, 2)),
       css: this.getReportCSS(),
-      reportContext: reportContext || 'extension', // devtools, extension, cli
-      script: this.getReportJS(),
+      reportContext: reportContext,
+      script: reportContext === 'devtools' ? '' : this.getReportJS(),
       aggregations: results.aggregations,
       auditsByCategory: this._createPWAAuditsByCategory(results.aggregations)
     });

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -173,8 +173,7 @@ class ReportGenerator {
    * @return {string}
    */
   getReportJS() {
-    const scriptSrc = fs.readFileSync(path.join(__dirname, './scripts/lighthouse-report.js'), 'utf8');
-    return `<script>${scriptSrc}</script>`;
+    return fs.readFileSync(path.join(__dirname, './scripts/lighthouse-report.js'), 'utf8');
   }
 
   /**
@@ -228,10 +227,12 @@ class ReportGenerator {
   /**
    * Generates the Lighthouse report HTML.
    * @param {!Object} results Lighthouse results.
-   * @param {!string} reportContext Where the report is going
+   * @param {!string} reportContext What app is requesting the report (eg. devtools, extension)
    * @returns {string} HTML of the report page.
    */
   generateHTML(results, reportContext) {
+    reportContext = reportContext || 'extension';
+
     // Ensure the formatter for each extendedInfo is registered.
     Object.keys(results.audits).forEach(audit => {
       // Use value rather than key for audit.
@@ -262,7 +263,6 @@ class ReportGenerator {
     });
 
     const template = Handlebars.compile(this.getReportTemplate());
-    reportContext = reportContext || 'extension'; // could be: devtools, extension
 
     return template({
       url: results.url,

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -23,14 +23,16 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <title>Lighthouse report: {{ url }}</title>
   <style>{{{ css }}}</style>
-  <script>{{{ script }}}</script>
+  {{{ script }}}
 </head>
 <body>
 
-<script>
-  // expose the original results
+<!--
+  <script>
+  // the original results
   self.lhresults = {{{ lhresults }}};
-</script>
+  </script>
+-->
 
 <div class="js-report report">
   <section class="report-body">

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -23,16 +23,11 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <title>Lighthouse report: {{ url }}</title>
   <style>{{{ css }}}</style>
-  {{{ script }}}
+  {{#if script }}
+    <script>{{{ script }}}</script>
+  {{/if}}
 </head>
 <body>
-
-<!--
-  <script>
-  // the original results
-  self.lhresults = {{{ lhresults }}};
-  </script>
--->
 
 <div class="js-report report">
   <section class="report-body">

--- a/lighthouse-core/test/report/report-test.js
+++ b/lighthouse-core/test/report/report-test.js
@@ -56,7 +56,6 @@ describe('Report', () => {
     const reportGenerator = new ReportGenerator();
     const html = reportGenerator.generateHTML(sampleResults);
 
-    assert.ok(html.includes('self.lhresults = {'), 'results object was not added');
     assert.ok(html.includes('<footer'), 'no footer tag found');
     assert.ok(html.includes('printButton = document.querySelector'),
               'lighthouse-report.js was not inlined');


### PR DESCRIPTION
Our devtools integration is that the report is hosted in and iframe (with a blob url).

DevTools has a CSP policy: https://github.com/ChromeDevTools/devtools-frontend/blob/master/front_end/inspector.html#L10
It prevents inline scripts from running.

That ends up throwing an error for our report. While there _may_ be some ways to handle this at a CSP layer, I'd prefer, in the short term, to make our report function without javascript.

The report only needs JS for the `window.print()` which is hidden from the devtools version (via `reportContext`).

This PR tweaks things so we don't ship a script tag to devtools; and we only ship 1 script tag to the extension.