### PR TITLE
Exclude artifacts from result handed to extension/devtools.

### DIFF
--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -20,6 +20,7 @@
 
 const Formatter = require('../formatters/formatter');
 const Handlebars = require('handlebars');
+const stringify = require('json-stringify-safe');
 const fs = require('fs');
 const path = require('path');
 const marked = require('marked');
@@ -251,7 +252,7 @@ class ReportGenerator {
       errMessage: err.message,
       errStack: err.stack,
       css: this.getReportCSS(),
-      results: JSON.stringify(results, null, 2)
+      results: stringify(results, null, 2)
     });
   }
 

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -30,6 +30,7 @@ const _flatten = arr => [].concat(...arr);
 
 let lighthouseIsRunning = false;
 let latestStatusLog = [];
+let latestArtifacts = undefined;
 
 /**
  * Filter out any unrequested aggregations from the config. If any audits are
@@ -96,6 +97,17 @@ function updateBadgeUI(optUrl) {
 }
 
 /**
+ * Removes artifacts from the result object for portability
+ * @param {!Object} results Lighthouse results object
+ */
+function filterOutArtifacts(result) {
+  // save artifacts in case the viewer will want them later.
+  latestArtifacts = result.artifacts;
+  // strip them out, as the networkRecords artifact has circular structures
+  result.artifacts = undefined;
+}
+
+/**
  * @param {!Connection} connection
  * @param {string} url
  * @param {!Object} options Lighthouse options.
@@ -120,6 +132,7 @@ window.runLighthouseForConnection = function(connection, url, options, requested
     .then(result => {
       lighthouseIsRunning = false;
       updateBadgeUI();
+      filterOutArtifacts(result);
       return result;
     })
     .catch(err => {
@@ -172,6 +185,7 @@ window.createReportPageAsBlob = function(results, reportContext) {
   let html;
   try {
     html = reportGenerator.generateHTML(results, reportContext);
+    throw new Error('sdlfjksdf');
   } catch (err) {
     html = reportGenerator.renderException(err, results);
   }
@@ -181,6 +195,13 @@ window.createReportPageAsBlob = function(results, reportContext) {
   performance.mark('report-end');
   performance.measure('generate report', 'report-start', 'report-end');
   return blobURL;
+};
+
+/**
+ * Returns full artifacts object from latest run
+ */
+window.getLatestArtifacts = function() {
+  return latestArtifacts;
 };
 
 /**

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -30,7 +30,6 @@ const _flatten = arr => [].concat(...arr);
 
 let lighthouseIsRunning = false;
 let latestStatusLog = [];
-let latestArtifacts = undefined;
 
 /**
  * Filter out any unrequested aggregations from the config. If any audits are
@@ -101,8 +100,6 @@ function updateBadgeUI(optUrl) {
  * @param {!Object} results Lighthouse results object
  */
 function filterOutArtifacts(result) {
-  // save artifacts in case the viewer will want them later.
-  latestArtifacts = result.artifacts;
   // strip them out, as the networkRecords artifact has circular structures
   result.artifacts = undefined;
 }
@@ -185,7 +182,6 @@ window.createReportPageAsBlob = function(results, reportContext) {
   let html;
   try {
     html = reportGenerator.generateHTML(results, reportContext);
-    throw new Error('sdlfjksdf');
   } catch (err) {
     html = reportGenerator.renderException(err, results);
   }
@@ -195,13 +191,6 @@ window.createReportPageAsBlob = function(results, reportContext) {
   performance.mark('report-end');
   performance.measure('generate report', 'report-start', 'report-end');
   return blobURL;
-};
-
-/**
- * Returns full artifacts object from latest run
- */
-window.getLatestArtifacts = function() {
-  return latestArtifacts;
 };
 
 /**


### PR DESCRIPTION
followup from #1163 

I was getting this guy:

![image](https://cloud.githubusercontent.com/assets/39191/21657680/3c8dc8d0-d278-11e6-9166-5c4291f871f0.png)

1. Fixes the circular JSON issues when the result was handed around. The circular references are currently only in `artifacts.networkRecords` FWIW. All other artifacts are safe.
1.  I've also moved the stringifier in `reportException` to be our `json-stringify-safe` for good defense.
1. ~~Introduced a ` window.getLatestArtifacts` for future use by devtools, and probably the viewer/perf-server (#1163).~~

R=@brendankenny, @WeiweiAtGit  
