### PR TITLE
Report: use accessible material colors

### DIFF
--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -29,10 +29,10 @@ span, div, p, section, header, h1, h2, li, ul {
   --text-color: #222;
   --secondary-text-color: #606060;
   --accent-color: #3879d9;
-  --poor-color: #e81e1b;
-  --good-color: #008a07;
-  --average-color: #9f6d00;
-  --warning-color: #947200;
+  --poor-color: #e53935; /* md red 600 */
+  --good-color: #43a047; /* md green 600 */
+  --average-color: #ef6c00; /* md orange 800 */
+  --warning-color: #757575; /* md grey 600 */
   --gutter-gap: 12px;
   --gutter-width: 40px;
   --body-font-size: 14px;


### PR DESCRIPTION
R: all

The report colors were recently adjusted to meet accessibility contrast for WCAG 2 AA, but the new average color is mustard and the red/green are quite deep. This PR dials them back a bit, returns the average color to an orange, but still keeps WCAG 2 AA at 18pt. I used [this](https://snook.ca/technical/colour_contrast/colour.htm) tool to verify the colors are still compliant.
The colors are from the MD color palette. 

cc @robdodson 

Before:

<img width="776" alt="screen shot 2017-02-21 at 1 04 08 pm" src="https://cloud.githubusercontent.com/assets/238208/23189289/5bc56490-f836-11e6-9d60-facbf57ce719.png">

After:

<img width="800" alt="screen shot 2017-02-21 at 1 01 43 pm" src="https://cloud.githubusercontent.com/assets/238208/23189294/5fba51dc-f836-11e6-92de-2ccab1bc3d90.png">




