### PR TITLE
fix: warn about redirected urls

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -281,6 +281,14 @@ function runLighthouse(url: string,
       return results;
     })
     .then((results: Results) => {
+      if (url !== results.url) {
+        const msg = `Redirect to ${results.url} detected. For best results, test this URL directly.`;
+        log.warn('Lighthouse CLI', msg);
+      }
+
+      return results;
+    })
+    .then((results: Results) => {
       if (flags.interactive) {
         return performanceXServer.hostExperiment({url, flags, config}, results);
       }


### PR DESCRIPTION
fixes #715 

How it looks. 
![image](https://cloud.githubusercontent.com/assets/2301202/22566303/2acb8a36-e940-11e6-8108-6e93e03d020b.png)

I stuck it after everything since putting at the top likely means no one will know.