### PR TITLE
Complete fix for #1820 - missing formatter output

### DIFF
--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -70,7 +70,7 @@ class Deprecations extends Audit {
       rawValue: deprecations.length === 0,
       displayValue,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
+        formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: deprecations
       }
     });

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -111,7 +111,7 @@ class DOMSize extends Audit {
       score: Math.round(score),
       displayValue: `${stats.totalDOMNodes.toLocaleString()} nodes`,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.CARD,
+        formatter: Formatter.SUPPORTED_FORMATS.CARDS,
         value: cards
       }
     });

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -29,7 +29,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     return {
       category: 'Performance',
       name: 'external-anchors-use-rel-noopener',
-      description: 'Opens external anchors using rel="noopener"',
+      description: 'Opens external anchors using `rel="noopener"`',
       helpText: 'Open new tabs using `rel="noopener"` to improve performance and ' +
           'prevent security vulnerabilities. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).',
@@ -71,7 +71,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     return ExternalAnchorsUseRelNoopenerAudit.generateAuditResult({
       rawValue: failingAnchors.length === 0,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
+        formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: failingAnchors
       },
       debugString

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -55,7 +55,7 @@ class GeolocationOnStart extends Audit {
     return GeolocationOnStart.generateAuditResult({
       rawValue: results.length === 0,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
+        formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: results
       }
     });

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -55,7 +55,7 @@ class NoDocWriteAudit extends Audit {
     return NoDocWriteAudit.generateAuditResult({
       rawValue: results.length === 0,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
+        formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: results
       }
     });

--- a/lighthouse-core/audits/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/notification-on-start.js
@@ -55,7 +55,7 @@ class NotificationOnStart extends Audit {
     return NotificationOnStart.generateAuditResult({
       rawValue: results.length === 0,
       extendedInfo: {
-        formatter: Formatter.SUPPORTED_FORMATS.URLLIST,
+        formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: results
       }
     });

--- a/lighthouse-core/formatters/formatter.js
+++ b/lighthouse-core/formatters/formatter.js
@@ -40,9 +40,9 @@ class Formatter {
   static _getFormatters() {
     this._formatters = {
       accessibility: require('./accessibility'),
-      card: require('./cards'),
+      cards: require('./cards'),
       criticalRequestChains: require('./critical-request-chains'),
-      urllist: require('./url-list'),
+      urlList: require('./url-list'),
       null: require('./null-formatter'),
       speedline: require('./speedline-formatter'),
       table: require('./table'),

--- a/lighthouse-core/formatters/partials/cards.html
+++ b/lighthouse-core/formatters/partials/cards.html
@@ -1,5 +1,5 @@
 <details class="subitem__details">
-  <summary class="subitem__detail">More information</summary>
+  <summary class="subitem__detail">View details</summary>
   <div class="cards__container">
     {{#each this}}
       <div class="subitem__detail scorecard" {{#if snippet}}title="{{snippet}}"{{/if}}>

--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -91,7 +91,7 @@ describe('Report', () => {
         '<code>&lt;meta name=&quot;viewport&quot;&gt;</code>'), 'escapes <code>, once.');
   });
 
-  it('does not include script for devtools', () => {
+  it('includes formatter output in HTML report', () => {
     const reportGenerator = new ReportGenerator();
     const html = reportGenerator.generateHTML(sampleResults);
     assert.ok(html.includes('scorecard'), 'contains output from cards formatter');

--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -93,6 +93,17 @@ describe('Report', () => {
 
   it('does not include script for devtools', () => {
     const reportGenerator = new ReportGenerator();
+    const html = reportGenerator.generateHTML(sampleResults);
+    assert.ok(html.includes('scorecard'), 'contains output from cards formatter');
+    assert.ok(html.includes('table_list'), 'contains output from table formatter');
+    assert.ok(html.includes('class="cnc-node"'),
+              'contains output from critical request chains formatter');
+    assert.ok(html.includes('class="subitem__detail http-resource"'),
+              'contains output from url list formatter');
+  });
+
+  it('does not include script for devtools', () => {
+    const reportGenerator = new ReportGenerator();
     const html = reportGenerator.generateHTML(sampleResults, 'devtools');
 
     assert.ok(!html.includes('<script'), 'script tag inlined');

--- a/lighthouse-core/test/results/sample.json
+++ b/lighthouse-core/test/results/sample.json
@@ -474,7 +474,7 @@
       "displayValue": "4 warnings found",
       "rawValue": false,
       "extendedInfo": {
-        "formatter": "urllist",
+        "formatter": "urlList",
         "value": [
           {
             "label": "line: 45",
@@ -911,7 +911,7 @@
       "rawValue": 33,
       "optimalValue": "1,500 nodes",
       "extendedInfo": {
-        "formatter": "card",
+        "formatter": "cards",
         "value": [
           {
             "title": "Total DOM Nodes",
@@ -942,7 +942,7 @@
       "displayValue": "",
       "rawValue": false,
       "extendedInfo": {
-        "formatter": "urllist",
+        "formatter": "urlList",
         "value": [
           {
             "url": "<a href=\"https://www.google.com/\" target=\"_blank\">"
@@ -962,7 +962,7 @@
       "displayValue": "",
       "rawValue": false,
       "extendedInfo": {
-        "formatter": "urllist",
+        "formatter": "urlList",
         "value": [
           {
             "label": "line: 252, col: 25",
@@ -1156,7 +1156,7 @@
       "displayValue": "",
       "rawValue": false,
       "extendedInfo": {
-        "formatter": "urllist",
+        "formatter": "urlList",
         "value": [
           {
             "label": "line: 153, col: 12",
@@ -1347,7 +1347,7 @@
       "displayValue": "",
       "rawValue": false,
       "extendedInfo": {
-        "formatter": "urllist",
+        "formatter": "urlList",
         "value": [
           {
             "label": "line: 262, col: 16",


### PR DESCRIPTION
R: @patrickhulce, all

https://github.com/GoogleChrome/lighthouse/pull/1821/files addressed #1820, but it did not completely address the missing formatter output. The card and urllist formatters were still being left out of the html report.

I've also added a test to make sure these special formatters that have obvious HTML hooks (things we can look for in a a test) are being caught.