### PR TITLE
Favicons may be named favicon-32x32.0.png etc

### DIFF
--- a/lighthouse-core/gather/computed/critical-request-chains.js
+++ b/lighthouse-core/gather/computed/critical-request-chains.js
@@ -42,8 +42,11 @@ class CriticalRequestChains extends ComputedArtifact {
     }
 
     // Treat favicons as non-critical resources
+    // Match on 1) strict mime-type, 2) strict filename 3) loose combination
     if (request.mimeType === 'image/x-icon' ||
-        (request.parsedURL && request.parsedURL.lastPathComponent === 'favicon.ico')) {
+        request.parsedURL && request.parsedURL.lastPathComponent == 'favicon.ico' ||
+        (request.parsedURL && request.parsedURL.lastPathComponent.includes('favicon')
+        && request.mimeType && request.mimeType.startsWith('image/'))) {
       return false;
     }
 

--- a/lighthouse-core/test/gather/computed/critical-request-chains-test.js
+++ b/lighthouse-core/test/gather/computed/critical-request-chains-test.js
@@ -287,7 +287,7 @@ describe('CriticalRequestChain gatherer: getCriticalChain function', () => {
   });
 
   it('discards favicons as non-critical', () => {
-    const networkRecords = mockTracingData([HIGH, HIGH, HIGH], [[0, 1], [0, 2]]);
+    const networkRecords = mockTracingData([HIGH, HIGH, HIGH, HIGH], [[0, 1], [0, 2], [0, 3]]);
 
     // 2nd record is a favicon
     networkRecords[1].url = 'https://example.com/favicon.ico';
@@ -296,6 +296,13 @@ describe('CriticalRequestChain gatherer: getCriticalChain function', () => {
     };
     // 3rd record is also a favicon
     networkRecords[2].mimeType = 'image/x-icon';
+    // 4th record is also a favicon
+    networkRecords[3].url = 'https://cdn2.vox-cdn.com/favicon-96x96.0.png';
+    networkRecords[3].mimeType = 'image/png';
+    networkRecords[3].parsedURL = {
+      lastPathComponent: 'favicon-96x96.0.png'
+    };
+
     return Gatherer.request(networkRecords).then(criticalChains => {
       assert.deepEqual(criticalChains, {
         0: {


### PR DESCRIPTION
theverge.com has favicons that we incorrectly identify as critical. here's their URLs:

```html
<link rel="shortcut icon" href="https://cdn0.vox-cdn.com/uploads/chorus_asset/file/7395361/favicon-64x64.0.ico">
<link rel="icon" type="image/png" href="https://cdn1.vox-cdn.com/uploads/chorus_asset/file/7395367/favicon-16x16.0.png" sizes="16x16">
<link rel="icon" type="image/png" href="https://cdn0.vox-cdn.com/uploads/chorus_asset/file/7395363/favicon-32x32.0.png" sizes="32x32">
<link rel="icon" type="image/png" href="https://cdn2.vox-cdn.com/uploads/chorus_asset/file/7395365/favicon-96x96.0.png" sizes="96x96">
<link rel="icon" type="image/png" href="https://cdn0.vox-cdn.com/uploads/chorus_asset/file/7395351/android-chrome-192x192.0.png" sizes="192x192">
<link rel="apple-touch-icon" href="https://cdn2.vox-cdn.com/uploads/chorus_asset/file/7395359/ios-icon.0.png" sizes="180x180">
```

this PR will loosen our favicon check to consider all images with "favicon" in their name.