### PR TITLE
remove mobile cli option. add test to assert no dead cli options.

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -64,7 +64,6 @@ const cliFlags = yargs
   })
 
   .group([
-    'mobile',
     'save-assets',
     'save-artifacts',
     'list-all-audits',

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -33,7 +33,8 @@ describe('CLI bin', function() {
     const optionsWithDescriptions = Object.keys(yargs.getUsageInstance().getDescriptions());
 
     allOptions.forEach(opt => {
-      assert.ok(~optionsWithDescriptions.indexOf(opt), `cli option '${opt}' has no description`);
+      assert.ok(optionsWithDescriptions.indexOf(opt) !== -1,
+          `cli option '${opt}' has no description`);
     });
   });
 });

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -33,7 +33,7 @@ describe('CLI bin', function() {
     const optionsWithDescriptions = Object.keys(yargs.getUsageInstance().getDescriptions());
 
     allOptions.forEach(opt => {
-      assert.ok(optionsWithDescriptions.includes(opt), `cli option '${opt}' has no description`);
+      assert.ok(~optionsWithDescriptions.indexOf(opt), `cli option '${opt}' has no description`);
     });
   });
 });

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/* eslint-env mocha */
+const assert = require('assert');
+
+require('../../bin');
+
+describe('CLI bin', function() {
+  it('all options should have descriptions', () => {
+    const yargs = require('yargs');
+
+    const optionGroups = yargs.getGroups();
+    const allOptions = [].concat(...Object.values(optionGroups));
+    const optionsWithDescriptions = Object.keys(yargs.getUsageInstance().getDescriptions());
+
+    allOptions.forEach(opt => {
+      assert.ok(optionsWithDescriptions.includes(opt), `cli option '${opt}' has no description`);
+    });
+  });
+});

--- a/lighthouse-cli/test/cli/bin-test.js
+++ b/lighthouse-cli/test/cli/bin-test.js
@@ -26,7 +26,10 @@ describe('CLI bin', function() {
     const yargs = require('yargs');
 
     const optionGroups = yargs.getGroups();
-    const allOptions = [].concat(...Object.values(optionGroups));
+    const allOptions = [];
+    Object.keys(optionGroups).forEach(key => {
+      allOptions.push(...optionGroups[key]);
+    });
     const optionsWithDescriptions = Object.keys(yargs.getUsageInstance().getDescriptions());
 
     allOptions.forEach(opt => {


### PR DESCRIPTION
I noticed the CLI still mentioned the `mobile` flag. whoops.
![image](https://cloud.githubusercontent.com/assets/39191/21256065/d40877fe-c324-11e6-8fca-b6a004a2f9df.png)


Removed it.
Added a test to catch undocumented CLI options.