### PR TITLE
simplify readme launcher example

### DIFF
--- a/docs/recipes/gulp/gulpfile.js
+++ b/docs/recipes/gulp/gulpfile.js
@@ -22,7 +22,7 @@ const lighthouse = require('lighthouse');
 const ChromeLauncher = require('lighthouse/lighthouse-cli/chrome-launcher').ChromeLauncher;
 const perfConfig = require('lighthouse/lighthouse-core/config/perf.json');
 const PORT = 8080;
-let launcher;
+let chromeLauncher;
 
 /**
  * Start server
@@ -40,18 +40,8 @@ const startServer = function() {
  */
 const stopServer = function() {
   connect.serverClose();
-  launcher.kill();
-};
-
-/**
- * Launch chrome
- */
-const launchChrome = function() {
-  launcher = new ChromeLauncher();
-  return launcher.isDebuggerReady()
-    .catch(() => {
-      return launcher.run();
-    });
+  chromeLauncher.kill();
+  chromeLauncher = null;
 };
 
 /**
@@ -85,7 +75,9 @@ const handleError = function(e) {
 };
 
 gulp.task('lighthouse', function() {
-  return launchChrome().then(_ => {
+  chromeLauncher = new ChromeLauncher();
+
+  return chromeLauncher.run().then(_ => {
     startServer();
     return runLighthouse()
       .then(handleOk)

--- a/readme.md
+++ b/readme.md
@@ -147,27 +147,21 @@ The example below shows how to setup and run Lighthouse programmatically as a No
 assumes you've installed Lighthouse as a dependency (`yarn add --dev lighthouse`).
 
 ```javascript
-const Lighthouse = require('lighthouse');
+const lighthouse = require('lighthouse');
 const ChromeLauncher = require('lighthouse/lighthouse-cli/chrome-launcher.js').ChromeLauncher;
 const Printer = require('lighthouse/lighthouse-cli/printer');
 
 function launchChromeAndRunLighthouse(url, flags, config) {
   const launcher = new ChromeLauncher({port: 9222, autoSelectChrome: true});
 
-  return launcher.isDebuggerReady()
-    .catch(() => {
-      if (flags.skipAutolaunch) {
-        return;
-      }
-      return launcher.run(); // Launch Chrome.
-    })
-    .then(() => Lighthouse(url, flags, config)) // Run Lighthouse.
+  return launcher.run() // Launch Chrome.
+    .then(() => lighthouse(url, flags, config)) // Run Lighthouse.
     .then(results => launcher.kill().then(() => results)) // Kill Chrome and return results.
     .catch(err => {
       // Kill Chrome if there's an error.
       return launcher.kill().then(() => {
         throw err;
-      }, console.error);
+      });
     });
 }
 


### PR DESCRIPTION
this removes a few excess lines in the readme programmatic example. Maybe arguable, but I think `skipAutolaunch` is a distraction that can be saved for those who want to go deep