### PR TITLE
Disable sharing button if gist is already saved

### DIFF
--- a/lighthouse-viewer/app/src/github.js
+++ b/lighthouse-viewer/app/src/github.js
@@ -32,6 +32,7 @@ class GithubAPI {
   constructor() {
     // this.CLIENT_ID = '48e4c3145c4978268ecb';
     this.auth = new FirebaseAuth();
+    this._saving = false;
   }
 
   static get LH_JSON_EXT() {
@@ -44,7 +45,12 @@ class GithubAPI {
    * @return {!Promise<string>} id of the created gist.
    */
   createGist(jsonFile) {
+    if (this._saving) {
+      return Promise.reject(new Error('Save already in progress'));
+    }
+
     logger.log('Saving report to Github...', false);
+    this._saving = true;
 
     return this.auth.getAccessToken()
       .then(accessToken => {
@@ -73,7 +79,11 @@ class GithubAPI {
       .then(resp => resp.json())
       .then(json => {
         logger.log('Saved!');
+        this._saving = false;
         return json.id;
+      }).catch(err => {
+        this._saving = false;
+        throw err;
       });
   }
 

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -72,10 +72,12 @@ class LighthouseViewerReport {
 
   enableShareButton() {
     this.shareButton.classList.remove('disable');
+    this.shareButton.disabled = false;
   }
 
   disableShareButton() {
     this.shareButton.classList.add('disable');
+    this.shareButton.disabled = true;
   }
 
   loadFromURL() {

--- a/lighthouse-viewer/app/styles/viewer.css
+++ b/lighthouse-viewer/app/styles/viewer.css
@@ -101,3 +101,7 @@
 #log.show {
   transform: translateY(0);
 }
+.share.disable {
+  opacity: 0.2;
+  pointer-events: none;
+}

--- a/lighthouse-viewer/app/styles/viewer.css
+++ b/lighthouse-viewer/app/styles/viewer.css
@@ -101,7 +101,7 @@
 #log.show {
   transform: translateY(0);
 }
-.share.disable {
+.share:disabled {
   opacity: 0.2;
-  pointer-events: none;
+  cursor: default;
 }


### PR DESCRIPTION
R: all

This disables (fades and `pointer-event: none`) the share to github button if the gist already exists on github. This will help prevent duplicates.

<img width="282" alt="screen shot 2016-12-06 at 10 13 05 pm" src="https://cloud.githubusercontent.com/assets/238208/20956828/33948d82-bc01-11e6-8191-8f95344b2101.png">


Part of https://github.com/GoogleChrome/lighthouse/issues/1108