### PR TITLE
Disable throttling for non-performance passes

### DIFF
--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -3,6 +3,7 @@
     "passName": "defaultPass",
     "recordNetwork": true,
     "recordTrace": true,
+    "useThrottling": true,
     "gatherers": [
       "url",
       "https",
@@ -17,6 +18,7 @@
   {
     "passName": "offlinePass",
     "recordNetwork": true,
+    "useThrottling": false,
     "gatherers": [
       "service-worker",
       "offline"
@@ -24,6 +26,7 @@
   },
   {
     "passName": "redirectPass",
+    "useThrottling": false,
     "gatherers": [
       "http-redirect",
       "html-without-javascript"
@@ -31,6 +34,7 @@
   }, {
     "passName": "dbw",
     "recordNetwork": true,
+    "useThrottling": false,
     "gatherers": [
       "chrome-console-messages",
       "styles",

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -2,6 +2,7 @@
   "passes": [{
     "recordNetwork": true,
     "recordTrace": true,
+    "useThrottling": true,
     "gatherers": [
       "url",
       "image-usage",
@@ -11,6 +12,7 @@
   {
     "passName": "css-image-usage",
     "recordNetwork": true,
+    "useThrottling": false,
     "gatherers": [
       "styles",
       "css-usage",

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -677,25 +677,29 @@ class Driver {
     return this.sendCommand('Runtime.enable');
   }
 
-  beginEmulation(flags) {
+  beginEmulation(options) {
     return Promise.resolve().then(_ => {
-      if (!flags.disableDeviceEmulation) {
+      if (!options.flags.disableDeviceEmulation) {
         return emulation.enableNexus5X(this);
       }
+    }).then(_ => {
+      return this.setThrottling(options.flags, {useThrottling: true});
     });
   }
 
   setThrottling(cliFlags, passConfig) {
-    const emulations = [
-      emulation.disableNetworkThrottling(this),
-      emulation.disableCPUThrottling(this)
-    ];
+    const emulations = [];
 
-    if (!cliFlags.disableNetworkThrottling && passConfig.useThrottling) {
-      emulations.push(emulation.enableNetworkThrottling(this));
+    if (!passConfig.useThrottling) {
+      emulations.push(emulation.disableNetworkThrottling(this));
+      emulations.push(emulation.disableCPUThrottling(this));
+      return Promise.all(emulations);
     }
 
-    if (!cliFlags.disableCpuThrottling && passConfig.useThrottling) {
+    if (!cliFlags.disableNetworkThrottling) {
+      emulations.push(emulation.enableNetworkThrottling(this));
+    }
+    if (!cliFlags.disableCpuThrottling) {
       emulations.push(emulation.enableCPUThrottling(this));
     }
     return Promise.all(emulations);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -677,32 +677,22 @@ class Driver {
     return this.sendCommand('Runtime.enable');
   }
 
-  beginEmulation(options) {
+  beginEmulation(flags) {
     return Promise.resolve().then(_ => {
-      if (!options.flags.disableDeviceEmulation) {
-        return emulation.enableNexus5X(this);
-      }
-    }).then(_ => {
-      return this.setThrottling(options.flags, {useThrottling: true});
-    });
+      if (!flags.disableDeviceEmulation) return emulation.enableNexus5X(this);
+    }).then(_ => this.setThrottling(flags, {useThrottling: true}));
   }
 
-  setThrottling(cliFlags, passConfig) {
-    const emulations = [];
-
-    if (!passConfig.useThrottling) {
-      emulations.push(emulation.disableNetworkThrottling(this));
-      emulations.push(emulation.disableCPUThrottling(this));
-      return Promise.all(emulations);
+  setThrottling(flags, passConfig) {
+    const p = [];
+    if (passConfig.useThrottling) {
+      if (!flags.disableNetworkThrottling) p.push(emulation.enableNetworkThrottling(this));
+      if (!flags.disableCpuThrottling) p.push(emulation.enableCPUThrottling(this));
+    } else {
+      p.push(emulation.disableNetworkThrottling(this));
+      p.push(emulation.disableCPUThrottling(this));
     }
-
-    if (!cliFlags.disableNetworkThrottling) {
-      emulations.push(emulation.enableNetworkThrottling(this));
-    }
-    if (!cliFlags.disableCpuThrottling) {
-      emulations.push(emulation.enableCPUThrottling(this));
-    }
-    return Promise.all(emulations);
+    return Promise.all(p);
   }
 
   /**
@@ -712,9 +702,7 @@ class Driver {
   goOffline() {
     return this.sendCommand('Network.enable')
       .then(_ => emulation.goOffline(this))
-      .then(_ => {
-        this.online = false;
-      });
+      .then(_ => this.online = false);
   }
 
   /**
@@ -724,9 +712,8 @@ class Driver {
    * @return {!Promise}
    */
   goOnline(options) {
-    return this.setThrottling(options.flags, options.config).then(_ => {
-      this.online = true;
-    });
+    return this.setThrottling(options.flags, options.config)
+        .then(_ => this.online = true);
   }
 
   cleanAndDisableBrowserCaches() {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -333,6 +333,7 @@ class GatherRunner {
         return passes.reduce((chain, config, passIndex) => {
           const runOptions = Object.assign({}, options, {config});
           return chain
+            .then(_ => driver.setThrottling(options.flags, config))
             .then(_ => GatherRunner.beforePass(runOptions, gathererResults))
             .then(_ => GatherRunner.pass(runOptions, gathererResults))
             .then(_ => GatherRunner.afterPass(runOptions, gathererResults))

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -96,7 +96,7 @@ class GatherRunner {
     const resetStorage = !options.flags.disableStorageReset;
     // Enable emulation based on flags
     return driver.assertNoSameOriginServiceWorkerClients(options.url)
-      .then(_ => driver.beginEmulation(options.flags))
+      .then(_ => driver.beginEmulation(options))
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
       .then(_ => resetStorage && driver.cleanAndDisableBrowserCaches())

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -96,7 +96,7 @@ class GatherRunner {
     const resetStorage = !options.flags.disableStorageReset;
     // Enable emulation based on flags
     return driver.assertNoSameOriginServiceWorkerClients(options.url)
-      .then(_ => driver.beginEmulation(options))
+      .then(_ => driver.beginEmulation(options.flags))
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
       .then(_ => resetStorage && driver.cleanAndDisableBrowserCaches())

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -31,6 +31,9 @@ module.exports = {
   beginEmulation() {
     return Promise.resolve();
   },
+  setThrottling() {
+    return Promise.resolve();
+  },
   assertNoSameOriginServiceWorkerClients() {
     return Promise.resolve();
   },

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -238,6 +238,7 @@ describe('GatherRunner', function() {
     const driver = {
       assertNoSameOriginServiceWorkerClients: asyncFunc,
       beginEmulation: asyncFunc,
+      setThrottling: asyncFunc,
       enableRuntimeEvents: asyncFunc,
       cacheNatives: asyncFunc,
       cleanAndDisableBrowserCaches: createCheck('calledDisableNetworkCache'),
@@ -264,6 +265,7 @@ describe('GatherRunner', function() {
     const driver = {
       assertNoSameOriginServiceWorkerClients: asyncFunc,
       beginEmulation: asyncFunc,
+      setThrottling: asyncFunc,
       enableRuntimeEvents: asyncFunc,
       cacheNatives: asyncFunc,
       cleanAndDisableBrowserCaches: createCheck('calledDisableNetworkCache'),


### PR DESCRIPTION
This is the approach that I ended up with after playing around a bit.

* `useThrottling` prop in the config for each pass
* if that is true and the disable CLI flags aren't set, then we'll turn it on.
* if the prop is false for a pass we'll definitely make sure throttling is off
* when `goOnline` comes back it'll restore whatever throttling should be for that pass.
* `setThrottling` method in driver does the work. the old `beginEmulation` now defers to it for some parts.

wdyt?