### PR TITLE
Isolate use of json-stringify-safe.

### DIFF
--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -18,7 +18,7 @@
 
 const fs = require('fs');
 const log = require('../../lighthouse-core/lib/log.js');
-const stringify = require('json-stringify-safe');
+const stringifySafe = require('json-stringify-safe');
 
 function getFilenamePrefix(options) {
   const url = options.url;
@@ -81,7 +81,8 @@ img {
 /* istanbul ignore next */
 function saveArtifacts(artifacts, filename) {
   const artifactsFilename = filename || 'artifacts.log';
-  fs.writeFileSync(artifactsFilename, stringify(artifacts));
+  // The networkRecords artifacts have circular references
+  fs.writeFileSync(artifactsFilename, stringifySafe(artifacts));
   log.log('artifacts file saved to disk', artifactsFilename);
 }
 
@@ -125,7 +126,7 @@ function saveAssets(options, artifacts) {
       const filenamePrefix = getFilenamePrefix(options);
 
       const traceData = data.traceData;
-      fs.writeFileSync(`${filenamePrefix}-${index}.trace.json`, stringify(traceData, null, 2));
+      fs.writeFileSync(`${filenamePrefix}-${index}.trace.json`, JSON.stringify(traceData, null, 2));
       log.log('trace file saved to disk', filenamePrefix);
 
       fs.writeFileSync(`${filenamePrefix}-${index}.screenshots.html`, data.html);

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -20,7 +20,6 @@
 
 const Formatter = require('../formatters/formatter');
 const Handlebars = require('handlebars');
-const stringify = require('json-stringify-safe');
 const fs = require('fs');
 const path = require('path');
 const marked = require('marked');
@@ -252,7 +251,7 @@ class ReportGenerator {
       errMessage: err.message,
       errStack: err.stack,
       css: this.getReportCSS(),
-      results: stringify(results, null, 2)
+      results: JSON.stringify(results, null, 2)
     });
   }
 


### PR DESCRIPTION
Our data structures do not have circular references, with the exception of networkRecords.
json-stringify-safe was added (by me) to the report generator, however it's unnecessary there.

Additionally, the devtools minifier attempted to minify `json-stringify-safe` and had trouble with [the semi-colon-less code style](https://github.com/isaacs/json-stringify-safe/blob/master/stringify.js#L19). (Yes, the devtools' minifier is lame, but oh well).

 👷 