### PR TITLE
DBW: improvements to CSS flexbox audit.

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -53,12 +53,12 @@ class NoOldFlexboxAudit extends Audit {
     }
 
     // TODO: consider usage of vendor prefixes
-    // TODO: consider usage of other older properties from
     // https://www.w3.org/TR/2009/WD-css3-flexbox-20090723/
     // (e.g. box-flex, box-orient, box-flex-group, display: flexbox (2011 version))
+    const propsNames = [ 'box-flex' , 'box-orient', 'box-flex-group', 'display' ];
+    const propsValues = [ 'box', 'flexbox' ];
     const sheetsUsingDisplayBox = StyleHelpers.filterStylesheetsByUsage(
-        artifacts.Styles, 'display', 'box'); // 2009 version
-
+        artifacts.Styles, propsNames, propsValues);
     const urlList = [];
     sheetsUsingDisplayBox.forEach(sheet => {
       sheet.parsedContent.forEach(props => {

--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -55,7 +55,7 @@ class NoOldFlexboxAudit extends Audit {
     // https://www.w3.org/TR/2009/WD-css3-flexbox-20090723/
     // (e.g. box-flex, box-orient, box-flex-group, display: flexbox (2011 version))
     const propsNames = ['box-flex', 'box-orient', 'box-flex-group', 'display'];
-    const propsNamesWithPrefixes = StyleHelpers.addWebPrefixes(propsNames);
+    const propsNamesWithPrefixes = StyleHelpers.addVendorPrefixes(propsNames);
     const propsValues = ['box', 'flexbox'];
     const sheetsUsingDisplayBox = StyleHelpers.filterStylesheetsByUsage(
         artifacts.Styles, propsNamesWithPrefixes, propsValues);

--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -55,8 +55,8 @@ class NoOldFlexboxAudit extends Audit {
     // TODO: consider usage of vendor prefixes
     // https://www.w3.org/TR/2009/WD-css3-flexbox-20090723/
     // (e.g. box-flex, box-orient, box-flex-group, display: flexbox (2011 version))
-    const propsNames = [ 'box-flex' , 'box-orient', 'box-flex-group', 'display' ];
-    const propsValues = [ 'box', 'flexbox' ];
+    const propsNames = ['box-flex', 'box-orient', 'box-flex-group', 'display'];
+    const propsValues = ['box', 'flexbox'];
     const sheetsUsingDisplayBox = StyleHelpers.filterStylesheetsByUsage(
         artifacts.Styles, propsNames, propsValues);
     const urlList = [];

--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -52,13 +52,13 @@ class NoOldFlexboxAudit extends Audit {
       return NoOldFlexboxAudit.generateAuditResult(artifacts.Styles);
     }
 
-    // TODO: consider usage of vendor prefixes
     // https://www.w3.org/TR/2009/WD-css3-flexbox-20090723/
     // (e.g. box-flex, box-orient, box-flex-group, display: flexbox (2011 version))
     const propsNames = ['box-flex', 'box-orient', 'box-flex-group', 'display'];
+    const propsNamesWithPrefixes = StyleHelpers.addWebPrefixes(propsNames);
     const propsValues = ['box', 'flexbox'];
     const sheetsUsingDisplayBox = StyleHelpers.filterStylesheetsByUsage(
-        artifacts.Styles, propsNames, propsValues);
+        artifacts.Styles, propsNamesWithPrefixes, propsValues);
     const urlList = [];
     sheetsUsingDisplayBox.forEach(sheet => {
       sheet.parsedContent.forEach(props => {

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -42,9 +42,11 @@ function filterStylesheetsByUsage(stylesheets, propName, propVal) {
       let usedVal = '';
       // Prevent indexOf on null value
       if (propName) {
+        propName = Array.from(propName);
         usedName = propName.indexOf(item.property.name) > -1;
       }
       if (propVal) {
+        propVal = Array.from(propVal);
         usedVal = propVal.indexOf(item.property.val) > -1;
       }
       // Allow search by css property name, a value, or name/value pair.

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -38,7 +38,7 @@ function filterStylesheetsByUsage(stylesheets, propName, propVal) {
 
   return deepClone.filter(s => {
     s.parsedContent = s.parsedContent.filter(item => {
-      let usedName = ''
+      let usedName = '';
       let usedVal = '';
       // Prevent indexOf on null value
       if (propName) {

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -21,10 +21,10 @@
  * or name/value pair.
  *
  * @param {!Array} stylesheets A list of stylesheets used by the page.
- * @param {string|string[]=} propName Optional name of the CSS property/propertys to filter
+ * @param {string|Array<string>=} propName Optional name of the CSS property/propertys to filter
  *     results on. If propVal is not specified, all stylesheets that use the property are
  *     returned. Otherwise, stylesheets that use the propName: propVal are returned.
- * @param {string|string[]=} propVal Optional value of the CSS property/propertys to filter
+ * @param {string|Array<string>=} propVal Optional value of the CSS property/propertys to filter
  *     results on.
  * @return {!Array} A list of stylesheets that use the CSS property.
  */

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -42,11 +42,11 @@ function filterStylesheetsByUsage(stylesheets, propName, propVal) {
       let usedVal = '';
       // Prevent indexOf on null value
       if (propName) {
-        propName = Array.isArray(propName) ? propName : new Array(propName);
+        propName = Array.isArray(propName) ? propName : [propName];
         usedName = propName.indexOf(item.property.name) > -1;
       }
       if (propVal) {
-        propVal = Array.isArray(propVal) ? propVal : new Array(propVal);
+        propVal = Array.isArray(propVal) ? propVal : [propVal];
         usedVal = propVal.indexOf(item.property.val) > -1;
       }
       // Allow search by css property name, a value, or name/value pair.
@@ -111,7 +111,7 @@ ${parsedContent.selector} {
  */
 function addVendorPrefixes(propsNames) {
   const vendorPrefixes = ['-o-', '-ms-', '-moz-', '-webkit-'];
-  propsNames = Array.isArray(propsNames) ? propsNames : new Array(propsNames);
+  propsNames = Array.isArray(propsNames) ? propsNames : [propsNames];
   let propsNamesWithPrefixes = propsNames;
   // Map vendorPrefixes to propsNames
   for (const prefix of vendorPrefixes) {

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -21,25 +21,32 @@
  * or name/value pair.
  *
  * @param {!Array} stylesheets A list of stylesheets used by the page.
- * @param {string=} propName Optional name of the CSS property to filter results
- *     on. If propVal is not specified, all stylesheets that use the property are
+ * @param {string|string[]=} propName Optional name of the CSS property/propertys to filter
+ *     results on. If propVal is not specified, all stylesheets that use the property are
  *     returned. Otherwise, stylesheets that use the propName: propVal are returned.
- * @param {string=} propVal Optional value of the CSS property to filter results on.
+ * @param {string|string[]=} propVal Optional value of the CSS property/propertys to filter
+ *     results on.
  * @return {!Array} A list of stylesheets that use the CSS property.
  */
 function filterStylesheetsByUsage(stylesheets, propName, propVal) {
   if (!propName && !propVal) {
     return [];
   }
-
   // Create deep clone of arrays so multiple calls to filterStylesheetsByUsage
   // don't alter the original artifacts in stylesheets arg.
   const deepClone = stylesheets.map(sheet => Object.assign({}, sheet));
 
   return deepClone.filter(s => {
     s.parsedContent = s.parsedContent.filter(item => {
-      const usedName = item.property.name.indexOf(propName) === 0;
-      const usedVal = item.property.val.indexOf(propVal) === 0; // val should start with needle
+      let usedName = ''
+      let usedVal = '';
+      // Prevent indexOf on null value
+      if (propName) {
+        usedName = propName.indexOf(item.property.name) > -1;
+      }
+      if (propVal) {
+        usedVal = propVal.indexOf(item.property.val) > -1;
+      }
       // Allow search by css property name, a value, or name/value pair.
       if (propName && !propVal) {
         return usedName;

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -111,15 +111,15 @@ ${parsedContent.selector} {
  */
 function addVendorPrefixes(propsNames) {
   const vendorPrefixes = ['-o-', '-ms-', '-moz-', '-webkit-'];
-
-  let propsNamesWithPrefixes = [];
+  propsNames = Array.isArray(propsNames) ? propsNames : new Array(propsNames);
+  let propsNamesWithPrefixes = propsNames;
   // Map vendorPrefixes to propsNames
   for (const prefix of vendorPrefixes) {
     const temp = propsNames.map(propName => `${prefix}${propName}`);
     propsNamesWithPrefixes = propsNamesWithPrefixes.concat(temp);
   }
   // Add original propNames
-  return propsNamesWithPrefixes.concat(propsNames);
+  return propsNamesWithPrefixes;
 }
 module.exports = {
   filterStylesheetsByUsage,

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -42,11 +42,11 @@ function filterStylesheetsByUsage(stylesheets, propName, propVal) {
       let usedVal = '';
       // Prevent indexOf on null value
       if (propName) {
-        propName = Array.from(propName);
+        propName = Array.isArray(propName) ? propName : new Array(propName);
         usedName = propName.indexOf(item.property.name) > -1;
       }
       if (propVal) {
-        propVal = Array.from(propVal);
+        propVal = Array.isArray(propVal) ? propVal : new Array(propVal);
         usedVal = propVal.indexOf(item.property.val) > -1;
       }
       // Allow search by css property name, a value, or name/value pair.

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -21,7 +21,7 @@
  * or name/value pair.
  *
  * @param {!Array} stylesheets A list of stylesheets used by the page.
- * @param {string|Array<string>=} propName Optional name of the CSS property/propertys to filter
+ * @param {string|Array<string>=} propName Optional name of the CSS property/properties to filter
  *     results on. If propVal is not specified, all stylesheets that use the property are
  *     returned. Otherwise, stylesheets that use the propName: propVal are returned.
  * @param {string|Array<string>=} propVal Optional value of the CSS property/propertys to filter
@@ -104,29 +104,25 @@ ${parsedContent.selector} {
 }
 
 /**
- * Returns a array of all CSS prefixes and the default CSS style names.
+ * Returns an array of all CSS prefixes and the default CSS style names.
  *
- * @param {string|Array<string>=} propNames CSS text content.
- * @param {Array<string>=} propsNamesWithPrefixes The parsed version content.
- * @return {{styleRule: string, location: string}} Formatted output.
+ * @param {string|Array<string>=} propNames CSS property names.
+ * @return {Array<string>=} CSS property names with and without vendor prefixes.
  */
-function addWebPrefixes(propsNames) {
+function addVendorPrefixes(propsNames) {
   const vendorPrefixes = ['-o-', '-ms-', '-moz-', '-webkit-'];
 
   let propsNamesWithPrefixes = [];
   // Map vendorPrefixes to propsNames
-  for(const i of vendorPrefixes) {
-    const temp = propsNames.map(function(x) {
-      return i + x;
-    });
+  for (const prefix of vendorPrefixes) {
+    const temp = propsNames.map(propName => `${prefix}${propName}`);
     propsNamesWithPrefixes = propsNamesWithPrefixes.concat(temp);
   }
-  // Add orginal propNames
-  propsNamesWithPrefixes = propsNamesWithPrefixes.concat(propsNames);
-  return propsNamesWithPrefixes;
+  // Add original propNames
+  return propsNamesWithPrefixes.concat(propsNames);
 }
 module.exports = {
   filterStylesheetsByUsage,
   getFormattedStyleRule,
-  addWebPrefixes
+  addVendorPrefixes
 };

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -103,7 +103,30 @@ ${parsedContent.selector} {
   };
 }
 
+/**
+ * Returns a array of all CSS prefixes and the default CSS style names.
+ *
+ * @param {string|Array<string>=} propNames CSS text content.
+ * @param {Array<string>=} propsNamesWithPrefixes The parsed version content.
+ * @return {{styleRule: string, location: string}} Formatted output.
+ */
+function addWebPrefixes(propsNames) {
+  const vendorPrefixes = ['-o-', '-ms-', '-moz-', '-webkit-'];
+
+  let propsNamesWithPrefixes = [];
+  // Map vendorPrefixes to propsNames
+  for(const i of vendorPrefixes) {
+    const temp = propsNames.map(function(x) {
+      return i + x;
+    });
+    propsNamesWithPrefixes = propsNamesWithPrefixes.concat(temp);
+  }
+  // Add orginal propNames
+  propsNamesWithPrefixes = propsNamesWithPrefixes.concat(propsNames);
+  return propsNamesWithPrefixes;
+}
 module.exports = {
   filterStylesheetsByUsage,
-  getFormattedStyleRule
+  getFormattedStyleRule,
+  addWebPrefixes
 };

--- a/lighthouse-core/lib/styles-helpers.js
+++ b/lighthouse-core/lib/styles-helpers.js
@@ -38,7 +38,7 @@ function filterStylesheetsByUsage(stylesheets, propName, propVal) {
 
   return deepClone.filter(s => {
     s.parsedContent = s.parsedContent.filter(item => {
-      const usedName = item.property.name === propName;
+      const usedName = item.property.name.indexOf(propName) === 0;
       const usedVal = item.property.val.indexOf(propVal) === 0; // val should start with needle
       // Allow search by css property name, a value, or name/value pair.
       if (propName && !propVal) {

--- a/lighthouse-core/test/lib/style-helpers-test.js
+++ b/lighthouse-core/test/lib/style-helpers-test.js
@@ -41,6 +41,10 @@ describe('style helpers', () => {
       results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, null, 'box');
       assert.equal(results.length, 1, 'accepts only CSS property value');
+
+      results = StyleHelpers.filterStylesheetsByUsage(
+          stylesheets, ['display'], ['box', 'flexbox']);
+      assert.equal(results.length, 1, 'accepts array CSS property name/value pair');
     });
 
     it('returns no results when not found', () => {
@@ -63,14 +67,17 @@ describe('style helpers', () => {
       results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, 'display', 'someunknownval');
       assert.equal(results.length, 0, 'known CSS property with unknown value not found');
-    });
+
+      results = StyleHelpers.filterStylesheetsByUsage(
+          stylesheets, ['display'], 'someunknownval');
+      assert.equal(results.length, 0, 'known CSS property in array with unknown value not found');
+  });
   });
 
   describe('getFormattedStyleRule()', function() {
     it('formats output correctly', () => {
       const results = StyleHelpers.filterStylesheetsByUsage(
-          stylesheets, 'display', 'box');
-
+          stylesheets, ['display'], ['box']);
       const actual = StyleHelpers.getFormattedStyleRule(
           results[0].content, results[0].parsedContent[0]);
       const expected = `p,div {

--- a/lighthouse-core/test/lib/style-helpers-test.js
+++ b/lighthouse-core/test/lib/style-helpers-test.js
@@ -32,6 +32,7 @@ describe('style helpers', () => {
 
       results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, 'display', 'box');
+          console.log(results);
       assert.equal(results.length, 1, 'accepts CSS property name/value pair');
 
       results = StyleHelpers.filterStylesheetsByUsage(
@@ -45,6 +46,24 @@ describe('style helpers', () => {
       results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, ['display'], ['box', 'flexbox']);
       assert.equal(results.length, 1, 'accepts array CSS property name/value pair');
+
+      results = StyleHelpers.filterStylesheetsByUsage(
+          stylesheets, 'display', ['box', 'flexbox']);
+      assert.equal(results.length, 1, 'accepts string CSS property name and array value pair');
+
+      results = StyleHelpers.filterStylesheetsByUsage(
+          stylesheets, ['display'], 'box');
+      assert.equal(results.length, 1, 'accepts array CSS property name and string value pair');
+
+      results = StyleHelpers.filterStylesheetsByUsage(
+          stylesheets, ['display'], 'box');
+      assert.equal(results.length, 1, 'accepts array CSS property name and string value pair');
+
+      results = StyleHelpers.filterStylesheetsByUsage(
+          stylesheets, ['box-flex', 'box-orient', 'box-flex-group', 'display'], 'box');
+      assert.equal(results.length, 1, 'accepts large array of CSS property names and string value pair');
+
+
     });
 
     it('returns no results when not found', () => {
@@ -75,6 +94,20 @@ describe('style helpers', () => {
   });
 
   describe('getFormattedStyleRule()', function() {
+    it('formats output correctly', () => {
+      const results = StyleHelpers.filterStylesheetsByUsage(
+          stylesheets, 'display', 'box');
+      console.log(results);
+      const actual = StyleHelpers.getFormattedStyleRule(
+          results[0].content, results[0].parsedContent[0]);
+      const expected = `p,div {
+  display: box;
+}`;
+
+      assert.equal(actual.location, 'line: 8, row: 4, col: 17');
+      assert.equal(actual.styleRule, expected);
+    });
+
     it('formats output correctly', () => {
       const results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, ['display'], ['box']);

--- a/lighthouse-core/test/lib/style-helpers-test.js
+++ b/lighthouse-core/test/lib/style-helpers-test.js
@@ -55,10 +55,6 @@ describe('style helpers', () => {
       assert.equal(results.length, 1, 'accepts array CSS property name and string value pair');
 
       results = StyleHelpers.filterStylesheetsByUsage(
-          stylesheets, ['display'], 'box');
-      assert.equal(results.length, 1, 'accepts array CSS property name and string value pair');
-
-      results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, ['box-flex', 'box-orient', 'box-flex-group', 'display'], 'box');
       assert.equal(results.length, 1, 'accepts array of CSS property names and string value pair');
     });
@@ -121,7 +117,7 @@ describe('style helpers', () => {
   describe('addWebPrefixes()', function() {
     it('correctly adds prefixes to the propsNames', () => {
       const propsNames = ['box-flex', 'box-orient', 'box-flex-group', 'display'];
-      const results = StyleHelpers.addWebPrefixes(propsNames);
+      const results = StyleHelpers.addVendorPrefixes(propsNames);
       const expected = ['-o-box-flex', '-o-box-orient', '-o-box-flex-group', '-o-display',
                         '-ms-box-flex', '-ms-box-orient', '-ms-box-flex-group', '-ms-display',
                         '-moz-box-flex', '-moz-box-orient', '-moz-box-flex-group', '-moz-display',

--- a/lighthouse-core/test/lib/style-helpers-test.js
+++ b/lighthouse-core/test/lib/style-helpers-test.js
@@ -32,7 +32,6 @@ describe('style helpers', () => {
 
       results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, 'display', 'box');
-          console.log(results);
       assert.equal(results.length, 1, 'accepts CSS property name/value pair');
 
       results = StyleHelpers.filterStylesheetsByUsage(
@@ -61,9 +60,7 @@ describe('style helpers', () => {
 
       results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, ['box-flex', 'box-orient', 'box-flex-group', 'display'], 'box');
-      assert.equal(results.length, 1, 'accepts large array of CSS property names and string value pair');
-
-
+      assert.equal(results.length, 1, 'accepts array of CSS property names and string value pair');
     });
 
     it('returns no results when not found', () => {
@@ -97,7 +94,6 @@ describe('style helpers', () => {
     it('formats output correctly', () => {
       const results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, 'display', 'box');
-      console.log(results);
       const actual = StyleHelpers.getFormattedStyleRule(
           results[0].content, results[0].parsedContent[0]);
       const expected = `p,div {
@@ -119,6 +115,19 @@ describe('style helpers', () => {
 
       assert.equal(actual.location, 'line: 8, row: 4, col: 17');
       assert.equal(actual.styleRule, expected);
+    });
+  });
+
+  describe('addWebPrefixes()', function() {
+    it('correctly adds prefixes to the propsNames', () => {
+      const propsNames = ['box-flex', 'box-orient', 'box-flex-group', 'display'];
+      const results = StyleHelpers.addWebPrefixes(propsNames);
+      const expected = ['-o-box-flex', '-o-box-orient', '-o-box-flex-group', '-o-display',
+                        '-ms-box-flex', '-ms-box-orient', '-ms-box-flex-group', '-ms-display',
+                        '-moz-box-flex', '-moz-box-orient', '-moz-box-flex-group', '-moz-display',
+                        '-webkit-box-flex', '-webkit-box-orient', '-webkit-box-flex-group',
+                        '-webkit-display', 'box-flex', 'box-orient', 'box-flex-group', 'display'];
+      assert.equal(results.toString(), expected.toString());
     });
   });
 });

--- a/lighthouse-core/test/lib/style-helpers-test.js
+++ b/lighthouse-core/test/lib/style-helpers-test.js
@@ -71,7 +71,7 @@ describe('style helpers', () => {
       results = StyleHelpers.filterStylesheetsByUsage(
           stylesheets, ['display'], 'someunknownval');
       assert.equal(results.length, 0, 'known CSS property in array with unknown value not found');
-  });
+    });
   });
 
   describe('getFormattedStyleRule()', function() {

--- a/lighthouse-core/test/lib/style-helpers-test.js
+++ b/lighthouse-core/test/lib/style-helpers-test.js
@@ -117,21 +117,22 @@ describe('style helpers', () => {
   describe('addWebPrefixes()', function() {
     it('correctly adds prefixes to array of propsNames', () => {
       const propsNames = ['box-flex', 'box-orient', 'box-flex-group', 'display'];
-      const results = StyleHelpers.addVendorPrefixes(propsNames);
+      const results = StyleHelpers.addVendorPrefixes(propsNames).sort();
       const expected = ['box-flex', 'box-orient', 'box-flex-group', 'display',
                         '-o-box-flex', '-o-box-orient', '-o-box-flex-group', '-o-display',
                         '-ms-box-flex', '-ms-box-orient', '-ms-box-flex-group', '-ms-display',
                         '-moz-box-flex', '-moz-box-orient', '-moz-box-flex-group', '-moz-display',
                         '-webkit-box-flex', '-webkit-box-orient', '-webkit-box-flex-group',
-                        '-webkit-display'];
-      assert.equal(results.toString(), expected.toString());
+                        '-webkit-display'].sort();
+      assert.deepEqual(results, expected);
     });
 
     it('correctly adds prefixes to a string propName', () => {
       const propName = 'display';
-      const results = StyleHelpers.addVendorPrefixes(propName);
-      const expected = ['display', '-o-display', '-ms-display', '-moz-display', '-webkit-display'];
-      assert.equal(results.toString(), expected.toString());
+      const results = StyleHelpers.addVendorPrefixes(propName).sort();
+      const expected = ['display', '-o-display', '-ms-display', '-moz-display',
+                        '-webkit-display'].sort();
+      assert.deepEqual(results, expected);
     });
   });
 });

--- a/lighthouse-core/test/lib/style-helpers-test.js
+++ b/lighthouse-core/test/lib/style-helpers-test.js
@@ -115,14 +115,22 @@ describe('style helpers', () => {
   });
 
   describe('addWebPrefixes()', function() {
-    it('correctly adds prefixes to the propsNames', () => {
+    it('correctly adds prefixes to array of propsNames', () => {
       const propsNames = ['box-flex', 'box-orient', 'box-flex-group', 'display'];
       const results = StyleHelpers.addVendorPrefixes(propsNames);
-      const expected = ['-o-box-flex', '-o-box-orient', '-o-box-flex-group', '-o-display',
+      const expected = ['box-flex', 'box-orient', 'box-flex-group', 'display',
+                        '-o-box-flex', '-o-box-orient', '-o-box-flex-group', '-o-display',
                         '-ms-box-flex', '-ms-box-orient', '-ms-box-flex-group', '-ms-display',
                         '-moz-box-flex', '-moz-box-orient', '-moz-box-flex-group', '-moz-display',
                         '-webkit-box-flex', '-webkit-box-orient', '-webkit-box-flex-group',
-                        '-webkit-display', 'box-flex', 'box-orient', 'box-flex-group', 'display'];
+                        '-webkit-display'];
+      assert.equal(results.toString(), expected.toString());
+    });
+
+    it('correctly adds prefixes to a string propName', () => {
+      const propName = 'display';
+      const results = StyleHelpers.addVendorPrefixes(propName);
+      const expected = ['display', '-o-display', '-ms-display', '-moz-display', '-webkit-display'];
       assert.equal(results.toString(), expected.toString());
     });
   });


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/768 

ISSUE:
Extend no-old-flexbox audit to include more old flexbox checks then just display: box
Extend styles helper by adding a method to add web prefixes to the propsNames
FIX:
Change how style-helper's filterStylesheetsByUsage function works by adding `propName.indexOf(item.property.name) > -1;` which will evaluate true when propName array or string contains item.property.name
Added arrays of the values that are considered old css flexbox properties
`const propsNames = [ 'box-flex' , 'box-orient', 'box-flex-group', 'display' ];
    const propsValues = [ 'box', 'flexbox' ];` 
(source: [https://www.w3.org/TR/2009/WD-css3-flexbox-20090723/](url))