### PR TITLE
Report: convert rest of URL list audits

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -77,7 +77,7 @@ class Audit {
     const tableRows = results.map(item => {
       return headings.map(heading => {
         const value = item[heading.key];
-        if (typeof value === 'object' && value.type) return value;
+        if (typeof value === 'object' && value && value.type) return value;
 
         return {
           type: heading.itemType,

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -61,6 +61,9 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       })
       .map(anchor => {
         return {
+          href: anchor.href || 'Unknown',
+          target: anchor.target || '',
+          rel: anchor.rel || '',
           url: '<a' +
               (anchor.href ? ` href="${anchor.href}"` : '') +
               (anchor.target ? ` target="${anchor.target}"` : '') +
@@ -68,12 +71,21 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
         };
       });
 
+    const headings = [
+      {key: 'href', itemType: 'url', text: 'URL'},
+      {key: 'target', itemType: 'text', text: 'Target'},
+      {key: 'rel', itemType: 'text', text: 'Rel'},
+    ];
+
+    const details = Audit.makeV2TableDetails(headings, failingAnchors);
+
     return {
       rawValue: failingAnchors.length === 0,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: failingAnchors
       },
+      details,
       debugString
     };
   }

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -52,12 +52,20 @@ class GeolocationOnStart extends Audit {
       }, err);
     });
 
+
+    const headings = [
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'label', itemType: 'text', text: 'Location'},
+    ];
+    const details = Audit.makeV2TableDetails(headings, results);
+
     return {
       rawValue: results.length === 0,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: results
-      }
+      },
+      details,
     };
   }
 

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -52,12 +52,19 @@ class NoDocWriteAudit extends Audit {
       }, err);
     });
 
+    const headings = [
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'label', itemType: 'text', text: 'Location'},
+    ];
+    const details = Audit.makeV2TableDetails(headings, results);
+
     return {
       rawValue: results.length === 0,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: results
-      }
+      },
+      details,
     };
   }
 }

--- a/lighthouse-core/audits/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/notification-on-start.js
@@ -52,12 +52,19 @@ class NotificationOnStart extends Audit {
       }, err);
     });
 
+    const headings = [
+      {key: 'url', itemType: 'url', text: 'URL'},
+      {key: 'label', itemType: 'text', text: 'Location'},
+    ];
+    const details = Audit.makeV2TableDetails(headings, results);
+
     return {
       rawValue: results.length === 0,
       extendedInfo: {
         formatter: Formatter.SUPPORTED_FORMATS.URL_LIST,
         value: results
-      }
+      },
+      details,
     };
   }
 

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -34,6 +34,7 @@ describe('External anchors use rel="noopener"', () => {
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);
+    assert.equal(auditResult.details.items.length, 0);
   });
 
   it('fails when links are from different hosts than the page host', () => {
@@ -46,6 +47,7 @@ describe('External anchors use rel="noopener"', () => {
     });
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 2);
+    assert.equal(auditResult.details.items.length, 2);
   });
 
   it('handles links with no href attribute', () => {
@@ -59,6 +61,7 @@ describe('External anchors use rel="noopener"', () => {
     });
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 3);
+    assert.equal(auditResult.details.items.length, 3);
     assert.ok(auditResult.debugString, 'includes debugString');
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/geolocation-on-start-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/geolocation-on-start-test.js
@@ -30,6 +30,7 @@ describe('UX: geolocation audit', () => {
     });
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 2);
+    assert.equal(auditResult.details.items.length, 2);
   });
 
   it('passes when geolocation has not been automatically requested', () => {
@@ -38,5 +39,6 @@ describe('UX: geolocation audit', () => {
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);
+    assert.equal(auditResult.details.items.length, 0);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/no-document-write-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-document-write-test.js
@@ -30,6 +30,7 @@ describe('Page does not use document.write()', () => {
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);
+    assert.equal(auditResult.details.items.length, 0);
   });
 
   it('fails when document.write() is used', () => {
@@ -43,5 +44,6 @@ describe('Page does not use document.write()', () => {
     });
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 3);
+    assert.equal(auditResult.details.items.length, 3);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/notification-on-start-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/notification-on-start-test.js
@@ -30,6 +30,7 @@ describe('UX: notification audit', () => {
     });
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.extendedInfo.value.length, 2);
+    assert.equal(auditResult.details.items.length, 2);
   });
 
   it('passes when notification has not been automatically requested', () => {
@@ -38,5 +39,6 @@ describe('UX: notification audit', () => {
     });
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.extendedInfo.value.length, 0);
+    assert.equal(auditResult.details.items.length, 0);
   });
 });


### PR DESCRIPTION
didn't actually implement a URL list renderer since tables seem to be fine

![image](https://cloud.githubusercontent.com/assets/2301202/25765294/1fb9aa3e-31a1-11e7-9271-994dd043a988.png)
