### PR TITLE
[WIP] Add audits renderer support + GroupByTag renderer

### DIFF
--- a/lighthouse-core/audits/accessibility/document-title.js
+++ b/lighthouse-core/audits/accessibility/document-title.js
@@ -33,6 +33,7 @@ class DocumentTitle extends AxeAudit {
       category: 'Accessibility',
       name: 'document-title',
       description: 'Document has a `<title>` element.',
+      renderer: AxeAudit.RENDERERS.GROUP_BY_TAG,
       helpText: 'Screen reader users use page titles to get an overview of the contents of ' +
           'the page.',
       requiredArtifacts: ['Accessibility']

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -37,6 +37,16 @@ class Audit {
   }
 
   /**
+   * @return {{GROUP_BY_STATUS: string, GROUP_BY_TAG: string}}
+   */
+  static get RENDERERS() {
+    return {
+      GROUP_BY_STATUS: 'GroupByStatus',
+      GROUP_BY_TAG: 'GroupByTag',
+    };
+  }
+
+  /**
    * @throws {Error}
    */
   static get meta() {
@@ -85,6 +95,7 @@ class Audit {
       debugString: result.debugString,
       optimalValue: result.optimalValue,
       extendedInfo: result.extendedInfo,
+      renderer: audit.meta.category === 'Accessibility' ? Audit.RENDERERS.GROUP_BY_TAG : Audit.RENDERERS.GROUP_BY_STATUS,
       scoringMode: audit.meta.scoringMode || Audit.SCORING_MODES.BINARY,
       informative: audit.meta.informative,
       name: audit.meta.name,

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -316,6 +316,7 @@ class Config {
     this._audits = Config.requireAudits(configJSON.audits, this._configDir);
     this._artifacts = expandArtifacts(configJSON.artifacts);
     this._categories = configJSON.categories;
+    this._tags = configJSON.tags;
 
     // validatePasses must follow after audits are required
     validatePasses(configJSON.passes, this._audits, this._configDir);
@@ -567,6 +568,11 @@ class Config {
   /** @type {Object<{audits: !Array<{id: string, weight: number}>}>} */
   get categories() {
     return this._categories;
+  }
+
+  /** @type {Object<string, {title: string, description: string}>} */
+  get tags() {
+    return this._tags;
   }
 }
 

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -589,6 +589,28 @@ module.exports = {
       }
     }]
   }],
+  "tags": {
+    "performance-metric": {
+      "title": "Critical Performance Metrics",
+      "description": "These performance metrics capture your user's experience. Performing well on _all_ of these is critical."
+    },
+    "accessibility-describe-contents": {
+      "title": "Elements Describe Contents Well",
+      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+    },
+    "accessibility-well-structured": {
+      "title": "Elements Are Well Structured",
+      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+    },
+    "accessibility-correct-attributes": {
+      "title": "Elements Use Attributes Correctly",
+      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+    },
+    "accessibility-language": {
+      "title": "Page Uses Language Correctly",
+      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+    }
+  },
   "categories": {
     "pwa": {
       "name": "Progressive Web App",
@@ -612,10 +634,10 @@ module.exports = {
       "name": "Performance",
       "description": "These encapsulate your app's performance.",
       "audits": [
-        {"id": "first-meaningful-paint", "weight": 5},
-        {"id": "speed-index-metric", "weight": 1},
-        {"id": "estimated-input-latency", "weight": 1},
-        {"id": "time-to-interactive", "weight": 5},
+        {"id": "first-meaningful-paint", "weight": 5, "tag": "performance-metric"},
+        {"id": "speed-index-metric", "weight": 1, "tag": "performance-metric"},
+        {"id": "estimated-input-latency", "weight": 1, "tag": "performance-metric"},
+        {"id": "time-to-interactive", "weight": 5, "tag": "performance-metric"},
         {"id": "link-blocking-first-paint", "weight": 0},
         {"id": "script-blocking-first-paint", "weight": 0},
         // {"id": "unused-css-rules", "weight": 0},
@@ -632,41 +654,41 @@ module.exports = {
       "name": "Accessibility",
       "description": "These audits validate that your app [works for all users](https://developers.google.com/web/fundamentals/accessibility/).",
       "audits": [
-        {"id": "accesskeys", "weight": 1},
-        {"id": "aria-allowed-attr", "weight": 1},
-        {"id": "aria-required-attr", "weight": 1},
-        {"id": "aria-required-children", "weight": 1},
-        {"id": "aria-required-parent", "weight": 1},
-        {"id": "aria-roles", "weight": 1},
-        {"id": "aria-valid-attr-value", "weight": 1},
-        {"id": "aria-valid-attr", "weight": 1},
-        {"id": "audio-caption", "weight": 1},
+        {"id": "accesskeys", "weight": 1, "tag": "accessibility-well-structured"},
+        {"id": "aria-allowed-attr", "weight": 1, "tag": "accessibility-correct-attributes"},
+        {"id": "aria-required-attr", "weight": 1, "tag": "accessibility-correct-attributes"},
+        {"id": "aria-required-children", "weight": 1, "tag": "accessibility-correct-attributes"},
+        {"id": "aria-required-parent", "weight": 1, "tag": "accessibility-correct-attributes"},
+        {"id": "aria-roles", "weight": 1, "tag": "accessibility-correct-attributes"},
+        {"id": "aria-valid-attr-value", "weight": 1, "tag": "accessibility-correct-attributes"},
+        {"id": "aria-valid-attr", "weight": 1, "tag": "accessibility-correct-attributes"},
+        {"id": "audio-caption", "weight": 1, "tag": "accessibility-describe-contents"},
         {"id": "button-name", "weight": 1},
         {"id": "bypass", "weight": 1},
         {"id": "color-contrast", "weight": 1},
-        {"id": "definition-list", "weight": 1},
-        {"id": "dlitem", "weight": 1},
-        {"id": "document-title", "weight": 1},
+        {"id": "definition-list", "weight": 1, "tag": "accessibility-well-structured"},
+        {"id": "dlitem", "weight": 1, "tag": "accessibility-well-structured"},
+        {"id": "document-title", "weight": 1, "tag": "accessibility-describe-contents"},
         {"id": "duplicate-id", "weight": 1},
-        {"id": "frame-title", "weight": 1},
-        {"id": "html-has-lang", "weight": 1},
-        {"id": "html-lang-valid", "weight": 1},
+        {"id": "frame-title", "weight": 1, "tag": "accessibility-describe-contents"},
+        {"id": "html-has-lang", "weight": 1, "tag": "accessibility-language"},
+        {"id": "html-lang-valid", "weight": 1, "tag": "accessibility-language"},
         {"id": "image-alt", "weight": 1},
         {"id": "input-image-alt", "weight": 1},
-        {"id": "label", "weight": 1},
-        {"id": "layout-table", "weight": 1},
+        {"id": "label", "weight": 1, "tag": "accessibility-describe-contents"},
+        {"id": "layout-table", "weight": 1, "tag": "accessibility-describe-contents"},
         {"id": "link-name", "weight": 1},
-        {"id": "list", "weight": 1},
-        {"id": "listitem", "weight": 1},
+        {"id": "list", "weight": 1, "tag": "accessibility-well-structured"},
+        {"id": "listitem", "weight": 1, "tag": "accessibility-well-structured"},
         {"id": "meta-refresh", "weight": 1},
         {"id": "meta-viewport", "weight": 1},
-        {"id": "object-alt", "weight": 1},
+        {"id": "object-alt", "weight": 1, "tag": "accessibility-describe-contents"},
         {"id": "tabindex", "weight": 1},
         {"id": "td-headers-attr", "weight": 1},
         {"id": "th-has-data-cells", "weight": 1},
-        {"id": "valid-lang", "weight": 1},
-        {"id": "video-caption", "weight": 1},
-        {"id": "video-description", "weight": 1},
+        {"id": "valid-lang", "weight": 1, "tag": "accessibility-language"},
+        {"id": "video-caption", "weight": 1, "tag": "accessibility-describe-contents"},
+        {"id": "video-description", "weight": 1, "tag": "accessibility-describe-contents"},
       ]
     },
     "best-practices": {

--- a/lighthouse-core/report/v2/renderer/audits-renderer.js
+++ b/lighthouse-core/report/v2/renderer/audits-renderer.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* globals self */
+
+class GroupByTagRenderer {
+  constructor(dom, renderAudit) {
+    this._dom = dom;
+    this._renderAudit = renderAudit;
+  }
+
+  _renderTagGroup(audits, tag) {
+    if (!tag) {
+      tag = {title: 'Miscellaneous', description: 'Random stuff!'};
+    }
+
+    const tmpl = this._dom.cloneTemplate('#tmpl-lh-tag-group', this._dom.document());
+
+    const titleEl = tmpl.querySelector('.lh-tag-group__title');
+    titleEl.textContent = tag.title;
+    const descriptionEl = tmpl.querySelector('.lh-tag-group__description');
+    descriptionEl.textContent = tag.description;
+
+    const detailsEl = tmpl.querySelector('.lh-tag-group__details');
+    audits.forEach(audit => {
+      detailsEl.appendChild(this._renderAudit(audit));
+    });
+    return tmpl;
+  }
+
+  render(audits, tags) {
+    const element = this._dom.createElement('div', 'lh-group-by-tag');
+    const auditsByTag = new Map();
+    audits.forEach(audit => {
+      const tagAudits = auditsByTag.get(audit.tag) || [];
+      tagAudits.push(audit);
+      auditsByTag.set(audit.tag, tagAudits);
+    });
+
+    for (const [tagKey, tagAudits] of auditsByTag.entries()) {
+      element.appendChild(this._renderTagGroup(tagAudits, tags[tagKey]));
+    }
+
+    return element;
+  }
+}
+
+class GroupByStatusRenderer {
+  constructor(dom, renderAudit) {
+    this._dom = dom;
+    this._renderAudit = renderAudit;
+  }
+
+  render(audits) {
+    const element = this._dom.createElement('div', 'lh-group-by-status');
+    const passedAudits = audits.filter(audit => audit.score === 100);
+    const nonPassedAudits = audits.filter(audit => !passedAudits.includes(audit));
+
+    for (const audit of nonPassedAudits) {
+      element.appendChild(this._renderAudit(audit));
+    }
+
+    // don't create a passed section if there are no passed
+    if (!passedAudits.length) return element;
+
+    const passedElem = this._dom.createElement('details', 'lh-passed-audits');
+    const passedSummary = this._dom.createElement('summary', 'lh-passed-audits-summary');
+    passedSummary.textContent = `View ${passedAudits.length} passed items`;
+    passedElem.appendChild(passedSummary);
+
+    for (const audit of passedAudits) {
+      passedElem.appendChild(this._renderAudit(audit));
+    }
+    element.appendChild(passedElem);
+    return element;
+  }
+}
+
+class AuditsRenderer {
+  /**
+   * @param {!DOM} dom
+   * @param {!function(!Object):Element} renderAudit
+   */
+  constructor(dom, renderAudit) {
+    this._dom = dom;
+    this._renderAudit = renderAudit;
+    this._renderers = {
+      GroupByStatus: new GroupByStatusRenderer(dom, renderAudit),
+      GroupByTag: new GroupByTagRenderer(dom, renderAudit),
+    };
+  }
+
+  /**
+   * @param {!Array} audits
+   * @return {!Element}
+   */
+  render(audits, tags) {
+    const auditGroupsEl = this._dom.createElement('div', 'lh-audits');
+
+    const auditsByRenderer = new Map();
+    audits.forEach(audit => {
+      console.log(audit);
+      const rendererKey = audit.result.renderer || 'GroupByStatus';
+      const rendererAudits = auditsByRenderer.get(rendererKey) || [];
+      rendererAudits.push(audit);
+      auditsByRenderer.set(rendererKey, rendererAudits);
+    });
+
+    for (const [rendererKey, rendererAudits] of auditsByRenderer.entries()) {
+      const renderer = this._renderers[rendererKey];
+      auditGroupsEl.appendChild(renderer.render(rendererAudits, tags));
+    }
+
+    return auditGroupsEl;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = AuditsRenderer;
+} else {
+  self.AuditsRenderer = AuditsRenderer;
+}

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -62,6 +62,7 @@ class ReportRenderer {
   constructor(dom, detailsRenderer) {
     this._dom = dom;
     this._detailsRenderer = detailsRenderer;
+    this._auditsRenderer = new AuditsRenderer(this._dom, this._renderAudit.bind(this));
 
     this._templateContext = this._dom.document();
   }
@@ -164,7 +165,7 @@ class ReportRenderer {
   _renderReport(report) {
     const element = this._dom.createElement('div', 'lh-report');
     for (const category of report.reportCategories) {
-      element.appendChild(this._renderCategory(category));
+      element.appendChild(this._renderCategory(category, report.reportTags));
     }
     return element;
   }
@@ -173,29 +174,10 @@ class ReportRenderer {
    * @param {!ReportRenderer.CategoryJSON} category
    * @return {!Element}
    */
-  _renderCategory(category) {
+  _renderCategory(category, tags) {
     const element = this._dom.createElement('div', 'lh-category');
     element.appendChild(this._renderCategoryScore(category));
-
-    const passedAudits = category.audits.filter(audit => audit.score === 100);
-    const nonPassedAudits = category.audits.filter(audit => !passedAudits.includes(audit));
-
-    for (const audit of nonPassedAudits) {
-      element.appendChild(this._renderAudit(audit));
-    }
-
-    // don't create a passed section if there are no passed
-    if (!passedAudits.length) return element;
-
-    const passedElem = this._dom.createElement('details', 'lh-passed-audits');
-    const passedSummary = this._dom.createElement('summary', 'lh-passed-audits-summary');
-    passedSummary.textContent = `View ${passedAudits.length} passed items`;
-    passedElem.appendChild(passedSummary);
-
-    for (const audit of passedAudits) {
-      passedElem.appendChild(this._renderAudit(audit));
-    }
-    element.appendChild(passedElem);
+    element.appendChild(this._auditsRenderer.render(category.audits, tags));
     return element;
   }
 

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -22,6 +22,7 @@ const REPORT_TEMPLATE = fs.readFileSync(__dirname + '/report-template.html', 'ut
 const REPORT_JAVASCRIPT = [
   fs.readFileSync(__dirname + '/renderer/dom.js', 'utf8'),
   fs.readFileSync(__dirname + '/renderer/details-renderer.js', 'utf8'),
+  fs.readFileSync(__dirname + '/renderer/audits-renderer.js', 'utf8'),
   fs.readFileSync(__dirname + '/renderer/report-renderer.js', 'utf8'),
 ].join(';\n');
 const REPORT_CSS = fs.readFileSync(__dirname + '/report-styles.css', 'utf8');

--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -24,3 +24,30 @@
     </details>
   </div>
 </template>
+
+<template id="tmpl-lh-tag-group">
+  <style>
+    .lh-tag-group {
+      margin: 30px 0;
+      padding-bottom: 20px;
+      border-bottom: 2px solid red;
+    }
+
+    .lh-tag-group__title {
+      font-size: 16px;
+    }
+
+    .lh-tag-group__description {
+      margin-top: 10px;
+    }
+  </style>
+  <div class="lh-tag-group">
+    <details class="lh-tag-group__details">
+      <summary class="lh-tag-group__header">
+        <span class="lh-tag-group__title"><!-- fill me --></span>
+        <div class="lh-tag-group__arrow" title="See audits"></div>
+      </summary>
+      <div class="lh-tag-group__description"><!-- fill me --></div>
+    </details>
+  </div>
+</template>

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -148,6 +148,7 @@ class Runner {
           artifacts: runResults.artifacts,
           runtimeConfig: Runner.getRuntimeConfig(opts.flags),
           score,
+          reportTags: config.tags,
           reportCategories,
           aggregations
         };


### PR DESCRIPTION
R: @ebidel @dgozman all

I wanted to throw this out there as my first *very* rough take on what different renderers would look like code-wise and get feedback before going any further. Please ignore UI :)

* Audits (optionally) specify a `renderer` property in their `meta` object similar to `scoringMode`
* Audits (optionally) specify a `tag` property in the config under their category entry
* `AuditsRenderer` groups audits by renderer and hands off the rendering to the specified class, this can be extended for a `PerformanceMetricRenderer` for the metrics and `PerformanceHintRenderer` for the blocking tags/byte efficiency audits.

If this rough angle looks good I'll close this PR and we can make the changes in stages:

1. I'll extract the pass/fail grouping to GroupByStatusRenderer and add the base logic for handling the `renderer` property.
2. I'll add the tags object to the config and report JSON with a shell of a GroupByTagRenderer.
3. Hand off to @robdodson to modify GroupByTagRenderer and apply tags to the a11y audits in whatever way makes the most sense there.


![image](https://cloud.githubusercontent.com/assets/2301202/25143706/454eb412-2420-11e7-90f1-5b84f8a83a39.png)
