### PR TITLE
fix: remove recovery logic for fmp

### DIFF
--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -29,7 +29,6 @@
  */
 
 const ComputedArtifact = require('./computed-artifact');
-const log = require('../../lib/log');
 
 class TraceOfTab extends ComputedArtifact {
   get name() {
@@ -70,23 +69,9 @@ class TraceOfTab extends ComputedArtifact {
     );
 
     // fMP will follow at/after the FP
-    let firstMeaningfulPaint = frameEvents.find(
+    const firstMeaningfulPaint = frameEvents.find(
       e => e.name === 'firstMeaningfulPaint' && e.ts > navigationStart.ts
     );
-
-    // If there was no firstMeaningfulPaint event found in the trace, the network idle detection
-    // may have not been triggered before Lighthouse finished tracing.
-    // In this case, we'll use the last firstMeaningfulPaintCandidate we can find.
-    // However, if no candidates were found (a bogus trace, likely), we fail.
-    if (!firstMeaningfulPaint) {
-      const fmpCand = 'firstMeaningfulPaintCandidate';
-      log.verbose('trace-of-tab', `No firstMeaningfulPaint found, falling back to last ${fmpCand}`);
-      const lastCandidate = frameEvents.filter(e => e.name === fmpCand).pop();
-      if (!lastCandidate) {
-        log.verbose('trace-of-tab', 'No `firstMeaningfulPaintCandidate` events found in trace');
-      }
-      firstMeaningfulPaint = lastCandidate;
-    }
 
     const onLoad = frameEvents.find(e => e.name === 'loadEventEnd' && e.ts > navigationStart.ts);
     const domContentLoaded = frameEvents.find(

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -23,7 +23,6 @@ const badNavStartTrace = require('../fixtures/traces/bad-nav-start-ts.json');
 const lateTracingStartedTrace = require('../fixtures/traces/tracingstarted-after-navstart.json');
 const preactTrace = require('../fixtures/traces/preactjs.com_ts_of_undefined.json');
 const noFMPtrace = require('../fixtures/traces/no_fmp_event.json');
-const noFCPtrace = require('../fixtures/traces/airhorner_no_fcp');
 
 const Runner = require('../../runner.js');
 const computedArtifacts = Runner.instantiateComputedArtifacts();
@@ -101,26 +100,11 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.ok(!result.debugString);
       });
     });
-
-    it('from candidates if no defined FMP exists', () => {
-      return FMPAudit.audit(generateArtifactsWithTrace(noFMPtrace)).then(result => {
-        assert.equal(result.displayValue, '4460.9ms');
-        assert.equal(result.rawValue, 4460.9);
-        assert.equal(result.extendedInfo.value.timings.fCP, 1494.73);
-        assert.ok(!result.debugString);
-      });
-    });
   });
 
-  it('handles traces missing an FCP', () => {
-    return FMPAudit.audit(generateArtifactsWithTrace(noFCPtrace)).then(result => {
-      assert.strictEqual(result.debugString, undefined);
-      assert.strictEqual(result.displayValue, '482.3ms');
-      assert.strictEqual(result.rawValue, 482.3);
-      assert.strictEqual(result.extendedInfo.value.timings.fCP, undefined);
-      assert.strictEqual(result.extendedInfo.value.timings.fMP, 482.318);
-      assert.strictEqual(result.extendedInfo.value.timestamps.fCP, undefined);
-      assert.strictEqual(result.extendedInfo.value.timestamps.fMP, 2149509604903);
-    });
+  it('throws on traces missing an FMP', () => {
+    return FMPAudit.audit(generateArtifactsWithTrace(noFMPtrace)).then(() => {
+      assert.ok(false, 'should have failed');
+    }).catch(() => assert.ok(true));
   });
 });

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -90,7 +90,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.startedInPageEvt.ts, 2146735802456);
       assert.equal(trace.navigationStartEvt.ts, 2146735807738);
       assert.equal(trace.firstContentfulPaintEvt.ts, 2146737302468);
-      assert.equal(trace.firstMeaningfulPaintEvt.ts, 2146740268666);
+      assert.equal(trace.firstMeaningfulPaintEvt, undefined);
     });
   });
 
@@ -99,7 +99,7 @@ describe('Trace of Tab computed artifact:', () => {
     assert.equal(trace.startedInPageEvt.ts, 2149509117532, 'bad tracingstartedInPage');
     assert.equal(trace.navigationStartEvt.ts, 2149509122585, 'bad navStart');
     assert.equal(trace.firstContentfulPaintEvt, undefined, 'bad fcp');
-    assert.equal(trace.firstMeaningfulPaintEvt.ts, 2149509604903, 'bad fmp');
+    assert.equal(trace.firstMeaningfulPaintEvt, undefined, 'bad fmp');
   });
 
   it('handles traces missing a paints (captured in background tab)', () => {


### PR DESCRIPTION
removes recovery logic for using the last FMPCandidate when FMP can't be found in the trace

this gives a misleading result and since our network idle wait time is far more generous now, the only cases this should happen is when it legitimately could not be computed or a bug that needs more investigation we shouldn't mask silently