### PR TITLE
test: deflake blocking links

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -22,27 +22,26 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 
-<!-- FAIL: block rendering -->
-<script src="./dbw_tester.js?delay=true"></script>
-
 <template id="links-blocking-first-paint-tmpl">
-  <link rel="stylesheet" href="./dbw_tester.css?scriptActivated&delay=true"> <!-- PASS: initiator is script -->
+  <link rel="stylesheet" href="./dbw_tester.css?scriptActivated&delay=200"> <!-- PASS: initiator is script -->
 </template>
 
 <!-- Note: these will only fail when using the static-server.js, which supports the ?delay=true param.
      If you're using your own server, the resource will load instantly and the
      stylesheets will be ignored for being below the threshold. -->
 <!-- we use a relative protocol url to test that `new URL(resource)` in the critical-request-chains.js formatter can handle it -->
-<link rel="stylesheet" href="//localhost:10200/dobetterweb/dbw_tester.css?delay=true"> <!-- FAIL, when run under smokehouse -->
-<link rel="stylesheet" href="./unknown404.css?delay=true"> <!-- FAIL -->
-<link rel="stylesheet" href="./dbw_tester.css?delay=true"> <!-- FAIL -->
-<link rel="stylesheet" href="./dbw_tester.css?tooquick=true"> <!-- PASS -->
-<link rel="stylesheet" href="./dbw_disabled.css?delay=true" disabled> <!-- PASS -->
-<link rel="import" href="./dbw_partial_a.html?delay=true"> <!-- FAIL -->
-<link rel="import" href="./dbw_partial_b.html?delay=true" async> <!-- PASS -->
+<link rel="stylesheet" href="//localhost:10200/dobetterweb/dbw_tester.css?delay=100"> <!-- FAIL, when run under smokehouse -->
+<link rel="stylesheet" href="./unknown404.css?delay=200"> <!-- FAIL -->
+<link rel="stylesheet" href="./dbw_tester.css?delay=2200"> <!-- FAIL -->
+<link rel="stylesheet" href="./dbw_disabled.css?delay=200" disabled> <!-- PASS -->
+<link rel="import" href="./dbw_partial_a.html?delay=200"> <!-- FAIL -->
+<link rel="import" href="./dbw_partial_b.html?delay=200" async> <!-- PASS -->
 
 <!-- PASS: preload that's activated later does not block rendering. -->
-<link rel="preload" href="./dbw_tester.css?delay=true" as="style" onload="this.rel = 'stylesheet'">
+<link rel="preload" href="./dbw_tester.css?delay=2000&async=true" as="style" onload="this.rel = 'stylesheet'">
+
+<!-- FAIL: block rendering -->
+<script src="./dbw_tester.js"></script>
 
 <style>
   body {

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -21,12 +21,13 @@
 const http = require('http');
 const path = require('path');
 const fs = require('fs');
+const parseQueryString = require('querystring').parse;
 const parseURL = require('url').parse;
 
 function requestHandler(request, response) {
   const requestUrl = parseURL(request.url);
   const filePath = requestUrl.pathname;
-  const queryString = requestUrl.search;
+  const queryString = requestUrl.search && parseQueryString(requestUrl.search.slice(1));
   let absoluteFilePath = path.join(__dirname, filePath);
 
   if (filePath === '/zone.js') {
@@ -64,10 +65,9 @@ function requestHandler(request, response) {
     }
     response.writeHead(statusCode, headers);
 
-    if (queryString && queryString.includes('delay')) {
+    if (queryString && typeof queryString.delay !== 'undefined') {
       response.write('');
-      const matched = queryString.match(/delay=(\d+)/);
-      const delay = (matched && parseInt(matched[1])) || 2000;
+      const delay = parseInt(queryString.delay) || 2000;
       return setTimeout(finishResponse, delay, data);
     }
     finishResponse(data);

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -66,7 +66,9 @@ function requestHandler(request, response) {
 
     if (queryString && queryString.includes('delay')) {
       response.write('');
-      return setTimeout(finishResponse, 2000, data);
+      const matched = queryString.match(/delay=(\d+)/);
+      const delay = (matched && parseInt(matched[1])) || 2000;
+      return setTimeout(finishResponse, delay, data);
     }
     finishResponse(data);
   }

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -65,9 +65,10 @@ function requestHandler(request, response) {
     }
     response.writeHead(statusCode, headers);
 
+    // Delay the response by the specified ms defaulting to 2000ms for non-numeric values
     if (queryString && typeof queryString.delay !== 'undefined') {
       response.write('');
-      const delay = parseInt(queryString.delay) || 2000;
+      const delay = parseInt(queryString.delay, 10) || 2000;
       return setTimeout(finishResponse, delay, data);
     }
     finishResponse(data);

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -59,7 +59,7 @@ module.exports = [
         extendedInfo: {
           value: {
             results: {
-              length: 3
+              length: 4
             }
           }
         }

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -71,7 +71,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
       endTime = Math.max(item.endTime, endTime);
 
       return {
-        url: URL.getDisplayName(item.tag.url),
+        url: URL.getDisplayName(item.tag.url, {preserveQuery: true}),
         totalKb: `${Math.round(item.transferSize / 1024)} KB`,
         totalMs: `${Math.round((item.endTime - startTime) * 1000)}ms`
       };


### PR DESCRIPTION
To continue the nightmare that is the blocking stylesheets audit false positives, the last PR helped in the wild, but smokehouse added delays to *all* other blocking sheets that pushed out when our detection script could fire (thus making detection rather flaky). This is just an bad approach, and I still advocate for parsing the document we received at some point instead of all these hoops, but this will make travis more reliable for now.

Real fix should be made in protocol to add initiator information that we need.