### PR TITLE
rename references to Audit subclasses for clarity

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -20,7 +20,7 @@
   */
 'use strict';
 
-const Audit = require('./byte-efficiency-audit');
+const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const TTIAudit = require('../time-to-interactive');
 const URL = require('../../lib/url-shim');
 
@@ -30,7 +30,7 @@ const ALLOWABLE_OFFSCREEN_Y = 200;
 const IGNORE_THRESHOLD_IN_BYTES = 2048;
 const IGNORE_THRESHOLD_IN_PERCENT = 75;
 
-class OffscreenImages extends Audit {
+class OffscreenImages extends ByteEfficiencyAudit {
   /**
    * @return {!AuditMeta}
    */

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -19,7 +19,7 @@
   */
 'use strict';
 
-const Audit = require('./byte-efficiency-audit');
+const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const Formatter = require('../../report/formatter');
 const TracingProcessor = require('../../lib/traces/tracing-processor');
 const URL = require('../../lib/url-shim');
@@ -30,7 +30,7 @@ const OPTIMAL_VALUE = 1600 * 1024;
 const SCORING_POINT_OF_DIMINISHING_RETURNS = 2500 * 1024;
 const SCORING_MEDIAN = 4000 * 1024;
 
-class TotalByteWeight extends Audit {
+class TotalByteWeight extends ByteEfficiencyAudit {
   /**
    * @return {!AuditMeta}
    */
@@ -45,7 +45,7 @@ class TotalByteWeight extends Audit {
           'Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) ' +
           'and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. ' +
           'Try to find ways to reduce the size of required files.',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoringMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['networkRecords']
     };
   }
@@ -55,7 +55,7 @@ class TotalByteWeight extends Audit {
    * @return {!Promise<!AuditResult>}
    */
   static audit(artifacts) {
-    const networkRecords = artifacts.networkRecords[Audit.DEFAULT_PASS];
+    const networkRecords = artifacts.networkRecords[ByteEfficiencyAudit.DEFAULT_PASS];
     return artifacts.requestNetworkThroughput(networkRecords).then(networkThroughput => {
       let totalBytes = 0;
       const results = networkRecords.reduce((prev, record) => {
@@ -88,7 +88,7 @@ class TotalByteWeight extends Audit {
       return {
         rawValue: totalBytes,
         optimalValue: this.meta.optimalValue,
-        displayValue: `Total size was ${Audit.bytesToKbString(totalBytes)}`,
+        displayValue: `Total size was ${ByteEfficiencyAudit.bytesToKbString(totalBytes)}`,
         score: Math.round(Math.max(0, Math.min(score, 100))),
         extendedInfo: {
           formatter: Formatter.SUPPORTED_FORMATS.TABLE,

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -16,12 +16,12 @@
  */
 'use strict';
 
-const Audit = require('./byte-efficiency-audit');
+const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const URL = require('../../lib/url-shim');
 
 const PREVIEW_LENGTH = 100;
 
-class UnusedCSSRules extends Audit {
+class UnusedCSSRules extends ByteEfficiencyAudit {
   /**
    * @return {!AuditMeta}
    */
@@ -171,7 +171,7 @@ class UnusedCSSRules extends Audit {
     const styles = artifacts.Styles;
     const usage = artifacts.CSSUsage;
     const pageUrl = artifacts.URL.finalUrl;
-    const networkRecords = artifacts.networkRecords[Audit.DEFAULT_PASS];
+    const networkRecords = artifacts.networkRecords[ByteEfficiencyAudit.DEFAULT_PASS];
 
     const indexedSheets = UnusedCSSRules.indexStylesheetsById(styles, networkRecords);
     UnusedCSSRules.countUnusedRules(usage, indexedSheets);

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -24,7 +24,7 @@
  */
 'use strict';
 
-const Audit = require('./byte-efficiency-audit');
+const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const URL = require('../../lib/url-shim');
 
 const IGNORE_THRESHOLD_IN_BYTES = 2048;
@@ -32,7 +32,7 @@ const TOTAL_WASTED_BYTES_THRESHOLD = 1000 * 1024;
 const JPEG_ALREADY_OPTIMIZED_THRESHOLD_IN_BYTES = 25 * 1024;
 const WEBP_ALREADY_OPTIMIZED_THRESHOLD_IN_BYTES = 100 * 1024;
 
-class UsesOptimizedImages extends Audit {
+class UsesOptimizedImages extends ByteEfficiencyAudit {
   /**
    * @return {!AuditMeta}
    */

--- a/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
@@ -20,14 +20,14 @@
  */
 'use strict';
 
-const Audit = require('./byte-efficiency-audit');
+const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const URL = require('../../lib/url-shim');
 
 const IGNORE_THRESHOLD_IN_BYTES = 1400;
 const IGNORE_THRESHOLD_IN_PERCENT = 0.1;
 const TOTAL_WASTED_BYTES_THRESHOLD = 10 * 1024; // 10KB
 
-class ResponsesAreCompressed extends Audit {
+class ResponsesAreCompressed extends ByteEfficiencyAudit {
   /**
    * @return {!AuditMeta}
    */

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -24,13 +24,13 @@
   */
 'use strict';
 
-const Audit = require('./byte-efficiency-audit');
+const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const URL = require('../../lib/url-shim');
 
 const IGNORE_THRESHOLD_IN_BYTES = 2048;
 const WASTEFUL_THRESHOLD_IN_BYTES = 25 * 1024;
 
-class UsesResponsiveImages extends Audit {
+class UsesResponsiveImages extends ByteEfficiencyAudit {
   /**
    * @return {!AuditMeta}
    */

--- a/lighthouse-core/audits/splash-screen.js
+++ b/lighthouse-core/audits/splash-screen.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const Audit = require('./multi-check-audit');
+const MultiCheckAudit = require('./multi-check-audit');
 
 /**
  * @fileoverview
@@ -21,7 +21,7 @@ const Audit = require('./multi-check-audit');
  *   * manifest contains icon that's a png and size >= 512px
  */
 
-class SplashScreen extends Audit {
+class SplashScreen extends MultiCheckAudit {
 
   /**
    * @return {!AuditMeta}

--- a/lighthouse-core/audits/themed-omnibox.js
+++ b/lighthouse-core/audits/themed-omnibox.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const Audit = require('./multi-check-audit');
+const MultiCheckAudit = require('./multi-check-audit');
 const validColor = require('../lib/web-inspector').Color.parse;
 
 /**
@@ -19,7 +19,7 @@ const validColor = require('../lib/web-inspector').Color.parse;
  *   * HTML has a valid theme-color meta
  */
 
-class ThemedOmnibox extends Audit {
+class ThemedOmnibox extends MultiCheckAudit {
 
   /**
    * @return {!AuditMeta}

--- a/lighthouse-core/audits/webapp-install-banner.js
+++ b/lighthouse-core/audits/webapp-install-banner.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const Audit = require('./multi-check-audit');
+const MultiCheckAudit = require('./multi-check-audit');
 const SWAudit = require('./service-worker');
 
 /**
@@ -29,7 +29,7 @@ const SWAudit = require('./service-worker');
  *   * it doesn't consider the site engagement score (naturally)
  */
 
-class WebappInstallBanner extends Audit {
+class WebappInstallBanner extends MultiCheckAudit {
 
   /**
    * @return {!AuditMeta}


### PR DESCRIPTION
small change so that it's more obvious when audit classes are extending subclasses of `Audit` instead of `Audit` directly.

I missed where `requiredArtifacts` were coming from in #2062 even after carefully checking all uses of the passed in `artifacts` and even double checking they were extending `Audit` and not something else. I did not, however, check the definition of `Audit` in those files :)