### PR TITLE
refactor: get artifacts directly from running gatherer methods

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -107,6 +107,20 @@ class GatherRunner {
   }
 
   /**
+   * Catches any `recoverable` errors from the supplied promise, rejecting on
+   * the rest.
+   * @param {!Promise<*>} promise
+   * @return {!Promise<*>}
+   */
+  static recoverOrThrow(promise) {
+    return promise.catch(err => {
+      if (!err.recoverable) {
+        throw err;
+      }
+    });
+  }
+
+  /**
    * Navigates to about:blank and calls beforePass() on gatherers before tracing
    * has started and before navigation to the target page.
    * @param {!Object} options
@@ -120,11 +134,7 @@ class GatherRunner {
       return chain.then(_ => {
         const artifactPromise = Promise.resolve().then(_ => gatherer.beforePass(options));
         gathererResults[gatherer.name] = [artifactPromise];
-        return artifactPromise.catch(err => {
-          if (!err.recoverable) {
-            throw err;
-          }
-        });
+        return GatherRunner.recoverOrThrow(artifactPromise);
       });
     }, pass);
   }
@@ -153,11 +163,7 @@ class GatherRunner {
       return chain.then(_ => {
         const artifactPromise = Promise.resolve().then(_ => gatherer.pass(options));
         gathererResults[gatherer.name].push(artifactPromise);
-        return artifactPromise.catch(err => {
-          if (!err.recoverable) {
-            throw err;
-          }
-        });
+        return GatherRunner.recoverOrThrow(artifactPromise);
       });
     }, pass);
   }
@@ -208,11 +214,7 @@ class GatherRunner {
         log.log('status', status);
         const artifactPromise = Promise.resolve().then(_ => gatherer.afterPass(options, passData));
         gathererResults[gatherer.name].push(artifactPromise);
-        return artifactPromise.catch(err => {
-          if (!err.recoverable) {
-            throw err;
-          }
-        });
+        return GatherRunner.recoverOrThrow(artifactPromise);
       }).then(_ => {
         log.verbose('statusEnd', status);
       });

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -52,17 +52,16 @@ class Accessibility extends Gatherer {
         .evaluateAsync(expression)
         .then(returnedValue => {
           if (!returnedValue) {
-            this.artifact = Accessibility._errorAccessibility('Unable to parse axe results');
-            return;
+            return Accessibility._errorAccessibility('Unable to parse axe results');
           }
 
           if (returnedValue.error) {
-            this.artifact = Accessibility._errorAccessibility(returnedValue.error);
-          } else {
-            this.artifact = returnedValue;
+            return Accessibility._errorAccessibility(returnedValue.error);
           }
+
+          return returnedValue;
         }, _ => {
-          this.artifact = Accessibility._errorAccessibility('Axe results timed out');
+          return Accessibility._errorAccessibility('Axe results timed out');
         });
   }
 }

--- a/lighthouse-core/gather/gatherers/cache-contents.js
+++ b/lighthouse-core/gather/gatherers/cache-contents.js
@@ -60,12 +60,11 @@ class CacheContents extends Gatherer {
         .evaluateAsync(`(${getCacheContents.toString()}())`)
         .then(returnedValue => {
           if (!returnedValue) {
-            this.artifact = CacheContents._error('Unable to retrieve cache contents');
-            return;
+            return CacheContents._error('Unable to retrieve cache contents');
           }
-          this.artifact = returnedValue;
+          return returnedValue;
         }, _ => {
-          this.artifact = CacheContents._error('Unable to retrieve cache contents');
+          return CacheContents._error('Unable to retrieve cache contents');
         });
   }
 }

--- a/lighthouse-core/gather/gatherers/content-width.js
+++ b/lighthouse-core/gather/gatherers/content-width.js
@@ -43,13 +43,12 @@ class ContentWidth extends Gatherer {
         throw new Error(`ContentWidth results were not numeric: ${JSON.stringify(returnedValue)}`);
       }
 
-      this.artifact = returnedValue;
+      return returnedValue;
     }, _ => {
-      this.artifact = {
+      return {
         scrollWidth: -1,
         viewportWidth: -1
       };
-      return;
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
@@ -135,9 +135,9 @@ class EventListeners extends Gatherer {
           return this.collectListeners(nodes);
         })
         .then(listeners => {
-          this.artifact = listeners;
+          return listeners;
         }).catch(_ => {
-          this.artifact = {
+          return {
             rawValue: -1,
             debugString: 'Unable to collect passive events listener usage.'
           };

--- a/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
@@ -133,9 +133,6 @@ class EventListeners extends Gatherer {
         .then(nodes => {
           nodes.push('document', 'window');
           return this.collectListeners(nodes);
-        })
-        .then(listeners => {
-          return listeners;
         }).catch(_ => {
           return {
             rawValue: -1,

--- a/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
@@ -34,7 +34,7 @@ class AnchorsWithNoRelNoopener extends Gatherer {
         return Promise.all(failingNodes);
       })
       .then(failingNodes => {
-        this.artifact = {
+        return {
           usages: failingNodes.map(node => {
             return {
               href: node[0],
@@ -45,7 +45,7 @@ class AnchorsWithNoRelNoopener extends Gatherer {
         };
       })
       .catch(_ => {
-        this.artifact = -1;
+        return -1;
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
@@ -27,10 +27,10 @@ class AppCacheManifest extends Gatherer {
     return driver.querySelector('html')
       .then(node => node && node.getAttribute('manifest'))
       .then(manifest => {
-        this.artifact = manifest;
+        return manifest;
       })
       .catch(_ => {
-        this.artifact = -1;
+        return -1;
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
@@ -26,9 +26,6 @@ class AppCacheManifest extends Gatherer {
 
     return driver.querySelector('html')
       .then(node => node && node.getAttribute('manifest'))
-      .then(manifest => {
-        return manifest;
-      })
       .catch(_ => {
         return -1;
       });

--- a/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
@@ -31,15 +31,14 @@ class ConsoleTimeUsage extends Gatherer {
 
   afterPass() {
     return this.collectUsage().then(consoleTimeUsage => {
-      this.artifact = {
+      return {
         usage: consoleTimeUsage
       };
     }, e => {
-      this.artifact = {
+      return {
         value: -1,
         debugString: e.message
       };
-      return;
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/datenow.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/datenow.js
@@ -31,15 +31,14 @@ class DateNowUse extends Gatherer {
 
   afterPass() {
     return this.collectUsage().then(dateNowUses => {
-      this.artifact = {
+      return {
         usage: dateNowUses
       };
     }, e => {
-      this.artifact = {
+      return {
         value: -1,
         debugString: e.message
       };
-      return;
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/document-write.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/document-write.js
@@ -31,15 +31,14 @@ class DocWriteUse extends Gatherer {
 
   afterPass() {
     return this.collectUsage().then(DocWriteUses => {
-      this.artifact = {
+      return {
         usage: DocWriteUses
       };
     }, e => {
-      this.artifact = {
+      return {
         value: -1,
         debugString: e.message
       };
-      return;
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/geolocation-on-start.js
@@ -36,24 +36,23 @@ class GeolocationOnStart extends Gatherer {
     return options.driver.queryPermissionState('geolocation')
         .then(state => {
           if (state === 'granted' || state === 'denied') {
-            this.artifact = {
+            return {
               value: -1,
               debugString: 'Unable to determine if this permission was requested ' +
                            'on page load because it had already been set. ' +
                            'Try resetting the permission and run Lighthouse again.'
             };
-            return;
           }
 
           return this.collectCurrentPosUsage().then(results => {
             return this.collectWatchPosUsage().then(results2 => results.concat(results2));
           }).then(results => {
-            this.artifact = {
+            return {
               usage: results
             };
           });
         }).catch(e => {
-          this.artifact = {
+          return {
             value: -1,
             debugString: e && e.message
           };

--- a/lighthouse-core/gather/gatherers/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/notification-on-start.js
@@ -34,22 +34,21 @@ class NotificationOnStart extends Gatherer {
     return options.driver.queryPermissionState('notifications')
         .then(state => {
           if (state === 'granted' || state === 'denied') {
-            this.artifact = {
+            return {
               value: -1,
               debugString: 'Unable to determine if this permission was requested ' +
                            'on page load because it had already been set. ' +
                            'Try resetting the permission and run Lighthouse again.'
             };
-            return;
           }
 
           return this.collectNotificationUsage().then(results => {
-            this.artifact = {
+            return {
               usage: results
             };
           });
         }).catch(e => {
-          this.artifact = {
+          return {
             value: -1,
             debugString: e && e.message
           };

--- a/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
@@ -116,10 +116,10 @@ class TagsBlockingFirstPaint extends Gatherer {
     return TagsBlockingFirstPaint
       .findBlockingTags(options.driver, tracingData.networkRecords)
       .then(artifact => {
-        this.artifact = artifact;
+        return artifact;
       })
       .catch(err => {
-        this.artifact = {
+        return {
           value: -1,
           debugString: err.message
         };

--- a/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
@@ -115,9 +115,6 @@ class TagsBlockingFirstPaint extends Gatherer {
   afterPass(options, tracingData) {
     return TagsBlockingFirstPaint
       .findBlockingTags(options.driver, tracingData.networkRecords)
-      .then(artifact => {
-        return artifact;
-      })
       .catch(err => {
         return {
           value: -1,

--- a/lighthouse-core/gather/gatherers/dobetterweb/websql.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/websql.js
@@ -46,14 +46,15 @@ class WebSQL extends Gatherer {
   afterPass(options) {
     return this.listenForDatabaseEvents(options.driver)
       .then(database => {
-        this.artifact = {
+        const artifact = {
           database
         };
         if (!database) {
-          this.artifact.debugString = 'No WebSQL databases were opened';
+          artifact.debugString = 'No WebSQL databases were opened';
         }
+        return artifact;
       }).catch(_ => {
-        this.artifact = {
+        return {
           database: -1,
           debugString: 'Unable to gather WebSQL database state'
         };

--- a/lighthouse-core/gather/gatherers/gatherer.js
+++ b/lighthouse-core/gather/gatherers/gatherer.js
@@ -17,7 +17,15 @@
 'use strict';
 
 /**
- * Base class for all gatherers; defines pass lifecycle methods.
+ * Base class for all gatherers; defines pass lifecycle methods. The artifact
+ * from the gatherer is the last not-undefined value returned by a lifecycle
+ * method. All methods can return the artifact value directly or return a
+ * Promise that resolves to that value.
+ *
+ * If an Error is thrown (or a Promise that rejects on an Error), the
+ * GatherRunner will check for a `recoverable` property on the Error. If set to
+ * `true`, the runner will treat it as an expected error internal to the
+ * gatherer and continue execution of any remaining gatherers.
  */
 class Gatherer {
   /**
@@ -32,6 +40,7 @@ class Gatherer {
   /**
    * Called before navigation to target url.
    * @param {!Object} options
+   * @return {*|!Promise<*>}
    */
   beforePass(options) { }
 
@@ -39,6 +48,7 @@ class Gatherer {
    * Called after target page is loaded. If a trace is enabled for this pass,
    * the trace is still being recorded.
    * @param {!Object} options
+   * @return {*|!Promise<*>}
    */
   pass(options) { }
 
@@ -48,6 +58,7 @@ class Gatherer {
    * and record of network activity are provided in `loadData`.
    * @param {!Object} options
    * @param {{networkRecords: !Array, trace: {traceEvents: !Array}} loadData
+   * @return {*|!Promise<*>}
    */
   afterPass(options, loadData) { }
 

--- a/lighthouse-core/gather/gatherers/html-without-javascript.js
+++ b/lighthouse-core/gather/gatherers/html-without-javascript.js
@@ -47,12 +47,12 @@ class HTMLWithoutJavaScript extends Gatherer {
           throw new Error('result was not a string');
         }
 
-        this.artifact = {
+        return {
           value: result
         };
       })
       .catch(err => {
-        this.artifact = {
+        return {
           value: -1,
           debugString: `Unable to get document body innerText: ${err.message}`
         };

--- a/lighthouse-core/gather/gatherers/html.js
+++ b/lighthouse-core/gather/gatherers/html.js
@@ -29,9 +29,9 @@ class HTML extends Gatherer {
           nodeId: nodeId
         }))
         .then(nodeHTML => {
-          this.artifact = nodeHTML.outerHTML;
+          return nodeHTML.outerHTML;
         }).catch(_ => {
-          this.artifact = {
+          return {
             value: -1,
             debugString: 'Unable to get document HTML'
           };

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -72,7 +72,7 @@ class HTTPRedirect extends Gatherer {
     ]).then(result => {
       // Clear timeout. No effect if it won, no need to wait if it lost.
       clearTimeout(noSecurityChangesTimeout);
-      this.artifact = result;
+      return result;
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/https.js
+++ b/lighthouse-core/gather/gatherers/https.js
@@ -64,7 +64,7 @@ class HTTPS extends Gatherer {
     ]).then(result => {
       // Clear timeout. No effect if it won, no need to wait if it lost.
       clearTimeout(noSecurityChangesTimeout);
-      this.artifact = result;
+      return result;
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/manifest.js
+++ b/lighthouse-core/gather/gatherers/manifest.js
@@ -51,13 +51,12 @@ class Manifest extends Gatherer {
             errorString = 'No manifest found.';
           }
 
-          this.artifact = Manifest._errorManifest(errorString);
-          return;
+          return Manifest._errorManifest(errorString);
         }
 
-        this.artifact = manifestParser(response.data, response.url, options.url);
+        return manifestParser(response.data, response.url, options.url);
       }, err => {
-        this.artifact = Manifest._errorManifest('Unable to retrieve manifest: ' + err);
+        return Manifest._errorManifest('Unable to retrieve manifest: ' + err);
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/offline.js
+++ b/lighthouse-core/gather/gatherers/offline.js
@@ -28,9 +28,9 @@ class Offline extends Gatherer {
       return record._url === options.url && record._fetchedViaServiceWorker;
     }).pop(); // Take the last record that matches.
 
-    this.artifact = navigationRecord ? navigationRecord.statusCode : -1;
-
-    return options.driver.goOnline(options);
+    return options.driver.goOnline(options).then(_ => {
+      return navigationRecord ? navigationRecord.statusCode : -1;
+    });
   }
 }
 

--- a/lighthouse-core/gather/gatherers/service-worker.js
+++ b/lighthouse-core/gather/gatherers/service-worker.js
@@ -32,8 +32,6 @@ class ServiceWorker extends Gatherer {
         return {
           debugString: `Error in querying Service Worker status: ${err.message}`
         };
-      }).then(artifact => {
-        return artifact;
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/service-worker.js
+++ b/lighthouse-core/gather/gatherers/service-worker.js
@@ -33,7 +33,7 @@ class ServiceWorker extends Gatherer {
           debugString: `Error in querying Service Worker status: ${err.message}`
         };
       }).then(artifact => {
-        this.artifact = artifact;
+        return artifact;
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -135,9 +135,9 @@ class Styles extends Gatherer {
         // the DevTools protocol). Another example is many instances of a shadow
         // root that share the same <style> tag.
         const map = new Map(stylesheets.map(s => [s.content, s]));
-        this.artifact = Array.from(map.values());
+        return Array.from(map.values());
       }, err => {
-        this.artifact = {
+        return {
           rawValue: -1,
           debugString: err
         };

--- a/lighthouse-core/gather/gatherers/theme-color.js
+++ b/lighthouse-core/gather/gatherers/theme-color.js
@@ -26,10 +26,10 @@ class ThemeColor extends Gatherer {
     return driver.querySelector('head meta[name="theme-color"]')
       .then(node => node && node.getAttribute('content'))
       .then(themeColorMeta => {
-        this.artifact = themeColorMeta;
+        return themeColorMeta;
       })
       .catch(_ => {
-        this.artifact = -1;
+        return -1;
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/theme-color.js
+++ b/lighthouse-core/gather/gatherers/theme-color.js
@@ -25,9 +25,6 @@ class ThemeColor extends Gatherer {
 
     return driver.querySelector('head meta[name="theme-color"]')
       .then(node => node && node.getAttribute('content'))
-      .then(themeColorMeta => {
-        return themeColorMeta;
-      })
       .catch(_ => {
         return -1;
       });

--- a/lighthouse-core/gather/gatherers/url.js
+++ b/lighthouse-core/gather/gatherers/url.js
@@ -25,7 +25,7 @@ class URL extends Gatherer {
     // in the manifest is stored in the cache.
     // Instead of the originally inputted URL (options.initialUrl), we want the resolved
     // post-redirect URL (which is here at options.url)
-    this.artifact = {
+    return {
       initialUrl: options.initialUrl,
       finalUrl: options.url
     };

--- a/lighthouse-core/gather/gatherers/viewport.js
+++ b/lighthouse-core/gather/gatherers/viewport.js
@@ -29,9 +29,6 @@ class Viewport extends Gatherer {
 
     return driver.querySelector('head meta[name="viewport"]')
       .then(node => node && node.getAttribute('content'))
-      .then(viewport => {
-        return viewport;
-      })
       .catch(_ => {
         return -1;
       });

--- a/lighthouse-core/gather/gatherers/viewport.js
+++ b/lighthouse-core/gather/gatherers/viewport.js
@@ -30,10 +30,10 @@ class Viewport extends Gatherer {
     return driver.querySelector('head meta[name="viewport"]')
       .then(node => node && node.getAttribute('content'))
       .then(viewport => {
-        this.artifact = viewport;
+        return viewport;
       })
       .catch(_ => {
-        this.artifact = -1;
+        return -1;
       });
   }
 }

--- a/lighthouse-core/test/fixtures/invalid-gatherers/missing-after-pass.js
+++ b/lighthouse-core/test/fixtures/invalid-gatherers/missing-after-pass.js
@@ -18,10 +18,6 @@
 'use strict';
 
 class MissingAfterPass {
-  constructor() {
-    this.artifact = {};
-  }
-
   beforePass() {}
   pass() {}
 }

--- a/lighthouse-core/test/fixtures/invalid-gatherers/missing-before-pass.js
+++ b/lighthouse-core/test/fixtures/invalid-gatherers/missing-before-pass.js
@@ -18,10 +18,6 @@
 'use strict';
 
 class MissingBeforePass {
-  constructor() {
-    this.artifact = {};
-  }
-
   pass() {}
   afterPass() {}
 }

--- a/lighthouse-core/test/fixtures/invalid-gatherers/missing-pass.js
+++ b/lighthouse-core/test/fixtures/invalid-gatherers/missing-pass.js
@@ -18,10 +18,6 @@
 'use strict';
 
 class MissingPass {
-  constructor() {
-    this.artifact = {};
-  }
-
   beforePass() {}
   afterPass() {}
 }

--- a/lighthouse-core/test/gather/gatherers/accessibility-test.js
+++ b/lighthouse-core/test/gather/gatherers/accessibility-test.js
@@ -34,8 +34,8 @@ describe('Accessibility gatherer', () => {
           return Promise.resolve();
         }
       }
-    }).then(_ => {
-      assert.ok(typeof accessibilityGather.artifact === 'object');
+    }).then(artifact => {
+      assert.ok(typeof artifact === 'object');
     });
   });
 
@@ -46,8 +46,8 @@ describe('Accessibility gatherer', () => {
           return Promise.reject('such a fail');
         }
       }
-    }).then(_ => {
-      assert.ok(accessibilityGather.artifact.debugString);
+    }).then(artifact => {
+      assert.ok(artifact.debugString);
     });
   });
 
@@ -61,8 +61,8 @@ describe('Accessibility gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.ok(accessibilityGather.artifact.debugString === error);
+    }).then(artifact => {
+      assert.ok(artifact.debugString === error);
     });
   });
 
@@ -75,9 +75,9 @@ describe('Accessibility gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.ok(typeof accessibilityGather.artifact === 'object');
-      assert.equal(accessibilityGather.artifact.name, 'a11y');
+    }).then(artifact => {
+      assert.ok(typeof artifact === 'object');
+      assert.equal(artifact.name, 'a11y');
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/cache-contents-test.js
+++ b/lighthouse-core/test/gather/gatherers/cache-contents-test.js
@@ -34,8 +34,8 @@ describe('Cache Contents gatherer', () => {
           return Promise.resolve();
         }
       }
-    }).then(_ => {
-      assert.ok(typeof cacheContentGather.artifact === 'object');
+    }).then(artifact => {
+      assert.ok(typeof artifact === 'object');
     });
   });
 
@@ -46,8 +46,8 @@ describe('Cache Contents gatherer', () => {
           return Promise.reject('such a fail');
         }
       }
-    }).then(_ => {
-      assert.ok(cacheContentGather.artifact.debugString);
+    }).then(artifact => {
+      assert.ok(artifact.debugString);
     });
   });
 
@@ -59,8 +59,8 @@ describe('Cache Contents gatherer', () => {
           return Promise.reject(error);
         }
       }
-    }).then(_ => {
-      assert.ok(cacheContentGather.artifact.debugString === error);
+    }).then(artifact => {
+      assert.ok(artifact.debugString === error);
     });
   });
 
@@ -71,9 +71,9 @@ describe('Cache Contents gatherer', () => {
           return Promise.resolve(['a', 'b', 'c']);
         }
       }
-    }).then(_ => {
-      assert.ok(Array.isArray(cacheContentGather.artifact));
-      assert.equal(cacheContentGather.artifact[0], 'a');
+    }).then(artifact => {
+      assert.ok(Array.isArray(artifact));
+      assert.equal(artifact[0], 'a');
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/content-width-test.js
+++ b/lighthouse-core/test/gather/gatherers/content-width-test.js
@@ -37,9 +37,9 @@ describe('Content Width gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.ok(typeof contentWidthGatherer.artifact === 'object');
-      assert.ok(contentWidthGatherer.artifact.viewportWidth === 400);
+    }).then(artifact => {
+      assert.ok(typeof artifact === 'object');
+      assert.ok(artifact.viewportWidth === 400);
     });
   });
 
@@ -50,8 +50,8 @@ describe('Content Width gatherer', () => {
           return Promise.reject('such a fail');
         }
       }
-    }).then(_ => {
-      assert.equal(contentWidthGatherer.artifact.scrollWidth, -1);
+    }).then(artifact => {
+      assert.equal(artifact.scrollWidth, -1);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/tags-blocking-first-paint-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/tags-blocking-first-paint-test.js
@@ -104,7 +104,7 @@ describe('First paint blocking tags', () => {
           return Promise.resolve([linkDetails, scriptDetails]);
         }
       }
-    }, traceData).then(_ => {
+    }, traceData).then(artifact => {
       const expected = {
         items: [
           {
@@ -123,7 +123,7 @@ describe('First paint blocking tags', () => {
           spendTime: 10000
         }
       };
-      assert.deepEqual(tagsBlockingFirstPaint.artifact, expected);
+      assert.deepEqual(artifact, expected);
     });
   });
 
@@ -134,9 +134,9 @@ describe('First paint blocking tags', () => {
           return Promise.reject(new Error('such a fail'));
         }
       }
-    }, traceData).then(_ => {
-      assert.equal(tagsBlockingFirstPaint.artifact.value, -1);
-      assert.ok(tagsBlockingFirstPaint.artifact.debugString);
+    }, traceData).then(artifact => {
+      assert.equal(artifact.value, -1);
+      assert.ok(artifact.debugString);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/html-test.js
+++ b/lighthouse-core/test/gather/gatherers/html-test.js
@@ -55,10 +55,10 @@ describe('HTML gatherer', () => {
           }
         }
       }
-    }).then(_ => {
-      assert.ok(typeof htmlGather.artifact === 'string');
-      assert.ok(/<!doctype/gim.test(htmlGather.artifact));
-      assert.ok(/Hello/gim.test(htmlGather.artifact));
+    }).then(artifact => {
+      assert.ok(typeof artifact === 'string');
+      assert.ok(/<!doctype/gim.test(artifact));
+      assert.ok(/Hello/gim.test(artifact));
     });
   });
 
@@ -69,9 +69,9 @@ describe('HTML gatherer', () => {
           return Promise.reject('such a fail');
         }
       }
-    }).then(_ => {
-      assert.equal(htmlGather.artifact.value, -1);
-      assert.ok(htmlGather.artifact.debugString);
+    }).then(artifact => {
+      assert.equal(artifact.value, -1);
+      assert.ok(artifact.debugString);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
+++ b/lighthouse-core/test/gather/gatherers/html-without-javascript-test.js
@@ -57,9 +57,9 @@ describe('HTML without JavaScript gatherer', () => {
           return Promise.resolve('Hello!');
         }
       }
-    }).then(_ => {
-      assert.ok(typeof htmlWithoutJavaScriptGather.artifact.value === 'string');
-      assert.ok(/Hello/gim.test(htmlWithoutJavaScriptGather.artifact.value));
+    }).then(artifact => {
+      assert.ok(typeof artifact.value === 'string');
+      assert.ok(/Hello/gim.test(artifact.value));
     });
   });
 
@@ -70,9 +70,9 @@ describe('HTML without JavaScript gatherer', () => {
           return Promise.resolve(null);
         }
       }
-    }).then(_ => {
-      assert.equal(htmlWithoutJavaScriptGather.artifact.value, -1);
-      assert.ok(htmlWithoutJavaScriptGather.artifact.debugString);
+    }).then(artifact => {
+      assert.equal(artifact.value, -1);
+      assert.ok(artifact.debugString);
     });
   });
 
@@ -83,9 +83,9 @@ describe('HTML without JavaScript gatherer', () => {
           return Promise.reject(new Error('such a fail'));
         }
       }
-    }).then(_ => {
-      assert.equal(htmlWithoutJavaScriptGather.artifact.value, -1);
-      assert.ok(/such a fail/i.test(htmlWithoutJavaScriptGather.artifact.debugString));
+    }).then(artifact => {
+      assert.equal(artifact.value, -1);
+      assert.ok(/such a fail/i.test(artifact.debugString));
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/http-redirect-test.js
+++ b/lighthouse-core/test/gather/gatherers/http-redirect-test.js
@@ -64,8 +64,8 @@ describe('HTTP Redirect gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.ok(httpRedirectGather.artifact.value);
+    }).then(artifact => {
+      assert.ok(artifact.value);
     });
   });
 
@@ -76,16 +76,15 @@ describe('HTTP Redirect gatherer', () => {
           return Promise.reject('such a fail');
         }
       }
-    }).then(_ => {
-      assert.equal(httpRedirectGather.artifact.value, false);
-      assert.ok(httpRedirectGather.artifact.debugString);
+    }).then(artifact => {
+      assert.equal(artifact.value, false);
+      assert.ok(artifact.debugString);
     });
   });
 
   it('handles driver timeout', () => {
     const fastTimeout = 50;
     const slowResolve = 200;
-    let artifact;
 
     return httpRedirectGather.afterPass({
       driver: {
@@ -101,17 +100,9 @@ describe('HTTP Redirect gatherer', () => {
       },
 
       _testTimeout: fastTimeout
-    }).then(_ => {
-      artifact = httpRedirectGather.artifact;
+    }).then(artifact => {
       assert.equal(artifact.value, false);
       assert.ok(artifact.debugString);
-
-      // Wait until after slow resolve to ensure artifact value didn't change.
-      return new Promise((resolve, reject) => {
-        setTimeout(resolve, slowResolve);
-      });
-    }).then(_ => {
-      assert.deepStrictEqual(httpRedirectGather.artifact, artifact);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/https-test.js
+++ b/lighthouse-core/test/gather/gatherers/https-test.js
@@ -36,8 +36,8 @@ describe('HTTPS gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.deepEqual(httpsGather.artifact.value, true);
+    }).then(artifact => {
+      assert.deepEqual(artifact.value, true);
     });
   });
 
@@ -48,16 +48,15 @@ describe('HTTPS gatherer', () => {
           return Promise.reject('such a fail');
         }
       }
-    }).then(_ => {
-      assert.equal(httpsGather.artifact.value, false);
-      assert.ok(httpsGather.artifact.debugString);
+    }).then(artifact => {
+      assert.equal(artifact.value, false);
+      assert.ok(artifact.debugString);
     });
   });
 
   it('handles driver timeout', () => {
     const fastTimeout = 50;
     const slowResolve = 200;
-    let artifact;
 
     return httpsGather.afterPass({
       driver: {
@@ -73,17 +72,9 @@ describe('HTTPS gatherer', () => {
       },
 
       _testTimeout: fastTimeout
-    }).then(_ => {
-      artifact = httpsGather.artifact;
+    }).then(artifact => {
       assert.equal(artifact.value, false);
       assert.ok(artifact.debugString);
-
-      // Wait until after slow resolve to ensure artifact value didn't change.
-      return new Promise((resolve, reject) => {
-        setTimeout(resolve, slowResolve);
-      });
-    }).then(_ => {
-      assert.deepStrictEqual(httpsGather.artifact, artifact);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -42,8 +42,8 @@ describe('Manifest gatherer', () => {
         }
       },
       url: EXAMPLE_DOC_URL
-    }).then(_ => {
-      assert.ok(typeof manifestGather.artifact === 'object');
+    }).then(artifact => {
+      assert.ok(typeof artifact === 'object');
     });
   });
 
@@ -55,9 +55,9 @@ describe('Manifest gatherer', () => {
           return Promise.reject(error);
         }
       }
-    }).then(_ => {
-      assert.ok(manifestGather.artifact.debugString);
-      assert.notStrictEqual(manifestGather.artifact.debugString.indexOf(error), -1);
+    }).then(artifact => {
+      assert.ok(artifact.debugString);
+      assert.notStrictEqual(artifact.debugString.indexOf(error), -1);
     });
   });
 
@@ -71,8 +71,8 @@ describe('Manifest gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.ok(manifestGather.artifact.debugString);
+    }).then(artifact => {
+      assert.ok(artifact.debugString);
     });
   });
 
@@ -87,8 +87,8 @@ describe('Manifest gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.ok(manifestGather.artifact.debugString);
+    }).then(artifact => {
+      assert.ok(artifact.debugString);
     });
   });
 
@@ -107,8 +107,8 @@ describe('Manifest gatherer', () => {
         }
       },
       url: EXAMPLE_DOC_URL
-    }).then(_ => {
-      assert.ok(typeof manifestGather.artifact.value === 'object');
+    }).then(artifact => {
+      assert.ok(typeof artifact.value === 'object');
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/offline-test.js
+++ b/lighthouse-core/test/gather/gatherers/offline-test.js
@@ -37,8 +37,8 @@ describe('Offline gatherer', () => {
       url: 'https://do-not-match.com/',
       driver: mockDriver
     };
-    return offlineGather.afterPass(options, tracingData).then(_ => {
-      assert.strictEqual(offlineGather.artifact, -1);
+    return offlineGather.afterPass(options, tracingData).then(artifact => {
+      assert.strictEqual(artifact, -1);
     });
   });
 
@@ -48,8 +48,8 @@ describe('Offline gatherer', () => {
       url: 'https://ifixit-pwa.appspot.com/',
       driver: mockDriver
     };
-    return offlineGather.afterPass(options, tracingData).then(_ => {
-      assert.strictEqual(offlineGather.artifact, 200);
+    return offlineGather.afterPass(options, tracingData).then(artifact => {
+      assert.strictEqual(artifact, 200);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/service-worker-test.js
+++ b/lighthouse-core/test/gather/gatherers/service-worker-test.js
@@ -41,8 +41,8 @@ describe('Service Worker gatherer', () => {
         }
       },
       url
-    }).then(_ => {
-      assert.deepEqual(serviceWorkerGatherer.artifact.versions, versions);
+    }).then(artifact => {
+      assert.deepEqual(artifact.versions, versions);
     });
   });
 
@@ -53,9 +53,9 @@ describe('Service Worker gatherer', () => {
           return Promise.reject('fail');
         }
       }
-    }).then(_ => {
-      assert.ok(!serviceWorkerGatherer.artifact.versions);
-      assert.ok(serviceWorkerGatherer.artifact.debugString);
+    }).then(artifact => {
+      assert.ok(!artifact.versions);
+      assert.ok(artifact.debugString);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/theme-color-test.js
+++ b/lighthouse-core/test/gather/gatherers/theme-color-test.js
@@ -38,8 +38,8 @@ describe('Theme Color gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.equal(themeColorGather.artifact, '#288A76');
+    }).then(artifact => {
+      assert.equal(artifact, '#288A76');
     });
   });
 
@@ -50,8 +50,8 @@ describe('Theme Color gatherer', () => {
           return Promise.reject('such a fail');
         }
       }
-    }).then(_ => {
-      assert.equal(themeColorGather.artifact, -1);
+    }).then(artifact => {
+      assert.equal(artifact, -1);
     });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/url-test.js
+++ b/lighthouse-core/test/gather/gatherers/url-test.js
@@ -24,10 +24,10 @@ describe('URL gatherer', () => {
   it('returns the correct URL from options', () => {
     const urlGather = new URLGather();
     const url = 'https://example.com';
-    urlGather.afterPass({
+    const artifact = urlGather.afterPass({
       url: url
     });
 
-    return assert.equal(urlGather.artifact.finalUrl, url);
+    return assert.equal(artifact.finalUrl, url);
   });
 });

--- a/lighthouse-core/test/gather/gatherers/viewport-test.js
+++ b/lighthouse-core/test/gather/gatherers/viewport-test.js
@@ -36,9 +36,9 @@ describe('Viewport gatherer', () => {
           });
         }
       }
-    }).then(_ => {
-      assert.ok(typeof viewportGather.artifact === 'string');
-      assert.ok(/width=/gim.test(viewportGather.artifact));
+    }).then(artifact => {
+      assert.ok(typeof artifact === 'string');
+      assert.ok(/width=/gim.test(artifact));
     });
   });
 
@@ -49,8 +49,8 @@ describe('Viewport gatherer', () => {
           return Promise.reject('such a fail');
         }
       }
-    }).then(_ => {
-      assert.equal(viewportGather.artifact, -1);
+    }).then(artifact => {
+      assert.equal(artifact, -1);
     });
   });
 });


### PR DESCRIPTION
R: @paulirish @patrickhulce 

next part of #941

- Removes `this.artifact` from gatherers and instead have gatherers return the artifact directly in whatever value is returned last from `beforePass()`, `pass()`, or `afterPass()`.
- When gatherers reject on an error, we have a new opt-in property `recoverable` on the error that gather-runner checks. If set to `true`, it will turn that into an "error artifact", equivalent to the many versions of -1 artifacts we have today.
- If `recoverable` isn't present, it throws the error and lighthouse exits on the error. By making it explicit when a gatherer expects an error, this should help catch more errors than our current system (which absorbs all errors in the gatherer stage)
- gatherer's methods can return (or throw) synchronously or asynchronously

This PR doesn't actually take advantage of recoverable errors yet, as it was already getting really big. Merely implements support for them, adds unit tests for them, and gets rid of `gatherer.artifact` on all the current artifacts. So most work here is in `gather-runner.js` and `gather-runner-test.js`.

Feel free to bikeshed/propose other control flows.

Next PR will delete all the -1 nonsense from gatherers and replace with this system when we're certain this is the direction we want to go.