### PR TITLE
Fix captureJSCallUsage in the face of Error polyfills.

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -88,6 +88,10 @@
   <a href="./doesnotexist" target="_blank">internal link is ok</a>
 </template>
 
+<!-- Some websites overwrite the original Error object. The captureJSCallUsage function
+  relies on the native Error object and prepareStackTrace from V8. When overwriting the stack
+  property the e.stack inside the gatherer won't be in the correct format
+  https://github.com/GoogleChrome/lighthouse/issues/1194 -->
 <script>window.Error = function(error) { this.stack = 'stacktrace'; };</script>
 <script>
 function stampTemplate(id, location) {

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -88,6 +88,7 @@
   <a href="./doesnotexist" target="_blank">internal link is ok</a>
 </template>
 
+<script>window.Error = function(error) { this.stack = 'stacktrace'; };</script>
 <script>
 function stampTemplate(id, location) {
   const template = document.querySelector('#' + id);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -712,7 +712,7 @@ class Driver {
  * @param {function(...*): *} funcRef The function call to track.
  * @param {!Set} set An empty set to populate with stack traces. Should be
  *     on the global object.
- * @param {Error} NativeError The origal error object some libraries overwrite it.
+ * @param {Error} NativeError The original error object some libraries overwrite it.
  *     So they can take full control of errors.
  * @return {function(...*): *} A wrapper around the original function.
  */

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -712,13 +712,13 @@ class Driver {
  * @param {function(...*): *} funcRef The function call to track.
  * @param {!Set} set An empty set to populate with stack traces. Should be
  *     on the global object.
- * @param {Error} nativeError The origal error object some libraries overwrite it.
+ * @param {Error} NativeError The origal error object some libraries overwrite it.
  *     So they can take full control of errors.
  * @return {function(...*): *} A wrapper around the original function.
  */
 function captureJSCallUsage(funcRef, set, NativeError) {
   const originalFunc = funcRef;
-  const originalPrepareStackTrace = nativeError.prepareStackTrace;
+  const originalPrepareStackTrace = NativeError.prepareStackTrace;
 
   return function() {
     // Note: this function runs in the context of the page that is being audited.

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -94,7 +94,8 @@ class GatherRunner {
     return driver.assertNoSameOriginServiceWorkerClients(options.url)
       .then(_ => driver.beginEmulation(options.flags))
       .then(_ => driver.enableRuntimeEvents())
-      .then(_ => driver.evaluateScriptOnLoad('window.__nativePromise = Promise;'))
+      .then(_ => driver.evaluateScriptOnLoad(`window.__nativePromise = Promise;
+        window.__nativeError = Error;`))
       .then(_ => driver.cleanAndDisableBrowserCaches())
       .then(_ => driver.clearDataForOrigin(options.url));
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -94,8 +94,7 @@ class GatherRunner {
     return driver.assertNoSameOriginServiceWorkerClients(options.url)
       .then(_ => driver.beginEmulation(options.flags))
       .then(_ => driver.enableRuntimeEvents())
-      .then(_ => driver.evaluateScriptOnLoad(`window.__nativePromise = Promise;
-        window.__nativeError = Error;`))
+      .then(_ => driver.cacheNatives())
       .then(_ => driver.cleanAndDisableBrowserCaches())
       .then(_ => driver.clearDataForOrigin(options.url));
   }

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -43,6 +43,9 @@ module.exports = {
   },
   cleanAndDisableBrowserCaches() {},
   clearDataForOrigin() {},
+  cacheNatives() {
+    return Promise.resolve();
+  },
   beginTrace() {
     return Promise.resolve();
   },

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -54,6 +54,9 @@ function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn) {
     assertNoSameOriginServiceWorkerClients() {
       return Promise.resolve();
     }
+    cacheNatives() {
+      return Promise.resolve();
+    }
     cleanAndDisableBrowserCaches() {}
     clearDataForOrigin() {}
   };


### PR DESCRIPTION
V8 has the property prepareStackTrace on errors where you can format a stacktrace. This only works on native errors not on custom ones.

Fixes issues like #1194