### PR TITLE
Start using errors instead of -1 for error artifacts

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -47,10 +47,6 @@ class NoOldFlexboxAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.Styles.rawValue === -1) {
-      return NoOldFlexboxAudit.generateAuditResult(artifacts.Styles);
-    }
-
     // https://www.w3.org/TR/2009/WD-css3-flexbox-20090723/
     // (e.g. box-flex, box-orient, box-flex-group, display: flexbox (2011 version))
     const propsNames = ['box-flex', 'box-orient', 'box-flex-group', 'display'];

--- a/lighthouse-core/audits/theme-color-meta.js
+++ b/lighthouse-core/audits/theme-color-meta.js
@@ -38,7 +38,7 @@ class ThemeColor extends Audit {
    */
   static audit(artifacts) {
     const themeColorMeta = artifacts.ThemeColor;
-    if (themeColorMeta === null || themeColorMeta === -1) {
+    if (themeColorMeta === null) {
       return ThemeColor.generateAuditResult({
         rawValue: false,
         debugString: 'No valid theme-color meta tag found.'

--- a/lighthouse-core/audits/unused-css-rules.js
+++ b/lighthouse-core/audits/unused-css-rules.js
@@ -132,12 +132,6 @@ class UnusedCSSRules extends Audit {
     const usage = artifacts.CSSUsage;
     const pageUrl = artifacts.URL.finalUrl;
 
-    if (styles.rawValue === -1) {
-      return UnusedCSSRules.generateAuditResult(styles);
-    } else if (usage.rawValue === -1) {
-      return UnusedCSSRules.generateAuditResult(usage);
-    }
-
     const indexedSheets = UnusedCSSRules.indexStylesheetsById(styles);
     const unused = UnusedCSSRules.countUnusedRules(usage, indexedSheets);
     const unusedRatio = (unused / usage.length) || 0;

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -39,10 +39,10 @@ class Viewport extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (typeof artifacts.Viewport !== 'string') {
+    if (artifacts.Viewport === null) {
       return Viewport.generateAuditResult({
-        debugString: 'Error in determining viewport',
-        rawValue: -1
+        debugString: 'No viewport meta tag found',
+        rawValue: false
       });
     }
 

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -29,8 +29,9 @@ class CSSUsage extends Gatherer {
       .catch(err => {
         // TODO(phulce): Remove this once CSS usage hits stable
         if (/startRuleUsageTracking/.test(err.message)) {
-          this.failure = 'CSS Usage tracking requires Chrome \u2265 56';
-          return;
+          const usageError = new Error('CSS Usage tracking requires Chrome \u2265 56');
+          usageError.recoverable = true;
+          throw usageError;
         }
 
         throw err;
@@ -44,11 +45,6 @@ class CSSUsage extends Gatherer {
       return driver.sendCommand('CSS.disable')
         .then(_ => driver.sendCommand('DOM.disable'))
         .then(_ => results.ruleUsage);
-    }).catch(err => {
-      return {
-        rawValue: -1,
-        debugString: this.failure || err,
-      };
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -147,11 +147,6 @@ class Styles extends Gatherer {
           stylesheet.isDuplicate = idInMap !== stylesheet.header.styleSheetId;
           return stylesheet;
         });
-      }, err => {
-        return {
-          rawValue: -1,
-          debugString: err
-        };
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/theme-color.js
+++ b/lighthouse-core/gather/gatherers/theme-color.js
@@ -20,14 +20,15 @@ const Gatherer = require('./gatherer');
 
 class ThemeColor extends Gatherer {
 
+  /**
+   * @param {{driver: !Object}} options Run options
+   * @return {!Promise<?string>} The value of the theme-color meta's content attribute, or null
+   */
   afterPass(options) {
     const driver = options.driver;
 
     return driver.querySelector('head meta[name="theme-color"]')
-      .then(node => node && node.getAttribute('content'))
-      .catch(_ => {
-        return -1;
-      });
+      .then(node => node && node.getAttribute('content'));
   }
 }
 

--- a/lighthouse-core/gather/gatherers/viewport.js
+++ b/lighthouse-core/gather/gatherers/viewport.js
@@ -21,17 +21,14 @@ const Gatherer = require('./gatherer');
 class Viewport extends Gatherer {
 
   /**
-   * @param {!{driver: !Object}} options Run options
+   * @param {{driver: !Object}} options Run options
    * @return {!Promise<?string>} The value of the viewport meta's content attribute, or null
    */
   afterPass(options) {
     const driver = options.driver;
 
     return driver.querySelector('head meta[name="viewport"]')
-      .then(node => node && node.getAttribute('content'))
-      .catch(_ => {
-        return -1;
-      });
+      .then(node => node && node.getAttribute('content'));
   }
 }
 

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -161,7 +161,7 @@ class Runner {
     return Promise.resolve().then(_ => {
       log.log('status', status);
 
-      // Return an early error if an artifact required for the audit is missing.
+      // Return an early error if an artifact required for the audit is missing or an error.
       for (const artifactName of audit.meta.requiredArtifacts) {
         const noArtifact = typeof artifacts[artifactName] === 'undefined';
 
@@ -175,6 +175,18 @@ class Runner {
           return audit.generateAuditResult({
             rawValue: -1,
             debugString: `Required ${artifactName} gatherer did not run.`
+          });
+        }
+
+        // If artifact was an error, it must be recoverable (or gatherRunner
+        // would have thrown). Output non-fatal error result on behalf of audit.
+        if (artifacts[artifactName] instanceof Error) {
+          const artifactError = artifacts[artifactName];
+          log.warn('Runner', `${artifactName} gatherer, required by audit ${audit.meta.name},` +
+            ` encountered an error: ${artifactError.message}`);
+          return audit.generateAuditResult({
+            rawValue: -1,
+            debugString: artifactError.message
           });
         }
       }

--- a/lighthouse-core/test/audits/dobetterweb/no-old-flexbox-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-old-flexbox-test.js
@@ -22,18 +22,6 @@ const stylesData = require('../../fixtures/styles-gatherer.json');
 /* eslint-env mocha */
 
 describe('Page does not use old CSS flexbox', () => {
-  it('debugString is present if gatherer fails', () => {
-    const debugString = 'No active stylesheets were collected.';
-    const auditResult = NoOldFlexboxAudit.audit({
-      Styles: {
-        rawValue: -1,
-        debugString: debugString
-      }
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('passes when no stylesheets were collected on the page', () => {
     const auditResult = NoOldFlexboxAudit.audit({
       Styles: []

--- a/lighthouse-core/test/audits/theme-color-meta-test.js
+++ b/lighthouse-core/test/audits/theme-color-meta-test.js
@@ -19,12 +19,12 @@
 const Audit = require('../../audits/theme-color-meta.js');
 const assert = require('assert');
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('HTML: theme-color audit', () => {
-  it('fails and warns when no value given', () => {
+  it('fails and warns when no theme-color meta tag found', () => {
     const nullColorAudit = Audit.audit({
-      ThemeColor: -1
+      ThemeColor: null
     });
 
     assert.equal(nullColorAudit.rawValue, false);

--- a/lighthouse-core/test/audits/unused-css-rules-test.js
+++ b/lighthouse-core/test/audits/unused-css-rules-test.js
@@ -118,17 +118,6 @@ describe('Best Practices: unused css rules audit', () => {
   });
 
   describe('#audit', () => {
-    it('fails when gatherers failed', () => {
-      const result = UnusedCSSAudit.audit({
-        URL: {finalUrl: ''},
-        CSSUsage: {rawValue: -1, debugString: 'It errored'},
-        Styles: []
-      });
-
-      assert.equal(result.debugString, 'It errored');
-      assert.equal(result.rawValue, -1);
-    });
-
     it('passes when rules are used', () => {
       const result = UnusedCSSAudit.audit({
         URL: {finalUrl: ''},

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -18,20 +18,12 @@
 const Audit = require('../../audits/viewport.js');
 const assert = require('assert');
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('Mobile-friendly: viewport audit', () => {
-  it('fails when no input present', () => {
-    const audit = Audit.audit({
-      Viewport: -1
-    });
-    assert.equal(audit.rawValue, -1);
-    assert.equal(audit.debugString, 'Error in determining viewport');
-  });
-
   it('fails when HTML does not contain a viewport meta tag', () => {
     return assert.equal(Audit.audit({
-      Viewport: ''
+      Viewport: null
     }).rawValue, false);
   });
 

--- a/lighthouse-core/test/gather/gatherers/theme-color-test.js
+++ b/lighthouse-core/test/gather/gatherers/theme-color-test.js
@@ -42,16 +42,4 @@ describe('Theme Color gatherer', () => {
       assert.equal(artifact, '#288A76');
     });
   });
-
-  it('handles driver failure', () => {
-    return themeColorGather.afterPass({
-      driver: {
-        querySelector() {
-          return Promise.reject('such a fail');
-        }
-      }
-    }).then(artifact => {
-      assert.equal(artifact, -1);
-    });
-  });
 });

--- a/lighthouse-core/test/gather/gatherers/viewport-test.js
+++ b/lighthouse-core/test/gather/gatherers/viewport-test.js
@@ -41,16 +41,4 @@ describe('Viewport gatherer', () => {
       assert.ok(/width=/gim.test(artifact));
     });
   });
-
-  it('handles driver failure', () => {
-    return viewportGather.afterPass({
-      driver: {
-        querySelector() {
-          return Promise.reject('such a fail');
-        }
-      }
-    }).then(artifact => {
-      assert.equal(artifact, -1);
-    });
-  });
 });


### PR DESCRIPTION
@ebidel @patrickhulce 

This is the next (and sort of last) major step of #941, actually using the recoverable Error infrastructure set up in #1122. Most easily reviewed by commit:

The first adds the last check needed in runner: if an artifact required for an audit is an Error it no longer runs the audit at all, instead directly generating an error result on behalf of the audit. This lets us leave out the -1 checks from all future audits.

This is opt-in for now while we feel this out, but also included are four gatherer conversions to just throwing an error when there's an error and the simplifications that allows in the audits that depend on them. The first two (meta viewport and theme-color) are simple, the last commit is giving that treatment to the slightly more complicated `Styles` and `CSSUsage` gatherers and the two audits that need them.

I think this is looking good so far. Thoughts?