### PR TITLE
Add --view flag. Don't default CLI report to stdout.

### DIFF
--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -23,8 +23,8 @@
  *   'json': JSON formatted results
  *   'html': An HTML report
  */
-enum OutputMode { pretty, json, html };
-type Mode = 'pretty' | 'json' | 'html';
+enum OutputMode { pretty, json, html, none };
+type Mode = 'pretty' | 'json' | 'html' | 'none';
 
 import {Results, AuditResult} from './types/types';
 
@@ -80,7 +80,10 @@ function createOutput(results: Results, outputMode: OutputMode): string {
     return JSON.stringify(results, null, 2);
   }
 
-  // Pretty printed.
+  // No report (the new default)
+  if (outputMode === OutputMode.none) return '';
+
+  // Pretty printed CLI report.
   const version = results.lighthouseVersion;
   let output = `\n\n${log.bold}Lighthouse (${version}) results:${log.reset} ${results.url}\n\n`;
 
@@ -184,7 +187,8 @@ function write(results: Results, mode: Mode, path: string): Promise<Results> {
 function GetValidOutputOptions():Array<Mode> {
   return [OutputMode[OutputMode.pretty] as Mode,
           OutputMode[OutputMode.json] as Mode,
-          OutputMode[OutputMode.html] as Mode];
+          OutputMode[OutputMode.html] as Mode,
+          OutputMode[OutputMode.none] as Mode];
 }
 
 export {


### PR DESCRIPTION
First step in closing #1739 (Is it time to deprecate the CLI report output?)

1. Adds a `--view` flag which will open the HTML report that the CLI generated in your default browser.
2. Default `output` changes from `pretty` to `none`, which means you dont get the full report flooding your terminal at the end. You _can_ re-enable it with `--output=pretty`, however. 
3. Log two little tips to stdout telling the CLI users about the change.

![image](https://cloud.githubusercontent.com/assets/39191/23242548/36788412-f92e-11e6-9562-f9ee3664e889.png)

