### PR TITLE
perf: enable speedline fastMode

### DIFF
--- a/lighthouse-core/gather/computed/speedline.js
+++ b/lighthouse-core/gather/computed/speedline.js
@@ -35,7 +35,10 @@ class Speedline extends ComputedArtifact {
       // Force use of nav start as reference point for speedline
       // See https://github.com/GoogleChrome/lighthouse/issues/2095
       const navStart = traceOfTab.timestamps.navigationStart * 1000;
-      return speedline(trace.traceEvents, {timeOrigin: navStart});
+      return speedline(trace.traceEvents, {
+        timeOrigin: navStart,
+        fastMode: true,
+      });
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "opn": "4.0.2",
     "rimraf": "2.2.8",
     "semver": "5.3.0",
-    "speedline": "1.1.1",
+    "speedline": "1.2.0",
     "update-notifier": "^2.1.0",
     "whatwg-url": "4.0.0",
     "ws": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,9 +2870,9 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-speedline@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/speedline/-/speedline-1.1.1.tgz#d70d7bfbe630eb63424a830ec0e02ddfcc6051b7"
+speedline@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/speedline/-/speedline-1.2.0.tgz#f5828dcf8e9b96a9f6c1da8ab298538820c6668d"
   dependencies:
     babar "0.0.3"
     image-ssim "^0.2.0"


### PR DESCRIPTION
in the name of OYB, shaves off ~4s from PSI computation (went from 5s to 1s 💣 💥 )

bonus perk: no test changes required all PSI values the same

closes #2227

