### PR TITLE
Introduce TraceOfTab computed artifact

### DIFF
--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -140,14 +140,6 @@ class FirstMeaningfulPaint extends Audit {
       firstContentfulPaint: firstFCP
     };
   }
-
-  // We want an fMP at or after our fCP, however we see traces with the sole fMP
-  // being up to 1ms BEFORE the fCP. We're okay if this happens, however if we see
-  // a gap of more than 2 frames (32,000 microseconds), then it's a bug that should
-  // be addressed in FirstMeaningfulPaintDetector.cpp
-  static get toleranceMs() {
-    return 32 * 1000;
-  }
 }
 
 module.exports = FirstMeaningfulPaint;

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -19,95 +19,6 @@
 
 const Audit = require('./audit');
 const Formatter = require('../formatters/formatter');
-const TimelineModel = require('../lib/traces/devtools-timeline-model');
-
-/**
- * @param {!Array<!Object>} traceData
- * @return {!Array<!UserTimingsExtendedInfo>}
- */
-function filterTrace(traceData) {
-  const userTimings = [];
-  const measuresStartTimes = {};
-  let traceStartFound = false;
-  let navigationStartTime;
-
-  // Fetch blink.user_timing events from the tracing data
-  const timelineModel = new TimelineModel(traceData);
-  const modeledTraceData = timelineModel.timelineModel();
-
-  // Get all blink.user_timing events
-  // The event phases we are interested in are mark and instant events (R, i, I)
-  // and duration events which correspond to measures (B, b, E, e).
-  // @see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#
-  modeledTraceData.mainThreadEvents()
-  .filter(ut => {
-    if (ut.name === 'TracingStartedInPage' || ut.name === 'navigationStart') {
-      return true;
-    }
-
-    if (ut.hasCategory('blink.user_timing')) {
-      // reject these "userTiming" events that aren't really UserTiming, by nuking ones with frame data (or requestStart)
-      // https://cs.chromium.org/search/?q=trace_event.*?user_timing&sq=package:chromium&type=cs
-      return ut.name !== 'requestStart' &&
-          ut.name !== 'paintNonDefaultBackgroundColor' &&
-          ut.args.frame === undefined;
-    }
-
-    return false;
-  })
-  .forEach(ut => {
-    // Mark events fall under phases R and I (or i)
-    if (ut.phase === 'R' || ut.phase.toUpperCase() === 'I') {
-      // We only care about trace events that have to do with the page
-      // Sometimes other frames can show up in the frame beforehand
-      if (ut.name === 'TracingStartedInPage' && !traceStartFound) {
-        traceStartFound = true;
-        return;
-      }
-
-      // Once TraceingStartedInPage has begun, the next navigationStart event
-      // marks the start of navigation
-      // Make sure to not record such events hereafter
-      if (ut.name === 'navigationStart' && traceStartFound && !navigationStartTime) {
-        navigationStartTime = ut.startTime;
-      }
-
-      // Add user timings event to array
-      if (ut.name !== 'navigationStart') {
-        userTimings.push({
-          name: ut.name,
-          isMark: true,        // defines type of performance metric
-          args: ut.args,
-          startTime: ut.startTime
-        });
-      }
-    } else if (ut.phase.toLowerCase() === 'b') {
-      // Beginning of measure event, keep track of this events start time
-      measuresStartTimes[ut.name] = ut.startTime;
-    } else if (ut.phase.toLowerCase() === 'e') {
-      // End of measure event
-      // Add to the array of events
-      userTimings.push({
-        name: ut.name,
-        isMark: false,
-        args: ut.args,
-        startTime: measuresStartTimes[ut.name],
-        duration: ut.startTime - measuresStartTimes[ut.name],
-        endTime: ut.startTime
-      });
-    }
-  });
-
-  userTimings.forEach(ut => {
-    ut.startTime -= navigationStartTime;
-    if (!ut.isMark) {
-      ut.endTime -= navigationStartTime;
-      ut.duration = ut.duration;
-    }
-  });
-
-  return userTimings;
-}
 
 class UserTimings extends Audit {
   /**
@@ -126,20 +37,84 @@ class UserTimings extends Audit {
   }
 
   /**
+   * @param {!Object} tabTrace
+   * @return {!Array<!UserTimingsExtendedInfo>}
+   */
+  static filterTrace(tabTrace) {
+    const userTimings = [];
+    const measuresStartTimes = {};
+
+    // Get all blink.user_timing events
+    // The event phases we are interested in are mark and instant events (R, i, I)
+    // and duration events which correspond to measures (B, b, E, e).
+    // @see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#
+    tabTrace.traceEvents.filter(evt => {
+      if (!evt.cat.includes('blink.user_timing')) {
+        return false;
+      }
+
+      // reject these "userTiming" events that aren't really UserTiming, by nuking ones with frame data (or requestStart)
+      // https://cs.chromium.org/search/?q=trace_event.*?user_timing&sq=package:chromium&type=cs
+      return evt.name !== 'requestStart' &&
+          evt.name !== 'paintNonDefaultBackgroundColor' &&
+          evt.args.frame === undefined;
+    })
+    .forEach(ut => {
+      // Mark events fall under phases R and I (or i)
+      if (ut.ph === 'R' || ut.ph.toUpperCase() === 'I') {
+        // Add user timings event to array
+        if (ut.name !== 'navigationStart') {
+          userTimings.push({
+            name: ut.name,
+            isMark: true,
+            args: ut.args,
+            startTime: ut.ts
+          });
+        }
+      } else if (ut.ph.toLowerCase() === 'b') {
+        // Beginning of measure event, keep track of this events start time
+        measuresStartTimes[ut.name] = ut.ts;
+      } else if (ut.ph.toLowerCase() === 'e') {
+        // End of measure event
+        userTimings.push({
+          name: ut.name,
+          isMark: false,
+          args: ut.args,
+          startTime: measuresStartTimes[ut.name],
+          endTime: ut.ts
+        });
+      }
+    });
+
+    // baseline the timestamps against navStart, and translate to milliseconds
+    userTimings.forEach(ut => {
+      ut.startTime = (ut.startTime - tabTrace.navigationStartEvt.ts) / 1000;
+      if (!ut.isMark) {
+        ut.endTime = (ut.endTime - tabTrace.navigationStartEvt.ts) / 1000;
+        ut.duration = ut.endTime - ut.startTime;
+      }
+    });
+
+    return userTimings;
+  }
+
+  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const traceContents = artifacts.traces[Audit.DEFAULT_PASS].traceEvents;
-    const userTimings = filterTrace(traceContents);
+    const trace = artifacts.traces[Audit.DEFAULT_PASS];
+    return artifacts.requestTabOfTrace(trace).then(tabTrace => {
+      const userTimings = this.filterTrace(tabTrace);
 
-    return UserTimings.generateAuditResult({
-      rawValue: true,
-      displayValue: userTimings.length,
-      extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.USER_TIMINGS,
-        value: userTimings
-      }
+      return UserTimings.generateAuditResult({
+        rawValue: true,
+        displayValue: userTimings.length,
+        extendedInfo: {
+          formatter: Formatter.SUPPORTED_FORMATS.USER_TIMINGS,
+          value: userTimings
+        }
+      });
     });
   }
 }

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -48,7 +48,7 @@ class UserTimings extends Audit {
     // The event phases we are interested in are mark and instant events (R, i, I)
     // and duration events which correspond to measures (B, b, E, e).
     // @see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#
-    tabTrace.traceEvents.filter(evt => {
+    tabTrace.processEvents.filter(evt => {
       if (!evt.cat.includes('blink.user_timing')) {
         return false;
       }

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -56,26 +56,26 @@ class UserTimings extends Audit {
       // reject these "userTiming" events that aren't really UserTiming, by nuking ones with frame data (or requestStart)
       // https://cs.chromium.org/search/?q=trace_event.*?user_timing&sq=package:chromium&type=cs
       return evt.name !== 'requestStart' &&
+          evt.name !== 'navigationStart' &&
           evt.name !== 'paintNonDefaultBackgroundColor' &&
           evt.args.frame === undefined;
     })
     .forEach(ut => {
       // Mark events fall under phases R and I (or i)
       if (ut.ph === 'R' || ut.ph.toUpperCase() === 'I') {
-        // Add user timings event to array
-        if (ut.name !== 'navigationStart') {
-          userTimings.push({
-            name: ut.name,
-            isMark: true,
-            args: ut.args,
-            startTime: ut.ts
-          });
-        }
+        userTimings.push({
+          name: ut.name,
+          isMark: true,
+          args: ut.args,
+          startTime: ut.ts
+        });
+
+      // Beginning of measure event, keep track of this events start time
       } else if (ut.ph.toLowerCase() === 'b') {
-        // Beginning of measure event, keep track of this events start time
         measuresStartTimes[ut.name] = ut.ts;
+
+      // End of measure event
       } else if (ut.ph.toLowerCase() === 'e') {
-        // End of measure event
         userTimings.push({
           name: ut.name,
           isMark: false,
@@ -104,7 +104,7 @@ class UserTimings extends Audit {
    */
   static audit(artifacts) {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
-    return artifacts.requestTabOfTrace(trace).then(tabTrace => {
+    return artifacts.requestTraceOfTab(trace).then(tabTrace => {
       const userTimings = this.filterTrace(tabTrace);
 
       return UserTimings.generateAuditResult({

--- a/lighthouse-core/gather/computed/computed-artifact.js
+++ b/lighthouse-core/gather/computed/computed-artifact.js
@@ -46,7 +46,7 @@ class ComputedArtifact {
       return Promise.resolve(this.cache.get(artifact));
     }
 
-    return Promise.resolve(this.compute_(artifact)).then(computedArtifact => {
+    return Promise.resolve().then(_ => this.compute_(artifact)).then(computedArtifact => {
       this.cache.set(artifact, computedArtifact);
       return computedArtifact;
     });

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -19,7 +19,7 @@
 
 const ComputedArtifact = require('./computed-artifact');
 
-class ScreenshotFilmstrip extends ComputedArtifact {
+class TabOfTrace extends ComputedArtifact {
 
   get name() {
     return 'TabOfTrace';
@@ -61,4 +61,4 @@ class ScreenshotFilmstrip extends ComputedArtifact {
   }
 }
 
-module.exports = ScreenshotFilmstrip;
+module.exports = TabOfTrace;

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ComputedArtifact = require('./computed-artifact');
+
+class ScreenshotFilmstrip extends ComputedArtifact {
+
+  get name() {
+    return 'TabOfTrace';
+  }
+
+  /**
+   * @param {{traceEvents: !Array}} trace
+   * @return {!Object}
+  */
+  compute_(trace) {
+    // Parse the trace for our key events and sort them by timestamp.
+    const keyEvents = trace.traceEvents.filter(e => {
+      return e.cat.includes('blink.user_timing') || e.name === 'TracingStartedInPage';
+    }).sort((event0, event1) => event0.ts - event1.ts);
+
+    // The first TracingStartedInPage in the trace is definitely our renderer thread of interest
+    // Beware: the tracingStartedInPage event can appear slightly after a navigationStart
+    const startedInPageEvt = keyEvents.find(e => e.name === 'TracingStartedInPage');
+    // Filter to just events matching the frame ID for sanity
+    const frameEvents = keyEvents.filter(e => e.args.frame === startedInPageEvt.args.data.page);
+
+    // Find our first FCP
+    const firstFCP = frameEvents.find(e => e.name === 'firstContentfulPaint');
+    // Our navStart will be the latest one before fCP.
+    const navigationStart = frameEvents.filter(e =>
+        e.name === 'navigationStart' && e.ts < firstFCP.ts).pop();
+
+    // subset all trace events to just our tab's process (incl threads other than main)
+    const allFrameEvents = trace.traceEvents.filter(e => {
+      return e.pid === startedInPageEvt.pid;
+    }).sort((event0, event1) => event0.ts - event1.ts);
+
+    return {
+      traceEvents: allFrameEvents,
+      startedInPageEvt: startedInPageEvt,
+      navigationStartEvt: navigationStart,
+      firstContentfulPaintEvt: firstFCP
+    };
+  }
+}
+
+module.exports = ScreenshotFilmstrip;

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -18,11 +18,12 @@
 'use strict';
 
 const ComputedArtifact = require('./computed-artifact');
+const fMPAudit = require('../../audits/first-meaningful-paint');
 
-class TabOfTrace extends ComputedArtifact {
+class TraceOfTab extends ComputedArtifact {
 
   get name() {
-    return 'TabOfTrace';
+    return 'TraceOfTab';
   }
 
   /**
@@ -47,6 +48,10 @@ class TabOfTrace extends ComputedArtifact {
     const navigationStart = frameEvents.filter(e =>
         e.name === 'navigationStart' && e.ts < firstFCP.ts).pop();
 
+    // fMP will follow at/after the FCP, though we allow some timestamp tolerance
+    const firstMeaningfulPaint = frameEvents.find(e =>
+        e.name === 'firstMeaningfulPaint' && e.ts >= (firstFCP.ts - fMPAudit.toleranceMs));
+
     // subset all trace events to just our tab's process (incl threads other than main)
     const allFrameEvents = trace.traceEvents.filter(e => {
       return e.pid === startedInPageEvt.pid;
@@ -56,9 +61,10 @@ class TabOfTrace extends ComputedArtifact {
       traceEvents: allFrameEvents,
       startedInPageEvt: startedInPageEvt,
       navigationStartEvt: navigationStart,
-      firstContentfulPaintEvt: firstFCP
+      firstContentfulPaintEvt: firstFCP,
+      firstMeaningfulPaintEvt: firstMeaningfulPaint
     };
   }
 }
 
-module.exports = TabOfTrace;
+module.exports = TraceOfTab;

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -46,7 +46,7 @@ class TraceOfTab extends ComputedArtifact {
 
   /**
    * @param {{traceEvents: !Array}} trace
-   * @return {!Object}
+   * @return {!{processEvents: !Array<TraceEvent>, startedInPageEvt: TraceEvent, navigationStartEvt: TraceEvent, firstContentfulPaintEvt: TraceEvent, firstMeaningfulPaintEvt: TraceEvent}}
   */
   compute_(trace) {
     // Parse the trace for our key events and sort them by timestamp.
@@ -71,12 +71,12 @@ class TraceOfTab extends ComputedArtifact {
         e.name === 'firstMeaningfulPaint' && e.ts >= (firstFCP.ts - TraceOfTab.fmpToleranceMs));
 
     // subset all trace events to just our tab's process (incl threads other than main)
-    const allFrameEvents = trace.traceEvents.filter(e => {
+    const processEvents = trace.traceEvents.filter(e => {
       return e.pid === startedInPageEvt.pid;
     }).sort((event0, event1) => event0.ts - event1.ts);
 
     return {
-      traceEvents: allFrameEvents,
+      processEvents,
       startedInPageEvt: startedInPageEvt,
       navigationStartEvt: navigationStart,
       firstContentfulPaintEvt: firstFCP,

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -23,12 +23,15 @@ const badNavStartTrace = require('../fixtures/traces/bad-nav-start-ts.json');
 const lateTracingStartedTrace = require('../fixtures/traces/tracingstarted-after-navstart.json');
 const preactTrace = require('../fixtures/traces/preactjs.com_ts_of_undefined.json');
 
-function getArtifacts(trace) {
-  return {
+const GatherRunner = require('../../gather/gather-runner.js');
+const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+
+function generateArtifactsWithTrace(trace) {
+  return Object.assign(computedArtifacts, {
     traces: {
       [Audit.DEFAULT_PASS]: {traceEvents: Array.isArray(trace) ? trace : trace.traceEvents}
     }
-  };
+  });
 }
 
 /* eslint-env mocha */
@@ -37,7 +40,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     let fmpResult;
 
     it('processes a valid trace file', () => {
-      return FMPAudit.audit(getArtifacts(traceEvents)).then(result => {
+      return FMPAudit.audit(generateArtifactsWithTrace(traceEvents)).then(result => {
         fmpResult = result;
       }).catch(_ => {
         assert.ok(false);
@@ -68,7 +71,7 @@ describe('Performance: first-meaningful-paint audit', () => {
 
   describe('finds correct FMP in various traces', () => {
     it('finds the fMP if there was a tracingStartedInPage after the frame\'s navStart', () => {
-      return FMPAudit.audit(getArtifacts(lateTracingStartedTrace)).then(result => {
+      return FMPAudit.audit(generateArtifactsWithTrace(lateTracingStartedTrace)).then(result => {
         assert.equal(result.displayValue, '529.9ms');
         assert.equal(result.rawValue, 529.9);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 29343540951);
@@ -78,7 +81,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     });
 
     it('finds the fMP if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
-      return FMPAudit.audit(getArtifacts(badNavStartTrace)).then(result => {
+      return FMPAudit.audit(generateArtifactsWithTrace(badNavStartTrace)).then(result => {
         assert.equal(result.displayValue, '632.4ms');
         assert.equal(result.rawValue, 632.4);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 8885424467);
@@ -88,7 +91,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     });
 
     it('finds the fMP if it appears slightly before the fCP', () => {
-      return FMPAudit.audit(getArtifacts(preactTrace)).then(result => {
+      return FMPAudit.audit(generateArtifactsWithTrace(preactTrace)).then(result => {
         assert.equal(result.displayValue, '878.4ms');
         assert.equal(result.rawValue, 878.4);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 1805796384607);

--- a/lighthouse-core/test/audits/time-to-interactive-test.js
+++ b/lighthouse-core/test/audits/time-to-interactive-test.js
@@ -21,28 +21,28 @@ const assert = require('assert');
 
 const pwaTrace = require('../fixtures/traces/progressive-app.json');
 
-const mockArtifacts = GatherRunner.instantiateComputedArtifacts();
 
 /* eslint-env mocha */
 describe('Performance: time-to-interactive audit', () => {
   it('scores a -1 with invalid trace data', () => {
-    return Audit.audit({
-      traces: {
-        [Audit.DEFAULT_PASS]: {
-          traceEvents: '[{"pid": 15256,"tid": 1295,"t'
-        }
-      },
-      requestSpeedline() {
-        return Promise.resolve({first: 500});
+    const artifacts = GatherRunner.instantiateComputedArtifacts();
+    artifacts.traces = {
+      [Audit.DEFAULT_PASS]: {
+        traceEvents: [{pid: 15256, tid: 1295, t: 5}]
       }
-    }).then(output => {
+    };
+    artifacts.requestSpeedline = _ => {
+      return Promise.resolve({first: 500});
+    };
+
+    return Audit.audit(artifacts).then(output => {
       assert.equal(output.rawValue, -1);
       assert(output.debugString);
     });
   });
 
   it('evaluates valid input correctly', () => {
-    const artifacts = mockArtifacts;
+    const artifacts = GatherRunner.instantiateComputedArtifacts();
     artifacts.traces = {
       [Audit.DEFAULT_PASS]: {
         traceEvents: pwaTrace

--- a/lighthouse-core/test/audits/user-timing-test.js
+++ b/lighthouse-core/test/audits/user-timing-test.js
@@ -19,24 +19,33 @@ const Audit = require('../../audits/user-timings.js');
 const assert = require('assert');
 const traceEvents = require('../fixtures/traces/trace-user-timings.json');
 
-/* eslint-env mocha */
+const GatherRunner = require('../../gather/gather-runner.js');
+const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
 
+function generateArtifactsWithTrace(trace) {
+  return Object.assign(computedArtifacts, {
+    traces: {
+      [Audit.DEFAULT_PASS]: {traceEvents: Array.isArray(trace) ? trace : trace.traceEvents}
+    }
+  });
+}
+
+/* eslint-env mocha */
 describe('Performance: user-timings audit', () => {
   it('evaluates valid input correctly', () => {
-    const auditResult = Audit.audit({
-      traces: {[Audit.DEFAULT_PASS]: {traceEvents}}
+    return Audit.audit(generateArtifactsWithTrace(traceEvents)).then(auditResult => {
+      assert.equal(auditResult.score, true);
+      assert.equal(auditResult.displayValue, 2);
+
+      assert.equal(auditResult.extendedInfo.value[0].isMark, true);
+      assert.equal(Math.floor(auditResult.extendedInfo.value[0].startTime), 1000);
+      assert.equal(typeof auditResult.extendedInfo.value[0].endTime, 'undefined');
+      assert.equal(typeof auditResult.extendedInfo.value[0].duration, 'undefined');
+
+      assert.equal(auditResult.extendedInfo.value[1].isMark, false);
+      assert.equal(Math.floor(auditResult.extendedInfo.value[1].startTime), 0);
+      assert.equal(Math.floor(auditResult.extendedInfo.value[1].endTime), 1000);
+      assert.equal(Math.floor(auditResult.extendedInfo.value[1].duration), 1000);
     });
-    assert.equal(auditResult.score, true);
-    assert.equal(auditResult.displayValue, 2);
-
-    assert.equal(auditResult.extendedInfo.value[0].isMark, true);
-    assert.equal(Math.floor(auditResult.extendedInfo.value[0].startTime), 1000);
-    assert.equal(typeof auditResult.extendedInfo.value[0].endTime, 'undefined');
-    assert.equal(typeof auditResult.extendedInfo.value[0].duration, 'undefined');
-
-    assert.equal(auditResult.extendedInfo.value[1].isMark, false);
-    assert.equal(Math.floor(auditResult.extendedInfo.value[1].startTime), 0);
-    assert.equal(Math.floor(auditResult.extendedInfo.value[1].endTime), 1000);
-    assert.equal(Math.floor(auditResult.extendedInfo.value[1].duration), 1000);
   });
 });

--- a/lighthouse-core/test/fixtures/traces/trace-user-timings.json
+++ b/lighthouse-core/test/fixtures/traces/trace-user-timings.json
@@ -1,6 +1,9 @@
-[{"pid":41904,"tid":1295,"ts":1676836141,"ph":"I","cat":"disabled-by-default-devtools.timeline","name":"TracingStartedInPage","args":{"data":{"page":"0xf5fc2501e08","sessionId":"9331.8"}},"tts":314881,"s":"t"},
-{"pid":41904,"tid":1295,"ts":506085991145,"ph":"R","cat":"blink.user_timing","name":"navigationStart","args":{"frame": 0},"tts":314882},
+[
+{"pid":41904,"tid":1295,"ts":1676836141,"ph":"I","cat":"disabled-by-default-devtools.timeline","name":"TracingStartedInPage","args":{"data":{"page":"0xf5fc2501e08","sessionId":"9331.8"}},"tts":314881,"s":"t"},
+{"pid":41904,"tid":1295,"ts":506085991145,"ph":"R","cat":"blink.user_timing","name":"navigationStart","args":{"frame": "0xf5fc2501e08"},"tts":314882},
+{"pid":41904,"tid":1295,"ts":506085991146,"ph":"R","cat":"blink.user_timing","name":"firstContentfulPaint","args":{"frame": "0xf5fc2501e08"},"tts":314883},
 {"pid":41904,"tid":1295,"ts":506085991146,"ph":"R","cat":"blink.user_timing","name":"paintNonDefaultBackgroundColor","args":{},"tts":314883},
 {"pid":41904,"tid":1295,"ts":506086992099,"ph":"R","cat":"blink.user_timing","name":"mark_test","args":{},"tts":331149},
 {"pid":41904,"tid":1295,"ts":506085991147,"ph":"b","cat":"blink.user_timing","name":"measure_test","args":{},"tts":331184,"id":"0x73b016"},
-{"pid":41904,"tid":1295,"ts":506086992112,"ph":"e","cat":"blink.user_timing","name":"measure_test","args":{},"tts":331186,"id":"0x73b016"}]
+{"pid":41904,"tid":1295,"ts":506086992112,"ph":"e","cat":"blink.user_timing","name":"measure_test","args":{},"tts":331186,"id":"0x73b016"}
+]

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Google Inc. All rights reserved.
+ * Copyright 2017 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,22 @@ const preactTrace = require('../../fixtures/traces/preactjs.com_ts_of_undefined.
 
 /* eslint-env mocha */
 describe('Trace of Tab computed artifact:', () => {
-  describe('finds correct FMP in various traces', () => {
-    it('finds the fMP if there was a tracingStartedInPage after the frame\'s navStart', () => {
+  it('gathers the events from the tab\'s process', () => {
+    const trace = traceOfTab.compute_(lateTracingStartedTrace);
+
+    const firstEvt = trace.traceEvents[0];
+    trace.traceEvents.forEach(evt => {
+      assert.equal(evt.pid, firstEvt.pid, 'A traceEvent is found from another process');
+    });
+
+    assert.ok(firstEvt.pid === trace.startedInPageEvt.pid);
+    assert.ok(firstEvt.pid === trace.navigationStartEvt.pid);
+    assert.ok(firstEvt.pid === trace.firstContentfulPaintEvt.pid);
+    assert.ok(firstEvt.pid === trace.firstMeaningfulPaintEvt.pid);
+  });
+
+  describe('finds correct FMP', () => {
+    it('if there was a tracingStartedInPage after the frame\'s navStart', () => {
       const trace = traceOfTab.compute_(lateTracingStartedTrace);
       assert.equal(trace.startedInPageEvt.ts, 29343544280);
       assert.equal(trace.navigationStartEvt.ts, 29343540951);
@@ -34,7 +48,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 29344070867);
     });
 
-    it('finds the fMP if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
+    it('if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
       const trace = traceOfTab.compute_(badNavStartTrace);
       assert.equal(trace.startedInPageEvt.ts, 8885435611);
       assert.equal(trace.navigationStartEvt.ts, 8885424467);
@@ -42,7 +56,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 8886056891);
     });
 
-    it('finds the fMP if it appears slightly before the fCP', () => {
+    it('if it appears slightly before the fCP', () => {
       const trace = traceOfTab.compute_(preactTrace);
       assert.equal(trace.startedInPageEvt.ts, 1805796376829);
       assert.equal(trace.navigationStartEvt.ts, 1805796384607);

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -28,8 +28,8 @@ describe('Trace of Tab computed artifact:', () => {
   it('gathers the events from the tab\'s process', () => {
     const trace = traceOfTab.compute_(lateTracingStartedTrace);
 
-    const firstEvt = trace.traceEvents[0];
-    trace.traceEvents.forEach(evt => {
+    const firstEvt = trace.processEvents[0];
+    trace.processEvents.forEach(evt => {
       assert.equal(evt.pid, firstEvt.pid, 'A traceEvent is found from another process');
     });
 

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const TraceOfTab = require('../../../gather/computed/trace-of-tab');
+const traceOfTab = new TraceOfTab();
+
+const assert = require('assert');
+const badNavStartTrace = require('../../fixtures/traces/bad-nav-start-ts.json');
+const lateTracingStartedTrace = require('../../fixtures/traces/tracingstarted-after-navstart.json');
+const preactTrace = require('../../fixtures/traces/preactjs.com_ts_of_undefined.json');
+
+/* eslint-env mocha */
+describe('Trace of Tab computed artifact:', () => {
+  describe('finds correct FMP in various traces', () => {
+    it('finds the fMP if there was a tracingStartedInPage after the frame\'s navStart', () => {
+      const trace = traceOfTab.compute_(lateTracingStartedTrace);
+      assert.equal(trace.startedInPageEvt.ts, 29343544280);
+      assert.equal(trace.navigationStartEvt.ts, 29343540951);
+      assert.equal(trace.firstContentfulPaintEvt.ts, 29343621005);
+      assert.equal(trace.firstMeaningfulPaintEvt.ts, 29344070867);
+    });
+
+    it('finds the fMP if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
+      const trace = traceOfTab.compute_(badNavStartTrace);
+      assert.equal(trace.startedInPageEvt.ts, 8885435611);
+      assert.equal(trace.navigationStartEvt.ts, 8885424467);
+      assert.equal(trace.firstContentfulPaintEvt.ts, 8886056886);
+      assert.equal(trace.firstMeaningfulPaintEvt.ts, 8886056891);
+    });
+
+    it('finds the fMP if it appears slightly before the fCP', () => {
+      const trace = traceOfTab.compute_(preactTrace);
+      assert.equal(trace.startedInPageEvt.ts, 1805796376829);
+      assert.equal(trace.navigationStartEvt.ts, 1805796384607);
+      assert.equal(trace.firstContentfulPaintEvt.ts, 1805797263653);
+      assert.equal(trace.firstMeaningfulPaintEvt.ts, 1805797262960);
+    });
+  });
+});


### PR DESCRIPTION
We often need to parse a trace and find the main thread, its navigationStart, and get our thread events available and sorted.

This PR introduces a computed artifact that can be reused across audits. It also migrates FMP, TTI, and user-timing audits to leverage it.

Reviewers: there is some noisiness in the diff that ?w=1 will nuke.

--

should fix #762