### PR TITLE
Adjust report-renderer init for devtools

### DIFF
--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -45,7 +45,7 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsJSON} text
+   * @param {!DetailsRenderer.DetailsJSON} text
    * @return {!Element}
    */
   _renderText(text) {
@@ -55,19 +55,20 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsJSON} block
+   * @param {!DetailsRenderer.DetailsJSON} block
    * @return {!Element}
    */
   _renderBlock(block) {
     const element = this._dom.createElement('div', 'lh-block');
-    for (const item of block.items) {
+    const items = block.items || [];
+    for (const item of items) {
       element.appendChild(this.render(item));
     }
     return element;
   }
 
   /**
-   * @param {!DetailsJSON} list
+   * @param {!DetailsRenderer.DetailsJSON} list
    * @return {!Element}
    */
   _renderList(list) {
@@ -78,11 +79,12 @@ class DetailsRenderer {
       element.appendChild(summary);
     }
 
-    const items = this._dom.createElement('div', 'lh-list__items');
-    for (const item of list.items) {
-      items.appendChild(this.render(item));
+    const itemsElem = this._dom.createElement('div', 'lh-list__items');
+    const items = list.items || [];
+    for (const item of items) {
+      itemsElem.appendChild(this.render(item));
     }
-    element.appendChild(items);
+    element.appendChild(itemsElem);
     return element;
   }
 
@@ -123,9 +125,21 @@ if (typeof module !== 'undefined' && module.exports) {
   self.DetailsRenderer = DetailsRenderer;
 }
 
-/** @typedef {{type: string, text: string|undefined, header: DetailsJSON|undefined, items: Array<DetailsJSON>|undefined}} */
+/**
+ * @typedef {{
+ *     type: string,
+ *     text: (string|undefined),
+ *     header: (DetailsRenderer.DetailsJSON|undefined),
+ *     items: (!Array<!DetailsRenderer.DetailsJSON>|undefined)
+ * }}
+ */
 DetailsRenderer.DetailsJSON; // eslint-disable-line no-unused-expressions
 
-
-/** @typedef {{type: string, text: string, header: DetailsJSON, items: Array<{title: string, value: string, snippet: string|undefined, target: string}>}} */
+/** @typedef {{
+ *     type: string,
+ *     text: string,
+ *     header: DetailsJSON,
+ *     items: Array<{title: string, value: string, snippet: string|undefined, target: string}>
+ * }}
+ */
 DetailsRenderer.CardsDetailsJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -119,7 +119,7 @@ class DetailsRenderer {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = DetailsRenderer;
-} else if (self) {
+} else {
   self.DetailsRenderer = DetailsRenderer;
 }
 

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+/* globals self */
+
 class DetailsRenderer {
   /**
    * @param {!DOM} dom
@@ -117,6 +119,8 @@ class DetailsRenderer {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = DetailsRenderer;
+} else if (self) {
+  self.DetailsRenderer = DetailsRenderer;
 }
 
 /** @typedef {{type: string, text: string|undefined, header: DetailsJSON|undefined, items: Array<DetailsJSON>|undefined}} */

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -36,7 +36,7 @@ class DetailsRenderer {
       case 'block':
         return this._renderBlock(details);
       case 'cards':
-        return this._renderCards(details);
+        return this._renderCards(/** @type {!DetailsRenderer.CardsDetailsJSON} */ (details));
       case 'list':
         return this._renderList(details);
       default:
@@ -89,7 +89,7 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!CardsDetailsJSON} details
+   * @param {!DetailsRenderer.CardsDetailsJSON} details
    * @return {!Element}
    */
   _renderCards(details) {
@@ -129,7 +129,7 @@ if (typeof module !== 'undefined' && module.exports) {
  * @typedef {{
  *     type: string,
  *     text: (string|undefined),
- *     header: (DetailsRenderer.DetailsJSON|undefined),
+ *     header: (!DetailsRenderer.DetailsJSON|undefined),
  *     items: (!Array<!DetailsRenderer.DetailsJSON>|undefined)
  * }}
  */
@@ -138,8 +138,8 @@ DetailsRenderer.DetailsJSON; // eslint-disable-line no-unused-expressions
 /** @typedef {{
  *     type: string,
  *     text: string,
- *     header: DetailsJSON,
- *     items: Array<{title: string, value: string, snippet: string|undefined, target: string}>
+ *     header: !DetailsRenderer.DetailsJSON,
+ *     items: !Array<{title: string, value: string, snippet: (string|undefined), target: string}>
  * }}
  */
 DetailsRenderer.CardsDetailsJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -23,6 +23,7 @@ class DOM {
    */
   constructor(document) {
     this._document = document;
+    this.templatesContext = this._document;
   }
 
  /**
@@ -52,19 +53,11 @@ class DOM {
    * @throws {Error}
    */
   cloneTemplate(selector) {
-    const template = this._retrieveTemplate(selector);
+    const template = this.templatesContext.querySelector(selector);
     if (!template) {
       throw new Error(`Template not found: template${selector}`);
     }
     return this._document.importNode(template.content, true);
-  }
-
-  /**
-   * @param {string} selector
-   * @return {!DocumentFragment} The original template content
-   */
-  _retrieveTemplate(selector) {
-    return this._document.querySelector(selector);
   }
 
   /**

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -23,7 +23,6 @@ class DOM {
    */
   constructor(document) {
     this._document = document;
-    this.templatesContext = this._document;
   }
 
  /**
@@ -34,7 +33,8 @@ class DOM {
    *     set the attribute on the node.
    * @return {!Element}
    */
-  createElement(name, className, attrs = {}) {
+  createElement(name, className, attrs) {
+    attrs = attrs || {};
     const element = this._document.createElement(name);
     if (className) {
       element.className = className;
@@ -49,20 +49,21 @@ class DOM {
 
   /**
    * @param {string} selector
+   * @param {!Document|!Element} context
    * @return {!DocumentFragment} A clone of the template content.
    * @throws {Error}
    */
-  cloneTemplate(selector) {
-    const template = this.templatesContext.querySelector(selector);
+  cloneTemplate(selector, context) {
+    const template = context.querySelector(selector);
     if (!template) {
       throw new Error(`Template not found: template${selector}`);
     }
-    return this._document.importNode(template.content, true);
+    return /** @type {!DocumentFragment} */ (this._document.importNode(template.content, true));
   }
 
   /**
    * @param {string} text
-   * @return {!HTMLSpanElement}
+   * @return {!Element}
    */
   createSpanFromMarkdown(text) {
     const element = this.createElement('span');
@@ -87,6 +88,13 @@ class DOM {
     }
 
     return element;
+  }
+
+  /**
+   * @return {!Document}
+   */
+  document() {
+    return this._document;
   }
 }
 

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -99,6 +99,6 @@ class DOM {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = DOM;
-} else if (self) {
+} else {
   self.DOM = DOM;
 }

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -34,14 +34,16 @@ class DOM {
    * @return {!Element}
    */
   createElement(name, className, attrs) {
+    // TODO(all): adopt `attrs` default arg when https://codereview.chromium.org/2821773002/ lands
     attrs = attrs || {};
     const element = this._document.createElement(name);
     if (className) {
       element.className = className;
     }
     Object.keys(attrs).forEach(key => {
-      if (attrs[key] !== undefined) {
-        element.setAttribute(key, attrs[key]);
+      const value = attrs[key];
+      if (typeof value !== 'undefined') {
+        element.setAttribute(key, value);
       }
     });
     return element;

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-/* globals URL */
+/* globals URL self */
 
 class DOM {
   /**
@@ -52,11 +52,19 @@ class DOM {
    * @throws {Error}
    */
   cloneTemplate(selector) {
-    const template = this._document.querySelector(selector);
+    const template = this._retrieveTemplate(selector);
     if (!template) {
       throw new Error(`Template not found: template${selector}`);
     }
     return this._document.importNode(template.content, true);
+  }
+
+  /**
+   * @param {string} selector
+   * @return {!DocumentFragment} The original template content
+   */
+  _retrieveTemplate(selector) {
+    return this._document.querySelector(selector);
   }
 
   /**
@@ -91,4 +99,6 @@ class DOM {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = DOM;
+} else if (self) {
+  self.DOM = DOM;
 }

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -62,10 +62,12 @@ class ReportRenderer {
   constructor(dom, detailsRenderer) {
     this._dom = dom;
     this._detailsRenderer = detailsRenderer;
+
+    this._templateContext = this._dom.document();
   }
 
   /**
-   * @param {!ReportJSON} report
+   * @param {!ReportRenderer.ReportJSON} report
    * @return {!Element}
    */
   renderReport(report) {
@@ -95,15 +97,22 @@ class ReportRenderer {
     element.querySelector('.lh-score__description')
         .appendChild(this._dom.createSpanFromMarkdown(description));
 
-    return element;
+    return /** @type {!Element} **/ (element);
   }
 
   /**
-   * @param {!AuditJSON} audit
+   * @param {!Document|!Element} context
+   */
+  setTemplateContext(context) {
+    this._templateContext = context;
+  }
+
+  /**
+   * @param {!ReportRenderer.AuditJSON} audit
    * @return {!Element}
    */
   _renderAuditScore(audit) {
-    const tmpl = this._dom.cloneTemplate('#tmpl-lh-audit-score');
+    const tmpl = this._dom.cloneTemplate('#tmpl-lh-audit-score', this._templateContext);
 
     const scoringMode = audit.result.scoringMode;
     const description = audit.result.helpText;
@@ -127,11 +136,11 @@ class ReportRenderer {
   }
 
   /**
-   * @param {!CategoryJSON} category
+   * @param {!ReportRenderer.CategoryJSON} category
    * @return {!Element}
    */
   _renderCategoryScore(category) {
-    const tmpl = this._dom.cloneTemplate('#tmpl-lh-category-score');
+    const tmpl = this._dom.cloneTemplate('#tmpl-lh-category-score', this._templateContext);
     const score = Math.round(category.score);
     return this._populateScore(tmpl, score, 'numeric', category.name, category.description);
   }
@@ -147,7 +156,7 @@ class ReportRenderer {
   }
 
   /**
-   * @param {!ReportJSON} report
+   * @param {!ReportRenderer.ReportJSON} report
    * @return {!Element}
    */
   _renderReport(report) {
@@ -159,7 +168,7 @@ class ReportRenderer {
   }
 
   /**
-   * @param {!CategoryJSON} category
+   * @param {!ReportRenderer.CategoryJSON} category
    * @return {!Element}
    */
   _renderCategory(category) {
@@ -186,7 +195,7 @@ class ReportRenderer {
   }
 
   /**
-   * @param {!AuditJSON} audit
+   * @param {!ReportRenderer.AuditJSON} audit
    * @return {!Element}
    */
   _renderAudit(audit) {
@@ -202,11 +211,41 @@ if (typeof module !== 'undefined' && module.exports) {
   self.ReportRenderer = ReportRenderer;
 }
 
-/** @typedef {{id: string, weight: number, score: number, result: {description: string, displayValue: string, helpText: string, score: number|boolean, details: DetailsRenderer.DetailsJSON|DetailsRenderer.CardsDetailsJSON|undefined}}} */
-let AuditJSON; // eslint-disable-line no-unused-vars
+/**
+ * @typedef {{
+ *     id: string, weight:
+ *     number, score: number,
+ *     result: {
+ *       description: string,
+ *       displayValue: string,
+ *       helpText: string,
+ *       score: (number|boolean),
+ *       scoringMode: string,
+ *       details: (DetailsRenderer.DetailsJSON|DetailsRenderer.CardsDetailsJSON|undefined)
+ *     }
+ * }}
+ */
+ReportRenderer.AuditJSON; // eslint-disable-line no-unused-expressions
 
-/** @typedef {{name: string, weight: number, score: number, description: string, audits: Array<AuditJSON>}} */
-let CategoryJSON; // eslint-disable-line no-unused-vars
+/**
+ * @typedef {{
+ *     name: string,
+ *     weight: number,
+ *     score: number,
+ *     description: string,
+ *     audits: Array<ReportRenderer.AuditJSON>
+ * }}
+ */
+ReportRenderer.CategoryJSON; // eslint-disable-line no-unused-expressions
 
-/** @typedef {{reportCategories: Array<CategoryJSON>}} */
-let ReportJSON; // eslint-disable-line no-unused-vars
+/**
+ * @typedef {{
+ *     lighthouseVersion: !string,
+ *     generatedTime: !string,
+ *     initialUrl: !string,
+ *     url: !string,
+ *     audits: ?Object,
+ *     reportCategories: !Array<!ReportRenderer.CategoryJSON>
+ * }}
+ */
+ReportRenderer.ReportJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -56,8 +56,8 @@ function formatNumber(number) {
 
 class ReportRenderer {
   /**
-   * @param {!DOM} DOM
-   * @param {!DetailsRenderer} DetailsRenderer
+   * @param {!DOM} dom
+   * @param {!DetailsRenderer} detailsRenderer
    */
   constructor(dom, detailsRenderer) {
     this._dom = dom;

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -22,7 +22,7 @@
  * Dummy text for ensuring report robustness: </script> pre$`post %%LIGHTHOUSE_JSON%%
  */
 
-/* globals DOM, DetailsRenderer */
+/* globals self */
 
 const RATINGS = {
   PASS: {label: 'pass', minScore: 75},
@@ -57,9 +57,10 @@ function formatNumber(number) {
 class ReportRenderer {
   /**
    * @param {!Document} document
+   * @param {!DOM} DOM
+   * @param {!DetailsRenderer} DetailsRenderer
    */
-  constructor(document) {
-    this._dom = new DOM(document);
+  constructor(document, DOM, DetailsRenderer) {
     this._detailsRenderer = new DetailsRenderer(this._dom);
   }
 
@@ -197,6 +198,8 @@ class ReportRenderer {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = ReportRenderer;
+} else if (self) {
+  self.ReportRenderer = ReportRenderer;
 }
 
 /** @typedef {{id: string, weight: number, score: number, result: {description: string, displayValue: string, helpText: string, score: number|boolean, details: DetailsRenderer.DetailsJSON|DetailsRenderer.CardsDetailsJSON|undefined}}} */

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -101,6 +101,8 @@ class ReportRenderer {
   }
 
   /**
+   * Define a custom element for <templates> to be extracted from. For example:
+   *     this.setTemplateContext(new DOMParser().parseFromString(htmlStr, 'text/html'))
    * @param {!Document|!Element} context
    */
   setTemplateContext(context) {
@@ -221,7 +223,7 @@ if (typeof module !== 'undefined' && module.exports) {
  *       helpText: string,
  *       score: (number|boolean),
  *       scoringMode: string,
- *       details: (DetailsRenderer.DetailsJSON|DetailsRenderer.CardsDetailsJSON|undefined)
+ *       details: (!DetailsRenderer.DetailsJSON|!DetailsRenderer.CardsDetailsJSON|undefined)
  *     }
  * }}
  */
@@ -233,7 +235,7 @@ ReportRenderer.AuditJSON; // eslint-disable-line no-unused-expressions
  *     weight: number,
  *     score: number,
  *     description: string,
- *     audits: Array<ReportRenderer.AuditJSON>
+ *     audits: !Array<!ReportRenderer.AuditJSON>
  * }}
  */
 ReportRenderer.CategoryJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -56,12 +56,12 @@ function formatNumber(number) {
 
 class ReportRenderer {
   /**
-   * @param {!Document} document
    * @param {!DOM} DOM
    * @param {!DetailsRenderer} DetailsRenderer
    */
-  constructor(document, DOM, DetailsRenderer) {
-    this._detailsRenderer = new DetailsRenderer(this._dom);
+  constructor(dom, detailsRenderer) {
+    this._dom = dom;
+    this._detailsRenderer = detailsRenderer;
   }
 
   /**
@@ -198,7 +198,7 @@ class ReportRenderer {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = ReportRenderer;
-} else if (self) {
+} else {
   self.ReportRenderer = ReportRenderer;
 }
 

--- a/lighthouse-core/report/v2/report-template.html
+++ b/lighthouse-core/report/v2/report-template.html
@@ -30,7 +30,7 @@ limitations under the License.
   <script>%%LIGHTHOUSE_JAVASCRIPT%%</script>
   <script>window.__LIGHTHOUSE_JSON__ = %%LIGHTHOUSE_JSON%%;</script>
   <script>
-    const renderer = new ReportRenderer(document);
+    const renderer = new ReportRenderer(document, DOM, DetailsRenderer);
     document.body.appendChild(renderer.renderReport(window.__LIGHTHOUSE_JSON__));
   </script>
 </body>

--- a/lighthouse-core/report/v2/report-template.html
+++ b/lighthouse-core/report/v2/report-template.html
@@ -30,8 +30,11 @@ limitations under the License.
   <script>%%LIGHTHOUSE_JAVASCRIPT%%</script>
   <script>window.__LIGHTHOUSE_JSON__ = %%LIGHTHOUSE_JSON%%;</script>
   <script>
-    const renderer = new ReportRenderer(document, DOM, DetailsRenderer);
-    document.body.appendChild(renderer.renderReport(window.__LIGHTHOUSE_JSON__));
+    const dom = new DOM(document);
+    const detailsRenderer = new DetailsRenderer(dom);
+    const renderer = new ReportRenderer(dom, detailsRenderer);
+    const reportElem = renderer.renderReport(window.__LIGHTHOUSE_JSON__);
+    document.body.appendChild(reportElem);
   </script>
 </body>
 </html>

--- a/lighthouse-core/test/report/v2/renderer/dom-test.js
+++ b/lighthouse-core/test/report/v2/renderer/dom-test.js
@@ -58,12 +58,16 @@ describe('DOM', () => {
 
   describe('cloneTemplate', () => {
     it('should clone a template', () => {
-      const clone = dom.cloneTemplate('#tmpl-lh-audit-score');
+      const clone = dom.cloneTemplate('#tmpl-lh-audit-score', dom.document());
       assert.ok(clone.querySelector('.lh-score'));
     });
 
     it('fails when template cannot be found', () => {
-      assert.throws(() => dom.cloneTemplate('#unknown-selector'));
+      assert.throws(() => dom.cloneTemplate('#unknown-selector', dom.document()));
+    });
+
+    it('fails when a template context isn\'t provided', () => {
+      assert.throws(() => dom.cloneTemplate('#tmpl-lh-audit-score'));
     });
   });
 

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -33,16 +33,14 @@ describe('ReportRenderer V2', () => {
 
   before(() => {
     global.URL = URL;
-    global.DOM = DOM;
-    global.DetailsRenderer = DetailsRenderer;
     const document = jsdom.jsdom(TEMPLATE_FILE);
-    renderer = new ReportRenderer(document);
+    const dom = new DOM(document);
+    const detailsRenderer = new DetailsRenderer(dom);
+    renderer = new ReportRenderer(dom, detailsRenderer);
   });
 
   after(() => {
     global.URL = undefined;
-    global.DOM = undefined;
-    global.DetailsRenderer = undefined;
   });
 
   describe('renderReport', () => {

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -94,4 +94,12 @@ describe('ReportRenderer V2', () => {
       assert.equal(audits.length, category.audits.length, 'renders correct number of audits');
     });
   });
+
+  it('can set a custom templateContext', () => {
+    assert.equal(renderer._templateContext, renderer._dom.document());
+
+    const otherDocument = jsdom.jsdom(TEMPLATE_FILE);
+    renderer.setTemplateContext(otherDocument);
+    assert.equal(renderer._templateContext, otherDocument);
+  });
 });


### PR DESCRIPTION
Gettin the new report going in DevTools and wanted some changes like these.

1. Since I'm subclassing, I need to pass in those subclasses.
1. Globals weren't being provided automatically. (I think because devtools uses eval?)


e.g. my subclass currently looks like (UPDATED):
![image](https://cloud.githubusercontent.com/assets/39191/25029302/dac9b662-2070-11e7-91ee-1dd6904a7a17.png)



Screenshot btw: 
![image](https://cloud.githubusercontent.com/assets/39191/24986193/9c2290f0-1fad-11e7-9609-033ab6eabf46.png)
