### PR TITLE
convert DoBetterWeb gatherers to new error system

### DIFF
--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -43,13 +43,6 @@ class AppCacheManifestAttr extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.AppCacheManifest === -1) {
-      return AppCacheManifestAttr.generateAuditResult({
-        rawValue: false,
-        debugString: 'Unable to determine if you\'re using AppCache.'
-      });
-    }
-
     const usingAppcache = artifacts.AppCacheManifest !== null;
     const debugString = usingAppcache ?
         `Found <html manifest="${artifacts.AppCacheManifest}">.` : '';

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -42,20 +42,13 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.AnchorsWithNoRelNoopener === -1) {
-      return ExternalAnchorsUseRelNoopenerAudit.generateAuditResult({
-        rawValue: -1,
-        debugString: 'Unknown error with the AnchorsWithNoRelNoopener gatherer.'
-      });
-    }
-
     let debugString;
     const pageHost = new URL(artifacts.URL.finalUrl).host;
     // Filter usages to exclude anchors that are same origin
     // TODO: better extendedInfo for anchors with no href attribute:
     // https://github.com/GoogleChrome/lighthouse/issues/1233
     // https://github.com/GoogleChrome/lighthouse/issues/1345
-    const failingAnchors = artifacts.AnchorsWithNoRelNoopener.usages
+    const failingAnchors = artifacts.AnchorsWithNoRelNoopener
       .filter(anchor => {
         try {
           return anchor.href === '' || new URL(anchor.href).host !== pageHost;

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -46,19 +46,7 @@ class GeolocationOnStart extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.GeolocationOnStart.value === -1) {
-      let debugString = 'Unknown error with the GeolocationOnStart gatherer';
-      if (artifacts.GeolocationOnStart.debugString) {
-        debugString = artifacts.GeolocationOnStart.debugString;
-      }
-
-      return GeolocationOnStart.generateAuditResult({
-        rawValue: -1,
-        debugString
-      });
-    }
-
-    const results = artifacts.GeolocationOnStart.usage.map(err => {
+    const results = artifacts.GeolocationOnStart.map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`
       }, err);

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -49,12 +49,6 @@ class LinkBlockingFirstPaintAudit extends Audit {
    */
   static computeAuditResultForTags(artifacts, tagFilter) {
     const artifact = artifacts.TagsBlockingFirstPaint;
-    if (artifact.value === -1) {
-      return {
-        rawValue: -1,
-        debugString: artifact.debugString
-      };
-    }
 
     const filtered = artifact.filter(item => item.tag.tagName === tagFilter);
 

--- a/lighthouse-core/audits/dobetterweb/no-console-time.js
+++ b/lighthouse-core/audits/dobetterweb/no-console-time.js
@@ -48,21 +48,9 @@ class NoConsoleTimeAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.ConsoleTimeUsage.value === -1) {
-      let debugString = 'Unknown error with the ConsoleTimeUsage gatherer';
-      if (artifacts.ConsoleTimeUsage.debugString) {
-        debugString = artifacts.ConsoleTimeUsage.debugString;
-      }
-
-      return NoConsoleTimeAudit.generateAuditResult({
-        rawValue: -1,
-        debugString
-      });
-    }
-
     let debugString;
     // Filter usage from other hosts and keep eval'd code.
-    const results = artifacts.ConsoleTimeUsage.usage.filter(err => {
+    const results = artifacts.ConsoleTimeUsage.filter(err => {
       if (err.isEval) {
         return !!err.url;
       }

--- a/lighthouse-core/audits/dobetterweb/no-datenow.js
+++ b/lighthouse-core/audits/dobetterweb/no-datenow.js
@@ -48,21 +48,9 @@ class NoDateNowAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.DateNowUse.value === -1) {
-      let debugString = 'Unknown error with the DateNowUse gatherer';
-      if (artifacts.DateNowUse.debugString) {
-        debugString = artifacts.DateNowUse.debugString;
-      }
-
-      return NoDateNowAudit.generateAuditResult({
-        rawValue: -1,
-        debugString
-      });
-    }
-
     let debugString;
     // Filter usage from other hosts and keep eval'd code.
-    const results = artifacts.DateNowUse.usage.filter(err => {
+    const results = artifacts.DateNowUse.filter(err => {
       if (err.isEval) {
         return !!err.url;
       }

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -46,19 +46,7 @@ class NoDocWriteAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.DocWriteUse.value === -1) {
-      let debugString = 'Unknown error with the DocWriteUse gatherer';
-      if (artifacts.DocWriteUse.debugString) {
-        debugString = artifacts.DocWriteUse.debugString;
-      }
-
-      return NoDocWriteAudit.generateAuditResult({
-        rawValue: -1,
-        debugString
-      });
-    }
-
-    const results = artifacts.DocWriteUse.usage.map(err => {
+    const results = artifacts.DocWriteUse.map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`
       }, err);

--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -62,10 +62,6 @@ class NoMutationEventsAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.EventListeners.rawValue === -1) {
-      return NoMutationEventsAudit.generateAuditResult(artifacts.EventListeners);
-    }
-
     let debugString;
     const listeners = artifacts.EventListeners;
 

--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -45,16 +45,9 @@ class NoWebSQLAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.WebSQL.database === -1) {
-      return NoWebSQLAudit.generateAuditResult({
-        rawValue: -1,
-        debugString: artifacts.WebSQL.debugString
-      });
-    }
-
-    const db = artifacts.WebSQL.database;
-    const debugString = (db && db.database ?
-        `Found database "${db.database.name}", version: ${db.database.version}.` : '');
+    const db = artifacts.WebSQL;
+    const debugString = (db ?
+        `Found database "${db.name}", version: ${db.version}.` : '');
 
     return NoWebSQLAudit.generateAuditResult({
       rawValue: !db,

--- a/lighthouse-core/audits/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/notification-on-start.js
@@ -46,19 +46,7 @@ class NotificationOnStart extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.NotificationOnStart.value === -1) {
-      let debugString = 'Unknown error with the NotificationOnStart gatherer';
-      if (artifacts.NotificationOnStart.debugString) {
-        debugString = artifacts.NotificationOnStart.debugString;
-      }
-
-      return NotificationOnStart.generateAuditResult({
-        rawValue: -1,
-        debugString
-      });
-    }
-
-    const results = artifacts.NotificationOnStart.usage.map(err => {
+    const results = artifacts.NotificationOnStart.map(err => {
       return Object.assign({
         label: `line: ${err.line}, col: ${err.col}`
       }, err);

--- a/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
+++ b/lighthouse-core/audits/dobetterweb/uses-optimized-images.js
@@ -81,10 +81,6 @@ class UsesOptimizedImages extends Audit {
   static audit_(artifacts, networkThroughput) {
     const images = artifacts.OptimizedImages;
 
-    if (images.rawValue === -1) {
-      return UsesOptimizedImages.generateAuditResult(images);
-    }
-
     const failedImages = [];
     let totalWastedBytes = 0;
     let hasAllEfficientImages = true;

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -54,10 +54,6 @@ class PassiveEventsAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    if (artifacts.EventListeners.rawValue === -1) {
-      return PassiveEventsAudit.generateAuditResult(artifacts.EventListeners);
-    }
-
     let debugString;
     const listeners = artifacts.EventListeners;
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -533,7 +533,7 @@ class Driver {
 
   /**
    * @param {string} selector Selector to find in the DOM
-   * @return {!Promise<Element[]>} The found elements, or [], resolved in a promise
+   * @return {!Promise<!Array<!Element>>} The found elements, or [], resolved in a promise
    */
   querySelectorAll(selector) {
     return this.sendCommand('DOM.getDocument')

--- a/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
@@ -41,7 +41,7 @@ class EventListeners extends Gatherer {
   /**
    * @param {number|string} nodeIdOrObject The node id of the element or the
    *     string of and object ('document', 'window').
-   * @return {!Promise<!Array.<EventListener>>}
+   * @return {!Promise<!Array<{listeners: !Array, tagName: string}>>}
    * @private
    */
   _listEventListeners(nodeIdOrObject) {
@@ -74,7 +74,7 @@ class EventListeners extends Gatherer {
    * listenForScriptParsedEvents should be called before this method to ensure
    * the page's parsed scripts are collected at page load.
    * @param {string} nodeId The node to look for attached event listeners.
-   * @return {!Promise<!Array.<Object>>} List of event listeners attached to
+   * @return {!Promise<!Array<!Object>>} List of event listeners attached to
    *     the node.
    */
   getEventListeners(nodeId) {
@@ -107,8 +107,8 @@ class EventListeners extends Gatherer {
 
   /**
    * Aggregates the event listeners used on each element into a single list.
-   * @param {Array.<Element>} nodes List of elements to fetch event listeners for.
-   * @return {!Promise<!Array.<Object>>} Resolves to a list of all the event
+   * @param {!Array<!Element>} nodes List of elements to fetch event listeners for.
+   * @return {!Promise<!Array<!Object>>} Resolves to a list of all the event
    *     listeners found across the elements.
    */
   collectListeners(nodes) {
@@ -127,18 +127,17 @@ class EventListeners extends Gatherer {
     return this.listenForScriptParsedEvents();
   }
 
+  /**
+   * @param {!Object} options
+   * @return {!Promise<!Array<!Object>>}
+   */
   afterPass(options) {
     return this.unlistenForScriptParsedEvents()
-        .then(_ => options.driver.querySelectorAll('body, body /deep/ *')) // drill into shadow trees
-        .then(nodes => {
-          nodes.push('document', 'window');
-          return this.collectListeners(nodes);
-        }).catch(_ => {
-          return {
-            rawValue: -1,
-            debugString: 'Unable to collect passive events listener usage.'
-          };
-        });
+      .then(_ => options.driver.querySelectorAll('body, body /deep/ *')) // drill into shadow trees
+      .then(nodes => {
+        nodes.push('document', 'window');
+        return this.collectListeners(nodes);
+      });
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
@@ -19,7 +19,10 @@
 const Gatherer = require('../gatherer');
 
 class AnchorsWithNoRelNoopener extends Gatherer {
-
+  /**
+   * @param {!Object} options
+   * @return {!Promise<!Array<{href: string, rel: string, target: string}>>}
+   */
   afterPass(options) {
     const driver = options.driver;
     return driver.querySelectorAll('a[target="_blank"]:not([rel~="noopener"])')
@@ -34,18 +37,13 @@ class AnchorsWithNoRelNoopener extends Gatherer {
         return Promise.all(failingNodes);
       })
       .then(failingNodes => {
-        return {
-          usages: failingNodes.map(node => {
-            return {
-              href: node[0],
-              rel: node[1],
-              target: node[2]
-            };
-          })
-        };
-      })
-      .catch(_ => {
-        return -1;
+        return failingNodes.map(node => {
+          return {
+            href: node[0],
+            rel: node[1],
+            target: node[2]
+          };
+        });
       });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/appcache.js
@@ -20,15 +20,17 @@
 const Gatherer = require('../gatherer');
 
 class AppCacheManifest extends Gatherer {
-
+  /**
+   * Retrurns the value of the html element's manifest attribute or null if it
+   * is not defined.
+   * @param {!Object} options
+   * @return {!Promise<?string>}
+   */
   afterPass(options) {
     const driver = options.driver;
 
     return driver.querySelector('html')
-      .then(node => node && node.getAttribute('manifest'))
-      .catch(_ => {
-        return -1;
-      });
+      .then(node => node && node.getAttribute('manifest'));
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/console-time-usage.js
@@ -29,17 +29,11 @@ class ConsoleTimeUsage extends Gatherer {
     this.collectUsage = options.driver.captureFunctionCallSites('console.time');
   }
 
+  /**
+   * @return {!Promise<!Array<{url: string, line: number, col: number}>>}
+   */
   afterPass() {
-    return this.collectUsage().then(consoleTimeUsage => {
-      return {
-        usage: consoleTimeUsage
-      };
-    }, e => {
-      return {
-        value: -1,
-        debugString: e.message
-      };
-    });
+    return this.collectUsage();
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/datenow.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/datenow.js
@@ -29,17 +29,11 @@ class DateNowUse extends Gatherer {
     this.collectUsage = options.driver.captureFunctionCallSites('Date.now');
   }
 
+  /**
+   * @return {!Promise<!Array<{url: string, line: number, col: number}>>}
+   */
   afterPass() {
-    return this.collectUsage().then(dateNowUses => {
-      return {
-        usage: dateNowUses
-      };
-    }, e => {
-      return {
-        value: -1,
-        debugString: e.message
-      };
-    });
+    return this.collectUsage();
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/document-write.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/document-write.js
@@ -29,17 +29,11 @@ class DocWriteUse extends Gatherer {
     this.collectUsage = options.driver.captureFunctionCallSites('document.write');
   }
 
+  /**
+   * @return {!Promise<!Array<{url: string, line: number, col: number}>>}
+   */
   afterPass() {
-    return this.collectUsage().then(DocWriteUses => {
-      return {
-        usage: DocWriteUses
-      };
-    }, e => {
-      return {
-        value: -1,
-        debugString: e.message
-      };
-    });
+    return this.collectUsage();
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/geolocation-on-start.js
@@ -32,31 +32,23 @@ class GeolocationOnStart extends Gatherer {
         'navigator.geolocation.watchPosition');
   }
 
+  /**
+   * @param {!Object} options
+   * @return {!Promise<!Array<{url: string, line: number, col: number}>>}
+   */
   afterPass(options) {
     return options.driver.queryPermissionState('geolocation')
-        .then(state => {
-          if (state === 'granted' || state === 'denied') {
-            return {
-              value: -1,
-              debugString: 'Unable to determine if this permission was requested ' +
-                           'on page load because it had already been set. ' +
-                           'Try resetting the permission and run Lighthouse again.'
-            };
-          }
+      .then(state => {
+        if (state === 'granted' || state === 'denied') {
+          throw new Error('Unable to determine if this permission was requested on page load ' +
+              'because it had already been set. Try resetting the permission and running ' +
+              'Lighthouse again.');
+        }
 
-          return this.collectCurrentPosUsage().then(results => {
-            return this.collectWatchPosUsage().then(results2 => results.concat(results2));
-          }).then(results => {
-            return {
-              usage: results
-            };
-          });
-        }).catch(e => {
-          return {
-            value: -1,
-            debugString: e && e.message
-          };
+        return this.collectCurrentPosUsage().then(results => {
+          return this.collectWatchPosUsage().then(results2 => results.concat(results2));
         });
+      });
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/notification-on-start.js
@@ -32,27 +32,15 @@ class NotificationOnStart extends Gatherer {
 
   afterPass(options) {
     return options.driver.queryPermissionState('notifications')
-        .then(state => {
-          if (state === 'granted' || state === 'denied') {
-            return {
-              value: -1,
-              debugString: 'Unable to determine if this permission was requested ' +
-                           'on page load because it had already been set. ' +
-                           'Try resetting the permission and run Lighthouse again.'
-            };
-          }
+      .then(state => {
+        if (state === 'granted' || state === 'denied') {
+          throw new Error('Unable to determine if this permission was requested on page load ' +
+              'because it had already been set. Try resetting the permission and running ' +
+              'Lighthouse again.');
+        }
 
-          return this.collectNotificationUsage().then(results => {
-            return {
-              usage: results
-            };
-          });
-        }).catch(e => {
-          return {
-            value: -1,
-            debugString: e && e.message
-          };
-        });
+        return this.collectNotificationUsage();
+      });
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
@@ -114,6 +114,11 @@ class OptimizedImages extends Gatherer {
     });
   }
 
+  /**
+   * @param {!Object} options
+   * @param {{networkRecords: !Array<!NetworRecord>}} traceData
+   * @return {!Promise<!Array<!Object>}
+   */
   afterPass(options, traceData) {
     const networkRecords = traceData.networkRecords;
     const imageRecords = OptimizedImages.filterImageRequests(options.url, networkRecords);
@@ -131,8 +136,6 @@ class OptimizedImages extends Gatherer {
       }
 
       return results;
-    }).catch(err => {
-      return {rawValue: -1, debugString: err};
     });
   }
 }

--- a/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
@@ -147,15 +147,14 @@ class TagsBlockingFirstPaint extends Gatherer {
     return options.driver.evaluateScriptOnLoad(scriptSrc);
   }
 
+  /**
+   * @param {!Object} options
+   * @param {{networkRecords: !Array<!NetworkRecord>}} tracingData
+   * @return {!Array<{tag: string, transferSize: number, startTime: number, endTime: number}>}
+   */
   afterPass(options, tracingData) {
     return TagsBlockingFirstPaint
-      .findBlockingTags(options.driver, tracingData.networkRecords)
-      .catch(err => {
-        return {
-          value: -1,
-          debugString: err.message
-        };
-      });
+      .findBlockingTags(options.driver, tracingData.networkRecords);
   }
 }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/websql.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/websql.js
@@ -43,21 +43,15 @@ class WebSQL extends Gatherer {
     });
   }
 
+  /**
+   * Returns WebSQL database information or null if none was found.
+   * @param {!Object} options
+   * @return {?{id: string, domain: string, name: string, version: string}}
+   */
   afterPass(options) {
     return this.listenForDatabaseEvents(options.driver)
-      .then(database => {
-        const artifact = {
-          database
-        };
-        if (!database) {
-          artifact.debugString = 'No WebSQL databases were opened';
-        }
-        return artifact;
-      }).catch(_ => {
-        return {
-          database: -1,
-          debugString: 'Unable to gather WebSQL database state'
-        };
+      .then(result => {
+        return result && result.database;
       });
   }
 }

--- a/lighthouse-core/test/audits/dobetterweb/appcache-manifest-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/appcache-manifest-test.js
@@ -21,14 +21,6 @@ const assert = require('assert');
 /* eslint-env mocha */
 
 describe('Appcache manifest audit', () => {
-  it('fails when gatherer failed', () => {
-    const auditResult = AppCacheManifestAttrAudit.audit({
-      AppCacheManifest: -1
-    });
-    assert.equal(auditResult.rawValue, false);
-    assert.ok(auditResult.debugString);
-  });
-
   it('fails when <html> contains a manifest attribute', () => {
     const auditResult = AppCacheManifestAttrAudit.audit({
       AppCacheManifest: 'manifest-name'

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -24,22 +24,12 @@ const URL = 'https://google.com/test';
 /* eslint-env mocha */
 
 describe('External anchors use rel="noopener"', () => {
-  it('fails when gatherer failed', () => {
-    const auditResult = ExternalAnchorsAudit.audit({
-      AnchorsWithNoRelNoopener: -1
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.ok(auditResult.debugString);
-  });
-
   it('passes when links are from same hosts as the page host', () => {
     const auditResult = ExternalAnchorsAudit.audit({
-      AnchorsWithNoRelNoopener: {
-        usages: [
-          {href: 'https://google.com/test'},
-          {href: 'https://google.com/test1'}
-        ]
-      },
+      AnchorsWithNoRelNoopener: [
+        {href: 'https://google.com/test'},
+        {href: 'https://google.com/test1'}
+      ],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, true);
@@ -48,12 +38,10 @@ describe('External anchors use rel="noopener"', () => {
 
   it('fails when links are from different hosts than the page host', () => {
     const auditResult = ExternalAnchorsAudit.audit({
-      AnchorsWithNoRelNoopener: {
-        usages: [
-          {href: 'https://example.com/test'},
-          {href: 'https://example.com/test1'}
-        ]
-      },
+      AnchorsWithNoRelNoopener: [
+        {href: 'https://example.com/test'},
+        {href: 'https://example.com/test1'}
+      ],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);
@@ -62,13 +50,11 @@ describe('External anchors use rel="noopener"', () => {
 
   it('handles links with no href attribute', () => {
     const auditResult = ExternalAnchorsAudit.audit({
-      AnchorsWithNoRelNoopener: {
-        usages: [
-          {href: ''},
-          {href: 'http://'},
-          {href: 'http:'}
-        ]
-      },
+      AnchorsWithNoRelNoopener: [
+        {href: ''},
+        {href: 'http://'},
+        {href: 'http:'}
+      ],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);

--- a/lighthouse-core/test/audits/dobetterweb/geolocation-on-start-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/geolocation-on-start-test.js
@@ -21,23 +21,12 @@ const assert = require('assert');
 /* eslint-env mocha */
 
 describe('UX: geolocation audit', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'interesting debug string';
-    const auditResult = GeolocationOnStartAudit.audit({
-      GeolocationOnStart: {value: -1, debugString}
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('fails when geolocation has been automatically requested', () => {
     const auditResult = GeolocationOnStartAudit.audit({
-      GeolocationOnStart: {
-        usage: [
-          {url: 'http://different.com/two', line: 2, col: 2},
-          {url: 'http://example2.com/two', line: 2, col: 22}
-        ]
-      },
+      GeolocationOnStart: [
+        {url: 'http://different.com/two', line: 2, col: 2},
+        {url: 'http://example2.com/two', line: 2, col: 22}
+      ],
     });
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 2);
@@ -45,7 +34,7 @@ describe('UX: geolocation audit', () => {
 
   it('passes when geolocation has not been automatically requested', () => {
     const auditResult = GeolocationOnStartAudit.audit({
-      GeolocationOnStart: {usage: []}
+      GeolocationOnStart: []
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);

--- a/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/link-blocking-first-paint-test.js
@@ -22,18 +22,6 @@ const assert = require('assert');
 /* eslint-env mocha */
 
 describe('Link Block First Paint audit', () => {
-  it('fails when error input present', () => {
-    const debugString = 'the uniquest debug string';
-    const auditResult = LinkBlockingFirstPaintAudit.audit({
-      TagsBlockingFirstPaint: {
-        value: -1,
-        debugString
-      }
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.strictEqual(auditResult.debugString, debugString);
-  });
-
   it('fails when there are links found which block first paint', () => {
     const linkDetails = {
       tagName: 'LINK',

--- a/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-console-time-test.js
@@ -23,18 +23,9 @@ const URL = 'https://example.com';
 /* eslint-env mocha */
 
 describe('Page does not use console.time()', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'interesting debug string';
-    const auditResult = NoConsoleTimeAudit.audit({
-      ConsoleTimeUsage: {value: -1, debugString}
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('passes when console.time() is not used', () => {
     const auditResult = NoConsoleTimeAudit.audit({
-      ConsoleTimeUsage: {usage: []},
+      ConsoleTimeUsage: [],
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, true);
@@ -43,12 +34,10 @@ describe('Page does not use console.time()', () => {
 
   it('passes when console.time() is used on a different origin', () => {
     const auditResult = NoConsoleTimeAudit.audit({
-      ConsoleTimeUsage: {
-        usage: [
-          {url: 'http://different.com/two', line: 2, col: 2},
-          {url: 'http://example2.com/two', line: 2, col: 22}
-        ]
-      },
+      ConsoleTimeUsage: [
+        {url: 'http://different.com/two', line: 2, col: 2},
+        {url: 'http://example2.com/two', line: 2, col: 22}
+      ],
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, true);
@@ -57,13 +46,11 @@ describe('Page does not use console.time()', () => {
 
   it('fails when console.time() is used on the origin', () => {
     const auditResult = NoConsoleTimeAudit.audit({
-      ConsoleTimeUsage: {
-        usage: [
-          {url: 'http://example.com/one', line: 1, col: 1},
-          {url: 'http://example.com/two', line: 10, col: 1},
-          {url: 'http://example2.com/two', line: 2, col: 22}
-        ]
-      },
+      ConsoleTimeUsage: [
+        {url: 'http://example.com/one', line: 1, col: 1},
+        {url: 'http://example.com/two', line: 10, col: 1},
+        {url: 'http://example2.com/two', line: 2, col: 22}
+      ],
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, false);
@@ -76,13 +63,11 @@ describe('Page does not use console.time()', () => {
 
   it('fails when console.time() is used in eval()', () => {
     const auditResult = NoConsoleTimeAudit.audit({
-      ConsoleTimeUsage: {
-        usage: [
-          {url: 'http://example.com/one', line: 1, col: 1, isEval: false},
-          {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: true},
-          {url: 'module.exports (blah/handler.js:3:18)', line: 3, col: 18, isEval: true}
-        ]
-      },
+      ConsoleTimeUsage: [
+        {url: 'http://example.com/one', line: 1, col: 1, isEval: false},
+        {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: true},
+        {url: 'module.exports (blah/handler.js:3:18)', line: 3, col: 18, isEval: true}
+      ],
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, false);
@@ -91,12 +76,10 @@ describe('Page does not use console.time()', () => {
 
   it('includes results when there is no .url', () => {
     const auditResult = NoConsoleTimeAudit.audit({
-      ConsoleTimeUsage: {
-        usage: [
-          {line: 10, col: 1},
-          {line: 2, col: 22}
-        ]
-      },
+      ConsoleTimeUsage: [
+        {line: 10, col: 1},
+        {line: 2, col: 22}
+      ],
       URL: {finalUrl: URL},
     });
 

--- a/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-datenow-test.js
@@ -23,18 +23,9 @@ const URL = 'https://example.com';
 /* eslint-env mocha */
 
 describe('Page does not use Date.now()', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'interesting debug string';
-    const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {value: -1, debugString}
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('passes when Date.now() is not used', () => {
     const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {usage: []},
+      DateNowUse: [],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, true);
@@ -43,12 +34,10 @@ describe('Page does not use Date.now()', () => {
 
   it('passes when Date.now() is used on a different origin', () => {
     const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {
-        usage: [
-          {url: 'http://different.com/two', line: 2, col: 2},
-          {url: 'http://example2.com/two', line: 2, col: 22}
-        ]
-      },
+      DateNowUse: [
+        {url: 'http://different.com/two', line: 2, col: 2},
+        {url: 'http://example2.com/two', line: 2, col: 22}
+      ],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, true);
@@ -57,13 +46,11 @@ describe('Page does not use Date.now()', () => {
 
   it('fails when Date.now() is used on the origin', () => {
     const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {
-        usage: [
-          {url: 'http://example.com/one', line: 1, col: 1},
-          {url: 'http://example.com/two', line: 10, col: 1},
-          {url: 'http://example2.com/two', line: 2, col: 22}
-        ]
-      },
+      DateNowUse: [
+        {url: 'http://example.com/one', line: 1, col: 1},
+        {url: 'http://example.com/two', line: 10, col: 1},
+        {url: 'http://example2.com/two', line: 2, col: 22}
+      ],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);
@@ -76,12 +63,10 @@ describe('Page does not use Date.now()', () => {
 
   it('only passes when has url property', () => {
     const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {
-        usage: [
-          {url: 'http://example.com/two', line: 10, col: 1},
-          {url: 'http://example2.com/two', line: 2, col: 22}
-        ]
-      },
+      DateNowUse: [
+        {url: 'http://example.com/two', line: 10, col: 1},
+        {url: 'http://example2.com/two', line: 2, col: 22}
+      ],
       URL: {finalUrl: URL},
     });
 
@@ -91,13 +76,11 @@ describe('Page does not use Date.now()', () => {
 
   it('fails when console.time() is used in eval()', () => {
     const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {
-        usage: [
-          {url: 'http://example.com/one', line: 1, col: 1, isEval: false},
-          {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: true},
-          {url: 'module.exports (blah/handler.js:3:18)', line: 3, col: 18, isEval: true}
-        ]
-      },
+      DateNowUse: [
+        {url: 'http://example.com/one', line: 1, col: 1, isEval: false},
+        {url: 'module.exports (blah/handler.js:5:18)', line: 5, col: 18, isEval: true},
+        {url: 'module.exports (blah/handler.js:3:18)', line: 3, col: 18, isEval: true}
+      ],
       URL: {finalUrl: URL}
     });
     assert.equal(auditResult.rawValue, false);
@@ -106,12 +89,10 @@ describe('Page does not use Date.now()', () => {
 
   it('includes results when there is no .url', () => {
     const auditResult = DateNowUseAudit.audit({
-      DateNowUse: {
-        usage: [
-          {line: 10, col: 1},
-          {line: 2, col: 22}
-        ]
-      },
+      DateNowUse: [
+        {line: 10, col: 1},
+        {line: 2, col: 22}
+      ],
       URL: {finalUrl: URL},
     });
 

--- a/lighthouse-core/test/audits/dobetterweb/no-document-write-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-document-write-test.js
@@ -23,18 +23,9 @@ const URL = 'https://example.com';
 /* eslint-env mocha */
 
 describe('Page does not use document.write()', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'interesting debug string';
-    const auditResult = DocWriteUseAudit.audit({
-      DocWriteUse: {value: -1, debugString}
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('passes when document.write() is not used', () => {
     const auditResult = DocWriteUseAudit.audit({
-      DocWriteUse: {usage: []},
+      DocWriteUse: [],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, true);
@@ -43,13 +34,11 @@ describe('Page does not use document.write()', () => {
 
   it('fails when document.write() is used', () => {
     const auditResult = DocWriteUseAudit.audit({
-      DocWriteUse: {
-        usage: [
-          {url: 'http://example.com/one', line: 1, col: 1},
-          {url: 'http://example.com/two', line: 10, col: 1},
-          {url: 'http://example2.com/two', line: 2, col: 22}
-        ]
-      },
+      DocWriteUse: [
+        {url: 'http://example.com/one', line: 1, col: 1},
+        {url: 'http://example.com/two', line: 10, col: 1},
+        {url: 'http://example2.com/two', line: 2, col: 22}
+      ],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);

--- a/lighthouse-core/test/audits/dobetterweb/no-mutation-events-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-mutation-events-test.js
@@ -25,19 +25,6 @@ const URL = 'https://example.com';
 /* eslint-env mocha */
 
 describe('Page does not use mutation events', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'event-y debug string';
-    const auditResult = NoMutationEventsAudit.audit({
-      EventListeners: {
-        rawValue: -1,
-        debugString
-      },
-      URL: {finalUrl: URL}
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.strictEqual(auditResult.debugString, debugString);
-  });
-
   it('passes when mutation events are not used', () => {
     const auditResult = NoMutationEventsAudit.audit({
       EventListeners: [],

--- a/lighthouse-core/test/audits/dobetterweb/no-websql-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-websql-test.js
@@ -21,36 +21,23 @@ const assert = require('assert');
 /* eslint-env mocha */
 
 describe('No websql audit', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'websql is the best';
-    const auditResult = NoWebSQLAudit.audit({
-      WebSQL: {
-        database: -1,
-        debugString
-      }
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('passes when no database is created', () => {
     assert.equal(NoWebSQLAudit.audit({
-      WebSQL: {
-        database: null
-      }
+      WebSQL: null
     }).rawValue, true);
   });
 
   it('fails when database is created', () => {
     const auditResult = NoWebSQLAudit.audit({
       WebSQL: {
-        database: {
-          database: 'db-name', version: 1.0
-        }
+        id: '1',
+        domain: 'example.com',
+        name: 'db-name',
+        version: '1.0'
       }
     });
 
     assert.equal(auditResult.rawValue, false);
-    assert.ok(auditResult.debugString.match(/Found database (.*), version: (.*)/));
+    assert.ok(auditResult.debugString.match(/Found database "db-name", version: 1.0/));
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/notification-on-start-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/notification-on-start-test.js
@@ -21,23 +21,12 @@ const assert = require('assert');
 /* eslint-env mocha */
 
 describe('UX: notification audit', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'interesting debug string';
-    const auditResult = NotificationOnStart.audit({
-      NotificationOnStart: {value: -1, debugString}
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('fails when notification has been automatically requested', () => {
     const auditResult = NotificationOnStart.audit({
-      NotificationOnStart: {
-        usage: [
-          {url: 'http://different.com/two', line: 2, col: 2},
-          {url: 'http://example2.com/two', line: 2, col: 22}
-        ]
-      },
+      NotificationOnStart: [
+        {url: 'http://different.com/two', line: 2, col: 2},
+        {url: 'http://example2.com/two', line: 2, col: 22}
+      ],
     });
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 2);
@@ -45,7 +34,7 @@ describe('UX: notification audit', () => {
 
   it('passes when notification has not been automatically requested', () => {
     const auditResult = NotificationOnStart.audit({
-      NotificationOnStart: {usage: []}
+      NotificationOnStart: []
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);

--- a/lighthouse-core/test/audits/dobetterweb/script-blocking-first-paint-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/script-blocking-first-paint-test.js
@@ -22,18 +22,6 @@ const assert = require('assert');
 /* eslint-env mocha */
 
 describe('Script Block First Paint audit', () => {
-  it('fails when error input present', () => {
-    const debugString = 'first paint debug string';
-    const auditResult = ScriptBlockingFirstPaintAudit.audit({
-      TagsBlockingFirstPaint: {
-        value: -1,
-        debugString
-      }
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.strictEqual(auditResult.debugString, debugString);
-  });
-
   it('fails when there are scripts found which block first paint', () => {
     const scriptDetails = {
       tagName: 'SCRIPT',

--- a/lighthouse-core/test/audits/dobetterweb/uses-optimized-images-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-optimized-images-test.js
@@ -37,18 +37,6 @@ function generateImage(type, originalSize, webpSize, jpegSize) {
 /* eslint-env mocha */
 
 describe('Page uses optimized images', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'All image optimizations failed.';
-    const auditResult = UsesOptimizedImagesAudit.audit_({
-      OptimizedImages: {
-        rawValue: -1,
-        debugString: debugString
-      },
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('fails when one jpeg image is unoptimized', () => {
     const auditResult = UsesOptimizedImagesAudit.audit_({
       OptimizedImages: [

--- a/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
@@ -24,19 +24,6 @@ const URL = 'https://example.com';
 /* eslint-env mocha */
 
 describe('Page uses passive events listeners where applicable', () => {
-  it('fails when gatherer returns error', () => {
-    const debugString = 'Unable to gather passive event listeners usage.';
-    const auditResult = PassiveEventsAudit.audit({
-      EventListeners: {
-        rawValue: -1,
-        debugString: debugString
-      },
-      URL: {finalUrl: URL}
-    });
-    assert.equal(auditResult.rawValue, -1);
-    assert.equal(auditResult.debugString, debugString);
-  });
-
   it('fails when scroll blocking listeners should be passive', () => {
     const auditResult = PassiveEventsAudit.audit({
       EventListeners: fixtureData,

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
@@ -126,12 +126,4 @@ describe('Optimized images', () => {
       assert.ok(/whoops/.test(failed.err.message), 'passed along error message');
     });
   });
-
-  it('handles total driver failure', () => {
-    options.driver.evaluateAsync = () => Promise.reject(new Error('fatal'));
-    return optimizedImages.afterPass(options, traceData).then(artifact => {
-      assert.equal(artifact.rawValue, -1);
-      assert.ok(artifact.debugString);
-    });
-  });
 });

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/tags-blocking-first-paint-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/tags-blocking-first-paint-test.js
@@ -155,17 +155,4 @@ describe('First paint blocking tags', () => {
       assert.deepEqual(artifact, expected);
     });
   });
-
-  it('handles driver failure', () => {
-    return tagsBlockingFirstPaint.afterPass({
-      driver: {
-        evaluateAsync() {
-          return Promise.reject(new Error('such a fail'));
-        }
-      }
-    }, traceData).then(artifact => {
-      assert.equal(artifact.value, -1);
-      assert.ok(artifact.debugString);
-    });
-  });
 });


### PR DESCRIPTION
with #1624 this completes the transition of the gatherers to using actual errors instead of -1 artifacts :)

These are all pretty straightforward so I grouped them more coarsely by similar gatherers per commit.

The biggest change was I changed the artifact returned by the call site gatherers (`Date.now`, `document.write`, etc) so instead of returning `{usage: [/* locations of call sites */]}` they just return `[/* locations of call sites */]`. If that's bad I can revert, but the indirection seems unnecessary now that we've lived with these for a while now.