### PR TITLE
Remove node URL parsing while bugs are being fixed

### DIFF
--- a/lighthouse-core/test/lib/url-shim-test.js
+++ b/lighthouse-core/test/lib/url-shim-test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2016 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * URL shim so we keep our code DRY
- */
-
 'use strict';
 
-/* global self */
+/* eslint-env mocha */
 
-// TODO: Add back node require('url').URL parsing when bug is resolved:
-// https://github.com/GoogleChrome/lighthouse/issues/1186
-module.exports = (typeof self !== 'undefined' && self.URL) || require('whatwg-url').URL;
+const URL = require('../../lib/url-shim');
+const assert = require('assert');
+
+describe('URL Shim', () => {
+  it('handles URLs beginning with multiple digits', () => {
+    // from https://github.com/GoogleChrome/lighthouse/issues/1186
+    const url = 'http://5321212.fls.doubleclick.net/activityi;src=5321212;type=unvsn_un;cat=unvsn_uv;ord=7762287885264.98?';
+    assert.doesNotThrow(_ => new URL(url));
+  });
+});


### PR DESCRIPTION
works around #1186 

Eventually we do want to move entirely to native node URL parsing, so we can leave that bug open to track it.

Test is arguably unnecessary (`whatwg-url` is tested using the [web platform tests](https://github.com/w3c/web-platform-tests/blob/master/url/urltestdata.json) and this is one corner case among a great many), but it's not really harmful, and it makes sure the URL shim is loading and running.