### PR TITLE
Fix screenshot capture.

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -18,7 +18,6 @@
     "**/dist/*",
     "**/app/scripts/*",
 
-
     "lighthouse-core/report/templates/*.js",
     "lighthouse-core/closure"
   ]

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -95,6 +95,11 @@ function enableNexus5X(driver) {
 
   return Promise.all([
     driver.sendCommand('Emulation.setDeviceMetricsOverride', NEXUS5X_EMULATION_METRICS),
+    // required for screenshotting emulated page size, rather than full size
+    driver.sendCommand('Emulation.setVisibleSize', {
+      width: NEXUS5X_EMULATION_METRICS.screenWidth,
+      height: NEXUS5X_EMULATION_METRICS.screenHeight
+    }),
     // Network.enable must be called for UA overriding to work
     driver.sendCommand('Network.enable'),
     driver.sendCommand('Network.setUserAgentOverride', NEXUS5X_USERAGENT),


### PR DESCRIPTION
For the past few weeks (and potentially longer..*) the screenshots we've grabbed during a trace have looked like this:

![image](https://cloud.githubusercontent.com/assets/39191/23730069/5401f670-041a-11e7-9247-25334fa06be1.png)


It appears this regressed during some headless screenshot work. Both webpagetest and calibre also noticed this within the last 15 days.
The fix is fairly straightforward, though not intuitive unless you sit next to the engineers who know. Luckily i do. phew. :)

[`Emulation.setVisibleSize`](https://chromedevtools.github.io/debugger-protocol-viewer/tot/Emulation/#method-setVisibleSize) to the rescue!

Also on the bright side, Perceptual Speed Index don't appear to have been significantly affected by this regression. Because its a good metric. :)