### PR TITLE
Add more chrome flags for testing.

### DIFF
--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -70,10 +70,16 @@ class ChromeLauncher {
   flags() {
     const flags = [
       `--remote-debugging-port=${this.port}`,
-      '--disable-extensions',
       '--disable-translate',
-      '--disable-default-apps',
-      '--no-first-run',
+      '--disable-extensions', // disable all chrome extensions entirely
+      // '--ignore-certificate-errors', // Ignore certificate errors, like self-signed
+      '--disable-background-networking', /* disables various background network services, including
+          extension updating, safe browsing service, upgrade detector, translate, UMA */
+      '--disable-sync', // disable syncing to a Google account
+      '--metrics-recording-only', // disables reporting to UMA, but allows for collection
+      '--safebrowsing-disable-auto-update', // New safebrowsing lists will not be fetched
+      '--disable-default-apps', // Disables installation of default apps on first run
+      '--no-first-run', // Skip first run wizards
       `--user-data-dir=${this.TMP_PROFILE_DIR}`
     ];
 

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -70,16 +70,24 @@ class ChromeLauncher {
   flags() {
     const flags = [
       `--remote-debugging-port=${this.port}`,
+      // Disable built-in Google Translate service
       '--disable-translate',
-      '--disable-extensions', // disable all chrome extensions entirely
-      // '--ignore-certificate-errors', // Ignore certificate errors, like self-signed
-      '--disable-background-networking', /* disables various background network services, including
-          extension updating, safe browsing service, upgrade detector, translate, UMA */
-      '--disable-sync', // disable syncing to a Google account
-      '--metrics-recording-only', // disables reporting to UMA, but allows for collection
-      '--safebrowsing-disable-auto-update', // New safebrowsing lists will not be fetched
-      '--disable-default-apps', // Disables installation of default apps on first run
-      '--no-first-run', // Skip first run wizards
+      // Disable all chrome extensions entirely
+      '--disable-extensions',
+      // Disable various background network services, including extension updating,
+      //   safe browsing service, upgrade detector, translate, UMA
+      '--disable-background-networking',
+      // Disable fetching safebrowsing lists, likely redundant due to disable-background-networking
+      '--safebrowsing-disable-auto-update',
+      // Disable syncing to a Google account
+      '--disable-sync',
+      // Disable reporting to UMA, but allows for collection
+      '--metrics-recording-only',
+      // Disable installation of default apps on first run
+      '--disable-default-apps',
+      // Skip first run wizards
+      '--no-first-run',
+      // Place Chrome profile in a custom location we'll rm -rf later
       `--user-data-dir=${this.TMP_PROFILE_DIR}`
     ];
 


### PR DESCRIPTION
I was inspired by https://cs.chromium.org/chromium/src/chrome/test/chromedriver/chrome_launcher.cc?sq=package:chromium&dr=C&l=64 which listed a bunch of flags we aren't using yet.

I've added the ones that make sense, along with comments to explain a few.

cc @janpot.. what do you think about flipping on `ignore-certificate-errors` for everyone here? I'm okay with it if you are. :)
