### PR TITLE
fix: always use navStart as speedline timeOrigin

### DIFF
--- a/lighthouse-core/gather/computed/speedline.js
+++ b/lighthouse-core/gather/computed/speedline.js
@@ -28,13 +28,14 @@ class Speedline extends ComputedArtifact {
   /**
    * @return {!Promise}
    */
-  compute_(trace) {
+  compute_(trace, computedArtifacts) {
     // speedline() may throw without a promise, so we resolve immediately
     // to get in a promise chain.
-    return Promise.resolve().then(_ => {
-      return speedline(trace.traceEvents);
-    }).then(speedlineResults => {
-      return speedlineResults;
+    return computedArtifacts.requestTraceOfTab(trace).then(traceOfTab => {
+      // Force use of nav start as reference point for speedline
+      // See https://github.com/GoogleChrome/lighthouse/issues/2095
+      const navStart = traceOfTab.timestamps.navigationStart * 1000;
+      return speedline(trace.traceEvents, {timeOrigin: navStart});
     });
   }
 }

--- a/lighthouse-core/test/fixtures/traces/threeframes-blank_content_more.json
+++ b/lighthouse-core/test/fixtures/traces/threeframes-blank_content_more.json
@@ -16,6 +16,36 @@
 				"tts": 4516530
 			},
 			{
+				"pid": 93449,
+				"tid": 1295,
+				"ts": 900000000000,
+				"ph": "X",
+				"cat": "toplevel",
+				"name": "TracingStartedInPage",
+				"args": {
+					"data": {
+						"page": "dummy"
+					}
+				},
+				"dur": 189,
+				"tdur": 186,
+				"tts": 4516530
+			},
+			{
+				"pid": 93449,
+				"tid": 1295,
+				"ts": 900000000000,
+				"ph": "X",
+				"cat": "loading",
+				"name": "navigationStart",
+				"args": {
+					"frame": "dummy"
+				},
+				"dur": 189,
+				"tdur": 186,
+				"tts": 4516530
+			},
+			{
 				"pid": 93267,
 				"tid": 1295,
 				"ts": 900001000000,


### PR DESCRIPTION
fixes #2095

See issue for background. I wish we had a sample trace to add a test for this, but I haven't been able to grab one. speedline already supports custom reference points so this should resolve the extreme case noted in #2095