### PR TITLE
Show runtime configuration on report

### DIFF
--- a/lighthouse-cli/performance-experiment/report/partials/config-panel.html
+++ b/lighthouse-cli/performance-experiment/report/partials/config-panel.html
@@ -63,9 +63,9 @@
   line-height: 17px;
 }
 
-.config-panel .url-blocking-entry__cancel-button {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 11v2h10v-2H7zm5-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>');
+.config-panel .url-blocking-entry__button {
   display: flex;
+  flex: 0 0 auto;
   padding: 0 0 0 0px;
   width: 18px;
   height: 18px;
@@ -76,17 +76,12 @@
   background-color: transparent;
 }
 
-.config-panel .url-blocking-entry__add-button {
+.config-panel .url-blocking-entry__button.cancel {
+  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 11v2h10v-2H7zm5-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>');
+}
+
+.config-panel .url-blocking-entry__button.add {
   background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/></svg>');
-  display: flex;
-  padding: 0 0 0 0px;
-  width: 18px;
-  height: 18px;
-  border: none;
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: 16px 16px;
-  background-color: transparent;
 }
 
 @media screen and (max-width: 767px) {
@@ -95,7 +90,7 @@
     width: 100%;
   }
   .config-panel__header {
-    padding-right: 2px;
+    padding-right: 20px;
   }
 }
 
@@ -242,12 +237,12 @@
         <ul class="url-blocking-patterns js-url-blocking-patterns">
           <template class="url-blocking-entry">
             <li class="url-blocking-entry" data-url-pattern="">
-              <button class="url-blocking-entry__cancel-button"></button>
+              <button class="url-blocking-entry__button cancel"></button>
               <div class="url-blocking-entry__pattern"></div>
             </li>
           </template>
           <li class="url-blocking-entry">
-            <button class="url-blocking-entry__add-button js-add-button"></button>
+            <button class="url-blocking-entry__button add js-add-button"></button>
             <input class="url-blocking-entry__pattern js-pattern-input" placeholder="URL blocking Patterns (* for wild card) e.g. *://www.evil.com/*">
           </li>
         </ul>

--- a/lighthouse-cli/performance-experiment/report/partials/config-panel.html
+++ b/lighthouse-cli/performance-experiment/report/partials/config-panel.html
@@ -27,6 +27,10 @@
 .config-panel__message {
   flex: 1 1 0;
   padding: 0 10px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  line-height: 25px;
 }
 
 .config-panel__panel-toggle {
@@ -57,8 +61,10 @@
 }
 
 .config-panel .url-blocking-entry__pattern {
-  flex: 1 0 auto;
-  display: flex;
+  flex: 1 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   margin-left: 10px;
   line-height: 17px;
 }

--- a/lighthouse-cli/performance-experiment/report/partials/config-panel.html
+++ b/lighthouse-cli/performance-experiment/report/partials/config-panel.html
@@ -26,7 +26,6 @@
 
 .config-panel__message {
   flex: 1 1 0;
-  padding: 0 10px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -34,7 +33,7 @@
 }
 
 .config-panel__panel-toggle {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"/><path d="M0-.25h24v24H0z" fill="none"/></svg>');
   width: 24px;
   height: 24px;
   border: none;
@@ -43,11 +42,11 @@
   background-position: center center;
   background-size: contain;
   background-color: transparent;
-  margin-left: 8px;
+  margin: 0 8px 0 8px;
 }
 
 .config-panel.expanded .config-panel__panel-toggle {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }
 
 .config-panel .url-blocking-entry {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -34,6 +34,7 @@ const path = require('path');
  *     iv. evaluateScriptOnLoad rescue native Promise from potential polyfill
  *     v. cleanAndDisableBrowserCaches
  *     vi. clearDataForOrigin
+ *     vii. blockUrlPatterns
  *
  * 2. For each pass in the config:
  *   A. GatherRunner.beforePass()

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -128,11 +128,23 @@ function disableCPUThrottling(driver) {
   return driver.sendCommand('Emulation.setCPUThrottlingRate', NO_CPU_THROTTLE_METRICS);
 }
 
+function getEmulationDesc() {
+  const {latency, downloadThroughput, uploadThroughput} = TYPICAL_MOBILE_THROTTLING_METRICS;
+  const byteToMbit = bytes => (bytes / 1024 / 1024 * 8).toFixed(1);
+  return {
+    'deviceEmulation': 'Nexus 5X',
+    'cpuThrottling': `${CPU_THROTTLE_METRICS.rate}x slowdown`,
+    'networkThrottling': `${latency} RTT, ${byteToMbit(downloadThroughput)} down, ` +
+        `${byteToMbit(uploadThroughput)} up`
+  };
+}
+
 module.exports = {
   enableNexus5X,
   enableNetworkThrottling,
   disableNetworkThrottling,
   enableCPUThrottling,
   disableCPUThrottling,
-  goOffline
+  goOffline,
+  getEmulationDesc
 };

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -134,8 +134,8 @@ function getEmulationDesc() {
   return {
     'deviceEmulation': 'Nexus 5X',
     'cpuThrottling': `${CPU_THROTTLE_METRICS.rate}x slowdown`,
-    'networkThrottling': `${latency} RTT, ${byteToMbit(downloadThroughput)} down, ` +
-        `${byteToMbit(uploadThroughput)} up`
+    'networkThrottling': `${latency}ms RTT, ${byteToMbit(downloadThroughput)}Mbps down, ` +
+        `${byteToMbit(uploadThroughput)}Mbps up`
   };
 }
 

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -318,6 +318,13 @@ class ReportGenerator {
       });
     });
 
+    const flags = results.opts.flags;
+    const environment = [
+      {name: 'Device Emulation Disabled', value: flags.disableDeviceEmulation === true},
+      {name: 'CPU Throttling Disabled', value: flags.disableCpuThrottling === true},
+      {name: 'Network Throttling Disabled', value: flags.disableNetworkThrottling === true}
+    ];
+
     const template = Handlebars.compile(this.getReportTemplate());
 
     return template({
@@ -329,7 +336,8 @@ class ReportGenerator {
       reportContext: reportContext,
       scripts: this.getReportJS(reportContext),
       aggregations: results.aggregations,
-      auditsByCategory: this._createPWAAuditsByCategory(results.aggregations)
+      auditsByCategory: this._createPWAAuditsByCategory(results.aggregations),
+      runtimeConfig: {environment, blockedUrlPatterns: flags.blockedUrlPatterns}
     });
   }
 }

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -318,13 +318,6 @@ class ReportGenerator {
       });
     });
 
-    const flags = results.opts.flags;
-    const environment = [
-      {name: 'Device Emulation Disabled', value: flags.disableDeviceEmulation === true},
-      {name: 'CPU Throttling Disabled', value: flags.disableCpuThrottling === true},
-      {name: 'Network Throttling Disabled', value: flags.disableNetworkThrottling === true}
-    ];
-
     const template = Handlebars.compile(this.getReportTemplate());
 
     return template({
@@ -337,7 +330,7 @@ class ReportGenerator {
       scripts: this.getReportJS(reportContext),
       aggregations: results.aggregations,
       auditsByCategory: this._createPWAAuditsByCategory(results.aggregations),
-      runtimeConfig: {environment, blockedUrlPatterns: flags.blockedUrlPatterns}
+      runtimeConfig: results.runtimeConfig
     });
   }
 }

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -41,6 +41,10 @@ class LighthouseReport {
     if (openButton) {
       openButton.addEventListener('click', this.sendJSONReport.bind(this));
     }
+
+    const headerContainer = document.querySelector('.js-fixed-header-container');
+    const toggleButton = headerContainer.querySelector('.js-header-toggle');
+    toggleButton.addEventListener('click', () => headerContainer.classList.toggle('expanded'));
   }
 
   /**

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -42,7 +42,7 @@ class LighthouseReport {
       openButton.addEventListener('click', this.sendJSONReport.bind(this));
     }
 
-    const headerContainer = document.querySelector('.js-fixed-header-container');
+    const headerContainer = document.querySelector('.js-header-container');
     const toggleButton = headerContainer.querySelector('.js-header-toggle');
     toggleButton.addEventListener('click', () => headerContainer.classList.toggle('expanded'));
   }

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -217,7 +217,6 @@ body {
 }
 
 .report-body__aggregations-container {
-  padding-top: var(--report-header-height);
   will-change: transform;
 }
 
@@ -327,7 +326,7 @@ body {
 .report-body__metadata {
   flex: 1 1 0;
   white-space: nowrap;
-  padding: 0 10px;
+  padding-right: 10px;
 }
 
 .report-body__buttons {
@@ -364,28 +363,22 @@ body {
   border: none;
 }
 
-.report-body__fixed-header-container {
+.report-body__header-container {
   background: #FAFAFA;
-  margin-left: var(--report-menu-width);
-  position: fixed;
-  will-change: transform;
-  z-index: 1;
-  max-width: calc( var(--report-width) - var(--report-menu-width));
-  width: calc(100vw - var(--report-menu-width));
 }
 
 .report-body__header {
   height: var(--report-header-height);
-  border-bottom: 1px solid #EBEBEB;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
   padding: 0 var(--heading-line-height) 0 0;
+  border-bottom: 1px solid #EBEBEB;
 }
 
 .report-body__header-toggle {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"/><path d="M0-.25h24v24H0z" fill="none"/></svg>');
   width: 24px;
   height: 24px;
   border: none;
@@ -394,46 +387,44 @@ body {
   background-position: center center;
   background-size: contain;
   background-color: transparent;
-  margin-left: 8px;
+  margin: 0 8px 0 8px;
 }
 
-.report-body__fixed-header-container.expanded .report-body__header-toggle {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+.report-body__header-container.expanded .report-body__header-toggle {
+  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }
 
-.report-body__header-dropdown {
+.report-body__header-content {
   display: none;
-  border-bottom: 1px solid #EBEBEB;
-  padding: 10px 10px 10px 20px;
-  overflow-y: scroll;
-  max-height: 250px;
+  padding: 10px 0 10px 42px;
 }
 
-.report-body__fixed-header-container.expanded .report-body__header-dropdown {
+.report-body__header-container.expanded .report-body__header-content {
   display: block;
+  border-bottom: 1px solid #EBEBEB;
 }
 
-.report-body__header-dropdown .config-section {
-  padding: 10px;
+.report-body__header-content .config-section {
+  padding: 15px 0 15px 0;
 }
 
-.report-body__header-dropdown .config-section__title {
+.report-body__header-content .config-section__title {
   font-size: var(--subheading-font-size);
   font-weight: normal;
   line-height: var(--subheading-line-height);
   color: var(--subheading-color);
 }
 
-.report-body__header-dropdown .config-section__items {
+.report-body__header-content .config-section__items {
   margin-left: 30px;
   margin-top: 15px;
 }
 
-.report-body__header-dropdown .config-section__item {
+.report-body__header-content .config-section__item {
   margin-top: 5px;
 }
 
-.report-body__header-dropdown .config-section__desc {
+.report-body__header-content .config-section__desc {
   line-height: var(--subitem-line-height);
   word-wrap: break-word;
 }
@@ -848,6 +839,7 @@ body {
 
 .export-section {
   position: relative;
+  display: none;
 }
 
 .export-button {
@@ -863,7 +855,6 @@ body {
   color: var(--secondary-text-color);
   outline: 0;
   font-weight: 500;
-  display: none;
 }
 
 .export-dropdown {
@@ -921,7 +912,7 @@ body {
     box-shadow: none;
   }
 
-  .report-body__fixed-header-container,
+  .report-body__header-container,
   .report-body__menu-container {
     display: none;
   }
@@ -950,16 +941,14 @@ body {
     display: none;
   }
   .report-body__content,
-  .report-body__fixed-header-container,
   .report-body__fixed-footer-container {
     margin-left: 0;
   }
-  .report-body__fixed-header-container,
   .report-body__fixed-footer-container {
     width: 100%;
   }
   .report-body__header {
-    padding: 0 8px 0 0;
+    padding-right: 8px;
   }
   .export-dropdown {
     right: 0;
@@ -987,7 +976,7 @@ body {
   display: none;
 }
 
-:root[data-report-context="devtools"] .report-body__fixed-header-container {
+:root[data-report-context="devtools"] .report-body__header-container {
   display: none;
 }
 
@@ -1000,6 +989,6 @@ body {
 }
 
 :root[data-report-context="viewer"] .share,
-:root[data-report-context="viewer"] .export-button {
+:root[data-report-context="viewer"] .export-section {
   display: initial;
 }

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -410,11 +410,10 @@ body {
 }
 
 .report-body__fixed-header-container.expanded .report-body__header-dropdown {
-  display: flex;
+  display: block;
 }
 
 .report-body__header-dropdown .config-section {
-  flex: 1 1 auto;
   padding: 10px;
 }
 
@@ -432,6 +431,11 @@ body {
 
 .report-body__header-dropdown .config-section__item {
   margin-top: 5px;
+}
+
+.report-body__header-dropdown .config-section__desc {
+  line-height: var(--subitem-line-height);
+  word-wrap: break-word;
 }
 
 .report-body__fixed-footer-container {

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -854,19 +854,6 @@ body {
   outline: 0;
 }
 
-.report-body__icon {
-  width: 24px;
-  height: 24px;
-  border: none;
-  cursor: pointer;
-  flex: 0 0 auto;
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: contain;
-  background-color: transparent;
-  margin-left: 8px;
-}
-
 .runtime-config__icon {
   width: 18px;
   height: 18px;

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -327,6 +327,7 @@ body {
 .report-body__metadata {
   flex: 1 1 0;
   white-space: nowrap;
+  padding: 0 10px;
 }
 
 .report-body__buttons {
@@ -363,21 +364,74 @@ body {
   border: none;
 }
 
-.report-body__header {
-  height: var(--report-header-height);
-  border-bottom: 1px solid #EBEBEB;
+.report-body__fixed-header-container {
   background: #FAFAFA;
   margin-left: var(--report-menu-width);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 0 var(--heading-line-height);
   position: fixed;
   will-change: transform;
   z-index: 1;
   max-width: calc( var(--report-width) - var(--report-menu-width));
   width: calc(100vw - var(--report-menu-width));
+}
+
+.report-body__header {
+  height: var(--report-header-height);
+  border-bottom: 1px solid #EBEBEB;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0 var(--heading-line-height) 0 0;
+}
+
+.report-body__header-toggle {
+  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  width: 24px;
+  height: 24px;
+  border: none;
+  flex: 0 0 auto;
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: contain;
+  background-color: transparent;
+  margin-left: 8px;
+}
+
+.report-body__fixed-header-container.expanded .report-body__header-toggle {
+  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+}
+
+.report-body__header-dropdown {
+  display: none;
+  border-bottom: 1px solid #EBEBEB;
+  padding: 10px 10px 10px 20px;
+  overflow-y: scroll;
+  max-height: 250px;
+}
+
+.report-body__fixed-header-container.expanded .report-body__header-dropdown {
+  display: flex;
+}
+
+.report-body__header-dropdown .config-section {
+  flex: 1 1 auto;
+  padding: 10px;
+}
+
+.report-body__header-dropdown .config-section__title {
+  font-size: var(--subheading-font-size);
+  font-weight: normal;
+  line-height: var(--subheading-line-height);
+  color: var(--subheading-color);
+}
+
+.report-body__header-dropdown .config-section__items {
+  margin-left: 30px;
+  margin-top: 15px;
+}
+
+.report-body__header-dropdown .config-section__item {
+  margin-top: 5px;
 }
 
 .report-body__fixed-footer-container {
@@ -854,30 +908,6 @@ body {
   outline: 0;
 }
 
-.runtime-config__icon {
-  width: 18px;
-  height: 18px;
-  background-size: contain;
-  transform: translate(0, 1px);
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: contain;
-  background-color: transparent;
-}
-
-.runtime-config__icon.cross {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
-}
-
-.runtime-config__icon.check {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/></svg>');
-}
-
-.runtime-config__icon.dot {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M24 24H0V0h24v24z" fill="none"/><circle cx="12" cy="12" fill="#010101" r="8"/></svg>');
-  background-size: 10px;
-}
-
 @media print {
   body {
     -webkit-print-color-adjust: exact; /* print background colors */
@@ -887,7 +917,7 @@ body {
     box-shadow: none;
   }
 
-  .report-body__header,
+  .report-body__fixed-header-container,
   .report-body__menu-container {
     display: none;
   }
@@ -916,16 +946,16 @@ body {
     display: none;
   }
   .report-body__content,
-  .report-body__header,
+  .report-body__fixed-header-container,
   .report-body__fixed-footer-container {
     margin-left: 0;
   }
-  .report-body__header,
+  .report-body__fixed-header-container,
   .report-body__fixed-footer-container {
     width: 100%;
   }
   .report-body__header {
-    padding: 8px;
+    padding: 0 8px 0 0;
   }
   .export-dropdown {
     right: 0;
@@ -953,7 +983,7 @@ body {
   display: none;
 }
 
-:root[data-report-context="devtools"] .report-body__header {
+:root[data-report-context="devtools"] .report-body__fixed-header-container {
   display: none;
 }
 

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -854,6 +854,43 @@ body {
   outline: 0;
 }
 
+.report-body__icon {
+  width: 24px;
+  height: 24px;
+  border: none;
+  cursor: pointer;
+  flex: 0 0 auto;
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: contain;
+  background-color: transparent;
+  margin-left: 8px;
+}
+
+.runtime-config__icon {
+  width: 18px;
+  height: 18px;
+  background-size: contain;
+  transform: translate(0, 1px);
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-color: transparent;
+}
+
+.runtime-config__icon.cross {
+  background-image: url('data:image/svg+xml;utf8,<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+}
+
+.runtime-config__icon.check {
+  background-image: url('data:image/svg+xml;utf8,<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/></svg>');
+}
+
+.runtime-config__icon.dot {
+  background-image: url('data:image/svg+xml;utf8,<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M24 24H0V0h24v24z" fill="none"/><circle cx="12" cy="12" fill="#010101" r="8"/></svg>');
+  background-size: 10px;
+}
+
 @media print {
   body {
     -webkit-print-color-adjust: exact; /* print background colors */

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -46,9 +46,6 @@ limitations under the License.
               </a>
             </li>
             {{/each}}
-            <li class="menu__nav-item">
-              <a class="menu__link" href="#runtime-configuration">Runtime Configuration</a>
-            </li>
           </ul>
         </div>
       </div>
@@ -85,7 +82,7 @@ limitations under the License.
               <li class="config-section__item">
                 <p class="config-section__desc">
                   {{ this.name }} ({{ this.description }}):
-                  <strong> {{#if this.value }}Enabled{{else}}Disabled{{/if}}</strong>
+                  <strong> {{#if this.enabled }}Enabled{{else}}Disabled{{/if}}</strong>
                 </p>
               </li>
               {{/each}}

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -48,7 +48,7 @@ limitations under the License.
               <a href="#" data-action="save-json">Save as JSON...</a>
             </ul>
           </span>
-          <button class="report-body__icon share js-share" title="Share report on Github"></button>
+          <button class="report-body__icon share js-share" title="Share report on GitHub"></button>
           <button class="report-body__icon copy js-copy" title="Copy JSON report"></button>
           <button class="report-body__icon open js-open" title="Open in Lighthouse Viewer"></button>
           {{#if_not_eq reportContext "viewer"}}
@@ -62,8 +62,8 @@ limitations under the License.
           <ul class="config-section__items">
             {{#each runtimeConfig.environment }}
             <li class="config-section__item">
-              <p class="subitem__desc">
-                {{ this.name }}: {{#if this.value }}Enabled{{else}}Disabled{{/if}}
+              <p class="config-section__desc">
+                {{ this.name }} ({{ this.description }}): {{#if this.value }}Enabled{{else}}Disabled{{/if}}
               </p>
             </li>
             {{/each}}
@@ -75,7 +75,7 @@ limitations under the License.
           <ul class="config-section__items">
             {{#each runtimeConfig.blockedUrlPatterns }}
             <li class="config-section__item">
-              <p class="subitem__desc">{{ this }}</p>
+              <p class="config-section__desc">{{ this }}</p>
             </li>
             {{/each}}
           </ul>

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -31,27 +31,56 @@ limitations under the License.
 
 <div class="js-report report">
   <section class="report-body">
-    <div class="report-body__header">
-      <div class="report-body__metadata">
-        <div class="report-body__url">Results for: <a href="{{ url }}" target="_blank">{{ url }}</a></div>
-        <div class="report-body__url">Generated on: {{generatedTime}}</div>
+    <div class="report-body__fixed-header-container js-fixed-header-container">
+      <div class="report-body__header">
+        <button class="report-body__header-toggle js-header-toggle"></button>
+        <div class="report-body__metadata">
+          <div class="report-body__url">Results for: <a href="{{ url }}" target="_blank">{{ url }}</a></div>
+          <div class="report-body__url">Generated on: {{generatedTime}}</div>
+        </div>
+        <div class="report-body__buttons">
+          <span class="export-section">
+            <button class="export-button js-export" title="Export report in different formats">Export...</button>
+            <ul class="export-dropdown">
+              <a href="#" data-action="print">Print...</a>
+              <a href="#" data-action="copy">Copy JSON...</a>
+              <a href="#" data-action="save-html">Save as HTML...</a>
+              <a href="#" data-action="save-json">Save as JSON...</a>
+            </ul>
+          </span>
+          <button class="report-body__icon share js-share" title="Share report on Github"></button>
+          <button class="report-body__icon copy js-copy" title="Copy JSON report"></button>
+          <button class="report-body__icon open js-open" title="Open in Lighthouse Viewer"></button>
+          {{#if_not_eq reportContext "viewer"}}
+            <button class="report-body__icon print js-print" title="Print HTML report"></button>
+          {{/if_not_eq}}
+        </div>
       </div>
-      <div class="report-body__buttons">
-        <span class="export-section">
-          <button class="export-button js-export" title="Export report in different formats">Export...</button>
-          <ul class="export-dropdown">
-            <a href="#" data-action="print">Print...</a>
-            <a href="#" data-action="copy">Copy JSON...</a>
-            <a href="#" data-action="save-html">Save as HTML...</a>
-            <a href="#" data-action="save-json">Save as JSON...</a>
+      <div class="report-body__header-dropdown">
+        <section class="config-section">
+          <h2 class="config-section__title">Runtime Environment</h2>
+          <ul class="config-section__items">
+            {{#each runtimeConfig.environment }}
+            <li class="config-section__item">
+              <p class="subitem__desc">
+                {{ this.name }}: {{#if this.value }}Enabled{{else}}Disabled{{/if}}
+              </p>
+            </li>
+            {{/each}}
           </ul>
-        </span>
-        <button class="report-body__icon share js-share" title="Share report on GitHub"></button>
-        <button class="report-body__icon copy js-copy" title="Copy JSON report"></button>
-        <button class="report-body__icon open js-open" title="Open in Lighthouse Viewer"></button>
-        {{#if_not_eq reportContext "viewer"}}
-          <button class="report-body__icon print js-print" title="Print HTML report"></button>
-        {{/if_not_eq}}
+        </section>
+        {{#if runtimeConfig.blockedUrlPatterns }}
+        <section class="config-section">
+          <h2 class="config-section__title">Blocked URL Patterns</h2>
+          <ul class="config-section__items">
+            {{#each runtimeConfig.blockedUrlPatterns }}
+            <li class="config-section__item">
+              <p class="subitem__desc">{{ this }}</p>
+            </li>
+            {{/each}}
+          </ul>
+        </section>
+        {{/if}}
       </div>
     </div>
     <div class="report-body__content">
@@ -172,43 +201,6 @@ limitations under the License.
         </div>
       </section>
       {{/each}}
-      <section class="js-breakdown aggregations" id="runtime-configuration">
-        <header class="aggregations__header">
-          <h1>Runtime Configuration</h1>
-        </header>
-        <section class="aggregation">
-          <header class="aggregation__header">
-            <h2>Runtime Environment</h2>
-          </header>
-          <ul class="subitems">
-            {{#each runtimeConfig.environment }}
-            <li class="subitem runtime-env">
-              <p class="subitem__desc">{{ this.name }}</p>
-              <div class="subitem-result">
-                <div class="runtime-config__icon {{#if this.value }}check{{else}}cross{{/if}}"></div>
-              </div>
-            </li>
-            {{/each}}
-          </ul>
-        </section>
-        {{#if runtimeConfig.blockedUrlPatterns }}
-        <section class="aggregation">
-          <header class="aggregation__header">
-            <h2>Blocked URL Patterns</h2>
-          </header>
-          <ul class="subitems">
-            {{#each runtimeConfig.blockedUrlPatterns }}
-            <li class="subitem">
-              <p class="subitem__desc">{{ this }}</p>
-              <div class="subitem-result">
-                <div class="runtime-config__icon dot"></div>
-              </div>
-            </li>
-            {{/each}}
-          </ul>
-        </section>
-        {{/if}}
-      </section>
       </div>
     </div>
 

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -69,6 +69,9 @@ limitations under the License.
               </a>
             </li>
             {{/each}}
+            <li class="menu__nav-item">
+              <a class="menu__link" href="#runtime-configuration">Runtime Configuration</a>
+            </li>
           </ul>
         </div>
       </div>
@@ -169,6 +172,43 @@ limitations under the License.
         </div>
       </section>
       {{/each}}
+      <section class="js-breakdown aggregations" id="runtime-configuration">
+        <header class="aggregations__header">
+          <h1>Runtime Configuration</h1>
+        </header>
+        <section class="aggregation">
+          <header class="aggregation__header">
+            <h2>Runtime Environment</h2>
+          </header>
+          <ul class="subitems">
+            {{#each runtimeConfig.environment }}
+            <li class="subitem runtime-env">
+              <p class="subitem__desc">{{ this.name }}</p>
+              <div class="subitem-result">
+                <div class="runtime-config__icon {{#if this.value }}check{{else}}cross{{/if}}"></div>
+              </div>
+            </li>
+            {{/each}}
+          </ul>
+        </section>
+        {{#if runtimeConfig.blockedUrlPatterns }}
+        <section class="aggregation">
+          <header class="aggregation__header">
+            <h2>Blocked URL Patterns</h2>
+          </header>
+          <ul class="subitems">
+            {{#each runtimeConfig.blockedUrlPatterns }}
+            <li class="subitem">
+              <p class="subitem__desc">{{ this }}</p>
+              <div class="subitem-result">
+                <div class="runtime-config__icon dot"></div>
+              </div>
+            </li>
+            {{/each}}
+          </ul>
+        </section>
+        {{/if}}
+      </section>
       </div>
     </div>
 

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -84,8 +84,8 @@ limitations under the License.
               {{#each runtimeConfig.environment }}
               <li class="config-section__item">
                 <p class="config-section__desc">
-                  {{ this.name }} ({{ this.description }})
-                  <strong>: {{#if this.value }}Enabled{{else}}Disabled{{/if}}</strong>
+                  {{ this.name }} ({{ this.description }}):
+                  <strong> {{#if this.value }}Enabled{{else}}Disabled{{/if}}</strong>
                 </p>
               </li>
               {{/each}}

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -31,58 +31,6 @@ limitations under the License.
 
 <div class="js-report report">
   <section class="report-body">
-    <div class="report-body__fixed-header-container js-fixed-header-container">
-      <div class="report-body__header">
-        <button class="report-body__header-toggle js-header-toggle"></button>
-        <div class="report-body__metadata">
-          <div class="report-body__url">Results for: <a href="{{ url }}" target="_blank">{{ url }}</a></div>
-          <div class="report-body__url">Generated on: {{generatedTime}}</div>
-        </div>
-        <div class="report-body__buttons">
-          <span class="export-section">
-            <button class="export-button js-export" title="Export report in different formats">Export...</button>
-            <ul class="export-dropdown">
-              <a href="#" data-action="print">Print...</a>
-              <a href="#" data-action="copy">Copy JSON...</a>
-              <a href="#" data-action="save-html">Save as HTML...</a>
-              <a href="#" data-action="save-json">Save as JSON...</a>
-            </ul>
-          </span>
-          <button class="report-body__icon share js-share" title="Share report on GitHub"></button>
-          <button class="report-body__icon copy js-copy" title="Copy JSON report"></button>
-          <button class="report-body__icon open js-open" title="Open in Lighthouse Viewer"></button>
-          {{#if_not_eq reportContext "viewer"}}
-            <button class="report-body__icon print js-print" title="Print HTML report"></button>
-          {{/if_not_eq}}
-        </div>
-      </div>
-      <div class="report-body__header-dropdown">
-        <section class="config-section">
-          <h2 class="config-section__title">Runtime Environment</h2>
-          <ul class="config-section__items">
-            {{#each runtimeConfig.environment }}
-            <li class="config-section__item">
-              <p class="config-section__desc">
-                {{ this.name }} ({{ this.description }}): {{#if this.value }}Enabled{{else}}Disabled{{/if}}
-              </p>
-            </li>
-            {{/each}}
-          </ul>
-        </section>
-        {{#if runtimeConfig.blockedUrlPatterns }}
-        <section class="config-section">
-          <h2 class="config-section__title">Blocked URL Patterns</h2>
-          <ul class="config-section__items">
-            {{#each runtimeConfig.blockedUrlPatterns }}
-            <li class="config-section__item">
-              <p class="config-section__desc">{{ this }}</p>
-            </li>
-            {{/each}}
-          </ul>
-        </section>
-        {{/if}}
-      </div>
-    </div>
     <div class="report-body__content">
       <div class="report-body__menu-container">
         <div class="menu">
@@ -104,7 +52,59 @@ limitations under the License.
           </ul>
         </div>
       </div>
-
+      <div class="report-body__header-container js-header-container">
+        <div class="report-body__header">
+          <button class="report-body__header-toggle js-header-toggle"></button>
+          <div class="report-body__metadata">
+            <div class="report-body__url">Results for: <a href="{{ url }}" target="_blank">{{ url }}</a></div>
+            <div class="report-body__url">Generated on: {{generatedTime}}</div>
+          </div>
+          <div class="report-body__buttons">
+            <span class="export-section">
+              <button class="export-button js-export" title="Export report in different formats">Export...</button>
+              <ul class="export-dropdown">
+                <a href="#" data-action="print">Print...</a>
+                <a href="#" data-action="copy">Copy JSON...</a>
+                <a href="#" data-action="save-html">Save as HTML...</a>
+                <a href="#" data-action="save-json">Save as JSON...</a>
+              </ul>
+            </span>
+            <button class="report-body__icon share js-share" title="Share report on GitHub"></button>
+            <button class="report-body__icon copy js-copy" title="Copy JSON report"></button>
+            <button class="report-body__icon open js-open" title="Open in Lighthouse Viewer"></button>
+            {{#if_not_eq reportContext "viewer"}}
+              <button class="report-body__icon print js-print" title="Print HTML report"></button>
+            {{/if_not_eq}}
+          </div>
+        </div>
+        <div class="report-body__header-content">
+          <section class="config-section">
+            <h2 class="config-section__title">Runtime Environment</h2>
+            <ul class="config-section__items">
+              {{#each runtimeConfig.environment }}
+              <li class="config-section__item">
+                <p class="config-section__desc">
+                  {{ this.name }} ({{ this.description }})
+                  <strong>: {{#if this.value }}Enabled{{else}}Disabled{{/if}}</strong>
+                </p>
+              </li>
+              {{/each}}
+            </ul>
+          </section>
+          {{#if runtimeConfig.blockedUrlPatterns }}
+          <section class="config-section">
+            <h2 class="config-section__title">Blocked URL Patterns</h2>
+            <ul class="config-section__items">
+              {{#each runtimeConfig.blockedUrlPatterns }}
+              <li class="config-section__item">
+                <p class="config-section__desc">{{ this }}</p>
+              </li>
+              {{/each}}
+            </ul>
+          </section>
+          {{/if}}
+        </div>
+      </div>
       <div class="report-body__aggregations-container">
       {{#each aggregations}}
       <section class="js-breakdown aggregations" id="{{nameToLink this.name}}">

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -133,6 +133,15 @@ class Runner {
             a => Aggregate.aggregate(a, runResults.auditResults));
         }
 
+        const runtimeConfig = {
+          environment: [
+            {name: 'CPU Throttling Disabled', value: !!opts.flags.disableCpuThrottling},
+            {name: 'Network Throttling Disabled', value: !!opts.flags.disableNetworkThrottling},
+            {name: 'Device Emulation Disabled', value: !!opts.flags.disableDeviceEmulation}
+          ],
+          blockedUrlPatterns: opts.flags.blockedUrlPatterns || []
+        };
+
         return {
           lighthouseVersion: require('../package').version,
           generatedTime: (new Date()).toJSON(),
@@ -141,7 +150,7 @@ class Runner {
           audits: formattedAudits,
           artifacts: runResults.artifacts,
           aggregations,
-          opts
+          runtimeConfig
         };
       });
 

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -273,17 +273,17 @@ class Runner {
     const environment = [
       {
         name: 'CPU Throttling',
-        value: !flags.disableCpuThrottling,
+        enabled: !flags.disableCpuThrottling,
         description: emulationDesc['cpuThrottling']
       },
       {
         name: 'Network Throttling',
-        value: !flags.disableNetworkThrottling,
+        enabled: !flags.disableNetworkThrottling,
         description: emulationDesc['networkThrottling']
       },
       {
         name: 'Device Emulation',
-        value: !flags.disableDeviceEmulation,
+        enabled: !flags.disableDeviceEmulation,
         description: emulationDesc['deviceEmulation']
       }
     ];

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -135,9 +135,9 @@ class Runner {
 
         const runtimeConfig = {
           environment: [
-            {name: 'CPU Throttling Disabled', value: !!opts.flags.disableCpuThrottling},
-            {name: 'Network Throttling Disabled', value: !!opts.flags.disableNetworkThrottling},
-            {name: 'Device Emulation Disabled', value: !!opts.flags.disableDeviceEmulation}
+            {name: 'CPU Throttling', value: !opts.flags.disableCpuThrottling},
+            {name: 'Network Throttling', value: !opts.flags.disableNetworkThrottling},
+            {name: 'Device Emulation', value: !opts.flags.disableDeviceEmulation}
           ],
           blockedUrlPatterns: opts.flags.blockedUrlPatterns || []
         };

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -140,7 +140,8 @@ class Runner {
           url: opts.url,
           audits: formattedAudits,
           artifacts: runResults.artifacts,
-          aggregations
+          aggregations,
+          opts
         };
       });
 


### PR DESCRIPTION
Added a section at the end of the report page which shows the runtime configuration of this report (e.g. disable CUP throttling).
Screenshot [updated]:
![current-config](https://cloud.githubusercontent.com/assets/20240088/22046443/ce0d4478-dd74-11e6-849d-6b6eeab73e42.png)

Will add some test cases later.