### PR TITLE
Compact license header

### DIFF
--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -1,18 +1,7 @@
 /**
- * @license
- * Copyright 2016 Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
 'use strict';

--- a/lighthouse-viewer/gulpfile.js
+++ b/lighthouse-viewer/gulpfile.js
@@ -30,7 +30,7 @@ const DIST_FOLDER = 'dist';
 
 function license() {
   return $.license('Apache', {
-    organization: 'Copyright 2016 Google Inc. All rights reserved.',
+    organization: 'Copyright 2017 Google Inc. All rights reserved.',
     tiny: true
   });
 }


### PR DESCRIPTION
This is motivated by wanting fewer than 16 lines of boilerplate at the top of every source file. :)

I have reviewed all internal licensing requirements (go/releasing/preparing) and this is the best we can do. The Golang project (and many projects in Go) use a very compact header. ([example](https://github.com/GoogleCloudPlatform/golang-samples/blob/e91e4141e3d689498a9989d2b88308d6ed2f027b/kms/crypter/crypter.go#L1-L3)) however while this shortform boilerplate is permitted for BSD and MIT, Apache requires all the text.

So essentially, we nuke all the newlines. :) 
And we drop from 16 total lines down to 5. 📉  sgtm!

As a start, this PR just changs a single source file header. If it's sgtm, then I will update _all_ files.