### PR TITLE
Add extended timing data to Speed Index audit results

### DIFF
--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -82,9 +82,18 @@ class SpeedIndexMetric extends Audit {
       score = Math.max(0, score);
 
       const extendedInfo = {
-        first: speedline.first,
-        complete: speedline.complete,
-        duration: speedline.duration,
+        timings: {
+          firstVisualChange: speedline.first,
+          visuallyComplete: speedline.complete,
+          speedIndex: speedline.speedIndex,
+          perceptualSpeedIndex: speedline.perceptualSpeedIndex
+        },
+        timestamps: {
+          firstVisualChange: (speedline.first + speedline.beginning) * 1000,
+          visuallyComplete: (speedline.complete + speedline.beginning) * 1000,
+          speedIndex: (speedline.speedIndex + speedline.beginning) * 1000,
+          perceptualSpeedIndex: (speedline.perceptualSpeedIndex + speedline.beginning) * 1000
+        },
         frames: speedline.frames.map(frame => {
           return {
             timestamp: frame.getTimeStamp(),

--- a/lighthouse-core/test/audits/speed-index-metric-test.js
+++ b/lighthouse-core/test/audits/speed-index-metric-test.js
@@ -80,6 +80,8 @@ describe('Performance: speed-index-metric audit', () => {
   it('scores speed index of 831 as 100', () => {
     const SpeedlineResult = {
       frames: [frame(), frame(), frame()],
+      first: 630,
+      complete: 930,
       speedIndex: 831,
       perceptualSpeedIndex: 845
     };
@@ -88,7 +90,10 @@ describe('Performance: speed-index-metric audit', () => {
     return Audit.audit(artifacts).then(response => {
       assert.equal(response.displayValue, '845');
       assert.equal(response.rawValue, 845);
-      assert.equal(response.score, 100);
+      assert.equal(response.extendedInfo.value.timings.firstVisualChange, 630);
+      assert.equal(response.extendedInfo.value.timings.visuallyComplete, 930);
+      assert.equal(response.extendedInfo.value.timings.speedIndex, 831);
+      assert.equal(response.extendedInfo.value.timings.perceptualSpeedIndex, 845);
     });
   });
 });


### PR DESCRIPTION
Much like the extended timing/timestamps for FMP and TTI that was added in #1152

This adds the same details for speed index, and perceptual speed index.