### PR TITLE
Tweak report colors so that we are WCAG2AA valid.

### DIFF
--- a/lighthouse-core/report/partials/cards.css
+++ b/lighthouse-core/report/partials/cards.css
@@ -30,6 +30,7 @@
   justify-content: center;
   align-items: center;
   border-bottom: 1px solid #ebebeb;
+  color: #4f4f4f;
 }
 .scorecard-value {
   font-size: 28px;

--- a/lighthouse-core/report/partials/critical-request-chains.css
+++ b/lighthouse-core/report/partials/critical-request-chains.css
@@ -51,11 +51,11 @@
 }
 
 .cnc-node__tree-hostname {
-  color: #767676;
+  color: #595959;
 }
 
 .initial-nav {
-  color: #767676;
+  color: #595959;
   margin: 10px 0 0;
   font-style: italic;
 }

--- a/lighthouse-core/report/partials/table.css
+++ b/lighthouse-core/report/partials/table.css
@@ -53,7 +53,7 @@
   white-space: nowrap;
 }
 .table-column-potential-savings em, .table-column-webp-savings em, .table-column-jpeg-savings em {
-  color: #767676;
+  color: #595959;
   font-style: normal;
   padding-left: 10px;
 }

--- a/lighthouse-core/report/styles/report.css
+++ b/lighthouse-core/report/styles/report.css
@@ -27,11 +27,11 @@ span, div, p, section, header, h1, h2, li, ul {
 :root {
   --text-font-family: "Roboto", -apple-system, BlinkMacSystemFont,  "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   --text-color: #222;
-  --secondary-text-color: #606060;
+  --secondary-text-color: #565656;
   --accent-color: #3879d9;
-  --poor-color: #e53935; /* md red 600 */
-  --good-color: #43a047; /* md green 600 */
-  --average-color: #ef6c00; /* md orange 800 */
+  --poor-color: #df332f;
+  --good-color: #2b882f;
+  --average-color: #c15700;
   --warning-color: #757575; /* md grey 600 */
   --gutter-gap: 12px;
   --gutter-width: 40px;
@@ -90,7 +90,7 @@ html, body {
 }
 
 a {
-  color: #15c;
+  color: #0c50c7;
 }
 
 body {
@@ -338,7 +338,7 @@ summary {
 .menu__link {
   padding: 0 20px;
   text-decoration: none;
-  color: #767676;
+  color: #595959;
   display: flex;
 }
 
@@ -629,7 +629,7 @@ summary {
   margin-left: var(--report-menu-width);
   font-size: 12px;
   border-top: 1px solid var(--report-border-color);
-  color: #767676;
+  color: #565656;
   background-color: var(--report-header-bg-color);
   border-top: 1px solid var(--report-border-color);
 }


### PR DESCRIPTION
| Before | After |
| ------------- |-------------| 
| ![1before](https://cloud.githubusercontent.com/assets/349621/23793455/03223c62-0594-11e7-9aa6-35f835f6e1d7.png) | ![2after](https://cloud.githubusercontent.com/assets/349621/23821804/5b23e6ec-0646-11e7-8b7b-bda3f7f01ce4.png)  |

Feel free to tweak this if you want to :)