### PR TITLE
tweak table styles

### DIFF
--- a/lighthouse-core/formatters/partials/table.css
+++ b/lighthouse-core/formatters/partials/table.css
@@ -10,7 +10,8 @@
 }
 .table_list th,
 .table_list td {
-  overflow: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .table_list th {
   background-color: #eee;
@@ -34,6 +35,7 @@
   display: block;
   margin: 0;
   overflow-x: auto;
+  overflow-y: hidden;
 }
 .table_list em + code, .table_list em + pre {
   margin-top: 10px;
@@ -51,6 +53,7 @@
   text-align: left;
   width: 250px;
   white-space: nowrap;
+  width: 440px;
 }
 .table-column-potential-savings em, .table-column-webp-savings em, .table-column-jpeg-savings em {
   color: #767676;


### PR DESCRIPTION
GIF showing before and after

![tablescrunch](https://cloud.githubusercontent.com/assets/39191/23536037/36a03102-ff77-11e6-93c1-ebf188cf3af1.gif)

3 changes

* wider URL column. I think we can afford this width now.
* The overflow auto on table cells seemed really awkward, so i went for ellipsis instead
  * to be honest, the ellipsis probably isn't better. so i could revert that.
* no more (inactive) vertical scrollbar on the URL 