### PR TITLE
Remove renderException

### DIFF
--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -47,19 +47,12 @@ class ReportRenderer {
    */
   renderReport(report, container) {
     container.textContent = ''; // Remove previous report.
+    const element = container.appendChild(this._renderReport(report));
 
-    let element;
-    try {
-      element = container.appendChild(this._renderReport(report));
-
-      // Hook in JS features and page-level event listeners after the report
-      // is in the document.
-      if (this._uiFeatures) {
-        this._uiFeatures.initFeatures(report);
-      }
-    } catch (/** @type {!Error} */ e) {
-      container.textContent = '';
-      element = container.appendChild(this._renderException(e));
+    // Hook in JS features and page-level event listeners after the report
+    // is in the document.
+    if (this._uiFeatures) {
+      this._uiFeatures.initFeatures(report);
     }
 
     return /** @type {!Element} **/ (element);
@@ -73,16 +66,6 @@ class ReportRenderer {
   setTemplateContext(context) {
     this._templateContext = context;
     this._categoryRenderer.setTemplateContext(context);
-  }
-
-  /**
-   * @param {!Error} e
-   * @return {!Element}
-   */
-  _renderException(e) {
-    const element = this._dom.createElement('div', 'lh-exception');
-    element.textContent = String(e.stack);
-    return element;
   }
 
   /**

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -83,16 +83,6 @@ describe('ReportRenderer V2', () => {
       assert.ok(container.contains(newReport), 'new report appended to container');
     });
 
-    it('should render an exception for invalid input', () => {
-      const container = renderer._dom._document.body;
-      const output = renderer.renderReport({
-        get reportCategories() {
-          throw new Error();
-        }
-      }, container);
-      assert.ok(output.classList.contains('lh-exception'));
-    });
-
     it('renders a header', () => {
       const header = renderer._renderReportHeader(sampleResults);
       assert.ok(header.querySelector('.lh-export'), 'contains export button');


### PR DESCRIPTION
This was mostly introduced because in the extension, we were generating the report in the background page and not the report. So errors were absorbed and harder to track down.

Now that exceptions during rendering happen right on the page itself (CLI, ext, and DT), we can remove this complexity.