### PR TITLE
Report: fixes for mobile. Also make header position: fixed again

### DIFF
--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -43,8 +43,10 @@ class LighthouseReport {
     }
 
     const headerContainer = document.querySelector('.js-header-container');
-    const toggleButton = headerContainer.querySelector('.js-header-toggle');
-    toggleButton.addEventListener('click', () => headerContainer.classList.toggle('expanded'));
+    if (headerContainer) {
+      const toggleButton = headerContainer.querySelector('.js-header-toggle');
+      toggleButton.addEventListener('click', () => headerContainer.classList.toggle('expanded'));
+    }
   }
 
   /**

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -214,6 +214,7 @@ body {
 
 .report-body__aggregations-container {
   will-change: transform;
+  padding-top: var(--report-header-height);
 }
 
 .report-body__menu-container {
@@ -323,6 +324,7 @@ body {
   flex: 1 1 0;
   white-space: nowrap;
   padding-right: 10px;
+  overflow: hidden;
 }
 
 .report-body__buttons {
@@ -359,10 +361,6 @@ body {
   border: none;
 }
 
-.report-body__header-container {
-  background: #FAFAFA;
-}
-
 .report-body__header {
   height: var(--report-header-height);
   display: flex;
@@ -371,6 +369,12 @@ body {
   justify-content: flex-start;
   padding: 0 var(--heading-line-height) 0 0;
   border-bottom: 1px solid #EBEBEB;
+  position: fixed;
+  width: calc(100vw - var(--report-menu-width));
+  max-width: calc( var(--report-width) - var(--report-menu-width));
+  z-index: 1;
+  will-change: transform;
+  background: #fafafa;
 }
 
 .report-body__header-toggle {
@@ -393,6 +397,10 @@ body {
 .report-body__header-content {
   display: none;
   padding: 10px 0 10px 42px;
+  top: 100%;
+  position: absolute;
+  width: 100%;
+  background: inherit;
 }
 
 .report-body__header-container.expanded .report-body__header-content {
@@ -962,6 +970,7 @@ body {
   .report-body__fixed-footer-container {
     margin-left: 0;
   }
+  .report-body__header,
   .report-body__fixed-footer-container {
     width: 100%;
   }

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -51,7 +51,7 @@ limitations under the License.
       </div>
       <div class="report-body__header-container js-header-container">
         <div class="report-body__header">
-          <button class="report-body__header-toggle js-header-toggle"></button>
+          <button class="report-body__header-toggle js-header-toggle" title="See report's runtime settings"></button>
           <div class="report-body__metadata">
             <div class="report-body__url">Results for: <a href="{{ url }}" target="_blank">{{ url }}</a></div>
             <div class="report-body__url">Generated on: {{generatedTime}}</div>
@@ -73,33 +73,33 @@ limitations under the License.
               <button class="report-body__icon print js-print" title="Print HTML report"></button>
             {{/if_not_eq}}
           </div>
-        </div>
-        <div class="report-body__header-content">
-          <section class="config-section">
-            <h2 class="config-section__title">Runtime Environment</h2>
-            <ul class="config-section__items">
-              {{#each runtimeConfig.environment }}
-              <li class="config-section__item">
-                <p class="config-section__desc">
-                  {{ this.name }} ({{ this.description }}):
-                  <strong> {{#if this.enabled }}Enabled{{else}}Disabled{{/if}}</strong>
-                </p>
-              </li>
-              {{/each}}
-            </ul>
-          </section>
-          {{#if runtimeConfig.blockedUrlPatterns }}
-          <section class="config-section">
-            <h2 class="config-section__title">Blocked URL Patterns</h2>
-            <ul class="config-section__items">
-              {{#each runtimeConfig.blockedUrlPatterns }}
-              <li class="config-section__item">
-                <p class="config-section__desc">{{ this }}</p>
-              </li>
-              {{/each}}
-            </ul>
-          </section>
-          {{/if}}
+          <div class="report-body__header-content">
+            <section class="config-section">
+              <h2 class="config-section__title">Runtime Environment</h2>
+              <ul class="config-section__items">
+                {{#each runtimeConfig.environment }}
+                <li class="config-section__item">
+                  <p class="config-section__desc">
+                    {{ this.name }} ({{ this.description }}):
+                    <strong> {{#if this.enabled }}Enabled{{else}}Disabled{{/if}}</strong>
+                  </p>
+                </li>
+                {{/each}}
+              </ul>
+            </section>
+            {{#if runtimeConfig.blockedUrlPatterns }}
+            <section class="config-section">
+              <h2 class="config-section__title">Blocked URL Patterns</h2>
+              <ul class="config-section__items">
+                {{#each runtimeConfig.blockedUrlPatterns }}
+                <li class="config-section__item">
+                  <p class="config-section__desc">{{ this }}</p>
+                </li>
+                {{/each}}
+              </ul>
+            </section>
+            {{/if}}
+          </div>
         </div>
       </div>
       <div class="report-body__aggregations-container">

--- a/lighthouse-viewer/app/index.html
+++ b/lighthouse-viewer/app/index.html
@@ -42,7 +42,7 @@ limitations under the License.
     </div>
     <div>
       <h1 class="viewer-placeholder__heading">Lighthouse Report Viewer</h1>
-      <div class="viewer-placeholder__help">To view report: Paste a report.json or Gist URL.<br>
+      <div class="viewer-placeholder__help">To view a report: Paste its json or a Gist URL.<br>
       You can also drag 'n drop the file or click here to select it.</div>
       <input type="url" class="viewer-placeholder__url js-gist-url"
              placeholder="Enter or paste Gist URL">


### PR DESCRIPTION
R: @paulirish 

- Moves the header area back to being position fixed so the config info, url, and buttons are always visible when scrolling the report.
- This fixes some issues with the mobile view of the report introduced in https://github.com/GoogleChrome/lighthouse/commit/a5416c46c957b9f57824117bc3928c5c80fdd75e.
- Also fixes some JS issues in the Viewer after the addition of the new toggle button.

![screen shot 2017-01-31 at 3 47 07 pm](https://cloud.githubusercontent.com/assets/238208/22489516/c94c7f8c-e7cc-11e6-8ac0-83208d651f02.png)
