### PR TITLE
add Closure type checking for report v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
 script:
   - npm run lint
   - npm run unit
+  - npm run closure
   - npm run smoke
   - npm run smokehouse
 after_success:

--- a/lighthouse-core/closure/conformance_config.textproto
+++ b/lighthouse-core/closure/conformance_config.textproto
@@ -15,18 +15,18 @@
 # This file defines the additional JS conformance tests run over lighthouse code
 # when compiled with the Closure Compiler. For more, see https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework
 
+# Better covered by newCheckTypesAllChecks under NTI
+# requirement: {
+#   type: CUSTOM
+#   java_class: 'com.google.javascript.jscomp.ConformanceRules$BanNullDeref'
+#   error_message: 'Dereferencing `null` or `undefined` is usually an error. See https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework#bannullderef'
+# }
+
 requirement: {
   type: CUSTOM
-  java_class: 'com.google.javascript.jscomp.ConformanceRules$BanNullDeref'
-  error_message: 'Dereferencing `null` or `undefined` is usually an error. See https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework#bannullderef'
+  java_class: 'com.google.javascript.jscomp.ConformanceRules$BanUnknownThis'
+  error_message: 'References to `this` that are typed as `unknown` are not allowed. See https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework#banunknownthis'
 }
-
-# TODO(bckenny): fix unknown this error(s)
-# requirement: {
-#  type: CUSTOM
-#  java_class: 'com.google.javascript.jscomp.ConformanceRules$BanUnknownThis'
-#  error_message: 'References to `this` that are typed as `unknown` are not allowed. See https://github.com/google/closure-compiler/wiki/JS-Conformance-Framework#banunknownthis'
-# }
 
 requirement: {
   type: CUSTOM

--- a/lighthouse-core/closure/third_party/commonjs.js
+++ b/lighthouse-core/closure/third_party/commonjs.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @externs
+ */
+
+/** @const */
+const module = {};
+
+/** @type {*} */
+module.exports;

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -22,23 +22,22 @@ class DetailsRenderer {
    * @param {!DOM} dom
    */
   constructor(dom) {
+    /** @private {!DOM} */
     this._dom = dom;
   }
 
   /**
-   * @param {(!DetailsRenderer.DetailsJSON|!DetailsRenderer.CardsDetailsJSON)} details
+   * @param {!DetailsRenderer.DetailsJSON} details
    * @return {!Element}
    */
   render(details) {
     switch (details.type) {
       case 'text':
         return this._renderText(details);
-      case 'block':
-        return this._renderBlock(details);
       case 'cards':
         return this._renderCards(/** @type {!DetailsRenderer.CardsDetailsJSON} */ (details));
       case 'list':
-        return this._renderList(details);
+        return this._renderList(/** @type {!DetailsRenderer.ListDetailsJSON} */ (details));
       default:
         throw new Error(`Unknown type: ${details.type}`);
     }
@@ -55,20 +54,7 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsRenderer.DetailsJSON} block
-   * @return {!Element}
-   */
-  _renderBlock(block) {
-    const element = this._dom.createElement('div', 'lh-block');
-    const items = block.items || [];
-    for (const item of items) {
-      element.appendChild(this.render(item));
-    }
-    return element;
-  }
-
-  /**
-   * @param {!DetailsRenderer.DetailsJSON} list
+   * @param {!DetailsRenderer.ListDetailsJSON} list
    * @return {!Element}
    */
   _renderList(list) {
@@ -80,8 +66,7 @@ class DetailsRenderer {
     }
 
     const itemsElem = this._dom.createElement('div', 'lh-list__items');
-    const items = list.items || [];
-    for (const item of items) {
+    for (const item of list.items) {
       itemsElem.appendChild(this.render(item));
     }
     element.appendChild(itemsElem);
@@ -128,17 +113,23 @@ if (typeof module !== 'undefined' && module.exports) {
 /**
  * @typedef {{
  *     type: string,
- *     text: (string|undefined),
- *     header: (!DetailsRenderer.DetailsJSON|undefined),
- *     items: (!Array<!DetailsRenderer.DetailsJSON>|undefined)
+ *     text: (string|undefined)
  * }}
  */
 DetailsRenderer.DetailsJSON; // eslint-disable-line no-unused-expressions
 
+/**
+ * @typedef {{
+ *     type: string,
+ *     header: ({text: string}|undefined),
+ *     items: !Array<{type: string, text: (string|undefined)}>
+ * }}
+ */
+DetailsRenderer.ListDetailsJSON; // eslint-disable-line no-unused-expressions
+
 /** @typedef {{
  *     type: string,
- *     text: string,
- *     header: !DetailsRenderer.DetailsJSON,
+ *     header: ({text: string}|undefined),
  *     items: !Array<{title: string, value: string, snippet: (string|undefined), target: string}>
  * }}
  */

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -55,7 +55,7 @@ class DOM {
    * @throws {Error}
    */
   cloneTemplate(selector, context) {
-    const template = /** @type {HTMLTemplateElement} */ (context.querySelector(selector));
+    const template = /** @type {?HTMLTemplateElement} */ (context.querySelector(selector));
     if (!template) {
       throw new Error(`Template not found: template${selector}`);
     }

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -101,11 +101,11 @@ class DOM {
   /**
    * Guaranteed context.querySelector. Always returns an element or throws if
    * nothing matches query.
-   * @param {!DocumentFragment|!Element} context
    * @param {string} query
+   * @param {!DocumentFragment|!Element} context
    * @return {!Element}
    */
-  static find(context, query) {
+  find(context, query) {
     const result = context.querySelector(query);
     if (result === null) {
       throw new Error(`query ${query} not found`);

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -22,6 +22,7 @@ class DOM {
    * @param {!Document} document
    */
   constructor(document) {
+    /** @private {!Document} */
     this._document = document;
   }
 
@@ -33,9 +34,7 @@ class DOM {
    *     set the attribute on the node.
    * @return {!Element}
    */
-  createElement(name, className, attrs) {
-    // TODO(all): adopt `attrs` default arg when https://codereview.chromium.org/2821773002/ lands
-    attrs = attrs || {};
+  createElement(name, className, attrs = {}) {
     const element = this._document.createElement(name);
     if (className) {
       element.className = className;
@@ -56,7 +55,7 @@ class DOM {
    * @throws {Error}
    */
   cloneTemplate(selector, context) {
-    const template = context.querySelector(selector);
+    const template = /** @type {HTMLTemplateElement} */ (context.querySelector(selector));
     if (!template) {
       throw new Error(`Template not found: template${selector}`);
     }
@@ -80,7 +79,7 @@ class DOM {
 
       // Append link if there are any.
       if (linkText && linkHref) {
-        const a = this.createElement('a');
+        const a = /** @type {!HTMLAnchorElement} */ (this.createElement('a'));
         a.rel = 'noopener';
         a.target = '_blank';
         a.textContent = linkText;
@@ -97,6 +96,21 @@ class DOM {
    */
   document() {
     return this._document;
+  }
+
+  /**
+   * Guaranteed context.querySelector. Always returns an element or throws if
+   * nothing matches query.
+   * @param {!DocumentFragment|!Element} context
+   * @param {string} query
+   * @return {!Element}
+   */
+  static find(context, query) {
+    const result = context.querySelector(query);
+    if (result === null) {
+      throw new Error(`query ${query} not found`);
+    }
+    return result;
   }
 }
 

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -22,7 +22,7 @@
  * Dummy text for ensuring report robustness: </script> pre$`post %%LIGHTHOUSE_JSON%%
  */
 
-/* globals self */
+/* globals self, DOM */
 
 const RATINGS = {
   PASS: {label: 'pass', minScore: 75},
@@ -60,9 +60,11 @@ class ReportRenderer {
    * @param {!DetailsRenderer} detailsRenderer
    */
   constructor(dom, detailsRenderer) {
+    /** @private {!DOM} */
     this._dom = dom;
+    /** @private {!DetailsRenderer} */
     this._detailsRenderer = detailsRenderer;
-
+    /** @private {!Document|!Element} */
     this._templateContext = this._dom.document();
   }
 
@@ -73,7 +75,7 @@ class ReportRenderer {
   renderReport(report) {
     try {
       return this._renderReport(report);
-    } catch (e) {
+    } catch (/** @type {!Error} */ e) {
       return this._renderException(e);
     }
   }
@@ -88,13 +90,13 @@ class ReportRenderer {
    */
   _populateScore(element, score, scoringMode, title, description) {
     // Fill in the blanks.
-    const valueEl = element.querySelector('.lh-score__value');
+    const valueEl = DOM.find(element, '.lh-score__value');
     valueEl.textContent = formatNumber(score);
     valueEl.classList.add(`lh-score__value--${calculateRating(score)}`,
-                          `lh-score__value--${scoringMode}`);
+        `lh-score__value--${scoringMode}`);
 
-    element.querySelector('.lh-score__title').textContent = title;
-    element.querySelector('.lh-score__description')
+    DOM.find(element, '.lh-score__title').textContent = title;
+    DOM.find(element, '.lh-score__description')
         .appendChild(this._dom.createSpanFromMarkdown(description));
 
     return /** @type {!Element} **/ (element);
@@ -128,7 +130,7 @@ class ReportRenderer {
     }
 
     // Append audit details to header section so the entire audit is within a <details>.
-    const header = tmpl.querySelector('.lh-score__header');
+    const header = /** @type {!HTMLDetailsElement} */ (DOM.find(tmpl, '.lh-score__header'));
     header.open = audit.score < 100; // expand failed audits
     if (audit.result.details) {
       header.appendChild(this._detailsRenderer.render(audit.result.details));
@@ -218,15 +220,17 @@ if (typeof module !== 'undefined' && module.exports) {
 
 /**
  * @typedef {{
- *     id: string, weight:
- *     number, score: number,
+ *     id: string,
+ *     weight: number,
+ *     score: number,
  *     result: {
  *       description: string,
  *       displayValue: string,
  *       helpText: string,
  *       score: (number|boolean),
  *       scoringMode: string,
- *       details: (!DetailsRenderer.DetailsJSON|!DetailsRenderer.CardsDetailsJSON|undefined)
+ *       optimalValue: number,
+ *       details: (!DetailsRenderer.DetailsJSON|undefined)
  *     }
  * }}
  */
@@ -245,11 +249,10 @@ ReportRenderer.CategoryJSON; // eslint-disable-line no-unused-expressions
 
 /**
  * @typedef {{
- *     lighthouseVersion: !string,
- *     generatedTime: !string,
- *     initialUrl: !string,
- *     url: !string,
- *     audits: ?Object,
+ *     lighthouseVersion: string,
+ *     generatedTime: string,
+ *     initialUrl: string,
+ *     url: string,
  *     reportCategories: !Array<!ReportRenderer.CategoryJSON>
  * }}
  */

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -22,7 +22,7 @@
  * Dummy text for ensuring report robustness: </script> pre$`post %%LIGHTHOUSE_JSON%%
  */
 
-/* globals self, DOM */
+/* globals self */
 
 const RATINGS = {
   PASS: {label: 'pass', minScore: 75},
@@ -90,13 +90,13 @@ class ReportRenderer {
    */
   _populateScore(element, score, scoringMode, title, description) {
     // Fill in the blanks.
-    const valueEl = DOM.find(element, '.lh-score__value');
+    const valueEl = this._dom.find(element, '.lh-score__value');
     valueEl.textContent = formatNumber(score);
     valueEl.classList.add(`lh-score__value--${calculateRating(score)}`,
         `lh-score__value--${scoringMode}`);
 
-    DOM.find(element, '.lh-score__title').textContent = title;
-    DOM.find(element, '.lh-score__description')
+    this._dom.find(element, '.lh-score__title').textContent = title;
+    this._dom.find(element, '.lh-score__description')
         .appendChild(this._dom.createSpanFromMarkdown(description));
 
     return /** @type {!Element} **/ (element);
@@ -130,7 +130,7 @@ class ReportRenderer {
     }
 
     // Append audit details to header section so the entire audit is within a <details>.
-    const header = /** @type {!HTMLDetailsElement} */ (DOM.find(tmpl, '.lh-score__header'));
+    const header = /** @type {!HTMLDetailsElement} */ (this._dom.find(tmpl, '.lh-score__header'));
     header.open = audit.score < 100; // expand failed audits
     if (audit.result.details) {
       header.appendChild(this._detailsRenderer.render(audit.result.details));

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -47,20 +47,6 @@ describe('DetailsRenderer', () => {
       assert.ok(el.classList.contains('lh-text'), 'adds classes');
     });
 
-    it('renders blocks', () => {
-      const el = renderer.render({
-        type: 'block',
-        items: [
-          {type: 'text', text: 'content 1'},
-          {type: 'text', text: 'content 2'},
-        ],
-      });
-
-      const children = el.querySelectorAll('.lh-text');
-      assert.equal(children.length, 2, 'renders children');
-      assert.ok(el.classList.contains('lh-block'), 'adds classes');
-    });
-
     it('renders lists with headers', () => {
       const el = renderer.render({
         type: 'list',
@@ -93,31 +79,6 @@ describe('DetailsRenderer', () => {
 
       const items = el.querySelector('.lh-list__items');
       assert.equal(items.children.length, 3, 'did not render children');
-    });
-
-    it('renders nested structures', () => {
-      const el = renderer.render({
-        type: 'block',
-        items: [
-          {type: 'text', text: 'content 1'},
-          {type: 'text', text: 'content 2'},
-          {
-            type: 'list',
-            header: {type: 'text', text: 'header'},
-            items: [
-              {type: 'text', text: 'sub-content 1'},
-              {type: 'text', text: 'sub-content 2'},
-            ]
-          },
-        ],
-      });
-
-      const textChild = el.querySelector('.lh-block > .lh-text');
-      const listChild = el.querySelector('.lh-block > .lh-details');
-      const textSubChild = el.querySelector('.lh-block .lh-details .lh-text');
-      assert.ok(textChild, 'did not render text children');
-      assert.ok(listChild, 'did not render list child');
-      assert.ok(textSubChild, 'did not render sub-children');
     });
 
     it('renders cards', () => {

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -33,6 +33,7 @@ describe('ReportRenderer V2', () => {
 
   before(() => {
     global.URL = URL;
+    global.DOM = DOM;
     const document = jsdom.jsdom(TEMPLATE_FILE);
     const dom = new DOM(document);
     const detailsRenderer = new DetailsRenderer(dom);
@@ -41,6 +42,7 @@ describe('ReportRenderer V2', () => {
 
   after(() => {
     global.URL = undefined;
+    global.DOM = undefined;
   });
 
   describe('renderReport', () => {

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -33,7 +33,6 @@ describe('ReportRenderer V2', () => {
 
   before(() => {
     global.URL = URL;
-    global.DOM = DOM;
     const document = jsdom.jsdom(TEMPLATE_FILE);
     const dom = new DOM(document);
     const detailsRenderer = new DetailsRenderer(dom);
@@ -42,7 +41,6 @@ describe('ReportRenderer V2', () => {
 
   after(() => {
     global.URL = undefined;
-    global.DOM = undefined;
   });
 
   describe('renderReport', () => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coverage": "node $(npm bin)/istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*-test.js') --timeout 10000 --reporter progress",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "start": "gulp && node ./lighthouse-cli/index.js",
-    "test": "npm run lint --silent && gulp && npm run unit",
+    "test": "npm run lint --silent && gulp && npm run unit && npm run closure",
     "core-unit": "bash lighthouse-core/scripts/run-mocha.sh --core",
     "cli-unit": "bash lighthouse-core/scripts/run-mocha.sh --cli",
     "viewer-unit": "bash lighthouse-core/scripts/run-mocha.sh --viewer",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "coveralls": "^2.11.9",
     "eslint": "^3.12.0",
     "eslint-config-google": "^0.7.1",
-    "google-closure-compiler": "^20161201.0.0",
+    "google-closure-compiler": "20170409.0.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-declare": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,12 +1237,12 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-google-closure-compiler@^20161201.0.0:
-  version "20161201.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20161201.0.0.tgz#2bcf0206060ad4f4031f64f73eaab7119ff76738"
+google-closure-compiler@20170409.0.0:
+  version "20170409.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20170409.0.0.tgz#dc1be29a9f7eef8611364533b271b9fac757c970"
   dependencies:
     chalk "^1.0.0"
-    vinyl "^1.2.0"
+    vinyl "^2.0.1"
     vinyl-sourcemaps-apply "^0.2.0"
 
 got@^6.7.1:
@@ -3232,15 +3232,7 @@ vinyl@^0.5.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-vinyl@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-1.2.0.tgz#5c88036cf565e5df05558bfc911f8656df218884"
-  dependencies:
-    clone "^1.0.0"
-    clone-stats "^0.0.1"
-    replace-ext "0.0.1"
-
-vinyl@^2.0.0:
+vinyl@^2.0.0, vinyl@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.0.1.tgz#1c3b4931e7ac4c1efee743f3b91a74c094407bb6"
   dependencies:


### PR DESCRIPTION
@paulirish already took this most of the way there in #2002, this is just cleaning up the rest and hitting some pretty strict rules, which is nice. It has to be manually run right now (`npm run closure`)...I wasn't sure if I should enable it or not yet in CI.

Two things that might be controversial:
1) `DetailsJSON` has been flattened into basically a base class (`DetailsJSON` with a `type` and optional `text` field) and derived classes `ListDetailsJSON`, and `CardDetailsJSON` (names are terrible :). Inheritance isn't actually used, however.

   Precipitating reason is that you can't do circular typedefs, so these weren't being checked at all. DevTools compilation didn't notice because it's not using the NewTypeInference engine (to be fair, we aren't either by default because of some lingering bugs). We *could* do an actual `@interface`, which handles circular references, but we aren't actually using the recursive nature of `DetailsJSON` anywhere and it really just makes it harder to figure out what type any particular place is dealing with. If every property on `DetailsJSON` was going to be optional except for `type`, and `type` determines which properties are defined on a particular instance and what function deals with rendering it...that sounds  a whole lot like a separate type, so lets just call it that.

   When dispatched from `_render` to their particular `_render*` method, they're cast to the specific type needed. Whole thing works because these are structural types, so as long as they fit the structure they're good to go.

   For lists and cards I tried to narrow the property types to how they're actually used. `_renderBlock` is never actually used, so I have no information there, so I just deleted rather than deal with it. Next PR that needs blocks can add it back :)

2) As mentioned offline to some, I've replaced instances of `context.querySelector(query)` (which can return `null` if nothing is found) with `DOM.find(context, query)` which never returns null so we don't have to constantly assure closure that it's not null. We use it for finding stuff in templates, so if the target isn't found we either screwed up the template or the query, and `DOM.find` helpfully throws an exception in that case.