### PR TITLE
Factor report into class

### DIFF
--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -19,65 +19,82 @@
 
 'use strict';
 
-/**
- * Opens a new tab to the online viewer and sends the local page's JSON results
- * to the online viewer using postMessage.
- */
-function sendJSONReport() {
-  const VIEWER_ORIGIN = 'https://googlechrome.github.io';
-  const VIEWER_URL = `${VIEWER_ORIGIN}/lighthouse/viewer/`;
+class LighthouseReport {
 
-  // Chrome doesn't allow us to immediately postMessage to a popup right
-  // after it's created. Normally, we could also listen for the popup window's
-  // load event, however it is cross-domain and won't fire. Instead, listen
-  // for a message from the target app saying "I'm open".
-  window.addEventListener('message', function msgHandler(e) {
-    if (e.origin !== VIEWER_ORIGIN) {
-      return;
+  /**
+   * @param {Object=} lhresults Lighthouse JSON results.
+   */
+  constructor(lhresults) {
+    this.json = lhresults || null;
+    this._addEventListeners();
+  }
+
+  _addEventListeners() {
+    this._setupExpandDetailsWhenPrinting();
+
+    const printButton = document.querySelector('.js-print');
+    if (printButton) {
+      printButton.addEventListener('click', _ => window.print());
     }
 
-    if (e.data.opened) {
-      popup.postMessage({lhresults: window.lhresults}, VIEWER_ORIGIN);
-      window.removeEventListener('message', msgHandler);
+    const openButton = document.querySelector('.js-open');
+    if (openButton) {
+      openButton.addEventListener('click', this.sendJSONReport.bind(this));
     }
-  });
+  }
 
-  const popup = window.open(VIEWER_URL, '_blank');
-}
+  /**
+   * Opens a new tab to the online viewer and sends the local page's JSON results
+   * to the online viewer using postMessage.
+   */
+  sendJSONReport() {
+    const VIEWER_ORIGIN = 'https://googlechrome.github.io';
+    const VIEWER_URL = `${VIEWER_ORIGIN}/lighthouse/viewer/`;
 
-/**
- * Sets up listeners to expand audit `<details>` when the user prints the page.
- * Ideally, a print stylesheet could take care of this, but CSS has no way to
- * open a `<details>` element. When the user closes the print dialog, all
- * `<details>` are collapsed.
- */
-function expandDetailsWhenPrinting() {
-  const details = Array.from(document.querySelectorAll('details'));
+    // Chrome doesn't allow us to immediately postMessage to a popup right
+    // after it's created. Normally, we could also listen for the popup window's
+    // load event, however it is cross-domain and won't fire. Instead, listen
+    // for a message from the target app saying "I'm open".
+    window.addEventListener('message', function msgHandler(e) {
+      if (e.origin !== VIEWER_ORIGIN) {
+        return;
+      }
 
-  // FF and IE implement these old events.
-  if ('onbeforeprint' in window) {
-    window.addEventListener('beforeprint', _ => {
-      details.map(detail => detail.open = true);
-    });
-    window.addEventListener('afterprint', _ => {
-      details.map(detail => detail.open = false);
-    });
-  } else {
-    // Note: while FF has media listeners, it doesn't fire when matching 'print'.
-    window.matchMedia('print').addListener(mql => {
-      details.map(detail => detail.open = mql.matches);
-    });
+      if (e.data.opened) {
+        popup.postMessage({lhresults: this.json}, VIEWER_ORIGIN);
+        window.removeEventListener('message', msgHandler);
+      }
+    }.bind(this));
+
+    const popup = window.open(VIEWER_URL, '_blank');
+  }
+
+  /**
+   * Sets up listeners to expand audit `<details>` when the user prints the page.
+   * Ideally, a print stylesheet could take care of this, but CSS has no way to
+   * open a `<details>` element. When the user closes the print dialog, all
+   * `<details>` are collapsed.
+   */
+  _setupExpandDetailsWhenPrinting() {
+    const details = Array.from(document.querySelectorAll('details'));
+
+    // FF and IE implement these old events.
+    if ('onbeforeprint' in window) {
+      window.addEventListener('beforeprint', _ => {
+        details.map(detail => detail.open = true);
+      });
+      window.addEventListener('afterprint', _ => {
+        details.map(detail => detail.open = false);
+      });
+    } else {
+      // Note: while FF has media listeners, it doesn't fire when matching 'print'.
+      window.matchMedia('print').addListener(mql => {
+        details.map(detail => detail.open = mql.matches);
+      });
+    }
   }
 }
 
 window.addEventListener('DOMContentLoaded', _ => {
-  expandDetailsWhenPrinting();
-
-  const printButton = document.querySelector('.js-print');
-  printButton.addEventListener('click', _ => {
-    window.print();
-  });
-
-  const openButton = document.querySelector('.js-open');
-  openButton.addEventListener('click', sendJSONReport);
+  new LighthouseReport(window.lhresults);
 });


### PR DESCRIPTION
R: all

This looks scarier than it is. It's a small refactor of the main report into a class. The idea is that other views can subclass the main report functionality. This is working towards https://github.com/GoogleChrome/lighthouse/issues/1166 and a cherry pick from https://github.com/GoogleChrome/lighthouse/pull/1169/files. 

Note: `class` and `=>` support is really good theses days, so not worried about any x-browser issues. 