### PR TITLE
fix: do not fail if chrome could not be killed

### DIFF
--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -237,11 +237,7 @@ class ChromeLauncher {
             process.kill(-this.chrome.pid);
           }
         } catch (err) {
-          if (/(not found|ESRCH)/.test(err.message)) {
-            log.warn('ChromeLauncher', 'Chrome was already killed');
-          } else {
-            throw err;
-          }
+          log.warn('ChromeLauncher', `Chrome could not be killed ${err.message}`);
         }
 
         this.chrome = null;

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -230,10 +230,18 @@ class ChromeLauncher {
         });
 
         log.log('ChromeLauncher', 'Killing all Chrome Instances');
-        if (isWindows) {
-          execSync(`taskkill /pid ${this.chrome.pid} /T /F`);
-        } else {
-          process.kill(-this.chrome.pid);
+        try {
+          if (isWindows) {
+            execSync(`taskkill /pid ${this.chrome.pid} /T /F`);
+          } else {
+            process.kill(-this.chrome.pid);
+          }
+        } catch (err) {
+          if (/(not found|ESRCH)/.test(err.message)) {
+            log.warn('ChromeLauncher', 'Chrome was already killed');
+          } else {
+            throw err;
+          }
         }
 
         this.chrome = null;


### PR DESCRIPTION
should deflake the appveyor tests that have been failing ~50% of the time because of this