### PR TITLE
use Error object instead of -1 audit results

### DIFF
--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -87,13 +87,7 @@ class EstimatedInputLatency extends Audit {
     const trace = artifacts.traces[this.DEFAULT_PASS];
 
     return artifacts.requestSpeedline(trace)
-      .then(speedline => EstimatedInputLatency.calculate(speedline, trace))
-      .catch(err => {
-        return EstimatedInputLatency.generateAuditResult({
-          rawValue: -1,
-          debugString: 'Speedline unable to parse trace contents: ' + err.message
-        });
-      });
+      .then(speedline => EstimatedInputLatency.calculate(speedline, trace));
   }
 }
 

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -80,12 +80,6 @@ class FirstMeaningfulPaint extends Audit {
           formatter: Formatter.SUPPORTED_FORMATS.NULL
         }
       });
-    }).catch(err => {
-      // Recover from trace parsing failures.
-      return FirstMeaningfulPaint.generateAuditResult({
-        rawValue: -1,
-        debugString: err.message
-      });
     });
   }
 

--- a/lighthouse-core/audits/screenshots.js
+++ b/lighthouse-core/audits/screenshots.js
@@ -41,13 +41,6 @@ class Screenshots extends Audit {
     const trace = artifacts.traces[this.DEFAULT_PASS];
 
     return artifacts.requestScreenshots(trace).then(screenshots => {
-      if (typeof screenshots === 'undefined') {
-        return Screenshots.generateAuditResult({
-          rawValue: -1,
-          debugString: 'No screenshot artifact'
-        });
-      }
-
       return Screenshots.generateAuditResult({
         rawValue: screenshots.length || 0,
         extendedInfo: {

--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -54,17 +54,11 @@ class SpeedIndexMetric extends Audit {
     // run speedline
     return artifacts.requestSpeedline(trace).then(speedline => {
       if (speedline.frames.length === 0) {
-        return SpeedIndexMetric.generateAuditResult({
-          rawValue: -1,
-          debugString: 'Trace unable to find visual progress frames.'
-        });
+        throw new Error('Trace unable to find visual progress frames.');
       }
 
       if (speedline.speedIndex === 0) {
-        return SpeedIndexMetric.generateAuditResult({
-          rawValue: -1,
-          debugString: 'Error in Speedline calculating Speed Index (speedIndex of 0).'
-        });
+        throw new Error('Error in Speedline calculating Speed Index (speedIndex of 0).');
       }
 
       // Use the CDF of a log-normal distribution for scoring.
@@ -110,11 +104,6 @@ class SpeedIndexMetric extends Audit {
           formatter: Formatter.SUPPORTED_FORMATS.SPEEDLINE,
           value: extendedInfo
         }
-      });
-    }).catch(err => {
-      return SpeedIndexMetric.generateAuditResult({
-        rawValue: -1,
-        debugString: err.message
       });
     });
   }

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -70,9 +70,6 @@ class TTIMetric extends Audit {
     return Promise.all([pendingSpeedline, pendingFMP]).then(results => {
       const speedline = results[0];
       const fmpResult = results[1];
-      if (fmpResult.rawValue === -1) {
-        return generateError(fmpResult.debugString);
-      }
 
       // Process the trace
       const tracingProcessor = new TracingProcessor();
@@ -114,7 +111,7 @@ class TTIMetric extends Audit {
         endTime = startTime + 500;
         // If there's no more room in the trace to look, we're done.
         if (endTime > endOfTraceTime) {
-          return generateError('Entire trace was found to be busy.');
+          throw new Error('Entire trace was found to be busy.');
         }
         // Get our expected latency for the time window
         const latencies = TracingProcessor.getRiskToResponsiveness(
@@ -164,25 +161,13 @@ class TTIMetric extends Audit {
         rawValue: parseFloat(timeToInteractive.toFixed(1)),
         displayValue: `${parseFloat(timeToInteractive.toFixed(1))}ms`,
         optimalValue: this.meta.optimalValue,
-        debugString: speedline.debugString,
         extendedInfo: {
           value: extendedInfo,
           formatter: Formatter.SUPPORTED_FORMATS.NULL
         }
       });
-    }).catch(err => {
-      return generateError(err);
     });
   }
 }
 
 module.exports = TTIMetric;
-
-function generateError(err) {
-  return TTIMetric.generateAuditResult({
-    value: -1,
-    rawValue: -1,
-    optimalValue: TTIMetric.meta.optimalValue,
-    debugString: err.message || err
-  });
-}

--- a/lighthouse-core/test/audits/estimated-input-latency-test.js
+++ b/lighthouse-core/test/audits/estimated-input-latency-test.js
@@ -33,14 +33,6 @@ function generateArtifactsWithTrace(trace) {
 /* eslint-env mocha */
 
 describe('Performance: estimated-input-latency audit', () => {
-  it('scores a -1 with invalid trace data', () => {
-    const artifacts = generateArtifactsWithTrace({traceEvents: [{pid: 15256, tid: 1295, t: 5}]});
-    return Audit.audit(artifacts).then(output => {
-      assert.equal(output.score, -1);
-      assert.ok(output.debugString);
-    });
-  });
-
   it('evaluates valid input correctly', () => {
     const artifacts = generateArtifactsWithTrace({traceEvents: pwaTrace});
     return Audit.audit(artifacts).then(output => {

--- a/lighthouse-core/test/audits/speed-index-metric-test.js
+++ b/lighthouse-core/test/audits/speed-index-metric-test.js
@@ -47,34 +47,23 @@ describe('Performance: speed-index-metric audit', () => {
     };
   }
 
-  it.skip('passes on errors from gatherer', () => {
-    const debugString = 'Real emergency here.';
-    const mockArtifacts = mockArtifactsWithSpeedlineResult();
-    return Audit.audit(mockArtifacts).then(response => {
-      assert.equal(response.rawValue, -1);
-      assert.equal(response.debugString, debugString);
-    });
-  });
-
-  it('gives error string if no frames', () => {
+  it('throws an error if no frames', () => {
     const artifacts = mockArtifactsWithSpeedlineResult({frames: []});
-    return Audit.audit(artifacts).then(response => {
-      assert.equal(response.rawValue, -1);
-      assert(response.debugString);
-    });
+    return Audit.audit(artifacts).then(
+      _ => assert.ok(false),
+      _ => assert.ok(true));
   });
 
-  it('gives error string if speed index of 0', () => {
+  it('throws an error if speed index of 0', () => {
     const SpeedlineResult = {
       frames: [frame(), frame(), frame()],
       speedIndex: 0
     };
     const artifacts = mockArtifactsWithSpeedlineResult(SpeedlineResult);
 
-    return Audit.audit(artifacts).then(response => {
-      assert.equal(response.rawValue, -1);
-      assert(response.debugString);
-    });
+    return Audit.audit(artifacts).then(
+      _ => assert.ok(false),
+      _ => assert.ok(true));
   });
 
   it('scores speed index of 831 as 100', () => {

--- a/lighthouse-core/test/audits/time-to-interactive-test.js
+++ b/lighthouse-core/test/audits/time-to-interactive-test.js
@@ -15,41 +15,23 @@
  */
 'use strict';
 
-const Audit = require('../../audits/time-to-interactive.js');
+const TimeToInteractive = require('../../audits/time-to-interactive.js');
 const GatherRunner = require('../../gather/gather-runner.js');
 const assert = require('assert');
 
 const pwaTrace = require('../fixtures/traces/progressive-app.json');
 
-
 /* eslint-env mocha */
 describe('Performance: time-to-interactive audit', () => {
-  it('scores a -1 with invalid trace data', () => {
-    const artifacts = GatherRunner.instantiateComputedArtifacts();
-    artifacts.traces = {
-      [Audit.DEFAULT_PASS]: {
-        traceEvents: [{pid: 15256, tid: 1295, t: 5}]
-      }
-    };
-    artifacts.requestSpeedline = _ => {
-      return Promise.resolve({first: 500});
-    };
-
-    return Audit.audit(artifacts).then(output => {
-      assert.equal(output.rawValue, -1);
-      assert(output.debugString);
-    });
-  });
-
   it('evaluates valid input correctly', () => {
     const artifacts = GatherRunner.instantiateComputedArtifacts();
     artifacts.traces = {
-      [Audit.DEFAULT_PASS]: {
+      [TimeToInteractive.DEFAULT_PASS]: {
         traceEvents: pwaTrace
       }
     };
 
-    return Audit.audit(artifacts).then(output => {
+    return TimeToInteractive.audit(artifacts).then(output => {
       assert.equal(output.rawValue, 1105.8, output.debugString);
       assert.equal(output.displayValue, '1105.8ms');
       assert.equal(output.extendedInfo.value.expectedLatencyAtTTI, 20.724);


### PR DESCRIPTION
@paulirish since these mostly affect FMP/TTI/speedline code you've touched recently

Eliminate some of the remaining catch statements in audits that were unaffected by migrating gatherers off -1s since they use mostly traces and network records. Technically their -1 results would keep working, but since #1591 they can just throw and Runner will take care of that properly for them.

After this and the manifest gatherer update in #1624, there won't be a single -1 result left from a gatherer or audit :)