### PR TITLE
Closure: handle rejection from stream

### DIFF
--- a/lighthouse-core/closure/closure-type-checking.js
+++ b/lighthouse-core/closure/closure-type-checking.js
@@ -93,6 +93,10 @@ gulp.task('compile-report', () => {
     formatting: 'PRETTY_PRINT',
     preserve_type_annotations: true,
   }))
+  .on('error', err => {
+    gutil.log(err.message);
+    return process.exit(1);
+  })
   .pipe(gulp.dest('../'))
   .on('end', () => {
     gutil.log('Closure compilation successful.');


### PR DESCRIPTION
we were getting unhandled rejection exceptions in closure-type-checking:
![image](https://cloud.githubusercontent.com/assets/39191/25676727/fcbbe2f4-2ff7-11e7-96e9-6d9290c42712.png)

This fixes it.