### PR TITLE
Add a smoke test for perf config.

### DIFF
--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Expected Lighthouse audit values for byte efficiency tests
+ */
+module.exports = [
+  {
+    initialUrl: 'http://localhost:10200/online-only.html',
+    url: 'http://localhost:10200/online-only.html',
+    audits: {
+      'speed-index-metric': {
+        score: 100,
+        extendedInfo: {
+          value: {
+            timings: {
+            }
+          }
+        }
+      },
+      'time-to-interactive': {
+        score: 100,
+        extendedInfo: {
+          value: {
+            foundLatencies: {
+              length: 1
+            }
+          }
+        }
+      }
+    }
+  },
+];

--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -17,7 +17,7 @@
 'use strict';
 
 /**
- * Expected Lighthouse audit values for byte efficiency tests
+ * Expected Lighthouse audit values for --perf tests
  */
 module.exports = [
   {
@@ -28,8 +28,9 @@ module.exports = [
         score: 100,
         extendedInfo: {
           value: {
-            timings: {
-            }
+            timings: {},
+            timestamps: {},
+            frames: []
           }
         }
       },
@@ -37,9 +38,8 @@ module.exports = [
         score: 100,
         extendedInfo: {
           value: {
-            foundLatencies: {
-              length: 1
-            }
+            timings: {},
+            timestamps: {}
           }
         }
       }

--- a/lighthouse-cli/test/smokehouse/perf/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/perf/run-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+node lighthouse-cli/test/fixtures/static-server.js &
+
+sleep 0.5s
+
+config="lighthouse-core/config/perf.json"
+expectations="lighthouse-cli/test/smokehouse/perf/expectations.js"
+
+npm run -s smokehouse -- --config-path=$config --expectations-path=$expectations
+exit_code=$?
+
+# kill test servers
+kill $(jobs -p)
+
+exit "$exit_code"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build-extension": "cd ./lighthouse-extension && npm run build",
     "build-viewer": "cd ./lighthouse-viewer && npm run build",
     "lint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .",
-    "smoke": "bash lighthouse-cli/test/smokehouse/offline-local/run-tests.sh && bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh && bash lighthouse-cli/test/smokehouse/byte-efficiency/run-tests.sh",
+    "smoke": "bash lighthouse-cli/test/smokehouse/offline-local/run-tests.sh && bash lighthouse-cli/test/smokehouse/perf/run-tests.sh && bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh && bash lighthouse-cli/test/smokehouse/byte-efficiency/run-tests.sh",
     "coverage": "node $(npm bin)/istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*-test.js') --timeout 10000 --reporter progress",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "start": "gulp && node ./lighthouse-cli/index.js",


### PR DESCRIPTION
Using a superfast local site, so we expect 100s on the scores.

Anything else I should add to the expectations?
