### PR TITLE
Report: add stub for NodeDetails renderer

### DIFF
--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -44,6 +44,8 @@ class DetailsRenderer {
         return this._renderTable(/** @type {!DetailsRenderer.TableDetailsJSON} */ (details));
       case 'code':
         return this._renderCode(details);
+      case 'node':
+        return this.renderNode(/** @type {!DetailsRenderer.NodeDetailsJSON} */(details));
       case 'list':
         return this._renderList(/** @type {!DetailsRenderer.ListDetailsJSON} */ (details));
       default:
@@ -144,6 +146,15 @@ class DetailsRenderer {
   }
 
   /**
+   * @param {!DetailsRenderer.NodeDetailsJSON} item
+   * @return {!Element}
+   * @protected
+   */
+  renderNode(item) {
+    throw new Error('Not yet implemented', item);
+  }
+
+  /**
    * @param {!DetailsRenderer.CardsDetailsJSON} details
    * @return {!Element}
    */
@@ -223,6 +234,17 @@ DetailsRenderer.CardsDetailsJSON; // eslint-disable-line no-unused-expressions
  * }}
  */
 DetailsRenderer.TableHeaderJSON; // eslint-disable-line no-unused-expressions
+
+/**
+ * @typedef {{
+ *     type: string,
+ *     text: (string|undefined),
+ *     path: (string|undefined),
+ *     selector: (string|undefined),
+ *     snippet:(string|undefined)
+ * }}
+ */
+DetailsRenderer.NodeDetailsJSON; // eslint-disable-line no-unused-expressions
 
 /** @typedef {{
  *     type: string,


### PR DESCRIPTION
yesterday, I rolled to devtools with some LH changes that aren't yet in master here (they're in #2206)

as a result, i broke `compile-devtools`. :)
https://travis-ci.org/GoogleChrome/lighthouse/jobs/231226842#L661

This adds a stub that restores compilation while 2206 gets sorted.