### PR TITLE
Network byte weight audit should not be informative

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -40,7 +40,6 @@ class TotalByteWeight extends ByteEfficiencyAudit {
       name: 'total-byte-weight',
       optimalValue: `< ${this.bytesToKbString(OPTIMAL_VALUE)}`,
       description: 'Avoids enormous network payloads',
-      informative: true,
       helpText:
           'Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) ' +
           'and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. ' +


### PR DESCRIPTION
R: all

Blue numbers, no more!

![screen shot 2017-05-03 at 5 35 04 pm](https://cloud.githubusercontent.com/assets/238208/25687153/c57d5648-3028-11e7-813d-dcbf37d94f9b.png)
