### PR TITLE
Enhance error wording around busy traces.

### DIFF
--- a/lighthouse-core/audits/consistently-interactive.js
+++ b/lighthouse-core/audits/consistently-interactive.js
@@ -193,8 +193,10 @@ class ConsistentlyInteractiveMetric extends Audit {
       }
     }
 
-    const culprit = cpuCandidate ? 'Network' : 'CPU';
-    throw new Error(`${culprit} did not quiet for at least 5s before the end of the trace.`);
+    const culprit = cpuCandidate ? 'Network' : 'Main thread';
+    throw new Error(`${culprit} activity continued through the end of the trace recording. ` +
+      'Consistently Interactive requires a minimum of 5 seconds of both main thread idle and ' +
+      'network idle.');
   }
 
   /**

--- a/lighthouse-core/gather/computed/first-interactive.js
+++ b/lighthouse-core/gather/computed/first-interactive.js
@@ -27,7 +27,7 @@ const MIN_TASK_CLUSTER_FMP_DISTANCE = 5000;
 
 const MAX_QUIET_WINDOW_SIZE = 5000;
 const TRACE_BUSY_MSG = 'The main thread was busy for the entire trace recording. ' +
-   'First Interactive requires the main thread to reach a more idle state.';
+   'First Interactive requires the main thread to be idle for several seconds.';
 
 // Window size should be three seconds at 15 seconds after FMP
 const EXPONENTIATION_COEFFICIENT = -Math.log(3 - 1) / 15;

--- a/lighthouse-core/gather/computed/first-interactive.js
+++ b/lighthouse-core/gather/computed/first-interactive.js
@@ -26,7 +26,8 @@ const MIN_TASK_CLUSTER_PADDING = 1000;
 const MIN_TASK_CLUSTER_FMP_DISTANCE = 5000;
 
 const MAX_QUIET_WINDOW_SIZE = 5000;
-const TRACE_BUSY_MSG = 'trace was busy the entire time';
+const TRACE_BUSY_MSG = 'The main thread was busy for the entire trace recording. ' +
+   'First Interactive requires the main thread to reach a more idle state.';
 
 // Window size should be three seconds at 15 seconds after FMP
 const EXPONENTIATION_COEFFICIENT = -Math.log(3 - 1) / 15;

--- a/lighthouse-core/test/audits/consistently-interactive-test.js
+++ b/lighthouse-core/test/audits/consistently-interactive-test.js
@@ -77,7 +77,7 @@ describe('Performance: consistently-interactive audit', () => {
 
       assert.throws(() => {
         ConsistentlyInteractive.findOverlappingQuietPeriods(cpu, network, traceOfTab);
-      }, /did not quiet/);
+      }, /activity continued/);
     });
 
     it('should throw when CPU is quiet but network is not', () => {
@@ -96,7 +96,7 @@ describe('Performance: consistently-interactive audit', () => {
 
       assert.throws(() => {
         ConsistentlyInteractive.findOverlappingQuietPeriods(cpu, network, traceOfTab);
-      }, /Network did not quiet/);
+      }, /Network activity continued/);
     });
 
     it('should throw when network is quiet but CPU is not', () => {
@@ -114,7 +114,7 @@ describe('Performance: consistently-interactive audit', () => {
 
       assert.throws(() => {
         ConsistentlyInteractive.findOverlappingQuietPeriods(cpu, network, traceOfTab);
-      }, /CPU did not quiet/);
+      }, /Main thread activity continued/);
     });
 
     it('should handle unfinished network requests', () => {
@@ -132,7 +132,7 @@ describe('Performance: consistently-interactive audit', () => {
 
       assert.throws(() => {
         ConsistentlyInteractive.findOverlappingQuietPeriods(cpu, network, traceOfTab);
-      }, /Network did not quiet/);
+      }, /Network activity continued/);
     });
 
     it('should find first overlapping quiet period', () => {
@@ -162,7 +162,7 @@ describe('Performance: consistently-interactive audit', () => {
         {start: 11500, end: 19000},
         {start: 11500, end: 19000},
         {start: 11500, end: 19500},
-        // quiet period during CPU activity
+        // quiet period during Main thread activity
         {start: 28000, end: 32000},
         {start: 28000, end: 32000},
         {start: 28000, end: 35000},

--- a/lighthouse-core/test/gather/computed/first-interactive-test.js
+++ b/lighthouse-core/test/gather/computed/first-interactive-test.js
@@ -284,7 +284,7 @@ describe('FirstInteractive computed artifact:', () => {
       const longTasks = [{start: 4000, end: 5700}];
       assert.throws(() => {
         FirstInteractive.findQuietWindow(200, 6000, longTasks);
-      }, /trace was busy/);
+      }, /main thread was busy/);
     });
   });
 });


### PR DESCRIPTION
to make these more understandable: 

![image](https://cloud.githubusercontent.com/assets/39191/26037109/6a8f1290-38a1-11e7-923a-379f07b43683.png)
