### PR TITLE
Viewport test: accept initial-scale and allow spaces

### DIFF
--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -41,12 +41,35 @@ class Viewport extends Audit {
   static audit(artifacts) {
     if (typeof artifacts.Viewport !== 'string') {
       return Viewport.generateAuditResult({
-        rawValue: false
+        debugString: 'Error in determining viewport',
+        rawValue: -1
       });
     }
 
-    const viewportProps = Parser.parseMetaViewPortContent(artifacts.Viewport).validProperties;
-    const hasMobileViewport = viewportProps['width'] || viewportProps['initial-scale'];
+    let debugString = '';
+    const parsedProps = Parser.parseMetaViewPortContent(artifacts.Viewport);
+
+    if (Object.keys(parsedProps.unknownProperties).length) {
+      debugString += `Invalid properties found: ${parsedProps.unknownProperties}`;
+    }
+    if (Object.keys(parsedProps.invalidValues).length) {
+      debugString += `Invalid values found: ${parsedProps.invalidValues}`;
+    }
+
+    const viewportProps = parsedProps.validProperties;
+    const hasMobileViewport = viewportProps.width || viewportProps['initial-scale'];
+
+    Viewport.generateAuditResult({
+      rawValue: !!hasMobileViewport,
+      debugString
+    });
+
+    if (typeof artifacts.Viewport !== 'string') {
+      return Viewport.generateAuditResult({
+        debugString: 'Error in determining viewport',
+        rawValue: -1
+      });
+    }
 
     return Viewport.generateAuditResult({
       rawValue: !!hasMobileViewport

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -59,20 +59,9 @@ class Viewport extends Audit {
     const viewportProps = parsedProps.validProperties;
     const hasMobileViewport = viewportProps.width || viewportProps['initial-scale'];
 
-    Viewport.generateAuditResult({
+    return Viewport.generateAuditResult({
       rawValue: !!hasMobileViewport,
       debugString
-    });
-
-    if (typeof artifacts.Viewport !== 'string') {
-      return Viewport.generateAuditResult({
-        debugString: 'Error in determining viewport',
-        rawValue: -1
-      });
-    }
-
-    return Viewport.generateAuditResult({
-      rawValue: !!hasMobileViewport
     });
   }
 }

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -50,10 +50,10 @@ class Viewport extends Audit {
     const parsedProps = Parser.parseMetaViewPortContent(artifacts.Viewport);
 
     if (Object.keys(parsedProps.unknownProperties).length) {
-      debugString += `Invalid properties found: ${parsedProps.unknownProperties}. `;
+      debugString += `Invalid properties found: ${JSON.stringify(parsedProps.unknownProperties)}. `;
     }
     if (Object.keys(parsedProps.invalidValues).length) {
-      debugString += `Invalid values found: ${parsedProps.invalidValues}. `;
+      debugString += `Invalid values found: ${JSON.stringify(parsedProps.invalidValues)}. `;
     }
     debugString = debugString.trim();
 

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -50,11 +50,12 @@ class Viewport extends Audit {
     const parsedProps = Parser.parseMetaViewPortContent(artifacts.Viewport);
 
     if (Object.keys(parsedProps.unknownProperties).length) {
-      debugString += `Invalid properties found: ${parsedProps.unknownProperties}`;
+      debugString += `Invalid properties found: ${parsedProps.unknownProperties}. `;
     }
     if (Object.keys(parsedProps.invalidValues).length) {
-      debugString += `Invalid values found: ${parsedProps.invalidValues}`;
+      debugString += `Invalid values found: ${parsedProps.invalidValues}. `;
     }
+    debugString = debugString.trim();
 
     const viewportProps = parsedProps.validProperties;
     const hasMobileViewport = viewportProps.width || viewportProps['initial-scale'];

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const Audit = require('./audit');
+const Parser = require('metaviewport-parser');
 
 class Viewport extends Audit {
   /**
@@ -26,7 +27,7 @@ class Viewport extends Audit {
     return {
       category: 'Mobile Friendly',
       name: 'viewport',
-      description: 'HTML has a `<meta name="viewport">` tag',
+      description: 'HTML has a `<meta name="viewport">` tag containing `width` or `initial-scale`',
       helpText: 'Add a viewport meta tag to optimize your app for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag").',
       requiredArtifacts: ['Viewport']
@@ -38,8 +39,15 @@ class Viewport extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const hasMobileViewport = typeof artifacts.Viewport === 'string' &&
-        artifacts.Viewport.includes('width=');
+    if (typeof artifacts.Viewport !== 'string') {
+      return Viewport.generateAuditResult({
+        rawValue: false
+      });
+    }
+
+    const viewportProps = Parser.parseMetaViewPortContent(artifacts.Viewport).validProperties;
+    const hasMobileViewport = viewportProps['width'] || viewportProps['initial-scale'];
+
     return Viewport.generateAuditResult({
       rawValue: !!hasMobileViewport
     });

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -22,9 +22,11 @@ const assert = require('assert');
 
 describe('Mobile-friendly: viewport audit', () => {
   it('fails when no input present', () => {
-    return assert.equal(Audit.audit({
+    const audit = Audit.audit({
       Viewport: -1
-    }).rawValue, -1);
+    });
+    assert.equal(audit.rawValue, -1);
+    assert.equal(audit.debugString, 'Error in determining viewport');
   });
 
   it('fails when HTML does not contain a viewport meta tag', () => {

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -35,6 +35,39 @@ describe('Mobile-friendly: viewport audit', () => {
     }).rawValue, false);
   });
 
+  it('fails when HTML contains a non-mobile friendly viewport meta tag', () => {
+    const viewport = 'maximum-scale=1';
+    assert.equal(Audit.audit({Viewport: viewport}).rawValue, false);
+    assert.equal(Audit.audit({
+      Viewport: viewport
+    }).debugString, '');
+  });
+
+  it('fails when HTML contains an invalid viewport meta tag key', () => {
+    const viewport = 'nonsense=true';
+    assert.equal(Audit.audit({Viewport: viewport}).rawValue, false);
+    assert.equal(Audit.audit({
+      Viewport: viewport
+    }).debugString, 'Invalid properties found: {"nonsense":"true"}.');
+  });
+
+  it('fails when HTML contains an invalid viewport meta tag value', () => {
+    const viewport = 'initial-scale=microscopic';
+    assert.equal(Audit.audit({Viewport: viewport}).rawValue, false);
+    assert.equal(Audit.audit({
+      Viewport: viewport
+    }).debugString, 'Invalid values found: {"initial-scale":"microscopic"}.');
+  });
+
+  it('fails when HTML contains an invalid viewport meta tag key and value', () => {
+    const viewport = 'nonsense=true, initial-scale=microscopic';
+    assert.equal(Audit.audit({Viewport: viewport}).rawValue, false);
+    assert.equal(Audit.audit({
+      Viewport: viewport
+    }).debugString, 'Invalid properties found: {"nonsense":"true"}. ' +
+        'Invalid values found: {"initial-scale":"microscopic"}.');
+  });
+
   it('passes when a valid viewport is provided', () => {
     const viewports = [
       'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1',

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -24,7 +24,7 @@ describe('Mobile-friendly: viewport audit', () => {
   it('fails when no input present', () => {
     return assert.equal(Audit.audit({
       Viewport: -1
-    }).rawValue, false);
+    }).rawValue, -1);
   });
 
   it('fails when HTML does not contain a viewport meta tag', () => {
@@ -38,6 +38,7 @@ describe('Mobile-friendly: viewport audit', () => {
       'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1',
       'width = device-width, initial-scale = 1',
       'initial-scale=1',
+      'width=device-width     ',
     ];
     viewports.forEach(viewport => {
       assert.equal(Audit.audit({

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -33,9 +33,16 @@ describe('Mobile-friendly: viewport audit', () => {
     }).rawValue, false);
   });
 
-  it('passes when a viewport is provided', () => {
-    return assert.equal(Audit.audit({
-      Viewport: 'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1'
-    }).rawValue, true);
+  it('passes when a valid viewport is provided', () => {
+    const viewports = [
+      'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1',
+      'width = device-width, initial-scale = 1',
+      'initial-scale=1',
+    ];
+    viewports.forEach(viewport => {
+      assert.equal(Audit.audit({
+        Viewport: viewport
+      }).rawValue, true);
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "handlebars": "^4.0.5",
     "json-stringify-safe": "^5.0.1",
     "marked": "^0.3.6",
+    "metaviewport-parser": "^0.0.1",
     "mkdirp": "^0.5.1",
     "opn": "^4.0.2",
     "rimraf": "^2.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,6 +1844,10 @@ meow@^3.3.0, meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
+metaviewport-parser@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/metaviewport-parser/-/metaviewport-parser-0.0.1.tgz#9b28179659b76ff9d21de84ae25583257909b206"
+
 micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"


### PR DESCRIPTION
Fixes #641. and comments in it; allow a viewport to pass if it has width *or* initial-scale, and tweak the displayed error message to say this. It also allows spaces in the viewport elements, they are explicitly given in an example on e.g. https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193