### PR TITLE
perf: tracingModel to computed artifact

### DIFF
--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -63,20 +63,15 @@ class TTIMetric extends Audit {
    */
   static audit(artifacts) {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
-    const pendingSpeedline = artifacts.requestSpeedline(trace);
-    const pendingFMP = FMPMetric.audit(artifacts);
 
     // We start looking at Math.Max(FMPMetric, visProgress[0.85])
-    return Promise.all([pendingSpeedline, pendingFMP]).then(results => {
-      const speedline = results[0];
-      const fmpResult = results[1];
-
-      // Process the trace
-      const tracingProcessor = new TracingProcessor();
-      const trace = artifacts.traces[Audit.DEFAULT_PASS];
-      const model = tracingProcessor.init(trace);
+    const pending = [
+      artifacts.requestSpeedline(trace),
+      FMPMetric.audit(artifacts),
+      artifacts.requestTracingModel(trace)
+    ];
+    return Promise.all(pending).then(([speedline, fmpResult, model]) => {
       const endOfTraceTime = model.bounds.max;
-
       const fmpTiming = fmpResult.rawValue;
       const fmpResultExt = fmpResult.extendedInfo.value;
 

--- a/lighthouse-core/gather/computed/tracing-model.js
+++ b/lighthouse-core/gather/computed/tracing-model.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ComputedArtifact = require('./computed-artifact');
+const TracingProcessor = require('../../lib/traces/tracing-processor');
+
+class TracingModel extends ComputedArtifact {
+
+  get name() {
+    return 'TracingModel';
+  }
+
+  /**
+   * Return catapult traceviewer model
+   * @param {{traceEvents: !Array}} trace
+   * @return {!Promise<{!TracingProcessorModel}>}
+   */
+  compute_(trace) {
+    const tracingProcessor = new TracingProcessor();
+    return tracingProcessor.init(trace);
+  }
+
+}
+
+module.exports = TracingModel;

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -21,9 +21,6 @@ if (typeof global.window === 'undefined') {
   global.window = global;
 }
 
-// TODO: move tracingProcessor to a computed artifact or nuke it
-const tracingModelCache = new Map();
-
 // The ideal input response latency, the time between the input task and the
 // first frame of the response.
 const BASE_RESPONSE_LATENCY = 16;
@@ -71,11 +68,6 @@ class TraceProcessor {
 
   // Create the importer and import the trace contents to a model.
   init(trace) {
-
-    if (tracingModelCache.has(trace)) {
-      return tracingModelCache.get(trace);
-    }
-
     const io = new traceviewer.importer.ImportOptions();
     io.showImportWarnings = false;
     io.pruneEmptyContainers = false;
@@ -85,7 +77,6 @@ class TraceProcessor {
     const importer = new traceviewer.importer.Import(model, io);
     importer.importTraces([trace]);
 
-    tracingModelCache.set(trace, model);
     return model;
   }
 

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -21,6 +21,9 @@ if (typeof global.window === 'undefined') {
   global.window = global;
 }
 
+// TODO: move tracingProcessor to a computed artifact or nuke it
+const tracingModelCache = new Map();
+
 // The ideal input response latency, the time between the input task and the
 // first frame of the response.
 const BASE_RESPONSE_LATENCY = 16;
@@ -68,6 +71,11 @@ class TraceProcessor {
 
   // Create the importer and import the trace contents to a model.
   init(trace) {
+
+    if (tracingModelCache.has(trace)) {
+      return tracingModelCache.get(trace);
+    }
+
     const io = new traceviewer.importer.ImportOptions();
     io.showImportWarnings = false;
     io.pruneEmptyContainers = false;
@@ -77,6 +85,7 @@ class TraceProcessor {
     const importer = new traceviewer.importer.Import(model, io);
     importer.importTraces([trace]);
 
+    tracingModelCache.set(trace, model);
     return model;
   }
 

--- a/lighthouse-core/test/gather/computed/tracing-model-test.js
+++ b/lighthouse-core/test/gather/computed/tracing-model-test.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2017 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,28 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
 
-const ComputedArtifact = require('./computed-artifact');
-const TracingProcessor = require('../../lib/traces/tracing-processor');
+const TracingModel = require('../../../gather/computed/tracing-model');
 
-class TracingModel extends ComputedArtifact {
+const assert = require('assert');
+const pwaTrace = require('../../fixtures/traces/progressive-app.json');
 
-  get name() {
-    return 'TracingModel';
-  }
-
-  /**
-   * Return catapult traceviewer model
-   * @param {{traceEvents: !Array}} trace
-   * @return {!TracingProcessorModel}
-   */
-  compute_(trace) {
-    const tracingProcessor = new TracingProcessor();
-    return tracingProcessor.init(trace);
-  }
-
-}
-
-module.exports = TracingModel;
+/* eslint-env mocha */
+describe('Tracing model computed artifact:', () => {
+  it('gets a tracing model', () => {
+    const tracingModel = new TracingModel();
+    const model = tracingModel.compute_(pwaTrace);
+    assert.ok(model instanceof global.tr.Model, 'return is not an instance of tr.Model');
+  });
+});


### PR DESCRIPTION
Right now we're generating a traceviewer tracingModel twice.

It's fairly expensive, so by moving it to a computed artifact, we get caching for free. Woo!