### PR TITLE
Add audit to check if start_url is cached by SW

### DIFF
--- a/lighthouse-cli/test/smokehouse/pwa-config.js
+++ b/lighthouse-cli/test/smokehouse/pwa-config.js
@@ -36,14 +36,14 @@ module.exports = {
     recordNetwork: true,
     gatherers: [
       'service-worker',
-      'offline'
+      'offline',
+      'start-url'
     ]
   },
   {
     gatherers: [
       'dobetterweb/domstats',
-      'http-redirect',
-      'start-url',
+      'http-redirect'
     ]
   }],
 

--- a/lighthouse-cli/test/smokehouse/pwa-config.js
+++ b/lighthouse-cli/test/smokehouse/pwa-config.js
@@ -42,7 +42,8 @@ module.exports = {
   {
     gatherers: [
       'dobetterweb/domstats',
-      'http-redirect'
+      'http-redirect',
+      'start-url',
     ]
   }],
 

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -93,46 +93,6 @@ module.exports = [
   },
 
   {
-    initialUrl: 'https://www.chromestatus.com/features',
-    url: 'https://www.chromestatus.com/features',
-    audits: {
-      'dom-size': {
-        score: 100,
-        extendedInfo: {
-          value: {
-            1: {value: '20'},
-            2: {snippet: /ul.versionlist/}
-          }
-        }
-      },
-      'is-on-https': {
-        score: true
-      },
-      'redirects-http': {
-        score: true
-      },
-      'service-worker': {
-        score: true
-      },
-      'works-offline': {
-        score: true
-      },
-      'webapp-install-banner': {
-        score: true
-      },
-      'splash-screen': {
-        score: true
-      },
-      'themed-omnibox': {
-        score: true
-      },
-      // 'cache-start-url': {
-      //   score: true
-      // }
-    }
-  },
-
-  {
     initialUrl: 'https://jakearchibald.github.io/svgomg/',
     url: 'https://jakearchibald.github.io/svgomg/',
     audits: {

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -78,6 +78,46 @@ module.exports = [
         score: false
       },
       'webapp-install-banner': {
+        score: false
+      },
+      'splash-screen': {
+        score: true
+      },
+      'themed-omnibox': {
+        score: true
+      },
+      // 'cache-start-url': {
+      //   score: true
+      // }
+    }
+  },
+
+  {
+    initialUrl: 'https://www.chromestatus.com/features',
+    url: 'https://www.chromestatus.com/features',
+    audits: {
+      'dom-size': {
+        score: 100,
+        extendedInfo: {
+          value: {
+            1: {value: '20'},
+            2: {snippet: /ul.versionlist/}
+          }
+        }
+      },
+      'is-on-https': {
+        score: true
+      },
+      'redirects-http': {
+        score: true
+      },
+      'service-worker': {
+        score: true
+      },
+      'works-offline': {
+        score: true
+      },
+      'webapp-install-banner': {
         score: true
       },
       'splash-screen': {

--- a/lighthouse-core/audits/webapp-install-banner.js
+++ b/lighthouse-core/audits/webapp-install-banner.js
@@ -40,7 +40,7 @@ class WebappInstallBanner extends Audit {
       name: 'webapp-install-banner',
       description: 'User can be prompted to Install the Web App',
       helpText: 'While users can manually add your site to their homescreen, the [prompt (aka app install banner)](https://developers.google.com/web/fundamentals/engage-and-retain/app-install-banners/) will proactively prompt the user to install the app if the various requirements are met and the user has moderate engagement with your site.',
-      requiredArtifacts: ['URL', 'ServiceWorker', 'Manifest']
+      requiredArtifacts: ['URL', 'ServiceWorker', 'Manifest', 'StartUrl']
     };
   }
 
@@ -74,12 +74,20 @@ class WebappInstallBanner extends Audit {
     }
   }
 
+  static assessOfflineStartUrl(artifacts, failures) {
+    const hasOfflineStartUrl = artifacts.StartUrl === 200;
+    if (!hasOfflineStartUrl) {
+      failures.push('Start url is cached by a Service Worker');
+    }
+  }
+
   static audit_(artifacts) {
     const failures = [];
 
     return artifacts.requestManifestValues(artifacts.Manifest).then(manifestValues => {
       WebappInstallBanner.assessManifest(manifestValues, failures);
       WebappInstallBanner.assessServiceWorker(artifacts, failures);
+      WebappInstallBanner.assessOfflineStartUrl(artifacts, failures);
 
       return {
         failures,

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -24,6 +24,7 @@ module.exports = {
     "gatherers": [
       "service-worker",
       "offline",
+      "start-url",
     ]
   },
   {
@@ -32,7 +33,6 @@ module.exports = {
     "gatherers": [
       "http-redirect",
       "html-without-javascript",
-      "start-url",
     ]
   }, {
     "passName": "dbw",

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -23,7 +23,7 @@ module.exports = {
     "useThrottling": false,
     "gatherers": [
       "service-worker",
-      "offline"
+      "offline",
     ]
   },
   {
@@ -31,7 +31,8 @@ module.exports = {
     "useThrottling": false,
     "gatherers": [
       "http-redirect",
-      "html-without-javascript"
+      "html-without-javascript",
+      "start-url",
     ]
   }, {
     "passName": "dbw",

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -711,26 +711,20 @@ class Driver {
     });
   }
 
-  endNetworkCollect(opts = {}) {
-    const pauseAfterLoadMs = (opts.flags && opts.flags.pauseAfterLoad) || PAUSE_AFTER_LOAD;
+  endNetworkCollect() {
     return new Promise((resolve, reject) => {
-      const waitForNetworkIdle = this._waitForNetworkIdle(pauseAfterLoadMs).promise;
+      this.off('Network.requestWillBeSent', this._networkRecorder.onRequestWillBeSent);
+      this.off('Network.requestServedFromCache', this._networkRecorder.onRequestServedFromCache);
+      this.off('Network.responseReceived', this._networkRecorder.onResponseReceived);
+      this.off('Network.dataReceived', this._networkRecorder.onDataReceived);
+      this.off('Network.loadingFinished', this._networkRecorder.onLoadingFinished);
+      this.off('Network.loadingFailed', this._networkRecorder.onLoadingFailed);
+      this.off('Network.resourceChangedPriority', this._networkRecorder.onResourceChangedPriority);
 
-      waitForNetworkIdle.then(() => {
-        const networkRecorder = this._networkRecorder;
-        this.off('Network.requestWillBeSent', networkRecorder.onRequestWillBeSent);
-        this.off('Network.requestServedFromCache', networkRecorder.onRequestServedFromCache);
-        this.off('Network.responseReceived', networkRecorder.onResponseReceived);
-        this.off('Network.dataReceived', networkRecorder.onDataReceived);
-        this.off('Network.loadingFinished', networkRecorder.onLoadingFinished);
-        this.off('Network.loadingFailed', networkRecorder.onLoadingFailed);
-        this.off('Network.resourceChangedPriority', networkRecorder.onResourceChangedPriority);
+      resolve(this._networkRecords);
 
-        resolve(this._networkRecords);
-
-        this.networkRecorder = null;
-        this._networkRecords = [];
-      }).catch(err => reject(err));
+      this._networkRecorder = null;
+      this._networkRecords = [];
     });
   }
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -259,6 +259,28 @@ class Driver {
     });
   }
 
+  getAppManifest() {
+    return new Promise((resolve, reject) => {
+      this.sendCommand('Page.getAppManifest')
+        .then(response => {
+          // We're not reading `response.errors` however it may contain critical and noncritical
+          // errors from Blink's manifest parser:
+          //   https://chromedevtools.github.io/debugger-protocol-viewer/tot/Page/#type-AppManifestError
+          if (!response.data) {
+            if (response.url) {
+              return reject(new Error(`Unable to retrieve manifest at ${response.url}.`));
+            }
+
+            // If both the data and the url are empty strings, the page had no manifest.
+            return reject('No web app manifest found.');
+          }
+
+          resolve(response);
+        })
+        .catch(err => reject(err));
+    });
+  }
+
   getSecurityState() {
     return new Promise((resolve, reject) => {
       this.once('Security.securityStateChanged', data => {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -246,7 +246,7 @@ class GatherRunner {
     const status = 'Retrieving network records';
     pass = pass.then(_ => {
       log.log('status', status);
-      return driver.endNetworkCollect();
+      return driver.endNetworkCollect(options);
     }).then(networkRecords => {
       GatherRunner.assertPageLoaded(options.url, driver, networkRecords);
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -246,7 +246,7 @@ class GatherRunner {
     const status = 'Retrieving network records';
     pass = pass.then(_ => {
       log.log('status', status);
-      return driver.endNetworkCollect(options);
+      return driver.endNetworkCollect();
     }).then(networkRecords => {
       GatherRunner.assertPageLoaded(options.url, driver, networkRecords);
 

--- a/lighthouse-core/gather/gatherers/offline.js
+++ b/lighthouse-core/gather/gatherers/offline.js
@@ -30,9 +30,8 @@ class Offline extends Gatherer {
         record._fetchedViaServiceWorker;
     }).pop(); // Take the last record that matches.
 
-    return options.driver.goOnline(options).then(_ => {
-      return navigationRecord ? navigationRecord.statusCode : -1;
-    });
+    return options.driver.goOnline(options)
+      .then(_ => navigationRecord ? navigationRecord.statusCode : -1);
   }
 }
 

--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -44,7 +44,9 @@ class StartUrl extends Gatherer {
 
         this.startUrl = manifest.value.start_url.value;
       }).then(_ => options.driver.evaluateAsync(
-          `fetch('${this.startUrl}').then(response => response.status)`
+          `fetch('${this.startUrl}')
+            .then(response => response.status)
+            .catch(err => err)`
       ));
   }
 
@@ -53,7 +55,8 @@ class StartUrl extends Gatherer {
       return Promise.reject(new Error('No start_url found inside the manifest'));
     }
 
-    const navigationRecord = tracingData.networkRecords.filter(record => {
+    const networkRecords = tracingData.networkRecords;
+    const navigationRecord = networkRecords.filter(record => {
       return URL.equalWithExcludedFragments(record._url, this.startUrl) &&
         record._fetchedViaServiceWorker;
     }).pop(); // Take the last record that matches.

--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const ManifestGatherer = require('./manifest');
+
+class StartUrl extends ManifestGatherer {
+  afterPass(options) {
+    let startUrl = options.url;
+
+    return super.afterPass(options)
+      .then(manifest => {
+        if (!manifest) {
+          return Promise.reject(`Unable to retrieve manifest at ${options.url}`);
+        }
+
+        startUrl = manifest.value.start_url.raw;
+      })
+      .then(_ => options.driver.goOffline())
+      .then(_ => options.driver.evaluateAsync(
+          `fetch('${startUrl}').then(response => response.status)
+            .catch(err => -1)`
+      ))
+      .then(code => {
+        return options.driver.goOnline(options)
+          .then(_ => code);
+      });
+  }
+}
+
+module.exports = StartUrl;

--- a/lighthouse-core/test/audits/webapp-install-banner-test.js
+++ b/lighthouse-core/test/audits/webapp-install-banner-test.js
@@ -27,6 +27,7 @@ function generateMockArtifacts() {
         scriptURL: 'https://example.com/sw.js'
       }]
     },
+    StartUrl: 200,
     URL: {finalUrl: 'https://example.com'}
   }));
   const mockArtifacts = Object.assign({}, computedArtifacts, clonedArtifacts);
@@ -128,10 +129,24 @@ describe('PWA: webapp install banner audit', () => {
   it('fails if page had no SW', () => {
     const artifacts = generateMockArtifacts();
     artifacts.ServiceWorker.versions = [];
+    artifacts.StartUrl = -1;
 
     return WebappInstallBannerAudit.audit(artifacts).then(result => {
       assert.strictEqual(result.rawValue, false);
       assert.ok(result.debugString.includes('Service Worker'), result.debugString);
+      const failures = result.extendedInfo.value.failures;
+      // start url will be -1 as well so failures will be 2
+      assert.strictEqual(failures.length, 2, failures);
+    });
+  });
+
+  it('fails if start_url is not cached', () => {
+    const artifacts = generateMockArtifacts();
+    artifacts.StartUrl = -1;
+
+    return WebappInstallBannerAudit.audit(artifacts).then(result => {
+      assert.strictEqual(result.rawValue, false);
+      assert.ok(result.debugString.includes('Start url'), result.debugString);
       const failures = result.extendedInfo.value.failures;
       assert.strictEqual(failures.length, 1, failures);
     });

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -51,7 +51,9 @@ describe('Manifest gatherer', () => {
     return manifestGather.afterPass({
       driver: {
         getAppManifest() {
-          return Promise.reject(new Error(`Unable to retrieve manifest at ${EXAMPLE_MANIFEST_URL}.`));
+          return Promise.reject(
+            new Error(`Unable to retrieve manifest at ${EXAMPLE_MANIFEST_URL}.`)
+          );
         }
       }
     }).then(

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -33,7 +33,7 @@ describe('Manifest gatherer', () => {
   it('returns an artifact', () => {
     return manifestGather.afterPass({
       driver: {
-        sendCommand() {
+        getAppManifest() {
           return Promise.resolve({
             data: '{}',
             errors: [],
@@ -50,11 +50,8 @@ describe('Manifest gatherer', () => {
   it('throws an error when unable to retrieve the manifest', () => {
     return manifestGather.afterPass({
       driver: {
-        sendCommand() {
-          return Promise.resolve({
-            errors: [],
-            url: EXAMPLE_MANIFEST_URL
-          });
+        getAppManifest() {
+          return Promise.reject(new Error(`Unable to retrieve manifest at ${EXAMPLE_MANIFEST_URL}.`));
         }
       }
     }).then(
@@ -65,12 +62,8 @@ describe('Manifest gatherer', () => {
   it('returns null when the page had no manifest', () => {
     return manifestGather.afterPass({
       driver: {
-        sendCommand() {
-          return Promise.resolve({
-            data: '',
-            errors: [],
-            url: ''
-          });
+        getAppManifest() {
+          return Promise.reject('No web app manifest found.');
         }
       }
     }).then(artifact => {
@@ -84,7 +77,7 @@ describe('Manifest gatherer', () => {
     });
     return manifestGather.afterPass({
       driver: {
-        sendCommand() {
+        getAppManifest() {
           return Promise.resolve({
             errors: [],
             data,

--- a/lighthouse-core/test/gather/gatherers/start-url-test.js
+++ b/lighthouse-core/test/gather/gatherers/start-url-test.js
@@ -44,14 +44,12 @@ const wrapSendCommand = (mockDriver, url) => {
     return record.statusCode;
   };
 
-  mockDriver.sendCommand = (name) => {
-    if (name === 'Page.getAppManifest') {
-      return Promise.resolve({
-        data: '{"start_url": "' + url + '"}',
-        errors: [],
-        url,
-      });
-    }
+  mockDriver.getAppManifest = () => {
+    return Promise.resolve({
+      data: '{"start_url": "' + url + '"}',
+      errors: [],
+      url,
+    });
   };
 
   return mockDriver;
@@ -74,13 +72,16 @@ describe('Start-url gatherer', () => {
     };
 
     return Promise.all([
+      startUrlGatherer.pass(options),
+      startUrlGatherer.pass(optionsWithQueryString)
+    ]).then(_ => Promise.all([
       startUrlGatherer.afterPass(options, tracingData).then(artifact => {
         assert.strictEqual(artifact, -1);
       }),
       startUrlGatherer.afterPass(optionsWithQueryString, tracingData).then(artifact => {
         assert.strictEqual(artifact, -1);
       }),
-    ]);
+    ]));
   });
 
   it('returns an artifact set to 200 when offline loading succeeds', () => {

--- a/lighthouse-core/test/gather/gatherers/start-url-test.js
+++ b/lighthouse-core/test/gather/gatherers/start-url-test.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* eslint-env mocha */
+
+const URL = require('../../../lib/url-shim');
+const StartUrlGatherer = require('../../../gather/gatherers/start-url');
+const assert = require('assert');
+const tracingData = require('../../fixtures/traces/network-records.json');
+
+const mockDriver = {
+  goOffline() {
+    return Promise.resolve();
+  },
+  goOnline() {
+    return Promise.resolve();
+  },
+};
+
+const wrapSendCommand = (mockDriver, url) => {
+  mockDriver.evaluateAsync = () => {
+    url = new URL(url);
+    url.hash = '';
+
+    const record = findRequestByUrl(url.href);
+    if (!record) {
+      return -1;
+    }
+
+    return record.statusCode;
+  };
+
+  mockDriver.sendCommand = (name) => {
+    if (name === 'Page.getAppManifest') {
+      return Promise.resolve({
+        data: '{"start_url": "' + url + '"}',
+        errors: [],
+        url,
+      });
+    }
+  };
+
+  return mockDriver;
+};
+
+const findRequestByUrl = (url) => {
+  return tracingData.networkRecords.find(record => record._url === url);
+};
+
+describe('Start-url gatherer', () => {
+  it('returns an artifact set to -1 when offline loading fails', () => {
+    const startUrlGatherer = new StartUrlGatherer();
+    const options = {
+      url: 'https://do-not-match.com/',
+      driver: wrapSendCommand(mockDriver, 'https://do-not-match.com/')
+    };
+    const optionsWithQueryString = {
+      url: 'https://ifixit-pwa.appspot.com/?history',
+      driver: wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/?history')
+    };
+
+    return Promise.all([
+      startUrlGatherer.afterPass(options, tracingData).then(artifact => {
+        assert.strictEqual(artifact, -1);
+      }),
+      startUrlGatherer.afterPass(optionsWithQueryString, tracingData).then(artifact => {
+        assert.strictEqual(artifact, -1);
+      }),
+    ]);
+  });
+
+  it('returns an artifact set to 200 when offline loading succeeds', () => {
+    const startUrlGatherer = new StartUrlGatherer();
+    const options = {
+      url: 'https://ifixit-pwa.appspot.com/',
+      driver: wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/')
+    };
+    const optionsWithFragment = {
+      url: 'https://ifixit-pwa.appspot.com/#/history',
+      driver: wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/#/history')
+    };
+    return Promise.all([
+      startUrlGatherer.afterPass(options, tracingData).then(artifact => {
+        assert.strictEqual(artifact, 200);
+      }),
+      startUrlGatherer.afterPass(optionsWithFragment, tracingData).then(artifact => {
+        assert.strictEqual(artifact, 200);
+      }),
+    ]);
+  });
+});

--- a/lighthouse-core/test/gather/gatherers/start-url-test.js
+++ b/lighthouse-core/test/gather/gatherers/start-url-test.js
@@ -29,6 +29,7 @@ const mockDriver = {
   goOnline() {
     return Promise.resolve();
   },
+  off() {}
 };
 
 const wrapSendCommand = (mockDriver, url) => {
@@ -39,10 +40,30 @@ const wrapSendCommand = (mockDriver, url) => {
 
     const record = findRequestByUrl(url.href);
     if (!record) {
-      return -1;
+      return Promise.reject(-1);
     }
 
-    return record.statusCode;
+    return Promise.resolve(record.statusCode);
+  };
+
+  mockDriver.on = (name, cb) => {
+    if (name === 'Network.requestWillBeSent') {
+      cb({
+        request: {
+          url,
+          requestId: 1
+        }
+      });
+    }
+
+    if (name === 'Network.loadingFinished') {
+      cb({
+        request: {
+          url,
+          requestId: 1
+        }
+      });
+    }
   };
 
   mockDriver.getAppManifest = () => {


### PR DESCRIPTION
I couldn't reuse the offline gatherer as it checks the current page from being cached by SW or not for the works-offline audit.

I added a start-url gatherer which lives in a pass other than offline as I need the manifest to work which fails if the current requested page is offline.