### PR TITLE
ignore URL fragment when asserting page loaded

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -19,6 +19,7 @@
 const log = require('../lib/log.js');
 const Audit = require('../audits/audit');
 const path = require('path');
+const URL = require('../lib/url-shim');
 
 /**
  * Class that drives browser to load the page and runs gatherer lifecycle hooks.
@@ -135,7 +136,10 @@ class GatherRunner {
    * @param {!Array<WebInspector.NetworkRequest>} networkRecords
    */
   static assertPageLoaded(url, driver, networkRecords) {
-    const mainRecord = networkRecords.find(record => record.url === url);
+    const mainRecord = networkRecords.find(record => {
+      // record.url is actual request url, so needs to be compared without any URL fragment.
+      return URL.equalWithExcludedFragments(record.url, url);
+    });
     if (driver.online && (!mainRecord || mainRecord.failed)) {
       const message = mainRecord ? mainRecord.localizedFailDescription : 'timeout reached';
       log.error('GatherRunner', message);

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -273,6 +273,7 @@ describe('GatherRunner', function() {
   });
 
   it('tells the driver to end tracing', () => {
+    const url = 'https://example.com';
     let calledTrace = false;
     const fakeTraceData = {traceEvents: ['reallyBelievableTraceEvents']};
 
@@ -290,7 +291,7 @@ describe('GatherRunner', function() {
       ]
     };
 
-    return GatherRunner.afterPass({driver, config}, {TestGatherer: []}).then(passData => {
+    return GatherRunner.afterPass({url, driver, config}, {TestGatherer: []}).then(passData => {
       assert.equal(calledTrace, true);
       assert.equal(passData.trace, fakeTraceData);
     });
@@ -319,6 +320,7 @@ describe('GatherRunner', function() {
   });
 
   it('tells the driver to end network collection', () => {
+    const url = 'https://example.com';
     let calledNetworkCollect = false;
 
     const driver = Object.assign({}, fakeDriver, {
@@ -339,7 +341,7 @@ describe('GatherRunner', function() {
       ]
     };
 
-    return GatherRunner.afterPass({driver, config}, {TestGatherer: []}).then(vals => {
+    return GatherRunner.afterPass({url, driver, config}, {TestGatherer: []}).then(vals => {
       assert.equal(calledNetworkCollect, true);
       assert.strictEqual(vals.networkRecords.marker, 'mocked');
     });
@@ -515,6 +517,12 @@ describe('GatherRunner', function() {
     it('passes when the page is loaded', () => {
       const url = 'http://the-page.com';
       const records = [{url}];
+      GatherRunner.assertPageLoaded(url, {online: true}, records);
+    });
+
+    it('passes when the page is loaded, ignoring any fragment', () => {
+      const url = 'http://example.com/#/page/list';
+      const records = [{url: 'http://example.com'}];
       GatherRunner.assertPageLoaded(url, {online: true}, records);
     });
 


### PR DESCRIPTION
came up in testing 1.5.0 for release. Runs fail testing e.g. `https://example.com/#/whatever`

Testing a URL with hash content will always fail the `GatherRunner.assertPageLoaded()` check so this uses `URL.equalWithExcludedFragments` instead of strict equality testing.