### PR TITLE
Report v2: Basic table formatter

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -70,7 +70,7 @@ class Audit {
    * Table cells will use the type specified in headings[x].itemType. However a custom type
    * can be provided: results[x].propName = {type: 'code', text: '...'}
    * @param {!Audit.Headings} headings
-   * @param {!Array<!Object<string, string>>} results
+   * @param {!Array<!Object<string, *>>} results
    * @return {!Array<!DetailsRenderer.DetailsJSON>}
    */
   static makeV2TableRows(headings, results) {
@@ -157,13 +157,20 @@ class Audit {
 
 module.exports = Audit;
 
+/** @typedef {
+ * !Array<{
+ *   key: string,
+ *   itemType: string,
+ *   text: string,
+ * }>}
+ */
+Audit.Headings; // eslint-disable-line no-unused-expressions
+
 /** @typedef {{
- *     key: string,
- *     itemType: string,
- *     text: string,
+ *   results: !Array<!Object<string, string>>,
+ *   headings: !Audit.Headings,
+ *   passes: boolean,
+ *   debugString: (string|undefined)
  * }}
  */
-Audit.Heading; // eslint-disable-line no-unused-expressions
-
-/** @typedef {!Array<!Audit.Heading>} */
-Audit.Headings; // eslint-disable-line no-unused-expressions
+Audit.HeadingsResult; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -81,7 +81,7 @@ class Audit {
 
         return {
           type: heading.itemType,
-          text: value[heading.key]
+          text: value
         };
       });
     });

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -57,6 +57,61 @@ class Audit {
   }
 
   /**
+   * @param  {!Audit.Headings} headings
+   * @return {*}
+   */
+  static makeV1TableHeadings(headings) {
+    const tableHeadings = {};
+    headings.forEach(heading => tableHeadings[heading.key] = heading.text);
+    return tableHeadings;
+  }
+
+  /**
+   * @param  {!Audit.Headings} headings
+   * @param  {!Object} results
+   * @return {!Array<!DetailsRenderer.DetailsJSON>}
+   */
+  static makeV2TableRows(headings, results) {
+    const tableRows = results.map(item => {
+      return headings.map(heading => {
+        return {
+          type: heading.itemType,
+          text: item[heading.key]
+        };
+      });
+    });
+    return tableRows;
+  }
+
+  /**
+   * @param  {!Audit.Headings} headings
+   * @return {!Array<!DetailsRenderer.DetailsJSON>}
+   */
+  static makeV2TableHeaders(headings) {
+    return headings.map(heading => ({
+      type: 'text',
+      text: heading.text
+    }));
+  }
+
+  /**
+   * @param  {!Audit.Headings} headings
+   * @param  {!Object} results
+   * @return {!DetailsRenderer.DetailsJSON}
+   */
+  static makeV2TableDetails(headings, results) {
+    const v2TableHeaders = Audit.makeV2TableHeaders(headings);
+    const v2TableRows = Audit.makeV2TableRows(headings, results);
+    return {
+      type: 'table',
+      header: 'View Details',
+      itemHeaders: v2TableHeaders,
+      items: v2TableRows
+    };
+  }
+
+
+  /**
    * @param {!Audit} audit
    * @param {!AuditResult} result
    * @return {!AuditFullResult}
@@ -97,3 +152,16 @@ class Audit {
 }
 
 module.exports = Audit;
+
+
+/** @typedef {{
+ *     key: string,
+ *     itemType: string,
+ *     text: string,
+ * }}
+ */
+Audit.Heading; // eslint-disable-line no-unused-expressions
+
+
+/** @typedef {!Array<!Audit.Heading>} */
+Audit.Headings; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -110,7 +110,6 @@ class Audit {
     };
   }
 
-
   /**
    * @param {!Audit} audit
    * @param {!AuditResult} result
@@ -153,7 +152,6 @@ class Audit {
 
 module.exports = Audit;
 
-
 /** @typedef {{
  *     key: string,
  *     itemType: string,
@@ -161,7 +159,6 @@ module.exports = Audit;
  * }}
  */
 Audit.Heading; // eslint-disable-line no-unused-expressions
-
 
 /** @typedef {!Array<!Audit.Heading>} */
 Audit.Headings; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -57,8 +57,8 @@ class Audit {
   }
 
   /**
-   * @param  {!Audit.Headings} headings
-   * @return {*}
+   * @param {!Audit.Headings} headings
+   * @return {!Array<string>}
    */
   static makeV1TableHeadings(headings) {
     const tableHeadings = {};
@@ -67,8 +67,8 @@ class Audit {
   }
 
   /**
-   * @param  {!Audit.Headings} headings
-   * @param  {!Object} results
+   * @param {!Audit.Headings} headings
+   * @param {!Array<!Object<string, string>>} results
    * @return {!Array<!DetailsRenderer.DetailsJSON>}
    */
   static makeV2TableRows(headings, results) {
@@ -84,7 +84,7 @@ class Audit {
   }
 
   /**
-   * @param  {!Audit.Headings} headings
+   * @param {!Audit.Headings} headings
    * @return {!Array<!DetailsRenderer.DetailsJSON>}
    */
   static makeV2TableHeaders(headings) {
@@ -95,8 +95,8 @@ class Audit {
   }
 
   /**
-   * @param  {!Audit.Headings} headings
-   * @param  {!Object} results
+   * @param {!Audit.Headings} headings
+   * @param {!Array<!Object<string, string>>} results
    * @return {!DetailsRenderer.DetailsJSON}
    */
   static makeV2TableDetails(headings, results) {

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -67,6 +67,8 @@ class Audit {
   }
 
   /**
+   * Table cells will use the type specified in headings[x].itemType. However a custom type
+   * can be provided: results[x].propName = {type: 'code', text: '...'}
    * @param {!Audit.Headings} headings
    * @param {!Array<!Object<string, string>>} results
    * @return {!Array<!DetailsRenderer.DetailsJSON>}
@@ -74,9 +76,12 @@ class Audit {
   static makeV2TableRows(headings, results) {
     const tableRows = results.map(item => {
       return headings.map(heading => {
+        const value = item[heading.key];
+        if (typeof value === 'object' && value.type) return value;
+
         return {
           type: heading.itemType,
-          text: item[heading.key]
+          text: value[heading.key]
         };
       });
     });

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -69,8 +69,7 @@ class UnusedBytes extends Audit {
   }
 
   /**
-   * @param {!{debugString: string=, passes: boolean=, headings: !Audit.Headings,
-   *    results: !Array<!Object<string, string>>}} result
+   * @param {!Audit.HeadingsResult} result
    * @param {number} networkThroughput
    * @return {!AuditResult}
    */

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -96,15 +96,8 @@ class UnusedBytes extends Audit {
       displayValue = `Potential savings of ${wastedKbDisplay} (~${wastedMsDisplay})`;
     }
 
-    const headingKeys = Object.keys(result.headings);
-    const tableRows = results.map(item => {
-      return headingKeys.map(key => {
-        return {
-          type: result.headings[key].itemType,
-          text: item[key]
-        };
-      });
-    });
+    const v1TableHeadings = Audit.makeV1TableHeadings(result.headings);
+    const v2TableDetails = Audit.makeV2TableDetails(result.headings, results);
 
     return {
       debugString,
@@ -114,17 +107,9 @@ class UnusedBytes extends Audit {
           !!result.passes,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
-        value: {results, tableHeadings: result.tableHeadings}
+        value: {results, tableHeadings: v1TableHeadings}
       },
-      details: {
-        type: 'table',
-        header: 'whats up',
-        itemHeaders: Object.keys(result.headings).map(key => ({
-          type: 'text',
-          text: result.headings[key].text
-        })),
-        items: tableRows
-      }
+      details: v2TableDetails
     };
   }
 

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -69,7 +69,7 @@ class UnusedBytes extends Audit {
   }
 
   /**
-   * @param {!{debugString: string=, passes: boolean=, tableHeadings: !Object,
+   * @param {!{debugString: string=, passes: boolean=, headings: !Audit.Headings,
    *    results: !Array<!Object<string, string>>}} result
    * @param {number} networkThroughput
    * @return {!AuditResult}

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -105,7 +105,8 @@ class UnusedBytes extends Audit {
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
         value: {results, tableHeadings: result.tableHeadings}
-      }
+      },
+      details: result.details
     };
   }
 

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -70,7 +70,7 @@ class UnusedBytes extends Audit {
 
   /**
    * @param {!{debugString: string=, passes: boolean=, tableHeadings: !Object,
-   *    results: !Array<!Object>}} result
+   *    results: !Array<!Object<string, string>>}} result
    * @param {number} networkThroughput
    * @return {!AuditResult}
    */

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -96,6 +96,16 @@ class UnusedBytes extends Audit {
       displayValue = `Potential savings of ${wastedKbDisplay} (~${wastedMsDisplay})`;
     }
 
+    const headingKeys = Object.keys(result.headings);
+    const tableRows = results.map(item => {
+      return headingKeys.map(key => {
+        return {
+          type: result.headings[key].itemType,
+          text: item[key]
+        };
+      });
+    });
+
     return {
       debugString,
       displayValue,
@@ -106,7 +116,15 @@ class UnusedBytes extends Audit {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
         value: {results, tableHeadings: result.tableHeadings}
       },
-      details: result.details
+      details: {
+        type: 'table',
+        header: 'whats up',
+        itemHeaders: Object.keys(result.headings).map(key => ({
+          type: 'text',
+          text: result.headings[key].text
+        })),
+        items: tableRows
+      }
     };
   }
 

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -95,8 +95,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
 
   /**
    * @param {!Artifacts} artifacts
-   * @return {{results: !Array<Object>, tableHeadings: Object,
-   *     passes: boolean=, debugString: string=}}
+   * @return {{results: !Array<Object>, headings: !Audit.Headings, debugString: string=}}
    */
   static audit_(artifacts) {
     const images = artifacts.ImageUsage;

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -132,15 +132,18 @@ class OffscreenImages extends ByteEfficiencyAudit {
         const loadedEarly = item.requestStartTime < ttiTimestamp;
         return isWasteful && loadedEarly;
       });
+
+      const headings = [
+        {key: 'preview', itemType: 'thumbnail', text: ''},
+        {key: 'url', itemType: 'url', text: 'URL'},
+        {key: 'totalKb', itemType: 'text', text: 'Original'},
+        {key: 'potentialSavings', itemType: 'text', text: 'Potential Savings'},
+      ];
+
       return {
         debugString,
         results,
-        tableHeadings: {
-          preview: '',
-          url: 'URL',
-          totalKb: 'Original',
-          potentialSavings: 'Potential Savings',
-        }
+        headings,
       };
     });
   }

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -96,7 +96,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
 
   /**
    * @param {!Artifacts} artifacts
-   * @return {{results: !Array<Object>, headings: !Audit.Headings, debugString: string=}}
+   * @return {!Audit.HeadingsResult}
    */
   static audit_(artifacts) {
     const images = artifacts.ImageUsage;

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -83,6 +83,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
     return {
       url,
       preview: {
+        type: 'thumbnail',
         url: image.networkRecord.url,
         mimeType: image.networkRecord.mimeType
       },

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -70,7 +70,7 @@ class TotalByteWeight extends ByteEfficiencyAudit {
           totalMs: this.bytesToMsString(record.transferSize, networkThroughput),
         };
 
-        totalBytes += totalBytes;
+        totalBytes += result.totalBytes;
         prev.push(result);
         return prev;
       }, []).sort((itemA, itemB) => itemB.totalBytes - itemA.totalBytes).slice(0, 10);

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -70,7 +70,7 @@ class TotalByteWeight extends ByteEfficiencyAudit {
           totalMs: this.bytesToMsString(record.transferSize, networkThroughput),
         };
 
-        totalBytes += result.totalBytes;
+        totalBytes += totalBytes;
         prev.push(result);
         return prev;
       }, []).sort((itemA, itemB) => itemB.totalBytes - itemA.totalBytes).slice(0, 10);
@@ -84,6 +84,15 @@ class TotalByteWeight extends ByteEfficiencyAudit {
           SCORING_MEDIAN, SCORING_POINT_OF_DIMINISHING_RETURNS);
       const score = 100 * distribution.computeComplementaryPercentile(totalBytes);
 
+      const headings = [
+        {key: 'url', itemType: 'url', text: 'URL'},
+        {key: 'totalKb', itemType: 'text', text: 'Total Size'},
+        {key: 'totalMs', itemType: 'text', text: 'Transfer Time'},
+      ];
+
+      const v1TableHeadings = Audit.makeV1TableHeadings(headings);
+      const v2TableDetails = Audit.makeV2TableDetails(headings, results);
+
       return {
         rawValue: totalBytes,
         optimalValue: this.meta.optimalValue,
@@ -93,13 +102,10 @@ class TotalByteWeight extends ByteEfficiencyAudit {
           formatter: Formatter.SUPPORTED_FORMATS.TABLE,
           value: {
             results,
-            tableHeadings: {
-              url: 'URL',
-              totalKb: 'Total Size',
-              totalMs: 'Transfer Time',
-            }
+            tableHeadings: v1TableHeadings
           }
-        }
+        },
+        details: v2TableDetails
       };
     });
   }

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -90,8 +90,8 @@ class TotalByteWeight extends ByteEfficiencyAudit {
         {key: 'totalMs', itemType: 'text', text: 'Transfer Time'},
       ];
 
-      const v1TableHeadings = Audit.makeV1TableHeadings(headings);
-      const v2TableDetails = Audit.makeV2TableDetails(headings, results);
+      const v1TableHeadings = ByteEfficiencyAudit.makeV1TableHeadings(headings);
+      const v2TableDetails = ByteEfficiencyAudit.makeV2TableDetails(headings, results);
 
       return {
         rawValue: totalBytes,

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -179,14 +179,17 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
       return UnusedCSSRules.mapSheetToResult(indexedSheets[sheetId], pageUrl);
     }).filter(sheet => sheet && sheet.wastedBytes > 1024);
 
+
+    const headings = [
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'numUnused', itemType: 'url', text: 'Unused Rules'},
+      {key: 'totalKb', itemType: 'text', text: 'Original'},
+      {key: 'potentialSavings', itemType: 'text', text: 'Potential Savings'},
+    ];
+
     return {
       results,
-      tableHeadings: {
-        url: 'URL',
-        numUnused: 'Unused Rules',
-        totalKb: 'Original',
-        potentialSavings: 'Potential Savings',
-      }
+      headings
     };
   }
 }

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -164,8 +164,7 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
 
   /**
    * @param {!Artifacts} artifacts
-   * @return {{results: !Array<Object>, tableHeadings: Object,
-   *     passes: boolean=, debugString: string=}}
+   * @return {{results: !Array<Object>, headings: !Audit.Headings}}
    */
   static audit_(artifacts) {
     const styles = artifacts.Styles;

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -63,7 +63,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
 
   /**
    * @param {!Artifacts} artifacts
-   * @return {{results: !Array<Object>, headings: !Audit.Headings, passes: boolean=, debugString: string=}}
+   * @return {!Audit.HeadingsResult}
    */
   static audit_(artifacts) {
     const images = artifacts.OptimizedImages;

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -121,24 +121,19 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
       debugString = `Lighthouse was unable to decode some of your images: ${urls.join(', ')}`;
     }
 
+    const headings = [
+      {key: 'preview', itemType: 'thumbnail', text: ''},
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'totalKb', itemType: 'text', text: 'Original'},
+      {key: 'webpSavings', itemType: 'text', text: 'Savings as WebP'},
+      {key: 'jpegSavings', itemType: 'text', text: 'Savings as JPEG'},
+    ];
+
     return {
       passes: hasAllEfficientImages && totalWastedBytes < TOTAL_WASTED_BYTES_THRESHOLD,
       debugString,
       results,
-      tableHeadings: {
-        preview: '',
-        url: 'URL',
-        totalKb: 'Original',
-        webpSavings: 'WebP Savings',
-        jpegSavings: 'JPEG Savings',
-      },
-      headings: {
-        preview: {itemType: 'thumbnail', text: ''},
-        url: {itemType: 'url', text: 'URL'},
-        totalKb: {itemType: 'text', text: 'Original'},
-        webpSavings: {itemType: 'text', text: 'Savings as WebP'},
-        jpegSavings: {itemType: 'text', text: 'Savings as JPEG'},
-      }
+      headings
     };
   }
 }

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -105,7 +105,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
       results.push({
         url,
         isCrossOrigin: !image.isSameOrigin,
-        preview: {url: image.url, mimeType: image.mimeType},
+        preview: {url: image.url, mimeType: image.mimeType, type: 'thumbnail'},
         totalBytes: image.originalSize,
         wastedBytes: webpSavings.bytes,
         webpSavings: this.toSavingsString(webpSavings.bytes, webpSavings.percent),

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -63,8 +63,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
 
   /**
    * @param {!Artifacts} artifacts
-   * @return {{results: !Array<Object>, tableHeadings: Object,
-   *     passes: boolean=, debugString: string=}}
+   * @return {{results: !Array<Object>, headings: !Audit.Headings, passes: boolean=, debugString: string=}}
    */
   static audit_(artifacts) {
     const images = artifacts.OptimizedImages;

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -131,6 +131,13 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
         totalKb: 'Original',
         webpSavings: 'WebP Savings',
         jpegSavings: 'JPEG Savings',
+      },
+      headings: {
+        preview: {itemType: 'thumbnail', text: ''},
+        url: {itemType: 'url', text: 'URL'},
+        totalKb: {itemType: 'text', text: 'Original'},
+        webpSavings: {itemType: 'text', text: 'Savings as WebP'},
+        jpegSavings: {itemType: 'text', text: 'Savings as JPEG'},
       }
     };
   }

--- a/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
@@ -47,7 +47,7 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
   /**
    * @param {!Artifacts} artifacts
    * @param {number} networkThroughput
-   * @return {{results: !Array<Object>, passes: boolean=, headings: !Audit.Headings, debugString: string=}}
+   * @return {!Audit.HeadingsResult}
    */
   static audit_(artifacts) {
     const uncompressedResponses = artifacts.ResponseCompression;

--- a/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
@@ -90,20 +90,17 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
     });
 
     let debugString;
+    const headings = [
+      {key: 'url', itemType: 'url', text: 'Uncompressed resource URL'},
+      {key: 'totalKb', itemType: 'text', text: 'Original'},
+      {key: 'potentialSavings', itemType: 'text', text: 'GZIP Savings'},
+    ];
+
     return {
       passes: totalWastedBytes < TOTAL_WASTED_BYTES_THRESHOLD,
       debugString,
       results,
-      tableHeadings: {
-        url: 'Uncompressed resource URL',
-        totalKb: 'Original',
-        potentialSavings: 'GZIP Savings',
-      },
-      headings: {
-        url: {itemType: 'url', text: 'Uncompressed resource URL'},
-        totalKb: {itemType: 'text', text: 'Original'},
-        potentialSavings: {itemType: 'text', text: 'GZIP Savings'},
-      }
+      headings,
     };
   }
 }

--- a/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
@@ -89,6 +89,14 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
       });
     });
 
+    const tableItems = results.map(result => {
+      return [
+        {type: 'url', text: result.url},
+        {type: 'text', text: result.totalBytes},
+        {type: 'text', text: result.potentialSavings},
+      ];
+    });
+
     let debugString;
     return {
       passes: totalWastedBytes < TOTAL_WASTED_BYTES_THRESHOLD,
@@ -98,6 +106,16 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
         url: 'Uncompressed resource URL',
         totalKb: 'Original',
         potentialSavings: 'GZIP Savings',
+      },
+
+      details: {
+        type: 'table',
+        header: [
+          {type: 'text', text: 'Uncompressed resource URL'},
+          {type: 'text', text: 'Original'},
+          {type: 'text', text: 'GZIP Savings'},
+        ],
+        items: tableItems
       }
     };
   }

--- a/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
@@ -89,14 +89,6 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
       });
     });
 
-    const tableItems = results.map(result => {
-      return [
-        {type: 'url', text: result.url},
-        {type: 'text', text: result.totalBytes},
-        {type: 'text', text: result.potentialSavings},
-      ];
-    });
-
     let debugString;
     return {
       passes: totalWastedBytes < TOTAL_WASTED_BYTES_THRESHOLD,
@@ -107,15 +99,10 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
         totalKb: 'Original',
         potentialSavings: 'GZIP Savings',
       },
-
-      details: {
-        type: 'table',
-        header: [
-          {type: 'text', text: 'Uncompressed resource URL'},
-          {type: 'text', text: 'Original'},
-          {type: 'text', text: 'GZIP Savings'},
-        ],
-        items: tableItems
+      headings: {
+        url: {itemType: 'url', text: 'Uncompressed resource URL'},
+        totalKb: {itemType: 'text', text: 'Original'},
+        potentialSavings: {itemType: 'text', text: 'GZIP Savings'},
       }
     };
   }

--- a/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
@@ -47,7 +47,7 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
   /**
    * @param {!Artifacts} artifacts
    * @param {number} networkThroughput
-   * @return {!AuditResult}
+   * @return {{results: !Array<Object>, passes: boolean=, headings: !Audit.Headings, debugString: string=}}
    */
   static audit_(artifacts) {
     const uncompressedResponses = artifacts.ResponseCompression;

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -80,8 +80,7 @@ class UsesResponsiveImages extends ByteEfficiencyAudit {
 
   /**
    * @param {!Artifacts} artifacts
-   * @return {{results: !Array<Object>, tableHeadings: Object,
-   *     passes: boolean=, debugString: string=}}
+   * @return {{results: !Array<Object>, headings: !Audit.Headings, passes: boolean=, debugString: string=}}
    */
   static audit_(artifacts) {
     const images = artifacts.ImageUsage;

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -81,7 +81,7 @@ class UsesResponsiveImages extends ByteEfficiencyAudit {
 
   /**
    * @param {!Artifacts} artifacts
-   * @return {{results: !Array<Object>, headings: !Audit.Headings, passes: boolean=, debugString: string=}}
+   * @return {!Audit.HeadingsResult}
    */
   static audit_(artifacts) {
     const images = artifacts.ImageUsage;

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -68,6 +68,7 @@ class UsesResponsiveImages extends ByteEfficiencyAudit {
     return {
       url,
       preview: {
+        type: 'thumbnail',
         url: image.networkRecord.url,
         mimeType: image.networkRecord.mimeType
       },

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -110,7 +110,7 @@ class UsesResponsiveImages extends ByteEfficiencyAudit {
     }, new Map());
 
     const results = Array.from(resultsMap.values())
-      .filter(item => item.wastedBytes > IGNORE_THRESHOLD_IN_BYTES);
+        .filter(item => item.wastedBytes > IGNORE_THRESHOLD_IN_BYTES);
 
     const headings = [
       {key: 'preview', itemType: 'thumbnail', text: ''},

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -110,17 +110,20 @@ class UsesResponsiveImages extends ByteEfficiencyAudit {
     }, new Map());
 
     const results = Array.from(resultsMap.values())
-        .filter(item => item.wastedBytes > IGNORE_THRESHOLD_IN_BYTES);
+      .filter(item => item.wastedBytes > IGNORE_THRESHOLD_IN_BYTES);
+
+    const headings = [
+      {key: 'preview', itemType: 'thumbnail', text: ''},
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'totalKb', itemType: 'text', text: 'Original'},
+      {key: 'potentialSavings', itemType: 'text', text: 'Potential Savings'},
+    ];
+
     return {
       debugString,
       passes: !results.find(item => item.isWasteful),
       results,
-      tableHeadings: {
-        preview: '',
-        url: 'URL',
-        totalKb: 'Original',
-        potentialSavings: 'Potential Savings',
-      }
+      headings,
     };
   }
 }

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -85,6 +85,15 @@ class LinkBlockingFirstPaintAudit extends Audit {
       displayValue = `${results.length} resource delayed first paint by ${delayTime}ms`;
     }
 
+    const headings = [
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'totalKb', itemType: 'text', text: 'Size (KB)'},
+      {key: 'totalMs', itemType: 'text', text: 'Delayed Paint By (ms)'},
+    ];
+
+    const v1TableHeadings = Audit.makeV1TableHeadings(headings);
+    const v2TableDetails = Audit.makeV2TableDetails(headings, results);
+
     return {
       displayValue,
       rawValue: results.length === 0,
@@ -92,13 +101,10 @@ class LinkBlockingFirstPaintAudit extends Audit {
         formatter: Formatter.SUPPORTED_FORMATS.TABLE,
         value: {
           results,
-          tableHeadings: {
-            url: 'URL',
-            totalKb: 'Size (KB)',
-            totalMs: 'Delayed Paint By (ms)'
-          }
+          tableHeadings: v1TableHeadings
         }
-      }
+      },
+      details: v2TableDetails
     };
   }
 

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -124,7 +124,7 @@ class DetailsRenderer {
   _renderTable(details) {
     const element = this._dom.createElement('details', 'lh-details', {open: true});
     if (details.header) {
-      element.appendChild(this._dom.createElement('summary')).textContent = details.header || 'SUP';
+      element.appendChild(this._dom.createElement('summary')).textContent = details.header;
     }
 
     const tableElem = element.createChild('table', 'lh-table lh-table__multicolumn');

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -38,8 +38,6 @@ class DetailsRenderer {
         return this._renderURL(details);
       case 'thumbnail':
         return this._renderThumbnail(details);
-      case 'block':
-        return this._renderBlock(details);
       case 'cards':
         return this._renderCards(/** @type {!DetailsRenderer.CardsDetailsJSON} */ (details));
       case 'table':
@@ -72,31 +70,18 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsRenderer.ThumbnailDetails} obj
-   * @return {!DocumentFragment}
+   * @param {!DetailsRenderer.ThumbnailDetails} value
+   * @return {!Element}
    */
   _renderThumbnail(value) {
     if (/^image/.test(value.mimeType) === false) {
-      return this.dom.createDocumentFragment();
+      return this._dom.createElement('span');
     }
 
     const element = this._dom.createElement('img', 'lh-thumbnail');
     element.src = value.url;
     element.alt = 'Image preview';
     element.title = value.url;
-    return element;
-  }
-
-  /**
-   * @param {!DetailsRenderer.DetailsJSON} block
-   * @return {!Element}
-   */
-  _renderBlock(block) {
-    const element = this._dom.createElement('div', 'lh-block');
-    const items = block.items || [];
-    for (const item of items) {
-      element.appendChild(this.render(item));
-    }
     return element;
   }
 
@@ -123,10 +108,10 @@ class DetailsRenderer {
 
   /**
    * @param {!DetailsRenderer.TableDetailsJSON} details
-   * @return {!DocumentFragment}
+   * @return {!Element}
    */
   _renderTable(details) {
-    if (!details.items.length) return this._dom.createDocumentFragment();
+    if (!details.items.length) return this._dom.createElement('span');
 
     const element = this._dom.createElement('details', 'lh-details');
     if (details.header) {
@@ -216,7 +201,7 @@ DetailsRenderer.CardsDetailsJSON; // eslint-disable-line no-unused-expressions
 /** @typedef {{
  *     type: string,
  *     header: ({text: string}|undefined),
- *     items: !Array<!DetailsRenderer.DetailsJSON>,
+ *     items: !Array<!Array<!DetailsRenderer.DetailsJSON>>,
  *     itemHeaders: !Array<!DetailsRenderer.DetailsJSON>
  * }}
  */

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -36,6 +36,8 @@ class DetailsRenderer {
         return this._renderText(details);
       case 'url':
         return this._renderURL(details);
+      case 'thumbnail':
+        return this._renderThumbnail(details);
       case 'block':
         return this._renderBlock(details);
       case 'cards':
@@ -59,14 +61,38 @@ class DetailsRenderer {
     return element;
   }
 
-
   /**
    * @param {!DetailsRenderer.DetailsJSON} text
    * @return {!Element}
    */
   _renderURL(text) {
-    const element = this._dom._renderText(text);
+    const element = this._renderText(text);
     element.classList.add('lh-text__url');
+    return element;
+  }
+
+  /**
+   * @param {!DetailsRenderer.DetailsJSON} obj
+   * @return {!Element}
+   */
+  _renderThumbnail(obj) {
+    const element = this._dom.createElement('img', 'lh-thumbnail');
+    element.src = obj.text.url;
+    // ignore obj.text.mimeType
+    element.alt = 'Image preview';
+    return element;
+  }
+
+  /**
+   * @param {!DetailsRenderer.DetailsJSON} block
+   * @return {!Element}
+   */
+  _renderBlock(block) {
+    const element = this._dom.createElement('div', 'lh-block');
+    const items = block.items || [];
+    for (const item of items) {
+      element.appendChild(this.render(item));
+    }
     return element;
   }
 
@@ -98,12 +124,12 @@ class DetailsRenderer {
   _renderTable(details) {
     const element = this._dom.createElement('details', 'lh-details', {open: true});
     if (details.header) {
-      element.appendChild(this._dom.createElement('summary')).textContent = 'View details';
+      element.appendChild(this._dom.createElement('summary')).textContent = details.header || 'SUP';
     }
 
     const tableElem = element.createChild('table', 'lh-table lh-table__multicolumn');
     const theadTrElem = tableElem.createChild('thead').createChild('tr');
-    for (const heading of details.header) {
+    for (const heading of details.itemHeaders) {
       theadTrElem.createChild('th').appendChild(this.render(heading));
     }
 

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -72,7 +72,7 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsRenderer.DetailsJSON} obj
+   * @param {!DetailsRenderer.ThumbnailDetails} obj
    * @return {!Element}
    */
   _renderThumbnail(obj) {
@@ -80,6 +80,7 @@ class DetailsRenderer {
     element.src = obj.text.url;
     // ignore obj.text.mimeType
     element.alt = 'Image preview';
+    element.title = obj.text.url;
     return element;
   }
 
@@ -122,22 +123,24 @@ class DetailsRenderer {
    * @return {!Element}
    */
   _renderTable(details) {
-    const element = this._dom.createElement('details', 'lh-details', {open: true});
+    const element = this._dom.createElement('details', 'lh-details');
     if (details.header) {
       element.appendChild(this._dom.createElement('summary')).textContent = details.header;
     }
 
-    const tableElem = element.createChild('table', 'lh-table lh-table__multicolumn');
-    const theadTrElem = tableElem.createChild('thead').createChild('tr');
+    const tableElem = this._dom.createChildOf(element, 'table', 'lh-table');
+    const theadElem = this._dom.createChildOf(tableElem, 'thead');
+    const theadTrElem = this._dom.createChildOf(theadElem, 'tr');
+
     for (const heading of details.itemHeaders) {
-      theadTrElem.createChild('th').appendChild(this.render(heading));
+      this._dom.createChildOf(theadTrElem, 'th').appendChild(this.render(heading));
     }
 
-    const tbodyElem = tableElem.createChild('tbody');
+    const tbodyElem = this._dom.createChildOf(tableElem, 'tbody');
     for (const row of details.items) {
-      const rowElem = tbodyElem.createChild('tr');
+      const rowElem = this._dom.createChildOf(tbodyElem, 'tr');
       for (const columnItem of row) {
-        rowElem.createChild('td').appendChild(this.render(columnItem));
+        this._dom.createChildOf(rowElem, 'td').appendChild(this.render(columnItem));
       }
     }
     return element;
@@ -204,3 +207,21 @@ DetailsRenderer.ListDetailsJSON; // eslint-disable-line no-unused-expressions
  * }}
  */
 DetailsRenderer.CardsDetailsJSON; // eslint-disable-line no-unused-expressions
+
+/** @typedef {{
+ *     type: string,
+ *     header: ({text: string}|undefined),
+ *     items: !Array<!DetailsRenderer.DetailsJSON>,
+ *     itemHeaders: !Array<!DetailsRenderer.DetailsJSON>
+ * }}
+ */
+DetailsRenderer.TableDetailsJSON; // eslint-disable-line no-unused-expressions
+
+
+/** @typedef {{
+ *     type: string,
+ *     url: ({text: string}|undefined),
+ *     mimeType: ({text: string}|undefined)
+ * }}
+ */
+DetailsRenderer.ThumbnailDetails; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -73,14 +73,17 @@ class DetailsRenderer {
 
   /**
    * @param {!DetailsRenderer.ThumbnailDetails} obj
-   * @return {!Element}
+   * @return {!DocumentFragment}
    */
-  _renderThumbnail(obj) {
+  _renderThumbnail(value) {
+    if (/^image/.test(value.mimeType) === false) {
+      return this.dom.createDocumentFragment();
+    }
+
     const element = this._dom.createElement('img', 'lh-thumbnail');
-    element.src = obj.text.url;
-    // ignore obj.text.mimeType
+    element.src = value.url;
     element.alt = 'Image preview';
-    element.title = obj.text.url;
+    element.title = value.url;
     return element;
   }
 
@@ -120,9 +123,11 @@ class DetailsRenderer {
 
   /**
    * @param {!DetailsRenderer.TableDetailsJSON} details
-   * @return {!Element}
+   * @return {!DocumentFragment}
    */
   _renderTable(details) {
+    if (!details.items.length) return this._dom.createDocumentFragment();
+
     const element = this._dom.createElement('details', 'lh-details');
     if (details.header) {
       element.appendChild(this._dom.createElement('summary')).textContent = details.header;

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -34,8 +34,14 @@ class DetailsRenderer {
     switch (details.type) {
       case 'text':
         return this._renderText(details);
+      case 'url':
+        return this._renderURL(details);
+      case 'block':
+        return this._renderBlock(details);
       case 'cards':
         return this._renderCards(/** @type {!DetailsRenderer.CardsDetailsJSON} */ (details));
+      case 'table':
+        return this._renderTable(/** @type {!DetailsRenderer.TableDetailsJSON} */ (details));
       case 'list':
         return this._renderList(/** @type {!DetailsRenderer.ListDetailsJSON} */ (details));
       default:
@@ -50,6 +56,17 @@ class DetailsRenderer {
   _renderText(text) {
     const element = this._dom.createElement('div', 'lh-text');
     element.textContent = text.text;
+    return element;
+  }
+
+
+  /**
+   * @param {!DetailsRenderer.DetailsJSON} text
+   * @return {!Element}
+   */
+  _renderURL(text) {
+    const element = this._dom._renderText(text);
+    element.classList.add('lh-text__url');
     return element;
   }
 
@@ -70,6 +87,33 @@ class DetailsRenderer {
       itemsElem.appendChild(this.render(item));
     }
     element.appendChild(itemsElem);
+    return element;
+  }
+
+
+  /**
+   * @param {!DetailsRenderer.TableDetailsJSON} details
+   * @return {!Element}
+   */
+  _renderTable(details) {
+    const element = this._dom.createElement('details', 'lh-details', {open: true});
+    if (details.header) {
+      element.appendChild(this._dom.createElement('summary')).textContent = 'View details';
+    }
+
+    const tableElem = element.createChild('table', 'lh-table lh-table__multicolumn');
+    const theadTrElem = tableElem.createChild('thead').createChild('tr');
+    for (const heading of details.header) {
+      theadTrElem.createChild('th').appendChild(this.render(heading));
+    }
+
+    const tbodyElem = tableElem.createChild('tbody');
+    for (const row of details.items) {
+      const rowElem = tbodyElem.createChild('tr');
+      for (const columnItem of row) {
+        rowElem.createChild('td').appendChild(this.render(columnItem));
+      }
+    }
     return element;
   }
 

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -70,6 +70,8 @@ class DetailsRenderer {
   }
 
   /**
+   * Create small thumbnail with scaled down image asset.
+   * If the supplied details doesn't have an image/* mimeType, then an empty span is returned.
    * @param {!DetailsRenderer.ThumbnailDetails} value
    * @return {!Element}
    */
@@ -80,7 +82,7 @@ class DetailsRenderer {
 
     const element = this._dom.createElement('img', 'lh-thumbnail');
     element.src = value.url;
-    element.alt = 'Image preview';
+    element.alt = '';
     element.title = value.url;
     return element;
   }

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -63,13 +63,6 @@ class DOM {
     return element;
   }
 
-   /**
-   * @return {!DocumentFragment}
-   */
-  createDocumentFragment() {
-    return this._document.createDocumentFragment();
-  }
-
   /**
    * @param {string} selector
    * @param {!Node} context

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -63,6 +63,13 @@ class DOM {
     return element;
   }
 
+   /**
+   * @return {!DocumentFragment}
+   */
+  createDocumentFragment() {
+    return this._document.createDocumentFragment();
+  }
+
   /**
    * @param {string} selector
    * @param {!Node} context

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -24,30 +24,6 @@ class DOM {
   constructor(document) {
     /** @private {!Document} */
     this._document = document;
-
-    this._installDOMExtensions();
-  }
-
-  /**
-   * Add some API sugar
-   */
-  _installDOMExtensions() {
-    if (typeof self === 'undefined' || !self.Element) return;
-    if (self.Element.prototype.createChild) return;
-    const instance = this;
-
-    /**
-     * From devtools' DOMExtension.js (minus the 3rd customElementType param)
-     * @param {string} elementName
-     * @param {string=} className
-     * @return {!Element}
-     */
-    self.Element.prototype.createChild = function(elementName, className) {
-      const element = instance.createElement(elementName, className);
-      this.appendChild(element);
-      return element;
-    };
-    self.DocumentFragment.prototype.createChild = self.Element.prototype.createChild;
   }
 
  /**
@@ -69,6 +45,21 @@ class DOM {
         element.setAttribute(key, value);
       }
     });
+    return element;
+  }
+
+ /**
+   * @param {!Element} parentElem
+   * @param {string} elementName
+   * @param {string=} className
+   * @param {!Object<string, (string|undefined)>=} attrs Attribute key/val pairs.
+   *     Note: if an attribute key has an undefined value, this method does not
+   *     set the attribute on the node.
+   * @return {!Element}
+   */
+  createChildOf(parentElem, elementName, className, attrs) {
+    const element = this.createElement(elementName, className, attrs);
+    parentElem.appendChild(element);
     return element;
   }
 

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -24,6 +24,28 @@ class DOM {
   constructor(document) {
     /** @private {!Document} */
     this._document = document;
+
+    this._registerDOMExtensions();
+  }
+
+  _registerDOMExtensions() {
+    if (typeof self === 'undefined' || !self.Element) return;
+    if (self.Element.prototype.createChild) return;
+
+    const instance = this;
+    /**
+     * From devtools' DOMExtension.js, except without 3rd customElementType param
+     * @param {string} elementName
+     * @param {string=} className
+     * @return {!Element}
+     */
+    self.Element.prototype.createChild = function(elementName, className) {
+      const element = instance.createElement(elementName, className);
+      this.appendChild(element);
+      return element;
+    };
+
+    self.DocumentFragment.prototype.createChild = self.Element.prototype.createChild;
   }
 
  /**

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -25,16 +25,19 @@ class DOM {
     /** @private {!Document} */
     this._document = document;
 
-    this._registerDOMExtensions();
+    this._installDOMExtensions();
   }
 
-  _registerDOMExtensions() {
+  /**
+   * Add some API sugar
+   */
+  _installDOMExtensions() {
     if (typeof self === 'undefined' || !self.Element) return;
     if (self.Element.prototype.createChild) return;
-
     const instance = this;
+
     /**
-     * From devtools' DOMExtension.js, except without 3rd customElementType param
+     * From devtools' DOMExtension.js (minus the 3rd customElementType param)
      * @param {string} elementName
      * @param {string=} className
      * @return {!Element}
@@ -44,7 +47,6 @@ class DOM {
       this.appendChild(element);
       return element;
     };
-
     self.DocumentFragment.prototype.createChild = self.Element.prototype.createChild;
   }
 

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -492,14 +492,10 @@ summary.lh-passed-audits-summary::-webkit-details-marker {
   --image-preview: 24px;
 }
 
-.lh-thumbnail img {
+img.lh-thumbnail {
   height: var(--image-preview);
   width: var(--image-preview);
   object-fit: contain;
-}
-
-.lh-thumbnail {
-  width: calc(var(--image-preview) * 2);
 }
 
 /*# sourceURL=report.styles.css */

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -488,12 +488,12 @@ summary.lh-passed-audits-summary::-webkit-details-marker {
 }
 
 .lh-table {
-  --image-preview: 24px;
+  --image-preview-size: 24px;
 }
 
 .lh-thumbnail {
-  height: var(--image-preview);
-  width: var(--image-preview);
+  height: var(--image-preview-size);
+  width: var(--image-preview-size);
   object-fit: contain;
 }
 

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -487,12 +487,11 @@ summary.lh-passed-audits-summary::-webkit-details-marker {
   }
 }
 
-
 .lh-table {
   --image-preview: 24px;
 }
 
-img.lh-thumbnail {
+.lh-thumbnail {
   height: var(--image-preview);
   width: var(--image-preview);
   object-fit: contain;

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -487,4 +487,19 @@ summary.lh-passed-audits-summary::-webkit-details-marker {
   }
 }
 
+
+.lh-table {
+  --image-preview: 24px;
+}
+
+.lh-thumbnail img {
+  height: var(--image-preview);
+  width: var(--image-preview);
+  object-fit: contain;
+}
+
+.lh-thumbnail {
+  width: calc(var(--image-preview) * 2);
+}
+
 /*# sourceURL=report.styles.css */

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -23,7 +23,7 @@ const assert = require('assert');
 describe('Byte efficiency base audit', () => {
   it('should format as extendedInfo', () => {
     const result = ByteEfficiencyAudit.createAuditResult({
-      tableHeadings: {value: 'Label'},
+      headings: [{key: 'value', text: 'Label'}],
       results: [],
     });
 
@@ -33,18 +33,18 @@ describe('Byte efficiency base audit', () => {
 
   it('should set the rawValue', () => {
     const goodResultInferred = ByteEfficiencyAudit.createAuditResult({
-      tableHeadings: {value: 'Label'},
+      headings: [{key: 'value', text: 'Label'}],
       results: [{wastedBytes: 2345, totalBytes: 3000, wastedPercent: 65}],
     });
 
     const badResultInferred = ByteEfficiencyAudit.createAuditResult({
-      tableHeadings: {value: 'Label'},
+      headings: [{key: 'value', text: 'Label'}],
       results: [{wastedBytes: 45000, totalBytes: 45000, wastedPercent: 100}],
     });
 
     const badResultExplicit = ByteEfficiencyAudit.createAuditResult({
       passes: false,
-      tableHeadings: {value: 'Label'},
+      headings: [{key: 'value', text: 'Label'}],
       results: [{wastedBytes: 2345, totalBytes: 3000, wastedPercent: 65}],
     });
 
@@ -55,7 +55,7 @@ describe('Byte efficiency base audit', () => {
 
   it('should populate Kb', () => {
     const result = ByteEfficiencyAudit.createAuditResult({
-      tableHeadings: {value: 'Label'},
+      headings: [{key: 'value', text: 'Label'}],
       results: [{wastedBytes: 2048, totalBytes: 4096, wastedPercent: 50}],
     });
 
@@ -65,7 +65,7 @@ describe('Byte efficiency base audit', () => {
 
   it('should populate Ms', () => {
     const result = ByteEfficiencyAudit.createAuditResult({
-      tableHeadings: {value: 'Label'},
+      headings: [{key: 'value', text: 'Label'}],
       results: [{wastedBytes: 350, totalBytes: 700, wastedPercent: 50}],
     }, 1000);
 
@@ -75,7 +75,7 @@ describe('Byte efficiency base audit', () => {
 
   it('should sort on wastedBytes', () => {
     const result = ByteEfficiencyAudit.createAuditResult({
-      tableHeadings: {value: 'Label'},
+      headings: [{key: 'value', text: 'Label'}],
       results: [
         {wastedBytes: 350, totalBytes: 700, wastedPercent: 50},
         {wastedBytes: 450, totalBytes: 1000, wastedPercent: 50},
@@ -90,7 +90,7 @@ describe('Byte efficiency base audit', () => {
 
   it('should create a display value', () => {
     const result = ByteEfficiencyAudit.createAuditResult({
-      tableHeadings: {value: 'Label'},
+      headings: [{key: 'value', text: 'Label'}],
       results: [
         {wastedBytes: 512, totalBytes: 700, wastedPercent: 50},
         {wastedBytes: 512, totalBytes: 1000, wastedPercent: 50},

--- a/lighthouse-core/test/audits/byte-efficiency/uses-optimized-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/uses-optimized-images-test.js
@@ -67,10 +67,10 @@ describe('Page uses optimized images', () => {
       ],
     });
 
-    const headings = auditResult.tableHeadings;
+    const headings = auditResult.headings.map(heading => heading.text);
     assert.equal(auditResult.passes, false);
-    assert.deepEqual(Object.keys(headings).map(key => headings[key]),
-        ['', 'URL', 'Original', 'WebP Savings', 'JPEG Savings'],
+    assert.deepEqual(headings,
+        ['', 'URL', 'Original', 'Savings as WebP', 'Savings as JPEG'],
         'table headings are correct and in order');
   });
 


### PR DESCRIPTION
It's not very pretty but the basics are there.

* adds thumbnail renderer
* adds URL renderer (just displays as text for now)
* adds table renderer (obviously)
* introduces `AuditResult.details.itemHeaders` for the `thead` cells

screenshot, lol:
![image](https://cloud.githubusercontent.com/assets/39191/25060974/c31315a0-215f-11e7-9a01-5004e3a02b31.png)
