### PR TITLE
Install banner audit: failures should say what the user didnt do

### DIFF
--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -27,8 +27,8 @@ class TTIMetric extends Audit {
     return {
       category: 'Performance',
       name: 'time-to-interactive',
-      description: 'Time To First Interactive (alpha)',
-      helpText: 'Time to First Interactive identifies the time at which your app appears to be ready ' +
+      description: 'Time To Interactive (alpha)',
+      helpText: 'Time to Interactive identifies the time at which your app appears to be ready ' +
           'enough to interact with. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive).',
       optimalValue: `< ${SCORING_TARGET.toLocaleString()} ms`,

--- a/lighthouse-core/audits/time-to-interactive.js
+++ b/lighthouse-core/audits/time-to-interactive.js
@@ -27,8 +27,8 @@ class TTIMetric extends Audit {
     return {
       category: 'Performance',
       name: 'time-to-interactive',
-      description: 'Time To Interactive (alpha)',
-      helpText: 'Time to Interactive identifies the time at which your app appears to be ready ' +
+      description: 'Time To First Interactive (alpha)',
+      helpText: 'Time to First Interactive identifies the time at which your app appears to be ready ' +
           'enough to interact with. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive).',
       optimalValue: `< ${SCORING_TARGET.toLocaleString()} ms`,

--- a/lighthouse-core/audits/webapp-install-banner.js
+++ b/lighthouse-core/audits/webapp-install-banner.js
@@ -70,14 +70,14 @@ class WebappInstallBanner extends MultiCheckAudit {
   static assessServiceWorker(artifacts, failures) {
     const hasServiceWorker = SWAudit.audit(artifacts).rawValue;
     if (!hasServiceWorker) {
-      failures.push('Site registers a Service Worker');
+      failures.push('Site does not register a Service Worker');
     }
   }
 
   static assessOfflineStartUrl(artifacts, failures) {
     const hasOfflineStartUrl = artifacts.StartUrl === 200;
     if (!hasOfflineStartUrl) {
-      failures.push('Start url is cached by a Service Worker');
+      failures.push('Manifest start_url is not cached by a Service Worker');
     }
   }
 

--- a/lighthouse-core/test/audits/webapp-install-banner-test.js
+++ b/lighthouse-core/test/audits/webapp-install-banner-test.js
@@ -146,7 +146,7 @@ describe('PWA: webapp install banner audit', () => {
 
     return WebappInstallBannerAudit.audit(artifacts).then(result => {
       assert.strictEqual(result.rawValue, false);
-      assert.ok(result.debugString.includes('Start url'), result.debugString);
+      assert.ok(result.debugString.includes('start_url'), result.debugString);
       const failures = result.extendedInfo.value.failures;
       assert.strictEqual(failures.length, 1, failures);
     });


### PR DESCRIPTION
Matches what the "Configure for a splash screen audit" does. It was confusing that the failure help text was saying the "site registers a sw", when in fact, it did not.

![screen shot 2017-05-10 at 2 06 37 pm](https://cloud.githubusercontent.com/assets/238208/25921464/5e6788e0-358a-11e7-8065-3548f2d92c15.png)


Also fixes https://github.com/GoogleChrome/lighthouse/issues/2189.