### PR TITLE
refactor: move instantiateComputedArtifacts to Runner

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -69,14 +69,17 @@ class Runner {
     // to check that there are artifacts specified in the config, and throw if not.
     if (validPassesAndAudits || validArtifactsAndAudits) {
       if (validPassesAndAudits) {
+        // Set up the driver and run gatherers.
         opts.driver = opts.driverMock || new Driver(connection);
-        // Finally set up the driver to gather.
         run = run.then(_ => GatherRunner.run(config.passes, opts));
       } else if (validArtifactsAndAudits) {
-        run = run.then(_ => {
-          return Object.assign(config.artifacts, GatherRunner.instantiateComputedArtifacts());
-        });
+        run = run.then(_ => config.artifacts);
       }
+
+      // Add computed artifacts.
+      run = run.then(artifacts => {
+        return Object.assign({}, artifacts, Runner.instantiateComputedArtifacts());
+      });
 
       // Basic check that the traces (gathered or loaded) are valid.
       run = run.then(artifacts => {
@@ -105,8 +108,8 @@ class Runner {
     } else if (config.auditResults) {
       // If there are existing audit results, surface those here.
       // Instantiate and return artifacts for consistency.
-      const artifacts = Object.assign(config.artifacts || {},
-          GatherRunner.instantiateComputedArtifacts());
+      const artifacts = Object.assign({}, config.artifacts || {},
+          Runner.instantiateComputedArtifacts());
       run = run.then(_ => {
         return {
           artifacts,
@@ -247,6 +250,27 @@ class Runner {
           .map(f => `dobetterweb/${f}`)
     ];
     return fileList.filter(f => /\.js$/.test(f) && f !== 'gatherer.js').sort();
+  }
+
+  /**
+   * @return {!ComputedArtifacts}
+   */
+  static instantiateComputedArtifacts() {
+    const computedArtifacts = {};
+    require('fs').readdirSync(__dirname + '/gather/computed').forEach(function(filename) {
+      // Skip base class.
+      if (filename === 'computed-artifact.js') {
+        return;
+      }
+
+      // Drop `.js` suffix to keep browserify import happy.
+      filename = filename.replace(/\.js$/, '');
+      const ArtifactClass = require('./gather/computed/' + filename);
+      const artifact = new ArtifactClass(computedArtifacts);
+      // define the request* function that will be exposed on `artifacts`
+      computedArtifacts['request' + artifact.name] = artifact.request.bind(artifact);
+    });
+    return computedArtifacts;
   }
 
   /**

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -259,9 +259,7 @@ class Runner {
     const computedArtifacts = {};
     require('fs').readdirSync(__dirname + '/gather/computed').forEach(function(filename) {
       // Skip base class.
-      if (filename === 'computed-artifact.js') {
-        return;
-      }
+      if (filename === 'computed-artifact.js') return;
 
       // Drop `.js` suffix to keep browserify import happy.
       filename = filename.replace(/\.js$/, '');

--- a/lighthouse-core/test/audits/estimated-input-latency-test.js
+++ b/lighthouse-core/test/audits/estimated-input-latency-test.js
@@ -16,12 +16,12 @@
 'use strict';
 
 const Audit = require('../../audits/estimated-input-latency.js');
-const GatherRunner = require('../../gather/gather-runner.js');
+const Runner = require('../../runner.js');
 const assert = require('assert');
 
 const pwaTrace = require('../fixtures/traces/progressive-app.json');
 
-const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+const computedArtifacts = Runner.instantiateComputedArtifacts();
 
 function generateArtifactsWithTrace(trace) {
   return Object.assign({

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -25,8 +25,8 @@ const preactTrace = require('../fixtures/traces/preactjs.com_ts_of_undefined.jso
 const noFMPtrace = require('../fixtures/traces/no_fmp_event.json');
 const noFCPtrace = require('../fixtures/traces/airhorner_no_fcp');
 
-const GatherRunner = require('../../gather/gather-runner.js');
-const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+const Runner = require('../../runner.js');
+const computedArtifacts = Runner.instantiateComputedArtifacts();
 
 function generateArtifactsWithTrace(trace) {
   return Object.assign({

--- a/lighthouse-core/test/audits/manifest-short-name-length-test.js
+++ b/lighthouse-core/test/audits/manifest-short-name-length-test.js
@@ -22,10 +22,10 @@ const manifestParser = require('../../lib/manifest-parser');
 const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 
-const GatherRunner = require('../../gather/gather-runner.js');
+const Runner = require('../../runner.js');
 
 function generateMockArtifacts() {
-  const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+  const computedArtifacts = Runner.instantiateComputedArtifacts();
   const mockArtifacts = Object.assign({}, computedArtifacts, {
     Manifest: null
   });

--- a/lighthouse-core/test/audits/splash-screen-test.js
+++ b/lighthouse-core/test/audits/splash-screen-test.js
@@ -15,10 +15,10 @@ const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 const exampleManifest = noUrlManifestParser(manifestSrc);
 
-const GatherRunner = require('../../gather/gather-runner.js');
+const Runner = require('../../runner.js');
 
 function generateMockArtifacts() {
-  const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+  const computedArtifacts = Runner.instantiateComputedArtifacts();
   const mockArtifacts = Object.assign({}, computedArtifacts, {
     Manifest: exampleManifest
   });

--- a/lighthouse-core/test/audits/themed-omnibox-test.js
+++ b/lighthouse-core/test/audits/themed-omnibox-test.js
@@ -15,10 +15,10 @@ const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 const exampleManifest = noUrlManifestParser(manifestSrc);
 
-const GatherRunner = require('../../gather/gather-runner.js');
+const Runner = require('../../runner.js');
 
 function generateMockArtifacts() {
-  const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+  const computedArtifacts = Runner.instantiateComputedArtifacts();
   const mockArtifacts = Object.assign({}, computedArtifacts, {
     Manifest: exampleManifest,
     ThemeColor: '#bada55'

--- a/lighthouse-core/test/audits/time-to-interactive-test.js
+++ b/lighthouse-core/test/audits/time-to-interactive-test.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const TimeToInteractive = require('../../audits/time-to-interactive.js');
-const GatherRunner = require('../../gather/gather-runner.js');
+const Runner = require('../../runner.js');
 const assert = require('assert');
 
 const pwaTrace = require('../fixtures/traces/progressive-app.json');
@@ -30,7 +30,7 @@ describe('Performance: time-to-interactive audit', () => {
           traceEvents: pwaTrace
         }
       }
-    }, GatherRunner.instantiateComputedArtifacts());
+    }, Runner.instantiateComputedArtifacts());
 
     return TimeToInteractive.audit(artifacts).then(output => {
       assert.equal(output.rawValue, 1105.8, output.debugString);

--- a/lighthouse-core/test/audits/user-timing-test.js
+++ b/lighthouse-core/test/audits/user-timing-test.js
@@ -19,8 +19,8 @@ const Audit = require('../../audits/user-timings.js');
 const assert = require('assert');
 const traceEvents = require('../fixtures/traces/trace-user-timings.json');
 
-const GatherRunner = require('../../gather/gather-runner.js');
-const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+const Runner = require('../../runner.js');
+const computedArtifacts = Runner.instantiateComputedArtifacts();
 
 function generateArtifactsWithTrace(trace) {
   return Object.assign({

--- a/lighthouse-core/test/audits/webapp-install-banner-test.js
+++ b/lighthouse-core/test/audits/webapp-install-banner-test.js
@@ -15,10 +15,10 @@ const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
 const exampleManifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
 
-const GatherRunner = require('../../gather/gather-runner.js');
+const Runner = require('../../runner.js');
 
 function generateMockArtifacts() {
-  const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
+  const computedArtifacts = Runner.instantiateComputedArtifacts();
   const clonedArtifacts = JSON.parse(JSON.stringify({
     Manifest: exampleManifest,
     ServiceWorker: {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -561,37 +561,6 @@ describe('GatherRunner', function() {
       /afterPass\(\) method/);
   });
 
-  it('can create computed artifacts', () => {
-    const computedArtifacts = GatherRunner.instantiateComputedArtifacts();
-    assert.ok(Object.keys(computedArtifacts).length, 'there are a few computed artifacts');
-    Object.keys(computedArtifacts).forEach(artifactRequest => {
-      assert.equal(typeof computedArtifacts[artifactRequest], 'function');
-    });
-  });
-
-  it('will instantiate computed artifacts during a run', () => {
-    const passes = [{
-      blankDuration: 0,
-      recordNetwork: true,
-      recordTrace: true,
-      passName: 'firstPass',
-      gatherers: [new TestGatherer()]
-    }];
-    const options = {driver: fakeDriver, url: 'https://example.com', flags: {}, config: {}};
-
-    return GatherRunner.run(passes, options)
-        .then(artifacts => {
-          const networkRecords = artifacts.networkRecords.firstPass;
-          const p = artifacts.requestCriticalRequestChains(networkRecords);
-          return p.then(chains => {
-            // fakeDriver will include networkRecords built from fixtures/perflog.json
-            assert.ok(chains['93149.1']);
-            assert.ok(chains['93149.1'].request);
-            assert.ok(chains['93149.1'].children);
-          });
-        });
-  });
-
   describe('#assertPageLoaded', () => {
     it('passes when the page is loaded', () => {
       const url = 'http://the-page.com';


### PR DESCRIPTION
very small refactor to fix something that's bothered me for a while: computed artifacts aren't part of gathering (we use them even if artifacts are provided by the config and Chrome is never run), so creating them should live in runner. Main benefit is we don't have both `runner` *and* `gather-runner` calling `instantiateComputedArtifacts`.

Also fixes a minor bug where the `computedArtifact` base class was being used as a computed artifact. Since it doesn't have a `name` property, it was showing up as `artifacts.requestundefined()` :)

originally part of #2018...but I forgot to push