### PR TITLE
perf: make network quiet threshold configurable per pass

### DIFF
--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -30,7 +30,7 @@ module.exports = {
   {
     "passName": "offlinePass",
     "useThrottling": false,
-    "networkQuietThresholdMs": 500,
+    "networkQuietThresholdMs": 100,
     "gatherers": [
       "service-worker",
       "offline",
@@ -40,7 +40,7 @@ module.exports = {
   {
     "passName": "redirectPass",
     "useThrottling": false,
-    "networkQuietThresholdMs": 500,
+    "networkQuietThresholdMs": 100,
     // Speed up the redirect pass by blocking stylesheets, fonts, and images
     "blockedUrlPatterns": ["*.css", "*.jpg", "*.jpeg", "*.png", "*.gif", "*.svg", "*.ttf", "*.woff", "*.woff2"],
     "gatherers": [

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -4,6 +4,7 @@ module.exports = {
   "passes": [{
     "passName": "defaultPass",
     "recordTrace": true,
+    "networkQuietThresholdMs": 5000,
     "pauseBeforeTraceEndMs": 5000,
     "useThrottling": true,
     "gatherers": [
@@ -29,6 +30,7 @@ module.exports = {
   {
     "passName": "offlinePass",
     "useThrottling": false,
+    "networkQuietThresholdMs": 500,
     "gatherers": [
       "service-worker",
       "offline",
@@ -38,6 +40,7 @@ module.exports = {
   {
     "passName": "redirectPass",
     "useThrottling": false,
+    "networkQuietThresholdMs": 500,
     // Speed up the redirect pass by blocking stylesheets, fonts, and images
     "blockedUrlPatterns": ["*.css", "*.jpg", "*.jpeg", "*.png", "*.gif", "*.svg", "*.ttf", "*.woff", "*.woff2"],
     "gatherers": [

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -4,8 +4,9 @@ module.exports = {
   "passes": [{
     "passName": "defaultPass",
     "recordTrace": true,
+    "pauseAfterLoadMs": 5000,
     "networkQuietThresholdMs": 5000,
-    "pauseBeforeTraceEndMs": 5000,
+    "pauseAfterNetworkQuietMs": 2500,
     "useThrottling": true,
     "gatherers": [
       "url",
@@ -30,7 +31,8 @@ module.exports = {
   {
     "passName": "offlinePass",
     "useThrottling": false,
-    "networkQuietThresholdMs": 100,
+    // Just wait for onload
+    "networkQuietThresholdMs": 0,
     "gatherers": [
       "service-worker",
       "offline",
@@ -40,7 +42,8 @@ module.exports = {
   {
     "passName": "redirectPass",
     "useThrottling": false,
-    "networkQuietThresholdMs": 100,
+    // Just wait for onload
+    "networkQuietThresholdMs": 0,
     // Speed up the redirect pass by blocking stylesheets, fonts, and images
     "blockedUrlPatterns": ["*.css", "*.jpg", "*.jpeg", "*.png", "*.gif", "*.svg", "*.ttf", "*.woff", "*.woff2"],
     "gatherers": [

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -25,8 +25,11 @@ const URL = require('../lib/url-shim');
 const log = require('../lib/log.js');
 const DevtoolsLog = require('./devtools-log');
 
+// Controls how long to wait after onLoad before continuing
 const DEFAULT_PAUSE_AFTER_LOAD = 0;
+// Controls how long to wait between network requests before determining the network is quiet
 const DEFAULT_NETWORK_QUIET_THRESHOLD = 5000;
+// Controls how long to wait after network quiet before continuing
 const DEFAULT_PAUSE_AFTER_NETWORK_QUIET = 0;
 
 const _uniq = arr => Array.from(new Set(arr));

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -92,6 +92,7 @@ class GatherRunner {
       waitForLoad: true,
       disableJavaScript: !!options.disableJavaScript,
       flags: options.flags,
+      config: options.config,
     }).then(finalUrl => {
       options.url = finalUrl;
     });

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -249,7 +249,7 @@ class GatherRunner {
     if (config.recordTrace) {
       pass = pass.then(_ => {
         log.log('status', 'Retrieving trace');
-        return driver.endTrace(config.pauseBeforeTraceEndMs);
+        return driver.endTrace();
       }).then(traceContents => {
         // Before Chrome 54.0.2816 (codereview.chromium.org/2161583004),
         // traceContents was an array of trace events; after, traceContents is

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -52,6 +52,10 @@ class NetworkRecorder extends EventEmitter {
     return this.activeRequestCount() === 0;
   }
 
+  is2Idle() {
+    return this.activeRequestCount() <= 2;
+  }
+
   /**
    * Listener for the NetworkManager's RequestStarted event, which includes both
    * web socket and normal request creation.
@@ -69,6 +73,11 @@ class NetworkRecorder extends EventEmitter {
     // idle to busy.
     if (activeCount === 1) {
       this.emit('networkbusy');
+    }
+
+    // If exactly three requests in progress, we've transitioned from 2-idle to 2-busy.
+    if (activeCount === 3) {
+      this.emit('network-2-busy');
     }
   }
 
@@ -91,6 +100,10 @@ class NetworkRecorder extends EventEmitter {
     // to idle.
     if (this.isIdle()) {
       this.emit('networkidle');
+    }
+
+    if (this.is2Idle()) {
+      this.emit('network-2-idle');
     }
   }
 

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -176,8 +176,8 @@ describe('Browser Driver', () => {
 
     const loadOptions = {
       waitForLoad: true,
-      flags: {
-        pauseAfterLoad: 1
+      config: {
+        networkQuietThresholdMs: 1
       }
     };
 


### PR DESCRIPTION
in the name of OYB, shaves off ~9 seconds from all runs with the default passes

renames pauseAfterLoad to the more appropriate networkQuietThreshold, previously the flag was for speeding up the tests and was not documented in the CLI