### PR TITLE
fMP: Use last fMPCandidate if no FMP is marked.

### DIFF
--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -19,7 +19,6 @@
 
 const Audit = require('./audit');
 const TracingProcessor = require('../lib/traces/tracing-processor');
-const log = require('../lib/log');
 const Formatter = require('../formatters/formatter');
 
 // Parameters (in ms) for log-normal CDF scoring. To see the curve:

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -54,19 +54,8 @@ class FirstMeaningfulPaint extends Audit {
   static audit(artifacts) {
     const trace = artifacts.traces[this.DEFAULT_PASS];
     return artifacts.requestTraceOfTab(trace).then(tabTrace => {
-      // If there was no firstMeaningfulPaint event found in the trace, the network idle detection
-      // may have not been triggered before Lighthouse finished tracing.
-      // In this case we'll use the last firstMeaningfulPaintCandidate we can find.
-      // However, if no candidates were found (a bogus trace, likely), we fail.
       if (!tabTrace.firstMeaningfulPaintEvt) {
-        const fmpCand = 'firstMeaningfulPaintCandidate';
-        log.verbose('fmp-audit', `No firstMeaningfulPaint found, falling back to last ${fmpCand}`);
-        const candidates = tabTrace.processEvents.filter(e => e.name === fmpCand);
-
-        if (candidates.length === 0) {
-          throw new Error('No usable `firstMeaningfulPaint(Candidate)` events found in trace');
-        }
-        tabTrace.firstMeaningfulPaintEvt = candidates.pop();
+        throw new Error('No usable `firstMeaningfulPaint(Candidate)` events found in trace');
       }
 
       // navigationStart is currently essential to FMP calculation.

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -29,6 +29,7 @@
  */
 
 const ComputedArtifact = require('./computed-artifact');
+const log = require('../../lib/log');
 
 class TraceOfTab extends ComputedArtifact {
 
@@ -51,7 +52,8 @@ class TraceOfTab extends ComputedArtifact {
   compute_(trace) {
     // Parse the trace for our key events and sort them by timestamp.
     const keyEvents = trace.traceEvents.filter(e => {
-      return e.cat.includes('blink.user_timing') || e.name === 'TracingStartedInPage';
+      return e.cat.includes('blink.user_timing') || e.cat.includes('loading') ||
+          e.name === 'TracingStartedInPage';
     }).sort((event0, event1) => event0.ts - event1.ts);
 
     // The first TracingStartedInPage in the trace is definitely our renderer thread of interest
@@ -67,8 +69,22 @@ class TraceOfTab extends ComputedArtifact {
         e.name === 'navigationStart' && e.ts < firstFCP.ts).pop();
 
     // fMP will follow at/after the FCP, though we allow some timestamp tolerance
-    const firstMeaningfulPaint = frameEvents.find(e =>
+    let firstMeaningfulPaint = frameEvents.find(e =>
         e.name === 'firstMeaningfulPaint' && e.ts >= (firstFCP.ts - TraceOfTab.fmpToleranceMs));
+
+    // If there was no firstMeaningfulPaint event found in the trace, the network idle detection
+    // may have not been triggered before Lighthouse finished tracing.
+    // In this case, we'll use the last firstMeaningfulPaintCandidate we can find.
+    // However, if no candidates were found (a bogus trace, likely), we fail.
+    if (!firstMeaningfulPaint) {
+      const fmpCand = 'firstMeaningfulPaintCandidate';
+      log.verbose('trace-of-tab', `No firstMeaningfulPaint found, falling back to last ${fmpCand}`);
+      const lastCandidate = frameEvents.filter(e => e.name === fmpCand).pop();
+      if (!lastCandidate) {
+        log.verbose('No `firstMeaningfulPaintCandidate` events found in trace');
+      }
+      firstMeaningfulPaint = lastCandidate;
+    }
 
     // subset all trace events to just our tab's process (incl threads other than main)
     const processEvents = trace.traceEvents.filter(e => {

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -81,7 +81,7 @@ class TraceOfTab extends ComputedArtifact {
       log.verbose('trace-of-tab', `No firstMeaningfulPaint found, falling back to last ${fmpCand}`);
       const lastCandidate = frameEvents.filter(e => e.name === fmpCand).pop();
       if (!lastCandidate) {
-        log.verbose('No `firstMeaningfulPaintCandidate` events found in trace');
+        log.verbose('trace-of-tab', 'No `firstMeaningfulPaintCandidate` events found in trace');
       }
       firstMeaningfulPaint = lastCandidate;
     }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -49,6 +49,7 @@ class Driver {
       'blink.console',
       'blink.user_timing',
       'benchmark',
+      'loading',
       'latencyInfo',
       'devtools.timeline',
       'disabled-by-default-devtools.timeline',

--- a/lighthouse-core/lib/traces/pwmetrics-events.js
+++ b/lighthouse-core/lib/traces/pwmetrics-events.js
@@ -148,7 +148,7 @@ class Metrics {
    * @param {number} navStartTs
    * @return {!Array} Pair of trace events (start/end)
    */
-  synthesizeEventPair(metric, navStartTs) {
+  synthesizeEventPair(metric, navStart) {
     // We'll masquerade our fake events to look mostly like navigationStart
     const eventBase = {
       pid: this.getNavigationStartEvt().pid,
@@ -160,7 +160,7 @@ class Metrics {
       id: `0x${((Math.random() * 1000000) | 0).toString(16)}`
     };
     const fakeMeasureStartEvent = Object.assign({}, eventBase, {
-      ts: navStartTs,
+      ts: navStart.ts,
       ph: 'b'
     });
     const fakeMeasureEndEvent = Object.assign({}, eventBase, {
@@ -182,8 +182,8 @@ class Metrics {
     }
 
     // confirm our navStart's correctly match
-    const navStartTs = metrics.find(e => e.id === 'navstart').ts;
-    if (this.getNavigationStartEvt().ts !== navStartTs) {
+    const navStartEvt = metrics.find(e => e.id === 'navstart');
+    if (!navStartEvt || this.getNavigationStartEvt().ts !== navStartEvt.ts) {
       log.error('pwmetrics-events', 'Reference navigationStart doesn\'t match fMP\'s navStart');
       return [];
     }
@@ -197,7 +197,7 @@ class Metrics {
         return;
       }
       log.verbose('pwmetrics-events', `Sythesizing trace events for ${metric.name}`);
-      fakeEvents.push(...this.synthesizeEventPair(metric, navStartTs));
+      fakeEvents.push(...this.synthesizeEventPair(metric, navStartEvt));
     });
     return fakeEvents;
   }

--- a/lighthouse-core/lib/traces/pwmetrics-events.js
+++ b/lighthouse-core/lib/traces/pwmetrics-events.js
@@ -145,7 +145,7 @@ class Metrics {
    *     { "pid": 89922,"tid":1295,"ts":77176783452,"ph":"b","cat":"blink.user_timing","name":"innermeasure","args":{},"tts":1257886,"id":"0xe66c67"}
    *     { "pid": 89922,"tid":1295,"ts":77176882592,"ph":"e","cat":"blink.user_timing","name":"innermeasure","args":{},"tts":1257898,"id":"0xe66c67"}
    * @param {{ts: number, id: string, name: string}} metric
-   * @param {number} navStartTs
+   * @param {{ts: number, id: string, name: string}} navStart
    * @return {!Array} Pair of trace events (start/end)
    */
   synthesizeEventPair(metric, navStart) {

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -22,6 +22,7 @@ const traceEvents = require('../fixtures/traces/progressive-app.json');
 const badNavStartTrace = require('../fixtures/traces/bad-nav-start-ts.json');
 const lateTracingStartedTrace = require('../fixtures/traces/tracingstarted-after-navstart.json');
 const preactTrace = require('../fixtures/traces/preactjs.com_ts_of_undefined.json');
+const noFMPtrace = require('../fixtures/traces/no_fmp_event.json');
 
 const GatherRunner = require('../../gather/gather-runner.js');
 const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
@@ -69,8 +70,8 @@ describe('Performance: first-meaningful-paint audit', () => {
     });
   });
 
-  describe('finds correct FMP in various traces', () => {
-    it('finds the fMP if there was a tracingStartedInPage after the frame\'s navStart', () => {
+  describe('finds correct FMP', () => {
+    it('if there was a tracingStartedInPage after the frame\'s navStart', () => {
       return FMPAudit.audit(generateArtifactsWithTrace(lateTracingStartedTrace)).then(result => {
         assert.equal(result.displayValue, '529.9ms');
         assert.equal(result.rawValue, 529.9);
@@ -80,7 +81,7 @@ describe('Performance: first-meaningful-paint audit', () => {
       });
     });
 
-    it('finds the fMP if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
+    it('if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
       return FMPAudit.audit(generateArtifactsWithTrace(badNavStartTrace)).then(result => {
         assert.equal(result.displayValue, '632.4ms');
         assert.equal(result.rawValue, 632.4);
@@ -90,12 +91,21 @@ describe('Performance: first-meaningful-paint audit', () => {
       });
     });
 
-    it('finds the fMP if it appears slightly before the fCP', () => {
+    it('if it appears slightly before the fCP', () => {
       return FMPAudit.audit(generateArtifactsWithTrace(preactTrace)).then(result => {
         assert.equal(result.displayValue, '878.4ms');
         assert.equal(result.rawValue, 878.4);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 1805796384607);
         assert.equal(result.extendedInfo.value.timings.fCP, 879.046);
+        assert.ok(!result.debugString);
+      });
+    });
+
+    it('from candidates if no defined FMP exists', () => {
+      return FMPAudit.audit(generateArtifactsWithTrace(noFMPtrace)).then(result => {
+        assert.equal(result.displayValue, '4460.9ms');
+        assert.equal(result.rawValue, 4460.9);
+        assert.equal(result.extendedInfo.value.timings.fCP, 1494.73);
         assert.ok(!result.debugString);
       });
     });

--- a/lighthouse-core/test/fixtures/traces/no_fmp_event.json
+++ b/lighthouse-core/test/fixtures/traces/no_fmp_event.json
@@ -1,0 +1,89 @@
+{
+  "traceEvents": [
+    {
+      "pid": 77472,
+      "tid": 775,
+      "ts": 2146735802456,
+      "ph": "I",
+      "cat": "disabled-by-default-devtools.timeline",
+      "name": "TracingStartedInPage",
+      "args": {
+        "data": {
+          "frames": [
+            {
+              "frame": "0x150343381dd0",
+              "name": "",
+              "url": "about:blank"
+            }
+          ],
+          "page": "0x150343381dd0",
+          "sessionId": "77472.1"
+        }
+      },
+      "tts": 341067,
+      "s": "t"
+    },
+    {
+      "pid": 77472,
+      "tid": 775,
+      "ts": 2146735807738,
+      "ph": "R",
+      "cat": "blink.user_timing",
+      "name": "navigationStart",
+      "args": {
+        "frame": "0x150343381dd0"
+      },
+      "tts": 341944
+    },
+    {
+      "pid": 77472,
+      "tid": 775,
+      "ts": 2146737301957,
+      "ph": "I",
+      "cat": "blink.user_timing,rail",
+      "name": "firstPaint",
+      "args": {
+        "frame": "0x150343381dd0"
+      },
+      "tts": 549087,
+      "s": "p"
+    },
+    {
+      "pid": 77472,
+      "tid": 775,
+      "ts": 2146737302468,
+      "ph": "R",
+      "cat": "blink.user_timing,rail",
+      "name": "firstImagePaint",
+      "args": {
+        "frame": "0x150343381dd0"
+      },
+      "tts": 549603
+    },
+    {
+      "pid": 77472,
+      "tid": 775,
+      "ts": 2146737302468,
+      "ph": "I",
+      "cat": "blink.user_timing,rail",
+      "name": "firstContentfulPaint",
+      "args": {
+        "frame": "0x150343381dd0"
+      },
+      "tts": 549599,
+      "s": "p"
+    },
+    {
+      "pid": 77472,
+      "tid": 775,
+      "ts": 2146740268666,
+      "ph": "R",
+      "cat": "loading",
+      "name": "firstMeaningfulPaintCandidate",
+      "args": {
+        "frame": "0x150343381dd0"
+      },
+      "tts": 1009771
+    }
+  ]
+}

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -22,6 +22,7 @@ const assert = require('assert');
 const badNavStartTrace = require('../../fixtures/traces/bad-nav-start-ts.json');
 const lateTracingStartedTrace = require('../../fixtures/traces/tracingstarted-after-navstart.json');
 const preactTrace = require('../../fixtures/traces/preactjs.com_ts_of_undefined.json');
+const noFMPtrace = require('../../fixtures/traces/no_fmp_event.json');
 
 /* eslint-env mocha */
 describe('Trace of Tab computed artifact:', () => {
@@ -62,6 +63,14 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 1805796384607);
       assert.equal(trace.firstContentfulPaintEvt.ts, 1805797263653);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 1805797262960);
+    });
+
+    it('from candidates if no defined FMP exists', () => {
+      const trace = traceOfTab.compute_(noFMPtrace);
+      assert.equal(trace.startedInPageEvt.ts, 2146735802456);
+      assert.equal(trace.navigationStartEvt.ts, 2146735807738);
+      assert.equal(trace.firstContentfulPaintEvt.ts, 2146737302468);
+      assert.equal(trace.firstMeaningfulPaintEvt.ts, 2146740268666);
     });
   });
 });


### PR DESCRIPTION
Good test page for this is https://madeby.google.com/phone/ which we always time out after 30s

fixes #1564 


--

fmpCandidate comes from `loading` trace category (for whatever reason). 

The changes in pwmetrics are for handling -1 failures a little better.