### PR TITLE
add explicit result error property for erroneous audit results

### DIFF
--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -110,7 +110,9 @@ function createOutput(results: Results, outputMode: OutputMode): string {
         if (auditResult.comingSoon === true)
           return;
 
-        let lineItem = ` ${log.doubleLightHorizontal} ${formatAggregationResultItem(auditResult.score)} ${auditResult.description}`;
+        const formattedScore = auditResult.error ? `${log.redify('‽')}` :
+            `${formatAggregationResultItem(auditResult.score)}`;
+        let lineItem = ` ${log.doubleLightHorizontal} ${formattedScore} ${auditResult.description}`;
         if (auditResult.displayValue) {
           lineItem += ` (${log.bold}${auditResult.displayValue}${log.reset})`;
         }

--- a/lighthouse-cli/types/types.ts
+++ b/lighthouse-cli/types/types.ts
@@ -3,6 +3,7 @@ interface AuditResult {
   debugString: string;
   comingSoon?: boolean;
   score: number;
+  error?: boolean;
   description: string;
   name: string;
   category: string;

--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -77,6 +77,12 @@ class Aggregate {
       throw new Error(msg);
     }
 
+    // Audit resulted in an error, so doesn't contribute to score.
+    // TODO: could do NaN instead, as score becomes somewhat meaningless.
+    if (result.error) {
+      return 0;
+    }
+
     if (typeof result === 'undefined' ||
         typeof result.score === 'undefined') {
       let msg =

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -34,6 +34,18 @@ class Audit {
   }
 
   /**
+   * @param {string} debugString
+   * @return {!AuditResult}
+   */
+  static generateErrorAuditResult(debugString) {
+    return this.generateAuditResult({
+      rawValue: null,
+      error: true,
+      debugString
+    });
+  }
+
+  /**
    * @param {!AuditResultInput} result
    * @return {!AuditResult}
    */
@@ -57,6 +69,7 @@ class Audit {
       score,
       displayValue: `${displayValue}`,
       rawValue: result.rawValue,
+      error: result.error,
       debugString: result.debugString,
       optimalValue: result.optimalValue,
       extendedInfo: result.extendedInfo,

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -33,6 +33,7 @@ span, div, p, section, header, h1, h2, li, ul {
   --good-color: #1ac123;
   --average-color: #ffae00;
   --unknown-color: #b3b3b3;
+  --warning-color: #f6be00;
   --gutter-gap: 12px;
   --gutter-width: 40px;
   --body-font-size: 14px;
@@ -895,6 +896,9 @@ body {
 }
 .score-poor-bg {
   background-color: var(--poor-color);
+}
+.score-warning-bg {
+  background-color: var(--warning-color);
 }
 .score-unknown-bg {
   background-color: var(--unknown-color);

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -189,6 +189,8 @@ limitations under the License.
                   <div class="subitem-result">
                     {{#if subItem.comingSoon}}
                           <span class="subitem-result__unknown score-unknown-bg">N/A</span>
+                    {{else if subItem.error}}
+                      <span class="subitem-result__unknown score-warning-bg">N/A</span>
                     {{else}}
                       {{#if (is-bool subItem.score)}}
                         {{#if subItem.score}}


### PR DESCRIPTION
Related to #941 
Fixes #1148
Makes #1567 non-fatal again

This PR does two things
- audits can now throw non-fatal errors (like gatherers after #1560) and the `Error` object will be converted into an error result . Any audits that require artifacts from gatherers that have already been converted to using errors will get this behavior today.
- these error results are explicitly handled by `aggregate.js` instead of throwing.

I was going hold off on doing this, but it turns out to be necessary for converting gatherers to using proper `Error` objects for errors. When Runner got an error artifact, [it was outputting `-1` results from audits that depend on them](https://github.com/GoogleChrome/lighthouse/blob/4442f53cb6da4b005733674f0ae996f4c2e8a70c/lighthouse-core/runner.js#L189-L191), but quickly ran into an issue with audits that have expected boolean values, since [aggregate checks that the audit result and the expected result have the same type](https://github.com/GoogleChrome/lighthouse/blob/4442f53cb6da4b005733674f0ae996f4c2e8a70c/lighthouse-core/aggregator/aggregate.js#L90), otherwise it throws (this actually happens on master, such as in #1148, since e.g. the [viewport audit used to use `-1` as its error score](https://github.com/GoogleChrome/lighthouse/blob/539241e78e4549921967f5f0ae78b4f3afc59846/lighthouse-core/audits/viewport.js#L43-L46) but expects `true`/`false` in the config).

One benefit is it takes the currently fatal error from the missing FCP event (#1567) and automatically turns it into a error audit result now. Going forward we can convert all the audits to this system, which will simplify audits and audit tests much like what's been going on with gatherers.