### PR TITLE
Ignore cache hits for "fast on 3g" check

### DIFF
--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -53,7 +53,12 @@ class LoadFastEnough4Pwa extends Audit {
   static audit(artifacts) {
     const networkRecords = artifacts.networkRecords[Audit.DEFAULT_PASS];
     const allRequestLatencies = networkRecords.map(record => {
-      if (!record._timing) return undefined;
+      // Ignore requests that don't have timing data or resources that have
+      // previously been requested and are coming from the cache.
+      if (!record._timing || record._fromDiskCache) {
+        return undefined;
+      }
+
       // Use DevTools' definition of Waiting latency: https://github.com/ChromeDevTools/devtools-frontend/blob/66595b8a73a9c873ea7714205b828866630e9e82/front_end/network/RequestTimingView.js#L164
       return record._timing.receiveHeadersEnd - record._timing.sendEnd;
     });

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -64,6 +64,15 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     });
   });
 
+  it('ignores resources coming from cache', () => {
+    const mockNetworkRecords = [
+      {_timing: {sendEnd: 0, receiveHeadersEnd: 50}, _fromDiskCache: true},
+    ];
+    return FastPWAAudit.audit(generateArtifacts(5000, mockNetworkRecords)).then(result => {
+      assert.equal(result.rawValue, true);
+      assert.strictEqual(result.debugString, undefined);
+    });
+  });
 
   it('passes a good TTI value and WITH throttling', () => {
     // latencies are very long


### PR DESCRIPTION
Proposed fix for https://github.com/GoogleChrome/lighthouse/issues/2109 which ignores requests that are coming from the cache.

This fixes chromestatus.com:

![screen shot 2017-05-03 at 5 23 46 pm](https://cloud.githubusercontent.com/assets/238208/25686732/593d64f8-3025-11e7-9346-50c2c97ecde1.png)

Fixes https://github.com/GoogleChrome/lighthouse/issues/2109.