### PR TITLE
Fixes #1263

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -63,8 +63,15 @@ class NoDateNowAudit extends Audit {
 
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts and keep eval'd code.
+    // If there is no .url in the violation, include it in the results because
+    // we cannot determine if it was from the user's page or a third party.
+    // TODO: better extendedInfo for violations with no URL.
+    // https://github.com/GoogleChrome/lighthouse/issues/1263
     const results = artifacts.DateNowUse.usage.filter(err => {
-      return err.isEval ? !!err.url : new URL(err.url).host === pageHost;
+      if (err.isEval) {
+        return !!err.url;
+      }
+      return err.url ? new URL(err.url).host === pageHost : true;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`,

--- a/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
@@ -99,4 +99,19 @@ describe('Page does not use Date.now()', () => {
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 3);
   });
+
+  it('includes results when there is no .url', () => {
+    const auditResult = DateNowUseAudit.audit({
+      DateNowUse: {
+        usage: [
+          {line: 10, col: 1},
+          {line: 2, col: 22}
+        ]
+      },
+      URL: {finalUrl: URL},
+    });
+
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.extendedInfo.value.length, 2);
+  });
 });


### PR DESCRIPTION
R: all

https://github.com/GoogleChrome/lighthouse/pull/1218 didn't fully fix the issue like we hoped. Adding extra protection in the date.now audit so we don't throw errors.