### PR TITLE
feat: support multiple output modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ last-run-results.html
 *.devtoolslog.json
 *.screenshots.html
 *.report.html
+*.report.json
+*.report.pretty
 *.artifacts.log
 
 closure-error.log

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -289,7 +289,16 @@ function saveResults(results: Results,
           });
     }
 
-    return promise.then(_ => Printer.write(results, flags.output, flags.outputPath));
+    return promise.then(_ => {
+      if (Array.isArray(flags.output)) {
+        return flags.output.reduce((innerPromise, outputType) => {
+          const outputPath = `${resolvedPath}.report.${outputType}`;
+          return innerPromise.then(_ => Printer.write(results, outputType, outputPath));
+        }, Promise.resolve(results));
+      } else {
+        return Printer.write(results, flags.output, flags.outputPath);
+      }
+    });
 }
 
 export async function runLighthouse(url: string,

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -94,7 +94,7 @@ const cliFlags = yargs
     'view'
   ], 'Output:')
   .describe({
-    'output': 'Reporter for the results',
+    'output': 'Reporter for the results, supports multiple values',
     'output-path': `The file path to output the results
 Example: --output-path=./lighthouse-results.html`,
     'view': 'Open HTML report in your browser'
@@ -293,7 +293,7 @@ function saveResults(results: Results,
       if (Array.isArray(flags.output)) {
         return flags.output.reduce((innerPromise, outputType) => {
           const outputPath = `${resolvedPath}.report.${outputType}`;
-          return innerPromise.then(_ => Printer.write(results, outputType, outputPath));
+          return innerPromise.then((_: Results) => Printer.write(results, outputType, outputPath));
         }, Promise.resolve(results));
       } else {
         return Printer.write(results, flags.output, flags.outputPath);

--- a/readme.md
+++ b/readme.md
@@ -65,8 +65,8 @@ Configuration:
                                 instability.                                        [default: 25000]
 
 Output:
-  --output       Reporter for the results
-                         [choices: "pretty", "json", "html"]                     [default: "pretty"]
+  --output       Reporter for the results, supports multiple values
+                         [choices: "none", "pretty", "json", "html"]               [default: "none"]
   --output-path  The file path to output the results
                  Example: --output-path=./lighthouse-results.html                [default: "stdout"]
 
@@ -78,19 +78,36 @@ Options:
                      installations are found                                               [boolean]
 ```
 
-##### Output Path examples
+##### Output Examples
+`lighthouse` generates
+* `./<HOST>_<DATE>.report.html`
 
-`--output-path=~/mydir/foo.out --save-assets` generates
-* `~/mydir/foo.out`
+`lighthouse --output json` generates
+* json output on `stdout`
+
+`lighthouse --output html --output-path ./report.html` generates
+* `./report.html`
+
+NOTE: specifying an output path with multiple formats ignores your specified extension for *ALL* formats
+
+`lighthouse --output json --output html --output-path ./myfile.json` generates
+* `./myfile.report.json`
+* `./myfile.report.html`
+
+`lighthouse --output json --output html` generates
+* `./<HOST>_<DATE>.report.json`
+* `./<HOST>_<DATE>.report.html`
+
+`lighthouse --output-path=~/mydir/foo.out --save-assets` generates
 * `~/mydir/foo.report.html`
 * `~/mydir/foo-0.trace.json`
 * `~/mydir/foo-0.screenshots.html`
 
-`--output-path=./report.json --output json --save-artifacts` generates
+`lighthouse --output-path=./report.json --output json --save-artifacts` generates
 * `./report.json`
 * `./report.artifacts.log`
 
-`--save-artifacts` prints a pretty report to `stdout` **and** generates
+`lighthouse --save-artifacts` generates
 * `./<HOST>_<DATE>.report.html`
 * `./<HOST>_<DATE>.artifacts.log`
 


### PR DESCRIPTION
fixes #1714 

not sure what to do exactly about the path, the meaning of the `--output-path` extension starts to fall apart a bit when you have multiple files so figured I'd stick with the current paradigm.

USAGE:

`lighthouse --output html --output json --output-path foobar.html` generates
* foobar.report.html
* foobar.report.json