### PR TITLE
feat: save each screenshot asset individually

### DIFF
--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -118,9 +118,11 @@ function prepareAssets(artifacts, results) {
       .then(screenshots => {
         const traceData = Object.assign({}, trace);
         const html = screenshotDump(screenshots, results);
+        const imageData = screenshots.map(shot => shot.datauri.replace(/^.*?base64,/, ''));
 
         assets.push({
           traceData,
+          imageData,
           html
         });
       });
@@ -139,11 +141,20 @@ function saveAssets(artifacts, results) {
     assets.forEach((data, index) => {
       const filenamePrefix = getFilenamePrefix(results);
       const traceData = data.traceData;
-      fs.writeFileSync(`${filenamePrefix}-${index}.trace.json`, JSON.stringify(traceData, null, 2));
-      log.log('trace file saved to disk', filenamePrefix);
 
-      fs.writeFileSync(`${filenamePrefix}-${index}.screenshots.html`, data.html);
-      log.log('screenshots saved to disk', filenamePrefix);
+      const traceFilename = `${filenamePrefix}-${index}.trace.json`;
+      fs.writeFileSync(traceFilename, JSON.stringify(traceData, null, 2));
+      log.log('trace file saved to disk', traceFilename);
+
+      data.imageData.forEach((imageData, imageIndex) => {
+        const filename = `${filenamePrefix}-${index}-screenshot${imageIndex}.jpg`;
+        fs.writeFileSync(filename, imageData, 'base64');
+        log.log('screenshot saved to disk', filename);
+      });
+
+      const screenshotsFilename = `${filenamePrefix}-${index}.screenshots.html`;
+      fs.writeFileSync(screenshotsFilename, data.html);
+      log.log('screenshots saved to disk', screenshotsFilename);
     });
   });
 }

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -93,5 +93,13 @@ describe('asset-saver helper', () => {
       assert.ok(ssFileContents.includes('{"timestamp":674089419.919'));
       fs.unlinkSync(ssFilename);
     });
+
+    it('each screenshot file saved to disk', () => {
+      screenshotFilmstrip.forEach((_, index) => {
+        const filename = assetSaver.getFilenamePrefix(options) + `-0-screenshot${index}.jpg`;
+        assert.ok(fs.existsSync(filename));
+        fs.unlinkSync(filename);
+      });
+    });
   });
 });


### PR DESCRIPTION
Came across this while working towards WPT integration. Not sure what the use case was for the screenshots file, so I might be missing context of the original decision.

**New Output:**
![image](https://cloud.githubusercontent.com/assets/2301202/22448107/d53d2902-e70b-11e6-99af-01b89db79290.png)
