### PR TITLE
track enabled debugger domains for safe simultaneous use

### DIFF
--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -100,7 +100,8 @@ class Connection {
       // handleRawError returns or throws synchronously; wrap to put into promise chain.
       return callback.resolve(Promise.resolve().then(_ => {
         if (object.error) {
-          return this.handleRawError(object.error, callback.method);
+          log.formatProtocol('method <= browser ERR', {method: callback.method}, 'error');
+          throw new Error(`Protocol error (${callback.method}): ${object.error.message}`);
         }
 
         log.formatProtocol('method <= browser OK',
@@ -111,27 +112,6 @@ class Connection {
     log.formatProtocol('<= event',
         {method: object.method, params: object.params}, 'verbose');
     this.emitNotification(object.method, object.params);
-  }
-
-  /**
-   * Handles error responses from the protocol, absorbing errors we don't care
-   * about and throwing on the rest.
-   *
-   * Currently the only error ignored is from defensive calls of `DOM.disable`
-   * when already disabled.
-   * @param {{message: string}} error
-   * @param {string} method Protocol method that received the error response.
-   * @throws {Error}
-   * @protected
-   */
-  handleRawError(error, method) {
-    // We proactively disable the DOM domain. Ignore any errors.
-    if (error.message && error.message.includes('DOM agent hasn\'t been enabled')) {
-      return;
-    }
-
-    log.formatProtocol('method <= browser ERR', {method}, 'error');
-    throw new Error(`Protocol error (${method}): ${error.message}`);
   }
 
   /**

--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -121,12 +121,10 @@ class Styles extends Gatherer {
       Promise.all(contentPromises).then(styleHeaders => {
         driver.off('CSS.styleSheetAdded', this._onStyleSheetAdded);
         driver.off('CSS.styleSheetRemoved', this._onStyleSheetRemoved);
-        resolve(styleHeaders);
-        // Currently both CSSUsage and Styles use these domains, so let it disable there.
-        // TODO: have a better way to specify used domains
-        // return driver.sendCommand('CSS.disable')
-        //   .then(_ => driver.sendCommand('DOM.disable'))
-        //   .then(_ => resolve(styleHeaders));
+
+        return driver.sendCommand('CSS.disable')
+          .then(_ => driver.sendCommand('DOM.disable'))
+          .then(_ => resolve(styleHeaders));
       }).catch(err => reject(err));
     });
   }


### PR DESCRIPTION
gatherRunner, driver, and gatherers enable and disable domains at will, and we currently have no system for tracking the state of them so that they don't interfere with each other. This has happened a few times in the past and it's difficult to track down why e.g. an event never fires because someone else disabled the domain you were listening to. Most recently this came up in [#1421](https://github.com/GoogleChrome/lighthouse/pull/1421/files#diff-99ebf6049dff383295940e4dc7b63754R125) where the `styles` and `css-usage` gatherers interfere when cleaning up after themselves.

This PR tracks `enable` and `disable` commands sent through the driver, eliminates redundant calls and prevents disabling by one user of the domain if others have also enabled it but have not yet disabled it.

The second commit is removing some of the places I've remembered us guarding against ourselves which is less necessary after this change.