### PR TITLE
fix(optimized-images): dedupe image URLs

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
@@ -71,7 +71,13 @@ class OptimizedImages extends Gatherer {
    * @return {!Array<{url: string, isBase64DataUri: boolean, mimeType: string, resourceSize: number}>}
    */
   static filterImageRequests(pageUrl, networkRecords) {
+    const seenUrls = new Set();
     return networkRecords.reduce((prev, record) => {
+      if (seenUrls.has(record._url)) {
+        return prev;
+      }
+
+      seenUrls.add(record._url);
       const isOptimizableImage = /image\/(png|bmp|jpeg)/.test(record._mimeType);
       const isSameOrigin = URL.hostsMatch(pageUrl, record._url);
       const isBase64DataUri = /^data:.{2,40}base64\s*,/.test(record._url);

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
@@ -45,6 +45,11 @@ const traceData = {
       _resourceSize: 12,
     },
     {
+      _url: 'http://google.com/image.bmp',
+      _mimeType: 'image/bmp',
+      _resourceSize: 12,
+    },
+    {
       _url: 'http://google.com/vector.svg',
       _mimeType: 'image/svg+xml',
       _resourceSize: 13,


### PR DESCRIPTION
addresses one of the failing tests in #1573 
earlier versions of Chrome apparently collect multiple network records for data URIs