### PR TITLE
Add TTI < 10s audit for PWA

### DIFF
--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -1,0 +1,62 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const Audit = require('./audit');
+const TTIMetric = require('./time-to-interactive');
+const Formatter = require('../formatters/formatter');
+
+// Maximum TTI to be considered "fast" for PWA baseline checklist
+//   https://developers.google.com/web/progressive-web-apps/checklist
+const MAXIMUM_TTI = 10 * 1000;
+
+class LoadFastEnough4Pwa extends Audit {
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return {
+      category: 'PWA',
+      name: 'load-fast-enough-for-pwa',
+      description: 'Page load is fast enough on 3G',
+      helpText: 'Satisfied if the _Time To Interactive_ duration is shorter than _10 seconds_, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist).',
+      requiredArtifacts: ['traces']
+    };
+  }
+
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    return TTIMetric.audit(artifacts).then(ttiResult => {
+      const timeToInteractive = ttiResult.extendedInfo.value.timings.timeToInteractive;
+      const isFast = timeToInteractive < MAXIMUM_TTI;
+
+      const extendedInfo = {
+        formatter: Formatter.SUPPORTED_FORMATS.NULL,
+        value: {timeToInteractive}
+      };
+
+      if (!isFast) {
+        return LoadFastEnough4Pwa.generateAuditResult({
+          rawValue: false,
+          debugString: `Under mobile conditions, the TTI was at ${ttiResult.displayValue}. ` +
+          'More details in "Performance" section.',
+          extendedInfo
+        });
+      }
+
+      return LoadFastEnough4Pwa.generateAuditResult({
+        rawValue: true,
+        extendedInfo
+      });
+    });
+  }
+}
+
+module.exports = LoadFastEnough4Pwa;

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -16,7 +16,7 @@ const Audit = require('./audit');
 const TTIMetric = require('./time-to-interactive');
 const Emulation = require('../lib/emulation');
 
-const Formatter = require('../formatters/formatter');
+const Formatter = require('../report/formatter');
 
 // Maximum TTI to be considered "fast" for PWA baseline checklist
 //   https://developers.google.com/web/progressive-web-apps/checklist

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -6,8 +6,16 @@
 
 'use strict';
 
+/** @fileoverview
+ *  This audit evaluates if a page's load performance is fast enough for it to be considered a PWA.
+ *  We are doublechecking that the network requests were throttled (or slow on their own)
+ *  Afterwards, we report if the TTI is less than 10 seconds.
+ */
+
 const Audit = require('./audit');
 const TTIMetric = require('./time-to-interactive');
+const Emulation = require('../lib/emulation');
+
 const Formatter = require('../formatters/formatter');
 
 // Maximum TTI to be considered "fast" for PWA baseline checklist
@@ -24,7 +32,7 @@ class LoadFastEnough4Pwa extends Audit {
       name: 'load-fast-enough-for-pwa',
       description: 'Page load is fast enough on 3G',
       helpText: 'Satisfied if the _Time To Interactive_ duration is shorter than _10 seconds_, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist).',
-      requiredArtifacts: ['traces']
+      requiredArtifacts: ['traces', 'networkRecords']
     };
   }
 
@@ -33,20 +41,39 @@ class LoadFastEnough4Pwa extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
+    const networkRecords = artifacts.networkRecords[Audit.DEFAULT_PASS];
+    const allRequestLatencies = networkRecords.map(record => {
+      if (!record._timing) return Infinity;
+      // Use DevTools' definition of Waiting latency: https://github.com/ChromeDevTools/devtools-frontend/blob/66595b8a73a9c873ea7714205b828866630e9e82/front_end/network/RequestTimingView.js#L164
+      return record._timing.receiveHeadersEnd - record._timing.sendEnd;
+    });
+
+    const latency3gMin = Emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.latency - 10;
+    const areLatenciesAll3G = allRequestLatencies.every(val => val > latency3gMin);
+
     return TTIMetric.audit(artifacts).then(ttiResult => {
       const timeToInteractive = ttiResult.extendedInfo.value.timings.timeToInteractive;
       const isFast = timeToInteractive < MAXIMUM_TTI;
 
       const extendedInfo = {
         formatter: Formatter.SUPPORTED_FORMATS.NULL,
-        value: {timeToInteractive}
+        value: {allRequestLatencies, timeToInteractive}
       };
+
+      if (!areLatenciesAll3G) {
+        return LoadFastEnough4Pwa.generateAuditResult({
+          rawValue: false,
+          // eslint-disable-next-line max-len
+          debugString: `The Time To Interactive was found at ${ttiResult.displayValue}, however, the network request latencies were not sufficiently realistic, so the performance measurements cannot be trusted.`,
+          extendedInfo
+        });
+      }
 
       if (!isFast) {
         return LoadFastEnough4Pwa.generateAuditResult({
           rawValue: false,
-          debugString: `Under mobile conditions, the TTI was at ${ttiResult.displayValue}. ` +
-          'More details in "Performance" section.',
+           // eslint-disable-next-line max-len
+          debugString: `Under 3G conditions, the Time To Interactive was at ${ttiResult.displayValue}. More details in the "Performance" section.`,
           extendedInfo
         });
       }

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -57,7 +57,7 @@ class LoadFastEnough4Pwa extends Audit {
 
       const extendedInfo = {
         formatter: Formatter.SUPPORTED_FORMATS.NULL,
-        value: {allRequestLatencies, timeToInteractive}
+        value: {areLatenciesAll3G, allRequestLatencies, isFast, timeToInteractive}
       };
 
       if (!areLatenciesAll3G) {

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -31,7 +31,7 @@ class LoadFastEnough4Pwa extends Audit {
       category: 'PWA',
       name: 'load-fast-enough-for-pwa',
       description: 'Page load is fast enough on 3G',
-      helpText: 'Satisfied if the _Time To Interactive_ duration is shorter than _10 seconds_, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist).',
+      helpText: 'Satisfied if the _Time To Interactive_ duration is shorter than _10 seconds_, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected).',
       requiredArtifacts: ['traces', 'networkRecords']
     };
   }

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -61,27 +61,27 @@ class LoadFastEnough4Pwa extends Audit {
       };
 
       if (!areLatenciesAll3G) {
-        return LoadFastEnough4Pwa.generateAuditResult({
+        return {
           rawValue: false,
           // eslint-disable-next-line max-len
           debugString: `The Time To Interactive was found at ${ttiResult.displayValue}, however, the network request latencies were not sufficiently realistic, so the performance measurements cannot be trusted.`,
           extendedInfo
-        });
+        };
       }
 
       if (!isFast) {
-        return LoadFastEnough4Pwa.generateAuditResult({
+        return {
           rawValue: false,
            // eslint-disable-next-line max-len
           debugString: `Under 3G conditions, the Time To Interactive was at ${ttiResult.displayValue}. More details in the "Performance" section.`,
           extendedInfo
-        });
+        };
       }
 
-      return LoadFastEnough4Pwa.generateAuditResult({
+      return {
         rawValue: true,
         extendedInfo
-      });
+      };
     });
   }
 }

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -1,7 +1,18 @@
 /**
- * @license Copyright 2017 Google Inc. All Rights Reserved.
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 'use strict';
@@ -43,13 +54,14 @@ class LoadFastEnough4Pwa extends Audit {
   static audit(artifacts) {
     const networkRecords = artifacts.networkRecords[Audit.DEFAULT_PASS];
     const allRequestLatencies = networkRecords.map(record => {
-      if (!record._timing) return Infinity;
+      if (!record._timing) return undefined;
       // Use DevTools' definition of Waiting latency: https://github.com/ChromeDevTools/devtools-frontend/blob/66595b8a73a9c873ea7714205b828866630e9e82/front_end/network/RequestTimingView.js#L164
       return record._timing.receiveHeadersEnd - record._timing.sendEnd;
     });
 
     const latency3gMin = Emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.latency - 10;
-    const areLatenciesAll3G = allRequestLatencies.every(val => val > latency3gMin);
+    const areLatenciesAll3G = allRequestLatencies.every(val =>
+        val === undefined || val > latency3gMin);
 
     return TTIMetric.audit(artifacts).then(ttiResult => {
       const timeToInteractive = ttiResult.extendedInfo.value.timings.timeToInteractive;

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -64,6 +64,7 @@
     "manifest-display",
     "without-javascript",
     "first-meaningful-paint",
+    "load-fast-enough-for-pwa",
     "speed-index-metric",
     "estimated-input-latency",
     "time-to-interactive",
@@ -134,6 +135,10 @@
       "name": "Page load performance is fast",
       "description": "Users notice if sites and apps don't perform well. These top-level metrics capture the most important perceived performance concerns.",
       "audits": {
+        "load-fast-enough-for-pwa": {
+          "expectedValue": true,
+          "weight": 1
+        },
         "first-meaningful-paint": {
           "expectedValue": 100,
           "weight": 1

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -151,5 +151,14 @@ module.exports = {
   enableCPUThrottling,
   disableCPUThrottling,
   goOffline,
-  getEmulationDesc
+  getEmulationDesc,
+  settings: {
+    NEXUS5X_EMULATION_METRICS,
+    NEXUS5X_USERAGENT,
+    TYPICAL_MOBILE_THROTTLING_METRICS,
+    OFFLINE_METRICS,
+    NO_THROTTLING_METRICS,
+    NO_CPU_THROTTLE_METRICS,
+    CPU_THROTTLE_METRICS
+  }
 };

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -1,0 +1,49 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const FastPWAAudit = require('../../audits/load-fast-enough-for-pwa');
+const TTIAudit = require('../../audits/time-to-interactive');
+const Audit = require('../../audits/audit.js');
+const assert = require('assert');
+const traceEvents = require('../fixtures/traces/progressive-app.json');
+
+const GatherRunner = require('../../gather/gather-runner.js');
+const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+
+function generateArtifactsWithTrace(trace) {
+  return Object.assign(computedArtifacts, {
+    traces: {
+      [Audit.DEFAULT_PASS]: {traceEvents: Array.isArray(trace) ? trace : trace.traceEvents}
+    }
+  });
+}
+
+/* eslint-env mocha */
+describe('PWA: load-fast-enough-for-pwa audit', () => {
+  it('returns boolean based on TTI value', () => {
+    return FastPWAAudit.audit(generateArtifactsWithTrace(traceEvents)).then(result => {
+      assert.equal(result.rawValue, true, 'fixture trace is not passing audit');
+    }).catch(err => {
+      assert.ok(false, err);
+    });
+  });
+
+  it('fails a bad TTI value', () => {
+    // mock a return for the TTI Audit
+    const origTTI = TTIAudit.audit;
+    const mockTTIResult = {extendedInfo: {value: {timings: {timeToInteractive: 15000}}}};
+    TTIAudit.audit = _ => Promise.resolve(mockTTIResult);
+
+    return FastPWAAudit.audit(generateArtifactsWithTrace(traceEvents)).then(result => {
+      assert.equal(result.rawValue, false, 'not failing a long TTI value');
+      TTIAudit.audit = origTTI;
+    }).catch(err => {
+      assert.ok(false, err);
+    });
+  });
+});

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -1,7 +1,18 @@
 /**
- * @license Copyright 2017 Google Inc. All Rights Reserved.
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 'use strict';
@@ -47,8 +58,6 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     TTIAudit.audit = generateTTIResults(5000);
     return FastPWAAudit.audit(generateArtifacts()).then(result => {
       assert.equal(result.rawValue, true, 'fixture trace is not passing audit');
-    }).catch(err => {
-      assert.ok(false, err);
     });
   });
 
@@ -57,8 +66,6 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     return FastPWAAudit.audit(generateArtifacts()).then(result => {
       assert.equal(result.rawValue, false, 'not failing a long TTI value');
       assert.ok(result.debugString);
-    }).catch(err => {
-      assert.ok(false, err);
     });
   });
 
@@ -74,8 +81,6 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     return FastPWAAudit.audit(generateArtifacts(mockNetworkRecords)).then(result => {
       assert.equal(result.rawValue, false);
       assert.ok(result.debugString.includes('network request latencies'));
-    }).catch(err => {
-      assert.ok(false, err);
     });
   });
 
@@ -92,8 +97,6 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     return FastPWAAudit.audit(generateArtifacts(mockNetworkRecords)).then(result => {
       assert.equal(result.rawValue, true);
       assert.strictEqual(result.debugString, undefined);
-    }).catch(err => {
-      assert.ok(false, err);
     });
   });
 });


### PR DESCRIPTION
Basic audit that just checks TTI value against a threshold.

Current UI is 
![image](https://cloud.githubusercontent.com/assets/39191/23730226/3832a74a-041b-11e7-97ad-7f29d398957a.png)

**Note:** I have this audit included in default.json here, but **I will remove it** _before landing this PR_. It's just there to make testing a bit easier. :)

Once landed, I will move the other perf metrics from PWA to Perf, leaving only this one in PWA.

Fixes #1831 