### PR TITLE
Paste/input gist URL for mobile. Fixes #1283

### DIFF
--- a/lighthouse-viewer/app/index.html
+++ b/lighthouse-viewer/app/index.html
@@ -39,10 +39,10 @@ limitations under the License.
     </div>
     <div>
       <h1 class="viewer-placeholder__heading">Lighthouse Report Viewer</h1>
-      <div class="viewer-placeholder__help">Click here, drag and drop a json report,<br>
-      or paste the URL of a saved gist.</div>
+      <div class="viewer-placeholder__help">To view report: Paste a report.json or Gist URL.<br>
+      You can also drag 'n drop the file or click here to select it.</div>
       <input type="url" class="viewer-placeholder__url js-gist-url"
-             placeholder="Enter full gist url">
+             placeholder="Enter or paste Gist URL">
     </div>
   </div>
 </div>

--- a/lighthouse-viewer/app/index.html
+++ b/lighthouse-viewer/app/index.html
@@ -39,7 +39,10 @@ limitations under the License.
     </div>
     <div>
       <h1 class="viewer-placeholder__heading">Lighthouse Report Viewer</h1>
-      <div class="viewer-placeholder__help">Click here or drag and drop a json report</div>
+      <div class="viewer-placeholder__help">Click here, drag and drop a json report,<br>
+      or paste the URL of a saved gist.</div>
+      <input type="url" class="viewer-placeholder__url js-gist-url"
+             placeholder="Enter full gist url">
     </div>
   </div>
 </div>

--- a/lighthouse-viewer/app/src/fileuploader.js
+++ b/lighthouse-viewer/app/src/fileuploader.js
@@ -52,8 +52,10 @@ class FileUploader {
   }
 
   addListeners() {
-    this.placeholder.firstElementChild.addEventListener('click', _ => {
-      this.fileInput.click();
+    this.placeholder.firstElementChild.addEventListener('click', e => {
+      if (e.target.localName !== 'input') {
+        this.fileInput.click();
+      }
     });
 
     // The mouseleave event is more reliable than dragleave when the user drops

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -235,7 +235,7 @@ class LighthouseViewerReport {
       // We want to write our own data to the clipboard, not the user's text selection.
       e.preventDefault();
       e.clipboardData.setData('text/plain', JSON.stringify(this.json, null, 2));
-      logger.log('Report copied to clipboard');
+      logger.log('Report JSON copied to clipboard');
     }
 
     this._copyAttempt = false;

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -330,9 +330,11 @@ class LighthouseViewerReport {
         return;
       }
 
-      const id = url.href.substring(url.href.lastIndexOf('/') + 1);
-      history.pushState({}, null, `${APP_URL}?gist=${id}`);
-      this.loadFromDeepLink();
+      const match = url.pathname.match(/[a-f0-9]{5,}/);
+      if (match) {
+        history.pushState({}, null, `${APP_URL}?gist=${match[0]}`);
+        this.loadFromDeepLink();
+      }
     } catch (err) {
       logger.error('Invalid URL');
     }

--- a/lighthouse-viewer/app/styles/viewer.css
+++ b/lighthouse-viewer/app/styles/viewer.css
@@ -45,6 +45,7 @@
   border-radius: 5px;
   padding: 25px;
   width: 33vw;
+  min-width: 250px;
   height: 20vh;
   display: flex;
   align-items: center;
@@ -63,7 +64,7 @@
   display: flex;
   align-items: center;
   border-radius: 5px;
-  padding: 40px 32px;
+  padding: 16px;
   max-width: 80vw;
   border: 2px dashed rgba(0,0,0,0.2);
   cursor: pointer;
@@ -78,10 +79,18 @@
 }
 .viewer-placeholder__help {
   margin-top: 12px;
+  line-height: 1.4;
 }
 .viewer-placeholder-logo {
-  width: 100px;
-  height: 100px;
+  width: 140px;
+  height: 140px;
+}
+.viewer-placeholder__url {
+  padding: 8px;
+  width: 100%;
+  border: 1px solid #eee;
+  margin-top: 16px;
+  display: none;
 }
 .log-wrapper {
   position: fixed;
@@ -121,9 +130,15 @@
     width: 100px;
     height: 100px;
   }
+  .viewer-placeholder__url {
+    display: block;
+  }
 }
 
 @media screen and (min-width: 636px) {
+  .viewer-placeholder-inner {
+    padding: 40px 32px;
+  }
   .viewer-placeholder__help::before {
     content: 'Instructions: ';
   }

--- a/lighthouse-viewer/app/styles/viewer.css
+++ b/lighthouse-viewer/app/styles/viewer.css
@@ -79,7 +79,7 @@
 }
 .viewer-placeholder__help {
   margin-top: 12px;
-  line-height: 1.4;
+  line-height: 1.6;
 }
 .viewer-placeholder-logo {
   width: 140px;
@@ -138,9 +138,6 @@
 @media screen and (min-width: 636px) {
   .viewer-placeholder-inner {
     padding: 40px 32px;
-  }
-  .viewer-placeholder__help::before {
-    content: 'Instructions: ';
   }
   .viewer-placeholder-logo {
     margin-right: 16px;


### PR DESCRIPTION
R: all

Part of #1283. On mobile, you'll get a url input:

<img width="410" alt="screen shot 2016-12-28 at 10 28 02 am" src="https://cloud.githubusercontent.com/assets/238208/21526249/58feb1fe-cce8-11e6-8002-b91bac3203de.png">

On mobile/desktop, you'll be able to paste the URL of a gist. Invalid urls will cause a butter bar warning. 