### PR TITLE
refactor performance experiment server

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -269,7 +269,7 @@ function runLighthouse(url: string,
     .then((results: Results) => {
       // If --view, host this experiment and open report.html in the default browser
       if (flags.view) {
-        return performanceXServer.hostExperiment({url, flags, config}, results);
+        return performanceXServer.serveAndOpenReport({url, flags, config}, results);
       }
     })
     .then(() => chromeLauncher.kill())

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -30,10 +30,8 @@ if (!environment.checkNodeCompatibility()) {
 const assetSaver = require('../lighthouse-core/lib/asset-saver.js');
 import {ChromeLauncher} from './chrome-launcher';
 import * as Commands from './commands/commands';
-import * as fs from 'fs';
 const lighthouse = require('../lighthouse-core');
 const log = require('../lighthouse-core/lib/log');
-const opn = require('opn');
 import * as path from 'path';
 const perfOnlyConfig = require('../lighthouse-core/config/perf.json');
 const performanceXServer = require('./performance-experiment/server');
@@ -264,12 +262,14 @@ function runLighthouse(url: string,
     .then((results: Results) => {
       if (flags.output === Printer.OutputMode[Printer.OutputMode.pretty]) {
         const filename = `${assetSaver.getFilenamePrefix({url})}.report.html`;
-        Printer.write(results, 'html', filename);
+        return Printer.write(results, 'html', filename);
       }
-
-      // If --view, save and host this experiment, and open report.html in the default browser
+      return results;
+    })
+    .then((results: Results) => {
+      // If --view, host this experiment and open report.html in the default browser
       if (flags.view) {
-        return performanceXServer.hostExperiment(flags, results).then(opn);
+        return performanceXServer.hostExperiment({url, flags, config}, results);
       }
     })
     .then(() => chromeLauncher.kill())

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -270,12 +270,7 @@ function runLighthouse(url: string,
 
       // If --view, generate report.html, host it, and open it in the default browser
       if (flags.view) {
-        return performanceXServer.startServer(0).then((port: number) => {
-          const filePath = `${performanceXServer.FOLDERS.REPORTS}/${filename}`;
-          return Printer.write(results, 'html', filePath).then(() => {
-            opn(`http://localhost:${port}/reports/${filename}`);
-          });
-        });
+        return performanceXServer.hostExperiment(flags, results).then(opn);
       }
     })
     .then(() => chromeLauncher.kill())

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -262,13 +262,12 @@ function runLighthouse(url: string,
     .then(() => lighthouse(url, flags, config))
     .then((results: Results) => Printer.write(results, flags.output, flags.outputPath))
     .then((results: Results) => {
-      const filename = `${assetSaver.getFilenamePrefix({url})}.report.html`;
-
       if (flags.output === Printer.OutputMode[Printer.OutputMode.pretty]) {
+        const filename = `${assetSaver.getFilenamePrefix({url})}.report.html`;
         Printer.write(results, 'html', filename);
       }
 
-      // If --view, generate report.html, host it, and open it in the default browser
+      // If --view, save and host this experiment, and open report.html in the default browser
       if (flags.view) {
         return performanceXServer.hostExperiment(flags, results).then(opn);
       }

--- a/lighthouse-cli/performance-experiment/server.js
+++ b/lighthouse-cli/performance-experiment/server.js
@@ -19,9 +19,8 @@
 /**
  * @fileoverview Server script for Project Performance Experiment.
  *
- * Functionalities:
- *   Host report pages.
- *     Report pages can be accessed via URL http://localhost:[PORT]/reports?key=[REPORT_KEY]
+ * Functionality:
+ *   Host and open report page.
  */
 
 const http = require('http');
@@ -38,7 +37,7 @@ const ReportGenerator = require('../../lighthouse-core/report/report-generator')
  * @return {!Promise<string>} Promise that resolves when server is closed
  */
 let lhResults;
-function hostExperiment(lighthouseParams, results) {
+function serveAndOpenReport(lighthouseParams, results) {
   lhResults = results;
   return new Promise(resolve => {
     const server = http.createServer(requestHandler);
@@ -75,5 +74,5 @@ function reportRequestHandler(request, response) {
 }
 
 module.exports = {
-  hostExperiment
+  serveAndOpenReport
 };

--- a/lighthouse-cli/performance-experiment/server.js
+++ b/lighthouse-cli/performance-experiment/server.js
@@ -27,21 +27,37 @@
 const http = require('http');
 const parse = require('url').parse;
 const path = require('path');
-const fs = require('fs');
+const opn = require('opn');
 const log = require('../../lighthouse-core/lib/log');
-const assetSaver = require('../../lighthouse-core/lib/asset-saver');
 const ReportGenerator = require('../../lighthouse-core/report/report-generator');
 
-const ROOT = `${__dirname}/src`;
-const server = http.createServer(requestHandler);
-server.on('error', err => log.error('PerformanceXServer', err.code, err));
+/**
+ * Start the server with an arbitrary port and open report page in the default browser.
+ * @param {!Object} lighthouseParams
+ * @param {!Object} results
+ * @return {!Promise<string>} Promise that resolves when server is closed
+ */
+let lhResults;
+function hostExperiment(lighthouseParams, results) {
+  lhResults = results;
+  return new Promise(resolve => {
+    const server = http.createServer(requestHandler);
+    server.listen(0);
+    server.on('listening', () => {
+      opn(`http://localhost:${server.address().port}/`);
+    });
+    server.on('error', err => log.error('PerformanceXServer', err.code, err));
+    server.on('close', resolve);
+    process.on('SIGINT', () => {
+      server.close();
+    });
+  });
+}
 
 function requestHandler(request, response) {
-  request.parsedUrl = parse(request.url, true);
-  const pathname = path.normalize(request.parsedUrl.pathname);
-  request.parsedUrl.pathname = pathname;
+  const pathname = path.normalize(parse(request.url).pathname);
 
-  if (pathname === '/reports') {
+  if (pathname === '/') {
     reportRequestHandler(request, response);
   } else {
     response.writeHead(400);
@@ -51,59 +67,13 @@ function requestHandler(request, response) {
 }
 
 function reportRequestHandler(request, response) {
-  const key = request.parsedUrl.query.key;
-  const filePath = `${ROOT}/${key}/results.json`;
-  if (fs.existsSync(filePath)) {
-    const reportGenerator = new ReportGenerator();
-    const results = JSON.parse(fs.readFileSync(filePath));
-    const html = reportGenerator.generateHTML(results, 'cli');
-    response.writeHead(200, {'Content-Type': 'text/html'});
-    response.write(html);
-  } else {
-    response.writeHead(404);
-    response.write(`404 - Report not found. Key = ${key}`);
-  }
+  const reportGenerator = new ReportGenerator();
+  const html = reportGenerator.generateHTML(lhResults, 'cli');
+  response.writeHead(200, {'Content-Type': 'text/html'});
+  response.write(html);
   response.end();
 }
 
-/**
- * Start the server with an arbitrary port if it's not already started.
- * Save experiment configuration (flags) and results
- * @param {!Object} flags
- * @param {!Object} results
- * @return {!Promise<string>} Promise that resolves to the url where report can be accessed
- */
-function hostExperiment(flags, results) {
-  return startServer(0).then(port => {
-    const key = assetSaver.getFilenamePrefix({url: results.initialUrl});
-    const dir = `${ROOT}/${key}`;
-    fs.mkdirSync(dir);
-    fs.writeFileSync(`${dir}/flags.json`, JSON.stringify(flags));
-    fs.writeFileSync(`${dir}/results.json`, JSON.stringify(results));
-    log.log('PerformanceXServer', 'Save experiment data:', `file path: ${dir}`);
-    return `http://localhost:${port}/reports?key=${key}`;
-  });
-}
-
-/**
- * Start the server if it's not already started.
- * @param {number} port
- * @return {!Promise<number>} Promise that resolves to port the server is listening to
- */
-let portPromise;
-function startServer(port) {
-  if (!portPromise) {
-    portPromise = new Promise(resolve => {
-      if (!fs.existsSync(ROOT)) {
-        fs.mkdirSync(ROOT);
-      }
-      server.listen(port, () => resolve(server.address().port));
-    });
-  }
-  return portPromise;
-}
-
 module.exports = {
-  hostExperiment,
-  startServer
+  hostExperiment
 };


### PR DESCRIPTION
Main changes:
1. Saving results as JSON instead of HTML. This can ease results comparison in Project Performance Experiment (Perf-X) #1143.
2. Save flags. Perf-X will need this to rerun the lighthouse (with some extra configurations).
3. Save file and construct report page URL in server.js instead of bin.ts. This hopefully can make bin.ts more readable and reduce coupling.