### PR TITLE
Fix typo in README: s/console.err/console.error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ function launchChromeAndRunLighthouse(url, flags, config) {
       // Kill Chrome if there's an error.
       return launcher.kill().then(() => {
         throw err;
-      }, console.err);
+      }, console.error);
     });
 }
 


### PR DESCRIPTION
For a second I thought `console.err` is a thing! 

✌🏼