### PR TITLE
Small status logging improvements

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -93,6 +93,12 @@ class Runner {
         return artifacts;
       });
 
+
+      run = run.then(artifacts => {
+        log.log('status', 'Analyzing and running audits...');
+        return artifacts;
+      });
+
       // Run each audit sequentially, the auditResults array has all our fine work
       const auditResults = [];
       for (const audit of config.audits) {
@@ -125,6 +131,8 @@ class Runner {
     // Format and aggregate results before returning.
     run = run
       .then(runResults => {
+        log.log('status', 'Generating results...');
+
         const resultsById = runResults.auditResults.reduce((results, audit) => {
           results[audit.name] = audit;
           return results;
@@ -202,6 +210,7 @@ class Runner {
     // Fill remaining audit result fields.
     }).then(auditResult => Audit.generateAuditResult(audit, auditResult))
     .catch(err => {
+      log.warn(audit.meta.name, `Caught exception: ${err.message}`);
       if (err.fatal) {
         throw err;
       }


### PR DESCRIPTION
1. Add two lifecycle logs
   - 'Analyzing and running audits...'
   - 'Generating results...'
2. Exceptions caught in audits will log an warning to the console
   - Exceptions in gatherers are already emitted, so we're good there.
1. `Loading page & waiting for onload` => `Loading page & waiting for idle`. 
   - And instead of just listing gatherer classnames we add the handy text of "Collecting data for "...

screenshot: 
![image](https://cloud.githubusercontent.com/assets/39191/25364910/74150f7c-291a-11e7-9dfd-80fe467e5714.png)


----

This was mostly motivated by this exception from the screenshot:
> consistently-interactive:warn Caught exception: TracingProcessor.getMainThreadTopLevelEvents is not a function

I was getting that exception, but was only surfaced in the report. On the CLI i had no idea it was happening.