### PR TITLE
Refactor critical-request-chains-test.js log code.

### DIFF
--- a/lighthouse-cli/test/cli/printer-test.js
+++ b/lighthouse-cli/test/cli/printer-test.js
@@ -23,6 +23,7 @@ const Printer = require('../../printer.js');
 const assert = require('assert');
 const fs = require('fs');
 const sampleResults = require('../fixtures/sample.json');
+const log = require('../../../lighthouse-core/lib/log');
 
 describe('Printer', () => {
   it('accepts valid output paths', () => {
@@ -86,7 +87,9 @@ describe('Printer', () => {
   it('writes extended info', () => {
     const mode = 'pretty';
     const prettyOutput = Printer.createOutput(sampleResults, mode);
+    const output = new RegExp(log.heavyHorizontal + log.heavyHorizontal +
+                   ' images\/chrome-touch-icon-384x384.png', 'i');
 
-    assert.ok(/━━ images\/chrome-touch-icon-384x384.png/i.test(prettyOutput));
+    assert.ok(output.test(prettyOutput));
   });
 });

--- a/lighthouse-core/formatters/critical-request-chains.js
+++ b/lighthouse-core/formatters/critical-request-chains.js
@@ -22,17 +22,10 @@ const path = require('path');
 const fs = require('fs');
 const Formatter = require('./formatter');
 const html = fs.readFileSync(path.join(__dirname, 'partials/critical-request-chains.html'), 'utf8');
+const log = require('../lib/log');
 
-const isWindows = process.platform === 'win32';
-
-// See https://github.com/GoogleChrome/lighthouse/issues/1228
-const heavyHorizontal = isWindows ? '\u2500' : '━';
-const heavyVertical = isWindows ? '\u2502 ' : '┃ ';
-const heavyUpAndRight = isWindows ? '\u2514' : '┗';
-const heavyUpAndRightLong = heavyUpAndRight + heavyHorizontal;
-const heavyVerticalAndRight = isWindows ? '\u251C' : '┣';
-const heavyVerticalAndRightLong = heavyVerticalAndRight + heavyHorizontal;
-const heavyDownAndHorizontal = isWindows ? '\u252C' : '┳';
+const heavyUpAndRightLong = log.heavyUpAndRight + log.heavyHorizontal;
+const heavyVerticalAndRightLong = log.heavyVerticalAndRight + log.heavyHorizontal;
 
 class CriticalRequestChains extends Formatter {
 
@@ -159,7 +152,7 @@ class CriticalRequestChains extends Formatter {
 
         // If the parent is the last child then don't drop the vertical bar.
         const ancestorTreeMarker = treeMarkers.reduce((markers, marker) => {
-          return markers + (marker ? heavyVertical : '  ');
+          return markers + (marker ? log.heavyVertical : '  ');
         }, '');
 
         // Copy the tree markers so that we don't change by reference.
@@ -172,7 +165,7 @@ class CriticalRequestChains extends Formatter {
         // node as well as whether or not it has children and is itself the last child.
         const treeMarker = ancestorTreeMarker +
             (isLastChild ? heavyUpAndRightLong : heavyVerticalAndRightLong) +
-            (hasChildren ? heavyDownAndHorizontal : heavyHorizontal);
+            (hasChildren ? log.heavyDownAndHorizontal : log.heavyHorizontal);
 
         const parsedURL = CriticalRequestChains.parseURL(node[id].request.url);
 

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -186,6 +186,26 @@ class Log {
     return isWindows ? '\u0387' : '▫';
   }
 
+  static get heavyHorizontal() {
+    return isWindows ? '\u2500' : '━';
+  }
+
+  static get heavyVertical() {
+    return isWindows ? '\u2502 ' : '┃ ';
+  }
+
+  static get heavyUpAndRight() {
+    return isWindows ? '\u2514' : '┗';
+  }
+
+  static get heavyVerticalAndRight() {
+    return isWindows ? '\u251C' : '┣';
+  }
+
+  static get heavyDownAndHorizontal() {
+    return isWindows ? '\u252C' : '┳';
+  }
+
   static get doubleLightHorizontal() {
     return '──';
   }

--- a/lighthouse-core/test/formatter/critical-request-chains-test.js
+++ b/lighthouse-core/test/formatter/critical-request-chains-test.js
@@ -19,6 +19,7 @@
 const criticalRequestChainFormatter = require('../../formatters/critical-request-chains.js');
 const assert = require('assert');
 const Handlebars = require('handlebars');
+const log = require('../../lib/log');
 const superLongName =
     'https://example.com/thisIsASuperLongURLThatWillTriggerFilenameTruncationWhichWeWantToTest.js';
 const extendedInfo = {
@@ -82,9 +83,16 @@ describe('CRC Formatter', () => {
     const output = formatter(extendedInfo);
     const truncatedURL = criticalRequestChainFormatter.parseURL(superLongName);
     const truncatedURLRegExp = new RegExp(truncatedURL.file, 'im');
-
-    assert.ok(/┗━┳ \/ \(example.com\)/im.test(output));
-    assert.ok(/┣━━ \/b.js \(example.com\) - 5000.00ms/im.test(output));
+    const testString = new RegExp(log.heavyUpAndRight +
+                                  log.heavyHorizontal +
+                                  log.heavyDownAndHorizontal +
+                                  ' \\/ \\(example.com\\)', 'im');
+    assert.ok(testString.test(output));
+    const testString2 = new RegExp(log.heavyVerticalAndRight +
+                                   log.heavyHorizontal +
+                                   log.heavyHorizontal +
+                                   ' \\/b.js \\(example.com\\) - 5000.00ms', 'im');
+    assert.ok(testString2.test(output));
     assert.ok(truncatedURLRegExp.test(output));
     assert.ok(/about:blank/.test(output));
   });


### PR DESCRIPTION
Now tests should pass on all platforms.

Part of the ongoing work to have tests pass on Windows.