### PR TITLE
Fix viewer's "Export -> Save as..." with Firefox.

### DIFF
--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -361,9 +361,12 @@ class LighthouseViewerReport extends LighthouseReport {
     const a = document.createElement('a');
     a.download = `${filename}${ext}`;
     a.href = URL.createObjectURL(blob);
+    document.body.appendChild(a); // Firefox requires anchor to be in the DOM.
     a.click();
 
-    setTimeout(_ => URL.revokeObjectURL(a.href), 500); // cleanup.
+    // cleanup.
+    document.body.removeChild(a);
+    setTimeout(_ => URL.revokeObjectURL(a.href), 500);
   }
 
   /**


### PR DESCRIPTION
For some weird reason, Firefox needs `document.body.appendChild(a)` too.

Fixes #1574.