### PR TITLE
Minor HTML hygiene.

### DIFF
--- a/lighthouse-cli/performance-experiment/report/partials/config-panel.html
+++ b/lighthouse-cli/performance-experiment/report/partials/config-panel.html
@@ -1,12 +1,12 @@
 <style>
 .config-panel {
-  padding: 0 0 0 0;
-  background: #FAFAFA;
+  padding: 0;
+  background: #fafafa;
 }
 
 .config-panel__header {
   height: 50px;
-  border-top: 1px solid #EBEBEB;
+  border-top: 1px solid #ebebeb;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -15,7 +15,7 @@
 }
 
 .config-panel__body {
-  border-top: 1px solid #EBEBEB;
+  border-top: 1px solid #ebebeb;
   height: 300px;
   display: none;
 }
@@ -42,7 +42,7 @@
   background-position: center center;
   background-size: contain;
   background-color: transparent;
-  margin: 0 8px 0 8px;
+  margin: 0 8px;
 }
 
 .config-panel.expanded .config-panel__panel-toggle {
@@ -71,7 +71,7 @@
 .config-panel .url-blocking-entry__button {
   display: flex;
   flex: 0 0 auto;
-  padding: 0 0 0 0px;
+  padding: 0;
   width: 18px;
   height: 18px;
   border: none;
@@ -108,10 +108,10 @@
 #config-panel__tabs__tree-panel .request-blocking-toggle {
   background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
   display: inline-block;
-  padding: 0 0 0 0px;
+  padding: 0;
   width: 18px;
   height: 18px;
-  transform: translate(0px, 5px);
+  transform: translate(0, 5px);
   border: none;
   flex: 0 0 auto;
   vertical-align: top;
@@ -142,7 +142,7 @@
 
 .config-panel__tabs__tab-bar {
   height: 40px;
-  border-bottom: 1px solid #EBEBEB;
+  border-bottom: 1px solid #ebebeb;
   padding: 0 20px;
 }
 
@@ -164,8 +164,8 @@
   display: block;
   margin: auto;
   height: 3px;
-  width: 0px;
-  transform: translate(0px, -3px);
+  width: 0;
+  transform: translate(0, -3px);
   background: transparent;
   transition: width .5s ease, background-color .5s ease;
 }

--- a/lighthouse-cli/test/fixtures/accessibility/accessibility_tester.html
+++ b/lighthouse-cli/test/fixtures/accessibility/accessibility_tester.html
@@ -18,7 +18,7 @@
 <html lang="en">
   <head>
     <title>A11y Test Page</title>
-    <meta charset="UTF-8">
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>

--- a/lighthouse-core/scripts/traceviewer-module-index.html
+++ b/lighthouse-core/scripts/traceviewer-module-index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 Copyright (c) 2014 The Chromium Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be

--- a/lighthouse-extension/app/popup.html
+++ b/lighthouse-extension/app/popup.html
@@ -20,7 +20,7 @@ limitations under the License.
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-  <meta name="author" content="Lighthouse Team" />
+  <meta name="author" content="Lighthouse Team">
   <meta name="viewport" content="width=device-width">
   <title>Lighthouse Report</title>
   <link rel="stylesheet" href="styles/lighthouse.css">


### PR DESCRIPTION
* Use lowercase `doctype` and `charset`
* Remove unneeded closing tag from self closing tag
* Clean up inline CSS