### PR TITLE
[ChromeLauncher] Catch createConnection error

### DIFF
--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -178,15 +178,22 @@ export class ChromeLauncher {
   // resolves if ready, rejects otherwise
   isDebuggerReady(): Promise<{}> {
     return new Promise((resolve, reject) => {
-      const client = net.createConnection(this.port);
-      client.once('error', err => {
-        this.cleanup(client);
+      let client
+
+      try {
+        client = net.createConnection(this.port);
+        client.once('error', err => {
+          this.cleanup(client);
+          reject(err);
+        });
+        client.once('connect', () => {
+          this.cleanup(client);
+          resolve();
+        });
+      } catch (err) {
+        if (client) this.cleanup(client);
         reject(err);
-      });
-      client.once('connect', () => {
-        this.cleanup(client);
-        resolve();
-      });
+      }
     });
   }
 


### PR DESCRIPTION
### What happens
When there is no Chrome instance ready to accept a connection on the CRI port, node's `net.createConnection` will throw an exception. 

### What was changed
This change wraps the call to `createConnection` in a try/catch.

### Demo of `createConnection` in action 💥 
![error](https://cloud.githubusercontent.com/assets/924/25580323/68958c06-2e80-11e7-8a1d-676a704af7a9.gif)
