### PR TITLE
.travis.yml: remove `npm run build-cli`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_script:
   - export LIGHTHOUSE_CHROMIUM_PATH="$(pwd)/chrome-linux/chrome"
   - sh -e /etc/init.d/xvfb start
   - ./lighthouse-core/scripts/download-chrome.sh
-  - npm run build-cli
   - npm run build-extension
   - npm run build-viewer
 script:


### PR DESCRIPTION
CLI is being built on install with a prepublish script. So now Travis behavior matches real installations.