### PR TITLE
Fix for Windows Environments

### DIFF
--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -29,6 +29,7 @@ const rimraf = require('rimraf');
 const log = require('../lighthouse-core/lib/log');
 const spawn = childProcess.spawn;
 const execSync = childProcess.execSync;
+const os = require('os');
 
 class ChromeLauncher {
   prepared: Boolean = false
@@ -191,7 +192,10 @@ class ChromeLauncher {
         launcher
           .isDebuggerReady()
           .then(() => {
-            log.log('ChromeLauncher', waitStatus + `${green}✓${reset}`);
+            if (os.platform() == 'win32')
+              log.log('ChromeLauncher', waitStatus + `${green}\u221A${reset}`);
+            else
+              log.log('ChromeLauncher', waitStatus + `${green}✓${reset}`);
             resolve();
           })
           .catch(err => {

--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -32,6 +32,7 @@ const fs = require('fs');
 const ReportGenerator = require('../lighthouse-core/report/report-generator');
 const Formatter = require('../lighthouse-core/formatters/formatter');
 const log = require('../lighthouse-core/lib/log');
+const os = require('os');
 
 /**
  * Verify output path to use, either stdout or a file path.
@@ -56,9 +57,15 @@ function formatAggregationResultItem(score: boolean | number | string, suffix?: 
   const reset = '\x1B[0m';
 
   if (typeof score === 'boolean') {
-    const check = `${green}✓${reset}`;
-    const fail = `${red}✘${reset}`;
-    return score ? check : fail;
+    if (os.platform() == 'win32') {
+      const check = `${green}\u221A${reset}`;
+      const fail = `${red}\u00D7${reset}`;
+      return score ? check : fail;
+    } else {
+      const check = `${green}✓${reset}`;
+      const fail = `${red}✘${reset}`;
+      return score ? check : fail;
+    }
   }
   if (typeof score !== 'number') {
     return `${purple}${score}${reset}`;
@@ -94,10 +101,15 @@ function createOutput(results: Results, outputMode: OutputMode): string {
   const bold = '\x1b[1m';
   const reset = '\x1B[0m';
   const version = results.lighthouseVersion;
+
   let output = `\n\n${bold}Lighthouse (${version}) results:${reset} ${results.url}\n\n`;
 
   results.aggregations.forEach(aggregation => {
-    output += `▫ ${bold}${aggregation.name}${reset}\n\n`;
+    if (os.platform() == 'win32') {
+      output += `\u0387 ${bold}${aggregation.name}${reset}\n\n`;
+    } else {
+      output += `▫ ${bold}${aggregation.name}${reset}\n\n`;
+    }
 
     aggregation.score.forEach(item => {
       const score = (item.overall * 100).toFixed(0);

--- a/lighthouse-core/formatters/critical-request-chains.js
+++ b/lighthouse-core/formatters/critical-request-chains.js
@@ -22,6 +22,7 @@ const path = require('path');
 const fs = require('fs');
 const Formatter = require('./formatter');
 const html = fs.readFileSync(path.join(__dirname, 'partials/critical-request-chains.html'), 'utf8');
+const os = require('os');
 
 class CriticalRequestChains extends Formatter {
 
@@ -148,7 +149,11 @@ class CriticalRequestChains extends Formatter {
 
         // If the parent is the last child then don't drop the vertical bar.
         const ancestorTreeMarker = treeMarkers.reduce((markers, marker) => {
-          return markers + (marker ? '┃ ' : '  ');
+          if (os.platform() == 'win32') {
+            return markers + (marker ? '\u2502 ' : '  ');
+          } else {
+            return markers + (marker ? '┃ ' : '  ');
+          }
         }, '');
 
         // Copy the tree markers so that we don't change by reference.
@@ -159,9 +164,16 @@ class CriticalRequestChains extends Formatter {
 
         // Create the appropriate tree marker based on the depth of this
         // node as well as whether or not it has children and is itself the last child.
-        const treeMarker = ancestorTreeMarker +
+        const treeMarker = ancestorTreeMarker;
+        if (os.platform() == 'win32') {
+          const treeMarker = ancestorTreeMarker +
+            (isLastChild ? '\u2514\u2500' : '\u251C\u2500') +
+            (hasChildren ? '\u252C' : '\u2500');
+        } else {
+          const treeMarker = ancestorTreeMarker +
             (isLastChild ? '┗━' : '┣━') +
             (hasChildren ? '┳' : '━');
+        }
 
         const parsedURL = CriticalRequestChains.parseURL(node[id].request.url);
 

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -32,13 +32,7 @@ const colors = {
 };
 
 // whitelist non-red/yellow colors for debug()
-if (isBrowser) {
-  const debugBrowser = require('debug/browser');
-  debugBrowser.colors = [colors.cyan, colors.green, colors.blue, colors.magenta];
-} else {
-  const debugNode = require('debug/node');
-  debugNode.colors = [colors.cyan, colors.green, colors.blue, colors.magenta];
-}
+debug.colors = [colors.cyan, colors.green, colors.blue, colors.magenta];
 
 class Emitter extends EventEmitter {
   /**
@@ -77,9 +71,11 @@ class Log {
       log = debug(title);
       loggersByTitle[title] = log;
       // errors with red, warnings with yellow.
-      // eslint-disable-next-line no-nested-ternary
-      log.color = title.endsWith('error') ? colors.red :
-          title.endsWith('warn') ? colors.yellow : undefined;
+      if (title.endsWith('error')) {
+        log.color = colors.red;
+      } else if (title.endsWith('warn')) {
+        log.color = colors.yellow;
+      }
     }
     return log;
   }


### PR DESCRIPTION
Fixes colors and marks for Windows OS #1228 

![colors](https://cloud.githubusercontent.com/assets/37474/21469257/4147d51c-ca28-11e6-8e2b-3e7e26c6ac63.PNG)

![marks](https://cloud.githubusercontent.com/assets/37474/21469259/4629bf96-ca28-11e6-9883-00cf6c364b1e.PNG)



For tree visualization, code is still here, but i don't know why isn't working well. I think it's a good fix, but not the better. Feel free to help in that point.