### PR TITLE
Generate DOM for markdown links in help text

### DIFF
--- a/lighthouse-core/report/v2/report-renderer.js
+++ b/lighthouse-core/report/v2/report-renderer.js
@@ -183,18 +183,17 @@ class ReportRenderer {
 
   /**
    * @param {string} text
-   * @return {!Element}
+   * @return {!HTMLSpanElement}
    */
   _convertMarkdownLinksToElement(text) {
     const element = this._createElement('span');
 
     // Split on markdown links (e.g. [some link](https://...)).
-    const parts = text.split(/(\[(.*?)\]\((https?:\/\/.*?)\))/g);
+    const parts = text.split(/\[(.*?)\]\((https?:\/\/.*?)\)/g);
 
     while (parts.length) {
-      // Remove the same number of elements as there are capture groups.
-      // eslint-disable-next-line no-unused-vars
-      const [preambleText, fullMarkdownLink, linkText, linkHref] = parts.splice(0, 4);
+      // Pop off the same number of elements as there are capture groups.
+      const [preambleText, linkText, linkHref] = parts.splice(0, 3);
       element.appendChild(this._document.createTextNode(preambleText));
 
       // Append link if there are any.

--- a/lighthouse-core/report/v2/report-renderer.js
+++ b/lighthouse-core/report/v2/report-renderer.js
@@ -195,7 +195,7 @@ class ReportRenderer {
       // Remove the same number of elements as there are capture groups.
       // eslint-disable-next-line no-unused-vars
       const [preambleText, fullMarkdownLink, linkText, linkHref] = parts.splice(0, 4);
-      element.appendChild(document.createTextNode(preambleText));
+      element.appendChild(this._document.createTextNode(preambleText));
 
       // Append link if there are any.
       if (linkText && linkHref) {

--- a/lighthouse-core/report/v2/report-renderer.js
+++ b/lighthouse-core/report/v2/report-renderer.js
@@ -202,12 +202,8 @@ class ReportRenderer {
         a.rel = 'noopener';
         a.target = '_blank';
         a.textContent = linkText;
-        try {
-          a.href = (new URL(linkHref)).href;
-          element.appendChild(a);
-        } catch (e) {
-          element.appendChild(this._document.createTextNode(linkText));
-        }
+        a.href = (new URL(linkHref)).href;
+        element.appendChild(a);
       }
     }
 

--- a/lighthouse-core/report/v2/report-renderer.js
+++ b/lighthouse-core/report/v2/report-renderer.js
@@ -201,9 +201,13 @@ class ReportRenderer {
         const a = this._createElement('a');
         a.rel = 'noopener';
         a.target = '_blank';
-        a.href = linkHref;
         a.textContent = linkText;
-        element.appendChild(a);
+        try {
+          a.href = (new URL(linkHref)).href;
+          element.appendChild(a);
+        } catch (e) {
+          element.appendChild(this._document.createTextNode(linkText));
+        }
       }
     }
 

--- a/lighthouse-core/report/v2/report-renderer.js
+++ b/lighthouse-core/report/v2/report-renderer.js
@@ -120,7 +120,8 @@ class ReportRenderer {
                           `lighthouse-score__value--${scoringMode}`);
 
     element.querySelector('.lighthouse-score__title').textContent = title;
-    element.querySelector('.lighthouse-score__description').textContent = description;
+    element.querySelector('.lighthouse-score__description')
+        .appendChild(this._convertMarkdownLinksToElement(description));
 
     return element;
   }
@@ -178,6 +179,36 @@ class ReportRenderer {
       default:
         throw new Error(`Unknown type: ${details.type}`);
     }
+  }
+
+  /**
+   * @param {string} text
+   * @return {!Element}
+   */
+  _convertMarkdownLinksToElement(text) {
+    const element = this._createElement('span');
+
+    // Split on markdown links (e.g. [some link](https://...)).
+    const parts = text.split(/(\[(.*?)\]\((https?:\/\/.*?)\))/g);
+
+    while (parts.length) {
+      // Remove the same number of elements as there are capture groups.
+      // eslint-disable-next-line no-unused-vars
+      const [preambleText, fullMarkdownLink, linkText, linkHref] = parts.splice(0, 4);
+      element.appendChild(document.createTextNode(preambleText));
+
+      // Append link if there are any.
+      if (linkText && linkHref) {
+        const a = this._createElement('a');
+        a.rel = 'noopener';
+        a.target = '_blank';
+        a.href = linkHref;
+        a.textContent = linkText;
+        element.appendChild(a);
+      }
+    }
+
+    return element;
   }
 
   /**

--- a/lighthouse-core/test/report/v2/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/report-renderer-test.js
@@ -87,12 +87,6 @@ describe('ReportRenderer V2', () => {
           'and some text afterwards.', 'link with spaces in brackets');
     });
 
-    it('handles invalid urls', () => {
-      const text = 'Text has [bad](https:///) link.';
-      const result = renderer._convertMarkdownLinksToElement(text);
-      assert.equal(result.innerHTML, 'Text has bad link.');
-    });
-
     it('ignores links that do not start with http', () => {
       const text = 'Sentence with [link](/local/path).';
       const result = renderer._convertMarkdownLinksToElement(text);

--- a/lighthouse-core/test/report/v2/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/report-renderer-test.js
@@ -59,12 +59,23 @@ describe('ReportRenderer V2', () => {
   });
 
   describe('_convertMarkdownLinksToElement', () => {
-    it('converts links', () => {
-      const result = renderer._convertMarkdownLinksToElement(
+    it('correctly converts links', () => {
+      let result = renderer._convertMarkdownLinksToElement(
           'Some [link](https://example.com/foo). [Learn more](http://example.com).');
       assert.equal(result.innerHTML,
           'Some <a rel="noopener" target="_blank" href="https://example.com/foo">link</a>. ' +
           '<a rel="noopener" target="_blank" href="http://example.com">Learn more</a>.');
+
+      result = renderer._convertMarkdownLinksToElement('[link](https://example.com/foo)');
+      assert.equal(result.innerHTML,
+          '<a rel="noopener" target="_blank" href="https://example.com/foo">link</a>',
+          'just a link');
+
+      result = renderer._convertMarkdownLinksToElement(
+          '[ Link ](https://example.com/foo) and some text afterwards.');
+      assert.equal(result.innerHTML,
+          '<a rel="noopener" target="_blank" href="https://example.com/foo"> Link </a> ' +
+          'and some text afterwards.', 'link with spaces in brackets');
     });
 
     it('ignores links that do not start with http', () => {

--- a/lighthouse-core/test/report/v2/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/report-renderer-test.js
@@ -20,16 +20,23 @@
 const assert = require('assert');
 const fs = require('fs');
 const jsdom = require('jsdom');
+const URL = require('../../../lib/url-shim');
 const ReportRenderer = require('../../../report/v2/report-renderer.js');
 const sampleResults = require('../../results/sample_v2.json');
-const URL = window.URL = require('../../../lib/url-shim'); // eslint-disable-line no-unused-vars
 
 const TEMPLATE_FILE = fs.readFileSync(__dirname + '/../../../report/v2/templates.html', 'utf8');
 
 describe('ReportRenderer V2', () => {
+  before(() => {
+    global.URL = URL;
+  });
+
+  after(() => {
+    global.URL = undefined;
+  });
+
   const document = jsdom.jsdom(TEMPLATE_FILE);
   const renderer = new ReportRenderer(document);
-
 
   describe('createElement', () => {
     it('creates a simple element using default values', () => {

--- a/lighthouse-core/test/report/v2/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/report-renderer-test.js
@@ -22,12 +22,14 @@ const fs = require('fs');
 const jsdom = require('jsdom');
 const ReportRenderer = require('../../../report/v2/report-renderer.js');
 const sampleResults = require('../../results/sample_v2.json');
+const URL = window.URL = require('../../../lib/url-shim'); // eslint-disable-line no-unused-vars
 
 const TEMPLATE_FILE = fs.readFileSync(__dirname + '/../../../report/v2/templates.html', 'utf8');
 
 describe('ReportRenderer V2', () => {
   const document = jsdom.jsdom(TEMPLATE_FILE);
   const renderer = new ReportRenderer(document);
+
 
   describe('createElement', () => {
     it('creates a simple element using default values', () => {
@@ -64,7 +66,7 @@ describe('ReportRenderer V2', () => {
           'Some [link](https://example.com/foo). [Learn more](http://example.com).');
       assert.equal(result.innerHTML,
           'Some <a rel="noopener" target="_blank" href="https://example.com/foo">link</a>. ' +
-          '<a rel="noopener" target="_blank" href="http://example.com">Learn more</a>.');
+          '<a rel="noopener" target="_blank" href="http://example.com/">Learn more</a>.');
 
       result = renderer._convertMarkdownLinksToElement('[link](https://example.com/foo)');
       assert.equal(result.innerHTML,
@@ -76,6 +78,12 @@ describe('ReportRenderer V2', () => {
       assert.equal(result.innerHTML,
           '<a rel="noopener" target="_blank" href="https://example.com/foo"> Link </a> ' +
           'and some text afterwards.', 'link with spaces in brackets');
+    });
+
+    it('handles invalid urls', () => {
+      const text = 'Text has [bad](https:///) link.';
+      const result = renderer._convertMarkdownLinksToElement(text);
+      assert.equal(result.innerHTML, 'Text has bad link.');
     });
 
     it('ignores links that do not start with http', () => {

--- a/lighthouse-core/test/report/v2/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/report-renderer-test.js
@@ -87,6 +87,13 @@ describe('ReportRenderer V2', () => {
           'and some text afterwards.', 'link with spaces in brackets');
     });
 
+    it('handles invalid urls', () => {
+      const text = 'Text has [bad](https:///) link.';
+      assert.throws(() => {
+        renderer._convertMarkdownLinksToElement(text);
+      });
+    });
+
     it('ignores links that do not start with http', () => {
       const text = 'Sentence with [link](/local/path).';
       const result = renderer._convertMarkdownLinksToElement(text);


### PR DESCRIPTION
R: all

Just support in help text / descriptions.

<img width="1055" alt="screen shot 2017-04-07 at 1 57 59 pm" src="https://cloud.githubusercontent.com/assets/238208/24819673/6da4cd5e-1b9a-11e7-90de-c71da7468b49.png">

Will add a test once https://github.com/GoogleChrome/lighthouse/pull/1963 lands.
