### PR TITLE
Report: do not expand help text by default when audit is violated

### DIFF
--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -127,7 +127,7 @@ limitations under the License.
                     {{/if}}
 
                     {{#if subItem.helpText }}
-                      <input type="checkbox" class="subitem__help-toggle" title="Toggle help text"  {{#if (shouldShowHelpText subItem.score)}}checked{{/if}}>
+                      <input type="checkbox" class="subitem__help-toggle" title="Toggle help text">
                       <span class="subitem__help">
                         {{ sanitize subItem.helpText }}
                       </span>


### PR DESCRIPTION
R: all

This was discussed at the meeting today and I wanted to see the difference. It's small change but I think it goes a lonnnnnng way to reduce the visual density of the report.

Before:

![screen shot 2017-01-27 at 3 46 20 pm](https://cloud.githubusercontent.com/assets/238208/22391760/fec27bc6-e4a7-11e6-8561-694bcfe854e4.png)

After:

![screen shot 2017-01-27 at 3 45 48 pm](https://cloud.githubusercontent.com/assets/238208/22391759/fb17d912-e4a7-11e6-86c9-25e7bf925fa0.png)
