### PR TITLE
handle anchor tags with no href in noopener audit

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -82,6 +82,9 @@
 <template id="noopener-links-tmpl">
   <!-- FAIL - does not use rel="noopener" to open external link -->
   <a href="https://www.google.com/" target="_blank">external link</a>
+  <!-- FAIL - does not use rel="noopener" and has no href attribute, giving an
+    href value of '' when read, which will throw in a `new URL('')` constructor -->
+  <a target="_blank">external link</a>
   <!-- PASS -->
   <a href="https://www.google.com/" target="_blank" rel="noopener nofollow">external link that uses rel noopener and another unrelated rel attribute</a>
   <!-- PASS -->

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -51,15 +51,16 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
 
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usages to exclude anchors that are same origin
+    // TODO: better extendedInfo for anchors with no href attribute:
+    // https://github.com/GoogleChrome/lighthouse/issues/1233
     const failingAnchors = artifacts.AnchorsWithNoRelNoopener.usages
-      .filter(anchor => new URL(anchor.href).host !== pageHost)
+      .filter(anchor => anchor.href === '' || new URL(anchor.href).host !== pageHost)
       .map(anchor => {
         return {
-          url: `<a
-            href="${anchor.href}"
-            ${anchor.target ? ` target="${anchor.target}"` : ''}
-            ${anchor.rel ? ` rel="${anchor.rel}"` : ''}>...
-          </a>`
+          url: '<a' +
+              (anchor.href ? ` href="${anchor.href}"` : '') +
+              (anchor.target ? ` target="${anchor.target}"` : '') +
+              (anchor.rel ? ` rel="${anchor.rel}"` : '') + '>'
         };
       });
 

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -59,4 +59,17 @@ describe('External anchors use rel="noopener"', () => {
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 2);
   });
+
+  it('handles links with no href attribute', () => {
+    const auditResult = ExternalAnchorsAudit.audit({
+      AnchorsWithNoRelNoopener: {
+        usages: [
+          {href: ''}
+        ]
+      },
+      URL: {finalUrl: URL},
+    });
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.extendedInfo.value.length, 1);
+  });
 });


### PR DESCRIPTION
addresses #1233. See that issue for details on why we still include anchors with no `href` in the audit results.

We might want to leave that open as the reporting of links with no href leaves something to be desired (e.g. the first link in the seamless example ends up as `<a target="_blank" >... </a>` in the URLs dropdown in the report).

Not sure how to make it easier to identify the links in question without starting to write formatters for all the major frameworks, though.

