### PR TITLE
Start using errors instead of -1 for error artifacts

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -48,10 +48,6 @@ class NoOldFlexboxAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.Styles.rawValue === -1) {
-      return NoOldFlexboxAudit.generateAuditResult(artifacts.Styles);
-    }
-
     // https://www.w3.org/TR/2009/WD-css3-flexbox-20090723/
     // (e.g. box-flex, box-orient, box-flex-group, display: flexbox (2011 version))
     const displayPropResults = StyleHelpers.filterStylesheetsByUsage(artifacts.Styles,

--- a/lighthouse-core/audits/theme-color-meta.js
+++ b/lighthouse-core/audits/theme-color-meta.js
@@ -38,7 +38,7 @@ class ThemeColor extends Audit {
    */
   static audit(artifacts) {
     const themeColorMeta = artifacts.ThemeColor;
-    if (themeColorMeta === null || themeColorMeta === -1) {
+    if (themeColorMeta === null) {
       return ThemeColor.generateAuditResult({
         rawValue: false,
         debugString: 'No valid theme-color meta tag found.'

--- a/lighthouse-core/audits/unused-css-rules.js
+++ b/lighthouse-core/audits/unused-css-rules.js
@@ -185,12 +185,6 @@ class UnusedCSSRules extends Audit {
     const pageUrl = artifacts.URL.finalUrl;
     const networkRecords = artifacts.networkRecords[Audit.DEFAULT_PASS];
 
-    if (styles.rawValue === -1) {
-      return UnusedCSSRules.generateAuditResult(styles);
-    } else if (usage.rawValue === -1) {
-      return UnusedCSSRules.generateAuditResult(usage);
-    }
-
     const indexedSheets = UnusedCSSRules.indexStylesheetsById(styles, networkRecords);
     const unused = UnusedCSSRules.countUnusedRules(usage, indexedSheets);
     const unusedRatio = (unused / usage.length) || 0;

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -39,10 +39,10 @@ class Viewport extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (typeof artifacts.Viewport !== 'string') {
+    if (artifacts.Viewport === null) {
       return Viewport.generateAuditResult({
-        debugString: 'Error in determining viewport',
-        rawValue: -1
+        debugString: 'No viewport meta tag found',
+        rawValue: false
       });
     }
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -110,14 +110,14 @@ class GatherRunner {
   }
 
   /**
-   * Catches any `recoverable` errors from the supplied promise, rejecting on
-   * the rest.
+   * Test any error output from the promise, absorbing non-fatal errors and
+   * throwing on fatal ones so that run is stopped.
    * @param {!Promise<*>} promise
    * @return {!Promise<*>}
    */
   static recoverOrThrow(promise) {
     return promise.catch(err => {
-      if (!err.recoverable) {
+      if (err.fatal) {
         throw err;
       }
     });
@@ -237,8 +237,8 @@ class GatherRunner {
   /**
    * Takes the results of each gatherer phase for each gatherer and uses the
    * last produced value (that's not undefined) as the artifact for that
-   * gatherer. If a recoverable error was rejected from a gatherer phase,
-   * uses that error as the artifact instead.
+   * gatherer. If a non-fatal error was rejected from a gatherer phase,
+   * uses that error object as the artifact instead.
    * @param {!Object<!Array<!Promise<*>>} gathererResults
    * @return {!Promise<!Artifacts>}
    */
@@ -257,7 +257,7 @@ class GatherRunner {
           }
           artifacts[gathererName] = artifact;
         }, err => {
-          // To reach this point, all errors are recoverable, so return err to
+          // To reach this point, all errors are non-fatal, so return err to
           // runner to handle turning it into an error audit.
           artifacts[gathererName] = err;
         });

--- a/lighthouse-core/gather/gatherers/css-usage.js
+++ b/lighthouse-core/gather/gatherers/css-usage.js
@@ -29,8 +29,7 @@ class CSSUsage extends Gatherer {
       .catch(err => {
         // TODO(phulce): Remove this once CSS usage hits stable
         if (/startRuleUsageTracking/.test(err.message)) {
-          this.failure = 'CSS Usage tracking requires Chrome \u2265 56';
-          return;
+          throw new Error('CSS Usage tracking requires Chrome \u2265 56');
         }
 
         throw err;
@@ -44,11 +43,6 @@ class CSSUsage extends Gatherer {
       return driver.sendCommand('CSS.disable')
         .then(_ => driver.sendCommand('DOM.disable'))
         .then(_ => results.ruleUsage);
-    }).catch(err => {
-      return {
-        rawValue: -1,
-        debugString: this.failure || err,
-      };
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/gatherer.js
+++ b/lighthouse-core/gather/gatherers/gatherer.js
@@ -23,9 +23,9 @@
  * Promise that resolves to that value.
  *
  * If an Error is thrown (or a Promise that rejects on an Error), the
- * GatherRunner will check for a `recoverable` property on the Error. If set to
- * `true`, the runner will treat it as an expected error internal to the
- * gatherer and continue execution of any remaining gatherers.
+ * GatherRunner will check for a `fatal` property on the Error. If not set to
+ * `true`, the runner will treat it as an error internal to the gatherer and
+ * continue execution of any remaining gatherers.
  */
 class Gatherer {
   /**

--- a/lighthouse-core/gather/gatherers/styles.js
+++ b/lighthouse-core/gather/gatherers/styles.js
@@ -147,11 +147,6 @@ class Styles extends Gatherer {
           stylesheet.isDuplicate = idInMap !== stylesheet.header.styleSheetId;
           return stylesheet;
         });
-      }, err => {
-        return {
-          rawValue: -1,
-          debugString: err
-        };
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/theme-color.js
+++ b/lighthouse-core/gather/gatherers/theme-color.js
@@ -20,14 +20,15 @@ const Gatherer = require('./gatherer');
 
 class ThemeColor extends Gatherer {
 
+  /**
+   * @param {{driver: !Object}} options
+   * @return {!Promise<?string>} The value of the theme-color meta's content attribute, or null
+   */
   afterPass(options) {
     const driver = options.driver;
 
     return driver.querySelector('head meta[name="theme-color"]')
-      .then(node => node && node.getAttribute('content'))
-      .catch(_ => {
-        return -1;
-      });
+      .then(node => node && node.getAttribute('content'));
   }
 }
 

--- a/lighthouse-core/gather/gatherers/viewport.js
+++ b/lighthouse-core/gather/gatherers/viewport.js
@@ -21,17 +21,14 @@ const Gatherer = require('./gatherer');
 class Viewport extends Gatherer {
 
   /**
-   * @param {!{driver: !Object}} options Run options
+   * @param {{driver: !Object}} options Run options
    * @return {!Promise<?string>} The value of the viewport meta's content attribute, or null
    */
   afterPass(options) {
     const driver = options.driver;
 
     return driver.querySelector('head meta[name="viewport"]')
-      .then(node => node && node.getAttribute('content'))
-      .catch(_ => {
-        return -1;
-      });
+      .then(node => node && node.getAttribute('content'));
   }
 }
 

--- a/lighthouse-core/test/audits/dobetterweb/no-old-flexbox-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-old-flexbox-test.js
@@ -22,19 +22,6 @@ const stylesData = require('../../fixtures/styles-gatherer.json');
 /* eslint-env mocha */
 
 describe('Page does not use old CSS flexbox', () => {
-  it('debugString is present if gatherer fails', () => {
-    const debugString = 'No active stylesheets were collected.';
-    const auditResult = NoOldFlexboxAudit.audit({
-      Styles: {
-        rawValue: -1,
-        debugString: debugString
-      },
-      URL: {finalUrl: 'https://example.com'},
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('passes when no stylesheets were collected on the page', () => {
     const auditResult = NoOldFlexboxAudit.audit({
       Styles: [],

--- a/lighthouse-core/test/audits/theme-color-meta-test.js
+++ b/lighthouse-core/test/audits/theme-color-meta-test.js
@@ -19,12 +19,12 @@
 const Audit = require('../../audits/theme-color-meta.js');
 const assert = require('assert');
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('HTML: theme-color audit', () => {
-  it('fails and warns when no value given', () => {
+  it('fails and warns when no theme-color meta tag found', () => {
     const nullColorAudit = Audit.audit({
-      ThemeColor: -1
+      ThemeColor: null
     });
 
     assert.equal(nullColorAudit.rawValue, false);

--- a/lighthouse-core/test/audits/unused-css-rules-test.js
+++ b/lighthouse-core/test/audits/unused-css-rules-test.js
@@ -142,18 +142,6 @@ describe('Best Practices: unused css rules audit', () => {
       ]
     };
 
-    it('fails when gatherers failed', () => {
-      const result = UnusedCSSAudit.audit_({
-        networkRecords,
-        URL: {finalUrl: ''},
-        CSSUsage: {rawValue: -1, debugString: 'It errored'},
-        Styles: []
-      });
-
-      assert.equal(result.debugString, 'It errored');
-      assert.equal(result.rawValue, -1);
-    });
-
     it('ignores missing stylesheets', () => {
       const result = UnusedCSSAudit.audit_({
         networkRecords,

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -18,20 +18,12 @@
 const Audit = require('../../audits/viewport.js');
 const assert = require('assert');
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('Mobile-friendly: viewport audit', () => {
-  it('fails when no input present', () => {
-    const audit = Audit.audit({
-      Viewport: -1
-    });
-    assert.equal(audit.rawValue, -1);
-    assert.equal(audit.debugString, 'Error in determining viewport');
-  });
-
   it('fails when HTML does not contain a viewport meta tag', () => {
     return assert.equal(Audit.audit({
-      Viewport: ''
+      Viewport: null
     }).rawValue, false);
   });
 

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -542,10 +542,7 @@ describe('GatherRunner', function() {
 
     it('uses the last not-undefined phase result as artifact', () => {
       const recoverableError = new Error('My recoverable error');
-      recoverableError.recoverable = true;
-
       const someOtherError = new Error('Bad, bad error.');
-      someOtherError.recoverable = true;
 
       // Gatherer results are all expected to be arrays of promises
       const gathererResults = {
@@ -586,28 +583,22 @@ describe('GatherRunner', function() {
       });
     });
 
-    it('supports sync and async throwing of recoverable errors from gatherers', () => {
+    it('supports sync and async throwing of non-fatal errors from gatherers', () => {
       const gatherers = [
         // sync
         new class BeforeSync extends Gatherer {
           beforePass() {
-            const err = new Error(this.name);
-            err.recoverable = true;
-            throw err;
+            throw new Error(this.name);
           }
         }(),
         new class PassSync extends Gatherer {
           pass() {
-            const err = new Error(this.name);
-            err.recoverable = true;
-            throw err;
+            throw new Error(this.name);
           }
         }(),
         new class AfterSync extends Gatherer {
           afterPass() {
-            const err = new Error(this.name);
-            err.recoverable = true;
-            throw err;
+            throw new Error(this.name);
           }
         }(),
 
@@ -615,21 +606,18 @@ describe('GatherRunner', function() {
         new class BeforePromise extends Gatherer {
           beforePass() {
             const err = new Error(this.name);
-            err.recoverable = true;
             return Promise.reject(err);
           }
         }(),
         new class PassPromise extends Gatherer {
           pass() {
             const err = new Error(this.name);
-            err.recoverable = true;
             return Promise.reject(err);
           }
         }(),
         new class AfterPromise extends Gatherer {
           afterPass() {
             const err = new Error(this.name);
-            err.recoverable = true;
             return Promise.reject(err);
           }
         }()
@@ -653,8 +641,10 @@ describe('GatherRunner', function() {
       });
     });
 
-    it('rejects if a gatherer returns an unrecoverable error', () => {
+    it('rejects if a gatherer returns a fatal error', () => {
       const errorMessage = 'Gather Failed in pass()';
+      const err = new Error(errorMessage);
+      err.fatal = true;
       const gatherers = [
         // sync
         new class GathererSuccess extends Gatherer {
@@ -664,7 +654,7 @@ describe('GatherRunner', function() {
         }(),
         new class GathererFailure extends Gatherer {
           pass() {
-            return Promise.reject(new Error(errorMessage));
+            return Promise.reject(err);
           }
         }
       ];

--- a/lighthouse-core/test/gather/gatherers/theme-color-test.js
+++ b/lighthouse-core/test/gather/gatherers/theme-color-test.js
@@ -42,16 +42,4 @@ describe('Theme Color gatherer', () => {
       assert.equal(artifact, '#288A76');
     });
   });
-
-  it('handles driver failure', () => {
-    return themeColorGather.afterPass({
-      driver: {
-        querySelector() {
-          return Promise.reject('such a fail');
-        }
-      }
-    }).then(artifact => {
-      assert.equal(artifact, -1);
-    });
-  });
 });

--- a/lighthouse-core/test/gather/gatherers/viewport-test.js
+++ b/lighthouse-core/test/gather/gatherers/viewport-test.js
@@ -41,16 +41,4 @@ describe('Viewport gatherer', () => {
       assert.ok(/width=/gim.test(artifact));
     });
   });
-
-  it('handles driver failure', () => {
-    return viewportGather.afterPass({
-      driver: {
-        querySelector() {
-          return Promise.reject('such a fail');
-        }
-      }
-    }).then(artifact => {
-      assert.equal(artifact, -1);
-    });
-  });
 });


### PR DESCRIPTION
retrying #1498 (as next step of #941), now with errors from gatherers being considered recoverable by default. If you want to stop a run, throw an error with a `fatal` property set to `true`.

Biggest benefit is that if something throws inside a gatherer that isn't something the gatherer cares about or is specifically watching for, it can just let the exception go. That means
- no more `catch` block in every gatherer
- no more `-1` artifacts...now they're just `Error` objects
- no more checking for `-1` artifacts in every audit. If one of an audit's `requiredArtifacts` is an error, the audit never runs and LH emits an error result on behalf of that audit.

First commits changes old `recoverable` infra to support `fatal`.
Other commits try switching over some of our gatherers to using this format.  The first two (`meta viewport` and `theme-color`) are simple, the last commit is giving that treatment to the slightly more complicated `Styles` and `CSSUsage` gatherers and the two audits that need them.

Thoughts?