### PR TITLE
Report: add user agent to runtime settings

### DIFF
--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -210,6 +210,7 @@ ReportRenderer.GroupJSON; // eslint-disable-line no-unused-expressions
 /**
  * @typedef {{
  *     lighthouseVersion: string,
+ *     userAgent: string,
  *     generatedTime: string,
  *     initialUrl: string,
  *     url: string,

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -80,6 +80,8 @@ class ReportRenderer {
     url.href = report.url;
     url.textContent = report.url;
 
+    this._dom.find('.lh-env__item__ua', header).textContent = report.userAgent;
+
     const env = this._dom.find('.lh-env__items', header);
     report.runtimeConfig.environment.forEach(runtime => {
       const item = this._dom.cloneTemplate('#tmpl-lh-env__items', env);

--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -290,6 +290,10 @@
           <div class="lh-env">
             <div class="lh-env__title">Runtime environment</div>
             <ul class="lh-env__items">
+              <li class="lh-env__item">
+                <span class="lh-env__name">User agent:</span>
+                <b class="lh-env__item__ua"><!-- fill me --></b>
+              </li>
               <template id="tmpl-lh-env__items">
                 <li class="lh-env__item">
                   <span class="lh-env__name"><!-- fill me --></span>

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -95,9 +95,12 @@ describe('ReportRenderer V2', () => {
       assert.equal(url.textContent, sampleResults.url);
       assert.equal(url.href, sampleResults.url);
 
+      const userAgent = header.querySelector('.lh-env__item__ua');
+      assert.equal(userAgent.textContent, sampleResults.userAgent, 'user agent populated');
+
       // Check runtime settings were populated.
       const enables = header.querySelectorAll('.lh-env__enabled');
-      const names = header.querySelectorAll('.lh-env__name');
+      const names = Array.from(header.querySelectorAll('.lh-env__name')).slice(1);
       const descriptions = header.querySelectorAll('.lh-env__description');
       sampleResults.runtimeConfig.environment.forEach((env, i) => {
         assert.equal(enables[i].textContent, env.enabled ? 'Enabled' : 'Disabled');


### PR DESCRIPTION
From chats today, its non-obvious what browser the report was generated against. This adds the usera gent to runtime settings so there's not confusion.

![screen shot 2017-05-04 at 1 23 54 pm](https://cloud.githubusercontent.com/assets/238208/25723461/f0a121e8-30cc-11e7-96bb-4be6f852223d.png)
