### PR TITLE
fix: table formatter image preview URL encode

### DIFF
--- a/lighthouse-core/formatters/table.js
+++ b/lighthouse-core/formatters/table.js
@@ -94,7 +94,9 @@ class Table extends Formatter {
         switch (key) {
           case 'preview':
             if (/^image/.test(value.mimeType)) {
-              return `[![Image preview](${value.url} "Image preview")](${value.url})`;
+              // Markdown can't handle URLs with parentheses which aren't automatically encoded
+              const encodedUrl = value.url.replace(/\)/g, '%29');
+              return `[![Image preview](${encodedUrl} "Image preview")](${encodedUrl})`;
             }
             return '';
           case 'code':

--- a/lighthouse-core/test/formatter/table-formatter-test.js
+++ b/lighthouse-core/test/formatter/table-formatter-test.js
@@ -34,7 +34,7 @@ describe('TableFormatter', () => {
       code: 'code snippet',
       isEval: true,
       pre: 'pre snippet',
-      preview: {url: 'http://example.com/i.jpg', mimeType: 'image/jpeg'}
+      preview: {url: 'http://example.com/(format:webp)/i.jpg', mimeType: 'image/jpeg'}
     }]
   };
 
@@ -57,8 +57,9 @@ describe('TableFormatter', () => {
     assert.equal(table.rows[0].cols[2], '\`code snippet\`');
     assert.equal(table.rows[0].cols[3], 'yes');
     assert.equal(table.rows[0].cols[4], '\`\`\`\npre snippet\`\`\`');
+    const expectedUrl = 'http://example.com/(format:webp%29/i.jpg';
     assert.equal(table.rows[0].cols[5],
-        '[![Image preview](http://example.com/i.jpg "Image preview")](http://example.com/i.jpg)');
+        `[![Image preview](${expectedUrl} "Image preview")](${expectedUrl})`);
   });
 
   it('generates valid pretty output', () => {


### PR DESCRIPTION
R: @ebidel all

Image previews were broken for URLs with `)` since markdown can't handle them

Before
![image](https://cloud.githubusercontent.com/assets/2301202/22809572/418bc828-eee8-11e6-9b65-153a53fad7d7.png)

After
![image](https://cloud.githubusercontent.com/assets/2301202/22809577/4a3b8058-eee8-11e6-87f7-b3b2ee1bdad2.png)
