### PR TITLE
add lighthouse calculation time to json results

### DIFF
--- a/lighthouse-core/config/plots.json
+++ b/lighthouse-core/config/plots.json
@@ -10,6 +10,8 @@
     "first-meaningful-paint",
     "speed-index-metric",
     "estimated-input-latency",
-    "time-to-interactive"
+    "time-to-interactive",
+    "first-interactive",
+    "consistently-interactive"
   ]
 }

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -38,9 +38,10 @@ const Config = require('./config/config');
  */
 
 module.exports = function(url, flags = {}, configJSON) {
-  return new Promise((resolve, reject) => {
+  const startTime = Date.now();
+  return Promise.resolve().then(_ => {
     if (!url) {
-      return reject(new Error('Lighthouse requires a URL'));
+      throw new Error('Lighthouse requires a URL');
     }
 
     // set logging preferences, assume quiet
@@ -53,7 +54,15 @@ module.exports = function(url, flags = {}, configJSON) {
     const connection = new ChromeProtocol(flags.port);
 
     // kick off a lighthouse run
-    resolve(Runner.run(connection, {url, flags, config}));
+    return Runner.run(connection, {url, flags, config})
+      .then(lighthouseResults => {
+        // Annotate with time to run lighthouse.
+        const endTime = Date.now();
+        lighthouseResults.timing = lighthouseResults.timing || {};
+        lighthouseResults.timing.total = endTime - startTime;
+
+        return lighthouseResults;
+      });
   });
 };
 

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -214,6 +214,7 @@ ReportRenderer.GroupJSON; // eslint-disable-line no-unused-expressions
  *     lighthouseVersion: string,
  *     userAgent: string,
  *     generatedTime: string,
+ *     timing: {total: number},
  *     initialUrl: string,
  *     url: string,
  *     artifacts: {traces: !Object},

--- a/lighthouse-core/test/index-test.js
+++ b/lighthouse-core/test/index-test.js
@@ -120,6 +120,8 @@ describe('Module Tests', function() {
       assert.ok(Array.isArray(results.aggregations));
       assert.equal(results.aggregations.length, 0);
       assert.ok(results.audits.viewport);
+      assert.ok(results.timing);
+      assert.equal(typeof results.timing.total, 'number');
     });
   });
 

--- a/plots/analyze.js
+++ b/plots/analyze.js
@@ -81,11 +81,17 @@ function analyzeSite(sitePath) {
  */
 function readResult(lighthouseReportPath) {
   const data = JSON.parse(fs.readFileSync(lighthouseReportPath));
-  return Metrics.metricsDefinitions.map(metric => ({
+  const metrics = Metrics.metricsDefinitions.map(metric => ({
     name: metric.name,
     id: metric.id,
     timing: metric.getTiming(data.audits)
   }));
+  const timings = Object.keys(constants.TIMING_NAME_MAP).map(timingName => ({
+    name: constants.TIMING_NAME_MAP[timingName],
+    id: 'timing' + timingName,
+    timing: data.timing[timingName]
+  }));
+  return [...metrics, ...timings];
 }
 
 /**
@@ -95,7 +101,10 @@ function readResult(lighthouseReportPath) {
  * @return {!ResultsByMetric}
  */
 function groupByMetrics(results) {
-  return Metrics.metricsDefinitions.map(metric => metric.name).reduce((acc, metricName, index) => {
+  const metricNames = Metrics.metricsDefinitions.map(metric => metric.name)
+      .concat(Object.keys(constants.TIMING_NAME_MAP).map(key => constants.TIMING_NAME_MAP[key]));
+
+  return metricNames.reduce((acc, metricName, index) => {
     acc[metricName] = results.map(siteResult => ({
       site: siteResult.site,
       metrics: siteResult.results.map(runResult => ({

--- a/plots/constants.js
+++ b/plots/constants.js
@@ -22,8 +22,13 @@ const OUT_PATH = path.resolve(__dirname, 'out');
 const LIGHTHOUSE_RESULTS_FILENAME = 'lighthouse.json';
 const SCREENSHOTS_FILENAME = 'assets-0.screenshots.json';
 
+const TIMING_NAME_MAP = {
+  'total': 'Lighthouse Execution'
+};
+
 module.exports = {
   OUT_PATH,
   LIGHTHOUSE_RESULTS_FILENAME,
-  SCREENSHOTS_FILENAME
+  SCREENSHOTS_FILENAME,
+  TIMING_NAME_MAP
 };


### PR DESCRIPTION
happy to bikeshed on the name and where it should be taken, but basically it would be nice to be able to track how long a lighthouse run takes. I was going to do it in plots/, but @wwwillchen pointed out that it's actually a generally useful thing to have in the LHR.

We could put this inside `runner`, but it's actually kind of nice to track config and connection construction too. This does ignore work done in `bin.ts`, however.