### PR TITLE
Remove debugString from accessibility audits + tests.

### DIFF
--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -37,25 +37,11 @@ class AxeAudit extends Audit {
 
     return this.generateAuditResult({
       rawValue: typeof rule === 'undefined',
-      debugString: this.createDebugString(rule),
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.ACCESSIBILITY,
         value: rule
       }
     });
-  }
-
-  /**
-   * @param {!{nodes: Array, help: string}} rule
-   * @return {!string}
-   */
-  static createDebugString(rule) {
-    if (typeof rule === 'undefined') {
-      return '';
-    }
-
-    const elementsStr = rule.nodes.length === 1 ? 'element' : 'elements';
-    return `${rule.help} (Failed on ${rule.nodes.length} ${elementsStr})`;
   }
 }
 

--- a/lighthouse-core/formatters/partials/accessibility.html
+++ b/lighthouse-core/formatters/partials/accessibility.html
@@ -5,7 +5,6 @@
     {{else}}
       {{this.nodes.length}} element fails this test
     {{/if}}
-    <a href="{{ this.helpUrl }}" target="_blank"><small>learn more</small></a>
   </summary>
   <ul class="subitem__details">
   {{#each this.nodes}}

--- a/lighthouse-core/formatters/partials/accessibility.html
+++ b/lighthouse-core/formatters/partials/accessibility.html
@@ -1,10 +1,10 @@
 <details class="subitem__details">
   <summary class="subitem__detail">
-    {{#if (gt this.nodes.length 1)}}
+    {{~#if (gt this.nodes.length 1)~}}
       {{this.nodes.length}} elements fail this test
-    {{else}}
-      {{this.nodes.length}} element fails this test
-    {{/if}}
+    {{~else~}}
+      {{this.nodes.length}} element failed this test
+    {{~/if~}}
   </summary>
   <ul class="subitem__details">
   {{#each this.nodes}}

--- a/lighthouse-core/test/audits/accessibility/aria-allowed-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-allowed-attr-test.js
@@ -36,7 +36,6 @@ describe('Accessibility: aria-allowed-attr audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
   it('generates an audit output (single node)', () => {
@@ -53,7 +52,6 @@ describe('Accessibility: aria-allowed-attr audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 
   it('doesn\'t throw an error when violations is undefined', () => {

--- a/lighthouse-core/test/audits/accessibility/aria-required-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-required-attr-test.js
@@ -36,7 +36,6 @@ describe('Accessibility: aria-required-attr audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
   it('generates an audit output (single node)', () => {
@@ -53,7 +52,6 @@ describe('Accessibility: aria-required-attr audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 
   it('doesn\'t throw an error when violations is undefined', () => {

--- a/lighthouse-core/test/audits/accessibility/aria-valid-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-valid-attr-test.js
@@ -36,7 +36,6 @@ describe('Accessibility: aria-valid-attr audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
   it('generates an audit output (single node)', () => {
@@ -53,7 +52,6 @@ describe('Accessibility: aria-valid-attr audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 
   it('doesn\'t throw an error when violations is undefined', () => {

--- a/lighthouse-core/test/audits/accessibility/aria-valid-attr-value-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-valid-attr-value-test.js
@@ -36,7 +36,6 @@ describe('Accessibility: aria-valid-attr-value audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
   it('generates an audit output (single node)', () => {
@@ -53,7 +52,6 @@ describe('Accessibility: aria-valid-attr-value audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 
   it('doesn\'t throw an error when violations is undefined', () => {

--- a/lighthouse-core/test/audits/accessibility/axe-audit-test.js
+++ b/lighthouse-core/test/audits/accessibility/axe-audit-test.js
@@ -48,41 +48,6 @@ describe('Accessibility: axe-audit', () => {
       const output = FakeA11yAudit.audit(artifacts);
       assert.equal(output.rawValue, false);
       assert.equal(output.displayValue, '');
-      assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
-    });
-  });
-
-  describe('createDebugString()', () => {
-    it('handles empty rules', () => {
-      const output = AxeAudit.createDebugString();
-      assert.ok(typeof output === 'string');
-    });
-
-    it('creates debug strings', () => {
-      const emptyDebugString = AxeAudit.createDebugString({
-        nodes: [],
-        help: 'http://example.com/'
-      });
-
-      assert.equal(emptyDebugString, 'http://example.com/ (Failed on 0 elements)');
-    });
-
-    it('refers to a single element if one failure', () => {
-      const debugString = AxeAudit.createDebugString({
-        nodes: [{}],
-        help: 'http://example.com/'
-      });
-
-      assert.equal(debugString, 'http://example.com/ (Failed on 1 element)');
-    });
-
-    it('refers to multiple elements if multiple failures', () => {
-      const debugString = AxeAudit.createDebugString({
-        nodes: [{}, {}],
-        help: 'http://example.com/'
-      });
-
-      assert.equal(debugString, 'http://example.com/ (Failed on 2 elements)');
     });
   });
 });

--- a/lighthouse-core/test/audits/accessibility/color-contrast-test.js
+++ b/lighthouse-core/test/audits/accessibility/color-contrast-test.js
@@ -36,7 +36,6 @@ describe('Accessibility: color-contrast audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
   it('generates an audit output (single node)', () => {
@@ -53,7 +52,6 @@ describe('Accessibility: color-contrast audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 
   it('doesn\'t throw an error when violations is undefined', () => {

--- a/lighthouse-core/test/audits/accessibility/image-alt-test.js
+++ b/lighthouse-core/test/audits/accessibility/image-alt-test.js
@@ -36,7 +36,6 @@ describe('Accessibility: image-alt audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
   it('generates an audit output (single node)', () => {
@@ -53,7 +52,6 @@ describe('Accessibility: image-alt audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 
   it('doesn\'t throw an error when violations is undefined', () => {

--- a/lighthouse-core/test/audits/accessibility/label-test.js
+++ b/lighthouse-core/test/audits/accessibility/label-test.js
@@ -36,7 +36,6 @@ describe('Accessibility: label audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
   it('generates an audit output (single node)', () => {
@@ -53,7 +52,6 @@ describe('Accessibility: label audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 
   it('doesn\'t throw an error when violations is undefined', () => {

--- a/lighthouse-core/test/audits/accessibility/tabindex-test.js
+++ b/lighthouse-core/test/audits/accessibility/tabindex-test.js
@@ -36,7 +36,6 @@ describe('Accessibility: tabindex audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 0 elements)');
   });
 
   it('generates an audit output (single node)', () => {
@@ -53,7 +52,6 @@ describe('Accessibility: tabindex audit', () => {
     const output = Audit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.displayValue, '');
-    assert.equal(output.debugString, 'http://example.com/ (Failed on 1 element)');
   });
 
   it('doesn\'t throw an error when violations is undefined', () => {

--- a/lighthouse-core/test/formatter/accessibility-test.js
+++ b/lighthouse-core/test/formatter/accessibility-test.js
@@ -16,10 +16,11 @@
 
 'use strict';
 
-const AccessibilityFormatter = require('../../formatters/accessibility.js');
-const assert = require('assert');
+/* eslint-env mocha */
 
-/* global describe, it */
+const AccessibilityFormatter = require('../../formatters/accessibility.js');
+const Handlebars = require('handlebars');
+const assert = require('assert');
 
 describe('Formatter', () => {
   it('handles invalid input', () => {
@@ -29,5 +30,21 @@ describe('Formatter', () => {
     assert.doesNotThrow(_ => pretty({impact: ''}));
     assert.doesNotThrow(_ => pretty({impact: '', helpUrl: ''}));
     assert.doesNotThrow(_ => pretty({impact: '', helpUrl: '', nodes: []}));
+  });
+
+  it('generates valid html output', () => {
+    Handlebars.registerHelper(AccessibilityFormatter.getHelpers());
+
+    const formatter = AccessibilityFormatter.getFormatter('html');
+    const template = Handlebars.compile(formatter);
+
+    let output = template({nodes: [{target: 'some-id'}]});
+    assert.ok(output.match(/1 element failed this test/g), 'msg for one input');
+    assert.ok(output.match(/<code>some-id<\/code>/g));
+
+    output = template({nodes: [{target: 'some-id'}, {target: 'some-id2'}]});
+    assert.ok(output.match(/2 elements fail this test/g), 'msg for more than one input');
+    assert.ok(output.match(/<code>some-id<\/code>/g));
+    assert.ok(output.match(/<code>some-id2<\/code>/g));
   });
 });

--- a/lighthouse-core/test/formatter/critical-request-chains-test.js
+++ b/lighthouse-core/test/formatter/critical-request-chains-test.js
@@ -16,6 +16,8 @@
 
 'use strict';
 
+/* eslint-env mocha */
+
 const criticalRequestChainFormatter = require('../../formatters/critical-request-chains.js');
 const assert = require('assert');
 const Handlebars = require('handlebars');
@@ -65,8 +67,6 @@ const extendedInfo = {
     }
   }
 };
-
-/* eslint-env mocha */
 
 describe('CRC Formatter', () => {
   it('copes with invalid input', () => {

--- a/lighthouse-core/test/formatter/formatter-test.js
+++ b/lighthouse-core/test/formatter/formatter-test.js
@@ -19,7 +19,7 @@
 const Formatter = require('../../formatters/formatter.js');
 const assert = require('assert');
 
-/* global describe, it */
+/* eslint-env mocha */
 
 describe('Formatter', () => {
   it('returns supported formats', () => {

--- a/lighthouse-core/test/formatter/formatters-test.js
+++ b/lighthouse-core/test/formatter/formatters-test.js
@@ -16,6 +16,7 @@
 'use strict';
 
 /* eslint max-nested-callbacks: ["error", 5] */
+/* eslint-env mocha */
 
 const assert = require('assert');
 const walk = require('walk');
@@ -40,8 +41,6 @@ const walkTree = new Promise((resolve, reject) => {
     resolve(formatters);
   });
 });
-
-/* global describe, it*/
 
 describe('Formatters', () => {
   it('has no formatters failing when getFormatter("html") is called', () => {

--- a/lighthouse-core/test/formatter/user-timings-test.js
+++ b/lighthouse-core/test/formatter/user-timings-test.js
@@ -16,10 +16,10 @@
 
 'use strict';
 
+/* eslint-env mocha */
+
 const UserTimingsFormatter = require('../../formatters/user-timings.js');
 const assert = require('assert');
-
-/* global describe, it */
 
 describe('Formatter', () => {
   it('handles invalid input', () => {


### PR DESCRIPTION
R: all

Follow up from suggestion in https://github.com/GoogleChrome/lighthouse/pull/1598#issuecomment-276824513.

Also added html tests for the a11y formatter.