### PR TITLE
handle driver.getObjectProperty results with no value property

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -496,7 +496,7 @@ class Driver {
   * @return {!Promise<string>} The property value, or null, if property not found
   */
   getObjectProperty(objectId, propName) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       this.sendCommand('Runtime.getProperties', {
         objectId,
         accessorPropertiesOnly: true,
@@ -507,12 +507,12 @@ class Driver {
         const propertyForName = properties.result
           .find(property => property.name === propName);
 
-        if (propertyForName) {
+        if (propertyForName && propertyForName.value) {
           resolve(propertyForName.value.value);
         } else {
           resolve(null);
         }
-      });
+      }).catch(reject);
     });
   }
 

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -74,6 +74,8 @@ connection.sendCommand = function(command, params) {
           value: {
             value: '123'
           }
+        }, {
+          name: 'novalue'
         }]
       });
     case 'Page.enable':
@@ -139,7 +141,13 @@ describe('Browser Driver', () => {
   });
 
   it('returns null when getObjectProperty finds no property name', () => {
-    return driverStub.getObjectProperty('invalid', 'invalid').catch(value => {
+    return driverStub.getObjectProperty('invalid', 'invalid').then(value => {
+      assert.deepEqual(value, null);
+    });
+  });
+
+  it('returns null when getObjectProperty finds property name with no value', () => {
+    return driverStub.getObjectProperty('test', 'novalue').then(value => {
       assert.deepEqual(value, null);
     });
   });


### PR DESCRIPTION
fixes #1891

`Runtime.getProperties` returns properties that, even if they're defined [might not have a value](https://chromedevtools.github.io/debugger-protocol-viewer/tot/Runtime/#type-PropertyDescriptor). This just returns null in that case. As mentioned in #1891, I'm not really sure why no value is being returned in this particular case, since no site I've seen has demonstrated this problem before. We may want to hold off on merging until we figure out the underlying cause so e.g. we could put a link like that into the smoke tests.

Also puts any thrown errors (or rejected promises) from the promise chain starting with `this.sendCommand` back into the main promise chain.