### PR TITLE
Report v2: category score gauges

### DIFF
--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -149,23 +149,25 @@ class CategoryRenderer {
    */
   renderScoreGauge(category) {
     const tmpl = this._dom.cloneTemplate('#tmpl-lh-gauge', this._templateContext);
-    tmpl.querySelector('.lh-gauge__wrapper').href = `#${category.id}`;
-    tmpl.querySelector('.lh-gauge__label').textContent = category.name;
+    this._dom.find('.lh-gauge__wrapper', tmpl).href = `#${category.id}`;
+    this._dom.find('.lh-gauge__label', tmpl).textContent = category.name;
 
     const score = Math.round(category.score);
     const fillRotation = Math.floor((score / 100) * 180);
 
-    const gauge = tmpl.querySelector('.lh-gauge');
+    const gauge = this._dom.find('.lh-gauge', tmpl);
     gauge.setAttribute('data-progress', score); // .dataset not supported in jsdom.
     gauge.classList.add(`lh-gauge--${calculateRating(score)}`);
 
-    Array.from(gauge.querySelectorAll('.lh-gauge__fill')).forEach(el => {
+    this._dom.findAll('.lh-gauge__fill', gauge).forEach(el => {
       el.style.transform = `rotate(${fillRotation}deg)`;
     });
 
-    gauge.querySelector('.lh-gauge__mask--full').style.transform = `rotate(${fillRotation}deg)`;
-    gauge.querySelector('.lh-gauge__fill--fix').style.transform = `rotate(${fillRotation * 2}deg)`;
-    gauge.querySelector('.lh-gauge__percentage').textContent = score;
+    this._dom.find('.lh-gauge__mask--full', gauge).style.transform =
+        `rotate(${fillRotation}deg)`;
+    this._dom.find('.lh-gauge__fill--fix', gauge).style.transform =
+        `rotate(${fillRotation * 2}deg)`;
+    this._dom.find('.lh-gauge__percentage', gauge).textContent = score;
 
     return tmpl;
   }

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -145,10 +145,38 @@ class CategoryRenderer {
 
   /**
    * @param {!ReportRenderer.CategoryJSON} category
+   * @return {!DocumentFragment}
+   */
+  renderScoreGauge(category) {
+    const tmpl = this._dom.cloneTemplate('#tmpl-lh-gauge', this._templateContext);
+    tmpl.querySelector('.lh-gauge__wrapper').href = `#${category.id}`;
+    tmpl.querySelector('.lh-gauge__label').textContent = category.name;
+
+    const score = Math.round(category.score);
+    const fillRotation = Math.floor((score / 100) * 180);
+
+    const gauge = tmpl.querySelector('.lh-gauge');
+    gauge.setAttribute('data-progress', score); // .dataset not supported in jsdom.
+    gauge.classList.add(`lh-gauge--${calculateRating(score)}`);
+
+    Array.from(gauge.querySelectorAll('.lh-gauge__fill')).forEach(el => {
+      el.style.transform = `rotate(${fillRotation}deg)`;
+    });
+
+    gauge.querySelector('.lh-gauge__mask--full').style.transform = `rotate(${fillRotation}deg)`;
+    gauge.querySelector('.lh-gauge__fill--fix').style.transform = `rotate(${fillRotation * 2}deg)`;
+    gauge.querySelector('.lh-gauge__percentage').textContent = score;
+
+    return tmpl;
+  }
+
+  /**
+   * @param {!ReportRenderer.CategoryJSON} category
    * @return {!Element}
    */
   render(category) {
     const element = this._dom.createElement('div', 'lh-category');
+    element.id = category.id;
     element.appendChild(this._renderCategoryScore(category));
 
     const passedAudits = category.audits.filter(audit => audit.score === 100);

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -60,16 +60,17 @@ class DOM {
       throw new Error(`Template not found: template${selector}`);
     }
 
-    const clone = this._document.importNode(template.content, true);
+    const clone = /** @type {!DocumentFragment} */ (
+        this._document.importNode(template.content, true));
 
     // Prevent duplicate styles in the DOM. After a template has been stamped
-    // for the first time, remove its styles so they're not re-added.
-    if (template.used) {
-      Array.from(clone.querySelectorAll('style')).forEach(style => style.remove());
+    // for the first time, remove the clone's styles so they're not re-added.
+    if (template.hasAttribute('data-stamped')) {
+      this.findAll('style', clone).forEach(style => style.remove());
     }
-    template.used = true;
+    template.setAttribute('data-stamped', true);
 
-    return /** @type {!DocumentFragment} */ (clone);
+    return clone;
   }
 
   /**
@@ -121,6 +122,16 @@ class DOM {
       throw new Error(`query ${query} not found`);
     }
     return result;
+  }
+
+  /**
+   * Helper for context.querySelectorAll. Returns an Array instead of a NodeList.
+   * @param {string} query
+   * @param {!DocumentFragment|!Element} context
+   * @return {!Array<Element>}
+   */
+  findAll(query, context) {
+    return Array.from(context.querySelectorAll(query));
   }
 }
 

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -59,7 +59,17 @@ class DOM {
     if (!template) {
       throw new Error(`Template not found: template${selector}`);
     }
-    return /** @type {!DocumentFragment} */ (this._document.importNode(template.content, true));
+
+    const clone = this._document.importNode(template.content, true);
+
+    // Prevent duplicate styles in the DOM. After a template has been stamped
+    // for the first time, remove its styles so they're not re-added.
+    if (template.used) {
+      Array.from(clone.querySelectorAll('style')).forEach(style => style.remove());
+    }
+    template.used = true;
+
+    return /** @type {!DocumentFragment} */ (clone);
   }
 
   /**

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -73,7 +73,10 @@ class ReportRenderer {
    */
   _renderReport(report) {
     const element = this._dom.createElement('div', 'lh-report');
+    const scoreHeader = element.appendChild(
+        this._dom.createElement('div', 'lh-scores-header'));
     for (const category of report.reportCategories) {
+      scoreHeader.appendChild(this._categoryRenderer.renderScoreGauge(category));
       element.appendChild(this._categoryRenderer.render(category));
     }
     return element;

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -111,6 +111,7 @@ ReportRenderer.AuditJSON; // eslint-disable-line no-unused-expressions
 /**
  * @typedef {{
  *     name: string,
+ *     id: string,
  *     weight: number,
  *     score: number,
  *     description: string,

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -45,6 +45,7 @@ body {
   font-size: var(--body-font-size);
   margin: 0;
   line-height: var(--body-line-height);
+  scroll-behavior: smooth;
 }
 
 [hidden] {
@@ -260,6 +261,11 @@ body {
 
 .lh-report {
   padding: var(--default-padding);
+}
+
+.lh-scores-header {
+  display: flex;
+  margin: var(--default-padding) 0 calc(var(--default-padding) * 2) 0;
 }
 
 .lh-category {

--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -24,3 +24,92 @@
     </details>
   </div>
 </template>
+
+<!-- Lighthouse score gauge -->
+<template id="tmpl-lh-gauge">
+  <style>
+    .lh-gauge {
+      --circle-size: 80px;
+      --circle-size-half: calc(var(--circle-size) / 2);
+      --circle-background: #eee;
+      --circle-border-width: 8px;
+      --inset-size: calc(var(--circle-size) - var(--circle-border-width));
+      --inset-color: #fff;
+      --transition-length: 1s;
+      width: var(--circle-size);
+      height: var(--circle-size);
+      background-color: var(--circle-background);
+      border-radius: 50%;
+    }
+    .lh-gauge--pass {
+      --circle-color: var(--pass-color);
+      color: var(--circle-color);
+    }
+    .lh-gauge--average {
+      --circle-color: var(--average-color);
+      color: var(--circle-color);
+    }
+    .lh-gauge--fail {
+      --circle-color: var(--fail-color);
+      color: var(--circle-color);
+    }
+    .lh-gauge__mask,
+    .lh-gauge__fill {
+      width: var(--circle-size);
+      height: var(--circle-size);
+      position: absolute;
+      transition: transform var(--transition-length);
+      border-radius: 50%;
+    }
+    .lh-gauge__mask {
+      clip: rect(0px, var(--circle-size), var(--circle-size), var(--circle-size-half));
+    }
+    .lh-gauge__mask .lh-gauge__fill {
+      clip: rect(0px, var(--circle-size-half), var(--circle-size), 0px);
+      background-color: var(--circle-color);
+      backface-visibility: hidden;
+    }
+    .lh-gauge__percentage {
+      --spacer: calc((var(--circle-size) - var(--inset-size)) / 2);
+      width: var(--inset-size);
+      height: var(--inset-size);
+      position: absolute;
+      margin-left: var(--spacer);
+      margin-top: var(--spacer);
+      background-color: var(--inset-color);
+      border-radius: inherit;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: calc(var(--circle-size) / 3);
+    }
+    .lh-gauge__wrapper {
+      display: inline-flex;
+      align-items: center;
+      flex-direction: column;
+      text-decoration: none;
+      color: inherit;
+      flex: 1;
+    }
+    .lh-gauge__label {
+      font-size: 16px;
+      margin-top: var(--default-padding);
+      white-space: nowrap;
+    }
+  </style>
+  <a href="#" class="lh-gauge__wrapper">
+    <div class="lh-gauge" data-progress="0">
+      <div class="lh-gauge__circle">
+        <div class="lh-gauge__mask lh-gauge__mask--full">
+          <div class="lh-gauge__fill"></div>
+        </div>
+        <div class="lh-gauge__mask lh-gauge__mask--half">
+          <div class="lh-gauge__fill"></div>
+          <div class="lh-gauge__fill lh-gauge__fill--fix"></div>
+        </div>
+      </div>
+      <div class="lh-gauge__percentage"></div>
+    </div>
+    <div class="lh-gauge__label"><!-- fill me --></div>
+  </a>
+</template>

--- a/lighthouse-core/test/report/v2/renderer/dom-test.js
+++ b/lighthouse-core/test/report/v2/renderer/dom-test.js
@@ -69,6 +69,13 @@ describe('DOM', () => {
     it('fails when a template context isn\'t provided', () => {
       assert.throws(() => dom.cloneTemplate('#tmpl-lh-audit-score'));
     });
+
+    it('does not inject duplicate styles', () => {
+      const clone = dom.cloneTemplate('#tmpl-lh-gauge', dom.document());
+      const clone2 = dom.cloneTemplate('#tmpl-lh-gauge', dom.document());
+      assert.ok(clone.querySelector('style'));
+      assert.ok(!clone2.querySelector('style'));
+    });
   });
 
   describe('createSpanFromMarkdown', () => {

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -49,6 +49,8 @@ describe('ReportRenderer V2', () => {
     it('should render a report', () => {
       const output = renderer.renderReport(sampleResults);
       assert.ok(output.classList.contains('lh-report'));
+      assert.equal(output.querySelectorAll('.lh-gauge').length,
+          sampleResults.reportCategories.length, 'renders category gauges');
     });
 
     it('should render an exception for invalid input', () => {


### PR DESCRIPTION
R: all

First go at the v2 mock score badges. I'm calling these gauges. Needs to be combined with https://github.com/GoogleChrome/lighthouse/pull/2000.

Example usage: `<div class="lh-gauge" data-progress="25">`.  #wouldbeasweetwebcomponent

<img width="788" alt="screen shot 2017-04-18 at 9 14 53 pm" src="https://cloud.githubusercontent.com/assets/238208/25164019/1c2e2654-2483-11e7-8498-5dceb4917a83.png">
