### PR TITLE
CRX: make disabling extension during run, optional

### DIFF
--- a/lighthouse-extension/app/popup.html
+++ b/lighthouse-extension/app/popup.html
@@ -57,8 +57,17 @@ limitations under the License.
   </aside>
 
   <aside class="options subpage">
-    <h2 class="options__title">Options</h2>
+    <h2 class="options__title">Settings</h2>
+    <div>
+      <label>
+        <input type="checkbox" class="setting-disable-extensions"
+               value="Disable other extensions while Lighthouse audits a page">Disable other extensions while Lighthouse audits a page.
+      </label>
+    </div>
+
+    <h2 class="options__title">Audit collections to include in report</h2>
     <ul class="options__list">
+      <!-- filled dynamically -->
     </ul>
 
     <button class="button button--ok" id="ok">OK</button>

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -26,8 +26,10 @@ const log = require('../../../lighthouse-core/lib/log');
 const ReportGenerator = require('../../../lighthouse-core/report/report-generator');
 
 const STORAGE_KEY = 'lighthouse_audits';
+const SETTINGS_KEY = 'lighthouse_settings';
 
 let installedExtensions = [];
+let DISABLE_EXTENSIONS_DURING_RUN = false;
 let lighthouseIsRunning = false;
 let latestStatusLog = [];
 
@@ -41,6 +43,10 @@ const _flatten = arr => [].concat(...arr);
  * @param {!Promise}
  */
 function enableOtherChromeExtensions(enable) {
+  if (!DISABLE_EXTENSIONS_DURING_RUN) {
+    return Promise.resolve();
+  }
+
   const str = enable ? 'enabling' : 'disabling';
   log.log('Chrome', `${str} ${installedExtensions.length} extensions.`);
 
@@ -251,27 +257,37 @@ window.getDefaultAggregations = function() {
 
 /**
  * Save currently selected set of aggregation categories to local storage.
- * @param {!Array<{name: string, audits: !Array<string>}>} selectedAggregations
+ * @param {!{selectedAggregations: Array<{name: string, audits: !Array<string>}>,
+ *           disableExtensions: boolean}} settings
+ * @param {!boolean} disableExtensions True if extensions should be disabled for the run.
  */
-window.saveSelectedAggregations = function(selectedAggregations) {
+window.saveSettings = function(settings) {
   const storage = {
-    [STORAGE_KEY]: {}
+    [STORAGE_KEY]: {},
+    [SETTINGS_KEY]: {}
   };
 
+  // Stash selected aggregations.
   window.getDefaultAggregations().forEach(audit => {
-    storage[STORAGE_KEY][audit.name] = selectedAggregations.includes(audit.name);
+    storage[STORAGE_KEY][audit.name] = settings.selectedAggregations.includes(audit.name);
   });
 
+  // Stash disable extensionS setting.
+  DISABLE_EXTENSIONS_DURING_RUN = settings.disableExtensions;
+  storage[SETTINGS_KEY].disableExtensions = DISABLE_EXTENSIONS_DURING_RUN;
+
+  // Save object to chrome local storage.
   chrome.storage.local.set(storage);
 };
 
 /**
  * Load selected aggregation categories from local storage.
- * @return {!Promise<!Object<boolean>>}
+ * @return {!Promise<{selectedAggregations: Array<{name: string, audits: !Array<string>}>,
+ *                    disableExtensions: boolean}>}
  */
-window.loadSelectedAggregations = function() {
+window.loadSettings = function() {
   return new Promise(resolve => {
-    chrome.storage.local.get(STORAGE_KEY, result => {
+    chrome.storage.local.get([STORAGE_KEY, SETTINGS_KEY], result => {
       // Start with list of all default aggregations set to true so list is
       // always up to date.
       const defaultAggregations = {};
@@ -279,13 +295,19 @@ window.loadSelectedAggregations = function() {
         defaultAggregations[aggregation.name] = true;
       });
 
-      // Load saved aggregation selections.
-      const savedSelections = result[STORAGE_KEY];
+      // Load saved aggregations and settings, overwriting defaults with any
+      // saved selections.
+      const savedAggregations = Object.assign(defaultAggregations, result[STORAGE_KEY]);
 
-      // Overwrite defaults with any saved aggregation selections.
-      resolve(
-        Object.assign(defaultAggregations, savedSelections)
-      );
+      const defaultSettings = {
+        disableExtensions: DISABLE_EXTENSIONS_DURING_RUN
+      };
+      const savedSettings = Object.assign(defaultSettings, result[SETTINGS_KEY]);
+
+      resolve({
+        selectedAggregations: savedAggregations,
+        disableExtensions: savedSettings.disableExtensions
+      });
     });
   });
 };

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -29,7 +29,7 @@ const STORAGE_KEY = 'lighthouse_audits';
 const SETTINGS_KEY = 'lighthouse_settings';
 
 let installedExtensions = [];
-let DISABLE_EXTENSIONS_DURING_RUN = false;
+let disableExtensionsDuringRun = false;
 let lighthouseIsRunning = false;
 let latestStatusLog = [];
 
@@ -43,7 +43,7 @@ const _flatten = arr => [].concat(...arr);
  * @param {!Promise}
  */
 function enableOtherChromeExtensions(enable) {
-  if (!DISABLE_EXTENSIONS_DURING_RUN) {
+  if (!disableExtensionsDuringRun) {
     return Promise.resolve();
   }
 
@@ -259,7 +259,6 @@ window.getDefaultAggregations = function() {
  * Save currently selected set of aggregation categories to local storage.
  * @param {!{selectedAggregations: Array<{name: string, audits: !Array<string>}>,
  *           disableExtensions: boolean}} settings
- * @param {!boolean} disableExtensions True if extensions should be disabled for the run.
  */
 window.saveSettings = function(settings) {
   const storage = {
@@ -273,8 +272,8 @@ window.saveSettings = function(settings) {
   });
 
   // Stash disable extensionS setting.
-  DISABLE_EXTENSIONS_DURING_RUN = settings.disableExtensions;
-  storage[SETTINGS_KEY].disableExtensions = DISABLE_EXTENSIONS_DURING_RUN;
+  disableExtensionsDuringRun = settings.disableExtensions;
+  storage[SETTINGS_KEY].disableExtensions = disableExtensionsDuringRun;
 
   // Save object to chrome local storage.
   chrome.storage.local.set(storage);
@@ -300,7 +299,7 @@ window.loadSettings = function() {
       const savedAggregations = Object.assign(defaultAggregations, result[STORAGE_KEY]);
 
       const defaultSettings = {
-        disableExtensions: DISABLE_EXTENSIONS_DURING_RUN
+        disableExtensions: disableExtensionsDuringRun
       };
       const savedSettings = Object.assign(defaultSettings, result[SETTINGS_KEY]);
 

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -257,8 +257,7 @@ window.getDefaultAggregations = function() {
 
 /**
  * Save currently selected set of aggregation categories to local storage.
- * @param {!{selectedAggregations: Array<{name: string, audits: !Array<string>}>,
- *           disableExtensions: boolean}} settings
+ * @param {{selectedAggregations: !Array<string>, disableExtensions: boolean}} settings
  */
 window.saveSettings = function(settings) {
   const storage = {
@@ -281,8 +280,7 @@ window.saveSettings = function(settings) {
 
 /**
  * Load selected aggregation categories from local storage.
- * @return {!Promise<{selectedAggregations: Array<{name: string, audits: !Array<string>}>,
- *                    disableExtensions: boolean}>}
+ * @return {!Promise<{selectedAggregations: !Object<boolean>, disableExtensions: boolean}>}
  */
 window.loadSettings = function() {
   return new Promise(resolve => {

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -189,12 +189,14 @@ function initPopup() {
 
     background.listenForStatus(logStatus);
 
-    background.loadSelectedAggregations().then(selectedAggregations => {
-      generateOptionsList(background, selectedAggregations);
+    background.loadSettings().then(settings => {
+      generateOptionsList(background, settings.selectedAggregations);
+
+      document.querySelector('.setting-disable-extensions').checked = settings.disableExtensions;
 
       const generateReportButton = document.getElementById('generate-report');
       generateReportButton.addEventListener('click', () => {
-        onGenerateReportButtonClick(background, selectedAggregations);
+        onGenerateReportButtonClick(background, settings.selectedAggregations);
       });
     });
 
@@ -207,9 +209,11 @@ function initPopup() {
     const okButton = document.getElementById('ok');
     okButton.addEventListener('click', () => {
       // Save selected aggregation categories on options page close.
-      const checkedAggregations = Array.from(optionsEl.querySelectorAll(':checked'))
+      const selectedAggregations = Array.from(optionsEl.querySelectorAll(':checked'))
           .map(input => input.value);
-      background.saveSelectedAggregations(checkedAggregations);
+      const disableExtensions = document.querySelector('.setting-disable-extensions').checked;
+
+      background.saveSettings({selectedAggregations, disableExtensions});
 
       optionsEl.classList.remove(subpageVisibleClass);
     });

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -208,7 +208,7 @@ function initPopup() {
 
     const okButton = document.getElementById('ok');
     okButton.addEventListener('click', () => {
-      // Save selected aggregation categories on options page close.
+      // Save settings when options page is closed.
       const selectedAggregations = Array.from(optionsEl.querySelectorAll(':checked'))
           .map(input => input.value);
       const disableExtensions = document.querySelector('.setting-disable-extensions').checked;

--- a/lighthouse-extension/app/styles/lighthouse.css
+++ b/lighthouse-extension/app/styles/lighthouse.css
@@ -216,15 +216,14 @@ html, body {
 .options {
   overflow: auto; /* [1] */
   display: block;
+  text-align: left;
 }
 
 .options__title {
-  margin: 0 auto;
   font-weight: 300;
 }
 
 .options__list {
   padding: 0;
   list-style: none;
-  text-align: left;
 }


### PR DESCRIPTION
R: @brendankenny, all

This makes the enabling/disabling of extension before a LH run a user setting:

<img width="453" alt="screen shot 2017-02-02 at 11 24 53 am" src="https://cloud.githubusercontent.com/assets/238208/22564676/3c8f6748-e93a-11e6-9e7a-d847835403b8.png">

My worry was that some users would find the current default behavior (disable all extension before the run) unexpected and frustrating. Any extensions that don't save state when they're killed off will lose data. I suspect there are many that don't follow best practices. Instead, we're making this a setting for people to opt into.

@brendankenny I tried to move some of the bg methods into popup.html like we chatted about but it was getting trickier than it was worth. We allow the user to dismiss the popup while LH is running. It was getting gnarly to make a transient popup communicate state back to the bg page for persistence, then repopulate the UI when the user reopens the popup. I was also finding myself piping more `background` page variables through popup.js methods...which defeated the original purpose of the code refactor (separation of concerns between bg page and popup.js).