### PR TITLE
Report: lingo cleanup, visual cleanup, remove redundant messaging

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -47,7 +47,7 @@ module.exports = [
       },
       'appcache-manifest': {
         score: false,
-        displayValue: '<html manifest="clock.appcache">'
+        debugString: 'Found <html manifest="clock.appcache">.'
       },
       'geolocation-on-start': {
         score: false
@@ -112,7 +112,7 @@ module.exports = [
       },
       'no-websql': {
         score: false,
-        displayValue: 'db name: mydb, version: 1.0'
+        debugString: 'Found database "mydb", version: 1.0.'
       },
       'notification-on-start': {
         score: false

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -33,7 +33,7 @@ class Deprecations extends Audit {
     return {
       category: 'Deprecations',
       name: 'deprecations',
-      description: 'Site does not use deprecated APIs',
+      description: 'Page avoids deprecated APIs',
       helpText: 'We found some uses of deprecated APIs. Please consider migrating ' +
           'to a newer option. [Learn more](https://www.chromestatus.com/features#deprecated).',
       requiredArtifacts: ['ChromeConsoleMessages']

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -33,7 +33,7 @@ class Deprecations extends Audit {
     return {
       category: 'Deprecations',
       name: 'deprecations',
-      description: 'Page avoids deprecated APIs',
+      description: 'Avoids deprecated APIs',
       helpText: 'We found some uses of deprecated APIs. Please consider migrating ' +
           'to a newer option. [Learn more](https://www.chromestatus.com/features#deprecated).',
       requiredArtifacts: ['ChromeConsoleMessages']

--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -32,7 +32,7 @@ class AppCacheManifestAttr extends Audit {
     return {
       category: 'Offline',
       name: 'appcache-manifest',
-      description: 'Page avoids using Application Cache',
+      description: 'Avoids using Application Cache',
       helpText: 'Application Cache has been [deprecated](https://html.spec.whatwg.org/multipage/browsers.html#offline) by [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers). Consider implementing an offline solution using the [Cache Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Cache).',
       requiredArtifacts: ['AppCacheManifest']
     };
@@ -51,11 +51,11 @@ class AppCacheManifestAttr extends Audit {
     }
 
     const usingAppcache = artifacts.AppCacheManifest !== null;
-    const displayValue = usingAppcache ? `<html manifest="${artifacts.AppCacheManifest}">` : '';
+    const debugString = usingAppcache ? `Found <html manifest="${artifacts.AppCacheManifest}">.` : '';
 
     return AppCacheManifestAttr.generateAuditResult({
       rawValue: !usingAppcache,
-      displayValue: displayValue
+      debugString
     });
   }
 }

--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -32,7 +32,7 @@ class AppCacheManifestAttr extends Audit {
     return {
       category: 'Offline',
       name: 'appcache-manifest',
-      description: 'Avoids using Application Cache',
+      description: 'Avoids Application Cache',
       helpText: 'Application Cache has been [deprecated](https://html.spec.whatwg.org/multipage/browsers.html#offline) by [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers). Consider implementing an offline solution using the [Cache Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Cache).',
       requiredArtifacts: ['AppCacheManifest']
     };

--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -51,7 +51,8 @@ class AppCacheManifestAttr extends Audit {
     }
 
     const usingAppcache = artifacts.AppCacheManifest !== null;
-    const debugString = usingAppcache ? `Found <html manifest="${artifacts.AppCacheManifest}">.` : '';
+    const debugString = usingAppcache ?
+        `Found <html manifest="${artifacts.AppCacheManifest}">.` : '';
 
     return AppCacheManifestAttr.generateAuditResult({
       rawValue: !usingAppcache,

--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -32,7 +32,7 @@ class AppCacheManifestAttr extends Audit {
     return {
       category: 'Offline',
       name: 'appcache-manifest',
-      description: 'Site does not use Application Cache',
+      description: 'Page avoids using Application Cache',
       helpText: 'Application Cache has been [deprecated](https://html.spec.whatwg.org/multipage/browsers.html#offline) by [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers). Consider implementing an offline solution using the [Cache Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Cache).',
       requiredArtifacts: ['AppCacheManifest']
     };

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -29,7 +29,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     return {
       category: 'Performance',
       name: 'external-anchors-use-rel-noopener',
-      description: 'Opens external anchors using rel="noopener"',
+      description: 'Page opens external anchors using rel="noopener"',
       helpText: 'Open new tabs using `rel="noopener"` to improve performance and ' +
           'prevent security vulnerabilities. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).',

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -29,7 +29,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     return {
       category: 'Performance',
       name: 'external-anchors-use-rel-noopener',
-      description: 'Page opens external anchors using rel="noopener"',
+      description: 'Opens external anchors using rel="noopener"',
       helpText: 'Open new tabs using `rel="noopener"` to improve performance and ' +
           'prevent security vulnerabilities. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).',

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -29,7 +29,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     return {
       category: 'Performance',
       name: 'external-anchors-use-rel-noopener',
-      description: 'Site opens external anchors using rel="noopener"',
+      description: 'Page opens external anchors using rel="noopener"',
       helpText: 'Open new tabs using `rel="noopener"` to improve performance and ' +
           'prevent security vulnerabilities. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).',

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -33,7 +33,7 @@ class GeolocationOnStart extends Audit {
     return {
       category: 'UX',
       name: 'geolocation-on-start',
-      description: 'Page avoids requesting the geolocation permission on page load',
+      description: 'Avoids requesting the geolocation permission on page load',
       helpText: 'Users are mistrustful of or confused by sites that request their ' +
           'location without context. Consider tying the request to user gestures instead. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).',

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -33,7 +33,7 @@ class GeolocationOnStart extends Audit {
     return {
       category: 'UX',
       name: 'geolocation-on-start',
-      description: 'Page does not automatically request geolocation on page load',
+      description: 'Page avoids requesting the geolocation permission on page load',
       helpText: 'Users are mistrustful of or confused by sites that request their ' +
           'location without context. Consider tying the request to user gestures instead. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).',

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -34,7 +34,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
     return {
       category: 'Performance',
       name: 'link-blocking-first-paint',
-      description: 'Avoids using `<link>` that delay first paint',
+      description: 'Avoids `<link>` that delay first paint',
       helpText: 'Link elements are blocking the first paint of your page. Consider ' +
           'inlining critical links and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -34,7 +34,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
     return {
       category: 'Performance',
       name: 'link-blocking-first-paint',
-      description: 'Site does not use <link> that delay first paint',
+      description: 'Page avoids using `<link>` that delay first paint',
       helpText: 'Link elements are blocking the first paint of your page. Consider ' +
           'inlining critical links and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -34,7 +34,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
     return {
       category: 'Performance',
       name: 'link-blocking-first-paint',
-      description: 'Page avoids using `<link>` that delay first paint',
+      description: 'Avoids using `<link>` that delay first paint',
       helpText: 'Link elements are blocking the first paint of your page. Consider ' +
           'inlining critical links and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -34,7 +34,7 @@ class NoConsoleTimeAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-console-time',
-      description: 'Site does not use `console.time()` in its own scripts',
+      description: 'Page avoids using `console.time()` in its own scripts',
       helpText: 'Consider using `performance.mark()` and `performance.measure()` ' +
           'from the User Timing API instead. They provide high-precision timestamps, ' +
           'independent of the system clock, and are integrated in the Chrome DevTools Timeline. ' +

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -34,7 +34,7 @@ class NoConsoleTimeAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-console-time',
-      description: 'Avoids using `console.time()` in its own scripts',
+      description: 'Avoids `console.time()` in its own scripts',
       helpText: 'Consider using `performance.mark()` and `performance.measure()` ' +
           'from the User Timing API instead. They provide high-precision timestamps, ' +
           'independent of the system clock, and are integrated in the Chrome DevTools Timeline. ' +

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -34,7 +34,7 @@ class NoConsoleTimeAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-console-time',
-      description: 'Page avoids using `console.time()` in its own scripts',
+      description: 'Avoids using `console.time()` in its own scripts',
       helpText: 'Consider using `performance.mark()` and `performance.measure()` ' +
           'from the User Timing API instead. They provide high-precision timestamps, ' +
           'independent of the system clock, and are integrated in the Chrome DevTools Timeline. ' +

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -35,7 +35,7 @@ class NoDateNowAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-datenow',
-      description: 'Site does not use `Date.now()` in its own scripts',
+      description: 'Page avoids using `Date.now()` in its own scripts',
       helpText: 'Consider using `performance.now()` from the User Timing API ' +
           'instead. It provides high-precision timestamps, independent of the system ' +
           'clock. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/date-now).',

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -35,7 +35,7 @@ class NoDateNowAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-datenow',
-      description: 'Page avoids using `Date.now()` in its own scripts',
+      description: 'Avoids using `Date.now()` in its own scripts',
       helpText: 'Consider using `performance.now()` from the User Timing API ' +
           'instead. It provides high-precision timestamps, independent of the system ' +
           'clock. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/date-now).',

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -35,7 +35,7 @@ class NoDateNowAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-datenow',
-      description: 'Avoids using `Date.now()` in its own scripts',
+      description: 'Avoids `Date.now()` in its own scripts',
       helpText: 'Consider using `performance.now()` from the User Timing API ' +
           'instead. It provides high-precision timestamps, independent of the system ' +
           'clock. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/date-now).',

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -33,7 +33,7 @@ class NoDocWriteAudit extends Audit {
     return {
       category: 'Performance',
       name: 'no-document-write',
-      description: 'Site does not use document.write()',
+      description: 'Page avoids using `document.write()`',
       helpText: 'For users on slow connections, external scripts dynamically injected via ' +
           '`document.write()` can delay page load by tens of seconds. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).',

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -33,7 +33,7 @@ class NoDocWriteAudit extends Audit {
     return {
       category: 'Performance',
       name: 'no-document-write',
-      description: 'Page avoids using `document.write()`',
+      description: 'Avoids using `document.write()`',
       helpText: 'For users on slow connections, external scripts dynamically injected via ' +
           '`document.write()` can delay page load by tens of seconds. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).',

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -33,7 +33,7 @@ class NoDocWriteAudit extends Audit {
     return {
       category: 'Performance',
       name: 'no-document-write',
-      description: 'Avoids using `document.write()`',
+      description: 'Avoids `document.write()`',
       helpText: 'For users on slow connections, external scripts dynamically injected via ' +
           '`document.write()` can delay page load by tens of seconds. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).',

--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -50,7 +50,7 @@ class NoMutationEventsAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-mutation-events',
-      description: 'Site does not use Mutation Events in its own scripts',
+      description: 'Page avoids using Mutation Events in its own scripts',
       helpText: 'Mutation Events are deprecated and harm performance. Consider using Mutation ' +
           'Observers instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/mutation-events).',
       requiredArtifacts: ['URL', 'EventListeners']

--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -50,7 +50,7 @@ class NoMutationEventsAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-mutation-events',
-      description: 'Page avoids using Mutation Events in its own scripts',
+      description: 'Avoids using Mutation Events in its own scripts',
       helpText: 'Mutation Events are deprecated and harm performance. Consider using Mutation ' +
           'Observers instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/mutation-events).',
       requiredArtifacts: ['URL', 'EventListeners']

--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -50,7 +50,7 @@ class NoMutationEventsAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'no-mutation-events',
-      description: 'Avoids using Mutation Events in its own scripts',
+      description: 'Avoids Mutation Events in its own scripts',
       helpText: 'Mutation Events are deprecated and harm performance. Consider using Mutation ' +
           'Observers instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/mutation-events).',
       requiredArtifacts: ['URL', 'EventListeners']

--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -36,7 +36,7 @@ class NoOldFlexboxAudit extends Audit {
     return {
       category: 'CSS',
       name: 'no-old-flexbox',
-      description: 'Site does not use the old CSS flexbox',
+      description: 'Page avoids using old CSS flexbox',
       helpText: 'The 2009 spec of Flexbox is deprecated and is 2.3x slower than the latest ' +
           'spec. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/old-flexbox).',
       requiredArtifacts: ['Styles', 'URL']

--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -36,7 +36,7 @@ class NoOldFlexboxAudit extends Audit {
     return {
       category: 'CSS',
       name: 'no-old-flexbox',
-      description: 'Page avoids using old CSS flexbox',
+      description: 'Avoids using old CSS flexbox',
       helpText: 'The 2009 spec of Flexbox is deprecated and is 2.3x slower than the latest ' +
           'spec. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/old-flexbox).',
       requiredArtifacts: ['Styles', 'URL']

--- a/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
+++ b/lighthouse-core/audits/dobetterweb/no-old-flexbox.js
@@ -36,7 +36,7 @@ class NoOldFlexboxAudit extends Audit {
     return {
       category: 'CSS',
       name: 'no-old-flexbox',
-      description: 'Avoids using old CSS flexbox',
+      description: 'Avoids old CSS flexbox',
       helpText: 'The 2009 spec of Flexbox is deprecated and is 2.3x slower than the latest ' +
           'spec. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/old-flexbox).',
       requiredArtifacts: ['Styles', 'URL']

--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -33,7 +33,7 @@ class NoWebSQLAudit extends Audit {
     return {
       category: 'Offline',
       name: 'no-websql',
-      description: 'Avoids using WebSQL DB',
+      description: 'Avoids WebSQL DB',
       helpText: 'Web SQL is deprecated. Consider using IndexedDB instead. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/web-sql).',
       requiredArtifacts: ['WebSQL']

--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -33,7 +33,7 @@ class NoWebSQLAudit extends Audit {
     return {
       category: 'Offline',
       name: 'no-websql',
-      description: 'Site does not use WebSQL DB.',
+      description: 'Page avoids using WebSQL DB',
       helpText: 'Web SQL is deprecated. Consider using IndexedDB instead. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/web-sql).',
       requiredArtifacts: ['WebSQL']

--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -33,7 +33,7 @@ class NoWebSQLAudit extends Audit {
     return {
       category: 'Offline',
       name: 'no-websql',
-      description: 'Page avoids using WebSQL DB',
+      description: 'Avoids using WebSQL DB',
       helpText: 'Web SQL is deprecated. Consider using IndexedDB instead. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/web-sql).',
       requiredArtifacts: ['WebSQL']
@@ -53,12 +53,12 @@ class NoWebSQLAudit extends Audit {
     }
 
     const db = artifacts.WebSQL.database;
-    const displayValue = (db && db.database ?
-        `db name: ${db.database.name}, version: ${db.database.version}` : '');
+    const debugString = (db && db.database ?
+        `Found database "${db.database.name}", version: ${db.database.version}.` : '');
 
     return NoWebSQLAudit.generateAuditResult({
       rawValue: !db,
-      displayValue: displayValue
+      debugString
     });
   }
 }

--- a/lighthouse-core/audits/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/notification-on-start.js
@@ -33,7 +33,7 @@ class NotificationOnStart extends Audit {
     return {
       category: 'UX',
       name: 'notification-on-start',
-      description: 'Page does not automatically request notification permissions on page load',
+      description: 'Page avoids requesting the notification permission on page load',
       helpText: 'Users are mistrustful of or confused by sites that request to send ' +
           'notifications without context. Consider tying the request to user gestures ' +
           'instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).',

--- a/lighthouse-core/audits/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/notification-on-start.js
@@ -33,7 +33,7 @@ class NotificationOnStart extends Audit {
     return {
       category: 'UX',
       name: 'notification-on-start',
-      description: 'Page avoids requesting the notification permission on page load',
+      description: 'Avoids requesting the notification permission on page load',
       helpText: 'Users are mistrustful of or confused by sites that request to send ' +
           'notifications without context. Consider tying the request to user gestures ' +
           'instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).',

--- a/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
@@ -33,7 +33,7 @@ class ScriptBlockingFirstPaint extends Audit {
     return {
       category: 'Performance',
       name: 'script-blocking-first-paint',
-      description: 'Avoids using `<script>` in head that delay first paint',
+      description: 'Avoids `<script>` in head that delay first paint',
       helpText: 'Script elements are blocking the first paint of your page. Consider inlining ' +
           'critical scripts and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
@@ -33,7 +33,7 @@ class ScriptBlockingFirstPaint extends Audit {
     return {
       category: 'Performance',
       name: 'script-blocking-first-paint',
-      description: 'Page avoids using `<script>` in head that delay first paint',
+      description: 'Avoids using `<script>` in head that delay first paint',
       helpText: 'Script elements are blocking the first paint of your page. Consider inlining ' +
           'critical scripts and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
@@ -33,7 +33,7 @@ class ScriptBlockingFirstPaint extends Audit {
     return {
       category: 'Performance',
       name: 'script-blocking-first-paint',
-      description: 'Site does not use <script> in head that delays first paint',
+      description: 'Page avoids using `<script>` in head that delay first paint',
       helpText: 'Script elements are blocking the first paint of your page. Consider inlining ' +
           'critical scripts and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -35,7 +35,7 @@ class UsesHTTP2Audit extends Audit {
     return {
       category: 'Performance',
       name: 'uses-http2',
-      description: 'Page uses HTTP/2 for its own resources',
+      description: 'Uses HTTP/2 for its own resources',
       helpText: 'HTTP/2 offers many benefits over HTTP/1.1, including binary headers, ' +
           'multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).',
       requiredArtifacts: ['URL', 'networkRecords']

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -35,7 +35,7 @@ class UsesHTTP2Audit extends Audit {
     return {
       category: 'Performance',
       name: 'uses-http2',
-      description: 'Site uses HTTP/2 for its own resources',
+      description: 'Page uses HTTP/2 for its own resources',
       helpText: 'HTTP/2 offers many benefits over HTTP/1.1, including binary headers, ' +
           'multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).',
       requiredArtifacts: ['URL', 'networkRecords']

--- a/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
@@ -41,7 +41,7 @@ class UsesOptimizedImages extends Audit {
     return {
       category: 'Images',
       name: 'uses-optimized-images',
-      description: 'Page uses optimized images',
+      description: 'Using optimized images',
       helpText: 'Images should be optimized to save network bytes. ' +
         'The following images could have smaller file sizes when compressed with ' +
         '[WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. ' +

--- a/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
@@ -41,7 +41,7 @@ class UsesOptimizedImages extends Audit {
     return {
       category: 'Images',
       name: 'uses-optimized-images',
-      description: 'Site uses optimized images',
+      description: 'Page uses optimized images',
       helpText: 'Images should be optimized to save network bytes. ' +
         'The following images could have smaller file sizes when compressed with ' +
         '[WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. ' +

--- a/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
@@ -41,7 +41,7 @@ class UsesOptimizedImages extends Audit {
     return {
       category: 'Images',
       name: 'uses-optimized-images',
-      description: 'Using optimized images',
+      description: 'Page uses optimized images',
       helpText: 'Images should be optimized to save network bytes. ' +
         'The following images could have smaller file sizes when compressed with ' +
         '[WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. ' +

--- a/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
@@ -41,7 +41,7 @@ class UsesOptimizedImages extends Audit {
     return {
       category: 'Images',
       name: 'uses-optimized-images',
-      description: 'Page uses optimized images',
+      description: 'Has optimized images',
       helpText: 'Images should be optimized to save network bytes. ' +
         'The following images could have smaller file sizes when compressed with ' +
         '[WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. ' +

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -41,7 +41,7 @@ class PassiveEventsAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'uses-passive-event-listeners',
-      description: 'Site uses passive listeners to improve scrolling performance',
+      description: 'Page uses passive listeners to improve scrolling performance',
       helpText: 'Consider marking your touch and wheel event listeners as `passive` ' +
           'to improve your page\'s scroll performance. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).',

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -41,7 +41,7 @@ class PassiveEventsAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'uses-passive-event-listeners',
-      description: 'Page uses passive listeners to improve scrolling performance',
+      description: 'Using passive listeners to improve scrolling performance',
       helpText: 'Consider marking your touch and wheel event listeners as `passive` ' +
           'to improve your page\'s scroll performance. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).',

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -41,7 +41,7 @@ class PassiveEventsAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'uses-passive-event-listeners',
-      description: 'Using passive listeners to improve scrolling performance',
+      description: 'Page uses passive listeners to improve scrolling performance',
       helpText: 'Consider marking your touch and wheel event listeners as `passive` ' +
           'to improve your page\'s scroll performance. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).',

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -41,7 +41,7 @@ class PassiveEventsAudit extends Audit {
     return {
       category: 'JavaScript',
       name: 'uses-passive-event-listeners',
-      description: 'Page uses passive listeners to improve scrolling performance',
+      description: 'Uses passive listeners to improve scrolling performance',
       helpText: 'Consider marking your touch and wheel event listeners as `passive` ' +
           'to improve your page\'s scroll performance. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).',

--- a/lighthouse-core/audits/dobetterweb/uses-responsive-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-responsive-images.js
@@ -39,7 +39,7 @@ class UsesResponsiveImages extends Audit {
     return {
       category: 'Images',
       name: 'uses-responsive-images',
-      description: 'Site uses appropriate image sizes',
+      description: 'Page uses appropriate image sizes',
       helpText:
         'Image sizes served should be based on the device display size to save network bytes. ' +
         'Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) ' +

--- a/lighthouse-core/audits/dobetterweb/uses-responsive-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-responsive-images.js
@@ -39,7 +39,7 @@ class UsesResponsiveImages extends Audit {
     return {
       category: 'Images',
       name: 'uses-responsive-images',
-      description: 'Uses appropriate image sizes',
+      description: 'Has appropriately sized images',
       helpText:
         'Image sizes served should be based on the device display size to save network bytes. ' +
         'Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) ' +

--- a/lighthouse-core/audits/dobetterweb/uses-responsive-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-responsive-images.js
@@ -39,7 +39,7 @@ class UsesResponsiveImages extends Audit {
     return {
       category: 'Images',
       name: 'uses-responsive-images',
-      description: 'Page uses appropriate image sizes',
+      description: 'Uses appropriate image sizes',
       helpText:
         'Image sizes served should be based on the device display size to save network bytes. ' +
         'Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) ' +

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -26,7 +26,7 @@ class HTTPS extends Audit {
     return {
       category: 'Security',
       name: 'is-on-https',
-      description: 'Site is on HTTPS',
+      description: 'Uses HTTPS',
       helpText: 'All sites should be protected with HTTPS, even ones that don\'t handle ' +
           'sensitive data. HTTPS prevents intruders from tampering with or passively listening ' +
           'in on the communications between your app and your users, and is a prerequisite for ' +

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -26,7 +26,7 @@ class HTTPS extends Audit {
     return {
       category: 'Security',
       name: 'is-on-https',
-      description: 'Using HTTPS',
+      description: 'Page uses HTTPS',
       helpText: 'All sites should be protected with HTTPS, even ones that don\'t handle ' +
           'sensitive data. HTTPS prevents intruders from tampering with or passively listening ' +
           'in on the communications between your app and your users, and is a prerequisite for ' +

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -26,7 +26,7 @@ class HTTPS extends Audit {
     return {
       category: 'Security',
       name: 'is-on-https',
-      description: 'Uses HTTPS',
+      description: 'Using HTTPS',
       helpText: 'All sites should be protected with HTTPS, even ones that don\'t handle ' +
           'sensitive data. HTTPS prevents intruders from tampering with or passively listening ' +
           'in on the communications between your app and your users, and is a prerequisite for ' +

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -26,7 +26,7 @@ class HTTPS extends Audit {
     return {
       category: 'Security',
       name: 'is-on-https',
-      description: 'Page uses HTTPS',
+      description: 'Uses HTTPS',
       helpText: 'All sites should be protected with HTTPS, even ones that don\'t handle ' +
           'sensitive data. HTTPS prevents intruders from tampering with or passively listening ' +
           'in on the communications between your app and your users, and is a prerequisite for ' +

--- a/lighthouse-core/audits/manifest-display.js
+++ b/lighthouse-core/audits/manifest-display.js
@@ -57,7 +57,7 @@ class ManifestDisplay extends Audit {
       rawValue: hasRecommendedValue,
       displayValue
     };
-    if (!hasRecommendedValue) {
+    if (manifest && !hasRecommendedValue) {
       auditResult.debugString = 'Manifest display property should be set.';
     }
     return ManifestDisplay.generateAuditResult(auditResult);

--- a/lighthouse-core/audits/manifest-icons-min-144.js
+++ b/lighthouse-core/audits/manifest-icons-min-144.js
@@ -53,7 +53,7 @@ class ManifestIconsMin144 extends Audit {
     if (matchingIcons.length) {
       displayValue = `found sizes: ${matchingIcons.join(', ')}`;
     } else {
-      debugString = 'WARNING: No icons are at least 144px';
+      debugString = 'No icons are at least 144px';
     }
 
     return ManifestIconsMin144.generateAuditResult({

--- a/lighthouse-core/audits/manifest-icons-min-144.js
+++ b/lighthouse-core/audits/manifest-icons-min-144.js
@@ -42,8 +42,7 @@ class ManifestIconsMin144 extends Audit {
 
     if (icons.doExist(manifest) === false) {
       return ManifestIconsMin144.generateAuditResult({
-        rawValue: false,
-        debugString: 'WARNING: No icons found in the manifest'
+        rawValue: false
       });
     }
 

--- a/lighthouse-core/audits/manifest-icons-min-192.js
+++ b/lighthouse-core/audits/manifest-icons-min-192.js
@@ -45,8 +45,7 @@ class ManifestIconsMin192 extends Audit {
 
     if (icons.doExist(manifest) === false) {
       return ManifestIconsMin192.generateAuditResult({
-        rawValue: false,
-        debugString: 'WARNING: No icons found in the manifest'
+        rawValue: false
       });
     }
 

--- a/lighthouse-core/audits/manifest-icons-min-192.js
+++ b/lighthouse-core/audits/manifest-icons-min-192.js
@@ -56,7 +56,7 @@ class ManifestIconsMin192 extends Audit {
     if (matchingIcons.length) {
       displayValue = `found sizes: ${matchingIcons.join(', ')}`;
     } else {
-      debugString = 'WARNING: No icons are at least 192px';
+      debugString = 'No icons are at least 192px';
     }
 
     return ManifestIconsMin192.generateAuditResult({

--- a/lighthouse-core/audits/redirects-http.js
+++ b/lighthouse-core/audits/redirects-http.js
@@ -26,7 +26,7 @@ class RedirectsHTTP extends Audit {
     return {
       category: 'Security',
       name: 'redirects-http',
-      description: 'Site redirects HTTP traffic to HTTPS',
+      description: 'Redirects HTTP traffic to HTTPS',
       helpText: 'If you\'ve already set up HTTPS, make sure that you redirect all HTTP traffic ' +
          'to HTTPS. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-redirects-to-https).',
       requiredArtifacts: ['HTTPRedirect']

--- a/lighthouse-core/audits/service-worker.js
+++ b/lighthouse-core/audits/service-worker.js
@@ -38,7 +38,7 @@ class ServiceWorker extends Audit {
     return {
       category: 'Offline',
       name: 'service-worker',
-      description: 'Has a registered Service Worker',
+      description: 'Registers a Service Worker',
       helpText: 'The service worker is the technology that enables your app to use many ' +
          'Progressive Web App features, such as offline, add to homescreen, and push ' +
          'notifications. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker).',
@@ -63,11 +63,9 @@ class ServiceWorker extends Audit {
     // artifacts.URL.finalUrl so audit accounts for any redirects.
     const version = getActivatedServiceWorker(
         artifacts.ServiceWorker.versions, artifacts.URL.finalUrl);
-    const debugString = version ? undefined : 'No active service worker found for this origin.';
 
     return ServiceWorker.generateAuditResult({
-      rawValue: !!version,
-      debugString: debugString
+      rawValue: !!version
     });
   }
 }

--- a/lighthouse-core/audits/theme-color-meta.js
+++ b/lighthouse-core/audits/theme-color-meta.js
@@ -27,7 +27,7 @@ class ThemeColor extends Audit {
     return {
       category: 'HTML',
       name: 'theme-color-meta',
-      description: 'HTML has a `<meta name="theme-color">` tag',
+      description: 'Page has a `<meta name="theme-color">` tag',
       requiredArtifacts: ['ThemeColor']
     };
   }
@@ -40,8 +40,7 @@ class ThemeColor extends Audit {
     const themeColorMeta = artifacts.ThemeColor;
     if (themeColorMeta === null) {
       return ThemeColor.generateAuditResult({
-        rawValue: false,
-        debugString: 'No valid theme-color meta tag found.'
+        rawValue: false
       });
     }
 

--- a/lighthouse-core/audits/theme-color-meta.js
+++ b/lighthouse-core/audits/theme-color-meta.js
@@ -27,7 +27,7 @@ class ThemeColor extends Audit {
     return {
       category: 'HTML',
       name: 'theme-color-meta',
-      description: 'Page contains a `<meta name="theme-color">` tag',
+      description: 'Has a `<meta name="theme-color">` tag',
       requiredArtifacts: ['ThemeColor']
     };
   }

--- a/lighthouse-core/audits/theme-color-meta.js
+++ b/lighthouse-core/audits/theme-color-meta.js
@@ -27,7 +27,7 @@ class ThemeColor extends Audit {
     return {
       category: 'HTML',
       name: 'theme-color-meta',
-      description: 'Page has a `<meta name="theme-color">` tag',
+      description: 'Page contains a `<meta name="theme-color">` tag',
       requiredArtifacts: ['ThemeColor']
     };
   }

--- a/lighthouse-core/audits/unused-css-rules.js
+++ b/lighthouse-core/audits/unused-css-rules.js
@@ -32,9 +32,10 @@ class UnusedCSSRules extends Audit {
     return {
       category: 'CSS',
       name: 'unused-css-rules',
-      description: 'Site does not have more than 10% unused CSS',
+      description: 'Page uses 90% of its CSS rules',
       helpText: 'Remove unused rules from stylesheets to reduce unnecessary ' +
-          'bytes consumed by network activity. [Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery)',
+          'bytes consumed by network activity. ' +
+          '[Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery)',
       requiredArtifacts: ['CSSUsage', 'Styles', 'URL', 'networkRecords']
     };
   }

--- a/lighthouse-core/audits/unused-css-rules.js
+++ b/lighthouse-core/audits/unused-css-rules.js
@@ -32,7 +32,7 @@ class UnusedCSSRules extends Audit {
     return {
       category: 'CSS',
       name: 'unused-css-rules',
-      description: 'Page uses 90% of its CSS rules',
+      description: 'Uses 90% of its CSS rules',
       helpText: 'Remove unused rules from stylesheets to reduce unnecessary ' +
           'bytes consumed by network activity. ' +
           '[Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery)',

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -27,7 +27,7 @@ class Viewport extends Audit {
     return {
       category: 'Mobile Friendly',
       name: 'viewport',
-      description: 'HTML has a `<meta name="viewport">` tag containing `width` or `initial-scale`',
+      description: 'Page has a `<meta name="viewport">` tag containing `width` or `initial-scale`',
       helpText: 'Add a viewport meta tag to optimize your app for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag").',
       requiredArtifacts: ['Viewport']

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -27,7 +27,7 @@ class Viewport extends Audit {
     return {
       category: 'Mobile Friendly',
       name: 'viewport',
-      description: 'Page contains a `<meta name="viewport">` element with `width` or `initial-scale`',
+      description: 'Has a `<meta name="viewport">` tag with `width` or `initial-scale`',
       helpText: 'Add a viewport meta tag to optimize your app for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag").',
       requiredArtifacts: ['Viewport']

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -27,7 +27,7 @@ class Viewport extends Audit {
     return {
       category: 'Mobile Friendly',
       name: 'viewport',
-      description: 'Page contains a `<meta name="viewport">` tag with `width` or `initial-scale`',
+      description: 'Page contains a `<meta name="viewport">` element with `width` or `initial-scale`',
       helpText: 'Add a viewport meta tag to optimize your app for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag").',
       requiredArtifacts: ['Viewport']

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -27,7 +27,7 @@ class Viewport extends Audit {
     return {
       category: 'Mobile Friendly',
       name: 'viewport',
-      description: 'Page has a `<meta name="viewport">` tag containing `width` or `initial-scale`',
+      description: 'Page contains a `<meta name="viewport">` tag with `width` or `initial-scale`',
       helpText: 'Add a viewport meta tag to optimize your app for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag").',
       requiredArtifacts: ['Viewport']

--- a/lighthouse-core/audits/without-javascript.js
+++ b/lighthouse-core/audits/without-javascript.js
@@ -27,7 +27,7 @@ class WithoutJavaScript extends Audit {
     return {
       category: 'JavaScript',
       name: 'without-javascript',
-      description: 'Page contains some content when JavaScript is not available',
+      description: 'Contains some content when JavaScript is not available',
       helpText: 'Your app should display some content when JavaScript is disabled, even if it\'s ' +
           'just a warning to the user that JavaScript is required to use the app. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/no-js).',

--- a/lighthouse-core/audits/without-javascript.js
+++ b/lighthouse-core/audits/without-javascript.js
@@ -27,7 +27,7 @@ class WithoutJavaScript extends Audit {
     return {
       category: 'JavaScript',
       name: 'without-javascript',
-      description: 'Page contains some content when its scripts are not available',
+      description: 'Page contains some content when JavaScript is not available',
       helpText: 'Your app should display some content when JavaScript is disabled, even if it\'s ' +
           'just a warning to the user that JavaScript is required to use the app. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/no-js).',

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -26,7 +26,7 @@ class WorksOffline extends Audit {
     return {
       category: 'Offline',
       name: 'works-offline',
-      description: 'URL responds with a 200 when offline',
+      description: 'Responds with a 200 when offline',
       helpText: 'If you\'re building a Progressive Web App, consider using a service worker so ' +
           'that your app can work offline. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).',

--- a/lighthouse-core/gather/gatherers/manifest.js
+++ b/lighthouse-core/gather/gatherers/manifest.js
@@ -43,6 +43,8 @@ class Manifest extends Gatherer {
         //   https://chromedevtools.github.io/debugger-protocol-viewer/tot/Page/#type-AppManifestError
         if (!response.data) {
           let errorString;
+          // The driver returns an empty string for url and the data if
+          // the page has no manifest.
           if (response.url) {
             errorString = `Unable to retrieve manifest at ${response.url}`;
           }

--- a/lighthouse-core/gather/gatherers/manifest.js
+++ b/lighthouse-core/gather/gatherers/manifest.js
@@ -45,10 +45,6 @@ class Manifest extends Gatherer {
           let errorString;
           if (response.url) {
             errorString = `Unable to retrieve manifest at ${response.url}`;
-          } else {
-            // The driver will return an empty string for url and the data if
-            // the page has no manifest.
-            errorString = 'No manifest found.';
           }
 
           return Manifest._errorManifest(errorString);

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -153,9 +153,9 @@ limitations under the License.
                 <li class="subitem {{#if subItem.comingSoon}}--coming-soon{{/if}} {{#if (shouldShowHelpText subItem.score)}}--show-help{{/if}}">
 
                   <p class="subitem__desc">
-                    {{#unless ../../scored }}
+                    <!--{{#unless ../../scored }}
                       <strong class="subitem__category">{{ subItem.category }}:</strong>
-                    {{/unless}}
+                    {{/unless}}-->
 
                     {{ sanitize subItem.description }}
 

--- a/lighthouse-core/test/audits/display-test.js
+++ b/lighthouse-core/test/audits/display-test.js
@@ -39,7 +39,6 @@ describe('Mobile-friendly: display audit', () => {
   it('fails when no manifest artifact present', () => {
     const output = Audit.audit({Manifest: {value: undefined}});
     assert.equal(output.rawValue, false);
-    assert.equal(output.debugString && output.debugString.length > 0, true);
   });
 
   it('falls back to the successful default when there is no manifest display property', () => {

--- a/lighthouse-core/test/audits/dobetterweb/appcache-manifest-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/appcache-manifest-test.js
@@ -34,7 +34,7 @@ describe('Appcache manifest audit', () => {
       AppCacheManifest: 'manifest-name'
     });
     assert.equal(auditResult.rawValue, false);
-    assert.ok(auditResult.displayValue);
+    assert.ok(auditResult.debugString);
   });
 
   it('passes when <html> does not contain a manifest attribute', () => {

--- a/lighthouse-core/test/audits/dobetterweb/websql-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/websql-test.js
@@ -51,6 +51,6 @@ describe('No websql audit', () => {
     });
 
     assert.equal(auditResult.rawValue, false);
-    assert.ok(auditResult.displayValue.match(/db name: (.*), version: (.*)/));
+    assert.ok(auditResult.debugString.match(/Found database (.*), version: (.*)/));
   });
 });

--- a/lighthouse-core/test/audits/icons-test.js
+++ b/lighthouse-core/test/audits/icons-test.js
@@ -48,9 +48,7 @@ describe('Manifest: icons audits', () => {
       const audit192 = Audit192.audit({Manifest});
 
       assert.equal(audit144.rawValue, false);
-      assert.ok(audit144.debugString.match(/^WARNING/));
       assert.equal(audit192.rawValue, false);
-      assert.ok(audit192.debugString.match(/^WARNING/));
     });
   });
 

--- a/lighthouse-core/test/audits/service-worker-test.js
+++ b/lighthouse-core/test/audits/service-worker-test.js
@@ -64,6 +64,5 @@ describe('Offline: Service Worker audit', () => {
 
     assert.equal(output.score, false);
     assert.equal(output.rawValue, false);
-    assert.ok(output.debugString);
   });
 });

--- a/lighthouse-core/test/audits/theme-color-meta-test.js
+++ b/lighthouse-core/test/audits/theme-color-meta-test.js
@@ -28,7 +28,6 @@ describe('HTML: theme-color audit', () => {
     });
 
     assert.equal(nullColorAudit.rawValue, false);
-    assert(nullColorAudit.debugString);
   });
 
   it('fails and warns when theme-color has an invalid CSS color', () => {

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -76,22 +76,6 @@ describe('Manifest gatherer', () => {
     });
   });
 
-  it('emits an error when there was no manifest', () => {
-    return manifestGather.afterPass({
-      driver: {
-        sendCommand() {
-          return Promise.resolve({
-            data: '',
-            errors: [],
-            url: ''
-          });
-        }
-      }
-    }).then(artifact => {
-      assert.ok(artifact.debugString);
-    });
-  });
-
   it('creates a manifest object for valid manifest content', () => {
     const data = JSON.stringify({
       name: 'App'


### PR DESCRIPTION
R: all

Users get confused when an audit description says "Site does not use x API..." and there's a red "X" for the audit result. "X" means the audit failed, but the double negative is confusing. I've heard the complaint a few times in the last couple of days and decided to fix it.

This PR changes the lingo we use in the report to be consistent throughout:

- Replace "Site does not use X" -> "Avoids X"
- Replace "Site uses..." -> "Page uses..." (we're testing a page and not the entire site)
- Remove redundant debugStrings like this:

<img width="357" alt="screen shot 2017-02-01 at 9 40 06 am" src="https://cloud.githubusercontent.com/assets/238208/22522145/6cb50a3e-e86f-11e6-94b4-0a3db8db190a.png">

- Removes categories from the audit names. Reduces visual clutter.

Before:

![screen shot 2017-02-01 at 11 16 27 am](https://cloud.githubusercontent.com/assets/238208/22522291/e74d5de6-e86f-11e6-8938-be8fcf744d8b.png)

Now:

![screen shot 2017-02-01 at 11 08 02 am](https://cloud.githubusercontent.com/assets/238208/22522157/7ccd602e-e86f-11e6-94ce-7474d3d90e67.png)

![screen shot 2017-02-01 at 11 07 53 am](https://cloud.githubusercontent.com/assets/238208/22522164/8162c282-e86f-11e6-9c85-fd070698ef99.png)

