### PR TITLE
Allow FMP trace event to appear slightly before the FCP

### DIFF
--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -139,11 +139,17 @@ class FirstMeaningfulPaint extends Audit {
     // Our navStart will be the latest one before fCP.
     const navigationStart = frameEvents.filter(e =>
         e.name === 'navigationStart' && e.ts < firstFCP.ts).pop();
-    // FMP will follow at/after the FCP, though we allow some timestamp tolerance
+    // fMP will follow at/after the FCP, though we allow some timestamp tolerance
     const firstMeaningfulPaint = frameEvents.find(e =>
         e.name === 'firstMeaningfulPaint' && e.ts >= (firstFCP.ts - FCPFMP_TOLERANCE));
 
     // Sometimes fMP is triggered before fCP
+    if (!firstMeaningfulPaint) {
+      throw new Error('No usable `firstMeaningfulPaint` event found in trace');
+    }
+
+    // Sometimes fMP is triggered before fCP
+    // (this happends when above the fold is being swapped with JS)
     if (!firstMeaningfulPaint) {
       throw new Error('No usable `firstMeaningfulPaint` event found in trace');
     }

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -26,6 +26,12 @@ const Formatter = require('../formatters/formatter');
 const SCORING_POINT_OF_DIMINISHING_RETURNS = 1600;
 const SCORING_MEDIAN = 4000;
 
+// We want an fMP at or after our fCP, however we see traces with the sole fMP
+// being up to 1ms BEFORE the fCP. We're okay if this happens, however if we see
+// a gap of more than 2 frames (32,000 microseconds), then it's a bug that should
+// be addressed in FirstMeaningfulPaintDetector.cpp
+const FCPFMP_TOLERANCE = 32 * 1000;
+
 class FirstMeaningfulPaint extends Audit {
   /**
    * @return {!AuditMeta}
@@ -133,9 +139,14 @@ class FirstMeaningfulPaint extends Audit {
     // Our navStart will be the latest one before fCP.
     const navigationStart = frameEvents.filter(e =>
         e.name === 'navigationStart' && e.ts < firstFCP.ts).pop();
-    // FMP will follow at/after the FCP
+    // FMP will follow at/after the FCP, though we allow some timestamp tolerance
     const firstMeaningfulPaint = frameEvents.find(e =>
-        e.name === 'firstMeaningfulPaint' && e.ts >= firstFCP.ts);
+        e.name === 'firstMeaningfulPaint' && e.ts >= (firstFCP.ts - FCPFMP_TOLERANCE));
+
+    // Sometimes fMP is triggered before fCP
+    if (!firstMeaningfulPaint) {
+      throw new Error('No usable `firstMeaningfulPaint` event found in trace');
+    }
 
     // navigationStart is currently essential to FMP calculation.
     // see: https://github.com/GoogleChrome/lighthouse/issues/753

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -148,12 +148,6 @@ class FirstMeaningfulPaint extends Audit {
       throw new Error('No usable `firstMeaningfulPaint` event found in trace');
     }
 
-    // Sometimes fMP is triggered before fCP
-    // (this happends when above the fold is being swapped with JS)
-    if (!firstMeaningfulPaint) {
-      throw new Error('No usable `firstMeaningfulPaint` event found in trace');
-    }
-
     // navigationStart is currently essential to FMP calculation.
     // see: https://github.com/GoogleChrome/lighthouse/issues/753
     if (!navigationStart) {

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -21,6 +21,7 @@ const assert = require('assert');
 const traceEvents = require('../fixtures/traces/progressive-app.json');
 const badNavStartTrace = require('../fixtures/traces/bad-nav-start-ts.json');
 const lateTracingStartedTrace = require('../fixtures/traces/tracingstarted-after-navstart.json');
+const preactTrace = require('../fixtures/traces/preactjs.com_ts_of_undefined.json');
 
 function getArtifacts(trace) {
   return {
@@ -73,9 +74,6 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.extendedInfo.value.timestamps.navStart, 29343540951);
         assert.equal(result.extendedInfo.value.timings.fCP, 80.054);
         assert.ok(!result.debugString);
-      }).catch(_ => {
-        console.error(_);
-        assert.ok(false);
       });
     });
 
@@ -86,8 +84,16 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.extendedInfo.value.timestamps.navStart, 8885424467);
         assert.equal(result.extendedInfo.value.timings.fCP, 632.419);
         assert.ok(!result.debugString);
-      }).catch(_ => {
-        assert.ok(false);
+      });
+    });
+
+    it('finds the fMP if it appears slightly before the fCP', () => {
+      return FMPAudit.audit(getArtifacts(preactTrace)).then(result => {
+        assert.equal(result.displayValue, '878.4ms');
+        assert.equal(result.rawValue, 878.4);
+        assert.equal(result.extendedInfo.value.timestamps.navStart, 1805796384607);
+        assert.equal(result.extendedInfo.value.timings.fCP, 879.046);
+        assert.ok(!result.debugString);
       });
     });
   });

--- a/lighthouse-core/test/fixtures/traces/preactjs.com_ts_of_undefined.json
+++ b/lighthouse-core/test/fixtures/traces/preactjs.com_ts_of_undefined.json
@@ -1,0 +1,77 @@
+{
+  "traceEvents": [
+    {
+      "pid": 6117,
+      "tid": 775,
+      "ts": 1805796376829,
+      "ph": "I",
+      "cat": "disabled-by-default-devtools.timeline",
+      "name": "TracingStartedInPage",
+      "args": {
+        "data": {
+          "frames": [
+            {
+              "frame": "0x25edaa521e58",
+              "name": "",
+              "url": "about:blank"
+            }
+          ],
+          "page": "0x25edaa521e58",
+          "sessionId": "6117.1"
+        }
+      },
+      "tts": 208554,
+      "s": "t"
+    },
+        {
+      "pid": 6117,
+      "tid": 775,
+      "ts": 1805797082647,
+      "ph": "R",
+      "cat": "blink.user_timing",
+      "name": "navigationStart",
+      "args": {
+        "frame": "0x25edaa655a98"
+      },
+      "tts": 330709
+    },
+        {
+      "pid": 6117,
+      "tid": 775,
+      "ts": 1805796384607,
+      "ph": "R",
+      "cat": "blink.user_timing",
+      "name": "navigationStart",
+      "args": {
+        "frame": "0x25edaa521e58"
+      },
+      "tts": 209369
+    },
+
+        {
+      "pid": 6117,
+      "tid": 775,
+      "ts": 1805797262960,
+      "ph": "R",
+      "cat": "blink.user_timing",
+      "name": "firstMeaningfulPaint",
+      "args": {
+        "frame": "0x25edaa521e58"
+      },
+      "tts": 826016
+    },
+      {
+      "pid": 6117,
+      "tid": 775,
+      "ts": 1805797263653,
+      "ph": "I",
+      "cat": "blink.user_timing,rail",
+      "name": "firstContentfulPaint",
+      "args": {
+        "frame": "0x25edaa521e58"
+      },
+      "tts": 473412,
+      "s": "p"
+    }
+  ]
+}


### PR DESCRIPTION
This is the core problem of #1253.

As @wardpeet deduced, we are hitting these because sometimes FMP trace events are added before FCP

This now allows there to be 32ms of tolerance between the two, as we found traces where FMP is just 0.7ms before FCP.


Fixes #1253.