### PR TITLE
Fixes #1282

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -108,6 +108,7 @@ function dateNowTest() {
     return Date.now();
   }
   helloDate();
+  const d = Date.now(); // FAIL
   eval('Date.now()'); // FAIL
   new Function('Date.now()')() // FAIL
 }

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -75,10 +75,9 @@ class NoConsoleTimeAudit extends Audit {
       try {
         return new URL(err.url).host === pageHost;
       } catch (e) {
-        debugString = 'Lighthouse was unable to determine if some uses of ' +
-                      'console.time() were made by this page. It\'s possible a ' +
-                      'Chrome extension content script or other eval\'d code ' +
-                      'is calling it.';
+        debugString = 'Lighthouse was unable to determine if some API uses ' +
+                      'were made by this page. It\'s possible a Chrome extension' +
+                      'content script or other eval\'d code is calling this API.';
       }
       return true;
     }).map(err => {

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -61,10 +61,26 @@ class NoConsoleTimeAudit extends Audit {
       });
     }
 
+    let debugString;
+
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts and keep eval'd code.
     const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
-      return err.isEval ? !!err.url : new URL(err.url).host === pageHost;
+      if (err.isEval) {
+        return !!err.url;
+      }
+
+      // If the violation doesn't have a valid url, don't filter it out, but
+      // warn the user that we don't know what the callsite is.
+      try {
+        return new URL(err.url).host === pageHost;
+      } catch (e) {
+        debugString = 'Lighthouse was unable to determine if some uses of ' +
+                      'console.time() were made by this page. It\'s possible a ' +
+                      'Chrome extension content script or other eval\'d code ' +
+                      'is calling it.';
+      }
+      return true;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`
@@ -76,7 +92,8 @@ class NoConsoleTimeAudit extends Audit {
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
         value: results
-      }
+      },
+      debugString
     });
   }
 }

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -78,8 +78,8 @@ class NoConsoleTimeAudit extends Audit {
         debugString = 'Lighthouse was unable to determine if some API uses ' +
                       'were made by this page. It\'s possible a Chrome extension' +
                       'content script or other eval\'d code is calling this API.';
+        return true;
       }
-      return true;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -75,10 +75,9 @@ class NoDateNowAudit extends Audit {
       try {
         return new URL(err.url).host === pageHost;
       } catch (e) {
-        debugString = 'Lighthouse was unable to determine if some uses of ' +
-                      'Date.now() were made by this page. It\'s possible a ' +
-                      'Chrome extension content script or other eval\'d code ' +
-                      'is calling it.';
+        debugString = 'Lighthouse was unable to determine if some API uses ' +
+                      'were made by this page. It\'s possible a Chrome extension' +
+                      'content script or other eval\'d code is calling this API.';
       }
       return true;
     }).map(err => {

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -78,8 +78,8 @@ class NoDateNowAudit extends Audit {
         debugString = 'Lighthouse was unable to determine if some API uses ' +
                       'were made by this page. It\'s possible a Chrome extension' +
                       'content script or other eval\'d code is calling this API.';
+        return true;
       }
-      return true;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`,

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -61,17 +61,26 @@ class NoDateNowAudit extends Audit {
       });
     }
 
+    let debugString;
+
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usage from other hosts and keep eval'd code.
-    // If there is no .url in the violation, include it in the results because
-    // we cannot determine if it was from the user's page or a third party.
-    // TODO: better extendedInfo for violations with no URL.
-    // https://github.com/GoogleChrome/lighthouse/issues/1263
     const results = artifacts.DateNowUse.usage.filter(err => {
       if (err.isEval) {
         return !!err.url;
       }
-      return err.url ? new URL(err.url).host === pageHost : true;
+
+      // If the violation doesn't have a valid url, don't filter it out, but
+      // warn the user that we don't know what the callsite is.
+      try {
+        return new URL(err.url).host === pageHost;
+      } catch (e) {
+        debugString = 'Lighthouse was unable to determine if some uses of ' +
+                      'Date.now() were made by this page. It\'s possible a ' +
+                      'Chrome extension content script or other eval\'d code ' +
+                      'is calling it.';
+      }
+      return true;
     }).map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`,
@@ -84,7 +93,8 @@ class NoDateNowAudit extends Audit {
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
         value: results
-      }
+      },
+      debugString
     });
   }
 }

--- a/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
@@ -84,4 +84,20 @@ describe('Page does not use console.time()', () => {
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 3);
   });
+
+  it('includes results when there is no .url', () => {
+    const auditResult = NoConsoleTimeAudit.audit({
+      ConsoleTimeUsage: {
+        usage: [
+          {line: 10, col: 1},
+          {line: 2, col: 22}
+        ]
+      },
+      URL: {finalUrl: URL},
+    });
+
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.extendedInfo.value.length, 2);
+    assert.ok(auditResult.debugString, 'includes debugString');
+  });
 });

--- a/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
@@ -113,5 +113,6 @@ describe('Page does not use Date.now()', () => {
 
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 2);
+    assert.ok(auditResult.debugString, 'includes debugString');
   });
 });


### PR DESCRIPTION
R: @brendankenny

You can test against https://geda.nkenspen.de/ to trigger the `debugString` path. DBW tester won't surface it partly because of https://github.com/GoogleChrome/lighthouse/issues/1286.