### PR TITLE
Report v2: port over cards formatter

### DIFF
--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -114,6 +114,11 @@ class DOMSize extends Audit {
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.CARDS,
         value: cards
+      },
+      details: {
+        type: 'cards',
+        header: {type: 'text', text: 'View details'},
+        items: cards
       }
     };
   }

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -24,7 +24,7 @@ class DetailsRenderer {
   }
 
   /**
-   * @param (!DetailsRenderer.DetailsJSON|!DetailsRenderer.CardsDetailsJSON)} details
+   * @param {(!DetailsRenderer.DetailsJSON|!DetailsRenderer.CardsDetailsJSON)} details
    * @return {!Element}
    */
   render(details) {

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -24,7 +24,7 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsJSON} details
+   * @param (!DetailsRenderer.DetailsJSON|!DetailsRenderer.CardsDetailsJSON)} details
    * @return {!Element}
    */
   render(details) {

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -33,6 +33,8 @@ class DetailsRenderer {
         return this._renderText(details);
       case 'block':
         return this._renderBlock(details);
+      case 'cards':
+        return this._renderCards(details);
       case 'list':
         return this._renderList(details);
       default:
@@ -78,6 +80,36 @@ class DetailsRenderer {
     for (const item of list.items) {
       items.appendChild(this.render(item));
     }
+    element.appendChild(items);
+    return element;
+  }
+
+  /**
+   * @param {!DetailsJSON} list
+   * @return {!Element}
+   */
+  _renderCards(list) {
+    const element = this._dom.createElement('details', 'lighthouse-details');
+    if (list.header) {
+      element.appendChild(this._dom.createElement('summary')).textContent = list.header.text;
+    }
+
+    const items = this._dom.createElement('div', 'lighthouse-scorecards');
+    for (const item of list.items) {
+      const card = items.appendChild(
+          this._dom.createElement('div', 'lighthouse-scorecard', {title: item.snippet}));
+      const titleEl = this._dom.createElement('div', 'lighthouse-scorecard__title');
+      const valueEl = this._dom.createElement('div', 'lighthouse-scorecard__value');
+      const targetEl = this._dom.createElement('div', 'lighthouse-scorecard__target');
+
+      card.appendChild(titleEl).textContent = item.title;
+      card.appendChild(valueEl).textContent = item.value;
+
+      if (item.target) {
+        card.appendChild(targetEl).textContent = `target: ${item.target}`;
+      }
+    }
+
     element.appendChild(items);
     return element;
   }

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -85,18 +85,18 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsJSON} list
+   * @param {!CardsDetailsJSON} details
    * @return {!Element}
    */
-  _renderCards(list) {
+  _renderCards(details) {
     const element = this._dom.createElement('details', 'lighthouse-details');
-    if (list.header) {
-      element.appendChild(this._dom.createElement('summary')).textContent = list.header.text;
+    if (details.header) {
+      element.appendChild(this._dom.createElement('summary')).textContent = details.header.text;
     }
 
-    const items = this._dom.createElement('div', 'lighthouse-scorecards');
-    for (const item of list.items) {
-      const card = items.appendChild(
+    const cardsParent = this._dom.createElement('div', 'lighthouse-scorecards');
+    for (const item of details.items) {
+      const card = cardsParent.appendChild(
           this._dom.createElement('div', 'lighthouse-scorecard', {title: item.snippet}));
       const titleEl = this._dom.createElement('div', 'lighthouse-scorecard__title');
       const valueEl = this._dom.createElement('div', 'lighthouse-scorecard__value');
@@ -110,7 +110,7 @@ class DetailsRenderer {
       }
     }
 
-    element.appendChild(items);
+    element.appendChild(cardsParent);
     return element;
   }
 }
@@ -121,3 +121,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
 /** @typedef {{type: string, text: string|undefined, header: DetailsJSON|undefined, items: Array<DetailsJSON>|undefined}} */
 DetailsRenderer.DetailsJSON; // eslint-disable-line no-unused-expressions
+
+
+/** @typedef {{type: string, text: string, header: DetailsJSON, items: Array<{title: string, value: string, snippet: string|undefined, target: string}>}} */
+DetailsRenderer.CardsDetailsJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -69,7 +69,7 @@ class DetailsRenderer {
    * @return {!Element}
    */
   _renderList(list) {
-    const element = this._dom.createElement('details', 'lh-list');
+    const element = this._dom.createElement('details', 'lh-details');
     if (list.header) {
       const summary = this._dom.createElement('summary', 'lh-list__header');
       summary.textContent = list.header.text;
@@ -89,18 +89,18 @@ class DetailsRenderer {
    * @return {!Element}
    */
   _renderCards(details) {
-    const element = this._dom.createElement('details', 'lighthouse-details');
+    const element = this._dom.createElement('details', 'lh-details');
     if (details.header) {
       element.appendChild(this._dom.createElement('summary')).textContent = details.header.text;
     }
 
-    const cardsParent = this._dom.createElement('div', 'lighthouse-scorecards');
+    const cardsParent = this._dom.createElement('div', 'lh-scorecards');
     for (const item of details.items) {
       const card = cardsParent.appendChild(
-          this._dom.createElement('div', 'lighthouse-scorecard', {title: item.snippet}));
-      const titleEl = this._dom.createElement('div', 'lighthouse-scorecard__title');
-      const valueEl = this._dom.createElement('div', 'lighthouse-scorecard__value');
-      const targetEl = this._dom.createElement('div', 'lighthouse-scorecard__target');
+          this._dom.createElement('div', 'lh-scorecard', {title: item.snippet}));
+      const titleEl = this._dom.createElement('div', 'lh-scorecard__title');
+      const valueEl = this._dom.createElement('div', 'lh-scorecard__value');
+      const targetEl = this._dom.createElement('div', 'lh-scorecard__target');
 
       card.appendChild(titleEl).textContent = item.title;
       card.appendChild(valueEl).textContent = item.value;

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -37,7 +37,9 @@ class DOM {
       element.className = className;
     }
     Object.keys(attrs).forEach(key => {
-      element.setAttribute(key, attrs[key]);
+      if (attrs[key] !== undefined) {
+        element.setAttribute(key, attrs[key]);
+      }
     });
     return element;
   }

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -28,7 +28,7 @@ class DOM {
  /**
    * @param {string} name
    * @param {string=} className
-   * @param {!Object<string, string>=} attrs Attribute key/val pairs.
+   * @param {!Object<?string, ?string>=} attrs Attribute key/val pairs.
    * @return {!Element}
    */
   createElement(name, className, attrs = {}) {

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -28,7 +28,7 @@ class DOM {
  /**
    * @param {string} name
    * @param {string=} className
-   * @param {!Object<?string, ?string>=} attrs Attribute key/val pairs.
+   * @param {!Object<string, (string|undefined)>=} attrs Attribute key/val pairs.
    * @return {!Element}
    */
   createElement(name, className, attrs = {}) {

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -29,6 +29,8 @@ class DOM {
    * @param {string} name
    * @param {string=} className
    * @param {!Object<string, (string|undefined)>=} attrs Attribute key/val pairs.
+   *     Note: uf an attribute key has an undefined value, this method does not
+   *     set the attribute on the node.
    * @return {!Element}
    */
   createElement(name, className, attrs = {}) {

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -29,7 +29,7 @@ class DOM {
    * @param {string} name
    * @param {string=} className
    * @param {!Object<string, (string|undefined)>=} attrs Attribute key/val pairs.
-   *     Note: uf an attribute key has an undefined value, this method does not
+   *     Note: if an attribute key has an undefined value, this method does not
    *     set the attribute on the node.
    * @return {!Element}
    */

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -199,7 +199,7 @@ if (typeof module !== 'undefined' && module.exports) {
   module.exports = ReportRenderer;
 }
 
-/** @typedef {{id: string, weight: number, score: number, result: {description: string, displayValue: string, helpText: string, score: number|boolean, details: DetailsRenderer.DetailsJSON|undefined}}} */
+/** @typedef {{id: string, weight: number, score: number, result: {description: string, displayValue: string, helpText: string, score: number|boolean, details: DetailsRenderer.DetailsJSON|DetailsRenderer.CardsDetailsJSON|undefined}}} */
 let AuditJSON; // eslint-disable-line no-unused-vars
 
 /** @typedef {{name: string, weight: number, score: number, description: string, audits: Array<AuditJSON>}} */

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -50,23 +50,64 @@ body {
   display: none !important;
 }
 
-/* List */
-.lh-list {
+.lh-details {
   font-size: smaller;
   margin-top: var(--default-padding);
 }
 
-.lh-list__header {
+.lh-details summary {
   cursor: pointer;
 }
 
-.lh-list__items {
+.lh-details[open] summary {
+  margin-bottom: var(--default-padding);
+}
+
+/* List */
+.kh-list__items {
   padding-left: 10px;
 }
 
 .lh-list__items > * {
   border-bottom: 1px solid gray;
   margin-bottom: 2px;
+}
+
+/* Card */
+.lighthouse-scorecards {
+  display: flex;
+  flex-wrap: wrap;
+}
+.lighthouse-scorecard {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 180px;
+  flex-direction: column;
+  padding: var(--default-padding);
+  padding-top: calc(32px + var(--default-padding));
+  border-radius: 3px;
+  margin-right: var(--default-padding);
+  position: relative;
+  line-height: inherit;
+  border: 1px solid #ebebeb;
+}
+.lighthouse-scorecard__title {
+  background-color: #eee;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: calc(var(--default-padding) / 2);
+}
+.lighthouse-scorecard__value {
+  font-size: 28px;
+}
+.lighthouse-scorecard__target {
+  margin-top: calc(var(--default-padding) / 2);
 }
 
 /* Score */

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -64,8 +64,8 @@ body {
 }
 
 /* List */
-.kh-list__items {
-  padding-left: 10px;
+.lh-list__items {
+  padding-left: var(--default-padding);
 }
 
 .lh-list__items > * {
@@ -74,11 +74,11 @@ body {
 }
 
 /* Card */
-.lighthouse-scorecards {
+.lh-scorecards {
   display: flex;
   flex-wrap: wrap;
 }
-.lighthouse-scorecard {
+.lh-scorecard {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -92,7 +92,7 @@ body {
   line-height: inherit;
   border: 1px solid #ebebeb;
 }
-.lighthouse-scorecard__title {
+.lh-scorecard__title {
   background-color: #eee;
   position: absolute;
   top: 0;
@@ -103,10 +103,10 @@ body {
   align-items: center;
   padding: calc(var(--default-padding) / 2);
 }
-.lighthouse-scorecard__value {
+.lh-scorecard__value {
   font-size: 28px;
 }
-.lighthouse-scorecard__target {
+.lh-scorecard__target {
   margin-top: calc(var(--default-padding) / 2);
 }
 

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -113,8 +113,8 @@ describe('DetailsRenderer', () => {
       });
 
       const textChild = el.querySelector('.lh-block > .lh-text');
-      const listChild = el.querySelector('.lh-block > .lh-list');
-      const textSubChild = el.querySelector('.lh-block .lh-list .lh-text');
+      const listChild = el.querySelector('.lh-block > .lh-details');
+      const textSubChild = el.querySelector('.lh-block .lh-details .lh-text');
       assert.ok(textChild, 'did not render text children');
       assert.ok(listChild, 'did not render list child');
       assert.ok(textSubChild, 'did not render sub-children');
@@ -131,21 +131,21 @@ describe('DetailsRenderer', () => {
       };
 
       const details = renderer._renderCards(list);
-      assert.ok(details.classList.contains('lighthouse-details'));
+      assert.ok(details.classList.contains('lh-details'));
       assert.equal(details.querySelector('summary').textContent, 'View details');
 
-      const cards = details.querySelectorAll('.lighthouse-scorecards > .lighthouse-scorecard');
+      const cards = details.querySelectorAll('.lh-scorecards > .lh-scorecard');
       assert.ok(cards.length, list.items.length, `renders ${list.items.length} cards`);
       assert.equal(cards[0].hasAttribute('title'), false,
           'does not add title attr if snippet is missing');
-      assert.equal(cards[0].querySelector('.lighthouse-scorecard__title').textContent,
+      assert.equal(cards[0].querySelector('.lh-scorecard__title').textContent,
           'Total DOM Nodes', 'fills title');
-      assert.equal(cards[0].querySelector('.lighthouse-scorecard__value').textContent,
+      assert.equal(cards[0].querySelector('.lh-scorecard__value').textContent,
           '3500', 'fills value');
-      assert.equal(cards[0].querySelector('.lighthouse-scorecard__target').textContent,
+      assert.equal(cards[0].querySelector('.lh-scorecard__target').textContent,
           'target: 1,500 nodes', 'fills target');
       assert.equal(cards[1].getAttribute('title'), 'snippet', 'adds title attribute for snippet');
-      assert.ok(!cards[1].querySelector('.lighthouse-scorecard__target'), 'handles missing target');
+      assert.ok(!cards[1].querySelector('.lh-scorecard__target'), 'handles missing target');
     });
   });
 });

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -119,5 +119,33 @@ describe('DetailsRenderer', () => {
       assert.ok(listChild, 'did not render list child');
       assert.ok(textSubChild, 'did not render sub-children');
     });
+
+    it('renders cards', () => {
+      const list = {
+        header: {type: 'text', text: 'View details'},
+        items: [
+          {title: 'Total DOM Nodes', value: 3500, target: '1,500 nodes'},
+          {title: 'DOM Depth', value: 10, snippet: 'snippet'},
+          {title: 'Maximum Children', value: 20, snippet: 'snippet2', target: 20}
+        ]
+      };
+
+      const details = renderer._renderCards(list);
+      assert.ok(details.classList.contains('lighthouse-details'));
+      assert.equal(details.querySelector('summary').textContent, 'View details');
+
+      const cards = details.querySelectorAll('.lighthouse-scorecards > .lighthouse-scorecard');
+      assert.ok(cards.length, list.items.length, `renders ${list.items.length} cards`);
+      assert.equal(cards[0].hasAttribute('title'), false,
+          'does not add title attr if snippet is missing');
+      assert.equal(cards[0].querySelector('.lighthouse-scorecard__title').textContent,
+          'Total DOM Nodes', 'fills title');
+      assert.equal(cards[0].querySelector('.lighthouse-scorecard__value').textContent,
+          '3500', 'fills value');
+      assert.equal(cards[0].querySelector('.lighthouse-scorecard__target').textContent,
+          'target: 1,500 nodes', 'fills target');
+      assert.equal(cards[1].getAttribute('title'), 'snippet', 'adds title attribute for snippet');
+      assert.ok(!cards[1].querySelector('.lighthouse-scorecard__target'), 'handles missing target');
+    });
   });
 });


### PR DESCRIPTION
R: all

<img width="1001" alt="screen shot 2017-04-10 at 10 10 26 pm" src="https://cloud.githubusercontent.com/assets/238208/24894433/310582ce-1e3f-11e7-940c-e47160817d63.png">

This should wait until https://github.com/GoogleChrome/lighthouse/pull/1979 and https://github.com/GoogleChrome/lighthouse/pull/1987 land and will probably need rebasing, but review can start now. The changes are standalone from those.