### PR TITLE
fix: report proper first paint delay for blocking tags audits

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -56,7 +56,9 @@ module.exports = [
         score: false,
         extendedInfo: {
           value: {
-            length: 4
+            results: {
+              length: 3
+            }
           }
         }
       },
@@ -113,7 +115,9 @@ module.exports = [
         score: false,
         extendedInfo: {
           value: {
-            length: 1
+            results: {
+              length: 1
+            }
           }
         }
       },

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const Audit = require('../audit');
+const URL = require('../../lib/url-shim');
 const Formatter = require('../../formatters/formatter');
 
 class LinkBlockingFirstPaintAudit extends Audit {
@@ -65,7 +66,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
       endTime = Math.max(item.endTime, endTime);
 
       return {
-        url: item.tag.url,
+        url: URL.getDisplayName(item.tag.url),
         totalKb: `${Math.round(item.transferSize / 1024)} KB`,
         totalMs: `${Math.round((item.endTime - startTime) * 1000)}ms`
       };

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -58,9 +58,8 @@ class LinkBlockingFirstPaintAudit extends Audit {
 
     const filtered = artifact.filter(item => item.tag.tagName === tagFilter);
 
-    let startTime = Number.MAX_VALUE;
+    const startTime = filtered.reduce((t, item) => Math.min(t, item.startTime), Number.MAX_VALUE);
     let endTime = 0;
-    startTime = filtered.reduce((t, item) => Math.min(t, item.startTime), startTime);
 
     const results = filtered.map(item => {
       endTime = Math.max(item.endTime, endTime);

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -55,31 +55,43 @@ class LinkBlockingFirstPaintAudit extends Audit {
       };
     }
 
-    let totalSpendTime = 0;
-    const results = artifact.items
-      .filter(item => item.tag.tagName === tagFilter)
-      .map(item => {
-        totalSpendTime += item.spendTime;
+    const filtered = artifact.filter(item => item.tag.tagName === tagFilter);
 
-        return {
-          url: item.tag.url,
-          label: `delayed first paint by ${item.spendTime}ms`
-        };
-      });
+    let startTime = Number.MAX_VALUE;
+    let endTime = 0;
+    startTime = filtered.reduce((t, item) => Math.min(t, item.startTime), startTime);
 
+    const results = filtered.map(item => {
+      endTime = Math.max(item.endTime, endTime);
+
+      return {
+        url: item.tag.url,
+        totalKb: `${Math.round(item.transferSize / 1024)} KB`,
+        totalMs: `${Math.round((item.endTime - startTime) * 1000)}ms`
+      };
+    });
+
+    const delayTime = Math.round((endTime - startTime) * 1000);
     let displayValue = '';
     if (results.length > 1) {
-      displayValue = `${results.length} resources delayed first paint by ${totalSpendTime}ms`;
+      displayValue = `${results.length} resources delayed first paint by ${delayTime}ms`;
     } else if (results.length === 1) {
-      displayValue = `${results.length} resource delayed first paint by ${totalSpendTime}ms`;
+      displayValue = `${results.length} resource delayed first paint by ${delayTime}ms`;
     }
 
     return {
       displayValue,
       rawValue: results.length === 0,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
-        value: results
+        formatter: Formatter.SUPPORTED_FORMATS.TABLE,
+        value: {
+          results,
+          tableHeadings: {
+            url: 'URL',
+            totalKb: 'Size (KB)',
+            totalMs: 'Delayed Paint By (ms)'
+          }
+        }
       }
     };
   }

--- a/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
@@ -123,31 +123,22 @@ class TagsBlockingFirstPaint extends Gatherer {
     return driver.evaluateAsync(scriptSrc).then(tags => {
       const requests = filteredAndIndexedByUrl(networkRecords);
 
-      let totalTransferSize = 0;
-      let totalSpendTime = 0;
-
-      const blockingTags = tags.reduce((prev, tag) => {
+      return tags.reduce((prev, tag) => {
         const request = requests[tag.url];
         if (request) {
-          const data = {
+          prev.push({
             tag,
-            transferSize: request.transferSize,
-            spendTime: Math.round((request.endTime - request.startTime) * 1000)
-          };
-          totalTransferSize += data.transferSize;
-          totalSpendTime += data.spendTime;
-          prev.push(data);
+            transferSize: request.transferSize || 0,
+            startTime: request.startTime,
+            endTime: request.endTime,
+          });
+
+          // Prevent duplicates from showing up again
+          requests[tag.url] = null;
         }
+
         return prev;
       }, []);
-
-      return {
-        items: blockingTags,
-        total: {
-          transferSize: totalTransferSize,
-          spendTime: totalSpendTime
-        }
-      };
     });
   }
 

--- a/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
@@ -67,7 +67,7 @@ describe('Link Block First Paint audit', () => {
     assert.equal(auditResult.rawValue, false);
     assert.ok(auditResult.displayValue.match('2 resources delayed first paint by 500ms'));
     assert.equal(auditResult.extendedInfo.value.results.length, 2);
-    assert.ok(auditResult.extendedInfo.value.results[0].url.match(linkDetails.href));
+    assert.equal(auditResult.extendedInfo.value.results[0].url, 'css/style.css');
     assert.equal(auditResult.extendedInfo.value.results[0].totalMs, '500ms');
     assert.equal(auditResult.extendedInfo.value.results[1].totalMs, '200ms');
   });

--- a/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
@@ -44,43 +44,39 @@ describe('Link Block First Paint audit', () => {
       rel: 'stylesheet'
     };
     const auditResult = LinkBlockingFirstPaintAudit.audit({
-      TagsBlockingFirstPaint: {
-        items: [
-          {
-            tag: linkDetails,
-            transferSize: 100,
-            spendTime: 100
-          },
-          {
-            tag: {tagName: 'SCRIPT'},
-            transferSize: 20,
-            spendTime: 20,
-          }
-        ],
-        total: {
-          transferSize: 120,
-          spendTime: 120
+      TagsBlockingFirstPaint: [
+        {
+          tag: linkDetails,
+          transferSize: 100,
+          startTime: 5,
+          endTime: 5.4,
+        },
+        {
+          tag: linkDetails,
+          transferSize: 100,
+          startTime: 4.9,
+          endTime: 5.1,
+        },
+        {
+          tag: {tagName: 'SCRIPT'},
+          transferSize: 20,
+          spendTime: 20,
         }
-      }
+      ]
     });
     assert.equal(auditResult.rawValue, false);
-    assert.ok(auditResult.displayValue.match('1 resource delayed first paint by 100ms'));
-    assert.ok(auditResult.extendedInfo.value.length, 1);
-    assert.ok(auditResult.extendedInfo.value[0].url.match(linkDetails.href));
-    assert.ok(auditResult.extendedInfo.value[0].label.match('delayed first paint'));
+    assert.ok(auditResult.displayValue.match('2 resources delayed first paint by 500ms'));
+    assert.equal(auditResult.extendedInfo.value.results.length, 2);
+    assert.ok(auditResult.extendedInfo.value.results[0].url.match(linkDetails.href));
+    assert.equal(auditResult.extendedInfo.value.results[0].totalMs, '500ms');
+    assert.equal(auditResult.extendedInfo.value.results[1].totalMs, '200ms');
   });
 
   it('passes when there are no links found which block first paint', () => {
     const auditResult = LinkBlockingFirstPaintAudit.audit({
-      TagsBlockingFirstPaint: {
-        items: [],
-        total: {
-          transferSize: 0,
-          spendTime: 0
-        }
-      }
+      TagsBlockingFirstPaint: []
     });
     assert.equal(auditResult.rawValue, true);
-    assert.ok(auditResult.extendedInfo.value.length === 0);
+    assert.equal(auditResult.extendedInfo.value.results.length, 0);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/script-blocking-first-paint-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/script-blocking-first-paint-test.js
@@ -41,48 +41,39 @@ describe('Script Block First Paint audit', () => {
       url: 'http://google.com/js/app.js',
     };
     const auditResult = ScriptBlockingFirstPaintAudit.audit({
-      TagsBlockingFirstPaint: {
-        items: [
-          {
-            tag: scriptDetails,
-            transferSize: 100,
-            spendTime: 100
-          },
-          {
-            tag: scriptDetails,
-            transferSize: 50,
-            spendTime: 50
-          },
-          {
-            tag: {tagName: 'LINK'},
-            transferSize: 110,
-            spendTime: 110
-          }
-        ],
-        total: {
-          transferSize: 260,
-          spendTime: 260
+      TagsBlockingFirstPaint: [
+        {
+          tag: scriptDetails,
+          transferSize: 100,
+          startTime: 1,
+          endTime: 1.1
+        },
+        {
+          tag: scriptDetails,
+          transferSize: 50,
+          startTime: .95,
+          endTime: 1
+        },
+        {
+          tag: {tagName: 'LINK'},
+          transferSize: 110,
+          spendTime: 110
         }
-      }
+      ]
     });
     assert.equal(auditResult.rawValue, false);
     assert.ok(auditResult.displayValue.match('2 resources delayed first paint by 150ms'));
-    assert.ok(auditResult.extendedInfo.value.length, 2);
-    assert.ok(auditResult.extendedInfo.value[0].url.match(scriptDetails.src));
-    assert.ok(auditResult.extendedInfo.value[0].label.match('delayed first paint'));
+    assert.equal(auditResult.extendedInfo.value.results.length, 2);
+    assert.ok(auditResult.extendedInfo.value.results[0].url.match(scriptDetails.src));
+    assert.equal(auditResult.extendedInfo.value.results[0].totalMs, '150ms');
+    assert.equal(auditResult.extendedInfo.value.results[1].totalMs, '50ms');
   });
 
   it('passes when there are no scripts found which block first paint', () => {
     const auditResult = ScriptBlockingFirstPaintAudit.audit({
-      TagsBlockingFirstPaint: {
-        items: [],
-        total: {
-          transferSize: 0,
-          spendTime: 0
-        }
-      }
+      TagsBlockingFirstPaint: []
     });
     assert.equal(auditResult.rawValue, true);
-    assert.ok(auditResult.extendedInfo.value.length === 0);
+    assert.equal(auditResult.extendedInfo.value.results.length, 0);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/script-blocking-first-paint-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/script-blocking-first-paint-test.js
@@ -64,7 +64,7 @@ describe('Script Block First Paint audit', () => {
     assert.equal(auditResult.rawValue, false);
     assert.ok(auditResult.displayValue.match('2 resources delayed first paint by 150ms'));
     assert.equal(auditResult.extendedInfo.value.results.length, 2);
-    assert.ok(auditResult.extendedInfo.value.results[0].url.match(scriptDetails.src));
+    assert.equal(auditResult.extendedInfo.value.results[0].url, 'js/app.js');
     assert.equal(auditResult.extendedInfo.value.results[0].totalMs, '150ms');
     assert.equal(auditResult.extendedInfo.value.results[1].totalMs, '50ms');
   });

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/tags-blocking-first-paint-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/tags-blocking-first-paint-test.js
@@ -138,24 +138,20 @@ describe('First paint blocking tags', () => {
         }
       }
     }, traceData).then(artifact => {
-      const expected = {
-        items: [
-          {
-            tag: linkDetails,
-            transferSize: 10,
-            spendTime: 0
-          },
-          {
-            tag: scriptDetails,
-            transferSize: 12,
-            spendTime: 10000
-          }
-        ],
-        total: {
-          transferSize: 22,
-          spendTime: 10000
+      const expected = [
+        {
+          tag: linkDetails,
+          transferSize: 10,
+          startTime: 10,
+          endTime: 10
+        },
+        {
+          tag: scriptDetails,
+          transferSize: 12,
+          startTime: 12,
+          endTime: 22
         }
-      };
+      ];
       assert.deepEqual(artifact, expected);
     });
   });

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/tags-blocking-first-paint-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/tags-blocking-first-paint-test.js
@@ -134,7 +134,7 @@ describe('First paint blocking tags', () => {
     return tagsBlockingFirstPaint.afterPass({
       driver: {
         evaluateAsync() {
-          return Promise.resolve([linkDetails, scriptDetails]);
+          return Promise.resolve([linkDetails, linkDetails, scriptDetails]);
         }
       }
     }, traceData).then(artifact => {


### PR DESCRIPTION
Switches the blocking tag audits to report the maximum delay of first paint rather than a sum of the individual delays. Moves us more in alignment with the actual impact these violations have on the UX.
Also removes duplicate URLs from showing up twice to be inline with our use of "resources" and switches to table formatter.

**Before**:
![image](https://cloud.githubusercontent.com/assets/2301202/22383091/2f417caa-e47d-11e6-9a42-b73dbb6f7b39.png)


**After**:
![image](https://cloud.githubusercontent.com/assets/2301202/22383152/70d10e10-e47d-11e6-9e0d-03fb0683229a.png)

