### PR TITLE
Use default args now that node 6 is required.

### DIFF
--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -46,10 +46,7 @@ function checkOutputPath(path: string): string {
   return path;
 }
 
-function formatAggregationResultItem(score: boolean | number | string, suffix?: string) {
-  // Until we only support node 6 we can not use default args.
-  suffix = suffix || '';
-
+function formatAggregationResultItem(score: boolean | number | string, suffix = '') {
   if (typeof score === 'boolean') {
     return score ? `${log.greenify(log.tick)}` : `${log.redify(log.cross)}`;
   }

--- a/lighthouse-core/formatters/critical-request-chains.js
+++ b/lighthouse-core/formatters/critical-request-chains.js
@@ -66,16 +66,11 @@ class CriticalRequestChains extends Formatter {
   }
 
   static _traverse(tree, cb) {
-    function walk(node, depth, startTime, transferSize) {
+    function walk(node, depth, startTime, transferSize = 0) {
       const children = Object.keys(node);
       if (children.length === 0) {
         return;
       }
-
-      if (!transferSize) {
-        transferSize = 0;
-      }
-
       children.forEach(id => {
         const child = node[id];
         if (!startTime) {

--- a/lighthouse-core/formatters/table.js
+++ b/lighthouse-core/formatters/table.js
@@ -77,10 +77,7 @@ class Table extends Formatter {
    * @param {!Array<!Object>} results Audit results.
    * @return {{headings: !Array<string>, rows: !Array<{cols: !Array<*>}>}}
    */
-  static createTable(headings, results) {
-    headings = headings || {};
-    results = results || [];
-
+  static createTable(headings = {}, results = []) {
     const headingKeys = Object.keys(headings);
 
     const rows = results.map(result => {

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -48,10 +48,9 @@ class Connection {
    * @param {!Object} params
    * @return {!Promise}
    */
-  sendCommand(method, params) {
+  sendCommand(method, params = {}) {
     log.formatProtocol('method => browser', {method, params}, 'verbose');
     const id = ++this._lastCommandId;
-    params = params || {};
     const message = JSON.stringify({id, method, params});
     this.sendRawMessage(message);
     return new Promise((resolve, reject) => {

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -37,13 +37,11 @@ const Config = require('./config/config');
  *
  */
 
-module.exports = function(url, flags, configJSON) {
+module.exports = function(url, flags = {}, configJSON) {
   return new Promise((resolve, reject) => {
     if (!url) {
       return reject(new Error('Lighthouse requires a URL'));
     }
-
-    flags = flags || {};
 
     // set logging preferences, assume quiet
     flags.logLevel = flags.logLevel || 'error';

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -117,9 +117,7 @@ class TraceProcessor {
    * @return {!Array<{percentile: number, time: number}>}
    * @private
    */
-  static _riskPercentiles(durations, totalTime, percentiles, clippedLength) {
-    clippedLength = clippedLength || 0;
-
+  static _riskPercentiles(durations, totalTime, percentiles, clippedLength = 0) {
     let busyTime = 0;
     for (let i = 0; i < durations.length; i++) {
       busyTime += durations[i];

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -307,9 +307,7 @@ class ReportGenerator {
    * @param {?Object} reportsCatalog Basic info about all the reports to include in left nav bar
    * @return {string} HTML of the report page.
    */
-  generateHTML(results, reportContext, reportsCatalog) {
-    reportContext = reportContext || 'extension';
-
+  generateHTML(results, reportContext = 'extension', reportsCatalog) {
     this._registerFormatters(results.audits);
 
     results.aggregations.forEach(aggregation => {

--- a/lighthouse-core/test/audits/dobetterweb/uses-responsive-images-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-responsive-images-test.js
@@ -27,18 +27,14 @@ function generateRecord(resourceSizeInKb, durationInMs) {
   };
 }
 
-function generateSize(width, height, prefix) {
-  prefix = prefix || 'client';
-
+function generateSize(width, height, prefix = 'client') {
   const size = {};
   size[`${prefix}Width`] = width;
   size[`${prefix}Height`] = height;
   return size;
 }
 
-function generateImage(clientSize, naturalSize, networkRecord, src) {
-  src = src || 'https://google.com/logo.png';
-
+function generateImage(clientSize, naturalSize, networkRecord, src = 'https://google.com/logo.png') {
   const image = {src, networkRecord};
   Object.assign(image, clientSize, naturalSize);
   return image;

--- a/lighthouse-core/test/audits/speed-index-metric-test.js
+++ b/lighthouse-core/test/audits/speed-index-metric-test.js
@@ -36,10 +36,7 @@ function mockArtifactsWithSpeedlineResult(result) {
 }
 
 describe('Performance: speed-index-metric audit', () => {
-  function frame(timestamp, progress) {
-    timestamp = timestamp || 0;
-    progress = progress || 0;
-
+  function frame(timestamp = 0, progress = 0) {
     return {
       getTimeStamp: () => timestamp,
       getProgress: () => progress,

--- a/lighthouse-core/test/audits/unused-css-rules-test.js
+++ b/lighthouse-core/test/audits/unused-css-rules-test.js
@@ -97,11 +97,10 @@ describe('Best Practices: unused css rules audit', () => {
     let baseSheet;
     const baseUrl = 'http://g.co/';
 
-    function map(overrides, url) {
+    function map(overrides, url = baseUrl) {
       if (overrides.header && overrides.header.sourceURL) {
         overrides.header.sourceURL = baseUrl + overrides.header.sourceURL;
       }
-      url = url || baseUrl;
       return UnusedCSSAudit.mapSheetToResult(Object.assign(baseSheet, overrides), url);
     }
 


### PR DESCRIPTION
There's also `polyfillNode4Support` which I can't quite look into now. If the name is wrong, the function should be renamed otherwise cleaned up.