### PR TITLE
Restore "first visual change" to output.

### DIFF
--- a/lighthouse-core/formatters/partials/speedline.html
+++ b/lighthouse-core/formatters/partials/speedline.html
@@ -5,6 +5,6 @@
 </style>
 
 <ul class="subitem__details">
-  <li class="subitem__detail">First Visual Change: <strong>{{this.first}}ms</strong></li>
-  <li class="subitem__detail">Last Visual Change: <strong>{{this.complete}}ms</strong></li>
+  <li class="subitem__detail">First Visual Change: <strong>{{this.timings.firstVisualChange}}ms</strong></li>
+  <li class="subitem__detail">Last Visual Change: <strong>{{this.timings.visuallyComplete}}ms</strong></li>
 </ul>

--- a/lighthouse-core/formatters/speedline-formatter.js
+++ b/lighthouse-core/formatters/speedline-formatter.js
@@ -26,12 +26,12 @@ class SpeedlineFormatter extends Formatter {
     switch (type) {
       case 'pretty':
         return function(info) {
-          if (!info || !Array.isArray(info.frames)) {
+          if (!info || !info.timings) {
             return '';
           }
 
-          const output = `    - First Visual Change: ${info.first}ms\n` +
-          `    - Last Visual Change: ${info.complete}ms\n`;
+          const output = `    - First Visual Change: ${info.timings.firstVisualChange}ms\n` +
+          `    - Last Visual Change: ${info.timings.visuallyComplete}ms\n`;
 
           return output;
         };

--- a/lighthouse-core/test/formatter/speedline-formatter-test.js
+++ b/lighthouse-core/test/formatter/speedline-formatter-test.js
@@ -20,18 +20,29 @@
 const SpeedlineFormatter = require('../../formatters/speedline-formatter.js');
 const assert = require('assert');
 
+const mockExtendedInfo = {
+  timings: {
+    firstVisualChange: 100,
+    visuallyComplete: 540,
+    speedIndex: 320,
+    perceptualSpeedIndex: 321
+  },
+  timestamps: {
+    firstVisualChange: 1100,
+    visuallyComplete: 1540,
+    speedIndex: 1320,
+    perceptualSpeedIndex: 1321
+  },
+  frames: []
+};
+
 describe('Formatter', () => {
   it('handles valid input', () => {
     const pretty = SpeedlineFormatter.getFormatter('pretty');
-    const formatted = pretty({
-      first: 0,
-      complete: 0,
-      duration: 0,
-      frames: [
-        {timestamp: 0, progress: 0}
-      ]
-    });
+    const formatted = pretty(mockExtendedInfo);
     assert.equal(typeof formatted, 'string');
-    assert(formatted.length > 0);
+    assert.ok(formatted.length > 0);
+    assert.ok(formatted.includes('100ms'), 'first visual change isnt printed');
+    assert.ok(formatted.includes('540ms'), 'last visual change isnt printed');
   });
 });


### PR DESCRIPTION
For a bit, these metrics have reported blanks: 
![image](https://cloud.githubusercontent.com/assets/39191/22391317/63e224b4-e4a5-11e6-8214-b9d5c24aabd6.png)


This was following the refactor of the speedindex extendedInfo. This PR fixes the output of CLI/HTML to correctly emit these timings.