### PR TITLE
Reformat the critical chain output

### DIFF
--- a/lighthouse-core/formatters/critical-request-chains.js
+++ b/lighthouse-core/formatters/critical-request-chains.js
@@ -41,16 +41,15 @@ class CriticalRequestChains extends Formatter {
             return '';
           }
 
-          const longestChain = CriticalRequestChains._getLongestChainLength(info);
-          const longestDuration =
-              CriticalRequestChains._getLongestChainDuration(info).toFixed(2);
+          const longestChain = CriticalRequestChains._getLongestChain(info).length;
+          const longestDuration = CriticalRequestChains.formatNumber(
+              CriticalRequestChains._getLongestChain(info).duration);
           const longestTransferSize = CriticalRequestChains.formatTransferSize(
-              CriticalRequestChains._getLongestChainTransferSize(info));
+              CriticalRequestChains._getLongestChain(info).transferSize);
           const urlTree = CriticalRequestChains._createURLTreeOutput(info);
 
-          const output = `    - Longest request chain (shorter is better): ${longestChain}\n` +
-          `    - Longest chain duration (shorter is better): ${longestDuration}ms\n` +
-          `    - Longest chain transfer size (smaller is better): ${longestTransferSize}KB\n` +
+          const output = `    - Longest request chain: ${longestDuration}ms` +
+          ` over ${longestChain } requests, totalling ${longestTransferSize}KB\n` +
           '    - Initial navigation\n' +
               '      ' + urlTree.replace(/\n/g, '\n      ') + '\n';
           return output;
@@ -94,39 +93,27 @@ class CriticalRequestChains extends Formatter {
     walk(tree, 0);
   }
 
-  static _getLongestChainLength(tree) {
-    let longestChain = 0;
-    this._traverse(tree, opts => {
-      const depth = opts.depth;
-      if (depth > longestChain) {
-        longestChain = depth;
-      }
-    });
-
-    // Always return the longest chain + 1 because the depth is zero indexed.
-    return (longestChain + 1);
-  }
-
-  static _getLongestChainDuration(tree) {
-    let longestChainDuration = 0;
+  /**
+   * Get stats about the longest initiator chain (as determined by time duration)
+   * @return {{duration: number, length: number, transferSize: number}}
+   */
+  static _getLongestChain(tree) {
+    const longest = {
+      duration: 0,
+      length: 0,
+      transferSize: 0
+    };
     this._traverse(tree, opts => {
       const duration = opts.chainDuration;
-      if (duration > longestChainDuration) {
-        longestChainDuration = duration;
+      if (duration > longest.duration) {
+        longest.duration = duration;
+        longest.transferSize = opts.chainTransferSize;
+        longest.length = opts.depth;
       }
     });
-    return longestChainDuration;
-  }
-
-  static _getLongestChainTransferSize(tree) {
-    let transferSize = 0;
-    this._traverse(tree, opts => {
-      const chainTransferSize = opts.chainTransferSize;
-      if (chainTransferSize > transferSize) {
-        transferSize = chainTransferSize;
-      }
-    });
-    return transferSize;
+    // Always return the longest chain + 1 because the depth is zero indexed.
+    longest.length++;
+    return longest;
   }
 
   /**
@@ -168,7 +155,8 @@ class CriticalRequestChains extends Formatter {
           startTime = node[id].request.startTime;
         }
 
-        const duration = ((node[id].request.endTime - startTime) * 1000).toFixed(2);
+        const duration = CriticalRequestChains.formatNumber(
+            (node[id].request.endTime - startTime) * 1000);
         const chainTransferSize = transferSize + node[id].request.transferSize;
         const formattedTransferSize = CriticalRequestChains.formatTransferSize(chainTransferSize);
 
@@ -195,12 +183,12 @@ class CriticalRequestChains extends Formatter {
     });
   }
 
-  static formatTime(time) {
-    return time.toFixed(2);
+  static formatNumber(num) {
+    return num.toLocaleString(undefined, {maximumFractionDigits: 1});
   }
 
   static formatTransferSize(size) {
-    return (size / 1024).toFixed(2);
+    return (size / 1024).toLocaleString(undefined, {maximumFractionDigits: 2});
   }
 
   static parseURL(resourceURL, opts) {
@@ -221,26 +209,26 @@ class CriticalRequestChains extends Formatter {
   static getHelpers() {
     return {
       longestChain(info) {
-        return CriticalRequestChains._getLongestChainLength(info);
+        return CriticalRequestChains._getLongestChain(info).length;
       },
 
       longestDuration(info) {
-        return CriticalRequestChains._getLongestChainDuration(info);
+        return CriticalRequestChains._getLongestChain(info).duration;
       },
 
       longestChainTransferSize(info) {
-        return CriticalRequestChains._getLongestChainTransferSize(info);
+        return CriticalRequestChains._getLongestChain(info).transferSize;
       },
 
       chainDuration(startTime, endTime) {
-        return ((endTime - startTime) * 1000).toFixed(2);
+        return CriticalRequestChains.formatNumber((endTime - startTime) * 1000);
       },
 
       formatTransferSize: CriticalRequestChains.formatTransferSize,
 
       parseURL: CriticalRequestChains.parseURL,
 
-      formatTime: CriticalRequestChains.formatTime,
+      formatNumber: CriticalRequestChains.formatNumber,
 
       /**
        * Helper function for Handlebars that creates the context for each node

--- a/lighthouse-core/formatters/critical-request-chains.js
+++ b/lighthouse-core/formatters/critical-request-chains.js
@@ -49,7 +49,7 @@ class CriticalRequestChains extends Formatter {
           const urlTree = CriticalRequestChains._createURLTreeOutput(info);
 
           const output = `    - Longest request chain: ${longestDuration}ms` +
-          ` over ${longestChain } requests, totalling ${longestTransferSize}KB\n` +
+          ` over ${longestChain} requests, totalling ${longestTransferSize}KB\n` +
           '    - Initial navigation\n' +
               '      ' + urlTree.replace(/\n/g, '\n      ') + '\n';
           return output;

--- a/lighthouse-core/formatters/partials/critical-request-chains.css
+++ b/lighthouse-core/formatters/partials/critical-request-chains.css
@@ -53,3 +53,9 @@
 .cnc-node__tree-hostname {
   color: #999;
 }
+
+.initial-nav {
+  color: #a9a9a9;
+  margin: 10px 0 0;
+  font-style: italic;
+}

--- a/lighthouse-core/formatters/partials/critical-request-chains.html
+++ b/lighthouse-core/formatters/partials/critical-request-chains.html
@@ -30,7 +30,8 @@
         <span class="cnc-node__tree-hostname">({{ this.hostname }})</span>
       {{/parseURL}}
       {{#unless hasChildren}}
-        - <span class="cnc-node__chain-duration">{{chainDuration startTime this.node.request.endTime }}ms, {{formatTransferSize this.transferSize}}KB</span>
+        - <span class="cnc-node__chain-duration">{{chainDuration startTime this.node.request.endTime }}ms</span>,
+          <span class="cnc-node__chain-duration">{{formatTransferSize this.transferSize}}KB</span>
       {{/unless}}
     </span>
   </div>
@@ -43,17 +44,19 @@
 {{/inline}}
 
 <ul class="subitem__details">
-  <li class="subitem__detail">Longest request chain (shorter is better): <strong>{{longestChain this}}</strong></li>
-  <li class="subitem__detail">Longest chain duration (shorter is better): <strong>{{formatTime (longestDuration this)}}ms</strong></li>
-  <li class="subitem__detail">Longest chain transfer size (smaller is better): <strong>{{formatTransferSize (longestChainTransferSize this)}}KB</strong></li>
+  <li class="subitem__detail">Longest chain: <strong>{{formatNumber (longestDuration this)}}ms</strong>
+   over <strong>{{longestChain this}}</strong> requests, totalling <strong>{{formatTransferSize (longestChainTransferSize this)}}KB</strong></li>
   <li class="subitem__detail">
-    <div>Initial navigation</div>
-    {{#createTreeRenderContext this}}
-      {{#each this.tree }}
-        {{#createContextFor ../tree @key undefined undefined ../startTime ../transferSize }}
-          {{> writeNode this }}
-        {{/createContextFor}}
-      {{/each}}
-    {{/createTreeRenderContext}}
+    <details>
+      <summary>View critical network waterfall</summary>
+      <div class="initial-nav">Initial navigation</div>
+      {{#createTreeRenderContext this}}
+        {{#each this.tree }}
+          {{#createContextFor ../tree @key undefined undefined ../startTime ../transferSize }}
+            {{> writeNode this }}
+          {{/createContextFor}}
+        {{/each}}
+      {{/createTreeRenderContext}}
+    </details>
   </li>
 </ul>

--- a/lighthouse-core/test/formatter/critical-request-chains-test.js
+++ b/lighthouse-core/test/formatter/critical-request-chains-test.js
@@ -46,7 +46,7 @@ const extendedInfo = {
       },
       2: {
         request: {
-          endTime: 17,
+          endTime: 17.123456789,
           responseReceivedTime: 15,
           startTime: 12,
           url: superLongName,
@@ -91,7 +91,8 @@ describe('CRC Formatter', () => {
     const testString2 = new RegExp(log.heavyVerticalAndRight +
                                    log.heavyHorizontal +
                                    log.heavyHorizontal +
-                                   ' \\/b.js \\(example.com\\) - 5000.00ms', 'im');
+                                   ' \\/b.js \\(example.com\\) - 5,000ms', 'im');
+    assert.ok(output.includes('6,123.5ms'), 'Millisecond values are not formatted as expected');
     assert.ok(testString2.test(output));
     assert.ok(truncatedURLRegExp.test(output));
     assert.ok(/about:blank/.test(output));
@@ -131,11 +132,12 @@ describe('CRC Formatter', () => {
       '<span class="cnc-node__tree-value">',
       '<span class="cnc-node__tree-file">/b.js</span>',
       '<span class="cnc-node__tree-hostname">\\(example.com\\)</span>',
-      '- <span class="cnc-node__chain-duration">16000.00ms, 0.00KB</span>',
+      '- <span class="cnc-node__chain-duration">16,000ms</span>,',
+      '<span class="cnc-node__chain-duration">0KB</span>',
       '</span>'
     ].join('\\s*'), 'im');
 
-    assert.ok(expectedTreeTwo.test(output));
+    assert.ok(expectedTreeTwo.test(output), output);
 
     const expectedTreeThree = new RegExp(`<div class="cnc-node" title="${superLongName}">`);
 


### PR DESCRIPTION
Some upgrades to this little guy to make it more concise.

* Put most of the details in a `details/summary` so its not too loud in the report
* The 3 "longest chain" stats from the top were looking at (potentially) 3 individual chains. I changed it to pick the winner based on total duration, and then report the req count & kb size total from it as well.
* Formatting for "initial navigation" in HTML so its clear it belongs to the ascii art.
* toLocaleString() so we have thousands separator. 
* Time durations (ms) reported with 1 decimal place. File sizes (kb) remain at 2 places.





Screenshots:

| before | after | 
|-------|----|
| ![image](https://cloud.githubusercontent.com/assets/39191/22670250/40b0fe22-ec7d-11e6-9b35-e8c7b3c35733.png) | ![image](https://cloud.githubusercontent.com/assets/39191/22670258/48a8df3c-ec7d-11e6-8d45-6e81244ed369.png) |



