### PR TITLE
Report: collapse aggregations when all audits pass

### DIFF
--- a/lighthouse-core/aggregator/aggregate.js
+++ b/lighthouse-core/aggregator/aggregate.js
@@ -147,10 +147,9 @@ class Aggregate {
    * Compares the set of audit results to the expected values.
    * @param {!Array<!AuditResult>} results The audit results.
    * @param {!Array<!AggregationItem>} items The aggregation's expected values and weighting.
-   * @param {!boolean} aggregationIsScored Whether or not the aggregation is scored.
    * @return {!Array<!AggregationResultItem>} The aggregation score.
    */
-  static compare(results, items, aggregationIsScored) {
+  static compare(results, items) {
     return items.map(item => {
       const expectedNames = Object.keys(item.audits);
 
@@ -174,21 +173,13 @@ class Aggregate {
 
         subItems.push(filteredAndRemappedResults[e].name);
 
-        // Only add to the score if this aggregation contributes to the
-        // overall score.
-        if (!aggregationIsScored) {
-          return;
-        }
-
         overallScore += Aggregate._convertToWeight(
             filteredAndRemappedResults[e],
             item.audits[e],
             e);
       });
 
-      if (aggregationIsScored) {
-        maxScore = Aggregate._getTotalWeight(item.audits);
-      }
+      maxScore = Aggregate._getTotalWeight(item.audits);
 
       return {
         overall: (overallScore / maxScore),
@@ -215,7 +206,7 @@ class Aggregate {
    * @return {!AggregationResult}
    */
   static aggregate(aggregation, auditResults) {
-    const score = Aggregate.compare(auditResults, aggregation.items, aggregation.scored);
+    const score = Aggregate.compare(auditResults, aggregation.items);
     return {
       name: aggregation.name,
       description: aggregation.description,

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -89,11 +89,21 @@ class DOMSize extends Audit {
     // Clamp the score to 0 <= x <= 100.
     score = Math.max(0, Math.min(100, score));
 
-    const cards = [
-      {title: 'Total DOM Nodes', value: stats.totalDOMNodes.toLocaleString()},
-      {title: 'DOM Depth', value: stats.depth.max.toLocaleString(), snippet: depthSnippet},
-      {title: 'Maximum Children', value: stats.width.max.toLocaleString(), snippet: widthSnippet}
-    ];
+    const cards = [{
+      title: 'Total DOM Nodes',
+      value: stats.totalDOMNodes.toLocaleString(),
+      target: `< ${MAX_DOM_NODES.toLocaleString()} nodes`
+    }, {
+      title: 'DOM Depth',
+      value: stats.depth.max.toLocaleString(),
+      snippet: depthSnippet,
+      target: `< ${MAX_DOM_TREE_DEPTH.toLocaleString()}`
+    }, {
+      title: 'Maximum Children',
+      value: stats.width.max.toLocaleString(),
+      snippet: widthSnippet,
+      target: `< ${MAX_DOM_TREE_WIDTH.toLocaleString()} nodes`
+    }];
 
     return DOMSize.generateAuditResult({
       rawValue: stats.totalDOMNodes,

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -258,73 +258,98 @@
       "name": "Using modern offline features",
       "audits": {
         "appcache-manifest": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         },
         "no-websql": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         }
       }
     }, {
       "name": "Using modern protocols",
       "audits": {
         "is-on-https": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         },
         "uses-http2": {
-          "expectedValue": false,
-          "description": "Resources made by this application should be severed over HTTP/2 for improved performance."
+          "expectedValue": true,
+          "description": "Resources made by this application should be severed over HTTP/2 for improved performance.",
+          "weight": 1
         }
       }
     }, {
       "name": "Using bytes efficiently",
       "audits": {
-        "unused-css-rules": {},
-        "uses-optimized-images": {},
-        "uses-responsive-images": {}
+        "unused-css-rules": {
+          "expectedValue": true,
+          "weight": 1
+        },
+        "uses-optimized-images": {
+          "expectedValue": true,
+          "weight": 1
+        },
+        "uses-responsive-images": {
+          "expectedValue": true,
+          "weight": 1
+        }
       }
     }, {
       "name": "Using modern CSS features",
       "audits": {
         "no-old-flexbox": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         }
       }
     }, {
       "name": "Using modern JavaScript features",
       "audits": {
         "uses-passive-event-listeners": {
-          "expectedValue": true
+          "expectedValue": true,
+          "weight": 1
         },
         "no-mutation-events": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         }
       }
     }, {
       "name": "Avoiding APIs that harm the user experience",
       "audits": {
         "no-document-write": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         },
         "link-blocking-first-paint": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         },
         "script-blocking-first-paint": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         },
         "external-anchors-use-rel-noopener": {
-          "expectedValue": true
+          "expectedValue": true,
+          "weight": 1
         },
         "geolocation-on-start": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         },
         "notification-on-start": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         }
       }
     }, {
       "name": "Avoiding deprecated APIs and browser interventions",
       "audits": {
-        "deprecations": {}
+        "deprecations": {
+          "expectedValue": true,
+          "weight": 1
+        }
       }
     }, {
       "name": "Accessibility",
@@ -387,11 +412,11 @@
           "weight": 1
         },
         "critical-request-chains": {
-          "expectedValue": 0,
+          "expectedValue": true,
           "weight": 1
         },
         "user-timings": {
-          "expectedValue": 0,
+          "expectedValue": true,
           "weight": 1
         }
       }
@@ -405,10 +430,12 @@
       "name": "New JavaScript features",
       "audits": {
         "no-datenow": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         },
         "no-console-time": {
-          "expectedValue": false
+          "expectedValue": true,
+          "weight": 1
         }
       }
     }]

--- a/lighthouse-core/formatters/partials/cards.css
+++ b/lighthouse-core/formatters/partials/cards.css
@@ -9,8 +9,8 @@
   justify-content: center;
   flex: 1 1 150px;
   flex-direction: column;
-  padding: calc(var(--padding) / 2);
-  padding-top: calc(32px + var(--padding) / 2);
+  padding: var(--padding);
+  padding-top: calc(33px + var(--padding));
   border-radius: 3px;
   margin-right: var(--padding);
   position: relative;
@@ -19,7 +19,6 @@
   border: 1px solid #ebebeb;
 }
 .scorecard-title {
-  /*text-transform: uppercase;*/
   font-size: var(--subitem-font-size);
   line-height: var(--heading-line-height);
   background-color: #eee;
@@ -33,8 +32,13 @@
   border-bottom: 1px solid #ebebeb;
 }
 .scorecard-value {
-  font-size: 24px;
+  font-size: 28px;
 }
-.scorecard-summary {
-  margin-top: calc(var(--padding) / 2);
+.scorecard-summary,
+.scorecard-target {
+  margin-top: var(--padding);
+}
+.scorecard-target {
+  font-size: 12px;
+  font-style: italic;
 }

--- a/lighthouse-core/formatters/partials/cards.html
+++ b/lighthouse-core/formatters/partials/cards.html
@@ -1,8 +1,12 @@
-<ul class="subitem__details cards__container">
-  {{#each this}}
-    <div class="subitem__detail scorecard" {{#if snippet}}title="{{snippet}}"{{/if}}>
-      <div class="scorecard-title">{{title}}</div>
-      <div class="scorecard-value">{{value}}</div>
-    </div>
-  {{/each}}
-</ul>
+<details class="subitem__details">
+  <summary class="subitem__detail">More information</summary>
+  <div class="cards__container">
+    {{#each this}}
+      <div class="subitem__detail scorecard" {{#if snippet}}title="{{snippet}}"{{/if}}>
+        <div class="scorecard-title">{{title}}</div>
+        <div class="scorecard-value">{{value}}</div>
+        {{#if target}}<div class="scorecard-target">target: {{target}}</div>{{/if}}
+      </div>
+    {{/each}}
+  </div>
+</details>

--- a/lighthouse-core/report/handlebar-helpers.js
+++ b/lighthouse-core/report/handlebar-helpers.js
@@ -63,6 +63,12 @@ const handlebarHelpers = {
     return calculateRating(totalScore);
   },
 
+  // Converts an aggregation's score to a rating used for styling.
+  getAggregationScoreRating: score => {
+    const rating = calculateRating(score * 100);
+    return rating !== 'good' ? 'poor' : rating; // avg rating maps to failure for aggregation.
+  },
+
   // Converts a value to a rating string, which can be used inside the report
   // for color styling.
   getItemRating,

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -97,6 +97,7 @@ body {
 
 summary {
   cursor: pointer;
+  display: block; /* Firefox compat */
 }
 
 .report-error {
@@ -440,6 +441,7 @@ summary {
   background-color: inherit;
   clip: rect(0, calc( var(--report-width) - var(--report-menu-width)), 0, 0);
   opacity: 0;
+  visibility: hidden;
   transition: all 200ms cubic-bezier(0,0,0.2,1);
   border-bottom: 1px solid #ebebeb;
 }
@@ -447,6 +449,7 @@ summary {
 .report-body__header-container.expanded .report-body__header-content {
   clip: rect(0, calc( var(--report-width) - var(--report-menu-width)), 200px, 0);
   opacity: 1;
+  visibility: visible;
 }
 
 .report-body__header-content .config-section {
@@ -708,6 +711,10 @@ summary {
   height: var(--aggregation-icon-size);
 }
 
+.aggregation__header :-moz-any(.aggregation__header__score) {
+  margin-top: calc(-1 * var(--subitem-indent) / 2); /* FF compat*/
+}
+
 .aggregation__header .aggregation__header__score::after {
   background-size: 14px;
 }
@@ -732,6 +739,10 @@ summary {
 
 .aggregation__details > summary {
   outline: none;
+}
+
+.aggregation__details > summary::-moz-list-bullet {
+  display: none;
 }
 
 .aggregation__details > summary::-webkit-details-marker {

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -96,6 +96,10 @@ body {
   background-color: #f5f5f5;
 }
 
+summary {
+  cursor: pointer;
+}
+
 .report-error {
   font-family: consolas, monospace;
 }
@@ -408,7 +412,7 @@ body {
   background-color: #fafafa;
 }
 
-.report-body__header-toggle {
+.report-body__more-toggle {
   background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"/><path d="M0-.25h24v24H0z" fill="none"/></svg>');
   width: 24px;
   height: 24px;
@@ -420,25 +424,30 @@ body {
   background-color: transparent;
   margin: 0 8px 0 8px;
   cursor: pointer;
+  transition: transform 150ms ease-in-out;
 }
 
-.report-body__header-container.expanded .report-body__header-toggle {
-  background-image: url('data:image/svg+xml;utf8,<svg fill="black" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+.report-body__header-container.expanded .report-body__more-toggle,
+.aggregation details[open] .report-body__more-toggle {
+  transform: rotateZ(90deg);
 }
 
 .report-body__header-content {
-  display: none;
   padding: 10px 0 10px 42px;
   top: 100%;
   left: 0;
   position: absolute;
   width: 100%;
   background-color: inherit;
+  clip: rect(0, calc( var(--report-width) - var(--report-menu-width)), 0, 0);
+  opacity: 0;
+  transition: all 200ms cubic-bezier(0,0,0.2,1);
+  border-bottom: 1px solid #ebebeb;
 }
 
 .report-body__header-container.expanded .report-body__header-content {
-  display: block;
-  border-bottom: 1px solid #ebebeb;
+  clip: rect(0, calc( var(--report-width) - var(--report-menu-width)), 200px, 0);
+  opacity: 1;
 }
 
 .report-body__header-content .config-section {
@@ -685,7 +694,17 @@ body {
 }
 
 .aggregation__header {
+  position: relative;
   max-width: var(--max-line-length);
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.aggregation__header > .aggregation__header__score {
+  margin-top: 0;
+  position: absolute;
+  left: calc(-1 * var(--subitem-indent));
 }
 
 .aggregation__header > h2 {
@@ -698,6 +717,22 @@ body {
 .aggregation {
   margin-top: var(--subheading-line-height);
   max-width: var(--max-line-length);
+}
+
+.aggregation__details {
+  display: inline-block;
+}
+
+.aggregation__details > summary {
+  outline: none;
+}
+
+.aggregation__details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.aggregation__details > summary:focus header h2 {
+  outline: rgb(59, 153, 252) auto 5px;
 }
 
 .aggregation__desc {
@@ -916,7 +951,6 @@ body {
   min-width: 125px;
   list-style-type: none;
   line-height: 1.5em;
-  visibility: hidden;
   clip: rect(0, 164px, 0, 0);
   opacity: 0;
   transition: all 200ms cubic-bezier(0,0,0.2,1);
@@ -928,7 +962,6 @@ body {
 }
 
 .export-button.active + .export-dropdown {
-  visibility: visible;
   opacity: 1;
   clip: rect(0, 164px, 200px, 0);
 }

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -44,7 +44,7 @@ span, div, p, section, header, h1, h2, li, ul {
   --subheading-color: inherit;
   --heading-font-size: 24px;
   --heading-line-height: 32px;
-  --subitem-indent: 24px;
+  --subitem-indent: 16px;
   --max-line-length: none;
 
   --report-width: 1280px;
@@ -63,7 +63,6 @@ span, div, p, section, header, h1, h2, li, ul {
   --report-header-height: 0;
   --heading-font-size: 20px;
   --heading-line-height: 24px;
-  --subitem-indent: 24px;
   --max-line-length: calc(60 * var(--body-font-size));
 }
 
@@ -701,10 +700,16 @@ summary {
   cursor: pointer;
 }
 
-.aggregation__header > .aggregation__header__score {
+.aggregation__header .aggregation__header__score {
   margin-top: 0;
   position: absolute;
-  left: calc(-1 * var(--subitem-indent));
+  left: calc(-1 * var(--aggregation-icon-size) - var(--subitem-indent) / 2);
+  width: var(--aggregation-icon-size);
+  height: var(--aggregation-icon-size);
+}
+
+.aggregation__header .aggregation__header__score::after {
+  background-size: 14px;
 }
 
 .aggregation__header > h2 {
@@ -715,8 +720,10 @@ summary {
 }
 
 .aggregation {
+  --aggregation-icon-size: 20px;
   margin-top: var(--subheading-line-height);
   max-width: var(--max-line-length);
+  padding-left: calc(var(--aggregation-icon-size) + var(--subitem-indent) / 2);
 }
 
 .aggregation__details {
@@ -737,6 +744,8 @@ summary {
 
 .aggregation__desc {
   font-size: var(--body-font-size);
+  /*font-style: italic;*/
+  color: var(--secondary-text-color);
   line-height: var(--body-line-height);
   margin-top: calc(var(--body-line-height) / 2);
 }
@@ -749,7 +758,7 @@ summary {
 .subitem {
   position: relative;
   font-size: var(--subitem-font-size);
-  padding-left: calc(var(--subitem-indent) + var(--gutter-width) + var(--gutter-gap));
+  padding-left: calc(var(--subitem-indent) * 3);
   margin-top: calc(var(--subitem-line-height) / 2);
 }
 
@@ -768,7 +777,7 @@ summary {
 .subitem-result {
   position: absolute;
   top: 0;
-  left: var(--subitem-indent);
+  left: 0;
   width: var(--gutter-width);
   display: flex;
   flex-direction: column;

--- a/lighthouse-core/report/templates/report-template.html
+++ b/lighthouse-core/report/templates/report-template.html
@@ -68,7 +68,7 @@ limitations under the License.
       </div>
       <div class="report-body__header-container js-header-container">
         <div class="report-body__header">
-          <button class="report-body__header-toggle js-header-toggle" title="See report's runtime settings"></button>
+          <button class="report-body__more-toggle js-header-toggle" title="See report's runtime settings"></button>
           <div class="report-body__metadata">
             <div class="report-body__url">Results for: <a href="{{ url }}" target="_blank" rel="noopener">{{ url }}</a></div>
             <div class="report-body__url">Generated on: {{ formatDateTime generatedTime}}</div>
@@ -136,15 +136,21 @@ limitations under the License.
 
         <div class="js-report-by-user-feature">
           {{#each this.score as |aggregation|}}
-            <section class="aggregation">
+            <section class="aggregation" data-rating="{{ getAggregationScoreRating aggregation.overall }}">
 
             {{#if aggregation.name }}
-            <header class="aggregation__header">
-              <h2>{{ aggregation.name }}</h2>
-              {{#if aggregation.description }}
-                <p class="aggregation__desc">{{ sanitize aggregation.description }}</p>
-              {{/if}}
-            </header>
+            <details class="aggregation__details" {{#ifEq (getAggregationScoreRating aggregation.overall) "poor"}}open{{/ifEq}}>
+              <summary>
+                <header class="aggregation__header">
+                  <span class="aggregation__header__score score-{{ getAggregationScoreRating aggregation.overall }}-bg subitem-result__{{ getAggregationScoreRating aggregation.overall }}"></span>
+                  <h2>{{ aggregation.name }}</h2>
+                  <div class="report-body__more-toggle" title="See audits"></div>
+                </header>
+              </summary>
+            {{/if}}
+
+            {{#if aggregation.description }}
+              <p class="aggregation__desc">{{ sanitize aggregation.description }}</p>
             {{/if}}
 
             <ul class="subitems">
@@ -208,6 +214,9 @@ limitations under the License.
               {{/each}}
             </ul>
           </section>
+          {{#if aggregation.name }}
+            </details>
+          {{/if}}
           {{/each}}
         </div>
       </section>

--- a/lighthouse-core/test/aggregator/aggregate-test.js
+++ b/lighthouse-core/test/aggregator/aggregate-test.js
@@ -250,9 +250,8 @@ describe('Aggregate', () => {
       score: 50,
       displayValue: '50'
     }];
-    const scored = true;
 
-    return assert.deepEqual(Aggregate.compare(results, items, scored)[0], {
+    return assert.deepEqual(Aggregate.compare(results, items)[0], {
       overall: 0.375,
       name: undefined,
       description: undefined,
@@ -288,10 +287,8 @@ describe('Aggregate', () => {
       score: 50,
       displayValue: '50'
     }];
-    const scored = false;
-
-    return assert.deepEqual(Aggregate.compare(results, items, scored)[0], {
-      overall: 0,
+    return assert.deepEqual(Aggregate.compare(results, items)[0], {
+      overall: 0.375,
       name: undefined,
       description: undefined,
       subItems: [
@@ -316,9 +313,8 @@ describe('Aggregate', () => {
       value: 'should be rawValue',
       displayValue: ''
     }];
-    const scored = true;
 
-    return assert.throws(_ => Aggregate.compare(results, items, scored));
+    return assert.throws(_ => Aggregate.compare(results, items));
   });
 
   it('throws when given an audit containing no expectedValue property', () => {
@@ -335,9 +331,8 @@ describe('Aggregate', () => {
       score: false,
       displayValue: ''
     }];
-    const scored = true;
 
-    return assert.throws(_ => Aggregate.compare(results, items, scored));
+    return assert.throws(_ => Aggregate.compare(results, items));
   });
 
   it('throws when attempting to aggregate an audit name not in audit results', () => {
@@ -358,8 +353,7 @@ describe('Aggregate', () => {
       contributesToScore: true
     }];
 
-    const scored = true;
-    assert.throws(_ => Aggregate.compare(results, items, scored)[0],
+    assert.throws(_ => Aggregate.compare(results, items)[0],
       /my-audit-test-name/);
   });
 
@@ -387,8 +381,7 @@ describe('Aggregate', () => {
       contributesToScore: true
     }];
 
-    const scored = true;
-    const aggregation = Aggregate.compare(results, items, scored)[0];
+    const aggregation = Aggregate.compare(results, items)[0];
     assert.deepEqual(aggregation, {
       overall: 1,
       name: undefined,
@@ -415,8 +408,7 @@ describe('Aggregate', () => {
       score: true,
       displayValue: ''
     }];
-    const scored = true;
-    return assert.equal(Aggregate.compare(results, items, scored)[0].overall, 1);
+    return assert.equal(Aggregate.compare(results, items)[0].overall, 1);
   });
 
   it('if audit result is an error it does not contribute to score', () => {
@@ -446,7 +438,7 @@ describe('Aggregate', () => {
       error: true
     }];
 
-    const aggregate = Aggregate.compare(results, items, true)[0];
+    const aggregate = Aggregate.compare(results, items)[0];
     assert.strictEqual(aggregate.overall, 0.5);
   });
 
@@ -467,8 +459,7 @@ describe('Aggregate', () => {
       displayValue: ''
     }];
 
-    const scored = true;
-    return assert.ok(Array.isArray(Aggregate.compare(results, items, scored)[0].subItems));
+    return assert.ok(Array.isArray(Aggregate.compare(results, items)[0].subItems));
   });
 
   it('aggregates', () => {

--- a/lighthouse-core/test/formatter/cards-formatter-test.js
+++ b/lighthouse-core/test/formatter/cards-formatter-test.js
@@ -24,9 +24,9 @@ const assert = require('assert');
 describe('CardsFormatter', () => {
   const extendedInfo = {
     value: [
-      {title: 'Total DOM Nodes', value: 3500},
+      {title: 'Total DOM Nodes', value: 3500, target: '1,500 nodes'},
       {title: 'DOM Depth', value: 10, snippet: 'snippet'},
-      {title: 'Maximum Children', value: 20, snippet: 'snippet2'}
+      {title: 'Maximum Children', value: 20, snippet: 'snippet2', target: 20}
     ]
   };
 
@@ -52,7 +52,9 @@ describe('CardsFormatter', () => {
     const template = Handlebars.compile(formatter);
     const output = template(extendedInfo.value).split('\n').join('');
     assert.ok(output.match('title="snippet"'), 'adds title attribute for snippet');
-    assert.ok(output.match('class="subitem__details cards__container"'), 'adds wrapper class');
+    assert.ok(output.match('class="cards__container"'), 'adds wrapper class');
+    assert.ok(output.match('target: 1,500 nodes'), 'adds target val html');
+    assert.ok(!output.match('target: 10'), 'omits target html without a value');
     assert.equal(output.match(/class=\"[^"]*scorecard-value/g).length, extendedInfo.value.length);
     assert.equal(output.match(/class=\"[^"]*scorecard-title/g).length, extendedInfo.value.length);
   });


### PR DESCRIPTION
R: @patrickhulce @paulirish 

In the act of de-cluttering, this PR addresses some of of https://github.com/GoogleChrome/lighthouse/issues/1613 and implements the proposed solution in https://github.com/GoogleChrome/lighthouse/issues/1613#issuecomment-277126590.

Now, if all audits pass, the entire aggregation is collapsed. If one or more audits fail, the aggregation is opened up.

Before:

<img width="905" alt="screen shot 2017-02-16 at 10 58 53 pm" src="https://cloud.githubusercontent.com/assets/238208/23055597/8a15fa2e-f49b-11e6-9343-5c5a5df44d2a.png">

After:

<img width="939" alt="screen shot 2017-02-16 at 10 40 05 pm" src="https://cloud.githubusercontent.com/assets/238208/23055557/5c3ff028-f49b-11e6-9151-15b7ad3f1cfc.png">

when an audit fail: 

<img width="895" alt="screen shot 2017-02-16 at 10 40 24 pm" src="https://cloud.githubusercontent.com/assets/238208/23055560/612ce5aa-f49b-11e6-8350-20b24b987199.png">

BTW, the aggregation icons are slightly bigger than the subaudits. I thought the size difference was good but I'm happy to make them all the homogeneous. 

- Aggregations now always create an overall score. Please look over those changes as I may have missed something.
- Adds css transitions to the details dropdown.
- @patrickhulce turns out the `expectedValues`/`weights` are important and we'll need to use them after all :) aggregate.js uses them to type check and calculate an overall score based on the weights.