### PR TITLE
perf: gather all event listeners in parallel

### DIFF
--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -46,7 +46,9 @@ class CriConnection extends Connection {
       this._pageId = response.id;
 
       return new Promise((resolve, reject) => {
-        const ws = new WebSocket(url);
+        const ws = new WebSocket(url, {
+          perMessageDeflate: false
+        });
         ws.on('open', () => {
           this._ws = ws;
           resolve();

--- a/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
@@ -112,13 +112,10 @@ class EventListeners extends Gatherer {
    *     listeners found across the elements.
    */
   collectListeners(nodes) {
-    return nodes.reduce((chain, node) => {
-      return chain.then(prevArr => {
-        // Call getEventListeners once for each node in the list.
-        return this.getEventListeners(node.element ? node.element.nodeId : node)
-            .then(result => prevArr.concat(result));
-      });
-    }, Promise.resolve([]));
+    // Gather event listeners from each node in parallel.
+    return Promise.all(nodes.map(node => {
+      return this.getEventListeners(node.element ? node.element.nodeId : node);
+    })).then(nestedListeners => [].concat(...nestedListeners));
   }
 
   beforePass(options) {


### PR DESCRIPTION
this was some low hanging performance fruit discussed last week, getting all the event listeners for all nodes in the page in parallel rather than waiting on each command to finish. We aren't enabling/disabling domains or listening for events, so this should be safe.

Profile for the `EventListeners` gatherer doesn't look all that different but it does save e.g. 700ms (1300 -> 600) when running on www.chromestatus.com.

before:
<img width="936" alt="screen shot 2017-02-07 at 17 09 05" src="https://cloud.githubusercontent.com/assets/316891/22719016/459cc8cc-ed58-11e6-9a2f-0168edd3f403.png">

after:
<img width="935" alt="screen shot 2017-02-07 at 17 09 20" src="https://cloud.githubusercontent.com/assets/316891/22719020/49af0c68-ed58-11e6-97b1-92b03d9862c0.png">

(purple block under 11750ms is all the commands now being sent at once. Remaining scatter of blocks is now just returning messages, not interleaved returning messages and sending messages)