### PR TITLE
Ignore when the which command fails

### DIFF
--- a/lighthouse-cli/chrome-finder.ts
+++ b/lighthouse-cli/chrome-finder.ts
@@ -106,12 +106,16 @@ export function linux() {
     'google-chrome',
   ];
   executables.forEach((executable: string) => {
-    const chromePath = execFileSync('which', [executable])
-      .toString()
-      .split(newLineRegex)[0];
+    try {
+      const chromePath = execFileSync('which', [executable])
+        .toString()
+        .split(newLineRegex)[0];
 
-    if (canAccess(chromePath)) {
-      installations.push(chromePath);
+      if (canAccess(chromePath)) {
+        installations.push(chromePath);
+      }
+    } catch (e) {
+      // Not installed.
     }
   });
 


### PR DESCRIPTION
Experimenting with running lighthouse on https://hub.docker.com/r/justinribeiro/chrome-headless/
Running into a few issues.