### PR TITLE
Removes uses of HTML injection in report

### DIFF
--- a/lighthouse-core/audits/accessibility/tabindex.js
+++ b/lighthouse-core/audits/accessibility/tabindex.js
@@ -32,7 +32,7 @@ class TabIndex extends AxeAudit {
     return {
       category: 'Accessibility',
       name: 'tabindex',
-      description: 'No element has a tabindex attribute greater than 0',
+      description: 'No element has a `tabindex` attribute greater than 0',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/content-width.js
+++ b/lighthouse-core/audits/content-width.js
@@ -28,7 +28,9 @@ class ContentWidth extends Audit {
       category: 'Mobile Friendly',
       name: 'content-width',
       description: 'Content is sized correctly for the viewport',
-      helpText: 'If the width of your app\'s content doesn\'t match the width of the viewport, your app might not be optimized for mobile screens. <a href="https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport" rel="noopener" target="_blank">Learn more</a>.',
+      helpText: 'If the width of your app\'s content doesn\'t match the width ' +
+          'of the viewport, your app might not be optimized for mobile screens. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport).',
       requiredArtifacts: ['ContentWidth']
     };
   }

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -30,7 +30,11 @@ class CriticalRequestChains extends Audit {
       name: 'critical-request-chains',
       description: 'Critical Request Chains',
       optimalValue: 0,
-      helpText: 'The Critical Request Chains below show you what resources are required for first render of this page. Improve page load by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources. <a href="https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains" rel="noopener" target="_blank">Learn more</a>.',
+      helpText: 'The Critical Request Chains below show you what resources are ' +
+          'required for first render of this page. Improve page load by reducing ' +
+          'the length of chains, reducing the download size of resources, or ' +
+          'deferring the download of unnecessary resources. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains).',
       requiredArtifacts: ['networkRecords']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -33,7 +33,7 @@ class AppCacheManifestAttr extends Audit {
       category: 'Offline',
       name: 'appcache-manifest',
       description: 'Site does not use Application Cache',
-      helpText: 'Application Cache has been <a href="https://html.spec.whatwg.org/multipage/browsers.html#offline" target="_blank">deprecated</a> by <a href="https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers" target="_blank">Service Workers</a>. Consider implementing an offline solution using the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Cache" target="_blank">Cache Storage API</a>.',
+      helpText: 'Application Cache has been [deprecated](https://html.spec.whatwg.org/multipage/browsers.html#offline) by [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers). Consider implementing an offline solution using the [Cache Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Cache).',
       requiredArtifacts: ['AppCacheManifest']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -30,9 +30,9 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       category: 'Performance',
       name: 'external-anchors-use-rel-noopener',
       description: 'Site opens external anchors using rel="noopener"',
-      helpText: 'Open new tabs using <code>rel="noopener"</code> to improve performance and ' +
-          'prevent security vulnerabilities. <a href="https://developers.google.com/web/tools/' +
-          'lighthouse/audits/noopener" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'Open new tabs using `rel="noopener"` to improve performance and ' +
+          'prevent security vulnerabilities. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).',
       requiredArtifacts: ['URL', 'AnchorsWithNoRelNoopener']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -36,8 +36,7 @@ class GeolocationOnStart extends Audit {
       description: 'Page does not automatically request geolocation on page load',
       helpText: 'Users are mistrustful of or confused by sites that request their ' +
           'location without context. Consider tying the request to user gestures instead. ' +
-          '<a href="https://developers.google.com/web/tools/lighthouse/audits/' +
-          'geolocation-on-load" target="_blank" rel="noopener">Learn more</a>.',
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).',
       requiredArtifacts: ['GeolocationOnStart']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -36,8 +36,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
       description: 'Site does not use <link> that delay first paint',
       helpText: 'Link elements are blocking the first paint of your page. Consider ' +
           'inlining critical links and deferring non-critical ones. ' +
-          '<a href="https://developers.google.com/web/tools/lighthouse/audits/' +
-          'blocking-resources" target="_blank" rel="noopener">Learn more</a>.',
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',
       requiredArtifacts: ['TagsBlockingFirstPaint']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -34,12 +34,11 @@ class NoConsoleTimeAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-console-time',
-      description: 'Site does not use console.time() in its own scripts',
-      helpText: 'Consider using <code>performance.mark()</code> and <code>performance.measure()' +
-          '</code> from the User Timing API instead. They provide high-precision timestamps, ' +
+      description: 'Site does not use `console.time()` in its own scripts',
+      helpText: 'Consider using `performance.mark()` and `performance.measure()` ' +
+          'from the User Timing API instead. They provide high-precision timestamps, ' +
           'independent of the system clock, and are integrated in the Chrome DevTools Timeline. ' +
-          '<a href="https://developers.google.com/web/tools/lighthouse/audits/console-time" ' +
-          'target="_blank" rel="noopener">Learn more</a>.',
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/console-time).',
       requiredArtifacts: ['URL', 'ConsoleTimeUsage']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -35,11 +35,10 @@ class NoDateNowAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-datenow',
-      description: 'Site does not use Date.now() in its own scripts',
-      helpText: 'Consider using <code>performance.now()</code> from the User Timing API ' +
+      description: 'Site does not use `Date.now()` in its own scripts',
+      helpText: 'Consider using `performance.now()` from the User Timing API ' +
           'instead. It provides high-precision timestamps, independent of the system ' +
-          'clock. <a href="https://developers.google.com/web/tools/lighthouse/audits/' +
-          'date-now" target="_blank" rel="noopener">Learn more</a>.',
+          'clock. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/date-now).',
       requiredArtifacts: ['URL', 'DateNowUse']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -35,9 +35,8 @@ class NoDocWriteAudit extends Audit {
       name: 'no-document-write',
       description: 'Site does not use document.write()',
       helpText: 'For users on slow connections, external scripts dynamically injected via ' +
-          '<code>document.write()</code> can delay page load by tens of seconds. ' +
-          '<a href="https://developers.google.com/web/tools/lighthouse/audits/' +
-          'document-write" target="_blank" rel="noopener">Learn more</a>.',
+          '`document.write()` can delay page load by tens of seconds. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).',
       requiredArtifacts: ['DocWriteUse']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -52,8 +52,7 @@ class NoMutationEventsAudit extends Audit {
       name: 'no-mutation-events',
       description: 'Site does not use Mutation Events in its own scripts',
       helpText: 'Mutation Events are deprecated and harm performance. Consider using Mutation ' +
-          'Observers instead. <a href="https://developers.google.com/web/tools/lighthouse' +
-          '/audits/mutation-events" target="_blank" rel="noopener">Learn more</a>.',
+          'Observers instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/mutation-events).',
       requiredArtifacts: ['URL', 'EventListeners']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -37,8 +37,7 @@ class NoOldFlexboxAudit extends Audit {
       name: 'no-old-flexbox',
       description: 'Site does not use the old CSS flexbox',
       helpText: 'The 2009 spec of Flexbox is deprecated and is 2.3x slower than the latest ' +
-          'spec. <a href="https://developers.google.com/web/tools/lighthouse/audits/' +
-          'old-flexbox" target="_blank" rel="noopener">Learn more</a>.',
+          'spec. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/old-flexbox).',
       requiredArtifacts: ['Styles']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -35,8 +35,7 @@ class NoWebSQLAudit extends Audit {
       name: 'no-websql',
       description: 'Site does not use WebSQL DB.',
       helpText: 'Web SQL is deprecated. Consider using IndexedDB instead. ' +
-          '<a href="https://developers.google.com/web/tools/lighthouse/audits/web-sql" ' +
-          'target="_blank" rel="noopener">Learn more</a>.',
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/web-sql).',
       requiredArtifacts: ['WebSQL']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/notification-on-start.js
@@ -36,8 +36,7 @@ class NotificationOnStart extends Audit {
       description: 'Page does not automatically request notification permissions on page load',
       helpText: 'Users are mistrustful of or confused by sites that request to send ' +
           'notifications without context. Consider tying the request to user gestures ' +
-          'instead. <a href="https://developers.google.com/web/tools/lighthouse/audits/' +
-          'notifications-on-load" target="_blank" rel="noopener">Learn more</a>.',
+          'instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).',
       requiredArtifacts: ['NotificationOnStart']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
@@ -36,8 +36,7 @@ class ScriptBlockingFirstPaint extends Audit {
       description: 'Site does not use <script> in head that delays first paint',
       helpText: 'Script elements are blocking the first paint of your page. Consider inlining ' +
           'critical scripts and deferring non-critical ones. ' +
-          '<a href="https://developers.google.com/web/tools/lighthouse/' +
-          'audits/blocking-resources" target="_blank" rel="noopener">Learn more</a>.',
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',
       requiredArtifacts: ['TagsBlockingFirstPaint']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -37,8 +37,7 @@ class UsesHTTP2Audit extends Audit {
       name: 'uses-http2',
       description: 'Site uses HTTP/2 for its own resources',
       helpText: 'HTTP/2 offers many benefits over HTTP/1.1, including binary headers, ' +
-          'multiplexing, and server push. <a href="https://developers.google.com/' +
-          'web/tools/lighthouse/audits/http2" target="_blank" rel="noopener">Learn more</a>.',
+          'multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).',
       requiredArtifacts: ['URL', 'networkRecords']
     };
   }

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -42,10 +42,9 @@ class PassiveEventsAudit extends Audit {
       category: 'JavaScript',
       name: 'uses-passive-event-listeners',
       description: 'Site uses passive listeners to improve scrolling performance',
-      helpText: 'Consider marking your touch and wheel event listeners as <code>passive</code> ' +
-          'to improve your page\'s scroll performance. <a href="https://developers.google.com/' +
-          'web/tools/lighthouse/audits/passive-event-listeners" target="_blank" ' +
-          'rel="noopener">Learn more</a>.',
+      helpText: 'Consider marking your touch and wheel event listeners as `passive` ' +
+          'to improve your page\'s scroll performance. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).',
       requiredArtifacts: ['URL', 'EventListeners']
     };
   }

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -35,7 +35,11 @@ class EstimatedInputLatency extends Audit {
       name: 'estimated-input-latency',
       description: 'Estimated Input Latency',
       optimalValue: SCORING_POINT_OF_DIMINISHING_RETURNS.toLocaleString() + 'ms',
-      helpText: 'The score above is an estimate of how long your app takes to respond to user input, in milliseconds. There is a 90% probability that a user encounters this amount of latency, or less. 10% of the time a user can expect additional latency. If your score is higher than Lighthouse\'s target score, users may perceive your app as laggy. <a href="https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency" rel="noopener" target="_blank">Learn more</a>.',
+      helpText: 'The score above is an estimate of how long your app takes to respond to user ' +
+          'input, in milliseconds. There is a 90% probability that a user encounters this amount ' +
+          'of latency, or less. 10% of the time a user can expect additional latency. If your ' +
+          'score is higher than Lighthouse\'s target score, users may perceive your app as ' +
+          'laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency).',
       requiredArtifacts: ['traces']
     };
   }

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -36,7 +36,8 @@ class FirstMeaningfulPaint extends Audit {
       name: 'first-meaningful-paint',
       description: 'First meaningful paint',
       optimalValue: SCORING_POINT_OF_DIMINISHING_RETURNS.toLocaleString() + 'ms',
-      helpText: 'First meaningful paint measures when the primary content of a page is visible. <a href="https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'First meaningful paint measures when the primary content of a page is visible. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint).',
       requiredArtifacts: ['traces']
     };
   }

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -27,7 +27,11 @@ class HTTPS extends Audit {
       category: 'Security',
       name: 'is-on-https',
       description: 'Site is on HTTPS',
-      helpText: 'All sites should be protected with HTTPS, even ones that don\'t handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. <a href="https://developers.google.com/web/tools/lighthouse/audits/https" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'All sites should be protected with HTTPS, even ones that don\'t handle ' +
+          'sensitive data. HTTPS prevents intruders from tampering with or passively listening ' +
+          'in on the communications between your app and your users, and is a prerequisite for ' +
+          'HTTP/2 and many new web platform APIs. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/https).',
       requiredArtifacts: ['HTTPS']
     };
   }

--- a/lighthouse-core/audits/manifest-background-color.js
+++ b/lighthouse-core/audits/manifest-background-color.js
@@ -28,7 +28,7 @@ class ManifestBackgroundColor extends Audit {
     return {
       category: 'Manifest',
       name: 'manifest-background-color',
-      description: 'Manifest contains background_color',
+      description: 'Manifest contains `background_color`',
       requiredArtifacts: ['Manifest']
     };
   }

--- a/lighthouse-core/audits/manifest-display.js
+++ b/lighthouse-core/audits/manifest-display.js
@@ -27,7 +27,7 @@ class ManifestDisplay extends Audit {
     return {
       category: 'Manifest',
       name: 'manifest-display',
-      description: 'Manifest\'s display property is set',
+      description: 'Manifest\'s `display` property is set',
       requiredArtifacts: ['Manifest']
     };
   }

--- a/lighthouse-core/audits/manifest-name.js
+++ b/lighthouse-core/audits/manifest-name.js
@@ -27,7 +27,7 @@ class ManifestName extends Audit {
     return {
       category: 'Manifest',
       name: 'manifest-name',
-      description: 'Manifest contains name',
+      description: 'Manifest contains `name`',
       requiredArtifacts: ['Manifest']
     };
   }

--- a/lighthouse-core/audits/manifest-short-name-length.js
+++ b/lighthouse-core/audits/manifest-short-name-length.js
@@ -27,7 +27,7 @@ class ManifestShortNameLength extends Audit {
     return {
       category: 'Manifest',
       name: 'manifest-short-name-length',
-      description: 'Manifest\'s short_name won\'t be truncated when displayed on homescreen',
+      description: 'Manifest\'s `short_name` won\'t be truncated when displayed on homescreen',
       requiredArtifacts: ['Manifest']
     };
   }

--- a/lighthouse-core/audits/manifest-short-name.js
+++ b/lighthouse-core/audits/manifest-short-name.js
@@ -27,7 +27,7 @@ class ManifestShortName extends Audit {
     return {
       category: 'Manifest',
       name: 'manifest-short-name',
-      description: 'Manifest contains short_name',
+      description: 'Manifest contains `short_name`',
       requiredArtifacts: ['Manifest']
     };
   }

--- a/lighthouse-core/audits/manifest-start-url.js
+++ b/lighthouse-core/audits/manifest-start-url.js
@@ -27,7 +27,7 @@ class ManifestStartUrl extends Audit {
     return {
       category: 'Manifest',
       name: 'manifest-start-url',
-      description: 'Manifest contains start_url',
+      description: 'Manifest contains `start_url`',
       requiredArtifacts: ['Manifest']
     };
   }

--- a/lighthouse-core/audits/manifest-theme-color.js
+++ b/lighthouse-core/audits/manifest-theme-color.js
@@ -27,7 +27,7 @@ class ManifestThemeColor extends Audit {
     return {
       category: 'Manifest',
       name: 'manifest-theme-color',
-      description: 'Manifest contains theme_color',
+      description: 'Manifest contains `theme_color`',
       requiredArtifacts: ['Manifest']
     };
   }

--- a/lighthouse-core/audits/redirects-http.js
+++ b/lighthouse-core/audits/redirects-http.js
@@ -27,7 +27,8 @@ class RedirectsHTTP extends Audit {
       category: 'Security',
       name: 'redirects-http',
       description: 'Site redirects HTTP traffic to HTTPS',
-      helpText: 'If you\'ve already set up HTTPS, make sure that you redirect all HTTP traffic to HTTPS. <a href="https://developers.google.com/web/tools/lighthouse/audits/http-redirects-to-https" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'If you\'ve already set up HTTPS, make sure that you redirect all HTTP traffic ' +
+         'to HTTPS. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-redirects-to-https).',
       requiredArtifacts: ['HTTPRedirect']
     };
   }

--- a/lighthouse-core/audits/service-worker.js
+++ b/lighthouse-core/audits/service-worker.js
@@ -39,7 +39,7 @@ class ServiceWorker extends Audit {
       category: 'Offline',
       name: 'service-worker',
       description: 'Has a registered Service Worker',
-      helpText: 'The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. <a href="https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker).',
       requiredArtifacts: ['URL', 'ServiceWorker']
     };
   }

--- a/lighthouse-core/audits/service-worker.js
+++ b/lighthouse-core/audits/service-worker.js
@@ -39,7 +39,9 @@ class ServiceWorker extends Audit {
       category: 'Offline',
       name: 'service-worker',
       description: 'Has a registered Service Worker',
-      helpText: 'The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker).',
+      helpText: 'The service worker is the technology that enables your app to use many ' +
+         'Progressive Web App features, such as offline, add to homescreen, and push ' +
+         'notifications. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker).',
       requiredArtifacts: ['URL', 'ServiceWorker']
     };
   }

--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -35,7 +35,8 @@ class SpeedIndexMetric extends Audit {
       category: 'Performance',
       name: 'speed-index-metric',
       description: 'Perceptual Speed Index',
-      helpText: 'Speed Index shows how quickly the contents of a page are visibly populated. <a href="https://developers.google.com/web/tools/lighthouse/audits/speed-index" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'Speed Index shows how quickly the contents of a page are visibly populated. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index).',
       optimalValue: SCORING_POINT_OF_DIMINISHING_RETURNS.toLocaleString(),
       requiredArtifacts: ['traces']
     };

--- a/lighthouse-core/audits/theme-color-meta.js
+++ b/lighthouse-core/audits/theme-color-meta.js
@@ -27,7 +27,7 @@ class ThemeColor extends Audit {
     return {
       category: 'HTML',
       name: 'theme-color-meta',
-      description: 'HTML has a theme-color <meta>',
+      description: 'HTML has a `<meta name="theme-color">` tag',
       requiredArtifacts: ['ThemeColor']
     };
   }

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -29,7 +29,9 @@ class TTIMetric extends Audit {
       category: 'Performance',
       name: 'time-to-interactive',
       description: 'Time To Interactive (alpha)',
-      helpText: 'Time to Interactive identifies the time at which your app appears to be ready enough to interact with. <a href="https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'Time to Interactive identifies the time at which your app appears to be ready ' +
+          'enough to interact with. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive).',
       optimalValue: SCORING_TARGET.toLocaleString() + 'ms',
       requiredArtifacts: ['traces']
     };

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -118,7 +118,9 @@ class UserTimings extends Audit {
       category: 'Performance',
       name: 'user-timings',
       description: 'User Timing marks and measures',
-      helpText: 'Consider instrumenting your app with the User Timing API to create custom, real-world measurements of key user experiences. <a href="https://developers.google.com/web/tools/lighthouse/audits/user-timing" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'Consider instrumenting your app with the User Timing API to create custom, ' +
+          'real-world measurements of key user experiences. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing).',
       requiredArtifacts: ['traces']
     };
   }

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -26,8 +26,9 @@ class Viewport extends Audit {
     return {
       category: 'Mobile Friendly',
       name: 'viewport',
-      description: 'HTML has a viewport <meta>',
-      helpText: 'Add a viewport meta tag to optimize your app for mobile screens. <a href="https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag" target="_blank" rel="noopener">Learn more</a>.',
+      description: 'HTML has a `<meta name="viewport">` tag',
+      helpText: 'Add a viewport meta tag to optimize your app for mobile screens. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag").',
       requiredArtifacts: ['Viewport']
     };
   }

--- a/lighthouse-core/audits/without-javascript.js
+++ b/lighthouse-core/audits/without-javascript.js
@@ -28,7 +28,9 @@ class WithoutJavaScript extends Audit {
       category: 'JavaScript',
       name: 'without-javascript',
       description: 'Page contains some content when its scripts are not available',
-      helpText: 'Your app should display some content when JavaScript is disabled, even if it\'s just a warning to the user that JavaScript is required to use the app. <a href="https://developers.google.com/web/tools/lighthouse/audits/no-js" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'Your app should display some content when JavaScript is disabled, even if it\'s ' +
+          'just a warning to the user that JavaScript is required to use the app. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/no-js).',
       requiredArtifacts: ['HTMLWithoutJavaScript']
     };
   }

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -27,7 +27,9 @@ class WorksOffline extends Audit {
       category: 'Offline',
       name: 'works-offline',
       description: 'URL responds with a 200 when offline',
-      helpText: 'If you\'re building a Progressive Web App, consider using a service worker so that your app can work offline. <a href="https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline" target="_blank" rel="noopener">Learn more</a>.',
+      helpText: 'If you\'re building a Progressive Web App, consider using a service worker so ' +
+          'that your app can work offline. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).',
       requiredArtifacts: ['Offline']
     };
   }

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -177,7 +177,7 @@
       }
     }, {
       "name": "User can be prompted to Add to Homescreen",
-      "description": "While users can manually add your site to their homescreen in the browser menu, the <a href=\"https://developers.google.com/web/updates/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android?hl=en\">prompt (aka app install banner)</a> will proactively prompt the user to install the app if the below requirements are met and the user has visited your site at least twice (with at least five minutes between visits).",
+      "description": "While users can manually add your site to their homescreen in the browser menu, the [prompt (aka app install banner)](https://developers.google.com/web/updates/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android) will proactively prompt the user to install the app if the below requirements are met and the user has visited your site at least twice (with at least five minutes between visits).",
       "see": "https://github.com/GoogleChrome/lighthouse/issues/23",
       "audits": {
         "service-worker": {
@@ -203,7 +203,7 @@
       }
     }, {
       "name": "Installed web app will launch with custom splash screen",
-      "description": "A default splash screen will be constructed, but meeting these requirements guarantee a high-quality and customizable <a href=\"https://developers.google.com/web/updates/2015/10/splashscreen?hl=en\">splash screen</a> the user sees between tapping the home screen icon and your app’s first paint.",
+      "description": "A default splash screen will be constructed, but meeting these requirements guarantee a high-quality and customizable [splash screen](https://developers.google.com/web/updates/2015/10/splashscreen) the user sees between tapping the home screen icon and your app's first paint.",
       "see": "https://github.com/GoogleChrome/lighthouse/issues/24",
       "audits": {
         "manifest-exists": {
@@ -229,7 +229,7 @@
       }
     }, {
       "name": "Address bar matches brand colors",
-      "description": "The browser address bar can be themed to match your site. A theme-color <a href=\"https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android\">meta tag</a> will upgrade the address bar when a user browses the site, and the <a href=\"https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color\">manifest theme-color</a> will apply the same theme site-wide once it's been added to homescreen.",
+      "description": "The browser address bar can be themed to match your site. A `theme-color` [meta tag](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android) will upgrade the address bar when a user browses the site, and the [manifest theme-color](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color) will apply the same theme site-wide once it's been added to homescreen.",
       "audits": {
         "manifest-exists": {
           "expectedValue": true,
@@ -388,21 +388,21 @@
           "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
-          "description": "Payment forms marked up with [autocomplete] attributes",
+          "description": "Payment forms marked up with `autocomplete` attributes",
           "category": "UX"
         },
         "login-autocomplete": {
           "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
-          "description": "Login forms marked up with [autocomplete] attributes",
+          "description": "Login forms marked up with `autocomplete` attributes",
           "category": "UX"
         },
         "input-type": {
           "expectedValue": true,
           "weight": 0,
           "comingSoon": true,
-          "description": "Input fields use appropriate [type] attributes for custom keyboards",
+          "description": "Input fields use appropriate `type` attributes for custom keyboards",
           "category": "UX"
         }
       }

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -100,7 +100,7 @@
     "categorizable": true,
     "items": [{
       "name": "App can load on offline/flaky connections",
-      "description": "Ensuring your web app can respond when the network connection is unavailable or flaky is critical to providing your users a good experience. This is achieved through use of a <a href=\"https://developers.google.com/web/fundamentals/primers/service-worker/\">Service Worker</a>.",
+      "description": "Ensuring your web app can respond when the network connection is unavailable or flaky is critical to providing your users a good experience. This is achieved through use of a [Service Worker](https://developers.google.com/web/fundamentals/primers/service-worker/).",
       "audits": {
         "service-worker": {
           "expectedValue": true,

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -137,7 +137,11 @@ class ReportGenerator {
         return str;
       };
 
-      str = marked(str, {renderer, sanitize: true});
+      try {
+        str = marked(str, {renderer, sanitize: true});
+      } catch (e) {
+        // Ignore fatal errors from marked js.
+      }
 
       // The input str has been santized and transformed. Mark it as safe so
       // handlebars renders the text as HTML.

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -116,29 +116,31 @@ class ReportGenerator {
       return arg;
     });
 
+    // eslint-disable-next-line no-unused-vars
     Handlebars.registerHelper('sanitize', function(str, opts) {
-      const isViewer = opts.data.root.reportContext === 'viewer';
+      // const isViewer = opts.data.root.reportContext === 'viewer';
 
-      // For viewer, sanitize the user's JSON input to mitigate against XSS.
-      // Define a renderer that only cares about transforming links and code
-      // snippets. Ignore everything else.
-      if (isViewer) {
-        const renderer = new marked.Renderer();
-        renderer.link = (href, title, text) => {
-          title = title || text;
-          return `<a href="${href}" target="_blank" rel="noopener" title="${title}">${text}</a>`;
-        };
-        renderer.codespan = function(str) {
-          return `<code>${str}</code>`;
-        };
-        // Nuke wrapper <p> tag that gets generated.
-        renderer.paragraph = function(str) {
-          return str;
-        };
+      // Allow the report to inject HTML, but sanitize it first.
+      // Viewer in particular, allows user's to upload JSON. To mitigate against
+      // XSS, define a renderer that only transforms links and code snippets.
+      // All other markdown ad HTML is ignored.
+      const renderer = new marked.Renderer();
+      renderer.link = (href, title, text) => {
+        title = title || text;
+        return `<a href="${href}" target="_blank" rel="noopener" title="${title}">${text}</a>`;
+      };
+      renderer.codespan = function(str) {
+        return `<code>${str}</code>`;
+      };
+      // Nuke wrapper <p> tag that gets generated.
+      renderer.paragraph = function(str) {
+        return str;
+      };
 
-        str = marked(str, {renderer, sanitize: true});
-      }
+      str = marked(str, {renderer, sanitize: true});
 
+      // The input str has been santized and transformed. Mark it as safe so
+      // handlebars renders the text as HTML.
       return new Handlebars.SafeString(str);
     });
   }

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -77,7 +77,7 @@ limitations under the License.
       <section class="js-breakdown aggregations" id="{{nameToLink this.name}}">
         <header class="aggregations__header">
           <h1>{{ this.name }}</h1>
-          <p class="aggregations__desc">{{ this.description }}</p>
+          <p class="aggregations__desc">{{ sanitize this.description }}</p>
           {{#if this.scored}}
           <div class="section-result">
             <span class="section-result__score score-{{ getTotalScoreRating this }}-bg">
@@ -111,7 +111,7 @@ limitations under the License.
                       <strong class="subitem__category">{{ subItem.category }}:</strong>
                     {{/unless}}
 
-                    {{ subItem.description }}
+                    {{ sanitize subItem.description }}
 
                     {{~#if (and subItem.displayValue (not (is-bool subItem.displayValue))) ~}}
                       <strong class="subitem__raw-value">: {{ subItem.displayValue }}</strong>

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -97,7 +97,7 @@ limitations under the License.
             <header class="aggregation__header">
               <h2>{{ aggregation.name }}</h2>
               {{#if aggregation.description }}
-                <p class="aggregation__desc">{{{ aggregation.description }}}</p>
+                <p class="aggregation__desc">{{ sanitize aggregation.description }}</p>
               {{/if}}
             </header>
             {{/if}}
@@ -128,14 +128,14 @@ limitations under the License.
                     {{#if subItem.helpText }}
                       <input type="checkbox" class="subitem__help-toggle" title="Toggle help text"  {{#if (shouldShowHelpText subItem.score)}}checked{{/if}}>
                       <span class="subitem__help">
-                        {{{ subItem.helpText }}}
+                        {{ sanitize subItem.helpText }}
                       </span>
                     {{/if}}
                   </p>
 
                   {{#if subItem.debugString }}
                     <div class="subitem__debug">
-                      {{{ subItem.debugString }}}
+                      {{ subItem.debugString }}
                     </div>
                   {{/if}}
 
@@ -151,7 +151,7 @@ limitations under the License.
                         {{/if}}
                       {{else}}
                         <span class="subitem-result__points score-{{ getItemRating subItem.score }}-bg">
-                          {{{ getItemValue subItem.score }}}
+                          {{ subItem.score }}
                         </span>
                       {{/if}}
                     {{/if}}

--- a/lighthouse-core/test/audits/accessibility/tabindex-test.js
+++ b/lighthouse-core/test/audits/accessibility/tabindex-test.js
@@ -64,6 +64,6 @@ describe('Accessibility: tabindex audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.description, 'No element has a tabindex attribute greater than 0');
+    assert.equal(output.description, 'No element has a `tabindex` attribute greater than 0');
   });
 });

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gl-matrix": "2.3.2",
     "handlebars": "^4.0.5",
     "json-stringify-safe": "^5.0.1",
+    "marked": "^0.3.6",
     "mkdirp": "^0.5.1",
     "opn": "^4.0.2",
     "rimraf": "^2.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,6 +1825,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+marked@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+
 meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"


### PR DESCRIPTION
R: @brendankenny @patrickhulce all

Fixes https://github.com/GoogleChrome/lighthouse/issues/1188.

This PR:
- removes the dangerous uses of `{{{}}}`, but keeps the ones where we control the input (`{{{css}}}` and `{{{script}}}`).
- Adds `marked` as a dependency. This module is lightweight (<30kb) and produces the necessary sanitization we need to escape unwanted HTML that gets loaded in the viewer/report.
- Moves the audits to use markdown snippets rather than HTML snippets. Makes `helpText` and `descriptions` shorter and easier to author.
- An added benefit is that we can now use markdown all over the place (aggregation descriptions, audit descriptions, help text). Just need to use `{{sanitize variableName}}`.

@kaycebasques for the FYI as this changes audit help text from html to using markdown.