### PR TITLE
update jsconfig for latest typescript & VSCode

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,18 +5,21 @@
 
   "compilerOptions": {
     "target": "ES6",
-    "outDir": "./dist",
+    "noEmit": true,
     "diagnostics": true
   },
   "exclude": [
-    "**/node_modules",
-    "**/third_party",
-    "**/dist",
-
-    "lighthouse-core/closure",
-
-    "lighthouse-extension",
     "lighthouse-cli",
-    "lighthouse-viewer"
+    "node_modules",
+    "coverage",
+
+    "**/node_modules/*",
+    "**/third_party/*",
+    "**/dist/*",
+    "**/app/scripts/*",
+
+
+    "lighthouse-core/report/templates/*.js",
+    "lighthouse-core/closure"
   ]
 }


### PR DESCRIPTION
Fixes some of our excludes so the typescript compiler doesn't OOM.

This restores intellisense for JS in VSCode.

Also now the extension and viewer JS files are included in intellisense. Woo.

----


protip for future me.. adding this line into typescript's `tsc.js` was pretty instrumental in figuring this out

```diff
        if (hasDiagnostics) {
            var memoryUsed = ts.sys.getMemoryUsage ? ts.sys.getMemoryUsage() : -1;
+           console.log(program.getSourceFiles().map(f => f.path).join('\n'));
            reportCountStatistic("Files", program.getSourceFiles().length);
            reportCountStatistic("Lines", countLines(program));
```