### PR TITLE
improve instructions for running behind a login

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ NOTE: specifying an output path with multiple formats ignores your specified ext
 
  - `chrome-debug`
  - open and login to your site
- - `lighthouse http://mysite.com`
+ - in a separate terminal tab `lighthouse http://mysite.com`
 
 ## Testing on a mobile device
 


### PR DESCRIPTION
As a user it isn't immediately clear that debug-chrome needs to be run and remain open when running lighthouse cli to access an area of a site that requires a login.