### PR TITLE
feat: add styling for informative audits

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-request-compression.js
@@ -35,6 +35,7 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
     return {
       category: 'Performance',
       name: 'uses-request-compression',
+      informative: true,
       description: 'Compression enabled for server responses',
       helpText: 'Text-based responses should be served with compression (gzip, deflate or brotli)' +
         ' to minimize total network bytes.' +

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -61,6 +61,11 @@ class CategoryRenderer {
       header.appendChild(this._detailsRenderer.render(audit.result.details));
     }
 
+    const scoreEl = this._dom.find('.lh-score', tmpl);
+    if (audit.result.informative) {
+      scoreEl.classList.add('lh-score--informative');
+    }
+
     return this._populateScore(tmpl, audit.score, scoringMode, title, description);
   }
 

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -171,6 +171,7 @@ if (typeof module !== 'undefined' && module.exports) {
  *     score: number,
  *     result: {
  *       description: string,
+ *       informative: boolean,
  *       debugString: string,
  *       displayValue: string,
  *       helpText: string,

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -195,12 +195,8 @@ summary {
 }
 
 .lh-score--informative .lh-score__value::after {
-  background: none;
-  content: 'ℹ';
-  font-size: 1.5em;
-  text-indent: 0px;
-  text-align: center;
-  top: -4px;
+  background: url('data:image/svg+xml;utf8,<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>info</title><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" fill="white"/></svg>') no-repeat 50% 50%;
+  background-size: calc(var(--lh-score-icon-background-size) * 2);
 }
 
 .lh-score__value--binary {

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -25,6 +25,7 @@
   /*--accent-color: #3879d9;*/
   --fail-color: #df332f;
   --pass-color: #2b882f;
+  --informative-color: #0c50c7;
   --average-color: #ef6c00; /* md orange 800 */
   --warning-color: #757575; /* md grey 600 */
 
@@ -186,6 +187,20 @@ summary {
   bottom: 0;
   background-color: #000;
   border-radius: inherit;
+}
+
+.lh-score--informative .lh-score__value {
+  background: var(--informative-color);
+  border-radius: 50%;
+}
+
+.lh-score--informative .lh-score__value::after {
+  background: none;
+  content: 'ℹ';
+  font-size: 1.5em;
+  text-indent: 0px;
+  text-align: center;
+  top: -4px;
 }
 
 .lh-score__value--binary {

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -75,6 +75,15 @@ describe('CategoryRenderer', () => {
     assert.ok(!audit2.querySelector('.lh-debug'));
   });
 
+  it('renders an informative audit', () => {
+    const auditDOM = renderer._renderAudit({
+      id: 'informative', score: 0,
+      result: {description: 'It informs', helpText: '', informative: true},
+    });
+
+    assert.ok(auditDOM.querySelector('.lh-score--informative'));
+  });
+
   it('renders a category', () => {
     const category = sampleResults.reportCategories[0];
     const categoryDOM = renderer.render(category);


### PR DESCRIPTION
paving the way for #2112, #2044, and splitting up the byte efficiency audits into the sparkline versions and the more aggressive "did you know" versions

basically informative audits will always look like a blue information icon and will not look like pass/fails, the score now simply controls visibility and auto-openness

![image](https://cloud.githubusercontent.com/assets/2301202/25596786/de20ad76-2e7f-11e7-9e7f-98454a4581f8.png)
