### PR TITLE
More concise unit test running

### DIFF
--- a/lighthouse-cli/test/cli/chrome-launcher-test.js
+++ b/lighthouse-cli/test/cli/chrome-launcher-test.js
@@ -19,15 +19,18 @@
 require('../../compiled-check.js')('chrome-launcher.js');
 
 const ChromeLauncher = require('../../chrome-launcher.js').ChromeLauncher;
+const log = require('../../../lighthouse-core/lib/log');
 const assert = require('assert');
 
 /* eslint-env mocha */
 
 describe('ChromeLauncher', () => {
   it('doesn\'t fail when killed twice', () => {
+    log.setLevel('error');
     const chromeInstance = new ChromeLauncher();
     return chromeInstance.run()
       .then(() => {
+        log.setLevel();
         return Promise.all([
           chromeInstance.kill(),
           chromeInstance.kill()
@@ -36,6 +39,7 @@ describe('ChromeLauncher', () => {
   });
 
   it('doesn\'t launch multiple chrome processes', () => {
+    log.setLevel('error');
     const chromeInstance = new ChromeLauncher();
     let pid;
     return chromeInstance.run()
@@ -44,6 +48,7 @@ describe('ChromeLauncher', () => {
         return chromeInstance.run();
       })
       .then(() => {
+        log.setLevel();
         assert.strictEqual(pid, chromeInstance.chrome.pid);
         return chromeInstance.kill();
       });

--- a/lighthouse-cli/test/cli/index-test.js
+++ b/lighthouse-cli/test/cli/index-test.js
@@ -22,7 +22,7 @@ const childProcess = require('child_process');
 
 describe('CLI Tests', function() {
   it('fails if a url is not provided', () => {
-    assert.throws(() => childProcess.execSync('node lighthouse-cli/index.js'),
+    assert.throws(() => childProcess.execSync('node lighthouse-cli/index.js', {stdio: 'pipe'}),
           /Please provide a url/);
   });
 

--- a/lighthouse-core/formatters/partials/speedline.html
+++ b/lighthouse-core/formatters/partials/speedline.html
@@ -1,9 +1,3 @@
-<style>
-  .speedline-measures {
-    font-size: 14px
-  }
-</style>
-
 <ul class="subitem__details">
   <li class="subitem__detail">First Visual Change: <strong>{{this.timings.firstVisualChange}}ms</strong></li>
   <li class="subitem__detail">Last Visual Change: <strong>{{this.timings.visuallyComplete}}ms</strong></li>

--- a/lighthouse-core/lib/log.js
+++ b/lighthouse-core/lib/log.js
@@ -87,13 +87,13 @@ class Log {
   static setLevel(level) {
     switch (level) {
       case 'silent':
-        debug.disable();
+        debug.enable('-*');
         break;
       case 'verbose':
         debug.enable('*');
         break;
       case 'error':
-        debug.enable('*:error');
+        debug.enable('-*, *:error');
         break;
       default:
         debug.enable('*, -*:verbose');

--- a/lighthouse-core/scripts/run-mocha.sh
+++ b/lighthouse-core/scripts/run-mocha.sh
@@ -2,10 +2,8 @@
 
 flag=$1
 
-reporter=$([ "$CI" == true ] && echo "dot" || echo "landing")
-
 function _runmocha() {
-  mocha --reporter $reporter $2 $(find $1/test -name '*-test.js') --timeout 60000;
+  mocha --reporter dot $2 $(find $1/test -name '*-test.js') --timeout 60000;
 }
 
 if [ "$flag" == '--watch' ]; then

--- a/lighthouse-core/scripts/run-mocha.sh
+++ b/lighthouse-core/scripts/run-mocha.sh
@@ -2,8 +2,10 @@
 
 flag=$1
 
+reporter=$([ "$CI" == true ] && echo "dot" || echo "landing")
+
 function _runmocha() {
-  mocha --reporter landing $2 $(find $1/test -name '*-test.js') --timeout 60000;
+  mocha --reporter $reporter $2 $(find $1/test -name '*-test.js') --timeout 60000;
 }
 
 if [ "$flag" == '--watch' ]; then

--- a/lighthouse-core/scripts/run-mocha.sh
+++ b/lighthouse-core/scripts/run-mocha.sh
@@ -15,5 +15,7 @@ elif [ "$flag" == '--viewer' ]; then
 elif [ "$flag" == '--core' ]; then
     _runmocha 'lighthouse-core'
 else
-    _runmocha 'lighthouse-cli' && _runmocha 'lighthouse-core' && _runmocha 'lighthouse-viewer'
+    echo "lighthouse-core tests" && _runmocha 'lighthouse-core' && \
+    echo "lighthouse-cli tests" && _runmocha 'lighthouse-cli' && \
+    echo "lighthouse-viewer tests" && _runmocha 'lighthouse-viewer'
 fi

--- a/lighthouse-core/scripts/run-mocha.sh
+++ b/lighthouse-core/scripts/run-mocha.sh
@@ -3,7 +3,7 @@
 flag=$1
 
 function _runmocha() {
-  mocha $2 $(find $1/test -name '*-test.js') --timeout 60000;
+  mocha --reporter landing $2 $(find $1/test -name '*-test.js') --timeout 60000;
 }
 
 if [ "$flag" == '--watch' ]; then


### PR DESCRIPTION
_Update: only dot now.. no more landing strip :(_

Using the landing strip reporter for us.  It looks like this:
![untitled](https://cloud.githubusercontent.com/assets/39191/22675233/5f893262-ec99-11e6-8a2e-b5fe9fc3a305.gif)

Pretty nice as it gives some idea of progress through the suite.

Travis logs every screen change, so I swapped it to the `dot` reporter, which looks like this:
![image](https://cloud.githubusercontent.com/assets/39191/22675118/989dbe7a-ec98-11e6-97dc-c653eb7da09e.png)

Errors in the suite are still reported the exact same way. It's just you see the progress differently

-----

a few other things:

* in chrome-launcher-test I silenced all the logging output (all about "waiting for browser.."
  * This required changing how we tell debug() to shut up, but I like this way better
* similarly, the `pipe` change in index-test was to avoid seeing "Please provide a url" logged to terminal
* And I also nuked some unused CSS in a driveby

PTAL!