### PR TITLE
Report css variable tweaks

### DIFF
--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-.lh-root {
+.lh-vars {
   --text-font-family: '.SFNSDisplay-Regular', 'Helvetica Neue', 'Lucida Grande', sans-serif;
   --body-font-size: 13px;
   --header-font-size: 16px;

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -399,6 +399,8 @@ summary {
 
 .lh-category .lh-score__gauge {
   margin: 10px var(--lh-score-margin);
+  flex-basis: var(--circle-size);
+  flex-shrink: 0;
 }
 
 .lh-category .lh-score__gauge .lh-gauge {

--- a/lighthouse-core/report/v2/report-template.html
+++ b/lighthouse-core/report/v2/report-template.html
@@ -24,7 +24,7 @@ limitations under the License.
   <title>Lighthouse Report</title>
   <style>/*%%LIGHTHOUSE_CSS%%*/</style>
 </head>
-<body class="lh-root">
+<body class="lh-root lh-vars">
   <noscript>Lighthouse report requires JavaScript. Please enable.</noscript>
   <div hidden>%%LIGHTHOUSE_TEMPLATES%%</div>
 


### PR DESCRIPTION
two things:

1. We want to reuse some of the constants in the CSS variables outside of the report.. for example: 
![image](https://cloud.githubusercontent.com/assets/39191/25684584/1d7cf090-3017-11e7-9fd3-f9be2e5228de.png)

So I've split `lh-root` into `lh-root` and `lh-vars`, where lh-vars can be applied to a subtree anywhere you want those variables.

2. The new category gauge was getting crowded on more narrow widths:

before:
![image](https://cloud.githubusercontent.com/assets/39191/25684622/45d20d00-3017-11e7-9609-92872e029d5e.png)

after:
![image](https://cloud.githubusercontent.com/assets/39191/25684628/4cd6069c-3017-11e7-90f2-4a15cada1941.png)
