### PR TITLE
Configure lighthouse run by whitelisting aggregations

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -321,15 +321,15 @@ class Config {
 
  /**
   * Filter out any unrequested items from the config, based on requested top-level aggregations.
-  * @param {!Object} oldConfig Lighthouse config object.
-  * @param {!Array<string>} aggregationNames Name values of aggregations to include.
+  * @param {!Object} oldConfig Lighthouse config object
+  * @param {!Array<string>} aggregationIDs Id values of aggregations to include
   * @return {Object} new config
   */
-  static generateNewConfigOfAggregations(oldConfig, aggregationNames) {
+  static generateNewConfigOfAggregations(oldConfig, aggregationIDs) {
     // 0. Clone config to avoid mutating it
     const config = JSON.parse(JSON.stringify(oldConfig));
     // 1. Filter to just the chosen aggregations
-    config.aggregations = config.aggregations.filter(agg => aggregationNames.includes(agg.name));
+    config.aggregations = config.aggregations.filter(agg => aggregationIDs.includes(agg.id));
 
     // 2. Resolve which audits will need to run
     const requestedAuditNames = Config.getAuditsNeededByAggregations(config.aggregations);
@@ -347,12 +347,15 @@ class Config {
   }
 
  /**
-  * Return names of top-level aggregations from a config. Used by tools driving lighthouse-core
+  * Return IDs of top-level aggregations from a config. Used by tools driving lighthouse-core
   * @param {{aggregations: !Array<{name: string}>}} Lighthouse config object.
   * @return {!Array<string>}  Name values of aggregations within
   */
-  static getAggregationNames(config) {
-    return config.aggregations.map(agg => agg.name);
+  static getAggregations(config) {
+    return config.aggregations.map(agg => ({
+      name: agg.name,
+      id: agg.id
+    }));
   }
 
   /**

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -27,11 +27,6 @@ const Audit = require('../audits/audit');
 const Runner = require('../runner');
 
 const _flatten = arr => [].concat(...arr);
-const _uniq = arr => Array.from(new Set(arr));
-
-const util = require('util');
-const logg = obj => console.log(util.inspect(obj, {showHidden: true, depth: null, colors: true}));
-
 
 // cleanTrace is run to remove duplicate TracingStartedInPage events,
 // and to change TracingStartedInBrowser events into TracingStartedInPage.

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -329,23 +329,34 @@ class Config {
   * no longer needed by any remaining aggregations, filter out those as well.
   * @param {!Object} config Lighthouse config object.
   * @param {!Array<string>} aggregationNames Name values of aggregations to include.
+  * @return {undefined} config is mutated, instead of returning
   */
   static generateConfigOfAggregations(config, aggregationNames) {
+    // 1. Filter to just the chosen aggregations
     config.aggregations = config.aggregations.filter(agg => aggregationNames.includes(agg.name));
 
+    // 2. Resolve which audits will need to run
     const requestedAuditNames = Config.getAuditsNeededByAggregations(config.aggregations);
-
-
     const auditPathToNameMap = Config.getMapOfAuditPathToName(config);
-
     config.audits = config.audits.filter(auditPath =>
         requestedAuditNames.has(auditPathToNameMap.get(auditPath)));
 
-
+    // 3. Resolve which gatherers will need to run
     const auditObjectsSelected = Config.requireAudits(config.audits);
     const requiredGatherers = Config.getGatherersNeededByAudits(auditObjectsSelected);
 
+    // 4. Filter to only the neccessary passes
     config.passes = Config.selectPassesNeededByGatherers(config.passes, requiredGatherers);
+  }
+
+  /**
+  * Filter out any unrequested aggregations from the config. If any audits are
+  * no longer needed by any remaining aggregations, filter out those as well.
+  * @param {!Object} config Lighthouse config object.
+  * @return {!Array<string>}  Name values of aggregations within
+  */
+  static getAggregationNames(config) {
+    return config.aggregations.map(agg => agg.name);
   }
 
   // Find audits required for remaining aggregations.

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -319,7 +319,7 @@ class Config {
     return merge(baseJSON, extendJSON);
   }
 
-  /**
+ /**
   * Filter out any unrequested aggregations from the config. If any audits are
   * no longer needed by any remaining aggregations, filter out those as well.
   * @param {!Object} oldConfig Lighthouse config object.
@@ -347,9 +347,8 @@ class Config {
     return config;
   }
 
-  /**
-  * Filter out any unrequested aggregations from the config. If any audits are
-  * no longer needed by any remaining aggregations, filter out those as well.
+ /**
+  * Return names of top-level aggregations from a config. Used by tools driving lighthouse-core
   * @param {!Object} config Lighthouse config object.
   * @return {!Array<string>}  Name values of aggregations within
   */
@@ -357,7 +356,11 @@ class Config {
     return config.aggregations.map(agg => agg.name);
   }
 
-  // Find audits required for remaining aggregations.
+  /**
+   * Find audits required for remaining aggregations.
+   * @param  {!Object} aggregations
+   * @return {!Set<string>}
+   */
   static getAuditsNeededByAggregations(aggregations) {
     const requestedItems = _flatten(aggregations.map(aggregation => aggregation.items));
     const requestedAudits = _flatten(requestedItems.map(item => Object.keys(item.audits)));
@@ -365,7 +368,9 @@ class Config {
   }
 
   /**
-   * @return {map} map from audit path (seein in config.audits) to audit.name used in config.aggregations
+   * Creates mapping from audit path (used in config.audits) to audit.name (used in config.aggregations)
+   * @param {!Object} config Lighthouse config object.
+   * @return {Map}
    */
   static getMapOfAuditPathToName(config) {
     // The `audits` property in the config is a list of paths of audits to run.
@@ -380,8 +385,13 @@ class Config {
     return auditPathToName;
   }
 
+  /**
+   * From some requested audits, return names of all required artifacts
+   * @param  {!Object} audits
+   * @return {!Set<string>}
+   */
   static getGatherersNeededByAudits(audits) {
-    // It's possible we didn't get given any audits (but existing audit results), in which case
+    // It's possible we weren't given any audits (but existing audit results), in which case
     // there is no need to do any work here.
     if (!audits) {
       return new Set();
@@ -393,6 +403,12 @@ class Config {
     }, new Set());
   }
 
+  /**
+   * Filters to only required passes and gatherers, returning a new passes object
+   * @param  {!Object} passes
+   * @param  {!Set<string>} requiredGatherers
+   * @return {!Object} fresh passes object
+   */
   static getPassesNeededByGatherers(passes, requiredGatherers) {
     const passesClone = JSON.parse(JSON.stringify(passes));
     const filteredPasses = passesClone.map(pass => {

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -113,6 +113,7 @@
 
   "aggregations": [{
     "name": "Progressive Web App",
+    "id": "pwa",
     "description": "These audits validate the aspects of a Progressive Web App. They are a subset of the [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
     "scored": true,
     "categorizable": true,
@@ -257,6 +258,7 @@
     }]
   }, {
     "name": "Best Practices",
+    "id": "bp",
     "description": "We've compiled some recommendations for modernizing your web app and avoiding performance pitfalls. These audits do not affect your score but are worth a look.",
     "scored": false,
     "categorizable": true,
@@ -384,6 +386,7 @@
     }]
   }, {
     "name": "Performance",
+    "id": "perf",
     "description": "These encapsulate your app's performance.",
     "scored": false,
     "categorizable": false,
@@ -429,6 +432,7 @@
     }]
   }, {
     "name": "Fancier stuff",
+    "id": "fancy",
     "description": "A list of newer features that you could be using in your app. These audits do not affect your score and are just suggestions.",
     "scored": false,
     "categorizable": true,

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -370,49 +370,52 @@ describe('Config', () => {
     });
   });
 
-  describe('getAggregationNames', () => {
-    it('returns the names of the aggregations', () => {
+  describe('getAggregations', () => {
+    it('returns the IDs & names of the aggregations', () => {
       const runConfig = JSON.parse(JSON.stringify(defaultConfig));
-      const names = Config.getAggregationNames(runConfig);
-      assert.equal(Array.isArray(names), true);
-      assert.equal(names.length, 4, 'Did not find more than three aggregations');
+      const aggs = Config.getAggregations(runConfig);
+      assert.equal(Array.isArray(aggs), true);
+      assert.equal(aggs.length, 4, 'Did not find more than three aggregations');
+      const haveName = aggs.every(agg => agg.name.length);
+      const haveID = aggs.every(agg => agg.id.length);
+      assert.equal(haveName === haveID === true, true, 'they dont have IDs and names');
     });
   });
 
   describe('generateConfigOfAggregations', () => {
-    const aggregationNames = ['Performance'];
+    const aggregationIDs = ['perf'];
     const totalAuditCount = defaultConfig.audits.length;
 
     it('should not mutate the original config', () => {
       const origConfig = JSON.parse(JSON.stringify(defaultConfig));
-      Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
+      Config.generateNewConfigOfAggregations(defaultConfig, aggregationIDs);
       assert.deepStrictEqual(origConfig, defaultConfig, 'Original config mutated');
     });
 
     it('should filter out other passes if passed Performance', () => {
-      const config = Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
+      const config = Config.generateNewConfigOfAggregations(defaultConfig, aggregationIDs);
       assert.equal(config.aggregations.length, 1, 'other aggregations are present');
       assert.equal(config.passes.length, 2, 'incorrect # of passes');
       assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
     });
 
     it('should filter out other passes if passed PWA', () => {
-      const config = Config.generateNewConfigOfAggregations(defaultConfig, ['Progressive Web App']);
+      const config = Config.generateNewConfigOfAggregations(defaultConfig, ['pwa']);
       assert.equal(config.aggregations.length, 1, 'other aggregations are present');
       assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
     });
 
     it('should filter out other passes if passed Best Practices', () => {
-      const config = Config.generateNewConfigOfAggregations(defaultConfig, ['Best Practices']);
+      const config = Config.generateNewConfigOfAggregations(defaultConfig, ['bp']);
       assert.equal(config.aggregations.length, 1, 'other aggregations are present');
       assert.equal(config.passes.length, 2, 'incorrect # of passes');
       assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
     });
 
     it('should only run audits for ones named by the aggregation', () => {
-      const config = Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
+      const config = Config.generateNewConfigOfAggregations(defaultConfig, aggregationIDs);
       const selectedAggregation = defaultConfig.aggregations
-          .find(agg => aggregationNames.includes(agg.name));
+          .find(agg => aggregationIDs.includes(agg.id));
       const auditCount = Object.keys(selectedAggregation.items[0].audits).length;
 
       assert.equal(config.audits.length, auditCount, '# of audits match aggregation list');

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -375,12 +375,13 @@ describe('Config', () => {
       const runConfig = JSON.parse(JSON.stringify(defaultConfig));
       const names = Config.getAggregationNames(runConfig);
       assert.equal(Array.isArray(names), true);
-      assert.ok(names.length > 3, 'Did not find more than three aggregations');
+      assert.equal(names.length, 4, 'Did not find more than three aggregations');
     });
   });
 
   describe('generateConfigOfAggregations', () => {
     const aggregationNames = ['Performance'];
+    const totalAuditCount = defaultConfig.audits.length;
 
     it('should not mutate the original config', () => {
       const origConfig = JSON.parse(JSON.stringify(defaultConfig));
@@ -392,7 +393,20 @@ describe('Config', () => {
       const config = Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
       assert.equal(config.aggregations.length, 1, 'other aggregations are present');
       assert.equal(config.passes.length, 2, 'incorrect # of passes');
-      assert.ok(config.audits.length < 15, 'audit filtering probably failed');
+      assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
+    });
+
+    it('should filter out other passes if passed PWA', () => {
+      const config = Config.generateNewConfigOfAggregations(defaultConfig, ['Progressive Web App']);
+      assert.equal(config.aggregations.length, 1, 'other aggregations are present');
+      assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
+    });
+
+    it('should filter out other passes if passed Best Practices', () => {
+      const config = Config.generateNewConfigOfAggregations(defaultConfig, ['Best Practices']);
+      assert.equal(config.aggregations.length, 1, 'other aggregations are present');
+      assert.equal(config.passes.length, 2, 'incorrect # of passes');
+      assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
     });
 
     it('should only run audits for ones named by the aggregation', () => {

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -370,25 +370,38 @@ describe('Config', () => {
     });
   });
 
+  describe('getAggregationNames', () => {
+    it('returns the names of the aggregations', () => {
+      const runConfig = JSON.parse(JSON.stringify(defaultConfig));
+      const names = Config.getAggregationNames(runConfig);
+      assert.equal(Array.isArray(names), true);
+      assert.ok(names.length > 3, 'Did not find more than three aggregations');
+    });
+  });
+
   describe('generateConfigOfAggregations', () => {
     const aggregationNames = ['Performance'];
 
+    it('should not mutate the original config', () => {
+      const origConfig = JSON.parse(JSON.stringify(defaultConfig));
+      Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
+      assert.deepStrictEqual(origConfig, defaultConfig, 'Original config mutated');
+    });
+
     it('should filter out other passes if passed Performance', () => {
-      const runConfig = JSON.parse(JSON.stringify(defaultConfig));
-      Config.generateConfigOfAggregations(runConfig, aggregationNames);
-      assert.equal(runConfig.aggregations.length, 1, 'other aggregations are present');
-      assert.equal(runConfig.passes.length, 2, 'incorrect # of passes');
-      assert.ok(runConfig.audits.length < 15, 'audit filtering probably failed');
+      const config = Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
+      assert.equal(config.aggregations.length, 1, 'other aggregations are present');
+      assert.equal(config.passes.length, 2, 'incorrect # of passes');
+      assert.ok(config.audits.length < 15, 'audit filtering probably failed');
     });
 
     it('should only run audits for ones named by the aggregation', () => {
-      const runConfig = JSON.parse(JSON.stringify(defaultConfig));
-      Config.generateConfigOfAggregations(runConfig, aggregationNames);
+      const config = Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
       const selectedAggregation = defaultConfig.aggregations
           .find(agg => aggregationNames.includes(agg.name));
       const auditCount = Object.keys(selectedAggregation.items[0].audits).length;
 
-      assert.equal(runConfig.audits.length, auditCount, '# of audits match aggregation list');
+      assert.equal(config.audits.length, auditCount, '# of audits match aggregation list');
     });
   });
 });

--- a/lighthouse-extension/app/popup.html
+++ b/lighthouse-extension/app/popup.html
@@ -65,7 +65,7 @@ limitations under the License.
       </label>
     </div>
 
-    <h2 class="options__title">Audit collections to include in report</h2>
+    <h2 class="options__title">Audit categories to include</h2>
     <ul class="options__list">
       <!-- filled dynamically -->
     </ul>

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -95,11 +95,11 @@ function filterOutArtifacts(result) {
  * @param {!Connection} connection
  * @param {string} url
  * @param {!Object} options Lighthouse options.
- * @param {!Array<string>} aggregationNames Name values of aggregations to include.
+ * @param {!Array<string>} aggregationIDs Name values of aggregations to include.
  * @return {!Promise}
  */
-window.runLighthouseForConnection = function(connection, url, options, aggregationNames) {
-  const newConfig = Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
+window.runLighthouseForConnection = function(connection, url, options, aggregationIDs) {
+  const newConfig = Config.generateNewConfigOfAggregations(defaultConfig, aggregationIDs);
   const config = new Config(newConfig);
 
   // Add url and config to fresh options object.
@@ -124,17 +124,17 @@ window.runLighthouseForConnection = function(connection, url, options, aggregati
 
 /**
  * @param {!Object} options Lighthouse options.
- * @param {!Array<string>} aggregationNames Name values of aggregations to include.
+ * @param {!Array<string>} aggregationIDs Name values of aggregations to include.
  * @return {!Promise}
  */
-window.runLighthouseInExtension = function(options, aggregationNames) {
+window.runLighthouseInExtension = function(options, aggregationIDs) {
   // Default to 'info' logging level.
   log.setLevel('info');
   const connection = new ExtensionProtocol();
   // return enableOtherChromeExtensions(false)
     // .then(_ => connection.getCurrentTabURL())
   return connection.getCurrentTabURL()
-    .then(url => window.runLighthouseForConnection(connection, url, options, aggregationNames))
+    .then(url => window.runLighthouseForConnection(connection, url, options, aggregationIDs))
     .then(results => {
       // return enableOtherChromeExtensions(true).then(_ => {
       const blobURL = window.createReportPageAsBlob(results, 'extension');
@@ -151,14 +151,14 @@ window.runLighthouseInExtension = function(options, aggregationNames) {
  * @param {!RawProtocol.Port} port
  * @param {string} url
  * @param {!Object} options Lighthouse options.
- * @param {!Array<string>} aggregationNames Name values of aggregations to include.
+ * @param {!Array<string>} aggregationIDs Name values of aggregations to include.
  * @return {!Promise}
  */
-window.runLighthouseInWorker = function(port, url, options, aggregationNames) {
+window.runLighthouseInWorker = function(port, url, options, aggregationIDs) {
   // Default to 'info' logging level.
   log.setLevel('info');
   const connection = new RawProtocol(port);
-  return window.runLighthouseForConnection(connection, url, options, aggregationNames);
+  return window.runLighthouseForConnection(connection, url, options, aggregationIDs);
 };
 
 /**

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -186,12 +186,10 @@ window.createReportPageAsBlob = function(results, reportContext) {
 
 /**
  * Returns list of top-level aggregation categories from the default config.
- * @return {!Array<{name: string}>}
+ * @return {!Array<string>}
  */
 window.getDefaultAggregations = function() {
-  return Config.getAggregationNames(defaultConfig).map(name => ({
-    name: name
-  }));
+  return Config.getAggregationNames(defaultConfig);
 };
 
 /**
@@ -205,8 +203,8 @@ window.saveSettings = function(settings) {
   };
 
   // Stash selected aggregations.
-  window.getDefaultAggregations().forEach(audit => {
-    storage[STORAGE_KEY][audit.name] = settings.selectedAggregations.includes(audit.name);
+  window.getDefaultAggregations().forEach(aggName => {
+    storage[STORAGE_KEY][aggName] = settings.selectedAggregations.includes(aggName);
   });
 
   // Stash disable extensions setting.
@@ -227,8 +225,8 @@ window.loadSettings = function() {
       // Start with list of all default aggregations set to true so list is
       // always up to date.
       const defaultAggregations = {};
-      window.getDefaultAggregations().forEach(aggregation => {
-        defaultAggregations[aggregation.name] = true;
+      window.getDefaultAggregations().forEach(aggName => {
+        defaultAggregations[aggName] = true;
       });
 
       // Load saved aggregations and settings, overwriting defaults with any

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -186,10 +186,10 @@ window.createReportPageAsBlob = function(results, reportContext) {
 
 /**
  * Returns list of top-level aggregation categories from the default config.
- * @return {!Array<string>}
+ * @return {!Array<{name: string, id: string}>}
  */
 window.getDefaultAggregations = function() {
-  return Config.getAggregationNames(defaultConfig);
+  return Config.getAggregations(defaultConfig);
 };
 
 /**
@@ -203,8 +203,8 @@ window.saveSettings = function(settings) {
   };
 
   // Stash selected aggregations.
-  window.getDefaultAggregations().forEach(aggName => {
-    storage[STORAGE_KEY][aggName] = settings.selectedAggregations.includes(aggName);
+  window.getDefaultAggregations().forEach(agg => {
+    storage[STORAGE_KEY][agg.id] = settings.selectedAggregations.includes(agg.id);
   });
 
   // Stash disable extensions setting.
@@ -221,12 +221,14 @@ window.saveSettings = function(settings) {
  */
 window.loadSettings = function() {
   return new Promise(resolve => {
+    // Protip: debug what's in storage with:
+    //   chrome.storage.local.get(['lighthouse_audits'], console.log)
     chrome.storage.local.get([STORAGE_KEY, SETTINGS_KEY], result => {
       // Start with list of all default aggregations set to true so list is
       // always up to date.
       const defaultAggregations = {};
-      window.getDefaultAggregations().forEach(aggName => {
-        defaultAggregations[aggName] = true;
+      window.getDefaultAggregations().forEach(agg => {
+        defaultAggregations[agg.id] = true;
       });
 
       // Load saved aggregations and settings, overwriting defaults with any

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -33,8 +33,6 @@ let disableExtensionsDuringRun = false;
 let lighthouseIsRunning = false;
 let latestStatusLog = [];
 
-const _flatten = arr => [].concat(...arr);
-
 // /**
 //  * Enables or disables all other installed chrome extensions. The initial list
 //  * of the user's extension is created when the background page is started.

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -191,28 +191,13 @@ window.createReportPageAsBlob = function(results, reportContext) {
 };
 
 /**
- * Returns list of aggregation categories (each with a list of its constituent
- * audits) from the default config.
- * @return {!Array<{name: string, audits: !Array<string>}>}
+ * Returns list of top-level aggregation categories from the default config.
+ * @return {!Array<{name: string}>}
  */
 window.getDefaultAggregations = function() {
-  return _flatten(
-    defaultConfig.aggregations.map(aggregation => {
-      if (aggregation.items.length === 1) {
-        return {
-          name: aggregation.name,
-          audits: aggregation.items[0].audits,
-        };
-      }
-
-      return aggregation.items;
-    })
-  ).map(aggregation => {
-    return {
-      name: aggregation.name,
-      audits: Object.keys(aggregation.audits)
-    };
-  });
+  return defaultConfig.aggregations.map(aggregation => ({
+    name: aggregation.name
+  }));
 };
 
 /**

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -99,11 +99,7 @@ function filterOutArtifacts(result) {
  * @return {!Promise}
  */
 window.runLighthouseForConnection = function(connection, url, options, aggregationNames) {
-  // Always start with a freshly parsed default config.
-  const runConfig = JSON.parse(JSON.stringify(defaultConfig));
-
-  // Change tags object to a plain array of tag strings
-  Config.generateConfigOfAggregations(runConfig, aggregationNames);
+  const runConfig = Config.generateNewConfigOfAggregations(runConfig, aggregationNames);
   const config = new Config(runConfig);
 
   // Add url and config to fresh options object.

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -99,8 +99,8 @@ function filterOutArtifacts(result) {
  * @return {!Promise}
  */
 window.runLighthouseForConnection = function(connection, url, options, aggregationNames) {
-  const runConfig = Config.generateNewConfigOfAggregations(runConfig, aggregationNames);
-  const config = new Config(runConfig);
+  const newConfig = Config.generateNewConfigOfAggregations(defaultConfig, aggregationNames);
+  const config = new Config(newConfig);
 
   // Add url and config to fresh options object.
   const runOptions = Object.assign({}, options, {url, config});
@@ -189,8 +189,8 @@ window.createReportPageAsBlob = function(results, reportContext) {
  * @return {!Array<{name: string}>}
  */
 window.getDefaultAggregations = function() {
-  return defaultConfig.aggregations.map(aggregation => ({
-    name: aggregation.name
+  return Config.getAggregationNames(defaultConfig).map(name => ({
+    name: name
   }));
 };
 

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -122,12 +122,15 @@ function onGenerateReportButtonClick(background, selectedAggregations) {
   const feedbackEl = document.querySelector('.feedback');
   feedbackEl.textContent = '';
 
+  const aggregationNames = Object.keys(selectedAggregations)
+      .filter(key => !!selectedAggregations[key]);
+
   background.runLighthouseInExtension({
     flags: {
       disableCpuThrottling: true
     },
     restoreCleanState: true
-  }, selectedAggregations).catch(err => {
+  }, aggregationNames).catch(err => {
     let message = err.message;
     let includeReportLink = true;
 
@@ -163,8 +166,8 @@ function generateOptionsList(background, selectedAggregations) {
   const frag = document.createDocumentFragment();
 
   background.getDefaultAggregations().forEach(aggregation => {
-    const isChecked = selectedAggregations[aggregation.name];
-    frag.appendChild(createOptionItem(aggregation.name, isChecked));
+    const isChecked = selectedAggregations[aggregation];
+    frag.appendChild(createOptionItem(aggregation, isChecked));
   });
 
   const optionsList = document.querySelector('.options__list');
@@ -199,10 +202,7 @@ function initPopup() {
     const generateReportButton = document.getElementById('generate-report');
     generateReportButton.addEventListener('click', () => {
       background.loadSettings().then(settings => {
-        const selectedAggregations = settings.selectedAggregations;
-        const aggregationNames = Object.keys(selectedAggregations)
-            .filter(key => !!selectedAggregations[key]);
-        onGenerateReportButtonClick(background, aggregationNames);
+        onGenerateReportButtonClick(background, settings.selectedAggregations);
       });
     });
 

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -94,10 +94,10 @@ function logStatus([, message, details]) {
   statusDetailsMessageEl.textContent = details;
 }
 
-function createOptionItem(text, isChecked) {
+function createOptionItem(text, id, isChecked) {
   const input = document.createElement('input');
   input.setAttribute('type', 'checkbox');
-  input.setAttribute('value', text);
+  input.setAttribute('value', id);
   if (isChecked) {
     input.setAttribute('checked', 'checked');
   }
@@ -122,7 +122,7 @@ function onGenerateReportButtonClick(background, selectedAggregations) {
   const feedbackEl = document.querySelector('.feedback');
   feedbackEl.textContent = '';
 
-  const aggregationNames = Object.keys(selectedAggregations)
+  const aggregationIDs = Object.keys(selectedAggregations)
       .filter(key => !!selectedAggregations[key]);
 
   background.runLighthouseInExtension({
@@ -130,7 +130,7 @@ function onGenerateReportButtonClick(background, selectedAggregations) {
       disableCpuThrottling: true
     },
     restoreCleanState: true
-  }, aggregationNames).catch(err => {
+  }, aggregationIDs).catch(err => {
     let message = err.message;
     let includeReportLink = true;
 
@@ -166,8 +166,8 @@ function generateOptionsList(background, selectedAggregations) {
   const frag = document.createDocumentFragment();
 
   background.getDefaultAggregations().forEach(aggregation => {
-    const isChecked = selectedAggregations[aggregation];
-    frag.appendChild(createOptionItem(aggregation, isChecked));
+    const isChecked = selectedAggregations[aggregation.id];
+    frag.appendChild(createOptionItem(aggregation.name, aggregation.id, isChecked));
   });
 
   const optionsList = document.querySelector('.options__list');

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -189,26 +189,31 @@ function initPopup() {
 
     background.listenForStatus(logStatus);
 
+    // generate checkboxes from saved settings
     background.loadSettings().then(settings => {
-      const selectedAggregations = settings.selectedAggregations;
-      generateOptionsList(background, selectedAggregations);
-
+      generateOptionsList(background, settings.selectedAggregations);
       document.querySelector('.setting-disable-extensions').checked = settings.disableExtensions;
+    });
 
-      const generateReportButton = document.getElementById('generate-report');
-      generateReportButton.addEventListener('click', () => {
+    // bind Generate Report button
+    const generateReportButton = document.getElementById('generate-report');
+    generateReportButton.addEventListener('click', () => {
+      background.loadSettings().then(settings => {
+        const selectedAggregations = settings.selectedAggregations;
         const aggregationNames = Object.keys(selectedAggregations)
             .filter(key => !!selectedAggregations[key]);
         onGenerateReportButtonClick(background, aggregationNames);
       });
     });
 
+    // bind View Options button
     const generateOptionsEl = document.getElementById('configure-options');
     const optionsEl = document.querySelector('.options');
     generateOptionsEl.addEventListener('click', () => {
       optionsEl.classList.add(subpageVisibleClass);
     });
 
+    // bind Save Options button
     const okButton = document.getElementById('ok');
     okButton.addEventListener('click', () => {
       // Save settings when options page is closed.

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -196,7 +196,8 @@ function initPopup() {
 
       const generateReportButton = document.getElementById('generate-report');
       generateReportButton.addEventListener('click', () => {
-        onGenerateReportButtonClick(background, settings.selectedAggregations);
+        const aggregationNames = settings.selectedAggregations.filter(tag => tag.value).map(tag => tag.id);
+        onGenerateReportButtonClick(background, aggregationNames);
       });
     });
 

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -190,13 +190,15 @@ function initPopup() {
     background.listenForStatus(logStatus);
 
     background.loadSettings().then(settings => {
-      generateOptionsList(background, settings.selectedAggregations);
+      const selectedAggregations = settings.selectedAggregations;
+      generateOptionsList(background, selectedAggregations);
 
       document.querySelector('.setting-disable-extensions').checked = settings.disableExtensions;
 
       const generateReportButton = document.getElementById('generate-report');
       generateReportButton.addEventListener('click', () => {
-        const aggregationNames = settings.selectedAggregations.filter(tag => tag.value).map(tag => tag.id);
+        const aggregationNames = Object.keys(selectedAggregations)
+            .filter(key => !!selectedAggregations[key]);
         onGenerateReportButtonClick(background, aggregationNames);
       });
     });

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -183,7 +183,7 @@ gulp.task('clean', () => {
 });
 
 
-gulp.task('watch', ['lint', 'compileReport', 'compilePartials', 'browserify', 'html'], () => {
+gulp.task('watch', ['compileReport', 'compilePartials', 'browserify', 'html'], () => {
   livereload.listen();
 
   gulp.watch([


### PR DESCRIPTION

This PR is brings back the unmerged patch applied to enable DevTools Audits 2.0 panel integration, and then cleans things up to be less terrible.

Screenshots of what this enables:

![image](https://cloud.githubusercontent.com/assets/39191/23686174/df859f08-035c-11e7-9d24-00a2c4d3a48a.png)
![image](https://cloud.githubusercontent.com/assets/39191/23686204/f8eaae3e-035c-11e7-8020-7b040d64c1b3.png)

The big change is allowing the user to select which top-level aggregations they want, rather than which 2nd-level aggregations they want. :)

Note that the config is expecting some large refactors in the near future. This PR allows the config to remain as is, but the new `Config.generateConfigOfAggregations` will be useful for the new `config.settings.only` and `config.settings.skip` options.

**Reviewers:**

* Note that `getGatherersNeededByAudits` just moved places
* `auditPathToName` is mostly moved from `lighthouse-background` to config. ish.
* The other green in config.js is indeed new, (but the majority of it has been in the devtools distribution for the past month ;)
* config-test.js got a whitespace adjustment, so ?ws=1 to neutralize half of it.
* added some basic integration tests for the `Config.generateConfigOfAggregations` run.
* The devtools-side matching CL is here: https://codereview.chromium.org/2736153002. I'm filtering out "Fancier stuff" from that UI manually. ;)

window.runLighthouseInWorker and window.runLighthouseInExtension just can get an array like `["Performance", "Best Practices"]` now. Earlier they took a more complex object with booleans. While those booleans are necessary for saving/restoring settings, they shouldn't cross over.

Lastly, the modifications in popup's `generateReportButton` is done as there is _currently_ a bug where changing the extension settings doesn't apply those changes immediately. It's using stale settings. So I fixed that bug while I was in here. :)


