### PR TITLE
Update --perf config to latest

### DIFF
--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -2,8 +2,22 @@
   "passes": [{
     "recordNetwork": true,
     "recordTrace": true,
-    "gatherers": []
-  }],
+    "gatherers": [
+      "url",
+      "image-usage",
+      "content-width"
+    ]
+  },
+  {
+    "passName": "css-image-usage",
+    "recordNetwork": true,
+    "gatherers": [
+      "styles",
+      "css-usage",
+      "dobetterweb/optimized-images"
+    ]
+  }
+  ],
 
   "audits": [
     "first-meaningful-paint",
@@ -12,7 +26,10 @@
     "time-to-interactive",
     "user-timings",
     "screenshots",
-    "critical-request-chains"
+    "critical-request-chains",
+    "unused-css-rules",
+    "dobetterweb/uses-optimized-images",
+    "dobetterweb/uses-responsive-images"
   ],
 
   "aggregations": [{
@@ -49,14 +66,11 @@
     "categorizable": false,
     "items": [{
       "audits": {
-        "critical-request-chains": {
-          "expectedValue": 0,
-          "weight": 1
-        },
-        "user-timings": {
-          "expectedValue": 0,
-          "weight": 1
-        }
+        "unused-css-rules": {},
+        "uses-optimized-images": {},
+        "uses-responsive-images": {},
+        "critical-request-chains": {},
+        "user-timings": {}
       }
     }]
   }]

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -14,6 +14,7 @@
     "gatherers": [
       "styles",
       "css-usage",
+      "dobetterweb/tags-blocking-first-paint",
       "dobetterweb/optimized-images"
     ]
   }
@@ -28,6 +29,8 @@
     "screenshots",
     "critical-request-chains",
     "unused-css-rules",
+    "dobetterweb/link-blocking-first-paint",
+    "dobetterweb/script-blocking-first-paint",
     "dobetterweb/uses-optimized-images",
     "dobetterweb/uses-responsive-images"
   ],
@@ -70,6 +73,8 @@
         "uses-optimized-images": {},
         "uses-responsive-images": {},
         "critical-request-chains": {},
+        "link-blocking-first-paint": {},
+        "script-blocking-first-paint": {},
         "user-timings": {}
       }
     }]


### PR DESCRIPTION
once we have tags in the default config (#1463), we can swap to that and won't have it fall behind again.

but until then..