### PR TITLE
prevent computing computed artifacts multiple times due to race condition

### DIFF
--- a/lighthouse-core/gather/computed/computed-artifact.js
+++ b/lighthouse-core/gather/computed/computed-artifact.js
@@ -55,12 +55,11 @@ class ComputedArtifact {
       return Promise.resolve(this._cache.get(artifact));
     }
 
-    return Promise.resolve()
-      .then(_ => this.compute_(artifact, this._allComputedArtifacts))
-      .then(computedArtifact => {
-        this._cache.set(artifact, computedArtifact);
-        return computedArtifact;
-      });
+    const artifactPromise = Promise.resolve()
+      .then(_ => this.compute_(artifact, this._allComputedArtifacts));
+    this._cache.set(artifact, artifactPromise);
+
+    return artifactPromise;
   }
 }
 


### PR DESCRIPTION
This was possible before, but much easier with computed artifacts able to call each other as of #2018.

problem:
`computedArtifacts.requestNetworkRecords(devtoolsLog)` calls `NetworkRecords.compute_(devtoolsLog)` internally. Imagine that `compute_` call takes a few promise turns internally.

Meanwhile `computedArtifacts.requestNetworkThroughput(devtoolsLog)` calls
```js
NetworkThroughput.compute_(devtoolsLog, allComputedArtifacts) {
  return allComputedArtifacts.requestNetworkRecords(devtoolsLog).then(records => {
    // calculate throughput
  });
}
```

Computed artifacts internally cache their computed values in order not to repeat expensive calculations. In this situation, however, a call of
```js
Promise.all([
  computedArtifacts.requestNetworkRecords(devtoolsLog),
  computedArtifacts.requestNetworkThroughput(devtoolsLog)
]).then(([records, throughput]) => {
  // ...
});
```
will compute the network records twice, since the network records won't be generated and cached from the first call before the second call also requests them.

This PR instead immediately caches the *promise* of the computed artifact, which is available synchronously. Since we were already returning a promise, this change is externally unobservable except for potential reduced computation time.

\* we don't currently have a problem with this anywhere and [`NetworkRecords.compute_`](https://github.com/GoogleChrome/lighthouse/blob/d926f32175c9f4b0508b15b21943588358e58c77/lighthouse-core/gather/computed/network-records.js) is sync, but it was just waiting for us to stumble into it :)