### PR TITLE
use FMP from TraceOfTab in TTI calc

### DIFF
--- a/lighthouse-core/test/audits/time-to-interactive-test.js
+++ b/lighthouse-core/test/audits/time-to-interactive-test.js
@@ -35,7 +35,7 @@ describe('Performance: time-to-interactive audit', () => {
       assert.equal(output.rawValue, 1105.8, output.debugString);
       assert.equal(output.displayValue, '1105.8ms');
       assert.equal(output.extendedInfo.value.expectedLatencyAtTTI, 20.724);
-      assert.equal(output.extendedInfo.value.timings.fMP, 1099.5);
+      assert.equal(output.extendedInfo.value.timings.fMP, 1099.523);
       assert.equal(output.extendedInfo.value.timings.timeToInteractive, 1105.798);
       assert.equal(output.extendedInfo.value.timings.visuallyReady, 1105.798);
     });


### PR DESCRIPTION
With FMP timing available in the `TraceOfTab` computed artifact after #1549, this moves TTI calculation to using that rather than calling into the FMP audit.

Helps with #1568