### PR TITLE
Update Manifest gatherer to use gather error instead of -1 artifact

### DIFF
--- a/lighthouse-core/audits/cache-start-url.js
+++ b/lighthouse-core/audits/cache-start-url.js
@@ -37,21 +37,18 @@ class CacheStartUrl extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    let cacheHasStartUrl = false;
-    const manifest = artifacts.Manifest.value;
-    const cacheContents = artifacts.CacheContents;
-
-    if (!(manifest && manifest.start_url && manifest.start_url.value)) {
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
       return CacheStartUrl.generateAuditResult({
         rawValue: false,
-        debugString: 'start_url not present in Manifest'
       });
     }
 
-    if (!Array.isArray(cacheContents)) {
+    const manifest = artifacts.Manifest.value;
+    if (!(manifest.start_url && manifest.start_url.value)) {
       return CacheStartUrl.generateAuditResult({
         rawValue: false,
-        debugString: cacheContents.debugString || 'No cache detected'
+        debugString: 'start_url not present in Manifest'
       });
     }
 
@@ -67,7 +64,8 @@ class CacheStartUrl extends Audit {
     // here would be to resolve this more completely by asking the Service Worker about the start
     // URL. However that would also necessitate the cache contents gatherer relying on the manifest
     // gather rather than being independent of it.
-    cacheHasStartUrl = cacheContents.find(req => {
+    const cacheContents = artifacts.CacheContents;
+    const cacheHasStartUrl = cacheContents.find(req => {
       return (startURL === req || altStartURL === req);
     });
 

--- a/lighthouse-core/audits/manifest-background-color.js
+++ b/lighthouse-core/audits/manifest-background-color.js
@@ -38,21 +38,19 @@ class ManifestBackgroundColor extends Audit {
   }
 
   /**
-   * @param {!Manifest=} manifest
-   * @return {boolean}
-   */
-  static getBackgroundColorValue(manifest) {
-    return manifest !== undefined &&
-      manifest.background_color.value;
-  }
-
-  /**
    * @param {!Artifacts} artifacts
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const bgColor = ManifestBackgroundColor.getBackgroundColorValue(artifacts.Manifest.value);
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
+      return ManifestBackgroundColor.generateAuditResult({
+        rawValue: false,
+      });
+    }
 
+    const manifest = artifacts.Manifest.value;
+    const bgColor = manifest.background_color.value;
     return ManifestBackgroundColor.generateAuditResult({
       rawValue: !!bgColor,
       extendedInfo: {

--- a/lighthouse-core/audits/manifest-display.js
+++ b/lighthouse-core/audits/manifest-display.js
@@ -48,16 +48,22 @@ class ManifestDisplay extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const manifest = artifacts.Manifest.value;
-    const displayValue = manifest && manifest.display.value;
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
+      return ManifestDisplay.generateAuditResult({
+        rawValue: false
+      });
+    }
 
+    const manifest = artifacts.Manifest.value;
+    const displayValue = manifest.display.value;
     const hasRecommendedValue = ManifestDisplay.hasRecommendedValue(displayValue);
 
     const auditResult = {
       rawValue: hasRecommendedValue,
       displayValue
     };
-    if (manifest && !hasRecommendedValue) {
+    if (!hasRecommendedValue) {
       auditResult.debugString = 'Manifest display property should be set.';
     }
     return ManifestDisplay.generateAuditResult(auditResult);

--- a/lighthouse-core/audits/manifest-exists.js
+++ b/lighthouse-core/audits/manifest-exists.js
@@ -40,6 +40,13 @@ class ManifestExists extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
+    if (!artifacts.Manifest) {
+      // Page has no manifest.
+      return ManifestExists.generateAuditResult({
+        rawValue: false
+      });
+    }
+
     return ManifestExists.generateAuditResult({
       rawValue: typeof artifacts.Manifest.value !== 'undefined',
       debugString: artifacts.Manifest.debugString

--- a/lighthouse-core/audits/manifest-icons-min-144.js
+++ b/lighthouse-core/audits/manifest-icons-min-144.js
@@ -38,8 +38,14 @@ class ManifestIconsMin144 extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const manifest = artifacts.Manifest.value;
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
+      return ManifestIconsMin144.generateAuditResult({
+        rawValue: false
+      });
+    }
 
+    const manifest = artifacts.Manifest.value;
     if (icons.doExist(manifest) === false) {
       return ManifestIconsMin144.generateAuditResult({
         rawValue: false

--- a/lighthouse-core/audits/manifest-icons-min-192.js
+++ b/lighthouse-core/audits/manifest-icons-min-192.js
@@ -41,8 +41,14 @@ class ManifestIconsMin192 extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const manifest = artifacts.Manifest.value;
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
+      return ManifestIconsMin192.generateAuditResult({
+        rawValue: false
+      });
+    }
 
+    const manifest = artifacts.Manifest.value;
     if (icons.doExist(manifest) === false) {
       return ManifestIconsMin192.generateAuditResult({
         rawValue: false

--- a/lighthouse-core/audits/manifest-name.js
+++ b/lighthouse-core/audits/manifest-name.js
@@ -39,15 +39,16 @@ class ManifestName extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    let hasName = false;
-    const manifest = artifacts.Manifest.value;
-
-    if (manifest && manifest.name) {
-      hasName = (!!manifest.name.value);
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
+      return ManifestName.generateAuditResult({
+        rawValue: false
+      });
     }
 
+    const manifest = artifacts.Manifest.value;
     return ManifestName.generateAuditResult({
-      rawValue: hasName
+      rawValue: !!manifest.name.value
     });
   }
 }

--- a/lighthouse-core/audits/manifest-short-name.js
+++ b/lighthouse-core/audits/manifest-short-name.js
@@ -40,15 +40,17 @@ class ManifestShortName extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    let hasShortName = false;
-    const manifest = artifacts.Manifest.value;
-
-    if (manifest) {
-      hasShortName = !!(manifest.short_name.value || manifest.name.value);
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
+      return ManifestShortName.generateAuditResult({
+        rawValue: false
+      });
     }
 
+    const manifest = artifacts.Manifest.value;
     return ManifestShortName.generateAuditResult({
-      rawValue: hasShortName
+      // When no shortname can be found we look for a name.
+      rawValue: !!(manifest.short_name.value || manifest.name.value)
     });
   }
 }

--- a/lighthouse-core/audits/manifest-start-url.js
+++ b/lighthouse-core/audits/manifest-start-url.js
@@ -40,15 +40,16 @@ class ManifestStartUrl extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    let hasStartUrl = false;
-    const manifest = artifacts.Manifest.value;
-
-    if (manifest && manifest.start_url) {
-      hasStartUrl = (!!manifest.start_url.value);
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
+      return ManifestStartUrl.generateAuditResult({
+        rawValue: false
+      });
     }
 
+    const manifest = artifacts.Manifest.value;
     return ManifestStartUrl.generateAuditResult({
-      rawValue: hasStartUrl
+      rawValue: !!manifest.start_url.value
     });
   }
 }

--- a/lighthouse-core/audits/manifest-theme-color.js
+++ b/lighthouse-core/audits/manifest-theme-color.js
@@ -40,15 +40,16 @@ class ManifestThemeColor extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    let hasThemeColor = false;
-    const manifest = artifacts.Manifest.value;
-
-    if (manifest && manifest.theme_color) {
-      hasThemeColor = (!!manifest.theme_color.value);
+    if (!artifacts.Manifest || !artifacts.Manifest.value) {
+      // Page has no manifest or was invalid JSON.
+      return ManifestThemeColor.generateAuditResult({
+        rawValue: false
+      });
     }
 
+    const manifest = artifacts.Manifest.value;
     return ManifestThemeColor.generateAuditResult({
-      rawValue: hasThemeColor
+      rawValue: !!manifest.theme_color.value
     });
   }
 }

--- a/lighthouse-core/closure/typedefs/Manifest.js
+++ b/lighthouse-core/closure/typedefs/Manifest.js
@@ -33,7 +33,7 @@ ManifestNode.prototype.raw;
 /** @type {T} */
 ManifestNode.prototype.value;
 
-/** @type {string} */
+/** @type {string|undefined} */
 ManifestNode.prototype.debugString;
 
 /**

--- a/lighthouse-core/gather/gatherers/cache-contents.js
+++ b/lighthouse-core/gather/gatherers/cache-contents.js
@@ -45,26 +45,21 @@ function getCacheContents() {
 }
 
 class CacheContents extends Gatherer {
-  static _error(errorString) {
-    return {
-      raw: undefined,
-      value: undefined,
-      debugString: errorString
-    };
-  }
-
+  /**
+   * Creates an array of cached URLs.
+   * @param {!Object} options
+   * @return {!Promise<!Array<string>>}
+   */
   afterPass(options) {
     const driver = options.driver;
 
     return driver
         .evaluateAsync(`(${getCacheContents.toString()}())`)
         .then(returnedValue => {
-          if (!returnedValue) {
-            return CacheContents._error('Unable to retrieve cache contents');
+          if (!returnedValue || !Array.isArray(returnedValue)) {
+            throw new Error('Unable to retrieve cache contents');
           }
           return returnedValue;
-        }, _ => {
-          return CacheContents._error('Unable to retrieve cache contents');
         });
   }
 }

--- a/lighthouse-core/gather/gatherers/manifest.js
+++ b/lighthouse-core/gather/gatherers/manifest.js
@@ -27,7 +27,7 @@ const manifestParser = require('../../lib/manifest-parser');
  */
 class Manifest extends Gatherer {
   /**
-   * Returns the parsed manifest or null, if the page had no manifest.
+   * Returns the parsed manifest or null if the page had no manifest.
    * @param {!Object} options
    * @return {!Promise<?Manifest>}
    */
@@ -42,8 +42,7 @@ class Manifest extends Gatherer {
             throw new Error(`Unable to retrieve manifest at ${response.url}`);
           }
 
-          // The driver will return an empty string for url and the data if
-          // the page has no manifest.
+          // If both the data and the url are empty strings, the page had no manifest.
           return null;
         }
 

--- a/lighthouse-core/gather/gatherers/manifest.js
+++ b/lighthouse-core/gather/gatherers/manifest.js
@@ -27,7 +27,9 @@ const manifestParser = require('../../lib/manifest-parser');
  */
 class Manifest extends Gatherer {
   /**
-   * Returns the parsed manifest or null if the page had no manifest.
+   * Returns the parsed manifest or null if the page had no manifest. If the manifest
+   * was unparseable as JSON, manifest.value will be undefined and manifest.debugString
+   * will have the reason. See manifest-parser.js for more information.
    * @param {!Object} options
    * @return {!Promise<?Manifest>}
    */

--- a/lighthouse-core/test/audits/cache-start-url-test.js
+++ b/lighthouse-core/test/audits/cache-start-url-test.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const Audit = require('../../audits/cache-start-url.js');
+const CacheStartUrlAudit = require('../../audits/cache-start-url.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
@@ -24,24 +24,21 @@ const URL = 'https://example.com';
 const AltURL = 'https://example.com/?utm_source=http203';
 const exampleManifest = manifestParser(manifestSrc, URL, URL);
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('Cache: start_url audit', () => {
-  it('fails when no cache contents given', () => {
-    const artifacts = {
-      Manifest: exampleManifest,
-      URL: {finalUrl: URL},
-      CacheContents: {
-        debugString: 'no cache contents'
-      }
-    };
-    const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
-    assert.ok(output.debugString);
+  it('fails with no debugString if page had no manifest', () => {
+    const result = CacheStartUrlAudit.audit({
+      Manifest: null,
+      CacheContents,
+      URL: {finalUrl: URL}
+    });
+    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.debugString, undefined);
   });
 
   it('succeeds when given a manifest with a start_url, cache contents, and a URL', () => {
-    return assert.equal(Audit.audit({
+    return assert.equal(CacheStartUrlAudit.audit({
       Manifest: exampleManifest,
       CacheContents,
       URL: {finalUrl: URL}
@@ -49,7 +46,7 @@ describe('Cache: start_url audit', () => {
   });
 
   it('handles URLs with utm params', () => {
-    return assert.equal(Audit.audit({
+    return assert.equal(CacheStartUrlAudit.audit({
       Manifest: exampleManifest,
       CacheContents,
       URL: {finalUrl: AltURL}

--- a/lighthouse-core/test/audits/manifest-background-color-test.js
+++ b/lighthouse-core/test/audits/manifest-background-color-test.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const Audit = require('../../audits/manifest-background-color.js');
+const ManifestBackgroundColorAudit = require('../../audits/manifest-background-color.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
@@ -34,22 +34,24 @@ function noUrlManifestParser(manifestSrc) {
   return manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
 }
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 // Need to disable camelcase check for dealing with background_color.
 /* eslint-disable camelcase */
 describe('Manifest: background color audit', () => {
-  it('fails when no manifest artifact present', () => {
-    return assert.equal(Audit.audit({Manifest: {
-      value: undefined
-    }}).rawValue, false);
+  it('fails with no debugString if page had no manifest', () => {
+    const result = ManifestBackgroundColorAudit.audit({
+      Manifest: null
+    });
+    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.debugString, undefined);
   });
 
   it('fails when an empty manifest is present', () => {
     const artifacts = {
       Manifest: noUrlManifestParser('{}')
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    return assert.equal(ManifestBackgroundColorAudit.audit(artifacts).rawValue, false);
   });
 
   it('fails when a minimal manifest contains no background_color', () => {
@@ -58,7 +60,7 @@ describe('Manifest: background color audit', () => {
         start_url: '/'
       }))
     };
-    const output = Audit.audit(artifacts);
+    const output = ManifestBackgroundColorAudit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.debugString, undefined);
   });
@@ -69,7 +71,7 @@ describe('Manifest: background color audit', () => {
         background_color: 'no'
       }))
     };
-    const output = Audit.audit(artifacts);
+    const output = ManifestBackgroundColorAudit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.debugString, undefined);
   });
@@ -80,13 +82,14 @@ describe('Manifest: background color audit', () => {
         background_color: '#FAFAFA'
       }))
     };
-    const output = Audit.audit(artifacts);
+    const output = ManifestBackgroundColorAudit.audit(artifacts);
     assert.equal(output.rawValue, true);
     assert.equal(output.extendedInfo.value, '#FAFAFA');
   });
 
   it('succeeds when a complete manifest contains a background_color', () => {
-    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
+    const result = ManifestBackgroundColorAudit.audit({Manifest: exampleManifest});
+    return assert.equal(result.rawValue, true);
   });
 });
 /* eslint-enable */

--- a/lighthouse-core/test/audits/manifest-display-test.js
+++ b/lighthouse-core/test/audits/manifest-display-test.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const Audit = require('../../audits/manifest-display.js');
+const ManifestDisplayAudit = require('../../audits/manifest-display.js');
 const manifestParser = require('../../lib/manifest-parser');
 const assert = require('assert');
 
@@ -24,28 +24,31 @@ const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 const exampleManifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('Mobile-friendly: display audit', () => {
   it('only accepts when a value is set for the display prop', () => {
-    assert.equal(Audit.hasRecommendedValue('fullscreen'), true);
-    assert.equal(Audit.hasRecommendedValue('standalone'), true);
-    assert.equal(Audit.hasRecommendedValue('browser'), true);
-    assert.equal(Audit.hasRecommendedValue('minimal-ui'), true);
-    assert.equal(Audit.hasRecommendedValue('different'), false);
-    assert.equal(Audit.hasRecommendedValue(undefined), false);
+    assert.equal(ManifestDisplayAudit.hasRecommendedValue('fullscreen'), true);
+    assert.equal(ManifestDisplayAudit.hasRecommendedValue('standalone'), true);
+    assert.equal(ManifestDisplayAudit.hasRecommendedValue('browser'), true);
+    assert.equal(ManifestDisplayAudit.hasRecommendedValue('minimal-ui'), true);
+    assert.equal(ManifestDisplayAudit.hasRecommendedValue('different'), false);
+    assert.equal(ManifestDisplayAudit.hasRecommendedValue(undefined), false);
   });
 
-  it('fails when no manifest artifact present', () => {
-    const output = Audit.audit({Manifest: {value: undefined}});
-    assert.equal(output.rawValue, false);
+  it('fails with no debugString if page had no manifest', () => {
+    const result = ManifestDisplayAudit.audit({
+      Manifest: null
+    });
+    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.debugString, undefined);
   });
 
   it('falls back to the successful default when there is no manifest display property', () => {
     const artifacts = {
       Manifest: manifestParser('{}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    const output = Audit.audit(artifacts);
+    const output = ManifestDisplayAudit.audit(artifacts);
 
     assert.equal(output.score, true);
     assert.equal(output.displayValue, 'browser');
@@ -59,7 +62,7 @@ describe('Mobile-friendly: display audit', () => {
         display: 'standalone'
       }), EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    const output = Audit.audit(artifacts);
+    const output = ManifestDisplayAudit.audit(artifacts);
     assert.equal(output.score, true);
     assert.equal(output.displayValue, 'standalone');
     assert.equal(output.rawValue, true);
@@ -67,6 +70,6 @@ describe('Mobile-friendly: display audit', () => {
   });
 
   it('succeeds when a complete manifest contains a display property', () => {
-    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
+    return assert.equal(ManifestDisplayAudit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/manifest-icons-test.js
+++ b/lighthouse-core/test/audits/manifest-icons-test.js
@@ -28,6 +28,20 @@ const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 /* eslint-env mocha */
 
 describe('Manifest: icons audits', () => {
+  it('fails with no debugString if page had no manifest', () => {
+    const result144 = Audit144.audit({
+      Manifest: null
+    });
+    assert.strictEqual(result144.rawValue, false);
+    assert.strictEqual(result144.debugString, undefined);
+
+    const result192 = Audit192.audit({
+      Manifest: null
+    });
+    assert.strictEqual(result192.rawValue, false);
+    assert.strictEqual(result192.debugString, undefined);
+  });
+
   describe('icons exist check', () => {
     it('fails when a manifest contains no icons array', () => {
       const manifestSrc = JSON.stringify({

--- a/lighthouse-core/test/audits/manifest-name-test.js
+++ b/lighthouse-core/test/audits/manifest-name-test.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const Audit = require('../../audits/manifest-theme-color.js');
+const ManifestNameAudit = require('../../audits/manifest-name.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
@@ -24,51 +24,43 @@ const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 const exampleManifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
 
-/* global describe, it*/
+/* eslint-env mocha */
 
-describe('Manifest: theme_color audit', () => {
-  it('fails when no manifest artifact present', () => {
-    return assert.equal(Audit.audit({Manifest: {
-      value: undefined
-    }}).rawValue, false);
+describe('Manifest: name audit', () => {
+  it('fails with no debugString if page had no manifest', () => {
+    const result = ManifestNameAudit.audit({
+      Manifest: null,
+    });
+    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.debugString, undefined);
   });
 
   it('fails when an empty manifest is present', () => {
     const artifacts = {
       Manifest: manifestParser('{}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
-    assert.equal(output.debugString, undefined);
+    return assert.equal(ManifestNameAudit.audit(artifacts).rawValue, false);
   });
 
-  // Need to disable camelcase check for dealing with theme_color.
-  /* eslint-disable camelcase */
-  it('fails when a minimal manifest contains no theme_color', () => {
+  it('fails when a manifest contains no name', () => {
     const artifacts = {
       Manifest: manifestParser(JSON.stringify({
-        start_url: '/'
+        display: '/'
       }), EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
-    assert.equal(output.debugString, undefined);
+    return assert.equal(ManifestNameAudit.audit(artifacts).rawValue, false);
   });
 
-  it('succeeds when a minimal manifest contains a theme_color', () => {
+  it('succeeds when a minimal manifest contains a name', () => {
     const artifacts = {
       Manifest: manifestParser(JSON.stringify({
-        theme_color: '#bada55'
+        name: 'Lighthouse PWA'
       }), EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, true);
-    assert.equal(output.debugString, undefined);
+    return assert.equal(ManifestNameAudit.audit(artifacts).rawValue, true);
   });
 
-  /* eslint-enable camelcase */
-
-  it('succeeds when a complete manifest contains a theme_color', () => {
-    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
+  it('succeeds when a complete manifest contains a name', () => {
+    return assert.equal(ManifestNameAudit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/audits/manifest-short-name-length-test.js
+++ b/lighthouse-core/test/audits/manifest-short-name-length-test.js
@@ -15,21 +15,29 @@
  */
 'use strict';
 
-const Audit = require('../../audits/manifest-short-name-length.js');
+const ManifestShortNameLengthAudit = require('../../audits/manifest-short-name-length.js');
 const assert = require('assert');
 const manifestParser = require('../../lib/manifest-parser');
 
 const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('Manifest: short_name_length audit', () => {
+  it('fails with no debugString if page had no manifest', () => {
+    const result = ManifestShortNameLengthAudit.audit({
+      Manifest: null
+    });
+    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.debugString, undefined);
+  });
+
   it('fails when an empty manifest is present', () => {
     const Manifest = manifestParser('{}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-    const result = Audit.audit({Manifest});
+    const result = ManifestShortNameLengthAudit.audit({Manifest});
     assert.equal(result.rawValue, false);
-    assert.equal(result.debugString, 'No short_name found.');
+    assert.equal(result.debugString, 'No short_name found in manifest.');
   });
 
   it('fails when a manifest contains no short_name and too long name', () => {
@@ -37,7 +45,7 @@ describe('Manifest: short_name_length audit', () => {
       name: 'i\'m much longer than the recommended size'
     });
     const Manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-    const out = Audit.audit({Manifest});
+    const out = ManifestShortNameLengthAudit.audit({Manifest});
     assert.equal(out.rawValue, false);
     assert.notEqual(out.debugString, undefined);
   });
@@ -49,7 +57,7 @@ describe('Manifest: short_name_length audit', () => {
       short_name: 'i\'m much longer than the recommended size'
     });
     const Manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-    const out = Audit.audit({Manifest});
+    const out = ManifestShortNameLengthAudit.audit({Manifest});
     assert.equal(out.rawValue, false);
     assert.notEqual(out.debugString, undefined);
   });
@@ -59,7 +67,7 @@ describe('Manifest: short_name_length audit', () => {
       short_name: 'Lighthouse'
     });
     const Manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-    return assert.equal(Audit.audit({Manifest}).rawValue, true);
+    return assert.equal(ManifestShortNameLengthAudit.audit({Manifest}).rawValue, true);
   });
   /* eslint-enable camelcase */
 });

--- a/lighthouse-core/test/audits/manifest-short-name-test.js
+++ b/lighthouse-core/test/audits/manifest-short-name-test.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const Audit = require('../../audits/manifest-short-name.js');
+const ManifestShortNameAudit = require('../../audits/manifest-short-name.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
@@ -24,20 +24,22 @@ const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 const exampleManifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
 
-/* global describe, it*/
+/* eslint-env mocha */
 
 describe('Manifest: short_name audit', () => {
-  it('fails when no manifest artfifact present', () => {
-    return assert.equal(Audit.audit({Manifest: {
-      value: undefined
-    }}).rawValue, false);
+  it('fails with no debugString if page had no manifest', () => {
+    const result = ManifestShortNameAudit.audit({
+      Manifest: null,
+    });
+    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.debugString, undefined);
   });
 
   it('fails when an empty manifest is present', () => {
     const artifacts = {
       Manifest: manifestParser('{}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    return assert.equal(ManifestShortNameAudit.audit(artifacts).rawValue, false);
   });
 
   // Need to disable camelcase check for dealing with short_name.
@@ -50,7 +52,7 @@ describe('Manifest: short_name audit', () => {
       }), EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
 
-    const output = Audit.audit(artifacts);
+    const output = ManifestShortNameAudit.audit(artifacts);
     assert.equal(output.rawValue, false);
     assert.equal(output.debugString, undefined);
   });
@@ -63,14 +65,14 @@ describe('Manifest: short_name audit', () => {
       }), EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
 
-    const output = Audit.audit(artifacts);
+    const output = ManifestShortNameAudit.audit(artifacts);
     assert.equal(output.rawValue, true);
     assert.equal(output.debugString, undefined);
   });
   /* eslint-enable camelcase */
 
   it('succeeds when a manifest contains a short_name', () => {
-    const output = Audit.audit({Manifest: exampleManifest});
+    const output = ManifestShortNameAudit.audit({Manifest: exampleManifest});
     assert.equal(output.rawValue, true);
     assert.equal(output.debugString, undefined);
   });

--- a/lighthouse-core/test/audits/manifest-start-url-test.js
+++ b/lighthouse-core/test/audits/manifest-start-url-test.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const Audit = require('../../audits/manifest-name.js');
+const ManifestStartUrlAudit = require('../../audits/manifest-start-url.js');
 const assert = require('assert');
 const manifestSrc = JSON.stringify(require('../fixtures/manifest.json'));
 const manifestParser = require('../../lib/manifest-parser');
@@ -24,41 +24,52 @@ const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 const exampleManifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
 
-/* global describe, it*/
+/* eslint-env mocha */
 
-describe('Manifest: name audit', () => {
-  it('fails when no manifest artifact present', () => {
-    return assert.equal(Audit.audit({Manifest: {
-      value: undefined
-    }}).rawValue, false);
+describe('Manifest: start_url audit', () => {
+  it('fails with no debugString if page had no manifest', () => {
+    const result = ManifestStartUrlAudit.audit({
+      Manifest: null,
+    });
+    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.debugString, undefined);
   });
 
   it('fails when an empty manifest is present', () => {
     const artifacts = {
       Manifest: manifestParser('{}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = ManifestStartUrlAudit.audit(artifacts);
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
 
-  it('fails when a manifest contains no name', () => {
+  // Need to disable camelcase check for dealing with start_url.
+  /* eslint-disable camelcase */
+  it('fails when a manifest contains no start_url', () => {
     const artifacts = {
       Manifest: manifestParser(JSON.stringify({
-        display: '/'
+        start_url: undefined
       }), EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, false);
+    const output = ManifestStartUrlAudit.audit(artifacts);
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
 
-  it('succeeds when a minimal manifest contains a name', () => {
+  it('succeeds when a minimal manifest contains a start_url', () => {
     const artifacts = {
       Manifest: manifestParser(JSON.stringify({
-        name: 'Lighthouse PWA'
+        start_url: '/'
       }), EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL)
     };
-    return assert.equal(Audit.audit(artifacts).rawValue, true);
+    const output = ManifestStartUrlAudit.audit(artifacts);
+    assert.equal(output.rawValue, true);
+    assert.equal(output.debugString, undefined);
   });
+  /* eslint-enable camelcase */
 
-  it('succeeds when a complete manifest contains a name', () => {
-    return assert.equal(Audit.audit({Manifest: exampleManifest}).rawValue, true);
+  it('succeeds when a complete manifest contains a start_url', () => {
+    return assert.equal(ManifestStartUrlAudit.audit({Manifest: exampleManifest}).rawValue, true);
   });
 });

--- a/lighthouse-core/test/gather/gatherers/cache-contents-test.js
+++ b/lighthouse-core/test/gather/gatherers/cache-contents-test.js
@@ -27,53 +27,15 @@ describe('Cache Contents gatherer', () => {
     cacheContentGather = new CacheContentGather();
   });
 
-  it('fails gracefully', () => {
+  it('throws an error when cache getter returns nothing', () => {
     return cacheContentGather.afterPass({
       driver: {
         evaluateAsync() {
           return Promise.resolve();
         }
       }
-    }).then(artifact => {
-      assert.ok(typeof artifact === 'object');
-    });
-  });
-
-  it('handles driver failure', () => {
-    return cacheContentGather.afterPass({
-      driver: {
-        evaluateAsync() {
-          return Promise.reject('such a fail');
-        }
-      }
-    }).then(artifact => {
-      assert.ok(artifact.debugString);
-    });
-  });
-
-  it('propagates error retrieving the results', () => {
-    const error = 'Unable to retrieve cache contents';
-    return cacheContentGather.afterPass({
-      driver: {
-        evaluateAsync() {
-          return Promise.reject(error);
-        }
-      }
-    }).then(artifact => {
-      assert.ok(artifact.debugString === error);
-    });
-  });
-
-  it('creates an object for valid results', () => {
-    return cacheContentGather.afterPass({
-      driver: {
-        evaluateAsync() {
-          return Promise.resolve(['a', 'b', 'c']);
-        }
-      }
-    }).then(artifact => {
-      assert.ok(Array.isArray(artifact));
-      assert.equal(artifact[0], 'a');
-    });
+    }).then(
+      _ => assert.ok(false),
+      _ => assert.ok(true));
   });
 });

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -47,21 +47,7 @@ describe('Manifest gatherer', () => {
     });
   });
 
-  it('propagates error from driver failure', () => {
-    const error = 'There was an error.';
-    return manifestGather.afterPass({
-      driver: {
-        sendCommand() {
-          return Promise.reject(error);
-        }
-      }
-    }).then(artifact => {
-      assert.ok(artifact.debugString);
-      assert.ok(artifact.debugString.includes(error));
-    });
-  });
-
-  it('emits an error when unable to retrieve the manifest', () => {
+  it('throws an error when unable to retrieve the manifest', () => {
     return manifestGather.afterPass({
       driver: {
         sendCommand() {
@@ -71,8 +57,24 @@ describe('Manifest gatherer', () => {
           });
         }
       }
+    }).then(
+      _ => assert.ok(false),
+      err => assert.ok(err.message.includes(EXAMPLE_MANIFEST_URL)));
+  });
+
+  it('returns null when the page had no manifest', () => {
+    return manifestGather.afterPass({
+      driver: {
+        sendCommand() {
+          return Promise.resolve({
+            data: '',
+            errors: [],
+            url: ''
+          });
+        }
+      }
     }).then(artifact => {
-      assert.ok(artifact.debugString);
+      assert.strictEqual(artifact, null);
     });
   });
 
@@ -93,6 +95,7 @@ describe('Manifest gatherer', () => {
       url: EXAMPLE_DOC_URL
     }).then(artifact => {
       assert.ok(typeof artifact.value === 'object');
+      assert.strictEqual(artifact.debugString, undefined);
     });
   });
 });


### PR DESCRIPTION
Part of #941. There a lot of audits that depend on the manifest gatherer, so separated this one from #1623.

The most impactful change I made was to make the manifest gatherer return `null` if the page has no manifest as it seems appropriate to have an explicit value for this (and obviously not having a manifest is not an error).

This sticks to the minimal redundancy of `debugString`s that #1598 started: if the page has no manifest, all the manifest audits will fail with no message. If the manifest was there but invalid JSON, they will all fail but only `manifest-exists` will report the `debugString`.

There's a good bit of redundancy here. It may make sense to split these into their own `audits/` subdirectory a la `accessibility/` and do some kind of base class thing (and unify testing...most of these tests are duplicates with only the tested property changed)