### PR TITLE
First pass on fixing Unicode console characters on Windows.

### DIFF
--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -29,6 +29,7 @@ type Mode = 'pretty' | 'json' | 'html';
 import {Results, AuditResult} from './types/types';
 
 const fs = require('fs');
+const figures = require('figures');
 const ReportGenerator = require('../lighthouse-core/report/report-generator');
 const Formatter = require('../lighthouse-core/formatters/formatter');
 const log = require('../lighthouse-core/lib/log');
@@ -56,8 +57,8 @@ function formatAggregationResultItem(score: boolean | number | string, suffix?: 
   const reset = '\x1B[0m';
 
   if (typeof score === 'boolean') {
-    const check = `${green}✓${reset}`;
-    const fail = `${red}✘${reset}`;
+    const check = `${green}${figures.tick}${reset}`;
+    const fail = `${red}${figures.cross}${reset}`;
     return score ? check : fail;
   }
   if (typeof score !== 'number') {
@@ -97,7 +98,7 @@ function createOutput(results: Results, outputMode: OutputMode): string {
   let output = `\n\n${bold}Lighthouse (${version}) results:${reset} ${results.url}\n\n`;
 
   results.aggregations.forEach(aggregation => {
-    output += `▫ ${bold}${aggregation.name}${reset}\n\n`;
+    output += `${figures.squareSmall} ${bold}${aggregation.name}${reset}\n\n`;
 
     aggregation.score.forEach(item => {
       const score = (item.overall * 100).toFixed(0);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "chrome-devtools-frontend": "1.0.422034",
     "debug": "^2.2.0",
     "devtools-timeline-model": "1.1.6",
+    "figures": "^2.0.0",
     "gl-matrix": "2.3.2",
     "handlebars": "^4.0.5",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
This partially fixes the issue on Windows.

**Before**
![before](https://cloud.githubusercontent.com/assets/349621/21459362/2c93465c-c946-11e6-8d6a-e2a53020a080.png)

**This patch**
![after](https://cloud.githubusercontent.com/assets/349621/21459439/c8b11000-c946-11e6-857c-c92a47e766ac.png)

---

There are more characters I have no idea what to replace with. Specifically, the ones in `treeMarker()`.

![after](https://cloud.githubusercontent.com/assets/349621/21459366/30672276-c946-11e6-9e68-0038d2bbdb21.png)

Tests also use the cross and tick characters, but since I can't really run the tests on Windows, I didn't touch them.
