### PR TITLE
perf(gather-runner): Clear cache selectively per-pass

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -795,19 +795,12 @@ class Driver {
         .then(_ => this.online = true);
   }
 
-  cleanAndDisableBrowserCaches() {
-    return Promise.all([
-      this.clearBrowserCache(),
-      this.disableBrowserCache()
-    ]);
-  }
-
-  clearBrowserCache() {
-    return this.sendCommand('Network.clearBrowserCache');
-  }
-
-  disableBrowserCache() {
-    return this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true});
+  cleanBrowserCaches() {
+    // wipe entire disk cache
+    return this.sendCommand('Network.clearBrowserCache')
+      // toggle 'Disable Cache' to evict the memory cache
+      .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true}))
+      .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false}));
   }
 
   clearDataForOrigin(url) {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -796,9 +796,9 @@ class Driver {
   }
 
   cleanBrowserCaches() {
-    // wipe entire disk cache
+    // Wipe entire disk cache
     return this.sendCommand('Network.clearBrowserCache')
-      // toggle 'Disable Cache' to evict the memory cache
+      // Toggle 'Disable Cache' to evict the memory cache
       .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true}))
       .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false}));
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -38,7 +38,7 @@ let GathererResults; // eslint-disable-line no-unused-vars
  *     ii. beginEmulation
  *     iii. enableRuntimeEvents
  *     iv. evaluateScriptOnLoad rescue native Promise from potential polyfill
- *     v. cleanAndDisableBrowserCaches
+ *     v. cleanBrowserCaches
  *     vi. clearDataForOrigin
  *
  * 2. For each pass in the config:
@@ -110,7 +110,7 @@ class GatherRunner {
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
       .then(_ => driver.dismissJavaScriptDialogs())
-      .then(_ => resetStorage && driver.cleanAndDisableBrowserCaches())
+      .then(_ => resetStorage && driver.cleanBrowserCaches())
       .then(_ => resetStorage && driver.clearDataForOrigin(options.url))
       .then(_ => gathererResults.UserAgent = [driver.getUserAgent()]);
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -118,6 +118,10 @@ class GatherRunner {
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
       .then(_ => driver.dismissJavaScriptDialogs())
+<<<<<<< HEAD
+=======
+      .then(_ => resetStorage && driver.cleanBrowserCaches())
+>>>>>>> Don't disable disk cache, just clear it once for perf.
       .then(_ => resetStorage && driver.clearDataForOrigin(options.url))
       .then(_ => gathererResults.UserAgent = [driver.getUserAgent()]);
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -49,7 +49,8 @@ let GathererResults; // eslint-disable-line no-unused-vars
  *   B. GatherRunner.pass()
  *     i. beginTrace (if requested) & beginDevtoolsLog
  *     ii. GatherRunner.loadPage()
- *       a. navigate to options.url (and wait for onload)
+ *       a. cleanBrowserCaches
+ *       b. navigate to options.url (and wait for onload)
  *     iii. all gatherers' pass()
  *   C. GatherRunner.afterPass()
  *     i. endTrace (if requested) & endDevtoolsLog & endThrottling
@@ -86,13 +87,20 @@ class GatherRunner {
    * @return {!Promise}
    */
   static loadPage(driver, options) {
-    return driver.gotoURL(options.url, {
-      waitForLoad: true,
-      disableJavaScript: !!options.disableJavaScript,
-      flags: options.flags,
-    }).then(finalUrl => {
-      options.url = finalUrl;
-    });
+    const resetStorage = !options.flags.disableStorageReset;
+    const recordTrace = options.config.recordTrace;
+    const useThrottling = options.config.useThrottling;
+    return Promise.resolve()
+      // Clear disk & memory cache if it's a perf run
+      .then(_ => resetStorage && recordTrace && useThrottling && driver.cleanBrowserCaches())
+      // Navigate.
+      .then(_ => driver.gotoURL(options.url, {
+        waitForLoad: true,
+        disableJavaScript: !!options.disableJavaScript,
+        flags: options.flags,
+      })).then(finalUrl => {
+        options.url = finalUrl;
+      });
   }
 
   /**
@@ -110,7 +118,6 @@ class GatherRunner {
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
       .then(_ => driver.dismissJavaScriptDialogs())
-      .then(_ => resetStorage && driver.cleanBrowserCaches())
       .then(_ => resetStorage && driver.clearDataForOrigin(options.url))
       .then(_ => gathererResults.UserAgent = [driver.getUserAgent()]);
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -47,10 +47,11 @@ let GathererResults; // eslint-disable-line no-unused-vars
  *     ii. Enable network request blocking for specified patterns
  *     iii. all gatherers' beforePass()
  *   B. GatherRunner.pass()
- *     i. beginTrace (if requested) & beginDevtoolsLog
- *     ii. GatherRunner.loadPage()
- *       a. cleanBrowserCaches
- *       b. navigate to options.url (and wait for onload)
+ *     i. cleanBrowserCaches() (if it's a perf run)
+ *     ii. beginDevtoolsLog()
+ *     iii. beginTrace (if requested)
+ *     iiv. GatherRunner.loadPage()
+ *       a. navigate to options.url (and wait for onload)
  *     iii. all gatherers' pass()
  *   C. GatherRunner.afterPass()
  *     i. endTrace (if requested) & endDevtoolsLog & endThrottling
@@ -87,20 +88,13 @@ class GatherRunner {
    * @return {!Promise}
    */
   static loadPage(driver, options) {
-    const resetStorage = !options.flags.disableStorageReset;
-    const recordTrace = options.config.recordTrace;
-    const useThrottling = options.config.useThrottling;
-    return Promise.resolve()
-      // Clear disk & memory cache if it's a perf run
-      .then(_ => resetStorage && recordTrace && useThrottling && driver.cleanBrowserCaches())
-      // Navigate.
-      .then(_ => driver.gotoURL(options.url, {
-        waitForLoad: true,
-        disableJavaScript: !!options.disableJavaScript,
-        flags: options.flags,
-      })).then(finalUrl => {
-        options.url = finalUrl;
-      });
+    return driver.gotoURL(options.url, {
+      waitForLoad: true,
+      disableJavaScript: !!options.disableJavaScript,
+      flags: options.flags,
+    }).then(finalUrl => {
+      options.url = finalUrl;
+    });
   }
 
   /**
@@ -208,15 +202,20 @@ class GatherRunner {
     const config = options.config;
     const gatherers = config.gatherers;
 
+    const resetStorage = !options.flags.disableStorageReset;
+    const recordTrace = config.recordTrace;
+    const useThrottling = config.useThrottling;
+
     const gatherernames = gatherers.map(g => g.name).join(', ');
     const status = 'Loading page & waiting for onload';
     log.log('status', status, gatherernames);
 
-    // Always record devtoolsLog.
-    driver.beginDevtoolsLog();
-
     const pass = Promise.resolve()
-      // Begin tracing only if requested by config.
+      // Clear disk & memory cache if it's a perf run
+      .then(_ => resetStorage && recordTrace && useThrottling && driver.cleanBrowserCaches())
+      // Always record devtoolsLog
+      .then(_ => driver.beginDevtoolsLog())
+      // Begin tracing if requested by config.
       .then(_ => config.recordTrace && driver.beginTrace(options.flags))
       // Navigate.
       .then(_ => GatherRunner.loadPage(driver, options))

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -118,10 +118,6 @@ class GatherRunner {
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
       .then(_ => driver.dismissJavaScriptDialogs())
-<<<<<<< HEAD
-=======
-      .then(_ => resetStorage && driver.cleanBrowserCaches())
->>>>>>> Don't disable disk cache, just clear it once for perf.
       .then(_ => resetStorage && driver.clearDataForOrigin(options.url))
       .then(_ => gathererResults.UserAgent = [driver.getUserAgent()]);
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -50,9 +50,9 @@ let GathererResults; // eslint-disable-line no-unused-vars
  *     i. cleanBrowserCaches() (if it's a perf run)
  *     ii. beginDevtoolsLog()
  *     iii. beginTrace (if requested)
- *     iiv. GatherRunner.loadPage()
+ *     iv. GatherRunner.loadPage()
  *       a. navigate to options.url (and wait for onload)
- *     iii. all gatherers' pass()
+ *     v. all gatherers' pass()
  *   C. GatherRunner.afterPass()
  *     i. endTrace (if requested) & endDevtoolsLog & endThrottling
  *     ii. all gatherers' afterPass()
@@ -202,9 +202,8 @@ class GatherRunner {
     const config = options.config;
     const gatherers = config.gatherers;
 
-    const resetStorage = !options.flags.disableStorageReset;
     const recordTrace = config.recordTrace;
-    const useThrottling = config.useThrottling;
+    const isPerfRun = !options.flags.disableStorageReset && recordTrace && config.useThrottling;
 
     const gatherernames = gatherers.map(g => g.name).join(', ');
     const status = 'Loading page & waiting for onload';
@@ -212,11 +211,11 @@ class GatherRunner {
 
     const pass = Promise.resolve()
       // Clear disk & memory cache if it's a perf run
-      .then(_ => resetStorage && recordTrace && useThrottling && driver.cleanBrowserCaches())
+      .then(_ => isPerfRun && driver.cleanBrowserCaches())
       // Always record devtoolsLog
       .then(_ => driver.beginDevtoolsLog())
       // Begin tracing if requested by config.
-      .then(_ => config.recordTrace && driver.beginTrace(options.flags))
+      .then(_ => recordTrace && driver.beginTrace(options.flags))
       // Navigate.
       .then(_ => GatherRunner.loadPage(driver, options))
       .then(_ => log.log('statusEnd', status));

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -50,7 +50,7 @@ module.exports = {
   evaluateScriptOnLoad() {
     return Promise.resolve();
   },
-  cleanAndDisableBrowserCaches() {},
+  cleanBrowserCaches() {},
   clearDataForOrigin() {},
   cacheNatives() {
     return Promise.resolve();

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -58,7 +58,7 @@ function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn, blo
     cacheNatives() {
       return Promise.resolve();
     }
-    cleanAndDisableBrowserCaches() {}
+    cleanBrowserCaches() {}
     clearDataForOrigin() {}
     getUserAgent() {
       return Promise.resolve('Fake user agent');
@@ -259,7 +259,7 @@ describe('GatherRunner', function() {
       dismissJavaScriptDialogs: asyncFunc,
       enableRuntimeEvents: asyncFunc,
       cacheNatives: asyncFunc,
-      cleanAndDisableBrowserCaches: createCheck('calledDisableNetworkCache'),
+      cleanBrowserCaches: createCheck('calledDisableNetworkCache'),
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
       getUserAgent: asyncFunc,
@@ -288,7 +288,7 @@ describe('GatherRunner', function() {
       dismissJavaScriptDialogs: asyncFunc,
       enableRuntimeEvents: asyncFunc,
       cacheNatives: asyncFunc,
-      cleanAndDisableBrowserCaches: createCheck('calledDisableNetworkCache'),
+      cleanBrowserCaches: createCheck('calledDisableNetworkCache'),
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
       getUserAgent: asyncFunc,

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -271,6 +271,34 @@ describe('GatherRunner', function() {
     });
   });
 
+  it('clears the disk & memory cache on a perf run', () => {
+    const asyncFunc = () => Promise.resolve();
+    const tests = {
+      calledCleanBrowserCaches: false
+    };
+    const createCheck = variable => () => {
+      tests[variable] = true;
+      return Promise.resolve();
+    };
+    const driver = {
+      beginDevtoolsLog: asyncFunc,
+      beginTrace: asyncFunc,
+      gotoURL: asyncFunc,
+      cleanBrowserCaches: createCheck('calledCleanBrowserCaches')
+    };
+    const config = {
+      recordTrace: true,
+      useThrottling: true,
+      gatherers: []
+    };
+    const flags = {
+      disableStorageReset: false
+    };
+    return GatherRunner.pass({driver, config, flags}, {TestGatherer: []}).then(_ => {
+      assert.equal(tests.calledCleanBrowserCaches, true);
+    });
+  });
+
   it('does not clear origin storage with flag --disable-storage-reset', () => {
     const asyncFunc = () => Promise.resolve();
     const tests = {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -242,10 +242,10 @@ describe('GatherRunner', function() {
     });
   });
 
-  it('clears the network cache and origin storage', () => {
+  it('clears origin storage', () => {
     const asyncFunc = () => Promise.resolve();
     const tests = {
-      calledDisableNetworkCache: false,
+      calledCleanBrowserCaches: false,
       calledClearStorage: false,
     };
     const createCheck = variable => () => {
@@ -259,22 +259,22 @@ describe('GatherRunner', function() {
       dismissJavaScriptDialogs: asyncFunc,
       enableRuntimeEvents: asyncFunc,
       cacheNatives: asyncFunc,
-      cleanBrowserCaches: createCheck('calledDisableNetworkCache'),
+      cleanBrowserCaches: createCheck('calledCleanBrowserCaches'),
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
       getUserAgent: asyncFunc,
     };
 
     return GatherRunner.setupDriver(driver, {}, {flags: {}}).then(_ => {
-      assert.equal(tests.calledDisableNetworkCache, true);
+      assert.equal(tests.calledCleanBrowserCaches, false);
       assert.equal(tests.calledClearStorage, true);
     });
   });
 
-  it('does not clear the cache & storage when disable-storage-reset flag is set', () => {
+  it('does not clear origin storage with flag --disable-storage-reset', () => {
     const asyncFunc = () => Promise.resolve();
     const tests = {
-      calledDisableNetworkCache: false,
+      calledCleanBrowserCaches: false,
       calledClearStorage: false,
     };
     const createCheck = variable => () => {
@@ -288,7 +288,7 @@ describe('GatherRunner', function() {
       dismissJavaScriptDialogs: asyncFunc,
       enableRuntimeEvents: asyncFunc,
       cacheNatives: asyncFunc,
-      cleanBrowserCaches: createCheck('calledDisableNetworkCache'),
+      cleanBrowserCaches: createCheck('calledCleanBrowserCaches'),
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
       getUserAgent: asyncFunc,
@@ -297,7 +297,7 @@ describe('GatherRunner', function() {
     return GatherRunner.setupDriver(driver, {}, {
       flags: {disableStorageReset: true}
     }).then(_ => {
-      assert.equal(tests.calledDisableNetworkCache, false);
+      assert.equal(tests.calledCleanBrowserCaches, false);
       assert.equal(tests.calledClearStorage, false);
     });
   });
@@ -357,8 +357,9 @@ describe('GatherRunner', function() {
         new TestGatherer()
       ]
     };
+    const flags = {};
 
-    return GatherRunner.pass({driver, config}, {TestGatherer: []}).then(_ => {
+    return GatherRunner.pass({driver, config, flags}, {TestGatherer: []}).then(_ => {
       assert.equal(calledTrace, true);
     });
   });
@@ -405,8 +406,9 @@ describe('GatherRunner', function() {
         new TestGatherer()
       ]
     };
+    const flags = {};
 
-    return GatherRunner.pass({driver, config}, {TestGatherer: []}).then(_ => {
+    return GatherRunner.pass({driver, config, flags}, {TestGatherer: []}).then(_ => {
       assert.equal(calledDevtoolsLogCollect, true);
     });
   });


### PR DESCRIPTION
Instead of once at the beginning, we now clear on a pass-level, but in reality this is the same as it was the first pass that we need it for.

Additionally, don't leave "disable cache" on. Just clear it and start from empty when necessary.

Cache is cleared if we're on a "perf pass" as defined by `recordTrace && useThrottling`.

_In the name of Operation Yaquina Bay #2146_. fixes #2089

------------------

From a perf perspective the wins are not as noticeable except on high-end hardware. That's because disk cache isn't really significantly faster than the network. lol. Usually pass #4 drops ~10% in duration (for google news, it was from 900ms total to 800ms total)
