### PR TITLE
require audit helpText

### DIFF
--- a/lighthouse-core/closure/typedefs/AuditResult.js
+++ b/lighthouse-core/closure/typedefs/AuditResult.js
@@ -100,7 +100,7 @@ AuditFullResult.prototype.category;
 /** @type {string} */
 AuditFullResult.prototype.description;
 
-/** @type {(string|undefined)} */
+/** @type {string} */
 AuditFullResult.prototype.helpText;
 
 /** @type {(Object|undefined)} */

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -199,6 +199,12 @@ function assertValidAudit(auditDefinition, auditPath) {
     );
   }
 
+  if (typeof auditDefinition.meta.helpText !== 'string') {
+    throw new Error(
+      `${auditName} has no meta.helpText property, or the property is not a string.`
+    );
+  }
+
   if (!Array.isArray(auditDefinition.meta.requiredArtifacts)) {
     throw new Error(
       `${auditName} has no meta.requiredArtifacts property, or the property is not an array.`

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -48,6 +48,7 @@ describe('Config', () => {
           name: 'MyAudit',
           category: 'mine',
           description: 'My audit',
+          helpText: '',
           requiredArtifacts: []
         };
       }
@@ -234,6 +235,10 @@ describe('Config', () => {
     assert.throws(_ => new Config({
       audits: [basePath + '/missing-description']
     }), /meta.description property/);
+
+    assert.throws(_ => new Config({
+      audits: [basePath + '/missing-help-text']
+    }), /meta.helpText property/);
 
     assert.throws(_ => new Config({
       audits: [basePath + '/missing-required-artifacts']

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-audit.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-audit.js
@@ -25,6 +25,7 @@ class MissingRequiredArtifacts extends LighthouseAudit {
       name: 'missing-category',
       category: 'Custom',
       description: 'Missing required artifacts',
+      helpText: '',
       requiredArtifacts: ['HTML']
     };
   }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-category.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-category.js
@@ -24,6 +24,7 @@ class MissingRequiredArtifacts extends LighthouseAudit {
     return {
       name: 'missing-category',
       description: 'Missing required artifacts',
+      helpText: '',
       requiredArtifacts: ['HTML']
     };
   }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-generate-audit-result.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-generate-audit-result.js
@@ -23,6 +23,7 @@ class MissingRequiredArtifacts {
       category: 'Custom',
       name: 'missing-required-artifacts',
       description: 'Missing required artifacts',
+      helpText: '',
       requiredArtifacts: ['HTML']
     };
   }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-help-text.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-help-text.js
@@ -24,7 +24,7 @@ class MissingRequiredArtifacts extends LighthouseAudit {
     return {
       name: 'missing-description',
       category: 'Custom',
-      helpText: '',
+      description: 'Missing required artifacts',
       requiredArtifacts: ['HTML']
     };
   }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-name.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-name.js
@@ -24,6 +24,7 @@ class MissingRequiredArtifacts extends LighthouseAudit {
     return {
       category: 'Custom',
       description: 'Missing name',
+      helpText: '',
       requiredArtifacts: ['HTML']
     };
   }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-required-artifacts.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-required-artifacts.js
@@ -24,7 +24,8 @@ class MissingRequiredArtifacts extends LighthouseAudit {
     return {
       category: 'Custom',
       name: 'missing-required-artifacts',
-      description: 'Missing required artifacts'
+      description: 'Missing required artifacts',
+      helpText: '',
     };
   }
 

--- a/lighthouse-core/test/fixtures/invalid-audits/require-error.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/require-error.js
@@ -25,6 +25,7 @@ class RequireErrorAudit extends LighthouseAudit {
       name: 'require-error',
       category: 'Custom',
       description: 'Require Error',
+      helpText: '',
       requiredArtifacts: ['HTML']
     };
   }

--- a/lighthouse-core/test/fixtures/valid-custom-audit.js
+++ b/lighthouse-core/test/fixtures/valid-custom-audit.js
@@ -25,6 +25,7 @@ class ValidCustomAudit extends LighthouseAudit {
       name: 'valid-audit',
       category: 'Custom',
       description: 'Valid Audit',
+      helpText: 'Valid-sounding helpText',
       requiredArtifacts: ['HTML']
     };
   }

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -197,6 +197,7 @@ describe('Runner', () => {
       category: 'ThrowThrow',
       name: 'throwy-audit',
       description: 'Always throws',
+      helpText: 'Test for always throwing',
       requiredArtifacts: []
     };
 


### PR DESCRIPTION
report v2 requires that there be audit `helpText`. This just asserts that it exists.

This could also go the other way and make it optional in report generation, but no one answered my question about it so here we are :)