### PR TITLE
Add table list formatter for HTML audits

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -31,7 +31,9 @@ module.exports = [
         score: false,
         extendedInfo: {
           value: {
-            length: 11
+            results: {
+              length: 11
+            }
           }
         }
       },
@@ -127,12 +129,21 @@ module.exports = [
           value: {
             // Note: This would normally be 7 but M56 defaults document-level
             // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
-            length: 4
+            results: {
+              length: 4
+            }
           }
         }
       },
       'uses-optimized-images': {
-        score: false
+        score: false,
+        extendedInfo: {
+          value: {
+            results: {
+              length: 1
+            }
+          }
+        }
       },
       'deprecations': {
         score: false,

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -58,8 +58,10 @@ class UsesHTTP2Audit extends Audit {
       return sameHost && notH2;
     }).map(record => {
       return {
-        label: record.protocol,
-        url: record.url // .url is a getter and not copied over for the assign.
+        cols: [
+          record.url,
+          record.protocol
+        ]
       };
     });
 
@@ -74,8 +76,11 @@ class UsesHTTP2Audit extends Audit {
       rawValue: resources.length === 0,
       displayValue: displayValue,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
-        value: resources
+        formatter: Formatter.SUPPORTED_FORMATS.TABLE,
+        value: {
+          headings: ['URL', 'Protocol'],
+          rows: resources
+        }
       }
     });
   }

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -58,10 +58,8 @@ class UsesHTTP2Audit extends Audit {
       return sameHost && notH2;
     }).map(record => {
       return {
-        cols: [
-          record.url,
-          record.protocol
-        ]
+        protocol: record.protocol,
+        url: record.url // .url is a getter and not copied over for the assign.
       };
     });
 
@@ -72,14 +70,17 @@ class UsesHTTP2Audit extends Audit {
       displayValue = `${resources.length} request was not handled over h2`;
     }
 
+    const createTable = Formatter.getByName(
+        Formatter.SUPPORTED_FORMATS.TABLE).createTable;
+
     return UsesHTTP2Audit.generateAuditResult({
       rawValue: resources.length === 0,
       displayValue: displayValue,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
         value: {
-          headings: ['URL', 'Protocol'],
-          rows: resources
+          table: createTable({url: 'URL', protocol: 'Protocol'}, resources),
+          results: resources
         }
       }
     });

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -70,17 +70,14 @@ class UsesHTTP2Audit extends Audit {
       displayValue = `${resources.length} request was not handled over h2`;
     }
 
-    const createTable = Formatter.getByName(
-        Formatter.SUPPORTED_FORMATS.TABLE).createTable;
-
     return UsesHTTP2Audit.generateAuditResult({
       rawValue: resources.length === 0,
       displayValue: displayValue,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
         value: {
-          table: createTable({url: 'URL', protocol: 'Protocol'}, resources),
-          results: resources
+          results: resources,
+          tableHeadings: {url: 'URL', protocol: 'Protocol'}
         }
       }
     });

--- a/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
@@ -103,12 +103,10 @@ class UsesOptimizedImages extends Audit {
 
       totalWastedBytes += webpSavings.bytes;
       results.push({
-        cols: [
-          url,
-          `${originalKb} KB`,
-          `${webpSavings ? webpSavings.percent + '%' : ''}`,
-          `${jpegSavings ? jpegSavings.percent + '%' : ''}`
-        ]
+        url,
+        total: `${originalKb} KB`,
+        webpSavings: `${webpSavings ? webpSavings.percent + '%' : ''}`,
+        jpegSavings: `${jpegSavings ? jpegSavings.percent + '%' : ''}`
       });
       return results;
     }, []);
@@ -124,6 +122,16 @@ class UsesOptimizedImages extends Audit {
       debugString = `Lighthouse was unable to decode some of your images: ${urls.join(', ')}`;
     }
 
+    const createTable = Formatter.getByName(
+        Formatter.SUPPORTED_FORMATS.TABLE).createTable;
+
+    const table = createTable({
+      url: 'URL',
+      total: 'Original (KB)',
+      webpSavings: 'WebP savings',
+      jpegSavings: 'JPEG savings'
+    }, results);
+
     return UsesOptimizedImages.generateAuditResult({
       displayValue,
       debugString,
@@ -131,8 +139,8 @@ class UsesOptimizedImages extends Audit {
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
         value: {
-          headings: ['URL', 'Original (KB)', 'WebP savings', 'JPEG savings'],
-          rows: results
+          results,
+          table
         }
       }
     });

--- a/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
@@ -123,16 +123,6 @@ class UsesOptimizedImages extends Audit {
       debugString = `Lighthouse was unable to decode some of your images: ${urls.join(', ')}`;
     }
 
-    const createTable = Formatter.getByName(
-        Formatter.SUPPORTED_FORMATS.TABLE).createTable;
-
-    const table = createTable({
-      url: 'URL',
-      total: 'Original (KB)',
-      webpSavings: 'WebP savings',
-      jpegSavings: 'JPEG savings'
-    }, results);
-
     return UsesOptimizedImages.generateAuditResult({
       displayValue,
       debugString,
@@ -141,7 +131,12 @@ class UsesOptimizedImages extends Audit {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
         value: {
           results,
-          table
+          tableHeadings: {
+            url: 'URL',
+            total: 'Original (KB)',
+            webpSavings: 'WebP savings',
+            jpegSavings: 'JPEG savings'
+          }
         }
       }
     });

--- a/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
@@ -93,11 +93,12 @@ class UsesOptimizedImages extends Audit {
         hasAllEfficientImages = false;
       }
 
-      let jpegSavings;
+      let jpegSavingsLabel;
       if (/(jpeg|bmp)/.test(image.mimeType)) {
-        jpegSavings = UsesOptimizedImages.computeSavings(image, 'jpeg');
+        const jpegSavings = UsesOptimizedImages.computeSavings(image, 'jpeg');
         if (jpegSavings.bytes > 0) {
           hasAllEfficientImages = false;
+          jpegSavingsLabel = `${jpegSavings.percent}%`;
         }
       }
 
@@ -105,8 +106,8 @@ class UsesOptimizedImages extends Audit {
       results.push({
         url,
         total: `${originalKb} KB`,
-        webpSavings: `${webpSavings ? webpSavings.percent + '%' : ''}`,
-        jpegSavings: `${jpegSavings ? jpegSavings.percent + '%' : ''}`
+        webpSavings: `${webpSavings.percent}%`,
+        jpegSavings: jpegSavingsLabel
       });
       return results;
     }, []);

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -80,11 +80,39 @@ class PassiveEventsAudit extends Audit {
 
     const groupedResults = EventHelpers.groupCodeSnippetsByLocation(results);
 
+    function createTable(headings, results) {
+      const rows = results.map(result => {
+        const keys = Object.keys(headings);
+
+        const arr = [];
+        keys.forEach(key => {
+          switch (key) {
+            case 'code':
+              arr.push('`' + result[key].trim() + '`');
+              break;
+            case 'lineCol':
+              arr.push(`${result.line}:${result.col}`);
+              break;
+            default:
+              arr.push(result[key]);
+          }
+        });
+        return {cols: arr};
+      });
+
+      return {
+        headings: Object.keys(headings).map(key => headings[key]),
+        rows
+      };
+    }
+
     return PassiveEventsAudit.generateAuditResult({
       rawValue: groupedResults.length === 0,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
-        value: groupedResults
+        formatter: Formatter.SUPPORTED_FORMATS.TABLE,
+        value: createTable({
+          url: 'URL', lineCol: 'Line/Col', type: 'Type', code: 'Snippet'
+        }, groupedResults)
       },
       debugString
     });

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -80,20 +80,13 @@ class PassiveEventsAudit extends Audit {
 
     const groupedResults = EventHelpers.groupCodeSnippetsByLocation(results);
 
-    const createTable = Formatter.getByName(
-        Formatter.SUPPORTED_FORMATS.TABLE).createTable;
-
-    const table = createTable({
-      url: 'URL', lineCol: 'Line/Col', type: 'Type', code: 'Snippet'
-    }, groupedResults);
-
     return PassiveEventsAudit.generateAuditResult({
       rawValue: groupedResults.length === 0,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
         value: {
           results: groupedResults,
-          table
+          tableHeadings: {url: 'URL', lineCol: 'Line/Col', type: 'Type', code: 'Snippet'}
         }
       },
       debugString

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -80,39 +80,21 @@ class PassiveEventsAudit extends Audit {
 
     const groupedResults = EventHelpers.groupCodeSnippetsByLocation(results);
 
-    function createTable(headings, results) {
-      const rows = results.map(result => {
-        const keys = Object.keys(headings);
+    const createTable = Formatter.getByName(
+        Formatter.SUPPORTED_FORMATS.TABLE).createTable;
 
-        const arr = [];
-        keys.forEach(key => {
-          switch (key) {
-            case 'code':
-              arr.push('`' + result[key].trim() + '`');
-              break;
-            case 'lineCol':
-              arr.push(`${result.line}:${result.col}`);
-              break;
-            default:
-              arr.push(result[key]);
-          }
-        });
-        return {cols: arr};
-      });
-
-      return {
-        headings: Object.keys(headings).map(key => headings[key]),
-        rows
-      };
-    }
+    const table = createTable({
+      url: 'URL', lineCol: 'Line/Col', type: 'Type', code: 'Snippet'
+    }, groupedResults);
 
     return PassiveEventsAudit.generateAuditResult({
       rawValue: groupedResults.length === 0,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
-        value: createTable({
-          url: 'URL', lineCol: 'Line/Col', type: 'Type', code: 'Snippet'
-        }, groupedResults)
+        value: {
+          results: groupedResults,
+          table
+        }
       },
       debugString
     });

--- a/lighthouse-core/formatters/formatter.js
+++ b/lighthouse-core/formatters/formatter.js
@@ -44,6 +44,7 @@ class Formatter {
       urllist: require('./url-list'),
       null: require('./null-formatter'),
       speedline: require('./speedline-formatter'),
+      table: require('./table'),
       userTimings: require('./user-timings')
     };
   }

--- a/lighthouse-core/formatters/partials/table.html
+++ b/lighthouse-core/formatters/partials/table.html
@@ -44,18 +44,20 @@
 }
 </style>
 
-{{#if table.rows}}
+{{#createTable tableHeadings results }}
+
+{{#if rows}}
 <details class="subitem__details">
   <summary class="subitem__detail">More information</summary>
-  <table class="table_list {{#if_not_eq table.headings.length 2}}multicolumn{{/if_not_eq}}"
+  <table class="table_list {{#if_not_eq headings.length 2}}multicolumn{{/if_not_eq}}"
          cellspacing="0">
     <thead>
       <tr>
-        {{#each table.headings}}<th>{{this}}</th>{{/each}}
+        {{#each headings}}<th>{{this}}</th>{{/each}}
       </tr>
     </thead>
     <tbody>
-      {{#each table.rows}}
+      {{#each rows}}
         <tr>
           {{#each cols}}
             <td>{{ sanitize this}}</td>
@@ -66,3 +68,5 @@
   </table>
 </details>
 {{/if}}
+
+{{/createTable}}

--- a/lighthouse-core/formatters/partials/table.html
+++ b/lighthouse-core/formatters/partials/table.html
@@ -1,0 +1,68 @@
+<style>
+.table_list {
+  margin-top: 8px;
+  border: 1px solid #EBEBEB;
+  max-width: 100%;
+}
+.table_list th,
+.table_list td {
+  overflow: auto;
+}
+.table_list th {
+  background-color: #eee;
+  padding: 15px 10px;
+}
+.table_list td {
+  padding: 10px;
+}
+.table_list th:first-of-type,
+.table_list td:first-of-type {
+  min-width: 40%;
+  white-space: nowrap;
+}
+.table_list tr:nth-child(even) {
+  background-color: #fafafa;
+}
+.table_list tr:hover {
+  background-color: #fafafa;
+}
+.table_list code {
+  white-space: pre;
+  font-family: monospace;
+}
+
+.table_list.multicolumn {
+  display: flex;
+  flex-direction: column;
+}
+.table_list.multicolumn tr {
+  display: flex;
+}
+.table_list.multicolumn th,
+.table_list.multicolumn td {
+  flex: 1;
+}
+</style>
+
+{{#if rows}}
+<details class="subitem__details">
+  <summary class="subitem__detail">More information</summary>
+  <table class="table_list {{#if_not_eq headings.length 2}}multicolumn{{/if_not_eq}}"
+         cellspacing="0">
+    <thead>
+      <tr>
+        {{#each headings}}<th>{{this}}</th>{{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each rows}}
+        <tr>
+          {{#each cols}}
+            <td>{{ sanitize this}}</td>
+          {{/each}}
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</details>
+{{/if}}

--- a/lighthouse-core/formatters/partials/table.html
+++ b/lighthouse-core/formatters/partials/table.html
@@ -44,18 +44,18 @@
 }
 </style>
 
-{{#if rows}}
+{{#if table.rows}}
 <details class="subitem__details">
   <summary class="subitem__detail">More information</summary>
-  <table class="table_list {{#if_not_eq headings.length 2}}multicolumn{{/if_not_eq}}"
+  <table class="table_list {{#if_not_eq table.headings.length 2}}multicolumn{{/if_not_eq}}"
          cellspacing="0">
     <thead>
       <tr>
-        {{#each headings}}<th>{{this}}</th>{{/each}}
+        {{#each table.headings}}<th>{{this}}</th>{{/each}}
       </tr>
     </thead>
     <tbody>
-      {{#each rows}}
+      {{#each table.rows}}
         <tr>
           {{#each cols}}
             <td>{{ sanitize this}}</td>

--- a/lighthouse-core/formatters/table.js
+++ b/lighthouse-core/formatters/table.js
@@ -27,12 +27,16 @@ class Table extends Formatter {
     switch (type) {
       case 'pretty':
         return result => {
-          if (!Array.isArray(result.headings) || !Array.isArray(result.rows)) {
+          if (!result) {
+            return '';
+          }
+          if (!result.table || !Array.isArray(result.table.headings) ||
+              !Array.isArray(result.table.rows)) {
             return '';
           }
 
           let output = '';
-          result.rows.forEach(row => {
+          result.table.rows.forEach(row => {
             output += '      ';
             row.cols.forEach(col => {
               // Omit code snippet cols.
@@ -53,6 +57,35 @@ class Table extends Formatter {
       default:
         throw new Error('Unknown formatter type');
     }
+  }
+
+  /**
+   * Preps a formatted table (headings/col vals) for output.
+   * @param {!Object<string, string>} headings
+   * @param {!Array<*>} results Audit results.
+   * @return {!{headings: string, rows: [{cols: [*]}]}} headings
+   */
+  static createTable(headings, results) {
+    const headingKeys = Object.keys(headings);
+
+    const rows = results.map(result => {
+      const cols = headingKeys.map(key => {
+        switch (key) {
+          case 'code':
+            return '`' + result[key].trim() + '`';
+          case 'lineCol':
+            return `${result.line}:${result.col}`;
+          default:
+            return result[key];
+        }
+      });
+
+      return {cols};
+    });
+
+    headings = headingKeys.map(key => headings[key]);
+
+    return {headings, rows};
   }
 }
 

--- a/lighthouse-core/formatters/table.js
+++ b/lighthouse-core/formatters/table.js
@@ -64,7 +64,7 @@ class Table extends Formatter {
    * @param {!Object<string, string>} headings for the table. The order of this
    *     object's key/value will be the order of the table's headings.
    * @param {!Array<*>} results Audit results.
-   * @return {!{headings: string, rows: [{cols: [*]}]}} headings
+   * @return {{headings: Array<string>, rows: [{cols: [*]}]}} headings
    */
   static createTable(headings, results) {
     const headingKeys = Object.keys(headings);

--- a/lighthouse-core/formatters/table.js
+++ b/lighthouse-core/formatters/table.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Formatter = require('./formatter');
+const path = require('path');
+const fs = require('fs');
+const html = fs.readFileSync(path.join(__dirname, 'partials/table.html'), 'utf8');
+
+class Table extends Formatter {
+  static getFormatter(type) {
+    switch (type) {
+      case 'pretty':
+        return result => {
+          if (!Array.isArray(result.headings) || !Array.isArray(result.rows)) {
+            return '';
+          }
+
+          let output = '';
+          result.rows.forEach(row => {
+            output += '      ';
+            row.cols.forEach(col => {
+              // Omit code snippet cols.
+              if (col.startsWith('`') && col.endsWith('`')) {
+                return;
+              }
+              output += `${col} `;
+            });
+            output += '\n';
+          });
+          return output;
+        };
+
+      case 'html':
+        // Returns a handlebars string to be used by the Report.
+        return html;
+
+      default:
+        throw new Error('Unknown formatter type');
+    }
+  }
+}
+
+module.exports = Table;

--- a/lighthouse-core/formatters/table.js
+++ b/lighthouse-core/formatters/table.js
@@ -61,7 +61,8 @@ class Table extends Formatter {
 
   /**
    * Preps a formatted table (headings/col vals) for output.
-   * @param {!Object<string, string>} headings
+   * @param {!Object<string, string>} headings for the table. The order of this
+   *     object's key/value will be the order of the table's headings.
    * @param {!Array<*>} results Audit results.
    * @return {!{headings: string, rows: [{cols: [*]}]}} headings
    */
@@ -72,8 +73,10 @@ class Table extends Formatter {
       const cols = headingKeys.map(key => {
         switch (key) {
           case 'code':
+            // Wrap code snippets in markdown ticks.
             return '`' + result[key].trim() + '`';
           case 'lineCol':
+            // Create a combined line/col numbers for the lineCol key.
             return `${result.line}:${result.col}`;
           default:
             return result[key];

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -89,7 +89,7 @@ class ReportGenerator {
     // !value
     Handlebars.registerHelper('not', value => !value);
 
-    // value != value2
+    // value !== value2
     Handlebars.registerHelper('if_not_eq', function(lhs, rhs, options) {
       if (lhs !== rhs) {
         // eslint-disable-next-line no-invalid-this

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -89,7 +89,7 @@ class ReportGenerator {
     // !value
     Handlebars.registerHelper('not', value => !value);
 
-    // value == value2?
+    // value != value2
     Handlebars.registerHelper('if_not_eq', function(lhs, rhs, options) {
       if (lhs !== rhs) {
         // eslint-disable-next-line no-invalid-this
@@ -139,7 +139,7 @@ class ReportGenerator {
         // Ignore fatal errors from marked js.
       }
 
-      // The input str has been santized and transformed. Mark it as safe so
+      // The input str has been sanitized and transformed. Mark it as safe so
       // handlebars renders the text as HTML.
       return new Handlebars.SafeString(str);
     });

--- a/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
@@ -34,10 +34,8 @@ describe('Resources are fetched over http/2', () => {
     assert.ok(auditResult.displayValue.match('4 requests were not'));
     assert.equal(auditResult.extendedInfo.value.results.length, 4);
 
-    assert.equal(auditResult.extendedInfo.value.table.headings.length,
-                 auditResult.extendedInfo.value.table.rows[0].cols.length,
-                 'number table headings matches number data columns');
-    assert.deepEqual(auditResult.extendedInfo.value.table.headings,
+    const headings = auditResult.extendedInfo.value.tableHeadings;
+    assert.deepEqual(Object.keys(headings).map(key => headings[key]),
                      ['URL', 'Protocol'], 'table headings are correct and in order');
   });
 

--- a/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
@@ -32,7 +32,13 @@ describe('Resources are fetched over http/2', () => {
     });
     assert.equal(auditResult.rawValue, false);
     assert.ok(auditResult.displayValue.match('4 requests were not'));
-    assert.equal(auditResult.extendedInfo.value.length, 4);
+    assert.equal(auditResult.extendedInfo.value.results.length, 4);
+
+    assert.equal(auditResult.extendedInfo.value.table.headings.length,
+                 auditResult.extendedInfo.value.table.rows[0].cols.length,
+                 'number table headings matches number data columns');
+    assert.deepEqual(auditResult.extendedInfo.value.table.headings,
+                     ['URL', 'Protocol'], 'table headings are correct and in order');
   });
 
   it('displayValue is correct when only one resource fails', () => {

--- a/lighthouse-core/test/audits/dobetterweb/uses-optimized-images-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-optimized-images-test.js
@@ -57,6 +57,12 @@ describe('Page uses optimized images', () => {
     });
 
     assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.extendedInfo.value.table.headings.length,
+                 auditResult.extendedInfo.value.table.rows[0].cols.length,
+                 'number table headings matches number data columns');
+    assert.deepEqual(auditResult.extendedInfo.value.table.headings,
+                     ['URL', 'Original (KB)', 'WebP savings', 'JPEG savings'],
+                     'table headings are correct and in order');
   });
 
   it('fails when one png image is highly unoptimized', () => {
@@ -103,7 +109,7 @@ describe('Page uses optimized images', () => {
       OptimizedImages: [image],
     });
 
-    const actualUrl = auditResult.extendedInfo.value[0].url;
+    const actualUrl = auditResult.extendedInfo.value.results[0].url;
     assert.ok(actualUrl.length < image.url.length, `${actualUrl} >= ${image.url}`);
   });
 

--- a/lighthouse-core/test/audits/dobetterweb/uses-optimized-images-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-optimized-images-test.js
@@ -57,10 +57,9 @@ describe('Page uses optimized images', () => {
     });
 
     assert.equal(auditResult.rawValue, false);
-    assert.equal(auditResult.extendedInfo.value.table.headings.length,
-                 auditResult.extendedInfo.value.table.rows[0].cols.length,
-                 'number table headings matches number data columns');
-    assert.deepEqual(auditResult.extendedInfo.value.table.headings,
+
+    const headings = auditResult.extendedInfo.value.tableHeadings;
+    assert.deepEqual(Object.keys(headings).map(key => headings[key]),
                      ['URL', 'Original (KB)', 'WebP savings', 'JPEG savings'],
                      'table headings are correct and in order');
   });

--- a/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
@@ -44,15 +44,22 @@ describe('Page uses passive events listeners where applicable', () => {
     });
     assert.equal(auditResult.rawValue, false);
 
-    for (let i = 0; i < auditResult.extendedInfo.value.length; ++i) {
-      const val = auditResult.extendedInfo.value[i];
+    for (let i = 0; i < auditResult.extendedInfo.value.results.length; ++i) {
+      const val = auditResult.extendedInfo.value.results[i];
       assert.ok(!val.passive, 'results should all be non-passive listeners');
       assert.notEqual(PassiveEventsAudit.SCROLL_BLOCKING_EVENTS.indexOf(val.type), -1,
           'results should not contain other types of events');
     }
-    assert.equal(auditResult.extendedInfo.value.length, 6);
-    assert.equal(auditResult.extendedInfo.value[0].url, fixtureData[0].url);
-    assert.ok(auditResult.extendedInfo.value[0].code.match(/addEventListener/));
+    assert.equal(auditResult.extendedInfo.value.results.length, 6);
+    assert.equal(auditResult.extendedInfo.value.results[0].url, fixtureData[0].url);
+    assert.ok(auditResult.extendedInfo.value.results[0].code.match(/addEventListener/));
+
+    assert.equal(auditResult.extendedInfo.value.table.headings.length,
+                 auditResult.extendedInfo.value.table.rows[0].cols.length,
+                 'number table headings matches number data columns');
+    assert.deepEqual(auditResult.extendedInfo.value.table.headings,
+                     ['URL', 'Line/Col', 'Type', 'Snippet'],
+                     'table headings are correct and in order');
   });
 
   it('passes scroll blocking listeners should be passive', () => {
@@ -61,7 +68,7 @@ describe('Page uses passive events listeners where applicable', () => {
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, true);
-    assert.equal(auditResult.extendedInfo.value.length, 0);
+    assert.equal(auditResult.extendedInfo.value.results.length, 0);
   });
 
   it('fails when listener is missing a url property', () => {
@@ -70,8 +77,8 @@ describe('Page uses passive events listeners where applicable', () => {
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);
-    assert.ok(auditResult.extendedInfo.value[1].url === undefined);
-    assert.equal(auditResult.extendedInfo.value.length, 6);
+    assert.ok(auditResult.extendedInfo.value.results[1].url === undefined);
+    assert.equal(auditResult.extendedInfo.value.results.length, 6);
   });
 
   it('fails when listener has a bad url property', () => {
@@ -91,7 +98,7 @@ describe('Page uses passive events listeners where applicable', () => {
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);
-    assert.ok(auditResult.extendedInfo.value[0].url === 'eval(<context>):54:21');
-    assert.equal(auditResult.extendedInfo.value.length, 1);
+    assert.ok(auditResult.extendedInfo.value.results[0].url === 'eval(<context>):54:21');
+    assert.equal(auditResult.extendedInfo.value.results.length, 1);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
@@ -54,10 +54,8 @@ describe('Page uses passive events listeners where applicable', () => {
     assert.equal(auditResult.extendedInfo.value.results[0].url, fixtureData[0].url);
     assert.ok(auditResult.extendedInfo.value.results[0].code.match(/addEventListener/));
 
-    assert.equal(auditResult.extendedInfo.value.table.headings.length,
-                 auditResult.extendedInfo.value.table.rows[0].cols.length,
-                 'number table headings matches number data columns');
-    assert.deepEqual(auditResult.extendedInfo.value.table.headings,
+    const headings = auditResult.extendedInfo.value.tableHeadings;
+    assert.deepEqual(Object.keys(headings).map(key => headings[key]),
                      ['URL', 'Line/Col', 'Type', 'Snippet'],
                      'table headings are correct and in order');
   });

--- a/lighthouse-core/test/formatter/table-formatter-test.js
+++ b/lighthouse-core/test/formatter/table-formatter-test.js
@@ -18,9 +18,21 @@
 /* eslint-env mocha */
 
 const TableFormatter = require('../../formatters/table.js');
+const Handlebars = require('handlebars');
+const ReportGenerator = require('../../report/report-generator.js');
 const assert = require('assert');
 
 describe('TableFormatter', () => {
+  const extendedInfo = {
+    tableHeadings: {url: 'URL', lineCol: 'Line/col', code: 'Snippet'},
+    results: [{
+      url: 'http://example.com',
+      line: 123,
+      col: 456,
+      code: 'code snippet'
+    }]
+  };
+
   it('handles invalid input', () => {
     const pretty = TableFormatter.getFormatter('pretty');
     assert.equal(pretty(), '');
@@ -30,19 +42,37 @@ describe('TableFormatter', () => {
   });
 
   it('createTable() produces formatted rows/cols', () => {
-    const headings = {url: 'URL', lineCol: 'Line/col', code: 'Snippet'};
-    const results = [{
-      url: 'http://example.com',
-      line: 123,
-      col: 456,
-      code: 'code snippet'
-    }];
-    const table = TableFormatter.createTable(headings, results);
+    const table = TableFormatter.createTable(extendedInfo.tableHeadings, extendedInfo.results);
+    const headings = extendedInfo.tableHeadings;
     assert.deepEqual(table.headings, Object.keys(headings).map(key => headings[key]));
     assert.equal(table.rows.length, 1);
     assert.equal(table.rows[0].cols.length, Object.keys(headings).length);
     assert.equal(table.rows[0].cols[0], 'http://example.com');
     assert.equal(table.rows[0].cols[1], '123:456');
     assert.equal(table.rows[0].cols[2], '\`code snippet\`');
+  });
+
+  it('generates valid pretty output', () => {
+    const pretty = TableFormatter.getFormatter('pretty');
+    assert.equal(pretty(extendedInfo), '      http://example.com 123:456 \n');
+  });
+
+  it('generates valid html output', () => {
+    new ReportGenerator(); // Registers the if_not_eq helper used by the html formatter.
+
+    Handlebars.registerHelper(TableFormatter.getHelpers());
+
+    const formatter = TableFormatter.getFormatter('html');
+    const template = Handlebars.compile(formatter);
+    const output = template(extendedInfo).split('\n').join('');
+    assert.ok(output.match('<table class="table_list'), 'creates a table');
+    assert.ok(output.match('multicolumn'), 'adds multicolumn class for large tables');
+
+    const extendedInfoShort = {
+      tableHeadings: {url: 'URL', lineCol: 'Line/col'},
+      results: extendedInfo.results
+    };
+    const output2 = template(extendedInfoShort).split('\n').join('');
+    assert.ok(!output2.match('multicolumn"'), 'does not add multicolumn class for small tables');
   });
 });

--- a/lighthouse-core/test/formatter/table-formatter-test.js
+++ b/lighthouse-core/test/formatter/table-formatter-test.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* eslint-env mocha */
+
+const TableFormatter = require('../../formatters/table.js');
+const assert = require('assert');
+
+describe('TableFormatter', () => {
+  it('handles invalid input', () => {
+    const pretty = TableFormatter.getFormatter('pretty');
+    assert.equal(pretty(), '');
+    assert.equal(pretty(null), '');
+    assert.equal(pretty({}), '');
+    assert.equal(pretty({results: 'blah'}), '');
+  });
+
+  it('createTable() produces formatted rows/cols', () => {
+    const headings = {url: 'URL', lineCol: 'Line/col', code: 'Snippet'};
+    const results = [{
+      url: 'http://example.com',
+      line: 123,
+      col: 456,
+      code: 'code snippet'
+    }];
+    const table = TableFormatter.createTable(headings, results);
+    assert.deepEqual(table.headings, Object.keys(headings).map(key => headings[key]));
+    assert.equal(table.rows.length, 1);
+    assert.equal(table.rows[0].cols.length, Object.keys(headings).length);
+    assert.equal(table.rows[0].cols[0], 'http://example.com');
+    assert.equal(table.rows[0].cols[1], '123:456');
+    assert.equal(table.rows[0].cols[2], '\`code snippet\`');
+  });
+});


### PR DESCRIPTION
R: all

This adds a new `<table>` formatter for HTML reports which increases clarity, fixes some overflow UI bugs we had with text, and will allow us to more easily add additional extended info in the future (e.g. extra properties from the gatherers, RUM data column, etc.)

An audit uses the formatter like so:

    const createTable = Formatter.getByName('table').createTable;
    ...
    extendedInfo: {
        formatter: Formatter.SUPPORTED_FORMATS.TABLE,
        value: {
          table: createTable({url: 'URL', protocol: 'Protocol'}, resources),
          results: resources
        }
    }

Notes:
- All the cells are `overflow: auto` so you can scroll them to reveal more of the url/code snippets
- the original `results` are also being returned in `extendedInfo` so unit testing is easier and so we have the full objects as returned by the gatherer. Might want to change this in the future b/c it does mean the JSON results will be larger than they need to be.
- This PR was getting big, so I only did 3 audits. When we're happy with this, we can move over other URLIST audits to use the TABLE formatter.

After: 

<img width="698" alt="screen shot 2017-01-20 at 2 01 54 pm" src="https://cloud.githubusercontent.com/assets/238208/22169510/75d3c1c2-df29-11e6-968a-1164a975ada0.png">

<img width="700" alt="screen shot 2017-01-20 at 2 01 58 pm" src="https://cloud.githubusercontent.com/assets/238208/22169511/75d461f4-df29-11e6-9496-fbfb50fea05d.png">

<img width="761" alt="screen shot 2017-01-20 at 2 02 01 pm" src="https://cloud.githubusercontent.com/assets/238208/22169523/8d567c9a-df29-11e6-8bb0-fffdfd99f674.png">

Before:

<img width="692" alt="screen shot 2017-01-20 at 4 04 18 pm" src="https://cloud.githubusercontent.com/assets/238208/22169607/2bd09860-df2a-11e6-9424-9af1c0948c0c.png">
<img width="685" alt="screen shot 2017-01-20 at 4 04 24 pm" src="https://cloud.githubusercontent.com/assets/238208/22169606/2bcf46ea-df2a-11e6-9412-055dfa663255.png">

