### PR TITLE
Fix: Save as PDF: Pages truncated

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -126,7 +126,7 @@ Example: --output-path=./lighthouse-results.html`,
 
   // default values
   .default('chrome-flags', '')
-  .default('disable-cpu-throttling', true)
+  .default('disable-cpu-throttling', false)
   .default('output', Printer.GetValidOutputOptions()[Printer.OutputMode.html])
   .default('port', 9222)
   .default('max-wait-for-load', Driver.MAX_WAIT_FOR_FULLY_LOADED)

--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -55,6 +55,10 @@ function generateInlineScriptWithSize(sizeInBytes, firstContent = '', used = fal
   <!-- PASS(responsive): image is used at full size -->
   <img src="lighthouse-unoptimized.jpg">
 
+  <!-- FAIL(optimized): image is not optimized -->
+  <!-- PASS(responsive): image is used at full size -->
+  <img src="http://localhost:10503/byte-efficiency/lighthouse-unoptimized.jpg">
+
   <!-- PASSWARN(optimized): image is JPEG optimized but not WebP -->
   <!-- FAIL(responsive): image is 25% used at DPR 2 -->
   <img style="width: 256px; height: 170px;" src="lighthouse-1024x680.jpg">

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -22,27 +22,26 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 
-<!-- FAIL: block rendering -->
-<script src="./dbw_tester.js?delay=true"></script>
-
 <template id="links-blocking-first-paint-tmpl">
-  <link rel="stylesheet" href="./dbw_tester.css?scriptActivated&delay=true"> <!-- PASS: initiator is script -->
+  <link rel="stylesheet" href="./dbw_tester.css?scriptActivated&delay=200"> <!-- PASS: initiator is script -->
 </template>
 
 <!-- Note: these will only fail when using the static-server.js, which supports the ?delay=true param.
      If you're using your own server, the resource will load instantly and the
      stylesheets will be ignored for being below the threshold. -->
 <!-- we use a relative protocol url to test that `new URL(resource)` in the critical-request-chains.js formatter can handle it -->
-<link rel="stylesheet" href="//localhost:10200/dobetterweb/dbw_tester.css?delay=true"> <!-- FAIL, when run under smokehouse -->
-<link rel="stylesheet" href="./unknown404.css?delay=true"> <!-- FAIL -->
-<link rel="stylesheet" href="./dbw_tester.css?delay=true"> <!-- FAIL -->
-<link rel="stylesheet" href="./dbw_tester.css?tooquick=true"> <!-- PASS -->
-<link rel="stylesheet" href="./dbw_disabled.css?delay=true" disabled> <!-- PASS -->
-<link rel="import" href="./dbw_partial_a.html?delay=true"> <!-- FAIL -->
-<link rel="import" href="./dbw_partial_b.html?delay=true" async> <!-- PASS -->
+<link rel="stylesheet" href="//localhost:10200/dobetterweb/dbw_tester.css?delay=100"> <!-- FAIL, when run under smokehouse -->
+<link rel="stylesheet" href="./unknown404.css?delay=200"> <!-- FAIL -->
+<link rel="stylesheet" href="./dbw_tester.css?delay=2200"> <!-- FAIL -->
+<link rel="stylesheet" href="./dbw_disabled.css?delay=200" disabled> <!-- PASS -->
+<link rel="import" href="./dbw_partial_a.html?delay=200"> <!-- FAIL -->
+<link rel="import" href="./dbw_partial_b.html?delay=200" async> <!-- PASS -->
 
 <!-- PASS: preload that's activated later does not block rendering. -->
-<link rel="preload" href="./dbw_tester.css?delay=true" as="style" onload="this.rel = 'stylesheet'">
+<link rel="preload" href="./dbw_tester.css?delay=2000&async=true" as="style" onload="this.rel = 'stylesheet'">
+
+<!-- FAIL: block rendering -->
+<script src="./dbw_tester.js"></script>
 
 <style>
   body {

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -21,12 +21,13 @@
 const http = require('http');
 const path = require('path');
 const fs = require('fs');
+const parseQueryString = require('querystring').parse;
 const parseURL = require('url').parse;
 
 function requestHandler(request, response) {
   const requestUrl = parseURL(request.url);
   const filePath = requestUrl.pathname;
-  const queryString = requestUrl.search;
+  const queryString = requestUrl.search && parseQueryString(requestUrl.search.slice(1));
   let absoluteFilePath = path.join(__dirname, filePath);
 
   if (filePath === '/zone.js') {
@@ -64,9 +65,11 @@ function requestHandler(request, response) {
     }
     response.writeHead(statusCode, headers);
 
-    if (queryString && queryString.includes('delay')) {
+    // Delay the response by the specified ms defaulting to 2000ms for non-numeric values
+    if (queryString && typeof queryString.delay !== 'undefined') {
       response.write('');
-      return setTimeout(finishResponse, 2000, data);
+      const delay = parseInt(queryString.delay, 10) || 2000;
+      return setTimeout(finishResponse, delay, data);
     }
     finishResponse(data);
   }

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -39,7 +39,7 @@ module.exports = [
         extendedInfo: {
           value: {
             results: {
-              length: 3
+              length: 4
             }
           }
         }

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -59,7 +59,7 @@ module.exports = [
         extendedInfo: {
           value: {
             results: {
-              length: 3
+              length: 4
             }
           }
         }

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -105,6 +105,7 @@ class UsesOptimizedImages extends Audit {
 
       results.push({
         url,
+        isCrossOrigin: !image.isSameOrigin,
         preview: {url: image.url, mimeType: image.mimeType},
         totalBytes: image.originalSize,
         wastedBytes: webpSavings.bytes,

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -71,7 +71,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
       endTime = Math.max(item.endTime, endTime);
 
       return {
-        url: URL.getDisplayName(item.tag.url),
+        url: URL.getDisplayName(item.tag.url, {preserveQuery: true}),
         totalKb: `${Math.round(item.transferSize / 1024)} KB`,
         totalMs: `${Math.round((item.endTime - startTime) * 1000)}ms`
       };

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -313,9 +313,8 @@ class GatherRunner {
       return Promise.reject(new Error('You must provide a config'));
     }
 
-    // CPU throttling is temporarily off by default
     if (typeof options.flags.disableCpuThrottling === 'undefined') {
-      options.flags.disableCpuThrottling = true;
+      options.flags.disableCpuThrottling = false;
     }
 
     passes = this.instantiateGatherers(passes, options.config.configDir);

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -67,7 +67,7 @@ const NO_CPU_THROTTLE_METRICS = {
   rate: 1
 };
 const CPU_THROTTLE_METRICS = {
-  rate: 5
+  rate: 4.5
 };
 
 function enableNexus5X(driver) {

--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -60,6 +60,19 @@ URL.hostsMatch = function hostsMatch(urlA, urlB) {
 };
 
 /**
+ * @param {string} urlA
+ * @param {string} urlB
+ * @return {boolean}
+ */
+URL.originsMatch = function originsMatch(urlA, urlB) {
+  try {
+    return new URL(urlA).origin === new URL(urlB).origin;
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
  * @param {string} url
  * @param {{numPathParts: number, preserveQuery: boolean, preserveHost: boolean}=} options
  * @return {string}

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -203,7 +203,6 @@ class LighthouseReport {
    */
   expandDetailsWhenPrinting() {
     const details = Array.from(document.querySelectorAll('details'));
-
     details.map(detail => detail.open = true);
   }
 

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -37,7 +37,7 @@ class LighthouseReport {
   }
 
   _addEventListeners() {
-    this._setupExpandDetailsWhenPrinting();
+    this._setUpCollaspeDetailsAfterPrinting();
 
     const headerContainer = document.querySelector('.js-header-container');
     if (headerContainer) {
@@ -127,6 +127,7 @@ class LighthouseReport {
         this.sendJSONReport();
         break;
       case 'print':
+        this.expandDetailsWhenPrinting();
         window.print();
         break;
       case 'save-json': {
@@ -196,26 +197,32 @@ class LighthouseReport {
   }
 
   /**
-   * Sets up listeners to expand audit `<details>` when the user prints the page.
+   * Expands audit `<details>` when the user prints the page.
    * Ideally, a print stylesheet could take care of this, but CSS has no way to
-   * open a `<details>` element. When the user closes the print dialog, all
-   * `<details>` are collapsed.
+   * open a `<details>` element.
    */
-  _setupExpandDetailsWhenPrinting() {
+  expandDetailsWhenPrinting() {
+    const details = Array.from(document.querySelectorAll('details'));
+
+    details.map(detail => detail.open = true);
+  }
+
+  /**
+   * Sets up listeners to collapse audit `<details>` when the user closes the
+   * print dialog, all `<details>` are collapsed.
+   */
+  _setUpCollaspeDetailsAfterPrinting() {
     const details = Array.from(document.querySelectorAll('details'));
 
     // FF and IE implement these old events.
     if ('onbeforeprint' in window) {
-      window.addEventListener('beforeprint', _ => {
-        details.map(detail => detail.open = true);
-      });
       window.addEventListener('afterprint', _ => {
         details.map(detail => detail.open = false);
       });
     } else {
       // Note: while FF has media listeners, it doesn't fire when matching 'print'.
       window.matchMedia('print').addListener(mql => {
-        details.map(detail => detail.open = mql.matches);
+        if(!mql.matches) details.map(detail => detail.open = mql.matches);
       });
     }
   }

--- a/lighthouse-core/report/scripts/lighthouse-report.js
+++ b/lighthouse-core/report/scripts/lighthouse-report.js
@@ -32,6 +32,7 @@ class LighthouseReport {
     this.onExportButtonClick = this.onExportButtonClick.bind(this);
     this.onExport = this.onExport.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
+    this.printShortCutDetect = this.printShortCutDetect.bind(this);
 
     this._addEventListeners();
   }
@@ -53,6 +54,7 @@ class LighthouseReport {
 
       document.addEventListener('copy', this.onCopy);
     }
+    document.addEventListener('keydown', this.printShortCutDetect);
   }
 
   /**
@@ -197,6 +199,15 @@ class LighthouseReport {
   }
 
   /**
+   * Expands details while user using short cut to printing report
+   */
+  printShortCutDetect(e) {
+    if ((e.ctrlKey || e.metaKey) && e.keyCode === 80) { // Ctrl+P
+      this.expandDetailsWhenPrinting();
+    }
+  }
+
+  /**
    * Expands audit `<details>` when the user prints the page.
    * Ideally, a print stylesheet could take care of this, but CSS has no way to
    * open a `<details>` element.
@@ -221,7 +232,9 @@ class LighthouseReport {
     } else {
       // Note: while FF has media listeners, it doesn't fire when matching 'print'.
       window.matchMedia('print').addListener(mql => {
-        if(!mql.matches) details.map(detail => detail.open = mql.matches);
+        if(!mql.matches) {
+          details.map(detail => detail.open = mql.matches);
+        }
       });
     }
   }

--- a/lighthouse-core/test/audits/time-to-interactive-test.js
+++ b/lighthouse-core/test/audits/time-to-interactive-test.js
@@ -35,7 +35,7 @@ describe('Performance: time-to-interactive audit', () => {
       assert.equal(output.rawValue, 1105.8, output.debugString);
       assert.equal(output.displayValue, '1105.8ms');
       assert.equal(output.extendedInfo.value.expectedLatencyAtTTI, 20.724);
-      assert.equal(output.extendedInfo.value.timings.fMP, 1099.5);
+      assert.equal(output.extendedInfo.value.timings.fMP, 1099.523);
       assert.equal(output.extendedInfo.value.timings.timeToInteractive, 1105.798);
       assert.equal(output.extendedInfo.value.timings.visuallyReady, 1105.798);
     });

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
@@ -57,7 +57,7 @@ const traceData = {
     {
       _url: 'http://gmail.com/image.jpg',
       _mimeType: 'image/jpeg',
-      _resourceSize: 14,
+      _resourceSize: 15,
     },
     {
       _url: 'data: image/jpeg ; base64 ,SgVcAT32587935321...',
@@ -76,18 +76,22 @@ describe('Optimized images', () => {
       driver: {
         evaluateAsync: function() {
           return Promise.resolve(fakeImageStats);
-        }
+        },
+        sendCommand: function() {
+          return Promise.resolve({base64Encoded: true, body: 'mydata'});
+        },
       }
     };
   });
 
-  it('returns only sameorigin and data URI images', () => {
+  it('returns all images', () => {
     return optimizedImages.afterPass(options, traceData).then(artifact => {
-      assert.equal(artifact.length, 4);
+      assert.equal(artifact.length, 5);
       assert.ok(/image.jpg/.test(artifact[0].url));
       assert.ok(/transparent.png/.test(artifact[1].url));
       assert.ok(/image.bmp/.test(artifact[2].url));
-      assert.ok(/data: image/.test(artifact[3].url));
+      assert.ok(/gmail.*image.jpg/.test(artifact[3].url));
+      assert.ok(/data: image/.test(artifact[4].url));
     });
   });
 
@@ -99,11 +103,12 @@ describe('Optimized images', () => {
     };
 
     return optimizedImages.afterPass(options, traceData).then(artifact => {
-      assert.equal(artifact.length, 4);
+      assert.equal(artifact.length, 5);
       checkSizes(artifact[0], 10, 60, 80);
       checkSizes(artifact[1], 11, 60, 80);
       checkSizes(artifact[2], 12, 60, 80);
-      checkSizes(artifact[3], 20, 80, 100); // uses base64 data
+      checkSizes(artifact[3], 15, 60, 80); // uses base64 data
+      checkSizes(artifact[4], 20, 80, 100); // uses base64 data
     });
   });
 
@@ -121,7 +126,7 @@ describe('Optimized images', () => {
     return optimizedImages.afterPass(options, traceData).then(artifact => {
       const failed = artifact.find(record => record.failed);
 
-      assert.equal(artifact.length, 4);
+      assert.equal(artifact.length, 5);
       assert.ok(failed, 'passed along failure');
       assert.ok(/whoops/.test(failed.err.message), 'passed along error message');
     });

--- a/lighthouse-core/test/lib/url-shim-test.js
+++ b/lighthouse-core/test/lib/url-shim-test.js
@@ -58,6 +58,24 @@ describe('URL Shim', () => {
     assert.equal(URL.hostsMatch(urlA, urlB), false);
   });
 
+  it('safely identifies same origins', () => {
+    const urlA = 'https://5321212.fls.net/page?query=string#hash';
+    const urlB = 'https://5321212.fls.net/deeply/nested/page';
+    assert.ok(URL.originsMatch(urlA, urlB));
+  });
+
+  it('safely identifies different origins', () => {
+    const urlA = 'https://5321212.fls.net/page?query=string#hash';
+    const urlB = 'http://5321212.fls.net/deeply/nested/page';
+    assert.equal(URL.originsMatch(urlA, urlB), false);
+  });
+
+  it('safely identifies different invalid origins', () => {
+    const urlA = 'https://google.com/page?query=string#hash';
+    const urlB = 'anonymous:90';
+    assert.equal(URL.originsMatch(urlA, urlB), false);
+  });
+
   describe('getDisplayName', () => {
     it('respects numPathParts option', () => {
       const url = 'http://example.com/a/deep/nested/file.css';

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -126,9 +126,6 @@ function onGenerateReportButtonClick(background, selectedAggregations) {
       .filter(key => !!selectedAggregations[key]);
 
   background.runLighthouseInExtension({
-    flags: {
-      disableCpuThrottling: true
-    },
     restoreCleanState: true
   }, aggregationIDs).catch(err => {
     let message = err.message;

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,7 +305,7 @@ binaryextensions@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-1.0.1.tgz#1e637488b35b58bda5f4774bf96a5212a8c90755"
 
-bl@~1.1.2:
+bl@^1.1.2, bl@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.1.2.tgz#fdca871a99713aa00d19e3bbba41c44787a65398"
   dependencies:
@@ -428,9 +428,17 @@ cliui@^3.0.3:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+clone-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
+
+clone-stats@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
 
 clone@^0.2.0:
   version "0.2.0"
@@ -439,6 +447,14 @@ clone@^0.2.0:
 clone@^1.0.0, clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
+
+cloneable-readable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.0.0.tgz#a6290d413f217a61232f95e458ff38418cfb0117"
+  dependencies:
+    inherits "^2.0.1"
+    process-nextick-args "^1.0.6"
+    through2 "^2.0.1"
 
 co@^4.6.0:
   version "4.6.0"
@@ -477,6 +493,12 @@ concat-stream@^1.4.6:
     inherits "~2.0.1"
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
+
+concat-with-sourcemaps@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz#f55b3be2aeb47601b10a2d5259ccfb70fd2f1dd6"
+  dependencies:
+    source-map "^0.5.1"
 
 convert-source-map@^1.1.0:
   version "1.3.0"
@@ -1145,6 +1167,38 @@ growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
+gulp-concat@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/gulp-concat/-/gulp-concat-2.6.1.tgz#633d16c95d88504628ad02665663cee5a4793353"
+  dependencies:
+    concat-with-sourcemaps "^1.0.0"
+    through2 "^2.0.0"
+    vinyl "^2.0.0"
+
+gulp-declare@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/gulp-declare/-/gulp-declare-0.3.0.tgz#86830fc6faa88e06382162c8664b8e94957afcd9"
+  dependencies:
+    nsdeclare "^0.1.0"
+    vinyl-map "^1.0.1"
+    xtend "^4.0.0"
+
+gulp-define-module@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/gulp-define-module/-/gulp-define-module-0.1.5.tgz#8ae57d80e9f3ed5563a0779477bca4369a4587e8"
+  dependencies:
+    gulp-util "^3.0.4"
+    lodash "^3.6.0"
+    through "^2.3.0"
+
+gulp-handlebars@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-handlebars/-/gulp-handlebars-4.0.0.tgz#b5ff46a4197e7ccc9f259a5092a2c29f47953b29"
+  dependencies:
+    gulp-util "^3.0.4"
+    handlebars "^3.0.0"
+    through2 "^0.6.3"
+
 gulp-replace@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/gulp-replace/-/gulp-replace-0.5.4.tgz#69a67914bbd13c562bff14f504a403796aa0daa9"
@@ -1153,7 +1207,7 @@ gulp-replace@^0.5.4:
     readable-stream "^2.0.1"
     replacestream "^4.0.0"
 
-gulp-util@^3.0.0, gulp-util@^3.0.7:
+gulp-util@^3.0.0, gulp-util@^3.0.4, gulp-util@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.7.tgz#78925c4b8f8b49005ac01a011c557e6218941cbb"
   dependencies:
@@ -1209,6 +1263,15 @@ handlebars@4.0.5, handlebars@^4.0.1:
     source-map "^0.4.4"
   optionalDependencies:
     uglify-js "^2.6"
+
+handlebars@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-3.0.3.tgz#0e09651a2f0fb3c949160583710d551f92e6d2ad"
+  dependencies:
+    optimist "^0.6.1"
+    source-map "^0.1.40"
+  optionalDependencies:
+    uglify-js "~2.3"
 
 har-validator@~2.0.6:
   version "2.0.6"
@@ -1300,7 +1363,7 @@ inherits@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-1.0.2.tgz#ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b"
 
-inherits@2, inherits@~2.0.1:
+inherits@2, inherits@^2.0.1, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1451,6 +1514,10 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1792,6 +1859,10 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
+lodash@^3.6.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.4.tgz#01ce306b9bad1319f2a5528674f88297aeb70127"
@@ -1955,6 +2026,12 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+new-from@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/new-from/-/new-from-0.0.3.tgz#1c4ad13613de3e15d6321b70ed5c23937ea25e67"
+  dependencies:
+    readable-stream "~1.1.8"
+
 node-uuid@~1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
@@ -1978,6 +2055,10 @@ normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
 
+nsdeclare@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/nsdeclare/-/nsdeclare-0.1.0.tgz#10daa153642382d3cf2c01a916f4eb20a128b19f"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -1997,6 +2078,10 @@ object-assign@^3.0.0:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
 object.omit@^2.0.0:
   version "2.0.0"
@@ -2033,6 +2118,12 @@ optimist@^0.6.1:
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
     minimist "~0.0.1"
+    wordwrap "~0.0.2"
+
+optimist@~0.3.5:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
+  dependencies:
     wordwrap "~0.0.2"
 
 optionator@^0.8.1, optionator@^0.8.2:
@@ -2180,7 +2271,7 @@ private@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.6.tgz#55c6a976d0f9bafb9924851350fe47b9b5fbb7c1"
 
-process-nextick-args@~1.0.6:
+process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
@@ -2214,7 +2305,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@>=1.0.33-1 <1.1.0-0":
+"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
@@ -2235,7 +2326,7 @@ readable-stream@^2.0.1, readable-stream@^2.0.2:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readable-stream@~1.1.9:
+readable-stream@~1.1.8, readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
@@ -2287,6 +2378,10 @@ regex-cache@^0.4.2:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"
 
+remove-trailing-separator@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz#615ebb96af559552d4bf4057c8436d486ab63cc4"
+
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
@@ -2310,6 +2405,10 @@ repeating@^2.0.0:
 replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
+
+replace-ext@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 replacestream@^4.0.0:
   version "4.0.2"
@@ -2449,6 +2548,12 @@ source-map-support@^0.4.2:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.3.tgz#693c8383d4389a4569486987c219744dfc601685"
   dependencies:
     source-map "^0.5.3"
+
+source-map@^0.1.40, source-map@~0.1.7:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -2599,21 +2704,28 @@ textextensions@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-1.0.2.tgz#65486393ee1f2bb039a60cbba05b0b68bd9501d2"
 
-through2@^0.6.1:
+through2@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
+  dependencies:
+    readable-stream "~1.0.17"
+    xtend "~2.1.1"
+
+through2@^0.6.1, through2@^0.6.3:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
   dependencies:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through2@^2.0.0:
+through2@^2.0.0, through2@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.1.tgz#384e75314d49f32de12eebb8136b8eb6b5d59da9"
   dependencies:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-through@^2.3.6:
+through@^2.3.0, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -2673,6 +2785,14 @@ uglify-js@^2.6:
     source-map "~0.5.1"
     uglify-to-browserify "~1.0.0"
     yargs "~3.10.0"
+
+uglify-js@~2.3:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.3.6.tgz#fa0984770b428b7a9b2a8058f46355d14fef211a"
+  dependencies:
+    async "~0.2.6"
+    optimist "~0.3.5"
+    source-map "~0.1.7"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
@@ -2736,6 +2856,14 @@ vinyl-fs@^0.3.0:
     through2 "^0.6.1"
     vinyl "^0.4.0"
 
+vinyl-map@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/vinyl-map/-/vinyl-map-1.0.2.tgz#a8b296025f973fa7cad62817967a48f1d176bf7c"
+  dependencies:
+    bl "^1.1.2"
+    new-from "0.0.3"
+    through2 "^0.4.1"
+
 vinyl-sourcemaps-apply@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
@@ -2764,6 +2892,18 @@ vinyl@^1.2.0:
     clone "^1.0.0"
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
+
+vinyl@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.0.1.tgz#1c3b4931e7ac4c1efee743f3b91a74c094407bb6"
+  dependencies:
+    clone "^1.0.0"
+    clone-buffer "^1.0.0"
+    clone-stats "^1.0.0"
+    cloneable-readable "^1.0.0"
+    is-stream "^1.1.0"
+    remove-trailing-separator "^1.0.1"
+    replace-ext "^1.0.0"
 
 webidl-conversions@^3.0.0, webidl-conversions@^3.0.1:
   version "3.0.1"
@@ -2839,6 +2979,12 @@ ws@1.1.1:
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xtend@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
+  dependencies:
+    object-keys "~0.4.0"
 
 y18n@^3.2.0:
   version "3.2.1"


### PR DESCRIPTION
Hi,

I did some researches of the issue: Print -> [Save as PDF : Pages truncated #1780](https://github.com/GoogleChrome/lighthouse/issues/1780), and here is my solution.

The main problem I found is, once the `window.print()` is called. The printing process will take current page height immediately. In fact, the function [ _setupExpandDetailsWhenPrinting](https://github.com/GoogleChrome/lighthouse/blob/9ac57cb05efd5b0aba6684047382fff670860ca0/lighthouse-core/report/scripts/lighthouse-report.js#L204-L221) works as expected in my tests, i.e. all details are labeled `open=true` when triggering `print` event. 

So the only problem is, for example, the page height is 2112px before the expanding, and the printing take it as 3 pages pdf file; however, after the expanding, the page height is 9230px, and it requires 11 pages pdf file. Then, the last 8 pages are truncated in this case.

I found two possibilities. 

First, I could solve it by adding a `min-height: 10000px ` under the `@media print `. It is obviously a bad idea. However, it works, so it confirms my hypophysis above.

Second, since my searching work implies that there is no way to change the page height dynamically in CSS or after `window.print()` is called, I would like to solve the problem through calling expand before calling `window.print()`. I left the collapse listener for the event when printing complete.

Thanks,

Zixu Zhao