### PR TITLE
perf(driver): only disable cache on trace passes

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -750,18 +750,12 @@ class Driver {
         .then(_ => this.online = true);
   }
 
-  cleanAndDisableBrowserCaches() {
-    return Promise.all([
-      this.clearBrowserCache(),
-      this.disableBrowserCache()
-    ]);
-  }
-
-  clearBrowserCache() {
-    return this.sendCommand('Network.clearBrowserCache');
+  enableBrowserCache() {
+    return this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false});
   }
 
   disableBrowserCache() {
+    log.warn('Driver', 'disabling network cache');
     return this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true});
   }
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -110,7 +110,6 @@ class GatherRunner {
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
       .then(_ => driver.dismissJavaScriptDialogs())
-      .then(_ => resetStorage && driver.cleanAndDisableBrowserCaches())
       .then(_ => resetStorage && driver.clearDataForOrigin(options.url))
       .then(_ => driver.blockUrlPatterns(options.flags.blockedUrlPatterns || []))
       .then(_ => gathererResults.UserAgent = [driver.getUserAgent()]);
@@ -348,7 +347,9 @@ class GatherRunner {
           return chain
             .then(_ => driver.setThrottling(options.flags, config))
             .then(_ => GatherRunner.beforePass(runOptions, gathererResults))
+            .then(_ => config.recordTrace && driver.disableBrowserCache())
             .then(_ => GatherRunner.pass(runOptions, gathererResults))
+            .then(_ => driver.enableBrowserCache())
             .then(_ => GatherRunner.afterPass(runOptions, gathererResults))
             .then(passData => {
               // If requested by config, merge trace -> tracingData


### PR DESCRIPTION
fixes #2089 (though it doesn't really seem to have any tangible impact on #2146 😢  maybe this isn't actually working? from what I can tell, master seemed to be using the cache on subsequent passes already)