### PR TITLE
[WIP] feat: base config v2 functionality

### DIFF
--- a/lighthouse-core/config/v2/config.js
+++ b/lighthouse-core/config/v2/config.js
@@ -1,3 +1,21 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
 const path = require('path');
 const log = require('../../lib/log');
 
@@ -14,8 +32,7 @@ class ConfigV2 {
       configPath = path.resolve(__dirname, defaultConfigPath);
     }
 
-    const configDir = typeof configPath === 'string' ?
-        path.dirname(configPath) : process.cwd();
+    const configDir = typeof configPath === 'string' ? path.dirname(configPath) : process.cwd();
     if (!path.isAbsolute(configDir)) {
       throw new Error('Must pass an absolute path to config');
     }
@@ -144,7 +161,7 @@ class ConfigV2 {
         extendedConfigPath,
         path.resolve(configDir, extendedConfigPath),
         path.resolve(process.cwd(), extendedConfigPath),
-      ])
+      ]);
       extendedConfigJson = ConfigV2._require(extendedConfigPath);
     }
 
@@ -209,7 +226,7 @@ class ConfigV2 {
         implementation = ConfigV2._require(definition.path);
       }
 
-      return Object.assign({}, definition, {implementation})
+      return Object.assign({}, definition, {implementation});
     });
   }
 
@@ -225,7 +242,10 @@ class ConfigV2 {
     const gathererIds = new Set(gatherers.map(item => item.id));
     const usedGathererIds = new Set();
     const usedGathererNames = new Set(['traces', 'networkRecords']);
-    const requestedGathererNames = new Set(_flatten(audits.map(audit => audit.implementation.meta.requiredArtifacts)));
+
+    const allRequiredArtifacts = audits.map(audit => audit.implementation.meta.requiredArtifacts);
+    const requestedGathererNames = new Set(_flatten(allRequiredArtifacts));
+
     const passDefinitions = ConfigV2.objectToArray(passesObject);
     const passes = passDefinitions.map(definition => {
       const foundGatherers = definition.gatherers.map(id => {
@@ -247,14 +267,14 @@ class ConfigV2 {
       log.warn('config', `Gatherers are unused: ${unused.join(', ')}`);
     }
 
-    const usedButNotNeeded = _differenceAsArray(usedGathererNames, requestedGathererNames);
-    if (usedButNotNeeded.length) {
-      log.warn('config', `Gatherers were configured but not needed: ${usedButNotNeeded.join(', ')}`);
+    const usedNotNeeded = _differenceAsArray(usedGathererNames, requestedGathererNames);
+    if (usedNotNeeded.length) {
+      log.warn('config', `Gatherers were configured but not needed: ${usedNotNeeded.join(', ')}`);
     }
 
-    const neededButNotGathered = _differenceAsArray(requestedGathererNames, usedGathererNames);
-    if (neededButNotGathered.length) {
-      log.warn('config', `Gatherers were needed but not configured: ${neededButNotGathered.join(', ')}`);
+    const neededNotUsed = _differenceAsArray(requestedGathererNames, usedGathererNames);
+    if (neededNotUsed.length) {
+      log.warn('config', `Gatherers were needed but not configured: ${neededNotUsed.join(', ')}`);
     }
 
     return passes;

--- a/lighthouse-core/config/v2/config.js
+++ b/lighthouse-core/config/v2/config.js
@@ -29,8 +29,8 @@ class ConfigV2 {
     configJson = ConfigV2.extendIfNecessary(configJson, configPath);
 
     this._json = configJson;
-    this._gatherers = ConfigV2.getGathererImplementations(configJson.gatherers);
-    this._audits = ConfigV2.getAuditImplementations(configJson.audits);
+    this._gatherers = ConfigV2.collectImplementations(configJson.gatherers);
+    this._audits = ConfigV2.collectImplementations(configJson.audits);
     this._passes = ConfigV2.computePasses(configJson, this._gatherers, this._audits);
     this._report = configJson.report;
   }
@@ -131,27 +131,15 @@ class ConfigV2 {
     }, []).sort((itemA, itemB) => itemA.order - itemB.order);
   }
 
-  static getGathererImplementations(gatherersObject) {
-    const gathererDefinitions = ConfigV2.objectToList(gatherersObject);
-    return gathererDefinitions.map(definition => {
+  static collectImplementations(definitionsObject) {
+    const definitions = ConfigV2.objectToList(definitionsObject);
+    return definitions.map(definition => {
       let implementation = definition.implementation;
       if (!implementation) {
         implementation = require(definition.path);
       }
 
       return Object.assign({}, definition, {implementation})
-    });
-  }
-
-  static getAuditImplementations(auditsObject) {
-    const auditDefinitions = ConfigV2.objectToList(auditsObject);
-    return auditDefinitions.map(definition => {
-      let implementation = definition.implementation;
-      if (!implementation) {
-        implementation = require(definition.path);
-      }
-
-      return Object.assign({}, definition, {implementation});
     });
   }
 

--- a/lighthouse-core/config/v2/config.js
+++ b/lighthouse-core/config/v2/config.js
@@ -163,7 +163,7 @@ class ConfigV2 {
   static resolvePaths(object, configDir, searchPaths = []) {
     object = Object.assign({}, object);
     Object.keys(object).forEach(key => {
-      // We don't need to resolve objects that already have
+      // We don't need to resolve paths whose implementation we already have
       if (object[key].implementation) {
         return;
       }

--- a/lighthouse-core/config/v2/config.js
+++ b/lighthouse-core/config/v2/config.js
@@ -1,0 +1,182 @@
+const path = require('path');
+
+const defaultConfigPath = './default.json';
+const defaultConfigJson = require(defaultConfigPath);
+
+const _flatten = arr => [].concat(...arr);
+const _subtract = (setA, setB) => Array.from(setA).filter(x => !setB.has(x));
+
+class ConfigV2 {
+  constructor(configJson, configPath) {
+    if (!configJson) {
+      configJson = defaultConfigJson;
+      configPath = path.resolve(__dirname, defaultConfigPath);
+    }
+
+    // Perform a shallow clone so we can adjust gatherers and audits
+    configJson = Object.assign({}, configJson);
+
+    // Resolve the paths of audits and gatherers
+    configJson.gatherers = ConfigV2.resolvePaths(configJson.gatherers, configPath, [
+      path.join(__dirname, '../../gather/gatherers'),
+    ]);
+    configJson.audits = ConfigV2.resolvePaths(configJson.audits, configPath, [
+      path.join(__dirname, '../../audits'),
+    ]);
+
+    // Extend only after our paths have been resolved
+    configJson = ConfigV2.extendIfNecessary(configJson, configPath);
+
+    this._json = configJson;
+    this._gatherers = ConfigV2.getGathererImplementations(configJson.gatherers);
+    this._audits = ConfigV2.getAuditImplementations(configJson.audits);
+    this._passes = ConfigV2.computePasses(configJson, this._gatherers, this._audits);
+    this._report = configJson.report;
+  }
+
+  asJson() {
+    return JSON.parse(JSON.stringify(this._json));
+  }
+
+  get audits() {
+    return [...this._audits];
+  }
+
+  get passes() {
+    return [...this._passes];
+  }
+
+  get report() {
+    return this._report;
+  }
+
+  static _tryResolveUntilSuccess(paths) {
+    for (const path of paths) {
+      try {
+        return require.resolve(path);
+      } catch (e) {}
+    }
+
+    throw new Error(`Unable to locate ${paths[0]}`);
+  }
+
+  static _mergeObjects(base, extension) {
+    if (!extension ||
+        typeof extension !== 'object' ||
+        typeof base !== 'object' ||
+        Array.isArray(base)) {
+      return extension;
+    }
+
+    for (const key in extension) {
+      if (key !== 'extends') {
+        base[key] = ConfigV2.mergeObjects(base[key], extension[key]);
+      }
+    }
+
+    return base;
+  }
+
+  static extendIfNecessary(configJson, configPath) {
+    if (!configJson.extends) {
+      return configJson;
+    }
+
+    let extendedConfigJson;
+    let extendedConfigPath = configJson.extends;
+    if (extendedConfigPath === 'lighthouse:default') {
+      extendedConfigJson = defaultConfigJson;
+      extendedConfigPath = defaultConfigPath;
+    } else {
+      extendedConfigPath = ConfigV2._tryResolveUntilSuccess([
+        extendedConfigPath,
+        path.resolve(configPath, extendedConfigPath),
+        path.resolve(process.cwd(), extendedConfigPath),
+      ])
+      extendedConfigJson = require(extendedConfigPath);
+    }
+
+    const extendedConfig = new ConfigV2(extendedConfigJson, extendedConfigPath);
+    return ConfigV2._mergeObjects(extendedConfig.asJson(), configJson);
+  }
+
+  static resolvePaths(object, configPath, searchPaths = []) {
+    object = Object.assign({}, object);
+    Object.keys(object).forEach(key => {
+      // We don't need to resolve objects that already have
+      if (object[key].implementation) {
+        return;
+      }
+
+      const rawPath = object[key].path || key;
+      const possiblePaths = searchPaths.map(searchPath => {
+        return path.resolve(searchPath, rawPath);
+      }).concat([
+        rawPath, // for npm plugins and absolute path usage
+        path.resolve(configPath, rawPath), // for relative config usage
+        path.resolve(process.cwd(), rawPath), // for node module usage
+      ]);
+      const resolvedPath = ConfigV2._tryResolveUntilSuccess(possiblePaths);
+      object[key] = Object.assign({}, object[key], {path: resolvedPath});
+    });
+    return object;
+  }
+
+  static objectToList(object) {
+    return Object.keys(object).reduce((list, id) => {
+      list.push(Object.assign({id}, object[id]));
+      return list;
+    }, []).sort((itemA, itemB) => itemA.order - itemB.order);
+  }
+
+  static getGathererImplementations(gatherersObject) {
+    const gathererDefinitions = ConfigV2.objectToList(gatherersObject);
+    return gathererDefinitions.map(definition => {
+      let implementation = definition.implementation;
+      if (!implementation) {
+        implementation = require(definition.path);
+      }
+
+      return Object.assign({}, definition, {implementation})
+    });
+  }
+
+  static getAuditImplementations(auditsObject) {
+    const auditDefinitions = ConfigV2.objectToList(auditsObject);
+    return auditDefinitions.map(definition => {
+      let implementation = definition.implementation;
+      if (!implementation) {
+        implementation = require(definition.path);
+      }
+
+      return Object.assign({}, definition, {implementation})
+    });
+  }
+
+  static computePasses(configJson, gatherers, audits) {
+    const gathererIds = new Set(gatherers.map(item => item.id));
+    const usedGathererIds = new Set();
+    const passDefinitions = ConfigV2.objectToList(configJson.passes);
+    const passes = passDefinitions.map(definition => {
+      const foundGatherers = definition.gatherers.map(id => {
+        const gatherer = gatherers.find(item => item.id === id);
+        if (!gatherer) {
+          throw new Error(`Missing required gatherer: ${id}`);
+        }
+
+        usedGathererIds.add(id);
+        return gatherer;
+      });
+
+      return Object.assign({}, definition, {gatherers: foundGatherers});
+    });
+
+    if (gathererIds.size !== usedGathererIds) {
+      const unused = _subtract(gathererIds, usedGathererIds);
+      console.warn(`Gatherers are unused: ${unused.join(', ')}`);
+    }
+    return passes;
+  }
+}
+
+module.exports = ConfigV2;

--- a/lighthouse-core/config/v2/config.js
+++ b/lighthouse-core/config/v2/config.js
@@ -5,7 +5,7 @@ const defaultConfigPath = './default.json';
 const defaultConfigJson = require(defaultConfigPath);
 
 const _flatten = arr => [].concat(...arr);
-const _subtract = (setA, setB) => Array.from(setA).filter(x => !setB.has(x));
+const _differenceAsArray = (setA, setB) => Array.from(setA).filter(x => !setB.has(x));
 
 class ConfigV2 {
   constructor(configJson, configPath) {
@@ -128,7 +128,7 @@ class ConfigV2 {
     return Object.keys(object).reduce((list, id) => {
       list.push(Object.assign({id}, object[id]));
       return list;
-    }, []).sort((itemA, itemB) => itemA.order - itemB.order);
+    }, []);
   }
 
   static collectImplementations(definitionsObject) {
@@ -165,16 +165,16 @@ class ConfigV2 {
     });
 
     if (gathererIds.size !== usedGathererIds.size) {
-      const unused = _subtract(gathererIds, usedGathererIds);
+      const unused = _differenceAsArray(gathererIds, usedGathererIds);
       log.warn('config', `Gatherers are unused: ${unused.join(', ')}`);
     }
 
-    const usedButNotNeeded = _subtract(usedGathererNames, requestedGathererNames);
+    const usedButNotNeeded = _differenceAsArray(usedGathererNames, requestedGathererNames);
     if (usedButNotNeeded.length) {
       log.warn('config', `Gatherers were configured but not needed: ${usedButNotNeeded.join(', ')}`);
     }
 
-    const neededButNotGathered = _subtract(requestedGathererNames, usedGathererNames);
+    const neededButNotGathered = _differenceAsArray(requestedGathererNames, usedGathererNames);
     if (neededButNotGathered.length) {
       log.warn('config', `Gatherers were needed but not configured: ${neededButNotGathered.join(', ')}`);
     }

--- a/lighthouse-core/config/v2/default.json
+++ b/lighthouse-core/config/v2/default.json
@@ -224,7 +224,7 @@
     "categories": {
       "pwa": {
         "name": "Progressive Web App",
-        "description": "",
+        "description": "These audits validate the aspects of a Progressive Web App. They are a subset of the [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
         "children": [
           {"id": "service-worker", "weight": 1},
           {"id": "works-offline", "weight": 1},
@@ -248,7 +248,7 @@
       },
       "performance": {
         "name": "Performance",
-        "description": "",
+        "description": "These encapsulate your app's performance.",
         "children": [
           {"id": "first-meaningful-paint", "weight": 5},
           {"id": "speed-index-metric", "weight": 1},
@@ -267,7 +267,7 @@
       },
       "accessibility": {
         "name": "Accessibility",
-        "description": "",
+        "description": "These audits validate that your app [works for all users](https://developers.google.com/web/fundamentals/accessibility/).",
         "children": [
           {"id": "aria-allowed-attr", "weight": 1},
           {"id": "aria-required-attr", "weight": 1},
@@ -281,7 +281,7 @@
       },
       "best-practices": {
         "name": "Best Practices",
-        "description": "",
+        "description": "We've compiled some recommendations for modernizing your web app and avoiding performance pitfalls. These audits do not affect your score but are worth a look.",
         "children": [
           {"id": "appcache-manifest", "weight": 1},
           {"id": "no-websql", "weight": 1},

--- a/lighthouse-core/config/v2/default.json
+++ b/lighthouse-core/config/v2/default.json
@@ -1,0 +1,308 @@
+{
+  "version": 2,
+
+  "gatherers": {
+    "url": {},
+    "https": {},
+    "viewport": {},
+    "theme-color": {},
+    "manifest": {},
+    "accessibility": {},
+    "image-usage": {},
+    "content-width": {},
+    "service-worker": {},
+    "offline": {},
+    "http-redirect": {},
+    "html-without-javascript": {},
+    "chrome-console-messages": {},
+    "styles": {},
+    "css-usage": {},
+    "all-event-listeners": {
+      "path": "dobetterweb/all-event-listeners"
+    },
+    "anchors-with-no-rel-noopener": {
+      "path": "dobetterweb/anchors-with-no-rel-noopener"
+    },
+    "appcache": {
+      "path": "dobetterweb/appcache"
+    },
+    "console-time-usage": {
+      "path": "dobetterweb/console-time-usage"
+    },
+    "datenow": {
+      "path": "dobetterweb/datenow"
+    },
+    "document-write": {
+      "path": "dobetterweb/document-write"
+    },
+    "geolocation-on-start": {
+      "path": "dobetterweb/geolocation-on-start"
+    },
+    "notification-on-start": {
+      "path": "dobetterweb/notification-on-start"
+    },
+    "domstats": {
+      "path": "dobetterweb/domstats"
+    },
+    "optimized-images": {
+      "path": "dobetterweb/optimized-images"
+    },
+    "tags-blocking-first-paint": {
+      "path": "dobetterweb/tags-blocking-first-paint"
+    },
+    "websql": {
+      "path": "dobetterweb/websql"
+    }
+  },
+
+  "passes": {
+    "defaultPass": {
+      "order": 10,
+      "recordNetwork": true,
+      "recordTrace": true,
+      "pauseBeforeTraceEndMs": 500,
+      "useThrottling": true,
+      "gatherers": [
+        "url",
+        "https",
+        "viewport",
+        "theme-color",
+        "manifest",
+        "accessibility",
+        "image-usage",
+        "content-width"
+      ]
+    },
+    "offlinePass": {
+      "order": 20,
+      "recordNetwork": true,
+      "useThrottling": false,
+      "gatherers": [
+        "service-worker",
+        "offline"
+      ]
+    },
+    "redirectPass": {
+      "order": 30,
+      "useThrottling": false,
+      "gatherers": [
+        "http-redirect",
+        "html-without-javascript"
+      ]
+    },
+    "dbw": {
+      "order": 40,
+      "recordNetwork": true,
+      "useThrottling": false,
+      "gatherers": [
+        "chrome-console-messages",
+        "styles",
+        "css-usage",
+        "all-event-listeners",
+        "anchors-with-no-rel-noopener",
+        "appcache",
+        "console-time-usage",
+        "datenow",
+        "document-write",
+        "geolocation-on-start",
+        "notification-on-start",
+        "domstats",
+        "optimized-images",
+        "tags-blocking-first-paint",
+        "websql"
+      ]
+    }
+  },
+
+  "audits": {
+    "is-on-https": {},
+    "redirects-http": {},
+    "service-worker": {},
+    "works-offline": {},
+    "viewport": {},
+    "manifest-display": {},
+    "without-javascript": {},
+    "first-meaningful-paint": {},
+    "speed-index-metric": {},
+    "estimated-input-latency": {},
+    "time-to-interactive": {},
+    "user-timings": {},
+    "screenshots": {},
+    "critical-request-chains": {},
+    "manifest-exists": {},
+    "manifest-background-color": {},
+    "manifest-theme-color": {},
+    "manifest-icons-min-192": {},
+    "manifest-icons-min-144": {},
+    "manifest-name": {},
+    "manifest-short-name": {},
+    "manifest-short-name-length": {},
+    "manifest-start-url": {},
+    "theme-color-meta": {},
+    "content-width": {},
+    "deprecations": {},
+    "aria-allowed-attr": {
+      "path": "accessibility/aria-allowed-attr"
+    },
+    "aria-required-attr": {
+      "path": "accessibility/aria-required-attr"
+    },
+    "aria-valid-attr-value": {
+      "path": "accessibility/aria-valid-attr-value"
+    },
+    "aria-valid-attr": {
+      "path": "accessibility/aria-valid-attr"
+    },
+    "color-contrast": {
+      "path": "accessibility/color-contrast"
+    },
+    "image-alt": {
+      "path": "accessibility/image-alt"
+    },
+    "label": {
+      "path": "accessibility/label"
+    },
+    "tabindex": {
+      "path": "accessibility/tabindex"
+    },
+    "total-byte-weight": {
+      "path": "byte-efficiency/total-byte-weight"
+    },
+    "unused-css-rules": {
+      "path": "byte-efficiency/unused-css-rules"
+    },
+    "uses-optimized-images": {
+      "path": "byte-efficiency/uses-optimized-images"
+    },
+    "uses-responsive-images": {
+      "path": "byte-efficiency/uses-responsive-images"
+    },
+    "appcache-manifest": {
+      "path": "dobetterweb/appcache-manifest"
+    },
+    "dom-size": {
+      "path": "dobetterweb/dom-size"
+    },
+    "external-anchors-use-rel-noopener": {
+      "path": "dobetterweb/external-anchors-use-rel-noopener"
+    },
+    "geolocation-on-start": {
+      "path": "dobetterweb/geolocation-on-start"
+    },
+    "link-blocking-first-paint": {
+      "path": "dobetterweb/link-blocking-first-paint"
+    },
+    "no-console-time": {
+      "path": "dobetterweb/no-console-time"
+    },
+    "no-datenow": {
+      "path": "dobetterweb/no-datenow"
+    },
+    "no-document-write": {
+      "path": "dobetterweb/no-document-write"
+    },
+    "no-mutation-events": {
+      "path": "dobetterweb/no-mutation-events"
+    },
+    "no-old-flexbox": {
+      "path": "dobetterweb/no-old-flexbox"
+    },
+    "no-websql": {
+      "path": "dobetterweb/no-websql"
+    },
+    "notification-on-start": {
+      "path": "dobetterweb/notification-on-start"
+    },
+    "script-blocking-first-paint": {
+      "path": "dobetterweb/script-blocking-first-paint"
+    },
+    "uses-http2": {
+      "path": "dobetterweb/uses-http2"
+    },
+    "uses-passive-event-listeners": {
+      "path": "dobetterweb/uses-passive-event-listeners"
+    }
+  },
+
+  "report": {
+    "categories": {
+      "pwa": {
+        "name": "Progressive Web App",
+        "description": "",
+        "children": [
+          {"id": "service-worker", "weight": 1},
+          {"id": "works-offline", "weight": 1},
+          {"id": "without-javascript", "weight": 1},
+          {"id": "is-on-https", "weight": 1},
+          {"id": "redirects-http", "weight": 1},
+          {"id": "manifest-exists", "weight": 1},
+          {"id": "manifest-start-url", "weight": 1},
+          {"id": "manifest-icons-min-144", "weight": 1},
+          {"id": "manifest-short-name", "weight": 1},
+          {"id": "manifest-exists", "weight": 1},
+          {"id": "manifest-name", "weight": 1},
+          {"id": "manifest-background-color", "weight": 1},
+          {"id": "manifest-theme-color", "weight": 1},
+          {"id": "manifest-icons-min-192", "weight": 1},
+          {"id": "manifest-exists", "weight": 1},
+          {"id": "theme-color-meta", "weight": 1},
+          {"id": "viewport", "weight": 1},
+          {"id": "content-width", "weight": 1}
+        ]
+      },
+      "performance": {
+        "name": "Performance",
+        "description": "",
+        "children": [
+          {"id": "first-meaningful-paint", "weight": 5},
+          {"id": "speed-index-metric", "weight": 1},
+          {"id": "estimated-input-latency", "weight": 1},
+          {"id": "time-to-interactive", "weight": 5},
+          {"id": "link-blocking-first-paint", "weight": 0},
+          {"id": "script-blocking-first-paint", "weight": 0},
+          {"id": "unused-css-rules", "weight": 0},
+          {"id": "uses-optimized-images", "weight": 0},
+          {"id": "uses-responsive-images", "weight": 0},
+          {"id": "total-byte-weight", "weight": 0},
+          {"id": "dom-size", "weight": 0},
+          {"id": "critical-request-chains", "weight": 0},
+          {"id": "user-timings", "weight": 0}
+        ]
+      },
+      "accessibility": {
+        "name": "Accessibility",
+        "description": "",
+        "children": [
+          {"id": "aria-allowed-attr", "weight": 1},
+          {"id": "aria-required-attr", "weight": 1},
+          {"id": "aria-valid-attr", "weight": 1},
+          {"id": "aria-valid-attr-value", "weight": 1},
+          {"id": "color-contrast", "weight": 1},
+          {"id": "image-alt", "weight": 1},
+          {"id": "label", "weight": 1},
+          {"id": "tabindex", "weight": 1}
+        ]
+      },
+      "best-practices": {
+        "name": "Best Practices",
+        "description": "",
+        "children": [
+          {"id": "appcache-manifest", "weight": 1},
+          {"id": "no-websql", "weight": 1},
+          {"id": "is-on-https", "weight": 1},
+          {"id": "uses-http2", "weight": 1},
+          {"id": "no-old-flexbox", "weight": 1},
+          {"id": "uses-passive-event-listeners", "weight": 1},
+          {"id": "no-mutation-events", "weight": 1},
+          {"id": "no-document-write", "weight": 1},
+          {"id": "external-anchors-use-rel-noopener", "weight": 1},
+          {"id": "geolocation-on-start", "weight": 1},
+          {"id": "notification-on-start", "weight": 1},
+          {"id": "deprecations", "weight": 1},
+          {"id": "manifest-short-name-length", "weight": 1},
+          {"id": "manifest-display", "weight": 1}
+        ]
+      }
+    }
+  }
+}

--- a/lighthouse-core/config/v2/default.json
+++ b/lighthouse-core/config/v2/default.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "configVersion": 2,
 
   "gatherers": {
     "url": {},
@@ -57,7 +57,6 @@
 
   "passes": {
     "defaultPass": {
-      "order": 10,
       "recordNetwork": true,
       "recordTrace": true,
       "pauseBeforeTraceEndMs": 500,
@@ -74,7 +73,6 @@
       ]
     },
     "offlinePass": {
-      "order": 20,
       "recordNetwork": true,
       "useThrottling": false,
       "gatherers": [
@@ -83,7 +81,6 @@
       ]
     },
     "redirectPass": {
-      "order": 30,
       "useThrottling": false,
       "gatherers": [
         "http-redirect",
@@ -91,7 +88,6 @@
       ]
     },
     "dbw": {
-      "order": 40,
       "recordNetwork": true,
       "useThrottling": false,
       "gatherers": [

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -431,6 +431,11 @@ class GatherRunner {
   static instantiateGatherers(passes, rootPath) {
     return passes.map(pass => {
       pass.gatherers = pass.gatherers.map(gatherer => {
+        if (gatherer.implementation) {
+          const GathererClass = gatherer.implementation;
+          return new GathererClass();
+        }
+
         // If this is already instantiated, don't do anything else.
         if (typeof gatherer !== 'string') {
           return gatherer;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -339,7 +339,7 @@ class GatherRunner {
             .then(passData => {
               // If requested by config, merge trace and network data for this
               // pass into tracingData.
-              const passName = config.passName || Audit.DEFAULT_PASS;
+              const passName = config.passName || config.id || Audit.DEFAULT_PASS;
               if (config.recordTrace) {
                 tracingData.traces[passName] = passData.trace;
                 tracingData.devtoolsLogs[passName] = passData.devtoolsLog;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -431,6 +431,7 @@ class GatherRunner {
   static instantiateGatherers(passes, rootPath) {
     return passes.map(pass => {
       pass.gatherers = pass.gatherers.map(gatherer => {
+        // support config v2 gatherer objects
         if (gatherer.implementation) {
           const GathererClass = gatherer.implementation;
           return new GathererClass();

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -21,6 +21,7 @@ const Runner = require('./runner');
 const log = require('./lib/log.js');
 const ChromeProtocol = require('./gather/connections/cri.js');
 const Config = require('./config/config');
+const ConfigV2 = require('./config/v2/config');
 
 /**
  * The relationship between these root modules:
@@ -48,7 +49,9 @@ module.exports = function(url, flags = {}, configJSON) {
     log.setLevel(flags.logLevel);
 
     // Use ConfigParser to generate a valid config file
-    const config = new Config(configJSON, flags.configPath);
+    const config = configJSON && configJSON.version === 2 ?
+      new ConfigV2(configJSON, flags.configPath) :
+      new Config(configJSON, flags.configPath);
 
     const connection = new ChromeProtocol(flags.port);
 

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -49,7 +49,7 @@ module.exports = function(url, flags = {}, configJSON) {
     log.setLevel(flags.logLevel);
 
     // Use ConfigParser to generate a valid config file
-    const config = configJSON && configJSON.version === 2 ?
+    const config = configJSON && configJSON.configVersion === 2 ?
       new ConfigV2(configJSON, flags.configPath) :
       new Config(configJSON, flags.configPath);
 

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -148,6 +148,29 @@ class ReportGenerator {
     });
   }
 
+  _getAggregations(results) {
+    if (results.aggregations.length) {
+      return results.aggregations;
+    }
+
+    return results.categories.map(category => {
+      const name = category.name;
+      const description = category.description;
+
+      return {
+        name, description,
+        categorizable: false,
+        scored: category.id === 'pwa',
+        total: category.score / 100,
+        score: [{
+          name, description,
+          overall: category.score / 100,
+          subItems: category.children.map(child => child.result),
+        }],
+      };
+    });
+  }
+
   /**
    * Generates the Lighthouse report HTML.
    * @param {!Object} results Lighthouse results.
@@ -176,7 +199,7 @@ class ReportGenerator {
       stylesheets: this.getReportCSS(),
       reportContext: reportContext,
       scripts: this.getReportJS(reportContext),
-      aggregations: results.aggregations,
+      aggregations: this._getAggregations(results),
       auditsByCategory: this._createPWAAuditsByCategory(results.aggregations),
       runtimeConfig: results.runtimeConfig,
       reportsCatalog

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -148,12 +148,18 @@ class ReportGenerator {
     });
   }
 
+  /**
+   * Returns aggregations directly from results or maps Config v2 categories to equivalent Config
+   * v1 aggregations.
+   * @param {{aggregations: !Array<!Object>, reportCategories: !Array<!Object>}} results
+   * @return {!Array<!Aggregation>}
+   */
   _getAggregations(results) {
     if (results.aggregations.length) {
       return results.aggregations;
     }
 
-    return results.categories.map(category => {
+    return results.reportCategories.map(category => {
       const name = category.name;
       const description = category.description;
 

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -1,17 +1,9 @@
 const ConfigV2 = require('../../config/v2/config');
 
 class ReportGeneratorV2 {
-  _scoreOfItem(item) {
-    if (typeof item.numericScore === 'number') {
-      return item.numericScore;
-    }
-
-    return Number(item.score) || 0;
-  }
-
   _arithmeticMean(items) {
     const results = items.reduce((result, item) => {
-      const score = this._scoreOfItem(item);
+      const score = Number(item.score) || 0;
       const weight = Number(item.weight) || 0;
       return {
         weight: result.weight + weight,
@@ -24,7 +16,7 @@ class ReportGeneratorV2 {
 
   _geometricMean(items) {
     const results = items.reduce((result, item) => {
-      const score = this._scoreOfItem(item);
+      const score = Number(item.score) || 0;
       const weight = Number(item.weight) || 0;
       return {
         weight: result.weight + weight,
@@ -39,12 +31,12 @@ class ReportGeneratorV2 {
     const categories = ConfigV2.objectToList(config.report.categories).map(category => {
       const children = category.children.map(item => {
         const result = resultsByAuditId[item.id];
-        let numericScore = Number(result.score) || 0;
+        let score = Number(result.score) || 0;
         if (typeof result.score === 'boolean') {
-          numericScore = result.score ? 100 : 0;
+          score = result.score ? 100 : 0;
         }
 
-        return Object.assign({}, item, {result, numericScore});
+        return Object.assign({}, item, {result, score});
       });
 
       const score = this._arithmeticMean(children);

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -1,3 +1,21 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
 const ConfigV2 = require('../../config/v2/config');
 
 class ReportGeneratorV2 {
@@ -28,7 +46,7 @@ class ReportGeneratorV2 {
   }
 
   generateReportJson(config, resultsByAuditId) {
-    const categories = ConfigV2.objectToList(config.report.categories).map(category => {
+    const categories = ConfigV2.objectToArray(config.report.categories).map(category => {
       const children = category.children.map(item => {
         const result = resultsByAuditId[item.id];
         let score = Number(result.score) || 0;

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -1,0 +1,68 @@
+const ConfigV2 = require('../../config/v2/config');
+
+class ReportGeneratorV2 {
+  _scoreOfItem(item) {
+    if (typeof item.numericScore === 'number') {
+      return item.numericScore;
+    }
+
+    return Number(item.score) || 0;
+  }
+
+  _arithmeticMean(items) {
+    const results = items.reduce((result, item) => {
+      const score = this._scoreOfItem(item);
+      const weight = Number(item.weight) || 0;
+      return {
+        weight: result.weight + weight,
+        sum: result.sum + score * weight,
+      };
+    }, {weight: 0, sum: 0});
+
+    return (results.sum / results.weight) || 0;
+  }
+
+  _geometricMean(items) {
+    const results = items.reduce((result, item) => {
+      const score = this._scoreOfItem(item);
+      const weight = Number(item.weight) || 0;
+      return {
+        weight: result.weight + weight,
+        product: result.product * Math.max(Math.pow(score, weight), 1),
+      };
+    }, {weight: 0, product: 1});
+
+    return Math.pow(results.product, 1 / results.weight) || 0;
+  }
+
+  generateReportJson(config, resultsByAuditId) {
+    const categories = ConfigV2.objectToList(config.report.categories).map(category => {
+      const children = category.children.map(item => {
+        const result = resultsByAuditId[item.id];
+        let numericScore = Number(result.score) || 0;
+        if (typeof result.score === 'boolean') {
+          numericScore = result.score ? 100 : 0;
+        }
+
+        return Object.assign({}, item, {result, numericScore});
+      });
+
+      const score = this._arithmeticMean(children);
+      return Object.assign({}, category, {children, score});
+    });
+
+    const scoreByCategory = categories.reduce((scores, category) => {
+      scores[category.id] = category.score;
+      return scores;
+    }, {});
+
+    const score = this._geometricMean([
+      {score: scoreByCategory.pwa, weight: 5},
+      {score: scoreByCategory.performance, weight: 5},
+      {score: scoreByCategory.accessibility, weight: 4},
+    ]);
+    return {score, categories};
+  }
+}
+
+module.exports = ReportGeneratorV2;

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -94,7 +94,9 @@ class Runner {
       // Run each audit sequentially, the auditResults array has all our fine work
       const auditResults = [];
       for (let audit of config.audits) {
+        // support config v2 audit objects
         audit = audit.implementation || audit;
+
         run = run.then(artifacts => {
           return Runner._runAudit(audit, artifacts)
             .then(ret => auditResults.push(ret))
@@ -136,10 +138,11 @@ class Runner {
             a => Aggregate.aggregate(a, runResults.auditResults));
         }
 
-        let categories = [];
+        // compute config v2 categories if available
+        let reportCategories = [];
         if (config.report) {
           const reportGenerator = new ReportGeneratorV2();
-          categories = reportGenerator.generateReportJson(config, resultsById).categories;
+          reportCategories = reportGenerator.generateReportJson(config, resultsById).categories;
         }
 
         return {
@@ -150,7 +153,7 @@ class Runner {
           audits: resultsById,
           artifacts: runResults.artifacts,
           runtimeConfig: Runner.getRuntimeConfig(opts.flags),
-          categories,
+          reportCategories,
           aggregations
         };
       });

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -19,6 +19,7 @@
 const Driver = require('./gather/driver.js');
 const GatherRunner = require('./gather/gather-runner');
 const Aggregate = require('./aggregator/aggregate');
+const ReportGeneratorV2 = require('./report/v2/report-generator');
 const Audit = require('./audits/audit');
 const emulation = require('./lib/emulation');
 const log = require('./lib/log');
@@ -92,7 +93,8 @@ class Runner {
 
       // Run each audit sequentially, the auditResults array has all our fine work
       const auditResults = [];
-      for (const audit of config.audits) {
+      for (let audit of config.audits) {
+        audit = audit.implementation || audit;
         run = run.then(artifacts => {
           return Runner._runAudit(audit, artifacts)
             .then(ret => auditResults.push(ret))
@@ -122,9 +124,9 @@ class Runner {
     // Format and aggregate results before returning.
     run = run
       .then(runResults => {
-        const formattedAudits = runResults.auditResults.reduce((formatted, audit) => {
-          formatted[audit.name] = audit;
-          return formatted;
+        const resultsById = runResults.auditResults.reduce((results, audit) => {
+          results[audit.name] = audit;
+          return results;
         }, {});
 
         // Only run aggregations if needed.
@@ -134,14 +136,21 @@ class Runner {
             a => Aggregate.aggregate(a, runResults.auditResults));
         }
 
+        let categories = [];
+        if (config.report) {
+          const reportGenerator = new ReportGeneratorV2();
+          categories = reportGenerator.generateReportJson(config, resultsById).categories;
+        }
+
         return {
           lighthouseVersion: require('../package').version,
           generatedTime: (new Date()).toJSON(),
           initialUrl: opts.initialUrl,
           url: opts.url,
-          audits: formattedAudits,
+          audits: resultsById,
           artifacts: runResults.artifacts,
           runtimeConfig: Runner.getRuntimeConfig(opts.flags),
+          categories,
           aggregations
         };
       });

--- a/lighthouse-core/test/config/v2/config-test.js
+++ b/lighthouse-core/test/config/v2/config-test.js
@@ -1,0 +1,264 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const ConfigV2 = require('../../../config/v2/config.js');
+const assert = require('assert');
+
+let resets = [];
+
+function deepFreeze(obj) {
+  for (const key in obj) {
+    const value = obj[key];
+    if (value && typeof value === 'object') {
+      obj[key] = deepFreeze(value);
+    }
+  }
+
+  return Object.freeze(obj);
+}
+
+function stub(object, property, retVal) {
+  const args = [];
+  const original = object[property];
+  resets.push({object, property, original});
+  object[property] = function () {
+    args.push(arguments);
+    return typeof retVal === 'function' ?
+        retVal.apply(this, arguments) :
+        retVal;
+  };
+  return args;
+}
+
+function reset() {
+  resets.forEach(reset => {
+    reset.object[reset.property] = reset.original;
+  });
+
+  resets = [];
+}
+
+function emptyConfig() {
+  return {
+    gatherers: {},
+    passes: {},
+    audits: {},
+    report: {},
+  };
+}
+
+describe('ConfigV2', () => {
+
+  afterEach(reset);
+
+  describe('#extendIfNecessary', () => {
+    it('should not extend when extends is not set', () => {
+      const configJson = emptyConfig();
+      const result = ConfigV2.extendIfNecessary(configJson, '');
+      assert.strictEqual(result, configJson);
+    });
+
+    it('should extend when extends lighthouse:default', () => {
+      const gatherers = {myGatherer: {}, websql: {foo: 'bar'}};
+      const configJson = {extends: 'lighthouse:default', gatherers};
+
+      const fakeDefaultConfig = emptyConfig();
+      fakeDefaultConfig.gatherers.websql = {path: 'resolved'};
+      fakeDefaultConfig.asJson = () => fakeDefaultConfig;
+      stub(ConfigV2, '_createInstance', fakeDefaultConfig);
+      const result = ConfigV2.extendIfNecessary(configJson, '');
+
+      assert.deepEqual(result.gatherers.myGatherer, {});
+      assert.equal(result.gatherers.websql.foo, 'bar');
+      assert.equal(result.gatherers.websql.path, 'resolved');
+    });
+
+    it('should extend when extends a file', () => {
+      const gatherers = {myGatherer: {}};
+      const configJson = {extends: '../myfile.json', gatherers};
+
+      const baseConfig = emptyConfig();
+      baseConfig.gatherers.original = {path: 'foo'};
+      baseConfig.asJson = () => baseConfig;
+      stub(ConfigV2, '_tryResolveUntilSuccess', '');
+      stub(ConfigV2, '_require', baseConfig);
+      stub(ConfigV2, '_createInstance', baseConfig);
+      const result = ConfigV2.extendIfNecessary(configJson, '');
+
+      assert.deepEqual(result.gatherers.myGatherer, {});
+      assert.deepEqual(result.gatherers.original, {path: 'foo'});
+    });
+
+    it('should not modify base config JSON');
+    it('should resolve paths at extension stage');
+  });
+
+  describe('#resolvePaths', () => {
+    it('should not attempt to resolve items with an implementation', () => {
+      const implementation = class MyClass {};
+      const object = deepFreeze({mykey: {implementation}});
+      const result = ConfigV2.resolvePaths(object, '');
+      assert.equal(result.mykey.implementation, implementation);
+      assert.equal(result.mykey.path, undefined);
+    });
+
+    it('should resolve items with an explicit path', () => {
+      stub(ConfigV2, '_tryResolveUntilSuccess', 'resolved');
+      const object = deepFreeze({mykey: {path: './special'}});
+      const result = ConfigV2.resolvePaths(object, '');
+      assert.equal(result.mykey.path, 'resolved');
+    });
+
+    it('should resolve items without an explicit path', () => {
+      stub(ConfigV2, '_tryResolveUntilSuccess', 'resolved');
+      const object = deepFreeze({mykey: {}});
+      const result = ConfigV2.resolvePaths(object, '');
+      assert.equal(result.mykey.path, 'resolved');
+    });
+
+    it('should try to resolve items along multiple paths', () => {
+      const resolveArgs = stub(ConfigV2, '_tryResolveUntilSuccess', 'resolved');
+      const object = deepFreeze({mykey: {path: './special'}, other: {}});
+      const result = ConfigV2.resolvePaths(object, '/config/nested', ['/other/path']);
+      assert.equal(result.mykey.path, 'resolved');
+
+      const firstCallPaths = resolveArgs[0][0];
+      assert.equal(firstCallPaths[0], '/other/path/special');
+      assert.equal(firstCallPaths[1], './special');
+      assert.equal(firstCallPaths[2], '/config/nested/special');
+      assert.ok(/lighthouse.*special/.test(firstCallPaths[3]), 'tests cwd');
+
+      const secondCallPaths = resolveArgs[1][0];
+      assert.equal(secondCallPaths[0], '/other/path/other');
+      assert.equal(secondCallPaths[1], 'other');
+      assert.equal(secondCallPaths[2], '/config/nested/other');
+    });
+  });
+
+  describe('#objectToArray', () => {
+    it('should work with empty object', () => {
+      const result = ConfigV2.objectToArray({});
+      assert.deepEqual(result, []);
+    });
+
+    it('should set ids on items', () => {
+      const result = ConfigV2.objectToArray({valA: {}, valB: {}});
+      assert.deepEqual(result, [{id: 'valA'}, {id: 'valB'}]);
+    });
+
+    it('should preserve existing properties', () => {
+      const result = ConfigV2.objectToArray({foo: {path: 'bar'}});
+      assert.deepEqual(result, [{id: 'foo', path: 'bar'}]);
+    });
+  });
+
+  describe('#collectImplementations', () => {
+    it('should require the implemention', () => {
+      const implementation = class MyClass {};
+      const requireArgs = stub(ConfigV2, '_require', () => implementation);
+      const result = ConfigV2.collectImplementations({myclass: {path: 'myclass'}});
+      assert.equal(requireArgs[0][0], 'myclass');
+      assert.deepEqual(result, [{id: 'myclass', path: 'myclass', implementation}]);
+    });
+    it('should not overwrite existing implementations', () => {
+      const implementation = class MyClass {};
+      const requireArgs = stub(ConfigV2, '_require', '');
+      const result = ConfigV2.collectImplementations({myclass: {implementation}});
+      assert.equal(requireArgs.length, 0);
+      assert.deepEqual(result, [{id: 'myclass', implementation}]);
+    });
+  });
+
+  describe('#computePasses', () => {
+    it('should replace gatherers with implementation', () => {
+      const passesObject = {
+        first: {
+          recordTrace: true,
+          gatherers: [
+            'mygatherer'
+          ]
+        },
+        second: {
+          recordNetwork: true,
+          gatherers: [
+            'othergatherer'
+          ]
+        },
+      };
+
+      const implementation = class MyClass {};
+      const gatherers = [
+        {id: 'mygatherer', implementation},
+        {id: 'othergatherer', implementation},
+      ];
+
+      const audits = [{implementation: {meta: {requiredArtifacts: ['MyClass']}}}];
+
+      const result = ConfigV2.computePasses(passesObject, gatherers, audits);
+      assert.equal(result.length, 2);
+      assert.deepEqual(result[0], {
+        id: 'first',
+        recordTrace: true,
+        gatherers: [gatherers[0]]
+      });
+      assert.deepEqual(result[1], {
+        id: 'second',
+        recordNetwork: true,
+        gatherers: [gatherers[1]]
+      });
+    });
+
+    it('should throw when missing a used gatherer', () => {
+      const passesObject = {first: {gatherers: ['huh']}};
+      assert.throws(() => {
+        ConfigV2.computePasses(passesObject, [], []);
+      }, 'Missing required gatherer: huh');
+    });
+  });
+
+  describe('#constructor', () => {
+    let numberOfDefaultAudits = 0;
+    it('should create a default config', () => {
+      const config = new ConfigV2();
+      assert.equal(config.passes.length, 4);
+      assert.ok(config.audits.length > 0, 'has audits');
+      numberOfDefaultAudits = config.audits.length;
+    });
+
+    it('should create a custom config', () => {
+      const configPath = require.resolve('../../fixtures/config-v2/config-v2.json');
+      const configJson = require(configPath);
+      const config = new ConfigV2(configJson, configPath);
+      assert.equal(config.passes.length, 1);
+      assert.equal(config.audits.length, 1);
+    });
+
+    it('should create an extending config', () => {
+      const configJson = {
+        extends: 'lighthouse:default',
+        audits: {
+          'my-audit': {
+            path: require.resolve('../../fixtures/config-v2/my-audit')
+          }
+        }
+      };
+
+      const config = new ConfigV2(configJson);
+      assert.ok(config.audits.length > numberOfDefaultAudits, 'added the audit');
+    });
+  });
+});

--- a/lighthouse-core/test/config/v2/config-test.js
+++ b/lighthouse-core/test/config/v2/config-test.js
@@ -15,12 +15,15 @@
  */
 'use strict';
 
+/* eslint-env mocha */
+
 const ConfigV2 = require('../../../config/v2/config.js');
 const assert = require('assert');
 
 let resets = [];
 
 function deepFreeze(obj) {
+  // eslint-disable-next-line guard-for-in
   for (const key in obj) {
     const value = obj[key];
     if (value && typeof value === 'object') {
@@ -35,10 +38,10 @@ function stub(object, property, retVal) {
   const args = [];
   const original = object[property];
   resets.push({object, property, original});
-  object[property] = function () {
-    args.push(arguments);
+  object[property] = function(...thisArgs) {
+    args.push(thisArgs);
     return typeof retVal === 'function' ?
-        retVal.apply(this, arguments) :
+        retVal.apply(this, thisArgs) :
         retVal;
   };
   return args;
@@ -62,7 +65,6 @@ function emptyConfig() {
 }
 
 describe('ConfigV2', () => {
-
   afterEach(reset);
 
   describe('#extendIfNecessary', () => {

--- a/lighthouse-core/test/fixtures/config-v2/config-v2.json
+++ b/lighthouse-core/test/fixtures/config-v2/config-v2.json
@@ -1,0 +1,27 @@
+{
+  "gatherers": {
+    "my-gatherer": {
+      "path": "./my-gatherer.js"
+    }
+  },
+  "audits": {
+    "my-audit": {
+      "path": "./my-audit.js"
+    }
+  },
+  "passes": {
+    "first": {
+      "gatherers": ["my-gatherer"]
+    }
+  },
+  "report": {
+    "categories": {
+      "custom": {
+        "name": "Custom Category",
+        "children": [
+          {"id": "my-audit", "weight": 1}
+        ]
+      }
+    }
+  }
+}

--- a/lighthouse-core/test/fixtures/config-v2/my-audit.js
+++ b/lighthouse-core/test/fixtures/config-v2/my-audit.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class MyAudit {
   static get meta() {
     return {

--- a/lighthouse-core/test/fixtures/config-v2/my-audit.js
+++ b/lighthouse-core/test/fixtures/config-v2/my-audit.js
@@ -1,0 +1,14 @@
+class MyAudit {
+  static get meta() {
+    return {
+      name: 'my-audit',
+      requiredArtifacts: ['MyGatherer']
+    };
+  }
+
+  static audit() {
+
+  }
+}
+
+module.exports = MyAudit;

--- a/lighthouse-core/test/fixtures/config-v2/my-gatherer.js
+++ b/lighthouse-core/test/fixtures/config-v2/my-gatherer.js
@@ -1,0 +1,7 @@
+class MyGatherer {
+  pass() {
+
+  }
+}
+
+module.exports = MyGatherer;

--- a/lighthouse-core/test/fixtures/config-v2/my-gatherer.js
+++ b/lighthouse-core/test/fixtures/config-v2/my-gatherer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class MyGatherer {
   pass() {
 


### PR DESCRIPTION
Implements the base functionality for the move to config v2 upon which all other features for the new format can be implemented.

[design doc](https://docs.google.com/document/d/1cN_m591PAQF4tkEf5nJ5M93pI2tM_U64XolmwpOuiUU/edit?usp=sharing)
related #1874 #1875 #1876 #1463 #1826

Missing because WIP (will be fixed before merge):
- ~category description text~
- ~jsdocs~
- ~tests~
- consensus :)

Missing because MVP:
- settings object
- audit/gatherer options
- customizable scoring functions (both proposed are already implemented just hardcoded atm)
- handling of auditResults/artifacts/trace files, planned to be split from config entirely in v2

Current look:

![image](https://cloud.githubusercontent.com/assets/2301202/24122341/b8a4203c-0d78-11e7-9827-47953e833b80.png)
