### PR TITLE
ignore core and viewer tests from npm module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -30,4 +30,5 @@ lighthouse-cli/types/*.map
 assets
 
 lighthouse-core/test
-lighthouse-viewer/test
+lighthouse-viewer
+lighthouse-extension

--- a/.npmignore
+++ b/.npmignore
@@ -28,3 +28,6 @@ lighthouse-cli/types/*.js
 lighthouse-cli/types/*.map
 
 assets
+
+lighthouse-core/test
+lighthouse-viewer/test


### PR DESCRIPTION
leaving in `lighthouse-cli/test` for now as it's relatively small (200KB, fixtures and all) and smokehouse is really convenient for testing that the npm module works before publishing