### PR TITLE
Add properties to Results interface

### DIFF
--- a/lighthouse-cli/types/types.ts
+++ b/lighthouse-cli/types/types.ts
@@ -45,6 +45,8 @@ interface Results {
   audits: Object;
   lighthouseVersion: string;
   artifacts?: Object;
+  initialUrl: string;
+  generatedTime: string;
 }
 
 export {


### PR DESCRIPTION
Since results contains 
```js
{
  "lighthouseVersion": "1.6.0",
  "generatedTime": "2017-03-21T07:57:38.994Z",
  "initialUrl": "http://example.com",
  "url": "http://example.com/",
  "audits": {
  ...
```

it will be nice to have `initialUrl` and `generatedTime`. We wanna reuse types form `lighthouse` in scope of `pwmetrics` :)