### PR TITLE
Fix html report context when generated by the CLI

### DIFF
--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -82,7 +82,7 @@ function createOutput(results: Results, outputMode: OutputMode): string {
 
   // HTML report.
   if (outputMode === OutputMode.html) {
-    return reportGenerator.generateHTML(results, {inline: true});
+    return reportGenerator.generateHTML(results, 'cli');
   }
 
   // JSON report.

--- a/lighthouse-cli/test/cli/printer-test.js
+++ b/lighthouse-cli/test/cli/printer-test.js
@@ -59,6 +59,7 @@ describe('Printer', () => {
     const mode = Printer.OutputMode.html;
     const htmlOutput = Printer.createOutput(sampleResults, mode);
     assert.ok(/<!doctype/gim.test(htmlOutput));
+    assert.ok(/<html data-report-context="cli"/gim.test(htmlOutput));
   });
 
   it('writes file for results', () => {


### PR DESCRIPTION
R: @brendankenny @paulirish 

`{inline: true}` is leftover from a previous age. This fixes cases where the html is generated by the CLI and we got `<html data-report-context="[object Object]">` in the report.