### PR TITLE
Offline audit: add warning if initial url != final url

### DIFF
--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -30,7 +30,7 @@ class WorksOffline extends Audit {
       helpText: 'If you\'re building a Progressive Web App, consider using a service worker so ' +
           'that your app can work offline. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).',
-      requiredArtifacts: ['Offline']
+      requiredArtifacts: ['Offline', 'URL']
     };
   }
 
@@ -39,8 +39,16 @@ class WorksOffline extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
+    let debugString;
+    if (artifacts.URL.initialUrl !== artifacts.URL.finalUrl) {
+      debugString = 'WARNING: You may be failing this check because your test URL ' +
+          `(${artifacts.URL.initialUrl}) was redirected to ${artifacts.URL.finalUrl}. ` +
+          'Try testing the second URL directly.';
+    }
+
     return {
-      rawValue: artifacts.Offline === 200
+      rawValue: artifacts.Offline === 200,
+      debugString
     };
   }
 }

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -16,6 +16,7 @@
  */
 'use strict';
 
+const URL = require('../lib/url-shim');
 const Audit = require('./audit');
 
 class WorksOffline extends Audit {
@@ -40,9 +41,9 @@ class WorksOffline extends Audit {
    */
   static audit(artifacts) {
     let debugString;
-    if (artifacts.URL.initialUrl !== artifacts.URL.finalUrl) {
+    if (!URL.equalWithExcludedFragments(artifacts.URL.initialUrl, artifacts.URL.finalUrl)) {
       debugString = 'WARNING: You may be failing this check because your test URL ' +
-          `(${artifacts.URL.initialUrl}) was redirected to ${artifacts.URL.finalUrl}. ` +
+          `(${artifacts.URL.initialUrl}) was redirected to "${artifacts.URL.finalUrl}". ` +
           'Try testing the second URL directly.';
     }
 

--- a/lighthouse-core/test/audits/works-offline-test.js
+++ b/lighthouse-core/test/audits/works-offline-test.js
@@ -18,18 +18,38 @@
 const Audit = require('../../audits/works-offline.js');
 const assert = require('assert');
 
-/* global describe, it*/
+/* eslint-env mocha */
+
+const URL = 'https://www.chromestatus.com';
 
 describe('Offline: works-offline audit', () => {
   it('correctly audits a 200 code', () => {
-    const output = Audit.audit({Offline: 200});
+    const output = Audit.audit({
+      Offline: 200,
+      URL: {initialUrl: URL, finalUrl: URL}
+    });
 
-    return assert.equal(output.rawValue, true);
+    assert.equal(output.rawValue, true);
+    assert.ok(!output.debugString);
+  });
+
+  it('warns if initial url does not match final url', () => {
+    const output = Audit.audit({
+      Offline: 200,
+      URL: {initialUrl: URL, finalUrl: '${URL}/features'}
+    });
+
+    assert.equal(output.rawValue, true);
+    assert.ok(output.debugString);
   });
 
   it('correctly audits a non-200 code', () => {
-    const output = Audit.audit({Offline: 203});
+    const output = Audit.audit({
+      Offline: 203,
+      URL: {initialUrl: URL, finalUrl: URL}
+    });
 
-    return assert.equal(output.rawValue, false);
+    assert.equal(output.rawValue, false);
+    assert.ok(!output.debugString);
   });
 });

--- a/lighthouse-core/test/audits/works-offline-test.js
+++ b/lighthouse-core/test/audits/works-offline-test.js
@@ -36,7 +36,7 @@ describe('Offline: works-offline audit', () => {
   it('warns if initial url does not match final url', () => {
     const output = Audit.audit({
       Offline: 200,
-      URL: {initialUrl: URL, finalUrl: '${URL}/features'}
+      URL: {initialUrl: URL, finalUrl: `${URL}/features`}
     });
 
     assert.equal(output.rawValue, true);


### PR DESCRIPTION
R: @brendankenny all

Fixes #715. I ran into this when debugging and was very confused.  Especially since the report header shows the `finalUrl` and we never tell the user there was a redirect.

https://github.com/GoogleChrome/lighthouse/issues/1917 is still open to message a top-level waring if initial url != final url.

Test with: 
```
# no warning
npm run fast -- --output=html --view https://www.chromestatus.com/features
# warning
npm run fast -- --output=html --view https://www.chromestatus.com
```