### PR TITLE
Speculative fix for getCurrentTabURL

### DIFF
--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -136,8 +136,7 @@ class ExtensionConnection extends Connection {
     return new Promise((resolve, reject) => {
       const queryOpts = {
         active: true,
-        lastFocusedWindow: true,
-        windowType: 'normal'
+        lastFocusedWindow: true
       };
 
       chrome.tabs.query(queryOpts, (tabs => {
@@ -159,7 +158,7 @@ class ExtensionConnection extends Connection {
   getCurrentTabURL() {
     return this._queryCurrentTab().then(tab => {
       if (!tab.url) {
-        log.error('ExtensionConnection', 'getCurrentTabURL returned empty string');
+        log.error('ExtensionConnection', 'getCurrentTabURL returned empty string', tab);
       }
       return tab.url;
     });

--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -136,7 +136,7 @@ class ExtensionConnection extends Connection {
     return new Promise((resolve, reject) => {
       const queryOpts = {
         active: true,
-        lastFocusedWindow: true
+        currentWindow: true
       };
 
       chrome.tabs.query(queryOpts, (tabs => {
@@ -146,6 +146,9 @@ class ExtensionConnection extends Connection {
         if (tabs.length === 0) {
           const message = 'Couldn\'t resolve current tab. Please file a bug.';
           return reject(new Error(message));
+        }
+        if (tabs.length > 1) {
+          log.warn('ExtensionConnection', '_queryCurrentTab returned multiple tabs');
         }
         resolve(tabs[0]);
       }));

--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -157,7 +157,12 @@ class ExtensionConnection extends Connection {
    * Used by lighthouse-background to kick off the run on the current page
    */
   getCurrentTabURL() {
-    return this._queryCurrentTab().then(tab => tab.url);
+    return this._queryCurrentTab().then(tab => {
+      if (!tab.url) {
+        log.error('ExtensionConnection', 'getCurrentTabURL returned empty string');
+      }
+      return tab.url;
+    });
   }
 }
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -302,7 +302,7 @@ class GatherRunner {
     };
 
     if (typeof options.url !== 'string' || options.url.length === 0) {
-      return Promise.reject(new Error('You must provide a url to the driver'));
+      return Promise.reject(new Error('You must provide a url to the gather-runner'));
     }
 
     if (typeof options.flags === 'undefined') {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -36,7 +36,7 @@ class Runner {
     // save the initialUrl provided by the user
     opts.initialUrl = opts.url;
     if (typeof opts.initialUrl !== 'string' || opts.initialUrl.length === 0) {
-      return Promise.reject(new Error('You must provide a url to the driver'));
+      return Promise.reject(new Error('You must provide a url to the runner'));
     }
 
     let parsedURL;


### PR DESCRIPTION
I am hoping this will fix #1214, but since the repro is particularly tricky, we won't know until later.

I believe is ultimately a chrome bug that's behavior is here: [546696 - chrome.windows.getLastFocused returns the last opened window, not the last focused, when an extension popup is visible - chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=546696#c4) but essentially its interplay between extensions with `onFocusChanged` `getLastFocused` and here, `chrome.tabs.query({lastFocusedWindow: true})`..


Of note, previous to the currentTab change in #680 I don't believe we had this bug, but we did have trouble when debugging the extension background page with a devtools window. I'm OK with regressing our developer ergonomics to get this user bug squashed.

http://stackoverflow.com/a/28794338 (by Rob W) describes the best solution to be:
```js
chrome.tabs.query({
    active: true,
    currentWindow: true    
}
```

The best practices around getting current tab have changed throughout the past 7 years, and there appear to be some still open bugs, so this is what we're running up against.

This PR adds extra error logging around all this so we'll have more information if the problem persists.