### PR TITLE
tests: use test-specific about:blank timer

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -62,11 +62,12 @@ class GatherRunner {
    * reload. We do not `waitForLoad` on about:blank since a page load event is
    * never fired on it.
    * @param {!Driver} driver
+   * @param {integer=} waitForLoadMs
    * @return {!Promise}
    */
-  static loadBlank(driver) {
+  static loadBlank(driver, waitForLoadMs = 300) {
     return driver.gotoURL('about:blank')
-      .then(_ => new Promise((resolve, reject) => setTimeout(resolve, 300)));
+      .then(_ => new Promise((resolve, reject) => setTimeout(resolve, waitForLoadMs)));
   }
 
   /**
@@ -153,7 +154,7 @@ class GatherRunner {
    * @return {!Promise}
    */
   static beforePass(options, gathererResults) {
-    const pass = GatherRunner.loadBlank(options.driver);
+    const pass = GatherRunner.loadBlank(options.driver, options._aboutBlankTimeout);
 
     return options.config.gatherers.reduce((chain, gatherer) => {
       return chain.then(_ => {
@@ -315,7 +316,7 @@ class GatherRunner {
     const gathererResults = {};
 
     return driver.connect()
-      .then(_ => GatherRunner.loadBlank(driver))
+      .then(_ => GatherRunner.loadBlank(driver, options._aboutBlankTimeout))
       .then(_ => GatherRunner.setupDriver(driver, options))
 
       // Run each pass

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -111,7 +111,7 @@ describe('GatherRunner', function() {
     const url = 'https://example.com';
     const driver = fakeDriver;
     const config = new Config({});
-    const options = {url, driver, config};
+    const options = {url, driver, config, _aboutBlankTimeout: 0};
 
     return GatherRunner.run([], options).then(_ => {
       assert.equal(typeof options.flags, 'object');
@@ -384,7 +384,8 @@ describe('GatherRunner', function() {
       driver: fakeDriver,
       url: 'https://example.com',
       flags,
-      config
+      config,
+      _aboutBlankTimeout: 0
     }).then(_ => {
       assert.ok(t1.called);
       assert.ok(t2.called);
@@ -403,7 +404,8 @@ describe('GatherRunner', function() {
       passName: 'secondPass',
       gatherers: [new TestGatherer()]
     }];
-    const options = {driver: fakeDriver, url: 'https://example.com', flags: {}, config: {}};
+    const options = {driver: fakeDriver, url: 'https://example.com', flags: {}, config: {},
+      _aboutBlankTimeout: 0};
 
     return GatherRunner.run(passes, options)
       .then(artifacts => {
@@ -496,7 +498,8 @@ describe('GatherRunner', function() {
       passName: 'firstPass',
       gatherers: [new TestGatherer()]
     }];
-    const options = {driver: fakeDriver, url: 'https://example.com', flags: {}, config: {}};
+    const options = {driver: fakeDriver, url: 'https://example.com', flags: {}, config: {},
+      _aboutBlankTimeout: 0};
 
     return GatherRunner.run(passes, options)
         .then(artifacts => {
@@ -581,7 +584,8 @@ describe('GatherRunner', function() {
         driver: fakeDriver,
         url: 'https://example.com',
         flags: {},
-        config: new Config({})
+        config: new Config({}),
+        _aboutBlankTimeout: 0
       }).then(artifacts => {
         gathererNames.forEach(gathererName => {
           assert.strictEqual(artifacts[gathererName], gathererName);
@@ -680,7 +684,8 @@ describe('GatherRunner', function() {
         driver: fakeDriver,
         url: 'https://example.com',
         flags: {},
-        config: new Config({})
+        config: new Config({}),
+        _aboutBlankTimeout: 0
       }).then(artifacts => {
         gathererNames.forEach(gathererName => {
           const errorArtifact = artifacts[gathererName];
@@ -715,7 +720,8 @@ describe('GatherRunner', function() {
         driver: fakeDriver,
         url: 'https://example.com',
         flags: {},
-        config: new Config({})
+        config: new Config({}),
+        _aboutBlankTimeout: 0
       }).then(
         _ => assert.ok(false),
         err => assert.strictEqual(err.message, errorMessage));
@@ -735,7 +741,8 @@ describe('GatherRunner', function() {
         driver: fakeDriver,
         url: 'https://example.com',
         flags: {},
-        config: new Config({})
+        config: new Config({}),
+        _aboutBlankTimeout: 0
       }).then(_ => assert.ok(false), _ => assert.ok(true));
     });
 
@@ -759,7 +766,8 @@ describe('GatherRunner', function() {
         driver: unresolvedDriver,
         url: 'http://www.some-non-existing-domain.com/',
         flags: {},
-        config: new Config({})
+        config: new Config({}),
+        _aboutBlankTimeout: 0
       })
         .then(_ => {
           assert.ok(false);
@@ -789,7 +797,8 @@ describe('GatherRunner', function() {
         driver: unresolvedDriver,
         url: 'http://www.some-non-existing-domain.com/',
         flags: {},
-        config: new Config({})
+        config: new Config({}),
+        _aboutBlankTimeout: 0
       })
         .then(_ => {
           assert.ok(true);


### PR DESCRIPTION
recently had to work on gather-runner and was going nuts on 7s test times...

cuts overall unit test time by about half

Before
![image](https://cloud.githubusercontent.com/assets/2301202/22805339/d9ca7ef2-eed1-11e6-9aa1-9d76ae5877a5.png)
After
![image](https://cloud.githubusercontent.com/assets/2301202/22805347/decccaf4-eed1-11e6-8beb-f368193e4b83.png)
