### PR TITLE
browserify axe-core as a string, not a Buffer

### DIFF
--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -16,18 +16,18 @@
  */
 'use strict';
 
-/* global document */
+/* global window, document */
 
 const Gatherer = require('./gatherer');
 const fs = require('fs');
-const axe = fs.readFileSync(require.resolve('axe-core/axe.min.js'), 'utf8');
+const axeLibSource = fs.readFileSync(require.resolve('axe-core/axe.min.js'), 'utf8');
 
 // This is run in the page, not Lighthouse itself.
 // axe.run returns a promise which fulfills with a results object
 // containing any violations.
 /* istanbul ignore next */
 function runA11yChecks() {
-  return axe.run(document, {
+  return window.axe.run(document, {
     runOnly: {
       type: 'tag',
       values: [
@@ -54,7 +54,7 @@ class Accessibility extends Gatherer {
   afterPass(options) {
     const driver = options.driver;
     const expression = `(function () {
-      ${axe};
+      ${axeLibSource};
       return (${runA11yChecks.toString()}());
     })()`;
 

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -20,9 +20,7 @@
 
 const Gatherer = require('./gatherer');
 const fs = require('fs');
-const axe = fs.readFileSync(
-  require.resolve('axe-core/axe.min.js')
-);
+const axe = fs.readFileSync(require.resolve('axe-core/axe.min.js'), 'utf8');
 
 // This is run in the page, not Lighthouse itself.
 // axe.run returns a promise which fulfills with a results object


### PR DESCRIPTION
@paulirish 

removes the slightly shady looking inlining of axe-core as a `Buffer` from the browserified output:

`const axe=Buffer("LyohIGFYZSB2Mi4xLjcKICogQ29weXJpZ2h0IChjKSAyMDE2IERlcXVlIFN5c3...`

and uses a regular string instead:

`const axe="/*! aXe v2.1.7\n * Copyright (c) 2016 Deque Systems, Inc.\n *\n * You...`

much more clear about what's going on there and actually saves 37KB in `lighthouse-background.js`!

may be a little faster too since it doesn't have to `.toString()` the polyfilled `Buffer`, but I don't see any measurable difference in the face of the axe testing that runs immediately afterwards :)