### PR TITLE
bin.ts simplification refactor

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -280,7 +280,9 @@ function runLighthouse(url: string,
       }
     })
     .then(() => chromeLauncher.kill())
-    .catch(handleError);
+    .catch(err => {
+      return chromeLauncher.kill().then(() => handleError(err), handleError);
+    });
 }
 
 function run() {

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -214,10 +214,10 @@ class ChromeLauncher {
         });
 
         log.log('ChromeLauncher', 'Killing all Chrome Instances');
-        this.chrome.kill();
-
         if (process.platform === 'win32') {
           spawnSync(`taskkill /pid ${this.chrome.pid} /T /F`);
+        } else {
+          process.kill(-this.chrome.pid);
         }
 
         this.chrome = null;

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -219,6 +219,7 @@ class ChromeLauncher {
         if (process.platform === 'win32') {
           spawnSync(`taskkill /pid ${this.chrome.pid} /T /F`);
         }
+
         this.chrome = null;
       } else {
         // fail silently as we did not start chrome

--- a/lighthouse-cli/random-port.ts
+++ b/lighthouse-cli/random-port.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import {createServer} from 'http';
+
+/**
+ * Return a random, unused port.
+ */
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0);
+    server.once('listening', () => {
+      const port = server.address().port;
+      server.close(() => resolve(port));
+    });
+    server.once('error', reject);
+  });
+}
+
+export {
+  getRandomPort
+};

--- a/lighthouse-cli/test/cli/random-port-test.js
+++ b/lighthouse-cli/test/cli/random-port-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const getRandomPort = require('../../random-port').getRandomPort;
+
+describe('Random port generation', () => {
+  it('generates a valid random port number', () => {
+    return getRandomPort().then(port => {
+      // Verify generated port number is valid integer.
+      assert.ok(Number.isInteger(port) && port > 0 && port <= 0xFFFF);
+    });
+  });
+});

--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -81,6 +81,7 @@ class ExtensionConnection extends Connection {
    */
   disconnect() {
     if (this._tabId === null) {
+      log.warn('ExtensionConnection', 'disconnect() was called without an established connection.');
       return Promise.resolve();
     }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "unit": "lighthouse-core/scripts/run-mocha.sh --default",
     "closure": "cd lighthouse-core && closure/closure-type-checking.js",
     "watch": "lighthouse-core/scripts/run-mocha.sh --watch",
-    "chrome": "lighthouse-core/scripts/launch-chrome.sh",
+    "chrome": "./lighthouse-cli/manual-chrome-launcher.js",
     "fast": "npm run start -- --disable-device-emulation --disable-cpu-throttling --disable-network-throttling",
     "smokehouse": "node $__node_harmony lighthouse-cli/test/smokehouse/smokehouse.js",
     "deploy-viewer": "cd lighthouse-viewer && gulp deploy"


### PR DESCRIPTION
the complexity of `bin.ts` was getting a little out of hand, so this refactors to linearize the control flow and hopefully make it easier to follow and alter in the future.

This also drops support for a list of urls on the command line and goes back to one url at a time. We could easily turn it back into a `reduce` loop over urls, but it adds some complication and we never actually documented support, so...

Opinions welcome.

no longer included: ~~One big change: most of the logic moves to `lighthouse-launcher.ts` so `bin.ts` really only handles cli flags and then calls `lighthouse-launcher.ts`. Main benefit is so downstream projects can import `run()` from `lighthouse-launcher.ts` and run it (currently if you try to import `bin.ts` if you don't happen to have something in your argv [it'll throw](https://github.com/GoogleChrome/lighthouse/blob/11e41a3ee51dbadac1094e2ee1759fe601235064/lighthouse-cli/bin.ts#L128)).~~