### PR TITLE
ChromeLauncher v1.0

### DIFF
--- a/chrome-launcher/chrome-finder.ts
+++ b/chrome-launcher/chrome-finder.ts
@@ -72,11 +72,11 @@ export function darwin() {
  * 3. Look for google-chrome-stable & google-chrome executables by using the which command
  */
 export function linux() {
-  let installations: Array<string> = [];
+  let installations: string[] = [];
 
   // 1. Look into LIGHTHOUSE_CHROMIUM_PATH env variable
   if (canAccess(process.env.LIGHTHOUSE_CHROMIUM_PATH)) {
-    installations.push(process.env.LIGHTHOUSE_CHROMIUM_PATH);
+    installations.push(process.env.LIGHTHOUSE_CHROMIUM_PATH as string);
   }
 
   // 2. Look into the directories where .desktop are saved on gnome based distro's
@@ -95,7 +95,8 @@ export function linux() {
   ];
   executables.forEach((executable: string) => {
     try {
-      const chromePath = execFileSync('which', [executable]).toString().split(newLineRegex)[0];
+      const chromePath =
+          execFileSync('which', [executable]).toString().split(newLineRegex)[0] as string;
 
       if (canAccess(chromePath)) {
         installations.push(chromePath);
@@ -141,22 +142,22 @@ export function win32() {
   return installations;
 }
 
-function sort(installations: Array<string>, priorities: Priorities) {
+function sort(installations: string[], priorities: Priorities) {
   const defaultPriority = 10;
   return installations
       // assign priorities
       .map((inst: string) => {
         for (const pair of priorities) {
           if (pair.regex.test(inst)) {
-            return [inst, pair.weight];
+            return {path: inst, weight: pair.weight};
           }
         }
-        return [inst, defaultPriority];
+        return {path: inst, weight: defaultPriority};
       })
       // sort based on priorities
-      .sort((a, b) => (<any>b)[1] - (<any>a)[1])
+      .sort((a, b) => (b.weight - a.weight))
       // remove priority flag
-      .map(pair => pair[0]);
+      .map(pair => pair.path);
 }
 
 function canAccess(file: string): Boolean {

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -40,6 +40,7 @@ export interface Options {
   chromeFlags?: Array<string>;
   port?: number;
   handleSIGINT?: boolean;
+  chromePath?: string;
 }
 
 export interface LaunchedChrome {
@@ -74,6 +75,7 @@ class ChromeLauncher {
   errFile?: number;
   pidFile: string;
   startingUrl: string;
+  chromePath?: string;
   chromeFlags: Array<string>;
   chrome?: childProcess.ChildProcess;
   port: number;
@@ -84,6 +86,7 @@ class ChromeLauncher {
     this.startingUrl = defaults(opts.startingUrl, 'about:blank');
     this.chromeFlags = defaults(opts.chromeFlags, []);
     this.port = defaults(opts.port, 0);
+    this.chromePath = opts.chromePath;
   }
 
   private get flags() {
@@ -139,13 +142,16 @@ class ChromeLauncher {
       this.prepare();
     }
 
-    const installations = await chromeFinder[process.platform as SupportedPlatforms]();
-    if (installations.length === 0) {
-      throw new Error('No Chrome Installations Found');
+    if (this.chromePath === undefined) {
+      const installations = await chromeFinder[process.platform as SupportedPlatforms]();
+      if (installations.length === 0) {
+        throw new Error('No Chrome Installations Found');
+      }
+
+      this.chromePath = installations[0];
     }
 
-    const chromePath = installations[0];
-    this.pid = await this.spawn(chromePath);
+    this.pid = await this.spawn(this.chromePath);
     return Promise.resolve();
   }
 

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -64,7 +64,7 @@ export async function launch(opts: Options = {}): Promise<LaunchedChrome> {
 
   await instance.launch();
 
-  return {pid: instance.pid!, port: instance.port, kill: instance.kill};
+  return {pid: instance.pid!, port: instance.port, kill: async () => instance.kill()};
 }
 
 export class Launcher {

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -21,7 +21,7 @@ import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as chromeFinder from './chrome-finder';
 import {DEFAULT_FLAGS} from './flags';
-import {defaults, delay, makeUnixTmpDir, makeWin32TmpDir} from './utils';
+import {makeTmpDir, defaults, delay} from './utils';
 import * as net from 'net';
 const rimraf = require('rimraf');
 const log = require('../lighthouse-core/lib/log');
@@ -30,6 +30,7 @@ const execSync = childProcess.execSync;
 const isWindows = process.platform === 'win32';
 const _SIGINT = 'SIGINT';
 const _SIGINT_EXIT_CODE = 130;
+const _SUPPORTED_PLATFORMS = new Set(['darwin', 'linux', 'win32']);
 
 type SupportedPlatforms = 'darwin'|'linux'|'win32';
 
@@ -101,20 +102,11 @@ class ChromeLauncher {
 
   private prepare() {
     const platform = process.platform as SupportedPlatforms;
-
-    switch (platform) {
-      case 'darwin':
-      case 'linux':
-        this.TMP_PROFILE_DIR = makeUnixTmpDir();
-        break;
-
-      case 'win32':
-        this.TMP_PROFILE_DIR = makeWin32TmpDir();
-        break;
-
-      default:
-        throw new Error(`Platform ${platform} is not supported`);
+    if (!_SUPPORTED_PLATFORMS.has(platform)) {
+      throw new Error(`Platform ${platform} is not supported`);
     }
+
+    this.TMP_PROFILE_DIR = makeTmpDir();
 
     this.outFile = fs.openSync(`${this.TMP_PROFILE_DIR}/chrome-out.log`, 'a');
     this.errFile = fs.openSync(`${this.TMP_PROFILE_DIR}/chrome-err.log`, 'a');

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -80,7 +80,7 @@ class ChromeLauncher {
     this.autoSelectChrome = defaults(opts.autoSelectChrome, true);
     this.startingUrl = defaults(opts.startingUrl, 'about:blank');
     this.chromeFlags = defaults(opts.chromeFlags, []);
-    this.port = defaults(opts.port, 9222);
+    this.port = defaults(opts.port, 0);
   }
 
   private get flags() {

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -69,15 +69,15 @@ export async function launch(opts: Options = {}): Promise<LaunchedChrome> {
 
 export class Launcher {
   private tmpDirandPidFileReady = false;
-  pollInterval: number = 500;
-  TMP_PROFILE_DIR: string;
-  outFile?: number;
-  errFile?: number;
-  pidFile: string;
-  startingUrl: string;
-  chromePath?: string;
-  chromeFlags: Array<string>;
-  chrome?: childProcess.ChildProcess;
+  private pollInterval: number = 500;
+  private pidFile: string;
+  private startingUrl: string;
+  private TMP_PROFILE_DIR: string;
+  private outFile?: number;
+  private errFile?: number;
+  private chromePath?: string;
+  private chromeFlags: string[];
+  private chrome?: childProcess.ChildProcess;
   port: number;
   pid?: number;
 

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -20,6 +20,7 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as chromeFinder from './chrome-finder';
+import {getRandomPort} from './random-port';
 import {DEFAULT_FLAGS} from './flags';
 import {makeTmpDir, defaults, delay} from './utils';
 import * as net from 'net';
@@ -143,10 +144,19 @@ class ChromeLauncher {
   }
 
   private spawn(execPath: string) {
-    const spawnPromise = new Promise(resolve => {
+    const spawnPromise = new Promise(async (resolve) => {
       if (this.chrome) {
         log.log('ChromeLauncher', `Chrome already running with pid ${this.chrome.pid}.`);
         return resolve(this.chrome.pid);
+      }
+
+
+      // If a zero value port is set, it means the launcher
+      // is responsible for generating the port number.
+      // We do this here so that we can know the port before
+      // we pass it into chrome.
+      if (this.port === 0) {
+        this.port = await getRandomPort();
       }
 
       const chrome = spawn(

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -63,7 +63,7 @@ export async function launch(opts: Options = {}): Promise<LaunchedChrome> {
 }
 
 class ChromeLauncher {
-  prepared = false;
+  private tmpDirandPidFileReady = false;
   pollInterval: number = 500;
   autoSelectChrome: boolean;
   TMP_PROFILE_DIR: string;
@@ -117,7 +117,7 @@ class ChromeLauncher {
 
     log.verbose('ChromeLauncher', `created ${this.TMP_PROFILE_DIR}`);
 
-    this.prepared = true;
+    this.tmpDirandPidFileReady = true;
   }
 
   async launch() {
@@ -132,7 +132,7 @@ class ChromeLauncher {
       }
     }
 
-    if (!this.prepared) {
+    if (!this.tmpDirandPidFileReady) {
       this.prepare();
     }
 

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -37,7 +37,6 @@ type SupportedPlatforms = 'darwin'|'linux'|'win32';
 export interface Options {
   startingUrl?: string;
   chromeFlags?: Array<string>;
-  autoSelectChrome?: boolean;
   port?: number;
   handleSIGINT?: boolean;
 }
@@ -65,7 +64,6 @@ export async function launch(opts: Options = {}): Promise<LaunchedChrome> {
 class ChromeLauncher {
   private tmpDirandPidFileReady = false;
   pollInterval: number = 500;
-  autoSelectChrome: boolean;
   TMP_PROFILE_DIR: string;
   outFile?: number;
   errFile?: number;
@@ -77,7 +75,6 @@ class ChromeLauncher {
 
   constructor(opts: Options = {}) {
     // choose the first one (default)
-    this.autoSelectChrome = defaults(opts.autoSelectChrome, true);
     this.startingUrl = defaults(opts.startingUrl, 'about:blank');
     this.chromeFlags = defaults(opts.chromeFlags, []);
     this.port = defaults(opts.port, 0);

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -19,12 +19,10 @@
 
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as chromeFinder from './chrome-finder';
-import {ask} from './ask';
 import {DEFAULT_FLAGS} from './flags';
+import {defaults, delay, makeUnixTmpDir, makeWin32TmpDir} from './utils';
 
-const mkdirp = require('mkdirp');
 import * as net from 'net';
 const rimraf = require('rimraf');
 const log = require('../lighthouse-core/lib/log');
@@ -82,11 +80,11 @@ type SupportedPlatforms = 'darwin'|'linux'|'win32';
     switch (platform) {
       case 'darwin':
       case 'linux':
-        this.TMP_PROFILE_DIR = unixTmpDir();
+        this.TMP_PROFILE_DIR = makeUnixTmpDir();
         break;
 
       case 'win32':
-        this.TMP_PROFILE_DIR = win32TmpDir();
+        this.TMP_PROFILE_DIR = makeWin32TmpDir();
         break;
 
       default:
@@ -241,25 +239,3 @@ type SupportedPlatforms = 'darwin'|'linux'|'win32';
     });
   }
 };
-
-function defaults<T>(val: T | undefined, def: T): T {
-  return typeof val === 'undefined' ? def : val;
-}
-
-function delay(time: number) {
-  return new Promise(resolve => setTimeout(resolve, time));
-}
-
-function unixTmpDir() {
-  return execSync('mktemp -d -t lighthouse.XXXXXXX').toString().trim();
-}
-
-function win32TmpDir() {
-  const winTmpPath = process.env.TEMP || process.env.TMP ||
-      (process.env.SystemRoot || process.env.windir) + '\\temp';
-  const randomNumber = Math.floor(Math.random() * 9e7 + 1e7);
-  const tmpdir = path.join(winTmpPath, 'lighthouse.' + randomNumber);
-
-  mkdirp.sync(tmpdir);
-  return tmpdir;
-}

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -52,7 +52,7 @@ export interface LaunchedChrome {
 export async function launch(opts: Options = {}): Promise<LaunchedChrome> {
   opts.handleSIGINT = defaults(opts.handleSIGINT, true);
 
-  const instance = new ChromeLauncher(opts);
+  const instance = new Launcher(opts);
 
   // Kill spawned Chrome process in case of ctrl-C.
   if (opts.handleSIGINT) {
@@ -67,7 +67,7 @@ export async function launch(opts: Options = {}): Promise<LaunchedChrome> {
   return {pid: instance.pid!, port: instance.port, kill: instance.kill};
 }
 
-class ChromeLauncher {
+export class Launcher {
   private tmpDirandPidFileReady = false;
   pollInterval: number = 500;
   TMP_PROFILE_DIR: string;

--- a/chrome-launcher/flags.ts
+++ b/chrome-launcher/flags.ts
@@ -1,3 +1,22 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
 export const DEFAULT_FLAGS = [
   // Disable built-in Google Translate service
   '--disable-translate',

--- a/chrome-launcher/manual-chrome-launcher.js
+++ b/chrome-launcher/manual-chrome-launcher.js
@@ -22,11 +22,9 @@ if (args.length) {
   startingUrl = args.find(flag => !flag.startsWith('--'));
 }
 
-const {ChromeLauncher} = require('./chrome-launcher');
-const chromeInstance = new ChromeLauncher({
+const {launch} = require('./chrome-launcher');
+
+launch({
   startingUrl,
   chromeFlags,
 });
-
-chromeInstance.prepare();
-chromeInstance.run();

--- a/chrome-launcher/manual-chrome-launcher.js
+++ b/chrome-launcher/manual-chrome-launcher.js
@@ -27,4 +27,4 @@ const {launch} = require('./chrome-launcher');
 launch({
   startingUrl,
   chromeFlags,
-});
+}).then(v => console.log(`✨  Chrome debugging port ${v.port}`))

--- a/chrome-launcher/package.json
+++ b/chrome-launcher/package.json
@@ -10,11 +10,12 @@
     "format": "clang-format -i -style=file *.ts"
   },
   "devDependencies": {
+    "clang-format": "^1.0.50",
     "mocha": "^3.2.0",
-    "typescript": "2.2.1",
-    "clang-format": "^1.0.50"
+    "typescript": "2.2.1"
   },
   "dependencies": {
+    "@types/mkdirp": "^0.3.29",
     "@types/node": "6.0.66"
   }
 }

--- a/chrome-launcher/random-port.ts
+++ b/chrome-launcher/random-port.ts
@@ -21,7 +21,7 @@ import {createServer} from 'http';
 /**
  * Return a random, unused port.
  */
-function getRandomPort(): Promise<number> {
+export function getRandomPort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const server = createServer();
     server.listen(0);
@@ -32,5 +32,3 @@ function getRandomPort(): Promise<number> {
     server.once('error', reject);
   });
 }
-
-export {getRandomPort};

--- a/chrome-launcher/test/chrome-launcher-test.js
+++ b/chrome-launcher/test/chrome-launcher-test.js
@@ -18,17 +18,17 @@
 
 require('../compiled-check.js')('chrome-launcher.js');
 
-const ChromeLauncher = require('../chrome-launcher.js').ChromeLauncher;
+const ChromeLauncher = require('../chrome-launcher.js').Launcher;
 const log = require('../../lighthouse-core/lib/log');
 const assert = require('assert');
 
 /* eslint-env mocha */
 
-describe('ChromeLauncher', () => {
+describe('Launcher', () => {
   it('doesn\'t fail when killed twice', () => {
     log.setLevel('error');
     const chromeInstance = new ChromeLauncher();
-    return chromeInstance.run().then(() => {
+    return chromeInstance.launch().then(() => {
       log.setLevel();
       return Promise.all([chromeInstance.kill(), chromeInstance.kill()]);
     });
@@ -38,10 +38,10 @@ describe('ChromeLauncher', () => {
     log.setLevel('error');
     const chromeInstance = new ChromeLauncher();
     let pid;
-    return chromeInstance.run()
+    return chromeInstance.launch()
         .then(() => {
           pid = chromeInstance.chrome.pid;
-          return chromeInstance.run();
+          return chromeInstance.launch();
         })
         .then(() => {
           log.setLevel();

--- a/chrome-launcher/test/random-port-test.js
+++ b/chrome-launcher/test/random-port-test.js
@@ -18,7 +18,7 @@
 /* eslint-env mocha */
 
 const assert = require('assert');
-const getRandomPort = require('../../random-port').getRandomPort;
+const getRandomPort = require('../random-port').getRandomPort;
 
 describe('Random port generation', () => {
   it('generates a valid random port number', () => {

--- a/chrome-launcher/utils.ts
+++ b/chrome-launcher/utils.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import {join} from 'path';
+import {execSync} from 'child_process';
+import * as mkdirp from 'mkdirp';
+
+export function defaults<T>(val: T | undefined, def: T): T {
+  return typeof val === 'undefined' ? def : val;
+}
+
+export async function delay(time: number) {
+  return new Promise(resolve => setTimeout(resolve, time));
+}
+
+export function makeUnixTmpDir() {
+  return execSync('mktemp -d -t lighthouse.XXXXXXX').toString().trim();
+}
+
+export function makeWin32TmpDir() {
+  const winTmpPath = process.env.TEMP || process.env.TMP ||
+      (process.env.SystemRoot || process.env.windir) + '\\temp';
+  const randomNumber = Math.floor(Math.random() * 9e7 + 1e7);
+  const tmpdir = join(winTmpPath, 'lighthouse.' + randomNumber);
+
+  mkdirp.sync(tmpdir);
+  return tmpdir;
+}

--- a/chrome-launcher/utils.ts
+++ b/chrome-launcher/utils.ts
@@ -29,11 +29,23 @@ export async function delay(time: number) {
   return new Promise(resolve => setTimeout(resolve, time));
 }
 
-export function makeUnixTmpDir() {
+export function makeTmpDir() {
+  switch (process.platform) {
+    case 'darwin':
+    case 'linux':
+      return makeUnixTmpDir();
+    case 'win32':
+      return makeWin32TmpDir();
+    default:
+      throw new Error(`Platform ${process.platform} is not supported`);
+  }
+}
+
+function makeUnixTmpDir() {
   return execSync('mktemp -d -t lighthouse.XXXXXXX').toString().trim();
 }
 
-export function makeWin32TmpDir() {
+function makeWin32TmpDir() {
   const winTmpPath = process.env.TEMP || process.env.TMP ||
       (process.env.SystemRoot || process.env.windir) + '\\temp';
   const randomNumber = Math.floor(Math.random() * 9e7 + 1e7);

--- a/chrome-launcher/yarn.lock
+++ b/chrome-launcher/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/mkdirp@^0.3.29":
+  version "0.3.29"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
+
 "@types/node@6.0.66":
   version "6.0.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.66.tgz#5680b74a6135d33d4c00447e7c3dc691a4601625"

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -30,7 +30,6 @@ import * as path from 'path';
 const perfOnlyConfig = require('../lighthouse-core/config/perf.json');
 const performanceXServer = require('./performance-experiment/server');
 import * as Printer from './printer';
-import * as randomPort from './random-port';
 import {Results} from './types/types';
 const pkg = require('../package.json');
 
@@ -77,24 +76,6 @@ log.setLevel(cliFlags.logLevel);
 
 if (cliFlags.output === Printer.OutputMode[Printer.OutputMode.json] && !cliFlags.outputPath) {
   cliFlags.outputPath = 'stdout';
-}
-
-/**
- * If the requested port is 0, set it to a random, unused port.
- */
-function initPort(flags: Flags): Promise<undefined> {
-  return Promise.resolve().then(() => {
-    if (flags.port !== 0) {
-      log.verbose('Lighthouse CLI', `Using supplied port ${flags.port}`);
-      return;
-    }
-
-    log.verbose('Lighthouse CLI', 'Generating random port.');
-    return randomPort.getRandomPort().then(portNumber => {
-      flags.port = portNumber;
-      log.verbose('Lighthouse CLI', `Using generated port ${flags.port}.`);
-    });
-  });
 }
 
 /**
@@ -196,7 +177,6 @@ export async function runLighthouse(
   let launchedChrome: LaunchedChrome|undefined;
 
   try {
-    await initPort(flags);
     launchedChrome = await getDebuggableChrome(flags);
     flags.port = launchedChrome.port;
     const results = await lighthouse(url, flags, config);

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -198,6 +198,7 @@ export async function runLighthouse(
   try {
     await initPort(flags);
     launchedChrome = await getDebuggableChrome(flags);
+    flags.port = launchedChrome.port;
     const results = await lighthouse(url, flags, config);
 
     const artifacts = results.artifacts;

--- a/lighthouse-cli/cli-flags.ts
+++ b/lighthouse-cli/cli-flags.ts
@@ -115,7 +115,7 @@ Example: --output-path=./lighthouse-results.html`,
       .default('chrome-flags', '')
       .default('disable-cpu-throttling', false)
       .default('output', GetValidOutputOptions()[OutputMode.domhtml])
-      .default('port', 9222)
+      .default('port', 0)
       .default('max-wait-for-load', Driver.MAX_WAIT_FOR_FULLY_LOADED)
       .check((argv: {listAllAudits?: boolean, listTraceCategories?: boolean, _: Array<any>}) => {
         // Make sure lighthouse has been passed a url, or at least one of --list-all-audits

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lighthouse-core/index.js",
   "bin": {
     "lighthouse": "./lighthouse-cli/index.js",
-    "chrome-debug": "./lighthouse-cli/manual-chrome-launcher.js"
+    "chrome-debug": "./chrome-launcher/manual-chrome-launcher.js"
   },
   "engines": {
     "node": ">=6"

--- a/plots/measure.js
+++ b/plots/measure.js
@@ -27,7 +27,7 @@ const constants = require('./constants.js');
 const utils = require('./utils.js');
 const config = require('../lighthouse-core/config/plots.json');
 const lighthouse = require('../lighthouse-core/index.js');
-const ChromeLauncher = require('../chrome-launcher/chrome-launcher.js').ChromeLauncher;
+const ChromeLauncher = require('../chrome-launcher/chrome-launcher.js');
 const Printer = require('../lighthouse-cli/printer');
 const assetSaver = require('../lighthouse-core/lib/asset-saver.js');
 
@@ -132,18 +132,11 @@ function main() {
     return;
   }
 
-  const launcher = new ChromeLauncher();
-  launcher
-    .isDebuggerReady()
-    .catch(() => launcher.run())
-    .then(() => runAnalysis())
-    .then(() => launcher.kill())
-    .catch(err => launcher.kill().then(
-      () => {
-        throw err;
-      },
-      console.error
-    ));
+  const launcher = ChromeLauncher.launch();
+
+  return launcher.then(() => runAnalysis())
+  .catch(err => console.error(err))
+  .then(() => launcher.kill());
 }
 
 main();

--- a/readme.md
+++ b/readme.md
@@ -160,18 +160,19 @@ assumes you've installed Lighthouse as a dependency (`yarn add --dev lighthouse`
 
 ```javascript
 const lighthouse = require('lighthouse');
-const ChromeLauncher = require('lighthouse/lighthouse-cli/chrome-launcher.js').ChromeLauncher;
+const ChromeLauncher = require('lighthouse/chrome-laucher/chrome-launcher.js');
 const Printer = require('lighthouse/lighthouse-cli/printer');
 
 function launchChromeAndRunLighthouse(url, flags, config) {
-  const launcher = new ChromeLauncher({port: 9222, autoSelectChrome: true});
+  const launchedChrome = ChromeLauncher.launch();
 
-  return launcher.run() // Launch Chrome.
+  launchedChrome
     .then(() => lighthouse(url, flags, config)) // Run Lighthouse.
-    .then(results => launcher.kill().then(() => results)) // Kill Chrome and return results.
+    .then(results => launchedChrome.kill())
+    .then(() => results) // Kill Chrome and return results.
     .catch(err => {
       // Kill Chrome if there's an error.
-      return launcher.kill().then(() => {
+      return launchedChrome.kill().then(() => {
         throw err;
       });
     });


### PR DESCRIPTION
📔  note:

> This CL consists of individual commits that build on each other, each commit is an atomic unit of work to make reviewing easier, as well as the commit history understandable.


#### Outline of the work done in this CL.

* Clean up use of any typing for chrome-finder by being smart with types. 🤔  🍎 
* Limit class interface for chrome launcher instance with private. 👮 
* Extract flags to a standalone module since it is more config than code. 🐴 
* Add missing type info for mkdirp. 🔍 
* Extract util functions to a standalone component since they are not coupled to the implementation of chrome launcher. :man_farmer: 
* make use of await / async. 😴 
* update plots to consume the new api. 📈 
* Add a new ability for the launcher to handle SIGINT 🔪 .
* launcher will now if a non-zero port is passed tried to connect to an existing connection there, if no connection is found it will launch chrome with the passed port exposed and carry on. :zero: 
* Made use of the port 0 pattern and moved random port selection into launcher :goal_net: 
* abstract mkdir pattern for multiple platforms 🔡 
* remove autoSelector noise from old api 💀 
* add the ability for a user to pass in a custom chrome path 🍮 

----

ref #2092 