### PR TITLE
remove handleRawError call from extension connection

### DIFF
--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -96,7 +96,6 @@ class Connection {
       const callback = this._callbacks.get(object.id);
       this._callbacks.delete(object.id);
 
-      // handleRawError returns or throws synchronously; wrap to put into promise chain.
       return callback.resolve(Promise.resolve().then(_ => {
         if (object.error) {
           log.formatProtocol('method <= browser ERR', {method: callback.method}, 'error');

--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -116,18 +116,14 @@ class ExtensionConnection extends Connection {
           // The error from the extension has a `message` property that is the
           // stringified version of the actual protocol error object.
           const message = chrome.runtime.lastError.message;
-          let error;
+          let errorMessage;
           try {
-            error = JSON.parse(message);
+            errorMessage = JSON.parse(message).message;
           } catch (e) {}
-          error = error || {message: 'Unknown debugger protocol error.'};
+          errorMessage = errorMessage || 'Unknown debugger protocol error.';
 
-          // handleRawError returns or throws synchronously, so try/catch awkwardly.
-          try {
-            return resolve(this.handleRawError(error, command));
-          } catch (err) {
-            return reject(err);
-          }
+          log.formatProtocol('method <= browser ERR', {method: command}, 'error');
+          return reject(new Error(`Protocol error (${command}): ${errorMessage}`));
         }
 
         log.formatProtocol('method <= browser OK', {method: command, params: result}, 'verbose');


### PR DESCRIPTION
fixes #1696

Missed this in #1474. Simply replaces the call of `handleRawError` in `extension.js` with what it contained before removal. 