### PR TITLE
update smokehouse to do deep result comparisons

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -24,42 +24,104 @@ module.exports = [
     initialUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
     url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
     audits: {
-      'is-on-https': false,
-      'uses-http2': false,
-      'external-anchors-use-rel-noopener': false,
-      'appcache-manifest': false,
-      'geolocation-on-start': false,
-      'link-blocking-first-paint': false,
-      'no-console-time': false,
-      'no-datenow': false,
-      'no-document-write': false,
-      'no-mutation-events': false,
-      'no-old-flexbox': false,
-      'no-websql': false,
-      'notification-on-start': false,
-      'script-blocking-first-paint': false,
-      'unused-css-rules': false,
-      'uses-passive-event-listeners': false
+      'is-on-https': {
+        score: false
+      },
+      'uses-http2': {
+        score: false
+      },
+      'external-anchors-use-rel-noopener': {
+        score: false
+      },
+      'appcache-manifest': {
+        score: false
+      },
+      'geolocation-on-start': {
+        score: false
+      },
+      'link-blocking-first-paint': {
+        score: false
+      },
+      'no-console-time': {
+        score: false
+      },
+      'no-datenow': {
+        score: false
+      },
+      'no-document-write': {
+        score: false
+      },
+      'no-mutation-events': {
+        score: false
+      },
+      'no-old-flexbox': {
+        score: false
+      },
+      'no-websql': {
+        score: false
+      },
+      'notification-on-start': {
+        score: false
+      },
+      'script-blocking-first-paint': {
+        score: false
+      },
+      'unused-css-rules': {
+        score: false
+      },
+      'uses-passive-event-listeners': {
+        score: false
+      }
     }
   }, {
     initialUrl: 'http://localhost:10200/online-only.html',
     url: 'http://localhost:10200/online-only.html',
     audits: {
-      'is-on-https': false,
-      'uses-http2': false,
-      'external-anchors-use-rel-noopener': true,
-      'appcache-manifest': true,
-      'geolocation-on-start': true,
-      'link-blocking-first-paint': true,
-      'no-console-time': true,
-      'no-datenow': true,
-      'no-document-write': true,
-      'no-mutation-events': true,
-      'no-old-flexbox': true,
-      'no-websql': true,
-      'script-blocking-first-paint': true,
-      'unused-css-rules': true,
-      'uses-passive-event-listeners': true
+      'is-on-https': {
+        score: false
+      },
+      'uses-http2': {
+        score: false
+      },
+      'external-anchors-use-rel-noopener': {
+        score: true
+      },
+      'appcache-manifest': {
+        score: true
+      },
+      'geolocation-on-start': {
+        score: true
+      },
+      'link-blocking-first-paint': {
+        score: true
+      },
+      'no-console-time': {
+        score: true
+      },
+      'no-datenow': {
+        score: true
+      },
+      'no-document-write': {
+        score: true
+      },
+      'no-mutation-events': {
+        score: true
+      },
+      'no-old-flexbox': {
+        score: true
+      },
+      'no-websql': {
+        score: true
+      },
+      'script-blocking-first-paint': {
+        score: true
+      },
+      'unused-css-rules': {
+        score: true
+      },
+      'uses-passive-event-listeners': {
+        score: true
+      }
     }
   }
 ];

--- a/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
@@ -26,32 +26,84 @@ module.exports = [
     initialUrl: 'http://localhost:10200/online-only.html',
     url: 'http://localhost:10200/online-only.html',
     audits: {
-      'is-on-https': false,
-      'redirects-http': false,
-      'service-worker': false,
-      'works-offline': false,
-      'viewport': true,
-      'manifest-display': false,
-      'without-javascript': true,
-      'user-timings': true,
-      'critical-request-chains': true,
-      'manifest-exists': false,
-      'manifest-background-color': false,
-      'manifest-theme-color': false,
-      'manifest-icons-min-192': false,
-      'manifest-icons-min-144': false,
-      'manifest-name': false,
-      'manifest-short-name': false,
-      'manifest-short-name-length': false,
-      'manifest-start-url': false,
-      'theme-color-meta': false,
-      'aria-valid-attr': true,
-      'aria-allowed-attr': true,
-      'color-contrast': true,
-      'image-alt': true,
-      'label': true,
-      'tabindex': true,
-      'content-width': true
+      'is-on-https': {
+        score: false
+      },
+      'redirects-http': {
+        score: false
+      },
+      'service-worker': {
+        score: false
+      },
+      'works-offline': {
+        score: false
+      },
+      'viewport': {
+        score: true
+      },
+      'manifest-display': {
+        score: false
+      },
+      'without-javascript': {
+        score: true
+      },
+      'user-timings': {
+        score: true
+      },
+      'critical-request-chains': {
+        score: true
+      },
+      'manifest-exists': {
+        score: false
+      },
+      'manifest-background-color': {
+        score: false
+      },
+      'manifest-theme-color': {
+        score: false
+      },
+      'manifest-icons-min-192': {
+        score: false
+      },
+      'manifest-icons-min-144': {
+        score: false
+      },
+      'manifest-name': {
+        score: false
+      },
+      'manifest-short-name': {
+        score: false
+      },
+      'manifest-short-name-length': {
+        score: false
+      },
+      'manifest-start-url': {
+        score: false
+      },
+      'theme-color-meta': {
+        score: false
+      },
+      'aria-valid-attr': {
+        score: true
+      },
+      'aria-allowed-attr': {
+        score: true
+      },
+      'color-contrast': {
+        score: true
+      },
+      'image-alt': {
+        score: true
+      },
+      'label': {
+        score: true
+      },
+      'tabindex': {
+        score: true
+      },
+      'content-width': {
+        score: true
+      }
     }
   },
 
@@ -59,32 +111,84 @@ module.exports = [
     initialUrl: 'http://localhost:10503/offline-ready.html',
     url: 'http://localhost:10503/offline-ready.html',
     audits: {
-      'is-on-https': false,
-      'redirects-http': false,
-      'service-worker': true,
-      'works-offline': true,
-      'viewport': true,
-      'manifest-display': false,
-      'without-javascript': true,
-      'user-timings': true,
-      'critical-request-chains': false,
-      'manifest-exists': false,
-      'manifest-background-color': false,
-      'manifest-theme-color': false,
-      'manifest-icons-min-192': false,
-      'manifest-icons-min-144': false,
-      'manifest-name': false,
-      'manifest-short-name': false,
-      'manifest-short-name-length': false,
-      'manifest-start-url': false,
-      'theme-color-meta': false,
-      'aria-valid-attr': true,
-      'aria-allowed-attr': true,
-      'color-contrast': true,
-      'image-alt': false,
-      'label': true,
-      'tabindex': true,
-      'content-width': true
+      'is-on-https': {
+        score: false
+      },
+      'redirects-http': {
+        score: false
+      },
+      'service-worker': {
+        score: true
+      },
+      'works-offline': {
+        score: true
+      },
+      'viewport': {
+        score: true
+      },
+      'manifest-display': {
+        score: false
+      },
+      'without-javascript': {
+        score: true
+      },
+      'user-timings': {
+        score: true
+      },
+      'critical-request-chains': {
+        score: false
+      },
+      'manifest-exists': {
+        score: false
+      },
+      'manifest-background-color': {
+        score: false
+      },
+      'manifest-theme-color': {
+        score: false
+      },
+      'manifest-icons-min-192': {
+        score: false
+      },
+      'manifest-icons-min-144': {
+        score: false
+      },
+      'manifest-name': {
+        score: false
+      },
+      'manifest-short-name': {
+        score: false
+      },
+      'manifest-short-name-length': {
+        score: false
+      },
+      'manifest-start-url': {
+        score: false
+      },
+      'theme-color-meta': {
+        score: false
+      },
+      'aria-valid-attr': {
+        score: true
+      },
+      'aria-allowed-attr': {
+        score: true
+      },
+      'color-contrast': {
+        score: true
+      },
+      'image-alt': {
+        score: false
+      },
+      'label': {
+        score: true
+      },
+      'tabindex': {
+        score: true
+      },
+      'content-width': {
+        score: true
+      }
     }
   }
 ];

--- a/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
@@ -48,10 +48,12 @@ module.exports = [
         score: true
       },
       'user-timings': {
-        score: true
+        score: true,
+        displayValue: '0'
       },
       'critical-request-chains': {
-        score: true
+        score: true,
+        displayValue: '0'
       },
       'manifest-exists': {
         score: false
@@ -133,10 +135,12 @@ module.exports = [
         score: true
       },
       'user-timings': {
-        score: true
+        score: true,
+        displayValue: '0'
       },
       'critical-request-chains': {
-        score: false
+        score: false,
+        displayValue: '1'
       },
       'manifest-exists': {
         score: false

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -25,20 +25,48 @@ module.exports = [
     initialUrl: 'https://airhorner.com',
     url: 'https://airhorner.com/',
     audits: {
-      'is-on-https': true,
-      'redirects-http': true,
-      'service-worker': true,
-      'works-offline': true,
-      'manifest-display': true,
-      'manifest-exists': true,
-      'manifest-background-color': true,
-      'manifest-theme-color': true,
-      'manifest-icons-min-192': true,
-      'manifest-icons-min-144': true,
-      'manifest-name': true,
-      'manifest-short-name': true,
-      'manifest-start-url': true,
-      // 'cache-start-url': true
+      'is-on-https': {
+        score: true
+      },
+      'redirects-http': {
+        score: true
+      },
+      'service-worker': {
+        score: true
+      },
+      'works-offline': {
+        score: true
+      },
+      'manifest-display': {
+        score: true
+      },
+      'manifest-exists': {
+        score: true
+      },
+      'manifest-background-color': {
+        score: true
+      },
+      'manifest-theme-color': {
+        score: true
+      },
+      'manifest-icons-min-192': {
+        score: true
+      },
+      'manifest-icons-min-144': {
+        score: true
+      },
+      'manifest-name': {
+        score: true
+      },
+      'manifest-short-name': {
+        score: true
+      },
+      'manifest-start-url': {
+        score: true
+      },
+      // 'cache-start-url': {
+      //   score: true
+      // }
     }
   },
 
@@ -46,20 +74,48 @@ module.exports = [
     initialUrl: 'https://www.chromestatus.com/',
     url: 'https://www.chromestatus.com/features',
     audits: {
-      'is-on-https': true,
-      'redirects-http': true,
-      'service-worker': true,
-      'works-offline': false,
-      'manifest-display': true,
-      'manifest-exists': true,
-      'manifest-background-color': true,
-      'manifest-theme-color': true,
-      'manifest-icons-min-192': true,
-      'manifest-icons-min-144': true,
-      'manifest-name': true,
-      'manifest-short-name': true,
-      'manifest-start-url': true,
-      // 'cache-start-url': true
+      'is-on-https': {
+        score: true
+      },
+      'redirects-http': {
+        score: true
+      },
+      'service-worker': {
+        score: true
+      },
+      'works-offline': {
+        score: false
+      },
+      'manifest-display': {
+        score: true
+      },
+      'manifest-exists': {
+        score: true
+      },
+      'manifest-background-color': {
+        score: true
+      },
+      'manifest-theme-color': {
+        score: true
+      },
+      'manifest-icons-min-192': {
+        score: true
+      },
+      'manifest-icons-min-144': {
+        score: true
+      },
+      'manifest-name': {
+        score: true
+      },
+      'manifest-short-name': {
+        score: true
+      },
+      'manifest-start-url': {
+        score: true
+      },
+      // 'cache-start-url': {
+      //   score: true
+      // }
     }
   },
 
@@ -67,20 +123,48 @@ module.exports = [
     initialUrl: 'https://jakearchibald.github.io/svgomg/',
     url: 'https://jakearchibald.github.io/svgomg/',
     audits: {
-      'is-on-https': true,
-      'redirects-http': true,
-      'service-worker': true,
-      'works-offline': true,
-      'manifest-display': true,
-      'manifest-exists': true,
-      'manifest-background-color': true,
-      'manifest-theme-color': true,
-      'manifest-icons-min-192': true,
-      'manifest-icons-min-144': true,
-      'manifest-name': true,
-      'manifest-short-name': true,
-      'manifest-start-url': true,
-      // 'cache-start-url': true
+      'is-on-https': {
+        score: true
+      },
+      'redirects-http': {
+        score: true
+      },
+      'service-worker': {
+        score: true
+      },
+      'works-offline': {
+        score: true
+      },
+      'manifest-display': {
+        score: true
+      },
+      'manifest-exists': {
+        score: true
+      },
+      'manifest-background-color': {
+        score: true
+      },
+      'manifest-theme-color': {
+        score: true
+      },
+      'manifest-icons-min-192': {
+        score: true
+      },
+      'manifest-icons-min-144': {
+        score: true
+      },
+      'manifest-name': {
+        score: true
+      },
+      'manifest-short-name': {
+        score: true
+      },
+      'manifest-start-url': {
+        score: true
+      },
+      // 'cache-start-url': {
+      //   score: true
+      // }
     }
   },
 
@@ -88,20 +172,48 @@ module.exports = [
     initialUrl: 'https://shop.polymer-project.org/',
     url: 'https://shop.polymer-project.org/',
     audits: {
-      'is-on-https': true,
-      'redirects-http': true,
-      'service-worker': true,
-      'works-offline': true,
-      'manifest-display': true,
-      'manifest-exists': true,
-      'manifest-background-color': true,
-      'manifest-theme-color': true,
-      'manifest-icons-min-192': true,
-      'manifest-icons-min-144': true,
-      'manifest-name': true,
-      'manifest-short-name': true,
-      'manifest-start-url': true,
-      // 'cache-start-url': true
+      'is-on-https': {
+        score: true
+      },
+      'redirects-http': {
+        score: true
+      },
+      'service-worker': {
+        score: true
+      },
+      'works-offline': {
+        score: true
+      },
+      'manifest-display': {
+        score: true
+      },
+      'manifest-exists': {
+        score: true
+      },
+      'manifest-background-color': {
+        score: true
+      },
+      'manifest-theme-color': {
+        score: true
+      },
+      'manifest-icons-min-192': {
+        score: true
+      },
+      'manifest-icons-min-144': {
+        score: true
+      },
+      'manifest-name': {
+        score: true
+      },
+      'manifest-short-name': {
+        score: true
+      },
+      'manifest-start-url': {
+        score: true
+      },
+      // 'cache-start-url': {
+      //   score: true
+      // }
     }
   },
 
@@ -109,20 +221,48 @@ module.exports = [
     initialUrl: 'https://pwa.rocks',
     url: 'https://pwa.rocks/',
     audits: {
-      'is-on-https': true,
-      'redirects-http': true,
-      'service-worker': true,
-      'works-offline': true,
-      'manifest-display': true,
-      'manifest-exists': true,
-      'manifest-background-color': true,
-      'manifest-theme-color': true,
-      'manifest-icons-min-192': true,
-      'manifest-icons-min-144': true,
-      'manifest-name': true,
-      'manifest-short-name': true,
-      'manifest-start-url': true,
-      // 'cache-start-url': true
+      'is-on-https': {
+        score: true
+      },
+      'redirects-http': {
+        score: true
+      },
+      'service-worker': {
+        score: true
+      },
+      'works-offline': {
+        score: true
+      },
+      'manifest-display': {
+        score: true
+      },
+      'manifest-exists': {
+        score: true
+      },
+      'manifest-background-color': {
+        score: true
+      },
+      'manifest-theme-color': {
+        score: true
+      },
+      'manifest-icons-min-192': {
+        score: true
+      },
+      'manifest-icons-min-144': {
+        score: true
+      },
+      'manifest-name': {
+        score: true
+      },
+      'manifest-short-name': {
+        score: true
+      },
+      'manifest-start-url': {
+        score: true
+      },
+      // 'cache-start-url': {
+      //   score: true
+      // }
     }
   }
 ];

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -38,13 +38,17 @@ module.exports = [
         score: true
       },
       'manifest-display': {
-        score: true
+        score: true,
+        displayValue: 'standalone'
       },
       'manifest-exists': {
         score: true
       },
       'manifest-background-color': {
-        score: true
+        score: true,
+        extendedInfo: {
+          value: '#2196F3'
+        }
       },
       'manifest-theme-color': {
         score: true
@@ -87,13 +91,17 @@ module.exports = [
         score: false
       },
       'manifest-display': {
-        score: true
+        score: true,
+        displayValue: 'standalone'
       },
       'manifest-exists': {
         score: true
       },
       'manifest-background-color': {
-        score: true
+        score: true,
+        extendedInfo: {
+          value: '#366597'
+        }
       },
       'manifest-theme-color': {
         score: true
@@ -136,22 +144,28 @@ module.exports = [
         score: true
       },
       'manifest-display': {
-        score: true
+        score: true,
+        displayValue: 'standalone'
       },
       'manifest-exists': {
         score: true
       },
       'manifest-background-color': {
-        score: true
+        score: true,
+        extendedInfo: {
+          value: '#bababa'
+        }
       },
       'manifest-theme-color': {
         score: true
       },
       'manifest-icons-min-192': {
-        score: true
+        score: true,
+        displayValue: 'found sizes: 600x600',
       },
       'manifest-icons-min-144': {
-        score: true
+        score: true,
+        displayValue: 'found sizes: 600x600',
       },
       'manifest-name': {
         score: true
@@ -185,13 +199,17 @@ module.exports = [
         score: true
       },
       'manifest-display': {
-        score: true
+        score: true,
+        displayValue: 'standalone'
       },
       'manifest-exists': {
         score: true
       },
       'manifest-background-color': {
-        score: true
+        score: true,
+        extendedInfo: {
+          value: '#fff'
+        }
       },
       'manifest-theme-color': {
         score: true
@@ -234,13 +252,17 @@ module.exports = [
         score: true
       },
       'manifest-display': {
-        score: true
+        score: true,
+        displayValue: 'standalone'
       },
       'manifest-exists': {
         score: true
       },
       'manifest-background-color': {
-        score: true
+        score: true,
+        extendedInfo: {
+          value: '#383838'
+        }
       },
       'manifest-theme-color': {
         score: true


### PR DESCRIPTION
Allows smokehouse expectations to be objects now. Smokehouse will walk the expected value until getting to any primitive leaves, comparing to the actual result at every step, failing if there is any difference. This allows for the expected value to not be complete, so it doesn't have to include noisy details (e.g. audit meta info) better checked by unit tests.

I augmented the PWA and offline smoke test expectations files, but it turns out all those older audits don't include anything that interesting in their extended info (at least compared to newer audits). `manifest-theme-color` doesn't even output what the `theme_color` actually is. We can kick off the DBW deep expectations after this PR.

Originally I planned to allow the old expectations format (if it's just a primitive value, assume that it's the `score` property on the actual audit result), but it's really not much work to just explicitly write out the object literal with a `score` property. The literals add considerably to the length of the file, but it means you don't have to keep that special case in mind while writing expectations files. In practice we tend to write these values once and barely touch them again, so it seems fine to be explicit. If others feel strongly about the shorter syntax when you only care about the audit's score, I can add that back in.

This doesn't quite finish #964, as this doesn't include comparator support (e.g. if you want to test the actual value with a regex or a floating point comparison (TTI is ≤ 5000 or whatever)), but that's an easy step after these changes.