### PR TITLE
Add details to "is fast on 3g" audit

### DIFF
--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -25,7 +25,6 @@
 
 const Audit = require('./audit');
 const Emulation = require('../lib/emulation');
-
 const Formatter = require('../report/formatter');
 
 // Maximum TTFI to be considered "fast" for PWA baseline checklist
@@ -41,7 +40,7 @@ class LoadFastEnough4Pwa extends Audit {
       category: 'PWA',
       name: 'load-fast-enough-for-pwa',
       description: 'Page load is fast enough on 3G',
-      helpText: 'Satisfied if the _Time To Interactive_ duration is shorter than _10 seconds_, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected).',
+      helpText: 'Satisfied if the Time To Interactive duration is shorter than 10 seconds, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected).',
       requiredArtifacts: ['traces', 'devtoolsLogs']
     };
   }
@@ -57,16 +56,21 @@ class LoadFastEnough4Pwa extends Audit {
         // Ignore requests that don't have timing data or resources that have
         // previously been requested and are coming from the cache.
         if (!record._timing || record._fromDiskCache || record._fromMemoryCache) {
-          return undefined;
+          return {url: record._url};
         }
 
         // Use DevTools' definition of Waiting latency: https://github.com/ChromeDevTools/devtools-frontend/blob/66595b8a73a9c873ea7714205b828866630e9e82/front_end/network/RequestTimingView.js#L164
-        return record._timing.receiveHeadersEnd - record._timing.sendEnd;
+        const latency = record._timing.receiveHeadersEnd - record._timing.sendEnd;
+
+        return {
+          url: record._url,
+          latency: latency.toLocaleString(undefined, {maximumFractionDigits: 2})
+        };
       });
 
       const latency3gMin = Emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.latency - 10;
       const areLatenciesAll3G = allRequestLatencies.every(val =>
-          val === undefined || val > latency3gMin);
+          val.latency === undefined || val.latency > latency3gMin);
 
       const trace = artifacts.traces[Audit.DEFAULT_PASS];
       return artifacts.requestFirstInteractive(trace).then(firstInteractive => {
@@ -78,12 +82,18 @@ class LoadFastEnough4Pwa extends Audit {
           value: {areLatenciesAll3G, allRequestLatencies, isFast, timeToFirstInteractive}
         };
 
+        const details = Audit.makeV2TableDetails([
+          {key: 'url', itemType: 'url', text: 'URL'},
+          {key: 'latency', itemType: 'text', text: 'Latency (ms)'},
+        ], allRequestLatencies.filter(record => record.latency !== undefined));
+
         if (!areLatenciesAll3G) {
           return {
             rawValue: false,
             // eslint-disable-next-line max-len
             debugString: `First Interactive was found at ${timeToFirstInteractive.toLocaleString()}, however, the network request latencies were not sufficiently realistic, so the performance measurements cannot be trusted.`,
-            extendedInfo
+            extendedInfo,
+            details
           };
         }
 
@@ -92,13 +102,15 @@ class LoadFastEnough4Pwa extends Audit {
             rawValue: false,
             // eslint-disable-next-line max-len
             debugString: `Under 3G conditions, First Interactive was at ${timeToFirstInteractive.toLocaleString()}. More details in the "Performance" section.`,
-            extendedInfo
+            extendedInfo,
+            details
           };
         }
 
         return {
           rawValue: true,
-          extendedInfo
+          extendedInfo,
+          details
         };
       });
     });

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -46,6 +46,12 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     });
   });
 
+  it('returns details', () => {
+    return FastPWAAudit.audit(generateArtifacts(5000)).then(result => {
+      assert.ok(result.details, 'contains details');
+    });
+  });
+
   it('fails a bad TTI value', () => {
     return FastPWAAudit.audit(generateArtifacts(15000)).then(result => {
       assert.equal(result.rawValue, false, 'not failing a long TTI value');

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -46,12 +46,6 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     });
   });
 
-  it('returns details', () => {
-    return FastPWAAudit.audit(generateArtifacts(5000)).then(result => {
-      assert.ok(result.details, 'contains details');
-    });
-  });
-
   it('fails a bad TTI value', () => {
     return FastPWAAudit.audit(generateArtifacts(15000)).then(result => {
       assert.equal(result.rawValue, false, 'not failing a long TTI value');
@@ -70,6 +64,7 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     return FastPWAAudit.audit(generateArtifacts(5000, mockNetworkRecords)).then(result => {
       assert.equal(result.rawValue, false);
       assert.ok(result.debugString.includes('network request latencies'));
+      assert.ok(result.details, 'contains details when latencies were not realistic');
     });
   });
 
@@ -94,6 +89,7 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     return FastPWAAudit.audit(generateArtifacts(5000, mockNetworkRecords)).then(result => {
       assert.equal(result.rawValue, true);
       assert.strictEqual(result.debugString, undefined);
+      assert.ok(!result.details, 'does not contain details when latencies are realistic');
     });
   });
 });


### PR DESCRIPTION
R: all

This is really handy for debugging...knowing what requests failed the check.
<img width="752" alt="screen shot 2017-05-05 at 10 23 23 am" src="https://cloud.githubusercontent.com/assets/238208/25756865/32f715a6-317d-11e7-9018-dd7d9118394f.png">

