### PR TITLE
Render usertiming in details/summary

### DIFF
--- a/lighthouse-core/formatters/partials/user-timings.html
+++ b/lighthouse-core/formatters/partials/user-timings.html
@@ -1,11 +1,14 @@
-<ul class="subitem__details">
-  {{#each this}}
-    <li class="subitem__detail">
-      {{#if this.isMark}}
-        <strong class="ut-measure_listing-duration">Mark: {{ decimal this.startTime }}ms</strong> - {{ this.name }}
-      {{else}}
-        <strong class="ut-measure_listing-duration">Measure {{ decimal this.duration }}ms</strong> - {{ this.name }}
-      {{/if}}
-    </li>
-  {{/each}}
-</ul>
+<details class="subitem__details">
+  <summary class="subitem__detail">View {{this.length}} entries</summary>
+  <ul class="subitem__details">
+    {{#each this}}
+      <li>
+        {{#if this.isMark}}
+          <strong class="ut-measure_listing-duration">Mark: {{ decimal this.startTime }}ms</strong> - {{ this.name }}
+        {{else}}
+          <strong class="ut-measure_listing-duration">Measure {{ decimal this.duration }}ms</strong> - {{ this.name }}
+        {{/if}}
+      </li>
+    {{/each}}
+  </ul>
+</details>


### PR DESCRIPTION
| before | after | 
|---|---|
| ![image](https://cloud.githubusercontent.com/assets/39191/23536677/718e1b90-ff7b-11e6-882f-3466bf389684.png) | ![image](https://cloud.githubusercontent.com/assets/39191/23536684/7a9bbcd8-ff7b-11e6-859b-419d4fdfacf0.png) |


### detail:
![image](https://cloud.githubusercontent.com/assets/39191/23536689/7fd46b32-ff7b-11e6-906e-f283e3edd59f.png)

![image](https://cloud.githubusercontent.com/assets/39191/23536691/82f0b456-ff7b-11e6-8f24-3904cbfda4a3.png)



Reviewers: use w=1: https://github.com/GoogleChrome/lighthouse/pull/1810/files?w=1