### PR TITLE
handle multiple javascript modal prompts

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -119,6 +119,7 @@
   property the e.stack inside the gatherer won't be in the correct format
   https://github.com/GoogleChrome/lighthouse/issues/1194 -->
 <script>window.Error = function(error) { this.stack = 'stacktrace'; };</script>
+<script>window.confirm('Is DBW Mega Tester the best site?')</script>
 <script>
 function stampTemplate(id, location) {
   const template = document.querySelector('#' + id);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -841,7 +841,9 @@ class Driver {
    */
   dismissJavaScriptDialogs() {
     return this.sendCommand('Page.enable').then(_ => {
-      this.on('Page.javascriptDialogOpening', _ => {
+      this.on('Page.javascriptDialogOpening', data => {
+        log.warn('Driver', `${data.type} dialog opened by the page automatically suppressed.`);
+
         // rejection intentionally unhandled
         this.sendCommand('Page.handleJavaScriptDialog', {
           accept: true,

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -841,7 +841,7 @@ class Driver {
    */
   dismissJavaScriptDialogs() {
     return this.sendCommand('Page.enable').then(_ => {
-      this.once('Page.javascriptDialogOpening', _ => {
+      this.on('Page.javascriptDialogOpening', _ => {
         // rejection intentionally unhandled
         this.sendCommand('Page.handleJavaScriptDialog', {
           accept: true,


### PR DESCRIPTION
followup to #2106. Solution there only closes the first dialog popup, but we want to always close them, including over a page reload per pass (the test site in #1939 must persist your selection somehow because it now works).

Discovered while adding a smoketest that we handle dismissing modal prompts, so PR also includes that :)