### PR TITLE
CLI: remove npm prepublish

### DIFF
--- a/lighthouse-cli/compiled-check.js
+++ b/lighthouse-cli/compiled-check.js
@@ -6,7 +6,7 @@ const path = require('path');
 module.exports = function(filename) {
   if (!fs.existsSync(path.join(__dirname, filename))) {
     console.log('Oops! Looks like the CLI needs to be compiled. Please run:');
-    console.log('   npm run build-cli');
+    console.log('   npm run install-cli');
     console.log('More at: https://github.com/GoogleChrome/lighthouse#develop');
     process.exit(1);
   }

--- a/lighthouse-cli/compiled-check.js
+++ b/lighthouse-cli/compiled-check.js
@@ -6,7 +6,7 @@ const path = require('path');
 module.exports = function(filename) {
   if (!fs.existsSync(path.join(__dirname, filename))) {
     console.log('Oops! Looks like the CLI needs to be compiled. Please run:');
-    console.log('   npm run install-cli');
+    console.log('   npm run build-cli');
     console.log('More at: https://github.com/GoogleChrome/lighthouse#develop');
     process.exit(1);
   }

--- a/lighthouse-cli/package.json
+++ b/lighthouse-cli/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "prepublish": "npm run build",
     "build": "tsc",
     "dev": "tsc -w"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "install-all": "npm run install-cli && npm run install-extension && npm run install-viewer",
-    "install-cli": "cd ./lighthouse-cli && npm install",
+    "install-cli": "cd ./lighthouse-cli && npm install && npm build",
     "install-extension": "cd ./lighthouse-extension && npm install",
     "install-viewer": "cd ./lighthouse-viewer && npm install",
     "build-all": "gulp && npm run build-cli && npm run build-extension && npm run build-viewer",


### PR DESCRIPTION
Fixes #1516

R: all

Finally getting rid of this. It's deprecated in npm 5 and we have convenient build scripts now.