### PR TITLE
A couple of package.json fixes.

### DIFF
--- a/lighthouse-cli/package.json
+++ b/lighthouse-cli/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "lighthouse-cli",
+  "private": true,
   "main": "index.js",
   "scripts": {
     "prepublish": "npm run build",

--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lighthouse",
+  "name": "lighthouse-extension",
   "private": true,
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
lighthouse-cli: specify name and private: true.
lighthouse-extension: fix name property.

The first fixes npm install warning `> undefined prepublish`.
The second fixes `npm ERR! Refusing to install lighthouse as a dependency of itself` when doing `npm run install-cli` or `npm run install-all`.