### PR TITLE
feat: allow extension of default config

### DIFF
--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -1,5 +1,6 @@
 {
   "passes": [{
+    "passName": "defaultPass",
     "recordNetwork": true,
     "recordTrace": true,
     "gatherers": [
@@ -22,13 +23,14 @@
     ]
   },
   {
+    "passName": "redirectPass",
     "gatherers": [
       "http-redirect",
       "html-without-javascript"
     ]
   }, {
-    "recordNetwork": true,
     "passName": "dbw",
+    "recordNetwork": true,
     "gatherers": [
       "chrome-console-messages",
       "styles",

--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,37 @@ Better docs coming soon, but in the meantime look at [PR #593](https://github.co
 
 You can supply your own run configuration to customize what audits you want details on. Copy the [default.json](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/default.json) and start customizing. Then provide to the CLI with `lighthouse --config-path=myconfig.json <url>`
 
+If you are simply adding additional audits/gatherers or tweaking flags, you can extend the default configuration without having to copy the default and maintain it. Passes with the same name will be merged together, all other arrays will be concatenated, and primitive values will override the defaults. See the example below that adds the a custom gatherer to the default pass and an audit.
+
+```json
+{
+  "extends": true,
+  "passes": [
+    {
+      "passName": "defaultPass",
+      "gatherers": ["path/to/custom/gatherer.js"]
+    }
+  ],
+  "audits": ["path/to/custom/audit.js"],
+  "aggregations": [
+    {
+      "name": "Custom Section",
+      "description": "Enter description here.",
+      "scored": false,
+      "categorizable": false,
+      "items": [
+        {
+          "name": "My Custom Audits",
+          "audits": {
+            "name-of-custom-audit": {}
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Tests
 
 Some basic unit tests forked are in `/test` and run via mocha. eslint is also checked for style violations.

--- a/readme.md
+++ b/readme.md
@@ -230,7 +230,7 @@ Better docs coming soon, but in the meantime look at [PR #593](https://github.co
 
 You can supply your own run configuration to customize what audits you want details on. Copy the [default.json](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/default.json) and start customizing. Then provide to the CLI with `lighthouse --config-path=myconfig.json <url>`
 
-If you are simply adding additional audits/gatherers or tweaking flags, you can extend the default configuration without having to copy the default and maintain it. Passes with the same name will be merged together, all other arrays will be concatenated, and primitive values will override the defaults. See the example below that adds the a custom gatherer to the default pass and an audit.
+If you are simply adding additional audits/gatherers or tweaking flags, you can extend the default configuration without having to copy the default and maintain it. Passes with the same name will be merged together, all other arrays will be concatenated, and primitive values will override the defaults. See the example below that adds a custom gatherer to the default pass and an audit.
 
 ```json
 {


### PR DESCRIPTION
would address part of #1730, it's rather out there so comments and thoughts welcome on other possible approaches

usage

```
{
  extends: true,
  passes: [
    {passName: "defaultPass", gatherers: [MyCustomGatherer]
  ],
  audits: [MyCustomAudit]
}
```