### PR TITLE
Only run axe tests that we have audits for

### DIFF
--- a/lighthouse-cli/test/fixtures/accessibility/accessibility_tester.html
+++ b/lighthouse-cli/test/fixtures/accessibility/accessibility_tester.html
@@ -37,13 +37,6 @@
         role="checkbox">
       </div>
     </section>
-    <h2>aria-required-attr</h2>
-    <section>
-      <div
-        id="aria-required-attr"
-        role="checkbox">
-      </div>
-    </section>
     <h2>aria-valid-attr</h2>
     <section>
       <div

--- a/lighthouse-core/audits/accessibility/aria-allowed-attr.js
+++ b/lighthouse-core/audits/accessibility/aria-allowed-attr.js
@@ -32,7 +32,7 @@ class ARIAAllowedAttr extends AxeAudit {
     return {
       category: 'Accessibility',
       name: 'aria-allowed-attr',
-      description: 'Element aria-* roles are valid',
+      description: 'Element aria-* attributes are allowed for this role',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -25,10 +25,24 @@ const axe = fs.readFileSync(
 );
 
 // This is run in the page, not Lighthouse itself.
+// axe.run returns a promise which fulfills with a results object
+// containing any violations.
 /* istanbul ignore next */
 function runA11yChecks() {
-  return new Promise((resolve, reject) => {
-    axe.a11yCheck(document, resolve);
+  return axe.run(document, {
+    runOnly: {
+      type: 'rule',
+      values: [
+        'aria-allowed-attr',
+        'aria-required-attr',
+        'aria-valid-attr',
+        'aria-valid-attr-value',
+        'color-contrast',
+        'image-alt',
+        'label',
+        'tabindex'
+      ]
+    }
   });
 }
 

--- a/lighthouse-core/test/audits/accessibility/aria-allowed-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-allowed-attr-test.js
@@ -64,6 +64,6 @@ describe('Accessibility: aria-allowed-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.description, 'Element aria-* roles are valid');
+    assert.equal(output.description, 'Element aria-* attributes are allowed for this role');
   });
 });


### PR DESCRIPTION
Switch to the new `axe.run` method which returns a promise. Now we're only running the tests that we actually audit for, instead of running the default entire axe suite. Also cleaned up a duplicate smoke test and improved the description of the aria-allowed-attr audit a bit.