### PR TITLE
bump axe-core, as it's now 8x faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "walk": "^2.3.9"
   },
   "dependencies": {
-    "axe-core": "^1.1.1",
+    "axe-core": "2.1.7",
     "chrome-devtools-frontend": "1.0.422034",
     "debug": "^2.2.0",
     "devtools-timeline-model": "1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,9 +155,9 @@ aws4@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
 
-axe-core@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-1.1.1.tgz#ae9da5da8ab4f1041907f1f5d8dfe39c946a92c5"
+axe-core@2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.1.7.tgz#4f66f2b3ee3b58ec2d3db4339dd124c5b33b79c3"
 
 babar@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
Big win if you've ever seen the "Retrieving: Accessibility..." message for longer than you'd expect.

Fixes #630 

Over in https://github.com/dequelabs/axe-core/issues/240 we reported some perf issues to the axe-core team. They've now addressed them and shipped the latest version of the library. 

There were pages like [Promise | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that took A LOT of time.

* **Before: 9.6 seconds**
* **After: 1.1 seconds** 

Death to forced layouts. 😀 


------------

Also, another win I didn't expect. The awesome team at @dequelabs also changed the runtime so that it [yields to the main thread on nearly every tick](https://github.com/dequelabs/axe-core/blob/c6dc85b7fd6d7c643995ac12fb5276ea743cde74/lib/core/base/check.js#L82) of its auditing engine, which leads to a much more responsive experience:

![image](https://cloud.githubusercontent.com/assets/39191/21162605/2600478c-c143-11e6-8542-185b9a3d2787.png)
