### PR TITLE
fix: report all indeterminable anchors

### DIFF
--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -58,11 +58,11 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     const failingAnchors = artifacts.AnchorsWithNoRelNoopener.usages
       .filter(anchor => {
         try {
-          return new URL(anchor.href).host !== pageHost;
+          return anchor.href === '' || new URL(anchor.href).host !== pageHost;
         } catch (err) {
           debugString = 'Lighthouse was unable to determine the destination ' +
-              'of some anchor tags. Remove the href attribute if they are not ' +
-              'used as hyperlinks';
+              'of some anchor tags. If they are not used as hyperlinks, ' +
+              'consider removing the _blank target.';
           return true;
         }
       })

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -49,12 +49,23 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       });
     }
 
+    let debugString;
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usages to exclude anchors that are same origin
     // TODO: better extendedInfo for anchors with no href attribute:
     // https://github.com/GoogleChrome/lighthouse/issues/1233
+    // https://github.com/GoogleChrome/lighthouse/issues/1345
     const failingAnchors = artifacts.AnchorsWithNoRelNoopener.usages
-      .filter(anchor => anchor.href === '' || new URL(anchor.href).host !== pageHost)
+      .filter(anchor => {
+        try {
+          return new URL(anchor.href).host !== pageHost;
+        } catch (err) {
+          debugString = 'Lighthouse was unable to determine the destination ' +
+              'of some anchor tags. Remove the href attribute if they are not ' +
+              'used as hyperlinks';
+          return true;
+        }
+      })
       .map(anchor => {
         return {
           url: '<a' +
@@ -69,7 +80,8 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
         value: failingAnchors
-      }
+      },
+      debugString
     });
   }
 }

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -64,12 +64,15 @@ describe('External anchors use rel="noopener"', () => {
     const auditResult = ExternalAnchorsAudit.audit({
       AnchorsWithNoRelNoopener: {
         usages: [
-          {href: ''}
+          {href: ''},
+          {href: 'http://'},
+          {href: 'http:'}
         ]
       },
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);
-    assert.equal(auditResult.extendedInfo.value.length, 1);
+    assert.equal(auditResult.extendedInfo.value.length, 3);
+    assert.ok(auditResult.debugString, 'includes debugString');
   });
 });


### PR DESCRIPTION
R: @ebidel 

Changes rel noopener audit to warn about all potentially violating anchor tags even when URL is malformed.

Addresses #1345