### PR TITLE
Revert escaping for code descriptions

### DIFF
--- a/lighthouse-core/report/handlebar-helpers.js
+++ b/lighthouse-core/report/handlebar-helpers.js
@@ -152,7 +152,7 @@ const handlebarHelpers = {
       return `<a href="${href}" target="_blank" rel="noopener" ${titleAttr}>${text}</a>`;
     };
     renderer.codespan = function(str) {
-      return `<code>${Handlebars.Utils.escapeExpression(str)}</code>`;
+      return `<code>${str}</code>`;
     };
     // eslint-disable-next-line no-unused-vars
     renderer.code = function(code, language) {


### PR DESCRIPTION
I introduced a boo boo for our descriptions that use markdown code snippets:

![screen shot 2017-02-27 at 3 32 23 pm](https://cloud.githubusercontent.com/assets/238208/23385067/91ae01e0-fd02-11e6-878b-5424e21fe0c9.png)

I was over cautious in adding the escape. This PR removes the addition (and we're only escaping`<pre>`).