### PR TITLE
Don't filter artifacts out of LHR

### DIFF
--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -170,7 +170,6 @@ window.runLighthouseInWorker = function(port, url, options, categoryIDs) {
  */
 window.createReportPageAsBlob = function(results, reportContext) {
   performance.mark('report-start');
-  filterOutArtifacts(results);
   const reportGenerator = new ReportGenerator();
   let html;
   try {

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -114,7 +114,6 @@ window.runLighthouseForConnection = function(connection, url, options, categoryI
     .then(result => {
       lighthouseIsRunning = false;
       updateBadgeUI();
-      filterOutArtifacts(result);
       return result;
     })
     .catch(err => {
@@ -138,6 +137,7 @@ window.runLighthouseInExtension = function(options, categoryIDs) {
   return connection.getCurrentTabURL()
     .then(url => window.runLighthouseForConnection(connection, url, options, categoryIDs))
     .then(results => {
+      filterOutArtifacts(results);
       // return enableOtherChromeExtensions(true).then(_ => {
       const blobURL = window.createReportPageAsBlob(results, 'extension');
       chrome.tabs.create({url: blobURL});
@@ -170,7 +170,7 @@ window.runLighthouseInWorker = function(port, url, options, categoryIDs) {
  */
 window.createReportPageAsBlob = function(results, reportContext) {
   performance.mark('report-start');
-
+  filterOutArtifacts(results);
   const reportGenerator = new ReportGenerator();
   let html;
   try {


### PR DESCRIPTION
Fixes #2124

this implements an alternate approach than what was proposed in issue.
now: artifacts are always included on the object and receiver chooses to ditch them or not.

* CLI: ditched in `bin.ts` right after `lighthouse()` completes (already implemented)
* extension: ditched in `runLighthouseInExtension` right after `runLighthouseInExtension` completes
* devtools: will be ditched before results sent into `renderReport`
