### PR TITLE
Bump axe-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "zone.js": "^0.7.3"
   },
   "dependencies": {
-    "axe-core": "2.1.7",
+    "axe-core": "2.2.0",
     "chrome-devtools-frontend": "1.0.422034",
     "debug": "2.2.0",
     "devtools-timeline-model": "1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,9 +164,9 @@ aws4@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
 
-axe-core@2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.1.7.tgz#4f66f2b3ee3b58ec2d3db4339dd124c5b33b79c3"
+axe-core@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.2.0.tgz#00b410b3fc899207d4f2f8e3753cff150d34e4bb"
 
 babar@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
Should fix false positives reported in #1615

I verified that the site mentioned in https://github.com/GoogleChrome/lighthouse/issues/1615#issuecomment-286830244 is no longer failing contrast checks.