### PR TITLE
fix: preserve query strings by default

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -64,7 +64,7 @@ class TotalByteWeight extends Audit {
         }
 
         const result = {
-          url: URL.getDisplayName(record.url, {preserveQuery: true}),
+          url: URL.getDisplayName(record.url),
           totalBytes: record.transferSize,
           totalKb: this.bytesToKbString(record.transferSize),
           totalMs: this.bytesToMsString(record.transferSize, networkThroughput),

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -141,7 +141,7 @@ class UnusedCSSRules extends Audit {
       const contentPreview = UnusedCSSRules.determineContentPreview(stylesheetInfo.content);
       url = '*inline*```' + contentPreview + '```';
     } else {
-      url = URL.getDisplayName(url, {preserveQuery: true});
+      url = URL.getDisplayName(url);
     }
 
     // If we don't know for sure how many bytes this sheet used on the network,

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -81,7 +81,7 @@ class UsesOptimizedImages extends Audit {
         return results;
       }
 
-      const url = URL.getDisplayName(image.url, {preserveQuery: true});
+      const url = URL.getDisplayName(image.url);
       const webpSavings = UsesOptimizedImages.computeSavings(image, 'webp');
 
       if (webpSavings.bytes > WEBP_ALREADY_OPTIMIZED_THRESHOLD_IN_BYTES) {

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -54,7 +54,7 @@ class UsesResponsiveImages extends Audit {
    * @return {?Object}
    */
   static computeWaste(image, DPR) {
-    const url = URL.getDisplayName(image.src, {preserveQuery: true});
+    const url = URL.getDisplayName(image.src);
     const actualPixels = image.naturalWidth * image.naturalHeight;
     const usedPixels = image.clientWidth * image.clientHeight * Math.pow(DPR, 2);
     const wastedRatio = 1 - (usedPixels / actualPixels);

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -71,7 +71,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
       endTime = Math.max(item.endTime, endTime);
 
       return {
-        url: URL.getDisplayName(item.tag.url, {preserveQuery: true}),
+        url: URL.getDisplayName(item.tag.url),
         totalKb: `${Math.round(item.transferSize / 1024)} KB`,
         totalMs: `${Math.round((item.endTime - startTime) * 1000)}ms`
       };

--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -80,7 +80,7 @@ URL.originsMatch = function originsMatch(urlA, urlB) {
 URL.getDisplayName = function getDisplayName(url, options) {
   options = Object.assign({
     numPathParts: 2,
-    preserveQuery: false,
+    preserveQuery: true,
     preserveHost: false,
   }, options);
 

--- a/lighthouse-core/test/lib/url-shim-test.js
+++ b/lighthouse-core/test/lib/url-shim-test.js
@@ -85,8 +85,8 @@ describe('URL Shim', () => {
 
     it('respects preserveQuery option', () => {
       const url = 'http://example.com/file.css?aQueryString=true';
-      const result = URL.getDisplayName(url, {preserveQuery: true});
-      assert.equal(result, '/file.css?aQueryString=true');
+      const result = URL.getDisplayName(url, {preserveQuery: false});
+      assert.equal(result, '/file.css');
     });
 
     it('respects preserveHost option', () => {
@@ -109,13 +109,13 @@ describe('URL Shim', () => {
 
     it('Elides query strings when can first parameter', () => {
       const url = 'http://example.com/file.css?aQueryString=true&other_long_query_stuff=false&some_other_super_long_query';
-      const result = URL.getDisplayName(url, {preserveQuery: true});
+      const result = URL.getDisplayName(url);
       assert.equal(result, '/file.css?aQueryString=\u2026');
     });
 
     it('Elides query strings when cannot preserve first parameter', () => {
       const url = 'http://example.com/file.css?superDuperNoGoodVeryLongExtraSpecialOnlyTheBestEnourmousQueryString=true';
-      const result = URL.getDisplayName(url, {preserveQuery: true});
+      const result = URL.getDisplayName(url);
       assert.equal(result, '/file.css?\u2026');
     });
 


### PR DESCRIPTION
Continues the spread of keeping query strings in `URL.getDisplayName` just helps with clarity and prevent the remaining "bugs" where it looks like duplicates are being shown.