### PR TITLE
Trace capture: include JS stacks, exclude netlog

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -47,13 +47,13 @@ class Driver {
       'blink.console',
       'blink.user_timing',
       'benchmark',
-      'netlog',
+      'latencyInfo',
       'devtools.timeline',
       'disabled-by-default-devtools.timeline',
       'disabled-by-default-devtools.timeline.frame',
       'disabled-by-default-devtools.timeline.stack',
-      // 'disabled-by-default-v8.cpu_profile',  // these would include JS stack samples, but
-      // 'disabled-by-default-v8.cpu_profile.hires', // will take the trace from 5MB -> 100MB
+      'disabled-by-default-v8.cpu_profiler',
+      'disabled-by-default-v8.cpu_profiler.hires',
       'disabled-by-default-devtools.screenshot'
     ];
   }


### PR DESCRIPTION
We can afford to include the JS stacks now, which allows us to start attributing cost at a function level. Moreover, when you view a LH trace in timeline, having the stacks tells fleshes out the flame chart inside of "Evaluate Script" etc.

I've looked at the trace size overhead of various categories and we can trade netlog for cpu_profiler right now for free.

I profiled the load of theverge.com in three modes:

1. hi-res sampling (cpu_profiler & cpu_profiler.hires)
1. lo-res sampling (cpu_profiler)
1. no sampling (no cpu_profiler at all)

![image](https://cloud.githubusercontent.com/assets/39191/21781212/5e9cc590-d663-11e6-9ad3-faca70b0ac48.png)

full details: https://docs.google.com/spreadsheets/d/1T_i2ikSWMH13YzqnKPfrRGjTXrs-C-98jj6x8sipfu0/edit#gid=2071721736&vpid=A6

You can see the size overhead of netlog (which we added [randomly](https://github.com/GoogleChrome/lighthouse/pull/650) without a clear usecase). Flipping that off and turning on cpu_profiler makes sense and shouldn't add much bytesize for general pageload traces.

I've also added latencyInfo which provides the "interaction" part of timeline, aka the "MouseUp" etc details. This has totally negligible filesize (or runtime) overhead.