### PR TITLE
Measure and visualize perf metrics

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -21,3 +21,6 @@ lighthouse-cli/types/*.js
 # Handlebar-templates
 lighthouse-core/report/templates/report-templates.js
 lighthouse-core/report/partials/templates/report-partials.js
+
+# Generated files
+plots/out/**

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ lighthouse-cli/types/*.map
 
 lighthouse-core/report/partials/templates/
 lighthouse-core/report/templates/*.js
+
+plots/out/

--- a/.npmignore
+++ b/.npmignore
@@ -27,6 +27,8 @@ lighthouse-cli/types/*.map
 node_modules/
 results/
 
+plots/
+
 # generated files
 **/pages/scripts/lighthouse-report.js
 *.report.html

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -175,6 +175,7 @@ class TTIMetric extends Audit {
         throw new Error('No firstMeaningfulPaint event found in trace');
       }
 
+      const onLoadTiming = tabTrace.timings.onLoad;
       const fmpTiming = tabTrace.timings.firstMeaningfulPaint;
       const traceEndTiming = tabTrace.timings.traceEnd;
 
@@ -214,6 +215,7 @@ class TTIMetric extends Audit {
 
       const extendedInfo = {
         timings: {
+          onLoad: onLoadTiming,
           fMP: parseFloat(fmpTiming.toFixed(3)),
           visuallyReady: parseFloat(visuallyReadyTiming.toFixed(3)),
           timeToInteractive: parseFloat(timeToInteractive.timeInMs.toFixed(3)),
@@ -222,6 +224,7 @@ class TTIMetric extends Audit {
           endOfTrace: traceEndTiming,
         },
         timestamps: {
+          onLoad: (onLoadTiming + navStartTsInMS) * 1000,
           fMP: fMPtsInMS * 1000,
           visuallyReady: (visuallyReadyTiming + navStartTsInMS) * 1000,
           timeToInteractive: (timeToInteractive.timeInMs + navStartTsInMS) * 1000,

--- a/lighthouse-core/config/plots.json
+++ b/lighthouse-core/config/plots.json
@@ -1,0 +1,16 @@
+{
+  "passes": [{
+    "recordNetwork": true,
+    "recordTrace": true,
+    "pauseBeforeTraceEndMs": 5000,
+    "useThrottling": true,
+    "gatherers": []
+  }],
+
+  "audits": [
+    "first-meaningful-paint",
+    "speed-index-metric",
+    "estimated-input-latency",
+    "time-to-interactive"
+  ]
+}

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -46,6 +46,7 @@ class TraceOfTab extends ComputedArtifact {
       .filter(e => {
         return e.cat.includes('blink.user_timing') ||
           e.cat.includes('loading') ||
+          e.cat.includes('devtools.timeline') ||
           e.name === 'TracingStartedInPage';
       })
       .sort((event0, event1) => event0.ts - event1.ts);
@@ -87,6 +88,8 @@ class TraceOfTab extends ComputedArtifact {
       firstMeaningfulPaint = lastCandidate;
     }
 
+    const onLoad = keyEvents.find(e => e.name === 'MarkLoad' && e.ts > navigationStart.ts);
+
     // subset all trace events to just our tab's process (incl threads other than main)
     const processEvents = trace.traceEvents
       .filter(e => e.pid === startedInPageEvt.pid)
@@ -102,6 +105,7 @@ class TraceOfTab extends ComputedArtifact {
       firstContentfulPaint,
       firstMeaningfulPaint,
       traceEnd,
+      onLoad,
     };
 
     const timings = {};
@@ -121,6 +125,7 @@ class TraceOfTab extends ComputedArtifact {
       firstPaintEvt: firstPaint,
       firstContentfulPaintEvt: firstContentfulPaint,
       firstMeaningfulPaintEvt: firstMeaningfulPaint,
+      onLoadEvt: onLoad,
     };
   }
 }

--- a/lighthouse-core/lib/traces/pwmetrics-events.js
+++ b/lighthouse-core/lib/traces/pwmetrics-events.js
@@ -18,6 +18,22 @@
 
 const log = require('../../../lighthouse-core/lib/log.js');
 
+/**
+ * @param {!Object} object
+ * @param {string} path
+ * @return {*}
+ */
+function safeGet(object, path) {
+  const components = path.split('.');
+  for (const component of components) {
+    if (!object) {
+      return null;
+    }
+    object = object[component];
+  }
+  return object;
+}
+
 class Metrics {
   constructor(traceEvents, auditResults) {
     this._traceEvents = traceEvents;
@@ -35,81 +51,145 @@ class Metrics {
         id: 'navstart',
         getTs: auditResults => {
           const fmpExt = auditResults['first-meaningful-paint'].extendedInfo;
-          return fmpExt.value.timestamps.navStart;
+          return safeGet(fmpExt, 'value.timestamps.navStart');
         },
+        getTiming: auditResults => {
+          const fmpExt = auditResults['first-meaningful-paint'].extendedInfo;
+          return safeGet(fmpExt, 'value.timings.navStart');
+        }
       },
       {
         name: 'First Contentful Paint',
         id: 'ttfcp',
         getTs: auditResults => {
           const fmpExt = auditResults['first-meaningful-paint'].extendedInfo;
-          return fmpExt.value.timestamps.fCP;
+          return safeGet(fmpExt, 'value.timestamps.fCP');
         },
+        getTiming: auditResults => {
+          const fmpExt = auditResults['first-meaningful-paint'].extendedInfo;
+          return safeGet(fmpExt, 'value.timings.fCP');
+        }
       },
       {
         name: 'First Meaningful Paint',
         id: 'ttfmp',
         getTs: auditResults => {
           const fmpExt = auditResults['first-meaningful-paint'].extendedInfo;
-          return fmpExt.value.timestamps.fMP;
+          return safeGet(fmpExt, 'value.timestamps.fMP');
         },
+        getTiming: auditResults => {
+          const fmpExt = auditResults['first-meaningful-paint'].extendedInfo;
+          return safeGet(fmpExt, 'value.timings.fMP');
+        }
       },
       {
         name: 'Perceptual Speed Index',
         id: 'psi',
         getTs: auditResults => {
           const siExt = auditResults['speed-index-metric'].extendedInfo;
-          return siExt.value.timestamps.perceptualSpeedIndex;
+          return safeGet(siExt, 'value.timestamps.perceptualSpeedIndex');
         },
+        getTiming: auditResults => {
+          const siExt = auditResults['speed-index-metric'].extendedInfo;
+          return safeGet(siExt, 'value.timings.perceptualSpeedIndex');
+        }
       },
       {
         name: 'First Visual Change',
         id: 'fv',
         getTs: auditResults => {
           const siExt = auditResults['speed-index-metric'].extendedInfo;
-          return siExt.value.timestamps.firstVisualChange;
+          return safeGet(siExt, 'value.timestamps.firstVisualChange');
         },
+        getTiming: auditResults => {
+          const siExt = auditResults['speed-index-metric'].extendedInfo;
+          return safeGet(siExt, 'value.timings.firstVisualChange');
+        }
       },
       {
         name: 'Visually Complete 85%',
         id: 'vc85',
         getTs: auditResults => {
           const siExt = auditResults['time-to-interactive'].extendedInfo;
-          return siExt.value.timestamps.visuallyReady;
+          return safeGet(siExt, 'value.timestamps.visuallyReady');
         },
+        getTiming: auditResults => {
+          const siExt = auditResults['time-to-interactive'].extendedInfo;
+          return safeGet(siExt, 'value.timings.visuallyReady');
+        }
       },
       {
         name: 'Visually Complete 100%',
         id: 'vc100',
         getTs: auditResults => {
           const siExt = auditResults['speed-index-metric'].extendedInfo;
-          return siExt.value.timestamps.visuallyComplete;
+          return safeGet(siExt, 'value.timestamps.visuallyComplete');
         },
+        getTiming: auditResults => {
+          const siExt = auditResults['speed-index-metric'].extendedInfo;
+          return safeGet(siExt, 'value.timings.visuallyComplete');
+        }
       },
       {
         name: 'Time to Interactive (vAlpha)',
         id: 'tti',
         getTs: auditResults => {
           const ttiExt = auditResults['time-to-interactive'].extendedInfo;
-          return ttiExt.value.timestamps.timeToInteractive;
+          return safeGet(ttiExt, 'value.timestamps.timeToInteractive');
         },
+        getTiming: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return safeGet(ttiExt, 'value.timings.timeToInteractive');
+        }
       },
       {
         name: 'Time to Interactive (vAlpha non-visual)',
         id: 'tti-non-visual',
         getTs: auditResults => {
           const ttiExt = auditResults['time-to-interactive'].extendedInfo;
-          return ttiExt.value.timestamps.timeToInteractiveB;
+          return safeGet(ttiExt, 'value.timestamps.timeToInteractiveB');
         },
+        getTiming: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return safeGet(ttiExt, 'value.timings.timeToInteractiveB');
+        }
       },
       {
         name: 'Time to Interactive (vAlpha non-visual, 5s)',
         id: 'tti-non-visual-5s',
         getTs: auditResults => {
           const ttiExt = auditResults['time-to-interactive'].extendedInfo;
-          return ttiExt.value.timestamps.timeToInteractiveC;
+          return safeGet(ttiExt, 'value.timestamps.timeToInteractiveC');
         },
+        getTiming: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return safeGet(ttiExt, 'value.timings.timeToInteractiveC');
+        }
       },
+      {
+        name: 'End of Trace',
+        id: 'eot',
+        getTs: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return safeGet(ttiExt, 'value.timestamps.endOfTrace');
+        },
+        getTiming: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return safeGet(ttiExt, 'value.timings.endOfTrace');
+        }
+      },
+      {
+        name: 'On Load',
+        id: 'onload',
+        getTs: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return safeGet(ttiExt, 'value.timestamps.onLoad');
+        },
+        getTiming: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return safeGet(ttiExt, 'value.timings.onLoad');
+        }
+      }
     ];
   }
 

--- a/lighthouse-core/test/fixtures/dbw_tester-perf-results.json
+++ b/lighthouse-core/test/fixtures/dbw_tester-perf-results.json
@@ -113,6 +113,7 @@
       "extendedInfo": {
         "value": {
           "timings": {
+            "onLoad": 2956.185,
             "fMP": 2946.14,
             "visuallyReady": 2955.548,
             "timeToInteractive": 2955.548,
@@ -121,6 +122,7 @@
             "endOfTrace": 8471.488999843597
           },
           "timestamps": {
+            "onLoad": 1082005348861.9999,
             "fMP": 1082005338816.9999,
             "visuallyReady": 1082005348224.9999,
             "timeToInteractive": 1082005348224.9999,

--- a/lighthouse-core/test/lib/traces/pwmetrics-events-test.js
+++ b/lighthouse-core/test/lib/traces/pwmetrics-events-test.js
@@ -27,7 +27,7 @@ const dbwResults = require('../../fixtures/dbw_tester-perf-results.json');
 /* eslint-env mocha */
 describe('metrics events class', () => {
   it('exposes metric definitions', () => {
-    assert.equal(Metrics.metricsDefinitions.length, 10, '10 metrics not exposed');
+    assert.equal(Metrics.metricsDefinitions.length, 11, '11 metrics not exposed');
   });
 
   it('generates fake trace events', () => {

--- a/lighthouse-core/test/lib/traces/pwmetrics-events-test.js
+++ b/lighthouse-core/test/lib/traces/pwmetrics-events-test.js
@@ -23,11 +23,10 @@ const assert = require('assert');
 const dbwTrace = require('../../fixtures/traces/dbw_tester.json');
 const dbwResults = require('../../fixtures/dbw_tester-perf-results.json');
 
-
 /* eslint-env mocha */
 describe('metrics events class', () => {
   it('exposes metric definitions', () => {
-    assert.equal(Metrics.metricsDefinitions.length, 11, '11 metrics not exposed');
+    assert.equal(Metrics.metricsDefinitions.length, 12, '12 metrics not exposed');
   });
 
   it('generates fake trace events', () => {

--- a/plots/README.md
+++ b/plots/README.md
@@ -1,0 +1,27 @@
+# Lighthouse Metrics Analysis
+
+For context and roadmap, please see issue:
+https://github.com/GoogleChrome/lighthouse/issues/1924
+
+## Workflow
+
+### Setup
+
+You need to build lighthouse first.
+
+### Commands
+
+```
+# View all commands
+$ cd plots
+$ npm run
+
+# Run lighthouse to collect metrics data
+$ npm run measure
+
+# Analyze the data to generate a summary file (i.e. out/generatedResults.js)
+$ npm run analyze
+
+# View visualization
+# Open index.html in browser
+```

--- a/plots/analyze.js
+++ b/plots/analyze.js
@@ -86,7 +86,7 @@ function readResult(lighthouseReportPath) {
 }
 
 /**
- * Aggregates sites results by performance metric because it's
+ * Aggregates site results by performance metric because it's
  * informative to compare a suite of sites for a particular metric.
  * @param {!Array<!SiteResults>} results
  * @return {!ResultsByMetric}

--- a/plots/analyze.js
+++ b/plots/analyze.js
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const constants = require('./constants');
+const utils = require('./utils');
+const Metrics = require('../lighthouse-core/lib/traces/pwmetrics-events');
+
+const GENERATED_RESULTS_PATH = path.resolve(constants.OUT_PATH, 'generatedResults.js');
+const LIGHTHOUSE_REPORT_FILENAME = 'lighthouse.json';
+
+/**
+ * Analyzes output generated from the measure step and
+ * generates a summary file for consumption by chart.js.
+ */
+function main() {
+  const allResults = [];
+  fs.readdirSync(constants.OUT_PATH).forEach(siteDir => {
+    const sitePath = path.resolve(constants.OUT_PATH, siteDir);
+    if (!utils.isDir(sitePath)) {
+      return;
+    }
+    allResults.push({site: siteDir, results: analyzeSite(sitePath)});
+  });
+  const generatedResults = groupByMetrics(allResults);
+  fs.writeFileSync(
+    GENERATED_RESULTS_PATH,
+    `var generatedResults = ${JSON.stringify(generatedResults)}`
+  );
+}
+
+main();
+
+/**
+ * Aggregates all the run results for a particular site.
+ * @param {string} sitePath
+ * @return {!RunResults}
+ */
+function analyzeSite(sitePath) {
+  console.log('Analyzing', sitePath); // eslint-disable-line no-console
+  const runResults = [];
+  fs.readdirSync(sitePath).forEach(runDir => {
+    const lighthouseReportPath = path.resolve(sitePath, runDir, LIGHTHOUSE_REPORT_FILENAME);
+    if (!utils.isFile(lighthouseReportPath)) {
+      return;
+    }
+    const metrics = readResult(lighthouseReportPath);
+    console.log(`Metric for ${runDir}: ${JSON.stringify(metrics)}`); // eslint-disable-line no-console
+    runResults[runDir] = {
+      runId: runDir,
+      metrics
+    };
+  });
+  return runResults;
+}
+
+/**
+ * Extracts the metrics data from a lighthouse json report.
+ * @param {string} resultPath
+ * @return {!Array<!Metric>}
+ */
+function readResult(lighthouseReportPath) {
+  const data = JSON.parse(fs.readFileSync(lighthouseReportPath));
+  return Metrics.metricsDefinitions.map(metric => ({
+    name: metric.name,
+    id: metric.id,
+    timing: metric.getTiming(data.audits)
+  }));
+}
+
+/**
+ * Aggregates sites results by performance metric because it's
+ * informative to compare a suite of sites for a particular metric.
+ * @param {!Array<!SiteResults>} results
+ * @return {!ResultsByMetric}
+ */
+function groupByMetrics(results) {
+  return Metrics.metricsDefinitions.map(metric => metric.name).reduce((acc, metricName, index) => {
+    acc[metricName] = results.map(siteResult => ({
+      site: siteResult.site,
+      metrics: siteResult.results.map(runResult => ({
+        timing: runResult.metrics[index].timing
+      }))
+    }));
+    return acc;
+  }, {});
+}
+
+/**
+ * @typedef {{site: string, results: !RunResults}}
+ */
+let SiteResults; // eslint-disable-line no-unused-vars
+
+/**
+ * @typedef {!Array<{runId: string, metrics: !Array<!Metric>}>}
+ */
+let RunResults; // eslint-disable-line no-unused-vars
+
+/**
+ * @typedef {{name: string, id: string, timing: number}}
+ */
+let Metric; // eslint-disable-line no-unused-vars
+
+/**
+ * @typedef {!Object<string, !Array<{site: string, metrics: !Array<{timing: number}>}>}
+ */
+let ResultsByMetric; // eslint-disable-line no-unused-vars

--- a/plots/chart.js
+++ b/plots/chart.js
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* global Plotly, generatedResults */
+/* eslint-env browser */
+
+const IGNORED_METRICS = ['Navigation Start'];
+
+let elementId = 1;
+
+/**
+ * Incrementally renders the plot, otherwise it hangs the browser
+ * because it's generating so many charts.
+ */
+const queuedPlots = [];
+function enqueuePlot(fn) {
+  const isFirst = queuedPlots.length == 0;
+  queuedPlots.push(fn);
+  if (isFirst) {
+    renderPlots();
+  }
+}
+function renderPlots() {
+  window.requestAnimationFrame(_ => {
+    const plotFn = queuedPlots.shift();
+    if (plotFn) {
+      plotFn();
+      renderPlots();
+    }
+  });
+}
+
+/**
+ * Generates a blox plot chart for each performance metric.
+ * If there's a lot of sites, it renders them in separate charts
+ * otherwise it's too hard to read the chart.
+ */
+function generateBoxPlotChartPerMetric() {
+  for (const metric in generatedResults) {
+    if (IGNORED_METRICS.indexOf(metric) !== -1) {
+      continue;
+    }
+    generateBoxPlotChartByBatch({metric, type: 'timing'});
+  }
+
+  function generateBoxPlotChartByBatch({metric, type}) {
+    const width = 30;
+    for (let i = 0; i < generatedResults[metric].length; i += width) {
+      generateBoxPlotChart({
+        title: metric,
+        data: generatedResults[metric].slice(i, i + width),
+        type: type
+      });
+    }
+  }
+
+  function generateBoxPlotChart({title, data, type}) {
+    data = data
+      .map(siteResult => {
+        return {
+          x: siteResult.metrics.map(m => m ? m[type] : null),
+          type: 'box',
+          name: siteResult.site,
+          boxpoints: 'all',
+          jitter: 0.9,
+          pointpos: -2,
+          hoverinfo: 'x+name'
+        };
+      })
+      .reverse(); // see: https://github.com/plotly/plotly.js/issues/1187
+
+    const layout = {
+      title: title + ' ' + type,
+      legend: {
+        traceorder: 'reversed'
+      },
+      xaxis: {
+        rangemode: 'tozero'
+      },
+      margin: {
+        l: 150
+      }
+    };
+    enqueuePlot(_ => {
+      Plotly.newPlot(createChartElement(1000), data, layout);
+    });
+  }
+}
+
+/**
+ * Generates a line plot chart for each performance metric.
+ * If there's a lot of sites, it renders them in separate charts
+ * otherwise it's too hard to read the chart.
+ */
+function generateLinePlotChartPerMetric() {
+  for (const metric in generatedResults) {
+    if (IGNORED_METRICS.indexOf(metric) !== -1) {
+      continue;
+    }
+    generateLinePlotByBatch({metric, type: 'timing'});
+  }
+
+  function generateLinePlotByBatch({metric, type}) {
+    const width = 20;
+    for (let i = 0; i < generatedResults[metric].length; i += width) {
+      generateLinePlot({
+        title: metric,
+        data: generatedResults[metric].slice(i, i + width),
+        type: type
+      });
+    }
+  }
+
+  function generateLinePlot({title, data, type}) {
+    data = data.map(siteResult => ({
+      name: siteResult.site,
+      y: siteResult.metrics.map(m => m ? m[type] : null),
+      type: 'scatter'
+    }));
+
+    const layout = {
+      title: title + ' ' + type,
+      yaxis: {
+        rangemode: 'tozero'
+      }
+    };
+    enqueuePlot(_ => {
+      Plotly.newPlot(createChartElement(), data, layout);
+    });
+  }
+}
+
+function createChartElement(height = 800) {
+  const div = document.createElement('div');
+  div.style = `width: 100%; height: ${height}px`;
+  div.id = 'chart' + elementId++;
+  document.body.appendChild(div);
+  return div.id;
+}
+
+generateBoxPlotChartPerMetric();
+generateLinePlotChartPerMetric();

--- a/plots/clean.js
+++ b/plots/clean.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const rimraf = require('rimraf');
+
+const constants = require('./constants');
+
+rimraf.sync(constants.OUT_PATH);

--- a/plots/constants.js
+++ b/plots/constants.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const path = require('path');
+
+const OUT_PATH = path.resolve(__dirname, 'out');
+
+module.exports = {
+  OUT_PATH
+};

--- a/plots/index.html
+++ b/plots/index.html
@@ -1,0 +1,29 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!doctype html>
+<html>
+
+<head>
+  <script src="https://cdn.plot.ly/plotly-1.25.2.min.js"></script>
+</head>
+
+<body>
+  <script src="./out/generatedResults.js"></script>
+  <script src="./chart.js"></script>
+</body>
+
+</html>

--- a/plots/measure.js
+++ b/plots/measure.js
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const path = require('path');
+const parseURL = require('url').parse;
+
+const mkdirp = require('mkdirp');
+
+const constants = require('./constants.js');
+const utils = require('./utils.js');
+const config = require('../lighthouse-core/config/plots.json');
+const lighthouse = require('../lighthouse-core/index.js');
+const ChromeLauncher = require('../lighthouse-cli/chrome-launcher.js').ChromeLauncher;
+const Printer = require('../lighthouse-cli/printer');
+const assetSaver = require('../lighthouse-core/lib/asset-saver.js');
+
+const NUMBER_OF_RUNS = 20;
+
+const URLS = [
+  // Flagship sites
+  'https://nytimes.com',
+  'https://flipkart.com',
+  'http://www.espn.com/',
+  'https://www.washingtonpost.com/pwa/',
+
+  // TTI Tester sites
+  'https://housing.com/in/buy/real-estate-hyderabad',
+  'http://www.npr.org/',
+  'http://www.vevo.com/',
+  'https://weather.com/',
+  'https://www.nasa.gov/',
+  'https://vine.co/',
+  'http://www.booking.com/',
+  'http://www.thestar.com.my',
+  'http://www.58pic.com',
+  'http://www.dawn.com/',
+  'https://www.ebs.in/IPS/',
+
+  // Sourced from: https://en.wikipedia.org/wiki/List_of_most_popular_websites
+  // (http://www.alexa.com/topsites)
+  // Removed adult websites and duplicates (e.g. google int'l websites)
+  // Also removed sites that don't have significant index pages:
+  // "t.co", "popads.net", "onclickads.net", "microsoftonline.com", "onclckds.com", "cnzz.com",
+  // "live.com", "adf.ly", "googleusercontent.com",
+
+  'https://google.com',
+  'https://youtube.com',
+  'https://facebook.com',
+  'https://baidu.com',
+  'https://wikipedia.org',
+  'https://yahoo.com',
+  'https://amazon.com',
+  'http://www.qq.com/',
+  'https://taobao.com',
+  'https://vk.com',
+  'https://twitter.com',
+  'https://instagram.com',
+  'http://www.hao123.cn/',
+  'http://www.sohu.com/',
+  'https://sina.com.cn',
+  'https://reddit.com',
+  'https://linkedin.com',
+  'https://tmall.com',
+  'https://weibo.com',
+  'https://360.cn',
+  'https://yandex.ru',
+  'https://ebay.com',
+  'https://bing.com',
+  'https://msn.com',
+  'https://www.sogou.com/',
+  'https://wordpress.com',
+  'https://microsoft.com',
+  'https://tumblr.com',
+  'https://aliexpress.com',
+  'https://blogspot.com',
+  'https://netflix.com',
+  'https://ok.ru',
+  'https://stackoverflow.com',
+  'https://imgur.com',
+  'https://apple.com',
+  'http://www.naver.com/',
+  'https://mail.ru',
+  'http://www.imdb.com/',
+  'https://office.com',
+  'https://github.com',
+  'https://pinterest.com',
+  'https://paypal.com',
+  'http://www.tianya.cn/',
+  'https://diply.com',
+  'https://twitch.tv',
+  'https://adobe.com',
+  'https://wikia.com',
+  'https://coccoc.com',
+  'https://so.com',
+  'https://fc2.com',
+  'https://www.pixnet.net/',
+  'https://dropbox.com',
+  'https://zhihu.com',
+  'https://whatsapp.com',
+  'https://alibaba.com',
+  'https://ask.com',
+  'https://bbc.com'
+];
+
+/**
+ * Launches Chrome once at the beginning, runs all the analysis,
+ * and then kills Chrome.
+ * TODO(chenwilliam): measure the overhead of starting chrome, if it's minimal
+ * then open a fresh Chrome instance for each run.
+ */
+function main() {
+  if (utils.isDir(constants.OUT_PATH)) {
+    console.log('ERROR: Found output from previous run at: ', constants.OUT_PATH); // eslint-disable-line no-console
+    console.log('Please run: npm run clean'); // eslint-disable-line no-console
+    return;
+  }
+
+  const launcher = new ChromeLauncher();
+  launcher
+    .isDebuggerReady()
+    .catch(() => launcher.run())
+    .then(() => runAnalysis())
+    .then(() => launcher.kill())
+    .catch(err => launcher.kill().then(
+      () => {
+        throw err;
+      },
+      console.error // eslint-disable-line no-console
+    ));
+}
+
+main();
+
+/**
+ * Returns a promise chain that analyzes all the sites n times.
+ * @return {!Promise}
+ */
+function runAnalysis() {
+  let promise = Promise.resolve();
+
+  // Running it n + 1 times because the first run is deliberately ignored
+  // because it has different perf characteristics from subsequent runs
+  // (e.g. DNS cache which can't be easily reset between runs)
+  for (let i = 0; i <= NUMBER_OF_RUNS; i++) {
+    // Averages out any order-dependent effects such as memory pressure
+    utils.shuffle(URLS);
+
+    const id = i.toString();
+    const isFirstRun = i === 0;
+    for (const url of URLS) {
+      promise = promise.then(() => singleRunAnalysis(url, id, {ignoreRun: isFirstRun}));
+    }
+  }
+  return promise;
+}
+
+/**
+ * Analyzes a site a single time using lighthouse.
+ * @param {string} url
+ * @param {string} id
+ * @param {{ignoreRun: boolean}} options
+ * @return {!Promise}
+ */
+function singleRunAnalysis(url, id, {ignoreRun}) {
+  console.log('Measuring site:', url, 'run:', id); // eslint-disable-line no-console
+  const parsedURL = parseURL(url);
+  const urlBasedFilename = sanitizeURL(`${parsedURL.host}-${parsedURL.pathname}`);
+  const runPath = path.resolve(constants.OUT_PATH, urlBasedFilename, id);
+  if (!ignoreRun) {
+    mkdirp.sync(runPath);
+  }
+  const outputPath = path.resolve(runPath, 'lighthouse.json');
+  const assetsPath = path.resolve(runPath, 'assets');
+  return analyzeWithLighthouse(url, outputPath, assetsPath, {ignoreRun});
+}
+
+/**
+ * Runs lighthouse and save the artifacts (not used directly by plots,
+ * but may be helpful for debugging outlier runs).
+ * @param {string} url
+ * @param {string} outputPath
+ * @param {string} assetsPath
+ * @param {{ignoreRun: boolean}} options
+ * @return {!Promise}
+ */
+function analyzeWithLighthouse(url, outputPath, assetsPath, {ignoreRun}) {
+  const flags = {output: 'json'};
+  return lighthouse(url, flags, config)
+    .then(lighthouseResults => {
+      if (ignoreRun) {
+        return;
+      }
+      return assetSaver
+        .saveAssets(lighthouseResults.artifacts, lighthouseResults.audits, assetsPath)
+        .then(() => {
+          lighthouseResults.artifacts = undefined;
+          return Printer.write(lighthouseResults, flags.output, outputPath);
+        });
+    })
+    .catch(err => console.error(err)); // eslint-disable-line no-console
+}
+
+/**
+ * Converts a URL into a filename-friendly string
+ * @param {string} string
+ * @return {string}
+ */
+function sanitizeURL(string) {
+  const illegalRe = /[\/\?<>\\:\*\|":]/g;
+  const controlRe = /[\x00-\x1f\x80-\x9f]/g; // eslint-disable-line no-control-regex
+  const reservedRe = /^\.+$/;
+
+  return string
+    .replace(illegalRe, '.')
+    .replace(controlRe, '\u2022')
+    .replace(reservedRe, '')
+    .replace(/\s+/g, '_');
+}

--- a/plots/package.json
+++ b/plots/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "index.js",
+  "scripts": {
+    "measure": "node measure.js",
+    "analyze": "node analyze.js",
+    "clean": "node clean.js"
+  }
+}

--- a/plots/utils.js
+++ b/plots/utils.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const fs = require('fs');
+
+/**
+ * @param {string} path
+ * @return {boolean}
+ */
+function isDir(path) {
+  try {
+    return fs.statSync(path).isDirectory();
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * @param {string} path
+ * @return {boolean}
+ */
+function isFile(path) {
+  try {
+    return fs.statSync(path).isFile();
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * @param {!Array} array
+ */
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+module.exports = {
+  isDir,
+  isFile,
+  shuffle
+};


### PR DESCRIPTION
Follow-up work:
* Do a side-by-side perf metrics comparison with a previous version of Lighthouse (allows you to easily see how a commit will change the metrics on real-world sites)
* Run this on a compute instance in Asia to test the hypothesis that the high variance for international sites is driven by network latency

Fixes part of #1924 