### PR TITLE
Warn users if they have not yet generated the file.

### DIFF
--- a/lighthouse-core/report/templates/report-templates.js
+++ b/lighthouse-core/report/templates/report-templates.js
@@ -1,0 +1,1 @@
+throw new Error('Missing build file! - You must first run gulp to generate this file.');

--- a/lighthouse-core/report/templates/report-templates.js
+++ b/lighthouse-core/report/templates/report-templates.js
@@ -1,1 +1,1 @@
-throw new Error('Missing build file! - You must first run gulp to generate this file.');
+throw new Error('Missing build file! You must first run `gulp` to generate this file.');


### PR DESCRIPTION
Prior to this fix users would be confused why their unit tests were
failing. The error was a missing file during a require, which made it seem like
something was messed up with their local clone. Now we can throw a
useful error message.

ref #2092