### PR TITLE
Eliminate errors from calling ChromeLauncher.kill() twice 

### DIFF
--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -248,7 +248,11 @@ class ChromeLauncher {
       // ignore
     }
 
-    return new Promise(resolve => rimraf(this.TMP_PROFILE_DIR, resolve));
+    return new Promise((resolve) => {
+      rimraf(this.TMP_PROFILE_DIR, function() {
+        resolve();
+      });
+    });
   }
 };
 

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -233,21 +233,22 @@ class ChromeLauncher {
 
     log.verbose('ChromeLauncher', `Removing ${this.TMP_PROFILE_DIR}`);
 
-    if (this.outFile) {
-      fs.closeSync(this.outFile);
-    }
-
-    if (this.errFile) {
-      fs.closeSync(this.errFile);
-    }
-
-    return new Promise((resolve) => {
-      rimraf(this.TMP_PROFILE_DIR, function() {
-        resolve();
+    return Promise.all([
+      closeFile(this.outFile),
+      closeFile(this.errFile)
+    ])
+      .then(() => {
+        return new Promise(resolve => rimraf(this.TMP_PROFILE_DIR, resolve));
       });
-    });
-  }
+   }
 };
+
+function closeFile(file) {
+  if (!file) {
+    return Promise.resolve();
+  }
+  return new Promise(resolve => fs.close(file, resolve));
+}
 
 function defaults(val: any, def: any) {
   return typeof val === 'undefined' ? def : val;

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -243,7 +243,7 @@ class ChromeLauncher {
    }
 };
 
-function closeFile(file) {
+function closeFile(file: number): Promise<undefined> {
   if (!file) {
     return Promise.resolve();
   }

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -240,7 +240,7 @@ class ChromeLauncher {
       .then(() => {
         return new Promise(resolve => rimraf(this.TMP_PROFILE_DIR, resolve));
       });
-   }
+  }
 };
 
 function closeFile(file: number): Promise<undefined> {

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -228,13 +228,13 @@ class ChromeLauncher {
   }
 
   destroyTmp(): Promise<undefined> {
-    if (!this.TMP_PROFILE_DIR) {
-      return Promise.resolve();
-    }
+    return new Promise(resolve => {
+      if (!this.TMP_PROFILE_DIR) {
+        return resolve();
+      }
 
-    log.verbose('ChromeLauncher', `Removing ${this.TMP_PROFILE_DIR}`);
+      log.verbose('ChromeLauncher', `Removing ${this.TMP_PROFILE_DIR}`);
 
-    try {
       if (this.outFile) {
         fs.closeSync(this.outFile);
         this.outFile = null;
@@ -244,14 +244,8 @@ class ChromeLauncher {
         fs.closeSync(this.errFile);
         this.errFile = null;
       }
-    } catch (e) {
-      // ignore
-    }
 
-    return new Promise((resolve) => {
-      rimraf(this.TMP_PROFILE_DIR, function() {
-        resolve();
-      });
+      rimraf(this.TMP_PROFILE_DIR, () => resolve());
     });
   }
 };

--- a/lighthouse-cli/test/cli/chrome-launcher-test.js
+++ b/lighthouse-cli/test/cli/chrome-launcher-test.js
@@ -18,7 +18,7 @@
 
 require('../../compiled-check.js')('chrome-launcher.js');
 
-const {ChromeLauncher} = require('../../chrome-launcher.js');
+const ChromeLauncher = require('../../chrome-launcher.js').ChromeLauncher;
 
 /* global describe, it */
 

--- a/lighthouse-cli/test/cli/chrome-launcher-test.js
+++ b/lighthouse-cli/test/cli/chrome-launcher-test.js
@@ -25,8 +25,7 @@ const ChromeLauncher = require('../../chrome-launcher.js').ChromeLauncher;
 describe('ChromeLauncher', () => {
   it('doesn\'t fail when killed twice', () => {
     const chromeInstance = new ChromeLauncher();
-    chromeInstance.run();
-    return chromeInstance.waitUntilReady()
+    return chromeInstance.run()
       .then(() => {
         return Promise.all([
           chromeInstance.kill(),

--- a/lighthouse-cli/test/cli/chrome-launcher-test.js
+++ b/lighthouse-cli/test/cli/chrome-launcher-test.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+require('../../compiled-check.js')('chrome-launcher.js');
+
+const {ChromeLauncher} = require('../../chrome-launcher.js');
+
+/* global describe, it */
+
+describe('ChromeLauncher', () => {
+  it('doesn\'t fail when killed twice', () => {
+    const chromeInstance = new ChromeLauncher();
+    chromeInstance.prepare();
+    chromeInstance.run();
+    return chromeInstance.waitUntilReady()
+      .then(() => {
+        return Promise.all([
+          chromeInstance.kill(),
+          chromeInstance.kill()
+        ]);
+      });
+  });
+});

--- a/lighthouse-cli/test/cli/chrome-launcher-test.js
+++ b/lighthouse-cli/test/cli/chrome-launcher-test.js
@@ -20,12 +20,11 @@ require('../../compiled-check.js')('chrome-launcher.js');
 
 const ChromeLauncher = require('../../chrome-launcher.js').ChromeLauncher;
 
-/* global describe, it */
+/* eslint-env mocha */
 
 describe('ChromeLauncher', () => {
   it('doesn\'t fail when killed twice', () => {
     const chromeInstance = new ChromeLauncher();
-    chromeInstance.prepare();
     chromeInstance.run();
     return chromeInstance.waitUntilReady()
       .then(() => {


### PR DESCRIPTION
The error happened outside the Promise chain and is uncatchable.