### PR TITLE
add url blocking function to driver

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -701,6 +701,14 @@ class Driver {
 
     return collectUsage;
   }
+
+  blockUrlPatterns(urlPatterns) {
+    const promiseArr = [];
+    for (const url of urlPatterns) {
+      promiseArr.push(this.sendCommand('Network.addBlockedURL', {url}));
+    }
+    return Promise.all(promiseArr);
+  }
 }
 
 /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -703,10 +703,7 @@ class Driver {
   }
 
   blockUrlPatterns(urlPatterns) {
-    const promiseArr = [];
-    for (const url of urlPatterns) {
-      promiseArr.push(this.sendCommand('Network.addBlockedURL', {url}));
-    }
+    const promiseArr = urlPatterns.map(url => this.sendCommand('Network.addBlockedURL', {url}));
     return Promise.all(promiseArr);
   }
 }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -96,7 +96,8 @@ class GatherRunner {
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.evaluateScriptOnLoad('window.__nativePromise = Promise;'))
       .then(_ => driver.cleanAndDisableBrowserCaches())
-      .then(_ => driver.clearDataForOrigin(options.url));
+      .then(_ => driver.clearDataForOrigin(options.url))
+      .then(_ => driver.blockUrlPatterns(options.flags.blockedUrlPatterns || []));
   }
 
   static disposeDriver(driver) {

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -61,5 +61,8 @@ module.exports = {
     return Promise.resolve({
       schemeIsCryptographic: true
     });
+  },
+  blockUrlPatterns() {
+    return Promise.resolve();
   }
 };


### PR DESCRIPTION
Added request blocking method in Driver and it will be called during GatherRunner.setupDriver().
Blocked URLs will be passed in flags.blockedUrlPatterns. The flag is not exposed to users since copy-pasting a bunch of URLs seems inconvenient in cli. It will mainly been used by Perf-X server #1143.