### PR TITLE
lock lighthouse-cli dependency versions to yarn versions

### DIFF
--- a/lighthouse-cli/package.json
+++ b/lighthouse-cli/package.json
@@ -7,9 +7,9 @@
     "dev": "tsc -w"
   },
   "devDependencies": {
-    "typescript": "^2.2.0"
+    "typescript": "2.2.1"
   },
   "dependencies": {
-    "@types/node": "^6.0.45"
+    "@types/node": "6.0.66"
   }
 }

--- a/lighthouse-cli/yarn.lock
+++ b/lighthouse-cli/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@types/node@^6.0.45":
+"@types/node@6.0.66":
   version "6.0.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.66.tgz#5680b74a6135d33d4c00447e7c3dc691a4601625"
 
-typescript@^2.2.0:
+typescript@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"


### PR DESCRIPTION
just ran into #2134 myself on a machine without yarn.