### PR TITLE
Store state of lighthouse in extension while running.

### DIFF
--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -28,6 +28,9 @@ const ReportGenerator = require('../../../lighthouse-core/report/report-generato
 const STORAGE_KEY = 'lighthouse_audits';
 const _flatten = arr => [].concat(...arr);
 
+let lighthouseIsRunning = false;
+let latestStatusLog = [];
+
 /**
  * Filter out any unrequested aggregations from the config. If any audits are
  * no longer needed by any remaining aggregations, filter out those as well.
@@ -87,8 +90,19 @@ window.runLighthouseForConnection = function(connection, url, options, requested
   // Add url and config to fresh options object.
   const runOptions = Object.assign({}, options, {url, config});
 
+  lighthouseIsRunning = true;
+
   // Run Lighthouse.
-  return Runner.run(connection, runOptions);
+  return Runner.run(connection, runOptions)
+    .then(result => {
+      lighthouseIsRunning = false;
+
+      return result;
+    })
+    .catch(err => {
+      lighthouseIsRunning = false;
+      throw err;
+    });
 };
 
 /**
@@ -213,7 +227,20 @@ window.loadSelectedAggregations = function() {
 };
 
 window.listenForStatus = function(callback) {
-  log.events.addListener('status', callback);
+  log.events.addListener('status', function(args) {
+    latestStatusLog = args;
+    callback(args);
+  });
+
+  // Show latest saved status log to give immediate feedback
+  // when reopening the popup message when lighthouse is running
+  if (lighthouseIsRunning && latestStatusLog) {
+    callback(latestStatusLog);
+  }
+};
+
+window.isRunning = function() {
+  return lighthouseIsRunning;
 };
 
 if (window.chrome && chrome.runtime) {

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -227,9 +227,9 @@ window.loadSelectedAggregations = function() {
 };
 
 window.listenForStatus = function(callback) {
-  log.events.addListener('status', function(args) {
-    latestStatusLog = args;
-    callback(args);
+  log.events.addListener('status', function(log) {
+    latestStatusLog = log;
+    callback(log);
   });
 
   // Show latest saved status log to give immediate feedback

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -128,6 +128,10 @@ document.addEventListener('DOMContentLoaded', _ => {
     return frag;
   }
 
+  if (background.isRunning()) {
+    startSpinner();
+  }
+
   background.listenForStatus(logstatus);
   background.loadSelectedAggregations().then(aggregations => {
     const frag = generateOptionsList(optionsList, aggregations);


### PR DESCRIPTION
When extension popup is closed & lighthouse is still running we show the state lighthouse is running in instead of showing the startup screen.
![schermopname](https://cloud.githubusercontent.com/assets/1120926/21368356/9a8e313a-c702-11e6-9de4-29416f7b2c4b.gif)
