### PR TITLE
Add line/code renderer to deprecations audit

### DIFF
--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -24,6 +24,7 @@
 
 const Audit = require('./audit');
 const Formatter = require('../report/formatter');
+const URL = require('../lib/url-shim');
 
 class Deprecations extends Audit {
   /**
@@ -65,12 +66,13 @@ class Deprecations extends Audit {
     function makeDepractionsV2(entries) {
       return entries.filter(log => log.entry.source === 'deprecation').map(log => {
         // CSS deprecations can have missing URLs and lineNumbers. See https://crbug.com/680832.
-        const label = log.entry.lineNumber ? `line: ${log.entry.lineNumber}` : 'line: ???';
-        const url = log.entry.url || 'Unable to determine URL';
+        const url = URL.isValid(log.entry.url) ? URL.getDisplayName(log.entry.url) : '';
         return {
           type: 'code',
           text: log.entry.text,
-          header: {type: 'text', text: `${url} (${label})`}
+          url,
+          source: log.entry.source,
+          lineNumber: log.entry.lineNumber
         };
       });
     }

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -61,9 +61,10 @@ class Deprecations extends Audit {
         });
 
     /**
+     * @param {!Array<!DetailsRenderer.CodeDetailsJSON>} entries
      * @return {!DetailsRenderer.CodeDetailsJSON} details
      */
-    function makeDepractionsV2(entries) {
+    function makeDeprecationsV2(entries) {
       return entries.filter(log => log.entry.source === 'deprecation').map(log => {
         // CSS deprecations can have missing URLs and lineNumbers. See https://crbug.com/680832.
         const url = URL.isValid(log.entry.url) ? URL.getDisplayName(log.entry.url) : '';
@@ -94,7 +95,7 @@ class Deprecations extends Audit {
       details: {
         type: 'list',
         header: {type: 'text', text: 'Deprecations & warnings'},
-        items: makeDepractionsV2(entries)
+        items: makeDeprecationsV2(entries)
       }
     };
   }

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -59,6 +59,19 @@ class Deprecations extends Audit {
           }, log.entry);
         });
 
+    function makeDepractionsV2(entries) {
+      return entries.filter(log => log.entry.source === 'deprecation').map(log => {
+        // CSS deprecations can have missing URLs and lineNumbers. See https://crbug.com/680832.
+        const label = log.entry.lineNumber ? `line: ${log.entry.lineNumber}` : 'line: ???';
+        const url = log.entry.url || 'Unable to determine URL';
+        return {
+          type: 'code',
+          text: log.entry.text,
+          header: {type: 'text', text: `${url} (${label})`}
+        };
+      });
+    }
+
     let displayValue = '';
     if (deprecations.length > 1) {
       displayValue = `${deprecations.length} warnings found`;
@@ -72,6 +85,11 @@ class Deprecations extends Audit {
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: deprecations
+      },
+      details: {
+        type: 'list',
+        header: {type: 'text', text: 'Deprecations & warnings'},
+        items: makeDepractionsV2(entries)
       }
     };
   }

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -59,6 +59,9 @@ class Deprecations extends Audit {
           }, log.entry);
         });
 
+    /**
+     * @return {!DetailsRenderer.CodeDetailsJSON} details
+     */
     function makeDepractionsV2(entries) {
       return entries.filter(log => log.entry.source === 'deprecation').map(log => {
         // CSS deprecations can have missing URLs and lineNumbers. See https://crbug.com/680832.

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -60,23 +60,24 @@ class Deprecations extends Audit {
           }, log.entry);
         });
 
-    /**
-     * @param {!Array<!DetailsRenderer.CodeDetailsJSON>} entries
-     * @return {!DetailsRenderer.CodeDetailsJSON} details
-     */
-    function makeDeprecationsV2(entries) {
-      return entries.filter(log => log.entry.source === 'deprecation').map(log => {
-        // CSS deprecations can have missing URLs and lineNumbers. See https://crbug.com/680832.
-        const url = URL.isValid(log.entry.url) ? URL.getDisplayName(log.entry.url) : '';
-        return {
-          type: 'code',
-          text: log.entry.text,
-          url,
-          source: log.entry.source,
-          lineNumber: log.entry.lineNumber
-        };
-      });
-    }
+    const deprecationsV2 = entries.filter(log => log.entry.source === 'deprecation').map(log => {
+      // CSS deprecations can have missing URLs and lineNumbers. See https://crbug.com/680832.
+      const url = URL.isValid(log.entry.url) ? URL.getDisplayName(log.entry.url) : '';
+      return {
+        type: 'code',
+        text: log.entry.text,
+        url,
+        source: log.entry.source,
+        lineNumber: log.entry.lineNumber
+      };
+    });
+
+    const headings = [
+      {key: 'text', itemType: 'code', text: 'Deprecation / Warning'},
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'lineNumber', itemType: 'text', text: 'Line'},
+    ];
+    const details = Audit.makeV2TableDetails(headings, deprecationsV2);
 
     let displayValue = '';
     if (deprecations.length > 1) {
@@ -92,11 +93,7 @@ class Deprecations extends Audit {
         formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: deprecations
       },
-      details: {
-        type: 'list',
-        header: {type: 'text', text: 'Deprecations & warnings'},
-        items: makeDeprecationsV2(entries)
-      }
+      details
     };
   }
 }

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -43,7 +43,7 @@ class DetailsRenderer {
       case 'table':
         return this._renderTable(/** @type {!DetailsRenderer.TableDetailsJSON} */ (details));
       case 'code':
-        return this._renderCode(/** @type {!DetailsRenderer.CodeDetailsJSON} */ (details));
+        return this._renderCode(details);
       case 'list':
         return this._renderList(/** @type {!DetailsRenderer.ListDetailsJSON} */ (details));
       default:
@@ -171,7 +171,7 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsRenderer.CodeDetailsJSON} details
+   * @param {!DetailsRenderer.DetailsJSON} details
    * @return {!Element}
    */
   _renderCode(details) {
@@ -229,14 +229,3 @@ DetailsRenderer.TableDetailsJSON; // eslint-disable-line no-unused-expressions
  * }}
  */
 DetailsRenderer.ThumbnailDetails; // eslint-disable-line no-unused-expressions
-
-/**
- * @typedef {{
- *     type: string,
- *     text: string,
- *     url: (string|undefined),
- *     source: string,
- *     lineNumber: (string|undefined)
- * }}
- */
-DetailsRenderer.CodeDetailsJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -175,17 +175,9 @@ class DetailsRenderer {
    * @return {!Element}
    */
   _renderCode(details) {
-    const element = this._dom.createElement('div', 'lh-details flex justified');
-
-    const pre = element.appendChild(this._dom.createElement('pre', 'lh-code'));
-    pre.textContent = details.source ? `[${details.source}] ${details.text}` : details.text;
-
-    if (details.url) {
-      const text = details.url + (details.lineNumber ? `:${details.lineNumber}` : '');
-      element.appendChild(this._renderURL({type: 'text', text}));
-    }
-
-    return element;
+    const pre = this._dom.createElement('pre', 'lh-code');
+    pre.textContent = details.text;
+    return pre;
   }
 }
 

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -42,6 +42,8 @@ class DetailsRenderer {
         return this._renderCards(/** @type {!DetailsRenderer.CardsDetailsJSON} */ (details));
       case 'table':
         return this._renderTable(/** @type {!DetailsRenderer.TableDetailsJSON} */ (details));
+      case 'code':
+        return this._renderCode(/** @type {!DetailsRenderer.CodeDetailsJSON} */ (details));
       case 'list':
         return this._renderList(/** @type {!DetailsRenderer.ListDetailsJSON} */ (details));
       default:
@@ -167,6 +169,25 @@ class DetailsRenderer {
     element.appendChild(cardsParent);
     return element;
   }
+
+  /**
+   * @param {!DetailsRenderer.CodeDetailsJSON} details
+   * @return {!Element}
+   */
+  _renderCode(details) {
+    const element = this._dom.createElement('div', 'lh-details');
+
+    const pre = this._dom.createElement('pre', 'lh-code');
+    pre.textContent = details.text;
+
+    if (details.header) {
+      element.appendChild(this._renderText(details.header));
+    }
+
+    element.appendChild(pre);
+
+    return element;
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {
@@ -217,3 +238,12 @@ DetailsRenderer.TableDetailsJSON; // eslint-disable-line no-unused-expressions
  * }}
  */
 DetailsRenderer.ThumbnailDetails; // eslint-disable-line no-unused-expressions
+
+/**
+ * @typedef {{
+ *     type: string,
+ *     text: string,
+ *     header: (!DetailsRenderer.DetailsJSON|undefined),
+ * }}
+ */
+DetailsRenderer.CodeDetailsJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -72,16 +72,6 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {!DetailsRenderer.DetailsJSON} text
-   * @return {!Element}
-   */
-  _renderURL(text) {
-    const element = this._renderText(text);
-    element.classList.add('lh-text__url');
-    return element;
-  }
-
-  /**
    * Create small thumbnail with scaled down image asset.
    * If the supplied details doesn't have an image/* mimeType, then an empty span is returned.
    * @param {!DetailsRenderer.ThumbnailDetails} value

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -55,6 +55,16 @@ class DetailsRenderer {
    * @param {!DetailsRenderer.DetailsJSON} text
    * @return {!Element}
    */
+  _renderURL(text) {
+    const element = this._renderText(text);
+    element.classList.add('lh-text__url');
+    return element;
+  }
+
+  /**
+   * @param {!DetailsRenderer.DetailsJSON} text
+   * @return {!Element}
+   */
   _renderText(text) {
     const element = this._dom.createElement('div', 'lh-text');
     element.textContent = text.text;
@@ -175,16 +185,15 @@ class DetailsRenderer {
    * @return {!Element}
    */
   _renderCode(details) {
-    const element = this._dom.createElement('div', 'lh-details');
+    const element = this._dom.createElement('div', 'lh-details flex justified');
 
-    const pre = this._dom.createElement('pre', 'lh-code');
-    pre.textContent = details.text;
+    const pre = element.appendChild(this._dom.createElement('pre', 'lh-code'));
+    pre.textContent = details.source ? `[${details.source}] ${details.text}` : details.text;
 
-    if (details.header) {
-      element.appendChild(this._renderText(details.header));
+    if (details.url) {
+      const text = details.url + (details.lineNumber ? `:${details.lineNumber}` : '');
+      element.appendChild(this._renderURL({type: 'text', text}));
     }
-
-    element.appendChild(pre);
 
     return element;
   }
@@ -243,7 +252,9 @@ DetailsRenderer.ThumbnailDetails; // eslint-disable-line no-unused-expressions
  * @typedef {{
  *     type: string,
  *     text: string,
- *     header: {type: string, text: (string|undefined)}
+ *     url: (string|undefined),
+ *     source: string,
+ *     lineNumber: (string|undefined)
  * }}
  */
 DetailsRenderer.CodeDetailsJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -243,7 +243,7 @@ DetailsRenderer.ThumbnailDetails; // eslint-disable-line no-unused-expressions
  * @typedef {{
  *     type: string,
  *     text: string,
- *     header: (!DetailsRenderer.DetailsJSON|undefined),
+ *     header: {type: string, text: (string|undefined)}
  * }}
  */
 DetailsRenderer.CodeDetailsJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -27,7 +27,7 @@
   --pass-color: #2b882f;
   --informative-color: #0c50c7;
   --average-color: #ef6c00; /* md orange 800 */
-  --warning-color: #757575; /* md grey 600 */
+  --warning-color: #ffab00; /* md amber a700 */
 
   --report-border-color: #ccc;
   --report-secondary-border-color: #ebebeb;
@@ -67,6 +67,22 @@ summary {
   cursor: pointer;
 }
 
+.flex {
+  display: flex;
+}
+.flex.vertical {
+  flex-direction: column;
+}
+.flex.vcenter {
+  align-items: center;
+}
+.flex.hcenter {
+  justify-content: center;
+}
+.flex.justified {
+  justify-content: space-between;
+}
+
 .lh-details {
   font-size: smaller;
   margin-top: var(--default-padding);
@@ -74,6 +90,10 @@ summary {
 
 .lh-details[open] summary {
   margin-bottom: var(--default-padding);
+}
+
+.lh-details.flex .lh-code {
+  max-width: 70%;
 }
 
 /* Report header */
@@ -339,6 +359,19 @@ summary {
   color: var(--fail-color);
 }
 
+.lh-debug::before {
+  display: inline-block;
+  content: '';
+  background: url('data:image/svg+xml;utf8,<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>warn</title><path d="M0 0h24v24H0z" fill="none"/><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" fill="#FFAB00"/></svg>') no-repeat 50% 50%;
+  background-size: contain;
+  width: 20px;
+  height: 20px;
+  position: relative;
+  margin-right: calc(var(--default-padding) / 2);
+  top: 5px;
+}
+
+
 /* Report */
 
 .lh-container {
@@ -356,10 +389,15 @@ summary {
   font-size: large;
 }
 
+.lh-text__url {
+  white-space: nowrap;
+}
+
 .lh-code {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: pre-line;
+  margin-top: 0;
 }
 
 .lh-scores-header {

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -67,22 +67,6 @@ summary {
   cursor: pointer;
 }
 
-.flex {
-  display: flex;
-}
-.flex.vertical {
-  flex-direction: column;
-}
-.flex.vcenter {
-  align-items: center;
-}
-.flex.hcenter {
-  justify-content: center;
-}
-.flex.justified {
-  justify-content: space-between;
-}
-
 .lh-details {
   font-size: smaller;
   margin-top: var(--default-padding);

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -356,6 +356,12 @@ summary {
   font-size: large;
 }
 
+.lh-code {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: pre-line;
+}
+
 .lh-scores-header {
   display: flex;
   margin: var(--report-header-height) 0 0 0;

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -118,12 +118,9 @@ describe('DetailsRenderer', () => {
         url: 'https://example.com/feature'
       });
 
-      const pre = el.querySelector('pre.lh-code');
-      assert.ok(pre, 'rendered pre tag');
-      assert.ok(pre.textContent.includes('deprecation'), 'rendered pre tag');
-
-      const label = el.querySelector('.lh-text.lh-text__url');
-      assert.ok(label.textContent.includes('https://example.com/feature:123'), 'contains url');
+      assert.ok(el.localName === 'pre');
+      assert.ok(el.classList.contains('lh-code'));
+      assert.equal(el.textContent, 'code snippet');
     });
   });
 });

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -108,5 +108,19 @@ describe('DetailsRenderer', () => {
       assert.equal(cards[1].getAttribute('title'), 'snippet', 'adds title attribute for snippet');
       assert.ok(!cards[1].querySelector('.lh-scorecard__target'), 'handles missing target');
     });
+
+    it('renders code', () => {
+      const el = renderer.render({
+        type: 'code',
+        text: 'code snippet',
+        header: {type: 'text', text: 'label (123)'}
+      });
+
+      const pre = el.querySelector('pre.lh-code');
+      assert.ok(pre, 'rendered pre tag');
+
+      const label = el.querySelector('.lh-text');
+      assert.ok(label.textContent.includes('label (123)'), 'contains label');
+    });
   });
 });

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -113,14 +113,17 @@ describe('DetailsRenderer', () => {
       const el = renderer.render({
         type: 'code',
         text: 'code snippet',
-        header: {type: 'text', text: 'label (123)'}
+        lineNumber: 123,
+        source: 'deprecation',
+        url: 'https://example.com/feature'
       });
 
       const pre = el.querySelector('pre.lh-code');
       assert.ok(pre, 'rendered pre tag');
+      assert.ok(pre.textContent.includes('deprecation'), 'rendered pre tag');
 
-      const label = el.querySelector('.lh-text');
-      assert.ok(label.textContent.includes('label (123)'), 'contains label');
+      const label = el.querySelector('.lh-text.lh-text__url');
+      assert.ok(label.textContent.includes('https://example.com/feature:123'), 'contains url');
     });
   });
 });


### PR DESCRIPTION
<img width="775" alt="screen shot 2017-05-03 at 9 16 57 pm" src="https://cloud.githubusercontent.com/assets/238208/25690411/dc140614-3045-11e7-8af8-45efbfdfb072.png">
