### PR TITLE
Report: Make Offscreen images informative, consistency cleanup

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -39,6 +39,7 @@ class OffscreenImages extends Audit {
       category: 'Images',
       name: 'offscreen-images',
       description: 'Offscreen images',
+      informative: true,
       helpText: 'Images that are not above the fold should be lazily loaded after the page is ' +
         'interactive. Consider using the [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) API.',
       requiredArtifacts: ['ImageUsage', 'ViewportDimensions', 'traces', 'networkRecords']

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -38,7 +38,7 @@ class UsesResponsiveImages extends Audit {
     return {
       category: 'Images',
       name: 'uses-responsive-images',
-      description: 'Oversized Images',
+      description: 'Oversized images',
       informative: true,
       helpText:
         'Image sizes served should be based on the device display size to save network bytes. ' +

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -40,7 +40,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
     return {
       category: 'Performance',
       name: 'link-blocking-first-paint',
-      description: 'Render-blocking Stylesheets',
+      description: 'Render-blocking stylesheets',
       informative: true,
       helpText: 'Link elements are blocking the first paint of your page. Consider ' +
           'inlining critical links and deferring non-critical ones. ' +

--- a/lighthouse-core/config/default.json
+++ b/lighthouse-core/config/default.json
@@ -576,12 +576,12 @@
     "categorizable": false,
     "items": [{
       "audits": {
-        "unused-css-rules": {
-          "expectedValue": true,
+        "total-byte-weight": {
+          "expectedValue": 100,
           "weight": 1
         },
-        "offscreen-images": {
-          "expectedValue": true,
+        "dom-size": {
+          "expectedValue": 100,
           "weight": 1
         },
         "uses-optimized-images": {
@@ -592,7 +592,11 @@
           "expectedValue": true,
           "weight": 1
         },
-        "critical-request-chains": {
+        "offscreen-images": {
+          "expectedValue": true,
+          "weight": 1
+        },
+         "unused-css-rules": {
           "expectedValue": true,
           "weight": 1
         },
@@ -604,12 +608,8 @@
           "expectedValue": true,
           "weight": 1
         },
-        "total-byte-weight": {
-          "expectedValue": 100,
-          "weight": 1
-        },
-        "dom-size": {
-          "expectedValue": 100,
+         "critical-request-chains": {
+          "expectedValue": true,
           "weight": 1
         },
         "user-timings": {


### PR DESCRIPTION
R: @patrickhulce, all

Bit consistency cleanup and rearranging.
 
- Made the offrescreen audit information to be consistent with the rest of the section.
- sentenced-cased a few audit descriptions
- related perf audits now sit together (stylesheets with css, image audits with other image audits)
- moved scored audits to top. Peeps 💘  dem scores.

Now:

![screen shot 2017-03-23 at 12 24 36 pm](https://cloud.githubusercontent.com/assets/238208/24266373/c092fc30-0fc3-11e7-8646-f9c5415d493e.png)
