### PR TITLE
Fix computed artifact path during browserify

### DIFF
--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('browserify-lighthouse', () => {
         bundle = bundle.require(gatherer, {expose: gatherer.replace(driverPath, './')});
       });
       computedArtifacts.forEach(artifact => {
-        bundle = bundle.require(artifact, {expose: artifact.replace(driverPath, './')});
+        bundle = bundle.require(artifact, {expose: artifact.replace(corePath, './')});
       });
 
       // Inject the new browserified contents back into our gulp pipeline


### PR DESCRIPTION
The bug:
![image](https://cloud.githubusercontent.com/assets/39191/25588799/b5ccac2e-2e5e-11e7-854d-0b1ffc61d96f.png)


Found when rolling latest to devtools and running it.

Small fix. stemmed from the move of instantiateComputedArtifacts() to Runner.