### PR TITLE
feat(tti): increase robustness of perf metrics

### DIFF
--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -44,9 +44,9 @@ class EstimatedInputLatency extends Audit {
     };
   }
 
-  static calculate(speedline, model, trace) {
+  static calculate(tabTrace, model, trace) {
     // Use speedline's first paint as start of range for input latency check.
-    const startTime = speedline.first;
+    const startTime = tabTrace.timings.firstMeaningfulPaint;
 
     const latencyPercentiles = TracingProcessor.getRiskToResponsiveness(model, trace, startTime);
     const ninetieth = latencyPercentiles.find(result => result.percentile === 0.9);
@@ -84,11 +84,12 @@ class EstimatedInputLatency extends Audit {
     const trace = artifacts.traces[this.DEFAULT_PASS];
 
     const pending = [
-      artifacts.requestSpeedline(trace),
+      artifacts.requestTraceOfTab(trace),
       artifacts.requestTracingModel(trace)
     ];
-    return Promise.all(pending).then(([speedline, model]) =>
-        EstimatedInputLatency.calculate(speedline, model, trace));
+    return Promise.all(pending).then(([tabTrace, model]) => {
+      return EstimatedInputLatency.calculate(tabTrace, model, trace);
+    });
   }
 }
 

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -45,7 +45,6 @@ class EstimatedInputLatency extends Audit {
   }
 
   static calculate(tabTrace, model, trace) {
-    // Use speedline's first paint as start of range for input latency check.
     const startTime = tabTrace.timings.firstMeaningfulPaint;
 
     const latencyPercentiles = TracingProcessor.getRiskToResponsiveness(model, trace, startTime);

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -42,10 +42,9 @@ class TTIMetric extends Audit {
    * @param {number} maxTime
    * @param {{model: !Object, trace: !Object}} data
    * @param {number=} windowSize
-   * @param {number=} minimumWindowSize
    * @return {{timeInMs: number|undefined, currentLatency: number, foundLatencies: !Array}}
    */
-  static _forwardWindowTTI(minTime, maxTime, data, windowSize = 500, minimumWindowSize = 500) {
+  static _forwardWindowTTI(minTime, maxTime, data, windowSize = 500) {
     // Find first window where Est Input Latency is <50ms at the 90% percentile.
     let startTime = minTime - 50;
     let endTime;
@@ -60,7 +59,7 @@ class TTIMetric extends Audit {
       startTime += 50;
       endTime = startTime + windowSize;
       // If there's no more room in the trace to look, we're done.
-      if (maxTime - startTime < minimumWindowSize) {
+      if (endTime > maxTime) {
         return {currentLatency, foundLatencies};
       }
 
@@ -126,8 +125,7 @@ class TTIMetric extends Audit {
       times.fmpTiming,
       times.endOfTraceTime,
       data,
-      5000,
-      1000
+      5000
     );
   }
 

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -32,10 +32,19 @@ class TTIMetric extends Audit {
           'enough to interact with. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive).',
       optimalValue: SCORING_TARGET.toLocaleString() + 'ms',
-      requiredArtifacts: ['traces', 'networkRecords']
+      requiredArtifacts: ['traces']
     };
   }
 
+  /**
+   *
+   * @param {number} minTime
+   * @param {number} maxTime
+   * @param {{model: !Object, trace: !Object}} data
+   * @param {number=} windowSize
+   * @param {number=} minimumWindowSize
+   * @return {{timeInMs: number|undefined, currentLatency: number, foundLatencies: !Array}}
+   */
   static _forwardWindowTTI(minTime, maxTime, data, windowSize = 500, minimumWindowSize = 500) {
     // Find first window where Est Input Latency is <50ms at the 90% percentile.
     let startTime = minTime - 50;
@@ -79,6 +88,11 @@ class TTIMetric extends Audit {
     };
   }
 
+  /**
+   * @param {{fmpTiming: number, visuallyReadyTiming: number, endOfTraceTime: number}} times
+   * @param {{model: !Object, trace: !Object}} data
+   * @return {{timeInMs: number|undefined, currentLatency: number, foundLatencies: !Array}}
+   */
   static findTTIAlpha(times, data) {
     return TTIMetric._forwardWindowTTI(
       Math.max(times.fmpTiming, times.visuallyReadyTiming),
@@ -88,6 +102,11 @@ class TTIMetric extends Audit {
     );
   }
 
+  /**
+   * @param {{fmpTiming: number, visuallyReadyTiming: number, endOfTraceTime: number}} times
+   * @param {{model: !Object, trace: !Object}} data
+   * @return {{timeInMs: number|undefined, currentLatency: number, foundLatencies: !Array}}
+   */
   static findTTIAlphaFMPOnly(times, data) {
     return TTIMetric._forwardWindowTTI(
       times.fmpTiming,
@@ -97,6 +116,11 @@ class TTIMetric extends Audit {
     );
   }
 
+  /**
+   * @param {{fmpTiming: number, visuallyReadyTiming: number, endOfTraceTime: number}} times
+   * @param {{model: !Object, trace: !Object}} data
+   * @return {{timeInMs: number|undefined, currentLatency: number, foundLatencies: !Array}}
+   */
   static findTTIAlphaFMPOnly5s(times, data) {
     return TTIMetric._forwardWindowTTI(
       times.fmpTiming,

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -32,8 +32,79 @@ class TTIMetric extends Audit {
           'enough to interact with. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive).',
       optimalValue: SCORING_TARGET.toLocaleString() + 'ms',
-      requiredArtifacts: ['traces']
+      requiredArtifacts: ['traces', 'networkRecords']
     };
+  }
+
+  static _forwardWindowTTI(minTime, maxTime, data, windowSize = 500, minimumWindowSize = 500) {
+    // Find first window where Est Input Latency is <50ms at the 90% percentile.
+    let startTime = minTime - 50;
+    let endTime;
+    let currentLatency = Infinity;
+    const percentiles = [0.9]; // [0.75, 0.9, 0.99, 1];
+    const threshold = 50;
+    const foundLatencies = [];
+
+    // When we've found a latency that's good enough, we're good.
+    while (currentLatency > threshold) {
+      // While latency is too high, increment just 50ms and look again.
+      startTime += 50;
+      endTime = startTime + windowSize;
+      // If there's no more room in the trace to look, we're done.
+      if (maxTime - startTime < minimumWindowSize) {
+        return {currentLatency, foundLatencies};
+      }
+
+      // Clip to the trace end
+      endTime = Math.min(endTime, maxTime);
+
+      // Get our expected latency for the time window
+      const latencies = TracingProcessor.getRiskToResponsiveness(
+        data.model, data.trace, startTime, endTime, percentiles);
+      const estLatency = latencies[0].time;
+      foundLatencies.push({
+        estLatency: estLatency,
+        startTime: startTime.toFixed(1)
+      });
+
+      // Grab this latency and try the threshold again
+      currentLatency = estLatency;
+    }
+
+    return {
+      // The start of our window is our TTI
+      timeInMs: startTime,
+      currentLatency,
+      foundLatencies,
+    };
+  }
+
+  static findTTIAlpha(times, data) {
+    return TTIMetric._forwardWindowTTI(
+      Math.max(times.fmpTiming, times.visuallyReadyTiming),
+      times.endOfTraceTime,
+      data,
+      500
+    );
+  }
+
+  static findTTIAlphaFMPOnly(times, data) {
+    return TTIMetric._forwardWindowTTI(
+      times.fmpTiming,
+      times.endOfTraceTime,
+      data,
+      500
+    );
+  }
+
+  static findTTIAlphaFMPOnly5s(times, data) {
+    return TTIMetric._forwardWindowTTI(
+      times.fmpTiming,
+      times.endOfTraceTime,
+      data,
+      5000,
+      1000
+    );
   }
 
   /**
@@ -63,9 +134,13 @@ class TTIMetric extends Audit {
   static audit(artifacts) {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
 
+    let debugString;
     // We start looking at Math.Max(FMP, visProgress[0.85])
     const pending = [
-      artifacts.requestSpeedline(trace),
+      artifacts.requestSpeedline(trace).catch(err => {
+        debugString = `Trace error: ${err.message}`;
+        return null;
+      }),
       artifacts.requestTraceOfTab(trace),
       artifacts.requestTracingModel(trace)
     ];
@@ -81,7 +156,7 @@ class TTIMetric extends Audit {
 
       // look at speedline results for 85% starting at FMP
       let visuallyReadyTiming = 0;
-      if (speedline.frames) {
+      if (speedline && speedline.frames) {
         const eightyFivePctVC = speedline.frames.find(frame => {
           return frame.getTimeStamp() >= fMPtsInMS && frame.getProgress() >= 85;
         });
@@ -90,37 +165,15 @@ class TTIMetric extends Audit {
         }
       }
 
-      // Find first 500ms window where Est Input Latency is <50ms at the 90% percentile.
-      let startTime = Math.max(fmpTiming, visuallyReadyTiming) - 50;
-      let endTime;
-      let currentLatency = Infinity;
-      const percentiles = [0.9]; // [0.75, 0.9, 0.99, 1];
-      const threshold = 50;
-      const foundLatencies = [];
+      const times = {fmpTiming, visuallyReadyTiming, endOfTraceTime};
+      const data = {tabTrace, model, trace};
+      const timeToInteractive = TTIMetric.findTTIAlpha(times, data);
+      const timeToInteractiveB = TTIMetric.findTTIAlphaFMPOnly(times, data);
+      const timeToInteractiveC = TTIMetric.findTTIAlphaFMPOnly5s(times, data);
 
-      // When we've found a latency that's good enough, we're good.
-      while (currentLatency > threshold) {
-        // While latency is too high, increment just 50ms and look again.
-        startTime += 50;
-        endTime = startTime + 500;
-        // If there's no more room in the trace to look, we're done.
-        if (endTime > endOfTraceTime) {
-          throw new Error('Entire trace was found to be busy.');
-        }
-        // Get our expected latency for the time window
-        const latencies = TracingProcessor.getRiskToResponsiveness(
-          model, trace, startTime, endTime, percentiles);
-        const estLatency = latencies[0].time;
-        foundLatencies.push({
-          estLatency: estLatency,
-          startTime: startTime.toFixed(1)
-        });
-
-        // Grab this latency and try the threshold again
-        currentLatency = estLatency;
+      if (!timeToInteractive.timeInMs) {
+        throw new Error('Entire trace was found to be busy.');
       }
-      // The start of our window is our TTI
-      const timeToInteractive = startTime;
 
       // Use the CDF of a log-normal distribution for scoring.
       //   < 1200ms: score≈100
@@ -128,7 +181,7 @@ class TTIMetric extends Audit {
       //   >= 15000ms: score≈0
       const distribution = TracingProcessor.getLogNormalDistribution(SCORING_MEDIAN,
           SCORING_POINT_OF_DIMINISHING_RETURNS);
-      let score = 100 * distribution.computeComplementaryPercentile(startTime);
+      let score = 100 * distribution.computeComplementaryPercentile(timeToInteractive.timeInMs);
 
       // Clamp the score to 0 <= x <= 100.
       score = Math.min(100, score);
@@ -139,21 +192,32 @@ class TTIMetric extends Audit {
         timings: {
           fMP: parseFloat(fmpTiming.toFixed(3)),
           visuallyReady: parseFloat(visuallyReadyTiming.toFixed(3)),
-          timeToInteractive: parseFloat(startTime.toFixed(3))
+          timeToInteractive: parseFloat(timeToInteractive.timeInMs.toFixed(3)),
+          timeToInteractiveB: timeToInteractiveB.timeInMs,
+          timeToInteractiveC: timeToInteractiveC.timeInMs,
+          endOfTrace: endOfTraceTime,
         },
         timestamps: {
           fMP: fMPtsInMS * 1000,
           visuallyReady: (visuallyReadyTiming + navStartTsInMS) * 1000,
-          timeToInteractive: (timeToInteractive + navStartTsInMS) * 1000
+          timeToInteractive: (timeToInteractive.timeInMs + navStartTsInMS) * 1000,
+          timeToInteractiveB: (timeToInteractiveB.timeInMs + navStartTsInMS) * 1000,
+          timeToInteractiveC: (timeToInteractiveC.timeInMs + navStartTsInMS) * 1000,
+          endOfTrace: (endOfTraceTime + navStartTsInMS) * 1000,
         },
-        expectedLatencyAtTTI: parseFloat(currentLatency.toFixed(3)),
-        foundLatencies
+        latencies: {
+          timeToInteractive: timeToInteractive.foundLatencies,
+          timeToInteractiveB: timeToInteractiveB.foundLatencies,
+          timeToInteractiveC: timeToInteractiveC.foundLatencies,
+        },
+        expectedLatencyAtTTI: parseFloat(timeToInteractive.currentLatency.toFixed(3))
       };
 
       return {
         score,
-        rawValue: parseFloat(timeToInteractive.toFixed(1)),
-        displayValue: `${parseFloat(timeToInteractive.toFixed(1))}ms`,
+        debugString,
+        rawValue: parseFloat(timeToInteractive.timeInMs.toFixed(1)),
+        displayValue: `${parseFloat(timeToInteractive.timeInMs.toFixed(1))}ms`,
         optimalValue: this.meta.optimalValue,
         extendedInfo: {
           value: extendedInfo,

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -63,9 +63,6 @@ class TTIMetric extends Audit {
         return {currentLatency, foundLatencies};
       }
 
-      // Clip to the trace end
-      endTime = Math.min(endTime, maxTime);
-
       // Get our expected latency for the time window
       const latencies = TracingProcessor.getRiskToResponsiveness(
         data.model, data.trace, startTime, endTime, percentiles);

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -4,7 +4,7 @@ module.exports = {
     "passName": "defaultPass",
     "recordNetwork": true,
     "recordTrace": true,
-    "pauseBeforeTraceEndMs": 1000,
+    "pauseBeforeTraceEndMs": 5000,
     "useThrottling": true,
     "gatherers": [
       "url",

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -4,7 +4,7 @@ module.exports = {
     "passName": "defaultPass",
     "recordNetwork": true,
     "recordTrace": true,
-    "pauseBeforeTraceEndMs": 500,
+    "pauseBeforeTraceEndMs": 1000,
     "useThrottling": true,
     "gatherers": [
       "url",

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -92,16 +92,29 @@ class TraceOfTab extends ComputedArtifact {
       .filter(e => e.pid === startedInPageEvt.pid)
       .sort((event0, event1) => event0.ts - event1.ts);
 
-    const metrics = {navigationStart, firstPaint, firstContentfulPaint, firstMeaningfulPaint};
+    const traceEnd = trace.traceEvents.reduce((max, evt) => {
+      return max.ts > evt.ts ? max : evt;
+    });
+
+    const metrics = {
+      navigationStart,
+      firstPaint,
+      firstContentfulPaint,
+      firstMeaningfulPaint,
+      traceEnd,
+    };
+
     const timings = {};
+    const timestamps = {};
 
     Object.keys(metrics).forEach(metric => {
-      timings[metric + 'Ts'] = metrics[metric] && metrics[metric].ts / 1000;
-      timings[metric] = timings[metric + 'Ts'] - timings.navigationStartTs;
+      timestamps[metric] = metrics[metric] && metrics[metric].ts / 1000;
+      timings[metric] = timestamps[metric] - timestamps.navigationStart;
     });
 
     return {
       timings,
+      timestamps,
       processEvents,
       startedInPageEvt: startedInPageEvt,
       navigationStartEvt: navigationStart,

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -92,7 +92,16 @@ class TraceOfTab extends ComputedArtifact {
       .filter(e => e.pid === startedInPageEvt.pid)
       .sort((event0, event1) => event0.ts - event1.ts);
 
+    const metrics = {navigationStart, firstPaint, firstContentfulPaint, firstMeaningfulPaint};
+    const timings = {};
+
+    Object.keys(metrics).forEach(metric => {
+      timings[metric + 'Ts'] = metrics[metric] && metrics[metric].ts / 1000;
+      timings[metric] = timings[metric + 'Ts'] - timings.navigationStartTs;
+    });
+
     return {
+      timings,
       processEvents,
       startedInPageEvt: startedInPageEvt,
       navigationStartEvt: navigationStart,

--- a/lighthouse-core/lib/traces/pwmetrics-events.js
+++ b/lighthouse-core/lib/traces/pwmetrics-events.js
@@ -94,6 +94,22 @@ class Metrics {
           return ttiExt.value.timestamps.timeToInteractive;
         },
       },
+      {
+        name: 'Time to Interactive (fMP Only)',
+        id: 'tti-fmp-only',
+        getTs: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return ttiExt.value.timestamps.timeToInteractiveB;
+        },
+      },
+      {
+        name: 'Time to Interactive (fMP Only - 5s)',
+        id: 'tti-fmp-only-5s',
+        getTs: auditResults => {
+          const ttiExt = auditResults['time-to-interactive'].extendedInfo;
+          return ttiExt.value.timestamps.timeToInteractiveC;
+        },
+      },
     ];
   }
 

--- a/lighthouse-core/lib/traces/pwmetrics-events.js
+++ b/lighthouse-core/lib/traces/pwmetrics-events.js
@@ -87,7 +87,7 @@ class Metrics {
         },
       },
       {
-        name: 'Time to Interactive',
+        name: 'Time to Interactive (vAlpha)',
         id: 'tti',
         getTs: auditResults => {
           const ttiExt = auditResults['time-to-interactive'].extendedInfo;
@@ -95,16 +95,16 @@ class Metrics {
         },
       },
       {
-        name: 'Time to Interactive (fMP Only)',
-        id: 'tti-fmp-only',
+        name: 'Time to Interactive (vAlpha non-visual)',
+        id: 'tti-non-visual',
         getTs: auditResults => {
           const ttiExt = auditResults['time-to-interactive'].extendedInfo;
           return ttiExt.value.timestamps.timeToInteractiveB;
         },
       },
       {
-        name: 'Time to Interactive (fMP Only - 5s)',
-        id: 'tti-fmp-only-5s',
+        name: 'Time to Interactive (vAlpha non-visual, 5s)',
+        id: 'tti-non-visual-5s',
         getTs: auditResults => {
           const ttiExt = auditResults['time-to-interactive'].extendedInfo;
           return ttiExt.value.timestamps.timeToInteractiveC;

--- a/lighthouse-core/test/audits/estimated-input-latency-test.js
+++ b/lighthouse-core/test/audits/estimated-input-latency-test.js
@@ -37,8 +37,8 @@ describe('Performance: estimated-input-latency audit', () => {
     const artifacts = generateArtifactsWithTrace({traceEvents: pwaTrace});
     return Audit.audit(artifacts).then(output => {
       assert.equal(output.debugString, undefined);
-      assert.equal(output.rawValue, 17.4);
-      assert.equal(output.displayValue, '17.4ms');
+      assert.equal(output.rawValue, 16.7);
+      assert.equal(output.displayValue, '16.7ms');
       assert.equal(output.score, 100);
     });
   });

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -42,6 +42,14 @@ describe('Trace of Tab computed artifact:', () => {
     assert.ok(firstEvt.pid === trace.firstMeaningfulPaintEvt.pid);
   });
 
+  it('computes timings of each event', () => {
+    const trace = traceOfTab.compute_(lateTracingStartedTrace);
+    assert.equal(Math.round(trace.timings.navigationStart), 0);
+    assert.equal(Math.round(trace.timings.firstPaint), 80);
+    assert.equal(Math.round(trace.timings.firstContentfulPaint), 80);
+    assert.equal(Math.round(trace.timings.firstMeaningfulPaint), 530);
+  });
+
   describe('finds correct FMP', () => {
     it('if there was a tracingStartedInPage after the frame\'s navStart', () => {
       const trace = traceOfTab.compute_(lateTracingStartedTrace);

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -48,6 +48,16 @@ describe('Trace of Tab computed artifact:', () => {
     assert.equal(Math.round(trace.timings.firstPaint), 80);
     assert.equal(Math.round(trace.timings.firstContentfulPaint), 80);
     assert.equal(Math.round(trace.timings.firstMeaningfulPaint), 530);
+    assert.equal(Math.round(trace.timings.traceEnd), 649);
+  });
+
+  it('computes timestamps of each event', () => {
+    const trace = traceOfTab.compute_(lateTracingStartedTrace);
+    assert.equal(Math.round(trace.timestamps.navigationStart), 29343541);
+    assert.equal(Math.round(trace.timestamps.firstPaint), 29343621);
+    assert.equal(Math.round(trace.timestamps.firstContentfulPaint), 29343621);
+    assert.equal(Math.round(trace.timestamps.firstMeaningfulPaint), 29344071);
+    assert.equal(Math.round(trace.timestamps.traceEnd), 29344190);
   });
 
   describe('finds correct FMP', () => {


### PR DESCRIPTION
First round of perf metric investigation, to be judged using #1936 :) Follow-up work includes adding in network reverse search methods for comparison.

- Adds two additional TTI candidates that don't rely on visual completeness.
	- First 500ms window after fMP where 90th percentile EIL is <50ms
	- First 5000ms window after fMP where 90th percentile EIL is <50ms (if at the end of trace, uses a minimum window of as low as 1000ms)
- Falls back to fMP when speedline fails to find screenshots in trace.
- Adds timing data to trace-of-tab computed artifact.