### PR TITLE
RTT = Latency * 2

### DIFF
--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -134,7 +134,7 @@ function getEmulationDesc() {
   return {
     'deviceEmulation': 'Nexus 5X',
     'cpuThrottling': `${CPU_THROTTLE_METRICS.rate}x slowdown`,
-    'networkThrottling': `${latency}ms RTT, ${byteToMbit(downloadThroughput)}Mbps down, ` +
+    'networkThrottling': `${latency * 2}ms RTT, ${byteToMbit(downloadThroughput)}Mbps down, ` +
         `${byteToMbit(uploadThroughput)}Mbps up`
   };
 }


### PR DESCRIPTION
I _believe_ Chrome's throttling settings introduce delay as latency, or the time it takes for a signal to pass from one point to the other.

Round trip time is the time there and back again. 

So... if we're displaying Round Trip Time (RTT) it should be latency times two.

![image](https://cloud.githubusercontent.com/assets/28967/23645866/26f3b356-02c3-11e7-9c89-ad5d811bfd97.png)

💕 