### PR TITLE
feat: Page execution timings (don't merge)

### DIFF
--- a/lighthouse-core/audits/page-execution-timings.js
+++ b/lighthouse-core/audits/page-execution-timings.js
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Audit = require('./audit');
+const Formatter = require('../formatters/formatter');
+const TimelineModel = require('../lib/traces/devtools-timeline-model');
+
+function dumpTree(tree, timeValue) {
+  const result = new Map();
+  tree.children.forEach((value, key) => result.set(key, value[timeValue].toFixed(1)));
+  return result;
+}
+
+function getTreeValue(key, tree) {
+  return tree.get(key) || 0;
+}
+
+/**
+ * @param {!Array<!Object>} traceData
+ * @return {!Array<!UserTimingsExtendedInfo>}
+ */
+function filterTrace(traceData) {
+  const pageExecutionTimings = [];
+  const timelineModel = new TimelineModel(traceData);
+  const bottomUpByName = timelineModel.bottomUpGroupBy('EventName');
+  const tree = dumpTree(bottomUpByName, 'selfTime');
+
+  // JavaScript
+  const compileTime = getTreeValue('Compile Script', tree);
+  const evalTime = getTreeValue('Evaluate Script', tree);
+  const minorGC = getTreeValue('Minor GC', tree);
+  const majorGC = getTreeValue('Major GC', tree);
+  const xhrLoad = getTreeValue('XHR Ready State Change', tree);
+  const xhrReadyStateChange = getTreeValue('XHR Ready State Change', tree);
+
+  // Layout, Paint, Composite and Recalc styles
+  const layout = getTreeValue('Layout', tree);
+  const paint = getTreeValue('Paint', tree);
+  const composite = getTreeValue('Composite Layers', tree);
+  const recalcStyle = getTreeValue('Recalculate Style', tree);
+
+  // DOM/CSS
+  const parseHTML = getTreeValue('Parse HTML', tree);
+  const parseCSS = getTreeValue('Parse Stylesheet', tree);
+  const domGC = getTreeValue('DOM GC', tree);
+
+  // Images
+  const imageDecode = getTreeValue('Image Decode', tree);
+
+  pageExecutionTimings.push({
+    compile: compileTime,
+    eval: evalTime,
+    minorGC: minorGC,
+    majorGC: majorGC,
+    layout: layout,
+    paint: paint,
+    composite: composite,
+    recalcStyle: recalcStyle,
+    parseHTML: parseHTML,
+    parseCSS: parseCSS,
+    domGC: domGC,
+    imageDecode: imageDecode,
+    xhrLoad: xhrLoad,
+    xhrReadyStateChange: xhrReadyStateChange
+  });
+
+  return pageExecutionTimings;
+}
+
+// Question: safe to just start renaming?
+class PageExecutionTimings extends Audit {
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return {
+      category: 'Performance',
+      name: 'page-execution-timings',
+      description: 'Page Execution Breakdown',
+      helpText: 'A break-down of where time is spent during page execution',
+      requiredArtifacts: ['traces']
+    };
+  }
+
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    const traceContents = artifacts.traces[Audit.DEFAULT_PASS].traceEvents;
+    const pageExecutionTimings = filterTrace(traceContents);
+
+    return PageExecutionTimings.generateAuditResult({
+      rawValue: true,
+      displayValue: pageExecutionTimings.length,
+      extendedInfo: {
+        formatter: Formatter.SUPPORTED_FORMATS.PAGE_EXECUTION_TIMINGS,
+        value: pageExecutionTimings
+      }
+    });
+  }
+}
+
+module.exports = PageExecutionTimings;

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -60,6 +60,7 @@
     "estimated-input-latency",
     "time-to-interactive",
     "user-timings",
+    "page-execution-timings",
     "screenshots",
     "critical-request-chains",
     "manifest-exists",
@@ -383,6 +384,10 @@
           "weight": 1
         },
         "user-timings": {
+          "expectedValue": 0,
+          "weight": 1
+        },
+        "page-execution-timings": {
           "expectedValue": 0,
           "weight": 1
         }

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -26,6 +26,7 @@
     "estimated-input-latency",
     "time-to-interactive",
     "user-timings",
+    "page-execution-timings",
     "screenshots",
     "critical-request-chains",
     "unused-css-rules",
@@ -75,7 +76,8 @@
         "critical-request-chains": {},
         "link-blocking-first-paint": {},
         "script-blocking-first-paint": {},
-        "user-timings": {}
+        "user-timings": {},
+        "page-execution-timings": {}
       }
     }]
   }]

--- a/lighthouse-core/formatters/formatter.js
+++ b/lighthouse-core/formatters/formatter.js
@@ -45,7 +45,8 @@ class Formatter {
       null: require('./null-formatter'),
       speedline: require('./speedline-formatter'),
       table: require('./table'),
-      userTimings: require('./user-timings')
+      userTimings: require('./user-timings'),
+      pageExecutionTimings: require('./page-execution-timings')
     };
   }
 

--- a/lighthouse-core/formatters/page-execution-timings.js
+++ b/lighthouse-core/formatters/page-execution-timings.js
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Formatter = require('./formatter');
+const path = require('path');
+const fs = require('fs');
+const html = fs.readFileSync(path.join(__dirname, 'partials/page-execution-timings.html'), 'utf8');
+
+class PageExecutionTimings extends Formatter {
+  static getFormatter(type) {
+    switch (type) {
+      case 'pretty':
+        return events => {
+          if (!Array.isArray(events)) {
+            return '';
+          }
+
+          const measuresStr = events.reduce((prev, event) => {
+            let output = '\nJavaScript:\n';
+            output += `    - Compile Time: ${event.compile}ms\n`;
+            output += `    - Eval Time: ${event.eval}ms\n`;
+            output += `    - Minor GC: ${event.minorGC}ms\n`;
+            output += `    - Major GC: ${event.majorGC}ms\n`;
+            output += `    - XHR Ready State Change: ${event.xhrReadyStateChange}ms\n`;
+            output += `    - XHR Load: ${event.xhrLoad}ms\n`;
+
+            output += '\nLayout, Paint, Composite and Recalc styles:\n';
+            output += `    - Layout: ${event.layout}ms\n`;
+            output += `    - Paint: ${event.paint}ms\n`;
+            output += `    - Composite Layers: ${event.composite}ms\n`;
+            output += `    - Recalc Styles: ${event.recalcStyle}ms\n`;
+
+            output += '\nDOM/CSS:\n';
+            output += `    - Parse HTML: ${event.parseHTML}ms\n`;
+            output += `    - Parse Stylesheet: ${event.parseCSS}ms\n`;
+            output += `    - DOM GC: ${event.domGC}ms\n`;
+
+            output += '\nImages:\n';
+            output += `    - Image decode: ${event.imageDecode}ms\n`;
+
+            return output + '\n';
+          }, '');
+
+          return measuresStr;
+        };
+
+      case 'html':
+        // Returns a handlebars string to be used by the Report.
+        return html;
+
+      default:
+        throw new Error('Unknown formatter type');
+    }
+  }
+}
+
+module.exports = PageExecutionTimings;

--- a/lighthouse-core/formatters/partials/page-execution-timings.html
+++ b/lighthouse-core/formatters/partials/page-execution-timings.html
@@ -1,0 +1,156 @@
+<style>
+  .ut-measure_listing-duration {
+    font-weight: bold
+  }
+
+  .timeline-aggregated-info-legend > div {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .timeline-aggregated-legend-value {
+    display: inline-block;
+    width: 70px;
+    text-align: right;
+  }
+
+  .timeline-aggregated-legend-swatch {
+    display: inline-block;
+    width: 11px;
+    height: 11px;
+    margin: 0 6px;
+    position: relative;
+    top: 1px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+
+  .timeline-aggregated-legend-javascript {
+    background-color: rgb(243, 210, 124);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+
+  .timeline-aggregated-legend-layout {
+    background-color: rgb(175, 153, 235);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+
+  .timeline-aggregated-legend-dom {
+    background-color: rgb(144, 183, 234);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+
+  .timeline-aggregated-legend-images {
+    background-color: rgb(144, 194, 133);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+
+  .timeline-aggregated-info-legend > div {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+</style>
+
+<ul class="subitem__details">
+  {{#each this}}
+    <li class="subitem__detail">
+        
+        <div class='timeline-aggregated-info-legend'>
+          <h4>JavaScript</h4>
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.compile }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-javascript'></span>
+              <span class='timeline-aggregated-legend-title'>Compile</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.eval }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-javascript'></span>
+              <span class='timeline-aggregated-legend-title'>Evaluate</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.minorGC }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-javascript'></span>
+              <span class='timeline-aggregated-legend-title'>Minor GC</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.majorGC }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-javascript'></span>
+              <span class='timeline-aggregated-legend-title'>Major GC</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.xhrReadyStateChange }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-javascript'></span>
+              <span class='timeline-aggregated-legend-title'>XHR Ready State Change</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.xhrLoad }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-javascript'></span>
+              <span class='timeline-aggregated-legend-title'>XHR Load</span>
+            </div>
+        </div>
+
+        <div class='timeline-aggregated-info-legend'>
+          <h4>Layout, Composite, Paint &amp; Recalc Styles</h4>
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.layout }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-layout'></span>
+              <span class='timeline-aggregated-legend-title'>Layout</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.composite }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-layout'></span>
+              <span class='timeline-aggregated-legend-title'>Composite</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.paint }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-layout'></span>
+              <span class='timeline-aggregated-legend-title'>Paint</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.recalcStyle }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-layout'></span>
+              <span class='timeline-aggregated-legend-title'>Recalculate Styles</span>
+            </div>
+        </div>
+
+        <div class='timeline-aggregated-info-legend'>
+          <h4>DOM, HTML &amp; CSS</h4>
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.parseHTML }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-dom'></span>
+              <span class='timeline-aggregated-legend-title'>Parse HTML</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.parseCSS }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-dom'></span>
+              <span class='timeline-aggregated-legend-title'>Parse CSS</span>
+            </div>
+
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.domGC }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-dom'></span>
+              <span class='timeline-aggregated-legend-title'>DOM GC</span>
+            </div>
+        </div>
+
+        <div class='timeline-aggregated-info-legend'>
+          <h4>Images</h4>
+            <div>
+              <span class='timeline-aggregated-legend-value'>{{ decimal this.this.imageDecode }}ms</span>
+              <span class='timeline-aggregated-legend-swatch timeline-aggregated-legend-images'></span>
+              <span class='timeline-aggregated-legend-title'>Image Decode</span>
+            </div>
+        </div>
+    </li>
+  {{/each}}
+</ul>


### PR DESCRIPTION
This initial PR adds support for page execution timings to the report. The ultimate goal of the feature is to inform developers where time is being spent during load and could be augmented to just show this before they are interactive.

Preview (extension):
![screen shot 2017-02-10 at 7 12 42 pm](https://cloud.githubusercontent.com/assets/110953/22850824/656be6be-efc5-11e6-8d88-13abf893c70a.jpg)

CLI:
![screen shot 2017-02-10 at 6 56 34 pm](https://cloud.githubusercontent.com/assets/110953/22850827/6bd9bc06-efc5-11e6-9cbc-c0685f853419.jpg)

**A few directions we could take this:**

- Improve approach to grouping. @paulirish shared this [nice](https://docs.google.com/spreadsheets/d/1jqbSfdkB5RMtuifJwQsGb70WUUhWvzir7hq41wYHXsU/edit#gid=0) categorization doc for Timeline events that could be used.
- Add support for V8 Runtime Call Stats (to address #1158). This could come later. 
- Eventually, I'd like to introduce page execution 'budgets' (e.g your Parse and Compile times are wayyyy too long. Read this doc on how to trim em' down) 
- Eventually distinguish between lifetime of page load and work done between FMP and TTI
