### PR TITLE
Asset-saver refactors

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -268,14 +268,14 @@ function runLighthouse(url: string,
         assetSaver.saveArtifacts(artifacts);
       }
       if (flags.saveAssets) {
-        return assetSaver.saveAssets({url: results.url}, artifacts).then(() => results);
+        return assetSaver.saveAssets(artifacts, results).then(() => results);
       }
       return results;
     })
     .then((results: Results) => Printer.write(results, flags.output, flags.outputPath))
     .then((results: Results) => {
       if (flags.output === Printer.OutputMode[Printer.OutputMode.pretty]) {
-        const filename = `${assetSaver.getFilenamePrefix({url})}.report.html`;
+        const filename = `${assetSaver.getFilenamePrefix(results)}.report.html`;
         return Printer.write(results, 'html', filename);
       }
       return results;

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -19,31 +19,36 @@
 const fs = require('fs');
 const log = require('../../lighthouse-core/lib/log.js');
 const stringifySafe = require('json-stringify-safe');
+const URL = require('./url-shim');
+const stringify = require('json-stringify-safe');
 
-function getFilenamePrefix(options) {
-  const url = options.url;
-  const hostname = url.match(/^.*?\/\/(.*?)(:?\/|$)/)[1];
+/**
+ * Generate a filenamePrefix of hostname_YYYY-MM-DD_HH-MM-SS
+ * Date/time uses the local timezone, however Node has unreliable ICU
+ * support, so we must construct a YYYY-MM-DD date format manually. :/
+ * @param {!Object} results
+ * @returns string
+ */
+function getFilenamePrefix(results) {
+  const hostname = new URL(results.url).hostname;
+  const date = (results.generatedTime && new Date(results.generatedTime)) || new Date();
 
-  const date = options.date || new Date();
-  const resolvedLocale = new Intl.DateTimeFormat().resolvedOptions().locale;
-  const time = date.toLocaleTimeString(resolvedLocale, {hour12: false});
-  const timeStampStr = date.toISOString().replace(/T.*/, '_' + time);
+  const timeStr = date.toLocaleTimeString('en-US', {hour12: false});
+  const dateParts = date.toLocaleDateString('en-US', {
+    year: 'numeric', month: '2-digit', day: '2-digit'
+  }).split('/');
+  dateParts.unshift(dateParts.pop());
+  const dateStr = dateParts.join('-');
 
-  const filenamePrefix = hostname + '_' + timeStampStr;
+  const filenamePrefix = `${hostname}_${dateStr}_${timeStr}`;
   // replace characters that are unfriendly to filenames
-  return (filenamePrefix).replace(/[\/\?<>\\:\*\|":]/g, '-');
+  return filenamePrefix.replace(/[\/\?<>\\:\*\|":]/g, '-');
 }
 
-// Some trace events are particularly large, and not only consume a LOT of disk
-// space, but also cause problems for the JSON stringifier. For simplicity, we exclude them
-function filterForSize(traceData) {
-  return traceData.filter(e => e.name !== 'LayoutTree');
-}
-
-function screenshotDump(options, screenshots) {
+function screenshotDump(screenshots, results) {
   return `
   <!doctype html>
-  <title>screenshots ${getFilenamePrefix(options)}</title>
+  <title>screenshots ${getFilenamePrefix(results)}</title>
   <style>
 html {
     overflow-x: scroll;
@@ -88,11 +93,12 @@ function saveArtifacts(artifacts, filename) {
 
 /**
  * Filter traces and extract screenshots to prepare for saving.
- * @param {!Object} options
- * @param {!Artifacts} artifacts
+
+ * @param {!Artifacts} artifactsFilename
+ * @param {!Results} results
  * @return {!Promise<!Array<{traceData: !Object, html: string}>>}
  */
-function prepareAssets(options, artifacts) {
+function prepareAssets(artifacts, results) {
   const passNames = Object.keys(artifacts.traces);
   const assets = [];
 
@@ -102,8 +108,7 @@ function prepareAssets(options, artifacts) {
     return chain.then(_ => artifacts.requestScreenshots(trace))
       .then(screenshots => {
         const traceData = Object.assign({}, trace);
-        traceData.traceEvents = filterForSize(traceData.traceEvents);
-        const html = screenshotDump(options, screenshots);
+        const html = screenshotDump(screenshots, results);
 
         assets.push({
           traceData,
@@ -116,15 +121,14 @@ function prepareAssets(options, artifacts) {
 
 /**
  * Writes trace(s) and associated screenshot(s) to disk.
- * @param {!Object} options
  * @param {!Artifacts} artifacts
+ * @param {!Results} results
  * @return {!Promise}
  */
-function saveAssets(options, artifacts) {
-  return prepareAssets(options, artifacts).then(assets => {
+function saveAssets(artifacts, results) {
+  return prepareAssets(artifacts, results).then(assets => {
     assets.forEach((data, index) => {
-      const filenamePrefix = getFilenamePrefix(options);
-
+      const filenamePrefix = getFilenamePrefix(results);
       const traceData = data.traceData;
       fs.writeFileSync(`${filenamePrefix}-${index}.trace.json`, JSON.stringify(traceData, null, 2));
       log.log('trace file saved to disk', filenamePrefix);

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -20,7 +20,6 @@ const fs = require('fs');
 const log = require('../../lighthouse-core/lib/log.js');
 const stringifySafe = require('json-stringify-safe');
 const URL = require('./url-shim');
-const stringify = require('json-stringify-safe');
 
 /**
  * Generate a filenamePrefix of hostname_YYYY-MM-DD_HH-MM-SS
@@ -45,6 +44,12 @@ function getFilenamePrefix(results) {
   return filenamePrefix.replace(/[\/\?<>\\:\*\|":]/g, '-');
 }
 
+/**
+ * Generate basic HTML page of screenshot filmstrip
+ * @param {!Array<{timestamp: number, datauri: string}>} screenshots
+ * @param {!Results} results
+ * @return {!string}
+ */
 function screenshotDump(screenshots, results) {
   return `
   <!doctype html>
@@ -82,10 +87,15 @@ img {
   `;
 }
 
+/**
+ * Save entire artifacts object to a single stringified file
+ * @param {!Artifacts} artifacts
+ * @param {!artifactsFilename} artifactsFilename
+ */
 // Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
 /* istanbul ignore next */
-function saveArtifacts(artifacts, filename) {
-  const artifactsFilename = filename || 'artifacts.log';
+function saveArtifacts(artifacts, artifactsFilename) {
+  artifactsFilename = artifactsFilename || 'artifacts.log';
   // The networkRecords artifacts have circular references
   fs.writeFileSync(artifactsFilename, stringifySafe(artifacts));
   log.log('artifacts file saved to disk', artifactsFilename);
@@ -93,8 +103,7 @@ function saveArtifacts(artifacts, filename) {
 
 /**
  * Filter traces and extract screenshots to prepare for saving.
-
- * @param {!Artifacts} artifactsFilename
+ * @param {!Artifacts} artifacts
  * @param {!Results} results
  * @return {!Promise<!Array<{traceData: !Object, html: string}>>}
  */

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -27,8 +27,26 @@ const Audit = require('../../audits/audit.js');
 
 /* eslint-env mocha */
 describe('asset-saver helper', () => {
+  it('generates filename prefixes', () => {
+    const results = {
+      url: 'https://testexample.com',
+      generatedTime: '2017-01-06T02:34:56.217Z'
+    };
+    const str = assetSaver.getFilenamePrefix(results);
+    // we want the filename to match user timezone, however these tests will run on multiple TZs
+    assert.ok(str.startsWith('testexample.com'), 'hostname is missing');
+    assert.ok(str.includes('2017-'), 'full year is missing');
+    assert.ok(str.endsWith('-56'), 'seconds value is not at the end');
+    // regex of hostname_YYYY-MM-DD_HH-MM-SS
+    const regex = /testexample\.com_\d{4}-[0-1][[0-9]-[0-1][[0-9]_[0-2][0-9]-[0-5][0-9]-[0-5][0-9]/;
+    assert.ok(regex.test(str), `${str} doesn't match pattern: hostname_YYYY-MM-DD_HH-MM-SS`);
+  });
+
   it('generates HTML', () => {
-    const options = {url: 'https://testexample.com'};
+    const options = {
+      url: 'https://testexample.com',
+      generatedTime: '2016-05-31T23:34:30.547Z'
+    };
     const artifacts = {
       traces: {
         [Audit.DEFAULT_PASS]: {
@@ -37,15 +55,15 @@ describe('asset-saver helper', () => {
       },
       requestScreenshots: () => Promise.resolve([]),
     };
-    return assetSaver.prepareAssets(options, artifacts).then(assets => {
+    return assetSaver.prepareAssets(artifacts, options).then(assets => {
       assert.ok(/<!doctype/gim.test(assets[0].html));
     });
   });
 
-  describe('saves files to disk with real filenames', function() {
+  describe('saves files.', function() {
     const options = {
       url: 'https://testexample.com/',
-      date: new Date(1464737670547),
+      generatedTime: '2016-05-31T23:34:30.547Z',
       flags: {
         saveAssets: true
       }
@@ -59,7 +77,7 @@ describe('asset-saver helper', () => {
       requestScreenshots: () => Promise.resolve(screenshotFilmstrip)
     };
 
-    assetSaver.saveAssets(options, artifacts);
+    assetSaver.saveAssets(artifacts, options);
 
     it('trace file saved to disk with data', () => {
       const traceFilename = assetSaver.getFilenamePrefix(options) + '-0.trace.json';

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -60,7 +60,7 @@ describe('asset-saver helper', () => {
     });
   });
 
-  describe('saves files.', function() {
+  describe('saves files', function() {
     const options = {
       url: 'https://testexample.com/',
       generatedTime: '2016-05-31T23:34:30.547Z',

--- a/lighthouse-viewer/app/src/github.js
+++ b/lighthouse-viewer/app/src/github.js
@@ -56,7 +56,7 @@ class GithubAPI {
       .then(accessToken => {
         const filename = getFilenamePrefix({
           url: jsonFile.url,
-          date: new Date(jsonFile.generatedTime)
+          generatedTime: jsonFile.generatedTime
         });
         const body = {
           description: 'Lighthouse json report',

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -347,7 +347,7 @@ class LighthouseViewerReport {
   _saveFile(blob) {
     const filename = getFilenamePrefix({
       url: this.json.url,
-      date: new Date(this.json.generatedTime)
+      generatedTime: this.json.generatedTime
     });
 
     const ext = blob.type.match('json') ? '.json' : '.html';


### PR DESCRIPTION
* Improved `getFilenamePrefix`.
  * Using `new URL()` for the hostname.
  * Fixes #1361 where inconsistent timezone used for date vs time
  * Added tests for this
* Changed parameters of `saveAssets`, `prepareAssets`, and `getFilenamePrefix`
  * Generally they all take the ending `results` object rather than the starting `options` object. So the URL is the finalUrl, rather than provided one. This lets use use the generatedTime, as before, we were not.
* Removed `filterForSize`. Unnecessary since the new FMP landed.
