### PR TITLE
Don't show ✓✘ icons on perf audit results

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -40,6 +40,7 @@ class TotalByteWeight extends Audit {
       name: 'total-byte-weight',
       optimalValue: this.bytesToKbString(OPTIMAL_VALUE),
       description: 'Avoids enormous network payloads',
+      informative: true,
       helpText:
           'Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) ' +
           'and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. ' +

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -30,6 +30,7 @@ class UnusedCSSRules extends Audit {
       category: 'CSS',
       name: 'unused-css-rules',
       description: 'Unused CSS rules',
+      informative: true,
       helpText: 'Remove unused rules from stylesheets to reduce unnecessary ' +
           'bytes consumed by network activity. ' +
           '[Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery)',

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -41,6 +41,7 @@ class UsesOptimizedImages extends Audit {
       category: 'Images',
       name: 'uses-optimized-images',
       description: 'Unoptimized images',
+      informative: true,
       helpText: 'Images should be optimized to save network bytes. ' +
         'The following images could have smaller file sizes when compressed with ' +
         '[WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. ' +

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -39,6 +39,7 @@ class UsesResponsiveImages extends Audit {
       category: 'Images',
       name: 'uses-responsive-images',
       description: 'Oversized Images',
+      informative: true,
       helpText:
         'Image sizes served should be based on the device display size to save network bytes. ' +
         'Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) ' +

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -29,6 +29,7 @@ class CriticalRequestChains extends Audit {
       category: 'Performance',
       name: 'critical-request-chains',
       description: 'Critical Request Chains',
+      informative: true,
       optimalValue: 0,
       helpText: 'The Critical Request Chains below show you what resources are ' +
           'required for first render of this page. Improve page load by reducing ' +

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -35,6 +35,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
       category: 'Performance',
       name: 'link-blocking-first-paint',
       description: 'Render-blocking Stylesheets',
+      informative: true,
       helpText: 'Link elements are blocking the first paint of your page. Consider ' +
           'inlining critical links and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
@@ -34,6 +34,7 @@ class ScriptBlockingFirstPaint extends Audit {
       category: 'Performance',
       name: 'script-blocking-first-paint',
       description: 'Render-blocking scripts',
+      informative: true,
       helpText: 'Script elements are blocking the first paint of your page. Consider inlining ' +
           'critical scripts and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -401,10 +401,6 @@
           "expectedValue": true,
           "weight": 1
         },
-        "total-byte-weight": {
-          "expectedValue": 100,
-          "weight": 1
-        },
         "critical-request-chains": {
           "expectedValue": true,
           "weight": 1
@@ -415,6 +411,10 @@
         },
         "script-blocking-first-paint": {
           "expectedValue": true,
+          "weight": 1
+        },
+        "total-byte-weight": {
+          "expectedValue": 100,
           "weight": 1
         },
         "dom-size": {


### PR DESCRIPTION
This is a stopgap solution until the new report design.

This changes the iconography on our boolean perf items so that we don't have a check or X next to them.

![image](https://cloud.githubusercontent.com/assets/39191/23572264/b166e786-0022-11e7-8505-d896b5295895.png)

This is enabled by sendil's PR #1750 

The warning icon is gray (rather than orangeish) due to #1758.

----

i'm shipping a release and so far this is the only thing I consider a blocker.  