### PR TITLE
Show total score in every output type

### DIFF
--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -97,7 +97,8 @@ function createOutput(results: Results, outputMode: OutputMode): string {
   let output = `\n\n${bold}Lighthouse (${version}) results:${reset} ${results.url}\n\n`;
 
   results.aggregations.forEach(aggregation => {
-    output += `▫ ${bold}${aggregation.name}${reset}\n\n`;
+		const total = aggregation.total ? ': ' + formatAggregationResultItem(Math.round(aggregation.total * 100), '%') : ''
+    output += `▫ ${bold}${aggregation.name}${reset}${total}\n\n`;
 
     aggregation.score.forEach(item => {
       const score = (item.overall * 100).toFixed(0);

--- a/lighthouse-cli/test/fixtures/sample.json
+++ b/lighthouse-cli/test/fixtures/sample.json
@@ -449,6 +449,7 @@
       "name": "Progressive Web App",
       "description": "These audits validate the aspects of a Progressive Web App.",
       "scored": true,
+      "total": 0.40625,
       "categorizable": true,
       "score": [
         {
@@ -559,6 +560,7 @@
       "name": "Best Practices",
       "description": "These audits do not affect your score but are worth a look.",
       "scored": false,
+      "total": null,
       "categorizable": false,
       "score": [
         {
@@ -614,6 +616,7 @@
       "name": "Performance Metrics",
       "description": "These encapsulate your app's performance.",
       "scored": false,
+      "total": null,
       "categorizable": false,
       "score": [
         {
@@ -629,6 +632,7 @@
       "name": "Do Better Web",
       "description": "We've compiled some recommendations for modernizing your web app and avoiding performance pitfalls.",
       "scored": false,
+      "total": null,
       "categorizable": true,
       "score": [
         {

--- a/lighthouse-cli/types/types.ts
+++ b/lighthouse-cli/types/types.ts
@@ -24,6 +24,7 @@ interface AggregationResultItem {
 interface Aggregation {
   name: string;
   score: Array<AggregationResultItem>;
+  total: number;
 }
 
 interface Results {

--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -208,18 +208,29 @@ class Aggregate {
   }
 
   /**
+   * Calculates total score of an aggregate.
+   * @param {!Array<!AggregationResultItem>} scores
+   * @return {number}
+   */
+  static getTotal(scores) {
+    return scores.reduce((total, s) => total + s.overall, 0) / scores.length;
+  }
+
+  /**
    * Aggregates all the results.
    * @param {!Aggregation} aggregation
    * @param {!Array<!AuditResult>} results
    * @return {!AggregationResult}
    */
   static aggregate(aggregation, auditResults) {
+    const score = Aggregate.compare(auditResults, aggregation.items, aggregation.scored);
     return {
       name: aggregation.name,
       description: aggregation.description,
       scored: aggregation.scored,
+      total: (aggregation.scored ? Aggregate.getTotal(score) : null),
       categorizable: aggregation.categorizable,
-      score: Aggregate.compare(auditResults, aggregation.items, aggregation.scored)
+      score: score
     };
   }
 }

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -43,11 +43,7 @@ class ReportGenerator {
 
   constructor() {
     const getTotalScore = aggregation => {
-      const totalScore = aggregation.score.reduce((total, s) => {
-        return total + s.overall;
-      }, 0) / aggregation.score.length;
-
-      return Math.round(totalScore * 100);
+      return Math.round(aggregation.total * 100);
     };
 
     const getItemRating = value => {

--- a/lighthouse-core/test/aggregator/aggregate-test.js
+++ b/lighthouse-core/test/aggregator/aggregate-test.js
@@ -457,4 +457,12 @@ describe('Aggregate', () => {
     assert.equal(output.score[0].overall, 1);
     return assert.equal(output.score[0].subItems.length, 1);
   });
+
+  it('counts a total', () => {
+    const scores = [
+      {overall: 1},
+      {overall: 0.5}
+    ];
+    assert.equal(Aggregate.getTotal(scores), 0.75);
+  });
 });

--- a/lighthouse-core/test/results/sample.json
+++ b/lighthouse-core/test/results/sample.json
@@ -838,6 +838,7 @@
       "name": "Progressive Web App",
       "description": "These audits validate the aspects of a Progressive Web App.",
       "scored": true,
+      "total": 0.375,
       "categorizable": true,
       "score": [
         {
@@ -947,6 +948,7 @@
       "name": "Best Practices",
       "description": "We've compiled some recommendations for modernizing your web app and avoiding performance pitfalls. These audits do not affect your score but are worth a look.",
       "scored": false,
+      "total": null,
       "categorizable": true,
       "score": [
         {
@@ -1053,6 +1055,7 @@
       "name": "Performance Metrics",
       "description": "These encapsulate your app's performance.",
       "scored": false,
+      "total": null,
       "categorizable": false,
       "score": [
         {


### PR DESCRIPTION
Adds a total score field to aggregate objects and presents that
information in every output type.

Closes: #1285

This pull request is moving html output only implementation of `getTotalScore` method from `lighthouse-core/report/report-generator.js`. It was placed in `Aggregate` object to keep JSON output as simple dump of result and to be easily available for all output types.