### PR TITLE
Reuse existing tab if creating new tab fails

### DIFF
--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -79,17 +79,12 @@ class CriConnection extends Connection {
       // hold on to id and ws URL of
       .then(tabs => ({webSocketDebuggerUrl, id} = tabs[0]))
       .then(tab => this._connectToSocket(tab))
-
-      .then(_ => this.sendCommand('Target.closeTarget', {targetId: id}))
-
-
-//       .then(_ => this.sendCommand('Target.createTarget', {url: 'about:blank'}))
-//       .then(target => {
-//       targetData = target;
-//       })
-//       .then(_ => this._runJsonCommand('list'))
-// //       .then(x => log.log('hi', x) || x)
-//       .then(_ => this.sendCommand('Target.getTargetInfo', targetData))
+      .then(_ => this.sendCommand('Target.createTarget', {url: 'about:blank'}))
+      .then(target => {
+        targetData = target;
+      })
+      .then(_ => this._runJsonCommand('list'))
+      .then(_ => this.sendCommand('Target.getTargetInfo', targetData))
       .then(data => {
         const targetInfo = data.targetInfo;
         const newId = targetInfo.targetId;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -106,6 +106,7 @@ class GatherRunner {
   static disposeDriver(driver) {
     // We dont need to hold up the reporting for the reload/disconnect,
     // so we will not return a promise in here.
+    console.trace()
     log.log('status', 'Disconnecting from browser...');
     driver.disconnect().catch(err => {
       // Ignore disconnecting error if browser was already closed.

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -106,7 +106,6 @@ class GatherRunner {
   static disposeDriver(driver) {
     // We dont need to hold up the reporting for the reload/disconnect,
     // so we will not return a promise in here.
-    console.trace()
     log.log('status', 'Disconnecting from browser...');
     driver.disconnect().catch(err => {
       // Ignore disconnecting error if browser was already closed.


### PR DESCRIPTION
Only happens in the CLI case, so far, as thats the only place we spawn a new tab.

Fixes https://github.com/GoogleChrome/lighthouse/issues/970

In this PR:

* We move most of the impl of `CriConnection.connect` into `_connectToSocket`
* We introduce a fallback mode if the `this._runJsonCommand('new')` rejects, where we reuse the first tab available. 
* We will make sure our chosen tab is in the foreground, as well.

