### PR TITLE
CLI PR: Rewrap the lines to 100 char. Fix format command

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -22,8 +22,7 @@ const _RUNTIME_ERROR_CODE = 1;
 const _PROTOCOL_TIMEOUT_EXIT_CODE = 67;
 
 const assetSaver = require('../lighthouse-core/lib/asset-saver.js');
-const getFilenamePrefix =
-    require('../lighthouse-core/lib/file-namer.js').getFilenamePrefix;
+const getFilenamePrefix = require('../lighthouse-core/lib/file-namer.js').getFilenamePrefix;
 import {ChromeLauncher} from './chrome-launcher';
 import * as Commands from './commands/commands';
 const lighthouse = require('../lighthouse-core');
@@ -92,8 +91,7 @@ if (cliFlags.verbose) {
 }
 log.setLevel(cliFlags.logLevel);
 
-if (cliFlags.output === Printer.OutputMode[Printer.OutputMode.json] &&
-    !cliFlags.outputPath) {
+if (cliFlags.output === Printer.OutputMode[Printer.OutputMode.json] && !cliFlags.outputPath) {
   cliFlags.outputPath = 'stdout';
 }
 
@@ -108,8 +106,7 @@ function showProtocolTimeoutError() {
 }
 
 function showPageLoadError() {
-  console.error(
-      'Unable to load the page. Please verify the url you are trying to review.');
+  console.error('Unable to load the page. Please verify the url you are trying to review.');
   process.exit(_RUNTIME_ERROR_CODE);
 }
 
@@ -151,8 +148,7 @@ async function getDebuggableChrome(flags: Flags) {
 
   // Kill spawned Chrome process in case of ctrl-C.
   process.on(_SIGINT, () => {
-    chromeLauncher.kill().then(
-        () => process.exit(_SIGINT_EXIT_CODE), handleError);
+    chromeLauncher.kill().then(() => process.exit(_SIGINT_EXIT_CODE), handleError);
   });
 
   try {
@@ -204,23 +200,19 @@ function saveResults(results: Results, artifacts: Object, flags: Flags) {
   }
 
   if (flags.saveAssets) {
-    promise = promise.then(
-        _ => assetSaver.saveAssets(artifacts, results.audits, resolvedPath));
+    promise = promise.then(_ => assetSaver.saveAssets(artifacts, results.audits, resolvedPath));
   }
 
-  const typeToExtension = (type: string) =>
-      type === 'domhtml' ? 'dom.html' : type;
+  const typeToExtension = (type: string) => type === 'domhtml' ? 'dom.html' : type;
   return promise.then(_ => {
     if (Array.isArray(flags.output)) {
       return flags.output.reduce((innerPromise, outputType) => {
-        const outputPath =
-            `${resolvedPath}.report.${typeToExtension(outputType)}`;
-        return innerPromise.then(
-            (_: Results) => Printer.write(results, outputType, outputPath));
+        const outputPath = `${resolvedPath}.report.${typeToExtension(outputType)}`;
+        return innerPromise.then((_: Results) => Printer.write(results, outputType, outputPath));
       }, Promise.resolve(results));
     } else {
-      const outputPath = flags.outputPath ||
-          `${resolvedPath}.report.${typeToExtension(flags.output)}`;
+      const outputPath =
+          flags.outputPath || `${resolvedPath}.report.${typeToExtension(flags.output)}`;
       return Printer.write(results, flags.output, outputPath).then(results => {
         if (flags.output === Printer.OutputMode[Printer.OutputMode.html] ||
             flags.output === Printer.OutputMode[Printer.OutputMode.domhtml]) {
@@ -239,8 +231,7 @@ function saveResults(results: Results, artifacts: Object, flags: Flags) {
   });
 }
 
-export async function runLighthouse(
-    url: string, flags: Flags, config: Object|null) {
+export async function runLighthouse(url: string, flags: Flags, config: Object|null) {
   let chromeLauncher: ChromeLauncher|undefined = undefined;
 
   try {

--- a/lighthouse-cli/chrome-launcher.ts
+++ b/lighthouse-cli/chrome-launcher.ts
@@ -67,12 +67,10 @@ export class ChromeLauncher {
       '--disable-translate',
       // Disable all chrome extensions entirely
       '--disable-extensions',
-      // Disable various background network services, including extension
-      // updating,
+      // Disable various background network services, including extension updating,
       //   safe browsing service, upgrade detector, translate, UMA
       '--disable-background-networking',
-      // Disable fetching safebrowsing lists, likely redundant due to
-      // disable-background-networking
+      // Disable fetching safebrowsing lists, likely redundant due to disable-background-networking
       '--safebrowsing-disable-auto-update',
       // Disable syncing to a Google account
       '--disable-sync',
@@ -98,24 +96,23 @@ export class ChromeLauncher {
 
   prepare() {
     switch (process.platform) {
-    case 'darwin':
-    case 'linux':
-      this.TMP_PROFILE_DIR = unixTmpDir();
-      break;
+      case 'darwin':
+      case 'linux':
+        this.TMP_PROFILE_DIR = unixTmpDir();
+        break;
 
-    case 'win32':
-      this.TMP_PROFILE_DIR = win32TmpDir();
-      break;
+      case 'win32':
+        this.TMP_PROFILE_DIR = win32TmpDir();
+        break;
 
-    default:
-      throw new Error('Platform ' + process.platform + ' is not supported');
+      default:
+        throw new Error('Platform ' + process.platform + ' is not supported');
     }
 
     this.outFile = fs.openSync(`${this.TMP_PROFILE_DIR}/chrome-out.log`, 'a');
     this.errFile = fs.openSync(`${this.TMP_PROFILE_DIR}/chrome-err.log`, 'a');
 
-    // fix for Node4
-    // you can't pass a fd to fs.writeFileSync
+    // fix for Node4: you can't pass a fd to fs.writeFileSync
     this.pidFile = `${this.TMP_PROFILE_DIR}/chrome.pid`;
 
     log.verbose('ChromeLauncher', `created ${this.TMP_PROFILE_DIR}`);
@@ -138,8 +135,7 @@ export class ChromeLauncher {
             return installations[0];
           }
 
-          return ask('Choose a Chrome installation to use with Lighthouse',
-                     installations);
+          return ask('Choose a Chrome installation to use with Lighthouse', installations);
         })
         .then(execPath => this.spawn(execPath));
   }
@@ -147,25 +143,22 @@ export class ChromeLauncher {
   spawn(execPath: string): Promise<any[]> {
     return new Promise(resolve => {
              if (this.chrome) {
-               log.log('ChromeLauncher',
-                       `Chrome already running with pid ${this.chrome.pid}.`);
+               log.log('ChromeLauncher', `Chrome already running with pid ${this.chrome.pid}.`);
                return resolve(this.chrome.pid);
              }
 
-             const chrome = spawn(execPath, this.flags(), {
-               detached : true,
-               stdio : [ 'ignore', this.outFile, this.errFile ]
-             });
+             const chrome = spawn(
+                 execPath, this.flags(),
+                 {detached: true, stdio: ['ignore', this.outFile, this.errFile]});
              this.chrome = chrome;
 
              fs.writeFileSync(this.pidFile, chrome.pid.toString());
 
              log.verbose(
-                 'ChromeLauncher',
-                 `Chrome running with pid ${chrome.pid} on port ${this.port}.`);
+                 'ChromeLauncher', `Chrome running with pid ${chrome.pid} on port ${this.port}.`);
              resolve(chrome.pid);
            })
-        .then(pid => Promise.all([ pid, this.waitUntilReady() ]));
+        .then(pid => Promise.all([pid, this.waitUntilReady()]));
   }
 
   cleanup(client?: net.Socket) {
@@ -209,8 +202,7 @@ export class ChromeLauncher {
 
         launcher.isDebuggerReady()
             .then(() => {
-              log.log('ChromeLauncher',
-                      waitStatus + `${log.greenify(log.tick)}`);
+              log.log('ChromeLauncher', waitStatus + `${log.greenify(log.tick)}`);
               resolve();
             })
             .catch(err => {
@@ -226,7 +218,9 @@ export class ChromeLauncher {
   kill(): Promise<{}> {
     return new Promise(resolve => {
       if (this.chrome) {
-        this.chrome.on('close', () => { this.destroyTmp().then(resolve); });
+        this.chrome.on('close', () => {
+          this.destroyTmp().then(resolve);
+        });
 
         log.log('ChromeLauncher', 'Killing all Chrome Instances');
         try {
@@ -236,8 +230,7 @@ export class ChromeLauncher {
             process.kill(-this.chrome.pid);
           }
         } catch (err) {
-          log.warn('ChromeLauncher',
-                   `Chrome could not be killed ${err.message}`);
+          log.warn('ChromeLauncher', `Chrome could not be killed ${err.message}`);
         }
 
         delete this.chrome;
@@ -285,7 +278,7 @@ function unixTmpDir() {
 
 function win32TmpDir() {
   const winTmpPath = process.env.TEMP || process.env.TMP ||
-                     (process.env.SystemRoot || process.env.windir) + '\\temp';
+      (process.env.SystemRoot || process.env.windir) + '\\temp';
   const randomNumber = Math.floor(Math.random() * 9e7 + 1e7);
   const tmpdir = path.join(winTmpPath, 'lighthouse.' + randomNumber);
 

--- a/lighthouse-cli/cli-flags.ts
+++ b/lighthouse-cli/cli-flags.ts
@@ -17,9 +17,9 @@ export function getCliFlags() {
       })
       .group(
           [
-            'save-assets', 'save-artifacts', 'list-all-audits',
-            'list-trace-categories', 'additional-trace-categories',
-            'config-path', 'chrome-flags', 'perf', 'port', 'max-wait-for-load'
+            'save-assets', 'save-artifacts', 'list-all-audits', 'list-trace-categories',
+            'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port',
+            'max-wait-for-load'
           ],
           'Configuration:')
       .describe({
@@ -31,19 +31,16 @@ export function getCliFlags() {
         'save-assets': 'Save the trace contents & screenshots to disk',
         'save-artifacts': 'Save all gathered artifacts to disk',
         'list-all-audits': 'Prints a list of all available audits and exits',
-        'list-trace-categories':
-            'Prints a list of all required trace categories and exits',
+        'list-trace-categories': 'Prints a list of all required trace categories and exits',
         'additional-trace-categories':
             'Additional categories to capture with the trace (comma-delimited).',
         'config-path': 'The path to the config JSON.',
         'chrome-flags': 'Custom flags to pass to Chrome.',
         'perf': 'Use a performance-test-only configuration',
-        'port':
-            'The port to use for the debugging protocol. Use 0 for a random port',
+        'port': 'The port to use for the debugging protocol. Use 0 for a random port',
         'max-wait-for-load':
             'The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue. WARNING: Very high values can lead to large traces and instability',
-        'skip-autolaunch':
-            'Skip autolaunch of Chrome when already running instance is not found',
+        'skip-autolaunch': 'Skip autolaunch of Chrome when already running instance is not found',
         'select-chrome':
             'Interactively choose version of Chrome to use when multiple installations are found',
         'interactive': 'Open Lighthouse in interactive mode'
@@ -51,8 +48,7 @@ export function getCliFlags() {
       .group(['output', 'output-path', 'view'], 'Output:')
       .describe({
         'output': `Reporter for the results, supports multiple values`,
-        'output-path':
-            `The file path to output the results. Use 'stdout' to write to stdout.
+        'output-path': `The file path to output the results. Use 'stdout' to write to stdout.
       If using JSON output, default is stdout.
       If using HTML output, default is a file in the working directory with a name based on the test URL and date.
       If using multiple outputs, --output-path is ignored.
@@ -61,11 +57,10 @@ export function getCliFlags() {
       })
       // boolean values
       .boolean([
-        'disable-storage-reset', 'disable-device-emulation',
-        'disable-cpu-throttling', 'disable-network-throttling', 'save-assets',
-        'save-artifacts', 'list-all-audits', 'list-trace-categories', 'perf',
-        'view', 'skip-autolaunch', 'select-chrome', 'verbose', 'quiet', 'help',
-        'interactive'
+        'disable-storage-reset', 'disable-device-emulation', 'disable-cpu-throttling',
+        'disable-network-throttling', 'save-assets', 'save-artifacts', 'list-all-audits',
+        'list-trace-categories', 'perf', 'view', 'skip-autolaunch', 'select-chrome', 'verbose',
+        'quiet', 'help', 'interactive'
       ])
       .choices('output', GetValidOutputOptions())
       // default values
@@ -74,17 +69,10 @@ export function getCliFlags() {
       .default('output', GetValidOutputOptions()[OutputMode.html])
       .default('eport', 9222)
       .default('max-wait-for-load', Driver.MAX_WAIT_FOR_FULLY_LOADED)
-      .check((argv: {
-               listAllAudits?: boolean,
-               listTraceCategories?: boolean,
-               _: Array<any>
-             }) => {
-        // Make sure lighthouse has been passed a url, or at least one of
-        // --list-all-audits
-        // or --list-trace-categories. If not, stop the program and ask for a
-        // url
-        if (!argv.listAllAudits && !argv.listTraceCategories &&
-            argv._.length === 0) {
+      .check((argv: {listAllAudits?: boolean, listTraceCategories?: boolean, _: Array<any>}) => {
+        // Make sure lighthouse has been passed a url, or at least one of --list-all-audits
+        // or --list-trace-categories. If not, stop the program and ask for a url
+        if (!argv.listAllAudits && !argv.listTraceCategories && argv._.length === 0) {
           throw new Error('Please provide a url');
         }
         return true;

--- a/lighthouse-cli/package.json
+++ b/lighthouse-cli/package.json
@@ -6,13 +6,10 @@
     "build": "tsc",
     "dev": "tsc -w",
     "test": "mocha --reporter dot test/**/*-test.js",
-    "format": "clang-format -i --style=file **/*.ts"
+    "format": "clang-format -i -style=file *.ts **/*.ts"
   },
   "devDependencies": {
     "mocha": "^3.2.0",
-    "typescript": "2.2.1"
-  },
-  "devDependencies": {
     "typescript": "2.2.1",
     "clang-format": "^1.0.50"
   },

--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -35,8 +35,7 @@ import {Results} from './types/types';
 
 const fs = require('fs');
 const ReportGenerator = require('../lighthouse-core/report/report-generator');
-const ReportGeneratorV2 =
-    require('../lighthouse-core/report/v2/report-generator');
+const ReportGeneratorV2 = require('../lighthouse-core/report/v2/report-generator');
 const log = require('../lighthouse-core/lib/log');
 
 /**
@@ -91,16 +90,14 @@ function writeToStdout(output: string): Promise<{}> {
 /**
  * Writes the output to a file.
  */
-function writeFile(filePath: string, output: string,
-                   outputMode: OutputMode): Promise<{}> {
+function writeFile(filePath: string, output: string, outputMode: OutputMode): Promise<{}> {
   return new Promise((resolve, reject) => {
     // TODO: make this mkdir to the filePath.
     fs.writeFile(filePath, output, 'utf8', (err: Error) => {
       if (err) {
         return reject(err);
       }
-      log.log('Printer',
-              `${OutputMode[outputMode]} output written to ${filePath}`);
+      log.log('Printer', `${OutputMode[outputMode]} output written to ${filePath}`);
       resolve();
     });
   });
@@ -115,8 +112,7 @@ function write(results: Results, mode: Mode, path: string): Promise<Results> {
 
     const output = createOutput(results, (<any>OutputMode)[mode]);
 
-    // Testing stdout is out of scope, and doesn't really achieve much besides
-    // testing Node,
+    // Testing stdout is out of scope, and doesn't really achieve much besides testing Node,
     // so we will skip this chunk of the code.
     /* istanbul ignore if */
     if (outputPath === 'stdout') {
@@ -124,7 +120,9 @@ function write(results: Results, mode: Mode, path: string): Promise<Results> {
     }
 
     return writeFile(outputPath, output, (<any>OutputMode)[mode])
-        .then(_ => { resolve(results); })
+        .then(_ => {
+          resolve(results);
+        })
         .catch(err => reject(err));
   });
 }

--- a/lighthouse-cli/shim-modules.ts
+++ b/lighthouse-cli/shim-modules.ts
@@ -31,9 +31,8 @@ try {
   updateNotifier = require('update-notifier');
 } catch (e) {
   updateNotifier = function shimUpdateNotifier() {
-    console.error(
-        'module `update-notifier` not installed. Not checking for new version.');
-    return {notify : () => false};
+    console.error('module `update-notifier` not installed. Not checking for new version.');
+    return {notify: () => false};
   };
 }
 


### PR DESCRIPTION
To merge into the CLI PR (#2173)

* fix double devdependencies
* fix calling of clang-format (a few things)
* when wrapped to < 100 chars a few comments were wrapped which was undesirable: 
  * https://github.com/GoogleChrome/lighthouse/compare/cli...cli-formattweak#diff-175d82b7239f837c6210ec1163cf38e3L88
  * https://github.com/GoogleChrome/lighthouse/compare/cli...cli-formattweak#diff-a791a2f1d313777e4ac39204107d38dbL70
  * https://github.com/GoogleChrome/lighthouse/compare/cli...cli-formattweak#diff-4234080a3c4293c9716cfcef55c909c8L118