### PR TITLE
Viewer: Remove Closure

### DIFF
--- a/lighthouse-viewer/gulpfile.js
+++ b/lighthouse-viewer/gulpfile.js
@@ -22,7 +22,6 @@ const gulp = require('gulp');
 const gulpLoadPlugins = require('gulp-load-plugins');
 const runSequence = require('run-sequence');
 const browserify = require('browserify');
-const closure = require('google-closure-compiler-js').gulp();
 const ghpages = require('gh-pages');
 
 const $ = gulpLoadPlugins();
@@ -86,7 +85,7 @@ gulp.task('browserify', () => {
         .transform('brfs')
         .bundle();
 
-      file.contents = bundle; // Inject transforme content back the gulp pipeline.
+      file.contents = bundle; // Inject transformed content back the gulp pipeline.
     }))
     .pipe(gulp.dest(`${DIST_FOLDER}/src`));
 });

--- a/lighthouse-viewer/package.json
+++ b/lighthouse-viewer/package.json
@@ -14,7 +14,6 @@
     "del": "^2.2.0",
     "eslint-config-xo": "^0.10.1",
     "gh-pages": "^0.12.0",
-    "google-closure-compiler-js": "^20161024.0.0",
     "gulp": "^3.9.1",
     "gulp-eslint": "^2.0.0",
     "gulp-license": "^1.1.0",
@@ -23,7 +22,9 @@
     "gulp-tap": "^0.1.3",
     "gulp-uglify": "^2.0.0",
     "gulp-util": "^3.0.7",
-    "run-sequence": "^1.1.5"
+    "run-sequence": "^1.1.5",
+    "tsify": "^2.0.3",
+    "typescript": "^2.1.4"
   },
   "dependencies": {
     "firebase": "^3.6.2",


### PR DESCRIPTION
R: all

This removes clsoure from the viewer build process and moves to using the tsc compiler. I chose TS over babel because it produces slim output, has similar support for polyfills like closure, and we're already using it elsewhere in the project, and allows us to migrate to es6 modules and .ts over time.

Now at 6s build for prod! But again, dev is still <1s.