### PR TITLE
DOMStat audit: fix for traversing shadow root anchor parents and svg .className

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -194,6 +194,20 @@ module.exports = [
       }
     }
   }, {
+    initialUrl: 'https://www.chromestatus.com/features',
+    url: 'https://www.chromestatus.com/features',
+    audits: {
+      'dom-size': {
+        score: 100,
+        extendedInfo: {
+          value: {
+            1: {value: '20'},
+            2: {snippet: 'Element with most children:\nul#versionlist.canaryisdev'}
+          }
+        }
+      }
+    }
+  }, {
     initialUrl: 'http://localhost:10200/online-only.html',
     url: 'http://localhost:10200/online-only.html',
     audits: {

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -194,20 +194,6 @@ module.exports = [
       }
     }
   }, {
-    initialUrl: 'https://www.chromestatus.com/features',
-    url: 'https://www.chromestatus.com/features',
-    audits: {
-      'dom-size': {
-        score: 100,
-        extendedInfo: {
-          value: {
-            1: {value: '20'},
-            2: {snippet: 'Element with most children:\nul#versionlist.canaryisdev'}
-          }
-        }
-      }
-    }
-  }, {
     initialUrl: 'http://localhost:10200/online-only.html',
     url: 'http://localhost:10200/online-only.html',
     audits: {

--- a/lighthouse-cli/test/smokehouse/pwa-config.js
+++ b/lighthouse-cli/test/smokehouse/pwa-config.js
@@ -41,11 +41,13 @@ module.exports = {
   },
   {
     gatherers: [
+      'dobetterweb/domstats',
       'http-redirect'
     ]
   }],
 
   audits: [
+    'dobetterweb/dom-size',
     'is-on-https',
     'redirects-http',
     'service-worker',

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -78,6 +78,15 @@ module.exports = [
     initialUrl: 'https://www.chromestatus.com/',
     url: 'https://www.chromestatus.com/features',
     audits: {
+      'dom-size': {
+        score: 100,
+        extendedInfo: {
+          value: {
+            1: {value: '20'},
+            2: {snippet: 'Element with most children:\nul#versionlist.canaryisdev'}
+          }
+        }
+      },
       'is-on-https': {
         score: true
       },

--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -39,9 +39,11 @@ function createSelectorsLabel(element) {
   if (idAttr) {
     name += `#${idAttr}`;
   }
-  const className = element.className;
+  // svg elements return SVGAnimatedString for .className, which is an object.
+  // Use the class attr instead.
+  const className = element.getAttribute && element.getAttribute('class');
   if (className) {
-    name += `.${className.replace(/\s+/g, '.')}`;
+    name += `.${className.trim().replace(/\s+/g, '.')}`;
   }
   return name;
 }
@@ -55,7 +57,11 @@ function elementPathInDOM(element) {
   const path = [createSelectorsLabel(element)];
   let node = element;
   while (node) {
-    node = node.parentNode && node.parentNode.host ? node.parentNode.host : node.parentElement;
+    // Anchor elements have a .host property. Be sure we've found a shadow root
+    // host and not an anchor.
+    const shadowHost = node.parentNode && node.parentNode.host &&
+                       node.parentNode.localName !== 'a';
+    node = shadowHost ? node.parentNode.host : node.parentElement;
     if (node) {
       path.unshift(createSelectorsLabel(node));
     }

--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -40,8 +40,8 @@ function createSelectorsLabel(element) {
     name += `#${idAttr}`;
   }
   // svg elements return SVGAnimatedString for .className, which is an object.
-  // Use the class attr instead.
-  const className = element.getAttribute && element.getAttribute('class');
+  // Stringify classList instead.
+  const className = element.classList.toString();
   if (className) {
     name += `.${className.trim().replace(/\s+/g, '.')}`;
   }


### PR DESCRIPTION
R: all

Couple of subtle edge cases found on https://www.chromestatus.com/features, which uses shadow dom and inline svg.

The first is traversing up through parent elements looking for shadow hosts / parentElements. Anchors have a `.host` property. So looking at `node.host` does not necessarily give you a shadow root :\ First time I've ran into this when working with web components!

Now we construct the depth properly:

<img width="325" alt="screen shot 2017-02-16 at 9 55 10 pm" src="https://cloud.githubusercontent.com/assets/238208/23054142/f5d5eb6a-f492-11e6-837f-8f7427786997.png">

The second issue fixed is checking `svgNode.className`. Turns out, svg nodes return a `SVGAnimatedString = {animVal: string, baseVal: string}` instead of a string. Ugh! Switched to using the `class` attr instead.

Added chromestatus.com to the smoketests.