### PR TITLE
Fixes no rel noopener when properties of anchor element cannot be resolved anymore

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -39,7 +39,7 @@ module.exports = [
       },
       'external-anchors-use-rel-noopener': {
         score: false,
-        debugString: 'Lighthouse was unable to determine the destination of some anchor tags.' +
+        debugString: 'Lighthouse was unable to determine the destination of some anchor tags. ' +
                      'If they are not used as hyperlinks, consider removing the _blank target.',
         extendedInfo: {
           value: {

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -39,9 +39,11 @@ module.exports = [
       },
       'external-anchors-use-rel-noopener': {
         score: false,
+        debugString: 'Lighthouse was unable to determine the destination of some anchor tags.' +
+                     'If they are not used as hyperlinks, consider removing the _blank target.',
         extendedInfo: {
           value: {
-            length: 2
+            length: 3
           }
         }
       },

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -494,7 +494,7 @@ class Driver {
   * @return {!Promise<string>} The property value, or null, if property not found
   */
   getObjectProperty(objectId, propName) {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this.sendCommand('Runtime.getProperties', {
         objectId,
         accessorPropertiesOnly: true,
@@ -508,7 +508,7 @@ class Driver {
         if (propertyForName) {
           resolve(propertyForName.value.value);
         } else {
-          reject(null);
+          resolve(null);
         }
       });
     });

--- a/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
@@ -29,7 +29,7 @@ class AnchorsWithNoRelNoopener extends Gatherer {
       .then(failingNodeList => {
         const failingNodes = failingNodeList.map(node => {
           return Promise.all([
-            node.getAttributes('href'),
+            node.getAttribute('href'),
             node.getAttribute('rel'),
             node.getAttribute('target')
           ]);

--- a/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
@@ -29,7 +29,7 @@ class AnchorsWithNoRelNoopener extends Gatherer {
       .then(failingNodeList => {
         const failingNodes = failingNodeList.map(node => {
           return Promise.all([
-            node.getAttribute('href'),
+            node.getProperty('href'),
             node.getAttribute('rel'),
             node.getAttribute('target')
           ]);

--- a/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
@@ -29,7 +29,7 @@ class AnchorsWithNoRelNoopener extends Gatherer {
       .then(failingNodeList => {
         const failingNodes = failingNodeList.map(node => {
           return Promise.all([
-            node.getProperty('href'),
+            node.getAttribute('href'),
             node.getAttribute('rel'),
             node.getAttribute('target')
           ]);

--- a/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
@@ -29,7 +29,7 @@ class AnchorsWithNoRelNoopener extends Gatherer {
       .then(failingNodeList => {
         const failingNodes = failingNodeList.map(node => {
           return Promise.all([
-            node.getProperty('href'),
+            node.getAttributes('href'),
             node.getAttribute('rel'),
             node.getAttribute('target')
           ]);

--- a/lighthouse-core/lib/element.js
+++ b/lighthouse-core/lib/element.js
@@ -58,7 +58,9 @@ class Element {
       })
       .then(resp => {
         return this.driver.getObjectProperty(resp.object.objectId, propName);
-      });
+      })
+      // getObjectProperty can reject with null so we make sure to resolve here instead of throwing
+      .catch(prop => prop);
   }
 }
 

--- a/lighthouse-core/lib/element.js
+++ b/lighthouse-core/lib/element.js
@@ -43,6 +43,7 @@ class Element {
         if (attrIndex === -1) {
           return null;
         }
+
         return resp.attributes[attrIndex + 1];
       });
   }
@@ -58,9 +59,7 @@ class Element {
       })
       .then(resp => {
         return this.driver.getObjectProperty(resp.object.objectId, propName);
-      })
-      // getObjectProperty can reject with null so we make sure to resolve here instead of throwing
-      .catch(prop => prop);
+      });
   }
 }
 


### PR DESCRIPTION
Fixes issue #1802. The problem is that [getObjectProperty](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/gather/driver.js#L511) rejects a null value which bubbles down into the [recoverOrThrow](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/gather/gather-runner.js#L128) function where `err = null`.

I fixed the bug by using the getAttribute function because href is also an attribute and is still available. I also caught the reject(null) from the `getObjectProperty` inside `getProperty` and resolve it with null so in the future other gatherers won't crash.

It's a pretty weird bug. Objects get collected but whenever you want to resolve the properties by `Runtime.getProperties` the object only has a `__proto__` property. My guess is that the object gets garbage collected or something and v8 can not resolve it's props anymore. Of course this is just a guess.