### PR TITLE
perf(gatherers): skip optimization of cross origin images

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -69,9 +69,10 @@ setTimeout(() => {
   <!-- FAIL(offscreen): image is offscreen -->
   <img style="position: absolute; top: -10000px;" src="lighthouse-unoptimized.jpg">
 
+  <!-- Image is cross-origin, which are disabled for now -->
   <!-- FAIL(optimized): image is not optimized -->
   <!-- PASS(responsive): image is used at full size -->
-  <img src="http://localhost:10503/byte-efficiency/lighthouse-unoptimized.jpg">
+  <!--<img src="http://localhost:10503/byte-efficiency/lighthouse-unoptimized.jpg">-->
 
   <!-- PASSWARN(optimized): image is JPEG optimized but not WebP -->
   <!-- FAIL(responsive): image is 25% used at DPR 2 -->

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -50,7 +50,7 @@ module.exports = [
         extendedInfo: {
           value: {
             results: {
-              length: 5
+              length: 4
             }
           }
         }

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
@@ -86,12 +86,13 @@ describe('Optimized images', () => {
 
   it('returns all images', () => {
     return optimizedImages.afterPass(options, traceData).then(artifact => {
-      assert.equal(artifact.length, 5);
+      assert.equal(artifact.length, 4);
       assert.ok(/image.jpg/.test(artifact[0].url));
       assert.ok(/transparent.png/.test(artifact[1].url));
       assert.ok(/image.bmp/.test(artifact[2].url));
-      assert.ok(/gmail.*image.jpg/.test(artifact[3].url));
-      assert.ok(/data: image/.test(artifact[4].url));
+      // skip cross-origin for now
+      // assert.ok(/gmail.*image.jpg/.test(artifact[3].url));
+      assert.ok(/data: image/.test(artifact[3].url));
     });
   });
 
@@ -103,12 +104,13 @@ describe('Optimized images', () => {
     };
 
     return optimizedImages.afterPass(options, traceData).then(artifact => {
-      assert.equal(artifact.length, 5);
+      assert.equal(artifact.length, 4);
       checkSizes(artifact[0], 10, 60, 80);
       checkSizes(artifact[1], 11, 60, 80);
       checkSizes(artifact[2], 12, 60, 80);
-      checkSizes(artifact[3], 15, 60, 80); // uses base64 data
-      checkSizes(artifact[4], 20, 80, 100); // uses base64 data
+      // skip cross-origin for now
+      // checkSizes(artifact[3], 15, 60, 80);
+      checkSizes(artifact[3], 20, 80, 100); // uses base64 data
     });
   });
 
@@ -126,7 +128,7 @@ describe('Optimized images', () => {
     return optimizedImages.afterPass(options, traceData).then(artifact => {
       const failed = artifact.find(record => record.failed);
 
-      assert.equal(artifact.length, 5);
+      assert.equal(artifact.length, 4);
       assert.ok(failed, 'passed along failure');
       assert.ok(/whoops/.test(failed.err.message), 'passed along error message');
     });


### PR DESCRIPTION
in the name of Operation Yaquina Bay #2146, fixes #1853 

shaves about ~25 seconds off heavy sites like cnn.com

