### PR TITLE
PWA Audits: add placeholders for rest of baseline checks.

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -147,6 +147,7 @@ class Audit {
       extendedInfo: result.extendedInfo,
       scoringMode: audit.meta.scoringMode || Audit.SCORING_MODES.BINARY,
       informative: audit.meta.informative,
+      manual: audit.meta.manual,
       name: audit.meta.name,
       category: audit.meta.category,
       description: audit.meta.description,

--- a/lighthouse-core/audits/manual/manual-audit.js
+++ b/lighthouse-core/audits/manual/manual-audit.js
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * @fileoverview Base class for audits that the user should verify manually on
+ * their site.
+ */
+
+const Audit = require('../audit');
+
+class ManualAudit extends Audit {
+
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return {
+      informative: true,
+      manual: true,
+      requiredArtifacts: []
+    };
+  }
+
+  /**
+   * @return {!AuditResult}
+   */
+  static audit() {
+    return {
+      rawValue: false,
+      // displayValue: '(needs manual verification)'
+    };
+  }
+}
+
+module.exports = ManualAudit;

--- a/lighthouse-core/audits/manual/pwa-cross-browser.js
+++ b/lighthouse-core/audits/manual/pwa-cross-browser.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ManualAudit = require('./manual-audit');
+
+/**
+ * @fileoverview Manual PWA audit for janky-free page transitions.
+ */
+
+class PWAPageTransitions extends ManualAudit {
+
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return Object.assign({
+      category: 'PWA',
+      name: 'pwa-page-transitions',
+      helpText: 'Transitions should feel snappy as you tap around, even on a slow network, a key ' +
+          'to perceived performance.',
+      description: 'Page transitions don\'t feel like they block on the network',
+    }, super.meta);
+  }
+}
+
+module.exports = PWAPageTransitions;

--- a/lighthouse-core/audits/manual/pwa-cross-browser.js
+++ b/lighthouse-core/audits/manual/pwa-cross-browser.js
@@ -33,7 +33,8 @@ class PWACrossBrowser extends ManualAudit {
     return Object.assign({
       category: 'PWA',
       name: 'pwa-cross-browser',
-      helpText: 'To reach the most number of users, sites should work across every major browser.',
+      helpText: 'To reach the most number of users, sites should work across ' +
+      'every major browser. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#site-works-cross-browser).',
       description: 'Site works cross-browser',
     }, super.meta);
   }

--- a/lighthouse-core/audits/manual/pwa-each-page-has-url.js
+++ b/lighthouse-core/audits/manual/pwa-each-page-has-url.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ManualAudit = require('./manual-audit');
+
+/**
+ * @fileoverview Manual PWA audit to ensure every page has a deep link.
+ */
+
+class PWAEachPageHasURL extends ManualAudit {
+
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return Object.assign({
+      category: 'PWA',
+      name: 'pwa-each-page-has-url',
+      helpText: 'Ensure individual pages are deep linkable via the URLs and that URLs are ' +
+          'unique for the purpose of shareability on social media.',
+      description: 'Each page has a URL',
+    }, super.meta);
+  }
+}
+
+module.exports = PWAEachPageHasURL;

--- a/lighthouse-core/audits/manual/pwa-each-page-has-url.js
+++ b/lighthouse-core/audits/manual/pwa-each-page-has-url.js
@@ -33,7 +33,7 @@ class PWAEachPageHasURL extends ManualAudit {
       category: 'PWA',
       name: 'pwa-each-page-has-url',
       helpText: 'Ensure individual pages are deep linkable via the URLs and that URLs are ' +
-          'unique for the purpose of shareability on social media.',
+          'unique for the purpose of shareability on social media. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#each-page-has-a-url).',
       description: 'Each page has a URL',
     }, super.meta);
   }

--- a/lighthouse-core/audits/manual/pwa-page-transitions.js
+++ b/lighthouse-core/audits/manual/pwa-page-transitions.js
@@ -20,10 +20,10 @@
 const ManualAudit = require('./manual-audit');
 
 /**
- * @fileoverview Manual PWA audit for cross browser support.
+ * @fileoverview Manual PWA audit for janky-free page transitions.
  */
 
-class PWACrossBrowser extends ManualAudit {
+class PWAPageTransitions extends ManualAudit {
 
   /**
    * @return {!AuditMeta}
@@ -31,11 +31,12 @@ class PWACrossBrowser extends ManualAudit {
   static get meta() {
     return Object.assign({
       category: 'PWA',
-      name: 'pwa-cross-browser',
-      helpText: 'To reach the most number of users, sites should work across every major browser.',
-      description: 'Site works cross-browser',
+      name: 'pwa-page-transitions',
+      helpText: 'Transitions should feel snappy as you tap around, even on a slow network, a key ' +
+          'to perceived performance.',
+      description: 'Page transitions don\'t feel like they block on the network',
     }, super.meta);
   }
 }
 
-module.exports = PWACrossBrowser;
+module.exports = PWAPageTransitions;

--- a/lighthouse-core/audits/manual/pwa-page-transitions.js
+++ b/lighthouse-core/audits/manual/pwa-page-transitions.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ManualAudit = require('./manual-audit');
+
+/**
+ * @fileoverview Manual PWA audit for cross browser support.
+ */
+
+class PWACrossBrowser extends ManualAudit {
+
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return Object.assign({
+      category: 'PWA',
+      name: 'pwa-cross-browser',
+      helpText: 'To reach the most number of users, sites should work across every major browser.',
+      description: 'Site works cross-browser',
+    }, super.meta);
+  }
+}
+
+module.exports = PWACrossBrowser;

--- a/lighthouse-core/audits/manual/pwa-page-transitions.js
+++ b/lighthouse-core/audits/manual/pwa-page-transitions.js
@@ -33,7 +33,7 @@ class PWAPageTransitions extends ManualAudit {
       category: 'PWA',
       name: 'pwa-page-transitions',
       helpText: 'Transitions should feel snappy as you tap around, even on a slow network, a key ' +
-          'to perceived performance.',
+          'to perceived performance. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#page-transitions-dont-feel-like-they-block-on-the-network).',
       description: 'Page transitions don\'t feel like they block on the network',
     }, super.meta);
   }

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -76,6 +76,9 @@ module.exports = {
     "manifest-short-name-length",
     "content-width",
     "deprecations",
+    "manual/pwa-cross-browser",
+    "manual/pwa-page-transitions",
+    "manual/pwa-each-page-has-url",
     "accessibility/accesskeys",
     "accessibility/aria-allowed-attr",
     "accessibility/aria-required-attr",
@@ -136,7 +139,7 @@ module.exports = {
   "aggregations": [{
     "name": "Progressive Web App",
     "id": "pwa",
-    "description": "These audits validate the aspects of a Progressive Web App. They are a subset of the [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
+    "description": "These audits validate the aspects of a Progressive Web App. They are a subset of the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
     "scored": true,
     "categorizable": true,
     "items": [{
@@ -606,42 +609,48 @@ module.exports = {
     },
     "a11y-color-contrast": {
       "title": "Color Contrast Is Satisfactory",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-describe-contents": {
       "title": "Elements Describe Contents Well",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-well-structured": {
       "title": "Elements Are Well Structured",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-aria": {
       "title": "ARIA Attributes Follow Best Practices",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-correct-attributes": {
       "title": "Elements Use Attributes Correctly",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-element-names": {
       "title": "Elements Have Discernable Names",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-language": {
       "title": "Page Specifies Valid Language",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-meta": {
       "title": "Meta Tags Used Properly",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
+    },
+    "manual-pwa-checks": {
+      "title": "¹ Manual checks to verify",
+      "description": "These audits are required by the baseline " +
+          "[PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are " +
+          "not automatically checked by Lighthouse. They do not affect your score but please verify them manually."
     },
   },
   "categories": {
     "pwa": {
       "name": "Progressive Web App",
       "weight": 1,
-      "description": "These audits validate the aspects of a Progressive Web App. They are a subset of the [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
+      "description": "These audits validate the aspects of a Progressive Web App. They are a subset¹ of the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
       "audits": [
         {"id": "service-worker", "weight": 1},
         {"id": "works-offline", "weight": 1},
@@ -653,7 +662,10 @@ module.exports = {
         {"id": "splash-screen", "weight": 1},
         {"id": "themed-omnibox", "weight": 1},
         {"id": "viewport", "weight": 1},
-        {"id": "content-width", "weight": 1}
+        {"id": "content-width", "weight": 1},
+        {"id": "pwa-cross-browser", "weight": 0, "group": "manual-pwa-checks"},
+        {"id": "pwa-page-transitions", "weight": 0, "group": "manual-pwa-checks"},
+        {"id": "pwa-each-page-has-url", "weight": 0, "group": "manual-pwa-checks"}
       ]
     },
     "performance": {

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -640,17 +640,17 @@ module.exports = {
       "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "manual-pwa-checks": {
-      "title": "¹ Manual checks to verify",
+      "title": "Manual checks to verify",
       "description": "These audits are required by the baseline " +
           "[PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are " +
-          "not automatically checked by Lighthouse. They do not affect your score but please verify them manually."
+          "not automatically checked by Lighthouse. They do not affect your score but it's important that you verify them manually."
     },
   },
   "categories": {
     "pwa": {
       "name": "Progressive Web App",
       "weight": 1,
-      "description": "These audits validate the aspects of a Progressive Web App. They are a subset¹ of the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
+      "description": "These audits validate the aspects of a Progressive Web App, as specified by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
       "audits": [
         {"id": "service-worker", "weight": 1},
         {"id": "works-offline", "weight": 1},

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -297,7 +297,7 @@ class CategoryRenderer {
 
     // Render manual audits after passing.
     const auditsGroupedByGroup = /** @type {!Object<string,
-        !Array<!ReportRenderer.AuditJSON>} */ ({});
+        !Array<!ReportRenderer.AuditJSON>>} */ ({});
     manualAudits.forEach(audit => {
       const group = auditsGroupedByGroup[audit.group] || [];
       group.push(audit);

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -66,6 +66,9 @@ class CategoryRenderer {
     if (audit.result.informative) {
       scoreEl.classList.add('lh-score--informative');
     }
+    if (audit.result.manual) {
+      scoreEl.classList.add('lh-score--unknown');
+    }
 
     return this._populateScore(tmpl, audit.score, scoringMode, title, description);
   }
@@ -185,7 +188,7 @@ class CategoryRenderer {
     auditGroupHeader.textContent = group.title;
 
     const auditGroupDescription = this._dom.createElement('div', 'lh-audit-group__description');
-    auditGroupDescription.textContent = group.description;
+    auditGroupDescription.appendChild(this._dom.createSpanFromMarkdown(group.description));
 
     const auditGroupSummary = this._dom.createElement('summary',
           'lh-audit-group__summary lh-expandable-details__summary');
@@ -262,34 +265,59 @@ class CategoryRenderer {
       case 'accessibility':
         return this._renderAccessibilityCategory(category, groups);
       default:
-        return this._renderDefaultCategory(category);
+        return this._renderDefaultCategory(category, groups);
     }
   }
 
   /**
    * @param {!ReportRenderer.CategoryJSON} category
+   * @param {!Object<string, !ReportRenderer.GroupJSON>} groupDefinitions
    * @return {!Element}
    */
-  _renderDefaultCategory(category) {
+  _renderDefaultCategory(category, groupDefinitions) {
     const element = this._dom.createElement('div', 'lh-category');
     element.id = category.id;
     element.appendChild(this._renderCategoryScore(category));
 
-    const passedAudits = category.audits.filter(audit => audit.score === 100);
-    const nonPassedAudits = category.audits.filter(audit => !passedAudits.includes(audit));
+    const manualAudits = category.audits.filter(audit => audit.result.manual);
+    const nonManualAudits = category.audits.filter(audit => !manualAudits.includes(audit));
+    const passedAudits = nonManualAudits.filter(audit => audit.score === 100);
+    const nonPassedAudits = nonManualAudits.filter(audit => !passedAudits.includes(audit));
 
     for (const audit of nonPassedAudits) {
       element.appendChild(this._renderAudit(audit));
     }
 
-    // Don't create a passed section if there are no passed.
-    if (!passedAudits.length) {
-      return element;
+    // Create a passed section if there are passing audits.
+    if (passedAudits.length) {
+      const passedElements = passedAudits.map(audit => this._renderAudit(audit));
+      const passedElem = this._renderPassedAuditsSection(passedElements);
+      element.appendChild(passedElem);
     }
 
-    const passedElements = passedAudits.map(audit => this._renderAudit(audit));
-    const passedElem = this._renderPassedAuditsSection(passedElements);
-    element.appendChild(passedElem);
+    // Render manual audits after passing.
+    const auditsGroupedByGroup = /** @type {!Object<string,
+        !Array<!ReportRenderer.AuditJSON>} */ ({});
+    manualAudits.forEach(audit => {
+      const group = auditsGroupedByGroup[audit.group] || [];
+      group.push(audit);
+      auditsGroupedByGroup[audit.group] = group;
+    });
+
+    Object.keys(auditsGroupedByGroup).forEach(groupId => {
+      const group = groupDefinitions[groupId];
+      const auditGroupElem = this._renderAuditGroup(group);
+
+      this._dom.find('.lh-audit-group__summary', auditGroupElem)
+          .classList.add('lh-audit-group__summary--manual');
+
+      auditsGroupedByGroup[groupId].forEach(audit => {
+        auditGroupElem.appendChild(this._renderAudit(audit));
+      });
+
+      element.appendChild(auditGroupElem);
+    });
+
     return element;
   }
 

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -176,6 +176,7 @@ if (typeof module !== 'undefined' && module.exports) {
  *       rawValue: (number|undefined),
  *       description: string,
  *       informative: boolean,
+ *       manual: boolean,
  *       debugString: string,
  *       displayValue: string,
  *       helpText: string,

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -27,7 +27,7 @@
   --fail-color: #df332f;
   --pass-color: #2b882f;
   --informative-color: #0c50c7;
-  --unknown-color: #757575;
+  --manual-color: #757575;
   --average-color: #ef6c00; /* md orange 800 */
   --warning-color: #ffab00; /* md amber a700 */
 
@@ -214,10 +214,10 @@ summary {
   background-size: var(--lh-score-icon-background-size);
 }
 
-.lh-score--unknown .lh-score__value::after {
+.lh-score--manual .lh-score__value::after {
   background: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><title>manual</title><path d="M2 5h8v2H2z" fill="#fff" fill-rule="evenodd"/></svg>') no-repeat 50% 50%;
   background-size: 18px;
-  background-color: var(--unknown-color);
+  background-color: var(--manual-color);
   width: 20px;
   height:  20px;
   position: relative;
@@ -475,7 +475,7 @@ summary {
 
 .lh-audit-group__summary--manual::-webkit-details-marker {
   display: initial;
-  background: var(--unknown-color) !important;
+  background: var(--manual-color) !important;
 }
 
 .lh-audit-group__description {

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -27,6 +27,7 @@
   --fail-color: #df332f;
   --pass-color: #2b882f;
   --informative-color: #0c50c7;
+  --unknown-color: #757575;
   --average-color: #ef6c00; /* md orange 800 */
   --warning-color: #ffab00; /* md amber a700 */
 
@@ -211,6 +212,15 @@ summary {
 .lh-score--informative .lh-score__value::after {
   background: url('data:image/svg+xml;utf8,<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>info</title><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" fill="#0c50c7"/></svg>') no-repeat 50% 50%;
   background-size: var(--lh-score-icon-background-size);
+}
+
+.lh-score--unknown .lh-score__value::after {
+  background: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><title>manual</title><path d="M2 5h8v2H2z" fill="#fff" fill-rule="evenodd"/></svg>') no-repeat 50% 50%;
+  background-size: 18px;
+  background-color: var(--unknown-color);
+  width: 20px;
+  height:  20px;
+  position: relative;
 }
 
 .lh-score__value--binary {
@@ -449,6 +459,25 @@ summary {
   font-size: 18px;
 }
 
+.lh-audit-group__summary--manual {
+  display: flex;
+  align-items: center;
+  font-size: 15px;
+}
+
+.lh-audit-group__summary--manual .lh-audit-group__header  {
+  font-size: inherit;
+}
+
+.lh-audit-group__summary--manual .lh-toggle-arrow {
+  display: none;
+}
+
+.lh-audit-group__summary--manual::-webkit-details-marker {
+  display: initial;
+  background: var(--unknown-color) !important;
+}
+
 .lh-audit-group__description {
   font-size: 16px;
   color: var(--secondary-text-color);
@@ -574,16 +603,16 @@ summary.lh-passed-audits-summary {
   align-items: center;
 }
 
-summary.lh-passed-audits-summary::-webkit-details-marker {
+summary.lh-passed-audits-summary::-webkit-details-marker,
+.lh-audit-group__summary--manual::-webkit-details-marker {
   background: var(--pass-color);
   color: white;
-  position: relative;
-  content: '';
   padding: 3px 3px 3px 6px;
   border-radius: 2px;
 }
 
-.lh-passed-audits[open] summary.lh-passed-audits-summary::-webkit-details-marker {
+.lh-passed-audits[open] summary.lh-passed-audits-summary::-webkit-details-marker,
+.lh-audit-group[open] summary.lh-audit-group__summary--manual::-webkit-details-marker {
   padding: 3px 5px 3px 4px;
 }
 

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -234,7 +234,8 @@ class Runner {
       'violation-audit.js',
       'accessibility/axe-audit.js',
       'multi-check-audit.js',
-      'byte-efficiency/byte-efficiency-audit.js'
+      'byte-efficiency/byte-efficiency-audit.js',
+      'manual/manual-audit.js'
     ];
 
     const fileList = [
@@ -243,7 +244,8 @@ class Runner {
       ...fs.readdirSync(path.join(__dirname, './audits/accessibility'))
           .map(f => `accessibility/${f}`),
       ...fs.readdirSync(path.join(__dirname, './audits/byte-efficiency'))
-          .map(f => `byte-efficiency/${f}`)
+          .map(f => `byte-efficiency/${f}`),
+      ...fs.readdirSync(path.join(__dirname, './audits/manual')).map(f => `manual/${f}`)
     ];
     return fileList.filter(f => {
       return /\.js$/.test(f) && !ignoredFiles.includes(f);

--- a/lighthouse-core/test/audits/manual-audit-test.js
+++ b/lighthouse-core/test/audits/manual-audit-test.js
@@ -1,6 +1,4 @@
-
 /**
- * @license
  * Copyright 2017 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,28 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
 
-const ManualAudit = require('./manual-audit');
+const ManualAudit = require('../../audits/manual/manual-audit.js');
+const assert = require('assert');
 
-/**
- * @fileoverview Manual PWA audit for cross browser support.
- */
+/* eslint-env mocha */
 
-class PWACrossBrowser extends ManualAudit {
-
-  /**
-   * @return {!AuditMeta}
-   */
+// Extend the Audit class but fail to implement meta. It should throw errors.
+class TestAudit extends ManualAudit {
   static get meta() {
     return Object.assign({
-      category: 'PWA',
-      name: 'pwa-cross-browser',
-      helpText: 'To reach the most number of users, sites should work across every major browser.',
-      description: 'Site works cross-browser',
+      category: 'AuditCategory',
+      name: 'manual-audit',
+      helpText: 'Some help text.',
     }, super.meta);
   }
 }
 
-module.exports = PWACrossBrowser;
+describe('ManualAudit', () => {
+  it('sets defaults', () => {
+    assert.equal(TestAudit.meta.name, 'manual-audit');
+    assert.equal(TestAudit.meta.requiredArtifacts.length, 0);
+    assert.equal(TestAudit.meta.informative, true);
+    assert.equal(TestAudit.meta.manual, true);
+  });
+});

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -110,12 +110,16 @@ describe('CategoryRenderer', () => {
     assert.equal(audits.length, category.audits.length, 'renders correct number of audits');
   });
 
-  it('renders manual audits', () => {
+  it('renders manual audits if the category contains them', () => {
     const pwaCategory = sampleResults.reportCategories.find(cat => cat.id === 'pwa');
     const categoryDOM = renderer.render(pwaCategory, sampleResults.reportGroups);
     assert.ok(categoryDOM.querySelector('.lh-audit-group__summary--manual'));
     assert.equal(categoryDOM.querySelectorAll('.lh-score--informative.lh-score--unknown').length, 3,
         'score shows informative and dash icon');
+
+    const perfCategory = sampleResults.reportCategories.find(cat => cat.id === 'performance');
+    const categoryDOM2 = renderer.render(perfCategory, sampleResults.reportGroups);
+    assert.ok(!categoryDOM2.querySelector('.lh-audit-group__summary--manual'));
   });
 
   describe('performance category', () => {

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -24,6 +24,8 @@ const Util = require('../../../../report/v2/renderer/util.js');
 const URL = require('../../../../lib/url-shim');
 const DOM = require('../../../../report/v2/renderer/dom.js');
 const DetailsRenderer = require('../../../../report/v2/renderer/details-renderer.js');
+const CriticalRequestChainRenderer = require(
+    '../../../../report/v2/renderer/crc-details-renderer.js');
 const CategoryRenderer = require('../../../../report/v2/renderer/category-renderer.js');
 const sampleResults = require('../../../results/sample_v2.json');
 
@@ -35,6 +37,7 @@ describe('CategoryRenderer', () => {
   before(() => {
     global.URL = URL;
     global.Util = Util;
+    global.CriticalRequestChainRenderer = CriticalRequestChainRenderer;
 
     const document = jsdom.jsdom(TEMPLATE_FILE);
     const dom = new DOM(document);
@@ -45,6 +48,7 @@ describe('CategoryRenderer', () => {
   after(() => {
     global.URL = undefined;
     global.Util = undefined;
+    global.CriticalRequestChainRenderer = undefined;
   });
 
   it('renders an audit', () => {
@@ -101,8 +105,17 @@ describe('CategoryRenderer', () => {
     assert.ok(description.querySelector('a'), 'description contains converted markdown links');
 
     const audits = categoryDOM.querySelectorAll('.lh-category > .lh-audit, ' +
-        '.lh-category > .lh-passed-audits > .lh-audit');
+        '.lh-category > .lh-passed-audits > .lh-audit, ' +
+        '.lh-audit-group__summary--manual ~ .lh-audit');
     assert.equal(audits.length, category.audits.length, 'renders correct number of audits');
+  });
+
+  it('renders manual audits', () => {
+    const pwaCategory = sampleResults.reportCategories.find(cat => cat.id === 'pwa');
+    const categoryDOM = renderer.render(pwaCategory, sampleResults.reportGroups);
+    assert.ok(categoryDOM.querySelector('.lh-audit-group__summary--manual'));
+    assert.equal(categoryDOM.querySelectorAll('.lh-score--informative.lh-score--unknown').length, 3,
+        'score shows informative and dash icon');
   });
 
   describe('performance category', () => {
@@ -149,7 +162,7 @@ describe('CategoryRenderer', () => {
       assert.ok(hintElement.querySelector('.lh-perf-hint__title'), 'did not render title');
       assert.ok(hintSparklineElement, 'did not render sparkline');
       assert.ok(hintElement.querySelector('.lh-perf-hint__stats'), 'did not render stats');
-      assert.ok(/Potential savings/.test(hintSparklineElement.title), 'did not render tooltip');
+      assert.ok(hintSparklineElement.title, 'did not render tooltip');
     });
 
     it('renders the performance hints with no extended info', () => {
@@ -234,22 +247,25 @@ describe('CategoryRenderer', () => {
   });
 
 
-  describe('grouping passed/failed', () => {
+  describe('grouping passed/failed/manual', () => {
     it('separates audits in the DOM', () => {
       const category = sampleResults.reportCategories[0];
-      const elem = renderer.render(category);
+      const elem = renderer.render(category, sampleResults.reportGroups);
       const passedAudits = elem.querySelectorAll('.lh-category > .lh-passed-audits > .lh-audit');
       const failedAudits = elem.querySelectorAll('.lh-category > .lh-audit');
+      const manualAudits = elem.querySelectorAll('.lh-audit-group__summary--manual ~ .lh-audit');
 
-      assert.equal(passedAudits.length + failedAudits.length, category.audits.length);
+      assert.equal(passedAudits.length + failedAudits.length + manualAudits.length,
+                   category.audits.length);
       assert.equal(passedAudits.length, 4);
       assert.equal(failedAudits.length, 7);
+      assert.equal(manualAudits.length, 3);
     });
 
     it('doesnt create a passed section if there were 0 passed', () => {
       const category = JSON.parse(JSON.stringify(sampleResults.reportCategories[0]));
       category.audits.forEach(audit => audit.score = 0);
-      const elem = renderer.render(category);
+      const elem = renderer.render(category, sampleResults.reportGroups);
       const passedAudits = elem.querySelectorAll('.lh-category > .lh-passed-audits > .lh-audit');
       const failedAudits = elem.querySelectorAll('.lh-category > .lh-audit');
 

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -114,7 +114,7 @@ describe('CategoryRenderer', () => {
     const pwaCategory = sampleResults.reportCategories.find(cat => cat.id === 'pwa');
     const categoryDOM = renderer.render(pwaCategory, sampleResults.reportGroups);
     assert.ok(categoryDOM.querySelector('.lh-audit-group__summary--manual'));
-    assert.equal(categoryDOM.querySelectorAll('.lh-score--informative.lh-score--unknown').length, 3,
+    assert.equal(categoryDOM.querySelectorAll('.lh-score--informative.lh-score--manual').length, 3,
         'score shows informative and dash icon');
 
     const perfCategory = sampleResults.reportCategories.find(cat => cat.id === 'performance');

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -26,6 +26,8 @@ const DOM = require('../../../../report/v2/renderer/dom.js');
 const DetailsRenderer = require('../../../../report/v2/renderer/details-renderer.js');
 const ReportUIFeatures = require('../../../../report/v2/renderer/report-ui-features.js');
 const CategoryRenderer = require('../../../../report/v2/renderer/category-renderer.js');
+const CriticalRequestChainRenderer = require(
+    '../../../../report/v2/renderer/crc-details-renderer.js');
 const ReportRenderer = require('../../../../report/v2/renderer/report-renderer.js');
 const sampleResults = require('../../../results/sample_v2.json');
 
@@ -39,6 +41,7 @@ describe('ReportRenderer V2', () => {
     global.URL = URL;
     global.Util = Util;
     global.ReportUIFeatures = ReportUIFeatures;
+    global.CriticalRequestChainRenderer = CriticalRequestChainRenderer;
 
     // Stub out matchMedia for Node.
     global.matchMedia = function() {
@@ -62,6 +65,7 @@ describe('ReportRenderer V2', () => {
     global.Util = undefined;
     global.ReportUIFeatures = undefined;
     global.matchMedia = undefined;
+    global.CriticalRequestChainRenderer = undefined;
   });
 
   describe('renderReport', () => {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1,9 +1,9 @@
 {
   "userAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/59.0.3033.0 Mobile Safari/537.36",
-  "lighthouseVersion": "2.0.0-alpha.1",
-  "generatedTime": "2017-05-04T17:10:12.716Z",
-  "initialUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
-  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+  "lighthouseVersion": "2.0.0-alpha.4",
+  "generatedTime": "2017-05-14T18:40:45.644Z",
+  "initialUrl": "http://localhost:3000/dobetterweb/dbw_tester.html",
+  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
   "audits": {
     "is-on-https": {
       "score": false,
@@ -88,21 +88,21 @@
       "helpText": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/no-js)."
     },
     "first-meaningful-paint": {
-      "score": 70,
-      "displayValue": "3041.3ms",
-      "rawValue": 3041.3,
+      "score": 98,
+      "displayValue": "1422.4ms",
+      "rawValue": 1422.4,
       "optimalValue": "< 1,600 ms",
       "extendedInfo": {
         "value": {
           "timestamps": {
-            "navStart": 177804923477,
-            "fCP": 177807964718,
-            "fMP": 177807964730
+            "navStart": 482337143550,
+            "fCP": 482338565967,
+            "fMP": 482338565978
           },
           "timings": {
             "navStart": 0,
-            "fCP": 3041.241,
-            "fMP": 3041.253
+            "fCP": 1422.417,
+            "fMP": 1422.428
           }
         },
         "formatter": "null"
@@ -122,62 +122,113 @@
         "value": {
           "areLatenciesAll3G": true,
           "allRequestLatencies": [
-            150.8799999719483,
-            154.82500000507596,
-            203.930999996373,
-            215.7330000190997,
-            221.29199997289098,
-            221.481999993557,
-            163.90799998771402,
-            158.19600000395462,
-            177.923000010196,
-            2010.1960000174572,
-            2204.622999997808,
-            155.95299997949056,
-            207.00600001146103,
-            154.0190000087024
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+              "latency": "151.95"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+              "latency": "155.11"
+            },
+            null,
+            {
+              "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+              "latency": "156.48"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+              "latency": "163.39"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+              "latency": "170.86"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+              "latency": "177.25"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+              "latency": "183.26"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+              "latency": "156.48"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+              "latency": "156.72"
+            },
+            {
+              "url": "http://localhost:3000/zone.js",
+              "latency": "164.22"
+            },
+            {
+              "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
+              "latency": "837.82"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+              "latency": "153.81"
+            },
+            {
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+              "latency": "157.18"
+            },
+            {
+              "url": "http://localhost:3000/zone.js",
+              "latency": "155.07"
+            },
+            {
+              "url": "http://localhost:3000/favicon.ico",
+              "latency": "154.19"
+            }
           ],
           "isFast": true,
-          "timeToFirstInteractive": 3050.7450000047684
+          "timeToFirstInteractive": 1735.8040000166893
         }
       },
       "scoringMode": "binary",
       "name": "load-fast-enough-for-pwa",
       "category": "PWA",
       "description": "Page load is fast enough on 3G",
-      "helpText": "Satisfied if the _Time To Interactive_ duration is shorter than _10 seconds_, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected)."
+      "helpText": "Satisfied if the Time To Interactive duration is shorter than 10 seconds, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected)."
     },
     "speed-index-metric": {
-      "score": 80,
-      "displayValue": "3051",
-      "rawValue": 3051,
+      "score": 97,
+      "displayValue": "1433",
+      "rawValue": 1433,
       "optimalValue": "< 1,250",
       "extendedInfo": {
         "formatter": "speedline",
         "value": {
           "timings": {
-            "firstVisualChange": 3051,
-            "visuallyComplete": 3051,
-            "speedIndex": 3051.097000002861,
-            "perceptualSpeedIndex": 3051.097000002861
+            "firstVisualChange": 1433,
+            "visuallyComplete": 1433,
+            "speedIndex": 1433.2870000004768,
+            "perceptualSpeedIndex": 1433.2870000004768
           },
           "timestamps": {
-            "firstVisualChange": 177807974477,
-            "visuallyComplete": 177807974477,
-            "speedIndex": 177807974574,
-            "perceptualSpeedIndex": 177807974574
+            "firstVisualChange": 482338576550,
+            "visuallyComplete": 482338576550,
+            "speedIndex": 482338576837,
+            "perceptualSpeedIndex": 482338576837
           },
           "frames": [
             {
-              "timestamp": 177804923.477,
+              "timestamp": 482337143.55,
               "progress": 0
             },
             {
-              "timestamp": 177807974.574,
+              "timestamp": 482338576.837,
               "progress": 100
             },
             {
-              "timestamp": 177808039.717,
+              "timestamp": 482338585.176,
+              "progress": 100
+            },
+            {
+              "timestamp": 482338897.487,
               "progress": 100
             }
           ]
@@ -210,11 +261,11 @@
           },
           {
             "percentile": 0.99,
-            "time": 16.349075434647187
+            "time": 82.478669999472
           },
           {
             "percentile": 1,
-            "time": 24.238000000002103
+            "time": 156.88399999999183
           }
         ],
         "formatter": "null"
@@ -226,13 +277,13 @@
       "helpText": "The score above is an estimate of how long your app takes to respond to user input, in milliseconds. There is a 90% probability that a user encounters this amount of latency, or less. 10% of the time a user can expect additional latency. If your score is higher than Lighthouse's target score, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
     },
     "first-interactive": {
-      "score": 93,
-      "displayValue": "3,050ms",
-      "rawValue": 3050.7450000047684,
+      "score": 99,
+      "displayValue": "1,740ms",
+      "rawValue": 1735.8040000166893,
       "extendedInfo": {
         "value": {
-          "timeInMs": 3050.7450000047684,
-          "timestamp": 177807974222
+          "timeInMs": 1735.8040000166893,
+          "timestamp": 482338879354.00006
         },
         "formatter": "null"
       },
@@ -242,52 +293,129 @@
       "description": "First Interactive (beta)",
       "helpText": "The first point at which necessary scripts of the page have loaded and the CPU is idle enough to handle most user input."
     },
+    "consistently-interactive": {
+      "score": 99,
+      "displayValue": "1,740ms",
+      "rawValue": 1735.8040000610351,
+      "extendedInfo": {
+        "value": {
+          "cpuQuietPeriod": {
+            "start": 482338879.35400003,
+            "end": 482346002.207
+          },
+          "networkQuietPeriod": {
+            "start": 482338404.903,
+            "end": 482346002.207
+          },
+          "cpuQuietPeriods": [
+            {
+              "start": 482338879.35400003,
+              "end": 482346002.207
+            }
+          ],
+          "networkQuietPeriods": [
+            {
+              "start": 482338404.903,
+              "end": 482346002.207
+            }
+          ],
+          "timestamp": 482338879354.00006,
+          "timeInMs": 1735.8040000610351
+        },
+        "formatter": "null"
+      },
+      "scoringMode": "numeric",
+      "name": "consistently-interactive",
+      "category": "Performance",
+      "description": "Consistently Interactive (beta)",
+      "helpText": "The point at which most network resources have finished loading and the CPU is idle for a prolonged period."
+    },
     "time-to-interactive": {
-      "score": 81,
-      "displayValue": "3051.1ms",
-      "rawValue": 3051.1,
+      "score": 97,
+      "displayValue": "1683.3ms",
+      "rawValue": 1683.3,
       "optimalValue": "< 5,000 ms",
       "extendedInfo": {
         "value": {
           "timings": {
-            "onLoad": 3053.918000012636,
-            "fMP": 3041.253,
-            "visuallyReady": 3051.097,
-            "timeToInteractive": 3051.097,
-            "timeToInteractiveB": 3041.2529999911785,
-            "timeToInteractiveC": 3041.2529999911785,
-            "endOfTrace": 8754.877000004053
+            "onLoad": 1729.5439999699593,
+            "fMP": 1422.428,
+            "visuallyReady": 1433.287,
+            "timeToInteractive": 1683.287,
+            "timeToInteractiveB": 1672.4279999732971,
+            "timeToInteractiveC": 1422.4279999732971,
+            "endOfTrace": 8858.657000005245
           },
           "timestamps": {
-            "onLoad": 177807977395,
-            "fMP": 177807964730,
-            "visuallyReady": 177807974574,
-            "timeToInteractive": 177807974574,
-            "timeToInteractiveB": 177807964730,
-            "timeToInteractiveC": 177807964730,
-            "endOfTrace": 177813678354
+            "onLoad": 482338873094,
+            "fMP": 482338565978,
+            "visuallyReady": 482338576837,
+            "timeToInteractive": 482338826837,
+            "timeToInteractiveB": 482338815978,
+            "timeToInteractiveC": 482338565978,
+            "endOfTrace": 482346002207
           },
           "latencies": {
             "timeToInteractive": [
               {
-                "estLatency": 16,
-                "startTime": "3051.1"
+                "estLatency": 106.88399999999996,
+                "startTime": "1433.3"
+              },
+              {
+                "estLatency": 106.88399999999996,
+                "startTime": "1483.3"
+              },
+              {
+                "estLatency": 106.88400000000001,
+                "startTime": "1533.3"
+              },
+              {
+                "estLatency": 106.88400000000001,
+                "startTime": "1583.3"
+              },
+              {
+                "estLatency": 68.51700001621248,
+                "startTime": "1633.3"
+              },
+              {
+                "estLatency": 19.120666672070815,
+                "startTime": "1683.3"
               }
             ],
             "timeToInteractiveB": [
               {
-                "estLatency": 16,
-                "startTime": "3041.3"
+                "estLatency": 106.88400000000013,
+                "startTime": "1422.4"
+              },
+              {
+                "estLatency": 106.88399999999996,
+                "startTime": "1472.4"
+              },
+              {
+                "estLatency": 106.88399999999996,
+                "startTime": "1522.4"
+              },
+              {
+                "estLatency": 106.88400000000001,
+                "startTime": "1572.4"
+              },
+              {
+                "estLatency": 79.3760000433922,
+                "startTime": "1622.4"
+              },
+              {
+                "estLatency": 29.376000043392196,
+                "startTime": "1672.4"
               }
             ],
             "timeToInteractiveC": [
               {
                 "estLatency": 16,
-                "startTime": "3041.3"
+                "startTime": "1422.4"
               }
             ]
           },
-          "expectedLatencyAtTTI": 16
+          "expectedLatencyAtTTI": 19.121
         },
         "formatter": "null"
       },
@@ -310,133 +438,175 @@
       "name": "user-timings",
       "category": "Performance",
       "description": "User Timing marks and measures",
-      "helpText": "Consider instrumenting your app with the User Timing API to create custom, real-world measurements of key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+      "helpText": "Consider instrumenting your app with the User Timing API to create custom, real-world measurements of key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Name"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Type"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Time"
+          }
+        ],
+        "items": []
+      }
     },
     "critical-request-chains": {
       "score": false,
-      "displayValue": "11",
+      "displayValue": "13",
       "rawValue": false,
       "optimalValue": 0,
       "extendedInfo": {
         "formatter": "critical-request-chains",
         "value": {
           "chains": {
-            "75268.1": {
+            "68289.1": {
               "request": {
-                "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                "startTime": 177804.925661,
-                "endTime": 177805.123481,
-                "responseReceivedTime": 177805.080619,
-                "transferSize": 10317
+                "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                "startTime": 482337.146085,
+                "endTime": 482337.352812,
+                "responseReceivedTime": 482337.302538,
+                "transferSize": 10664
               },
               "children": {
-                "75268.3": {
+                "68289.2": {
+                  "request": {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                    "startTime": 482337.376297,
+                    "endTime": 482337.532551,
+                    "responseReceivedTime": 482337.531899,
+                    "transferSize": 984
+                  },
+                  "children": {}
+                },
+                "68289.3": {
                   "request": {
                     "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
-                    "startTime": 177805.117895,
-                    "endTime": 177805.274093,
-                    "responseReceivedTime": 177805.273648,
-                    "transferSize": 859
+                    "startTime": 482337.379707,
+                    "endTime": 482337.39337,
+                    "responseReceivedTime": -1,
+                    "transferSize": 0
                   },
                   "children": {}
                 },
-                "75268.4": {
+                "68289.4": {
                   "request": {
-                    "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
-                    "startTime": 177805.118221,
-                    "endTime": 177805.324375,
-                    "responseReceivedTime": 177805.323597,
-                    "transferSize": 139
+                    "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+                    "startTime": 482337.380844,
+                    "endTime": 482337.541672,
+                    "responseReceivedTime": 482337.538673,
+                    "transferSize": 133
                   },
                   "children": {}
                 },
-                "75268.6": {
+                "68289.5": {
                   "request": {
-                    "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200",
-                    "startTime": 177805.119508,
-                    "endTime": 177805.338533,
-                    "responseReceivedTime": 177805.338083,
-                    "transferSize": 1146
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+                    "startTime": 482337.381144,
+                    "endTime": 482337.546151,
+                    "responseReceivedTime": 482337.545695,
+                    "transferSize": 984
                   },
                   "children": {}
                 },
-                "75268.7": {
+                "68289.6": {
                   "request": {
-                    "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200",
-                    "startTime": 177805.119977,
-                    "endTime": 177805.345399,
-                    "responseReceivedTime": 177805.345063,
-                    "transferSize": 770
+                    "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                    "startTime": 482337.381999,
+                    "endTime": 482337.55391,
+                    "responseReceivedTime": 482337.55344,
+                    "transferSize": 1273
                   },
                   "children": {}
                 },
-                "75268.8": {
+                "68289.7": {
                   "request": {
-                    "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200",
-                    "startTime": 177805.12127,
-                    "endTime": 177805.496218,
-                    "responseReceivedTime": 177805.495865,
-                    "transferSize": 767
+                    "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+                    "startTime": 482337.382781,
+                    "endTime": 482337.56081,
+                    "responseReceivedTime": 482337.560413,
+                    "transferSize": 920
                   },
                   "children": {}
                 },
-                "75268.9": {
+                "68289.8": {
                   "request": {
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-                    "startTime": 177805.122028,
-                    "endTime": 177805.509764,
-                    "responseReceivedTime": 177805.48814,
-                    "transferSize": 1630
+                    "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+                    "startTime": 482337.383554,
+                    "endTime": 482337.567984,
+                    "responseReceivedTime": 482337.567541,
+                    "transferSize": 917
                   },
                   "children": {}
                 },
-                "75268.18": {
+                "68289.9": {
+                  "request": {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                    "startTime": 482337.384843,
+                    "endTime": 482337.689976,
+                    "responseReceivedTime": 482337.689377,
+                    "transferSize": 984
+                  },
+                  "children": {}
+                },
+                "68289.10": {
+                  "request": {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                    "startTime": 482337.385661,
+                    "endTime": 482337.70328,
+                    "responseReceivedTime": 482337.69617,
+                    "transferSize": 1749
+                  },
+                  "children": {}
+                },
+                "68289.11": {
+                  "request": {
+                    "url": "http://localhost:3000/zone.js",
+                    "startTime": 482337.386495,
+                    "endTime": 482338.489729,
+                    "responseReceivedTime": 482337.710627,
+                    "transferSize": 133
+                  },
+                  "children": {}
+                },
+                "68289.12": {
                   "request": {
                     "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
-                    "startTime": 177805.129849,
-                    "endTime": 177805.524424,
-                    "responseReceivedTime": 177805.331196,
-                    "transferSize": 31674
+                    "startTime": 482337.386939,
+                    "endTime": 482338.369126,
+                    "responseReceivedTime": 482338.22519,
+                    "transferSize": 30874
                   },
                   "children": {}
                 },
-                "75268.17": {
+                "68289.22": {
                   "request": {
-                    "url": "http://localhost:10200/zone.js",
-                    "startTime": 177805.129377,
-                    "endTime": 177805.86017,
-                    "responseReceivedTime": 177805.516777,
-                    "transferSize": 71654
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+                    "startTime": 482338.24998,
+                    "endTime": 482338.404903,
+                    "responseReceivedTime": 482338.404314,
+                    "transferSize": 984
                   },
                   "children": {}
                 },
-                "75268.2": {
+                "68289.24": {
                   "request": {
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true",
-                    "startTime": 177805.115359,
-                    "endTime": 177807.12637,
-                    "responseReceivedTime": 177807.126014,
-                    "transferSize": 859
-                  },
-                  "children": {}
-                },
-                "75268.5": {
-                  "request": {
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
-                    "startTime": 177805.11908,
-                    "endTime": 177807.32654,
-                    "responseReceivedTime": 177807.326161,
-                    "transferSize": 859
-                  },
-                  "children": {}
-                },
-                "75268.21": {
-                  "request": {
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-                    "startTime": 177807.426194,
-                    "endTime": 177807.63423,
-                    "responseReceivedTime": 177807.633715,
-                    "transferSize": 859
+                    "url": "http://localhost:3000/zone.js",
+                    "startTime": 482338.577149,
+                    "endTime": 482338.735018,
+                    "responseReceivedTime": 482338.733016,
+                    "transferSize": 133
                   },
                   "children": {}
                 }
@@ -444,9 +614,9 @@
             }
           },
           "longestChain": {
-            "duration": 2708.5690000094473,
+            "duration": 1588.9329999918118,
             "length": 2,
-            "transferSize": 859
+            "transferSize": 133
           }
         }
       },
@@ -455,18 +625,174 @@
       "name": "critical-request-chains",
       "category": "Performance",
       "description": "Critical Request Chains",
-      "helpText": "The Critical Request Chains below show you what resources are required for first render of this page. Improve page load by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+      "helpText": "The Critical Request Chains below show you what resources are required for first render of this page. Improve page load by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains).",
+      "details": {
+        "type": "criticalrequestchain",
+        "header": {
+          "type": "text",
+          "text": "View critical network waterfall:"
+        },
+        "chains": {
+          "68289.1": {
+            "request": {
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+              "startTime": 482337.146085,
+              "endTime": 482337.352812,
+              "responseReceivedTime": 482337.302538,
+              "transferSize": 10664
+            },
+            "children": {
+              "68289.2": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                  "startTime": 482337.376297,
+                  "endTime": 482337.532551,
+                  "responseReceivedTime": 482337.531899,
+                  "transferSize": 984
+                },
+                "children": {}
+              },
+              "68289.3": {
+                "request": {
+                  "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
+                  "startTime": 482337.379707,
+                  "endTime": 482337.39337,
+                  "responseReceivedTime": -1,
+                  "transferSize": 0
+                },
+                "children": {}
+              },
+              "68289.4": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+                  "startTime": 482337.380844,
+                  "endTime": 482337.541672,
+                  "responseReceivedTime": 482337.538673,
+                  "transferSize": 133
+                },
+                "children": {}
+              },
+              "68289.5": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+                  "startTime": 482337.381144,
+                  "endTime": 482337.546151,
+                  "responseReceivedTime": 482337.545695,
+                  "transferSize": 984
+                },
+                "children": {}
+              },
+              "68289.6": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                  "startTime": 482337.381999,
+                  "endTime": 482337.55391,
+                  "responseReceivedTime": 482337.55344,
+                  "transferSize": 1273
+                },
+                "children": {}
+              },
+              "68289.7": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+                  "startTime": 482337.382781,
+                  "endTime": 482337.56081,
+                  "responseReceivedTime": 482337.560413,
+                  "transferSize": 920
+                },
+                "children": {}
+              },
+              "68289.8": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+                  "startTime": 482337.383554,
+                  "endTime": 482337.567984,
+                  "responseReceivedTime": 482337.567541,
+                  "transferSize": 917
+                },
+                "children": {}
+              },
+              "68289.9": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                  "startTime": 482337.384843,
+                  "endTime": 482337.689976,
+                  "responseReceivedTime": 482337.689377,
+                  "transferSize": 984
+                },
+                "children": {}
+              },
+              "68289.10": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                  "startTime": 482337.385661,
+                  "endTime": 482337.70328,
+                  "responseReceivedTime": 482337.69617,
+                  "transferSize": 1749
+                },
+                "children": {}
+              },
+              "68289.11": {
+                "request": {
+                  "url": "http://localhost:3000/zone.js",
+                  "startTime": 482337.386495,
+                  "endTime": 482338.489729,
+                  "responseReceivedTime": 482337.710627,
+                  "transferSize": 133
+                },
+                "children": {}
+              },
+              "68289.12": {
+                "request": {
+                  "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
+                  "startTime": 482337.386939,
+                  "endTime": 482338.369126,
+                  "responseReceivedTime": 482338.22519,
+                  "transferSize": 30874
+                },
+                "children": {}
+              },
+              "68289.22": {
+                "request": {
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+                  "startTime": 482338.24998,
+                  "endTime": 482338.404903,
+                  "responseReceivedTime": 482338.404314,
+                  "transferSize": 984
+                },
+                "children": {}
+              },
+              "68289.24": {
+                "request": {
+                  "url": "http://localhost:3000/zone.js",
+                  "startTime": 482338.577149,
+                  "endTime": 482338.735018,
+                  "responseReceivedTime": 482338.733016,
+                  "transferSize": 133
+                },
+                "children": {}
+              }
+            }
+          }
+        },
+        "longestChain": {
+          "duration": 1588.9329999918118,
+          "length": 2,
+          "transferSize": 133
+        }
+      }
     },
     "webapp-install-banner": {
       "score": false,
       "displayValue": "",
       "rawValue": false,
-      "debugString": "Failures: No manifest was fetched, Site registers a Service Worker.",
+      "debugString": "Failures: No manifest was fetched, Site does not register a Service Worker, Manifest start_url is not cached by a Service Worker.",
       "extendedInfo": {
         "value": {
           "failures": [
             "No manifest was fetched",
-            "Site registers a Service Worker"
+            "Site does not register a Service Worker",
+            "Manifest start_url is not cached by a Service Worker"
           ],
           "manifestValues": {
             "isParseFailure": true,
@@ -562,26 +888,26 @@
         "value": [
           {
             "label": "line: 45",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
             "code": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details.",
             "source": "deprecation",
             "level": "warning",
             "text": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details.",
-            "timestamp": 1493917811116.72,
+            "timestamp": 1494787235458.94,
             "lineNumber": 45,
             "stackTrace": {
               "callFrames": [
                 {
                   "functionName": "",
-                  "scriptId": "107",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                  "scriptId": "32",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                   "lineNumber": 45,
                   "columnNumber": 6
                 },
                 {
                   "functionName": "",
-                  "scriptId": "107",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                  "scriptId": "32",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                   "lineNumber": 48,
                   "columnNumber": 2
                 }
@@ -589,56 +915,56 @@
             }
           },
           {
-            "label": "line: 292",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+            "label": "line: 294",
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
             "code": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.",
             "source": "deprecation",
             "level": "warning",
             "text": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.",
-            "timestamp": 1493917811174.34,
-            "lineNumber": 292,
+            "timestamp": 1494787236069.11,
+            "lineNumber": 294,
             "stackTrace": {
               "callFrames": [
                 {
                   "functionName": "deprecationsTest",
-                  "scriptId": "110",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "lineNumber": 292,
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 294,
                   "columnNumber": 6
                 },
                 {
                   "functionName": "",
-                  "scriptId": "110",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "lineNumber": 312,
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 314,
                   "columnNumber": 2
                 }
               ]
             }
           },
           {
-            "label": "line: 295",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+            "label": "line: 297",
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
             "code": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead.",
             "source": "deprecation",
             "level": "warning",
             "text": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead.",
-            "timestamp": 1493917811178.06,
-            "lineNumber": 295,
+            "timestamp": 1494787236231.84,
+            "lineNumber": 297,
             "stackTrace": {
               "callFrames": [
                 {
                   "functionName": "deprecationsTest",
-                  "scriptId": "110",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "lineNumber": 295,
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 297,
                   "columnNumber": 8
                 },
                 {
                   "functionName": "",
-                  "scriptId": "110",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "lineNumber": 312,
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 314,
                   "columnNumber": 2
                 }
               ]
@@ -651,7 +977,7 @@
             "source": "deprecation",
             "level": "warning",
             "text": "/deep/ combinator is deprecated and will be a no-op in M60, around August 2017. See https://www.chromestatus.com/features/4964279606312960 for more details.",
-            "timestamp": 1493917811228.05
+            "timestamp": 1494787236238.11
           }
         ]
       },
@@ -659,7 +985,121 @@
       "name": "deprecations",
       "category": "Deprecations",
       "description": "Avoids deprecated APIs",
-      "helpText": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated)."
+      "helpText": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "code",
+            "text": "Deprecation / Warning"
+          },
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Line"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "code",
+              "text": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details."
+            },
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.js"
+            },
+            {
+              "type": "text",
+              "text": 45
+            }
+          ],
+          [
+            {
+              "type": "code",
+              "text": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/."
+            },
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": 294
+            }
+          ],
+          [
+            {
+              "type": "code",
+              "text": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead."
+            },
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": 297
+            }
+          ],
+          [
+            {
+              "type": "code",
+              "text": "/deep/ combinator is deprecated and will be a no-op in M60, around August 2017. See https://www.chromestatus.com/features/4964279606312960 for more details."
+            },
+            {
+              "type": "url",
+              "text": ""
+            },
+            {
+              "type": "text"
+            }
+          ]
+        ]
+      }
+    },
+    "pwa-page-transitions": {
+      "score": false,
+      "displayValue": "",
+      "rawValue": false,
+      "scoringMode": "binary",
+      "informative": true,
+      "manual": true,
+      "name": "pwa-page-transitions",
+      "category": "PWA",
+      "description": "Page transitions don't feel like they block on the network",
+      "helpText": "Transitions should feel snappy as you tap around, even on a slow network, a key to perceived performance."
+    },
+    "pwa-cross-browser": {
+      "score": false,
+      "displayValue": "",
+      "rawValue": false,
+      "scoringMode": "binary",
+      "informative": true,
+      "manual": true,
+      "name": "pwa-cross-browser",
+      "category": "PWA",
+      "description": "Site works cross-browser",
+      "helpText": "To reach the most number of users, sites should work across every major browser."
+    },
+    "pwa-each-page-has-url": {
+      "score": false,
+      "displayValue": "",
+      "rawValue": false,
+      "scoringMode": "binary",
+      "informative": true,
+      "manual": true,
+      "name": "pwa-each-page-has-url",
+      "category": "PWA",
+      "description": "Each page has a URL",
+      "helpText": "Ensure individual pages are deep linkable via the URLs and that URLs are unique for the purpose of shareability on social media."
     },
     "accesskeys": {
       "score": true,
@@ -789,7 +1229,7 @@
       "name": "button-name",
       "category": "Accessibility",
       "description": "Buttons have an accessible name.",
-      "helpText": "An accessible name helps convey the purpose of a button. Without one, a screen reader will only announce the word \"button\"."
+      "helpText": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/button-name)."
     },
     "bypass": {
       "score": true,
@@ -1231,70 +1671,70 @@
     },
     "total-byte-weight": {
       "score": 100,
-      "displayValue": "Total size was 129 KB",
-      "rawValue": 132075,
+      "displayValue": "Total size was 51 KB",
+      "rawValue": 52569,
       "optimalValue": "< 1,600 KB",
       "extendedInfo": {
         "formatter": "table",
         "value": {
           "results": [
             {
-              "url": "/zone.js",
-              "totalBytes": 71654,
-              "totalKb": "70 KB",
-              "totalMs": "340ms"
-            },
-            {
               "url": "…3.2.1/jquery.min.js",
-              "totalBytes": 31674,
-              "totalKb": "31 KB",
-              "totalMs": "150ms"
+              "totalBytes": 30874,
+              "totalKb": "30 KB",
+              "totalMs": "130ms"
             },
             {
               "url": "/dobetterweb/dbw_tester.html",
-              "totalBytes": 10317,
+              "totalBytes": 10664,
               "totalKb": "10 KB",
-              "totalMs": "50ms"
-            },
-            {
-              "url": "/dobetterweb/dbw_tester.html",
-              "totalBytes": 10317,
-              "totalKb": "10 KB",
-              "totalMs": "50ms"
+              "totalMs": "40ms"
             },
             {
               "url": "/dobetterweb/dbw_tester.js",
-              "totalBytes": 1630,
+              "totalBytes": 1749,
               "totalKb": "2 KB",
               "totalMs": "10ms"
             },
             {
-              "url": "/dobetterweb/dbw_disabled.css?delay=200",
-              "totalBytes": 1146,
+              "url": "/favicon.ico",
+              "totalBytes": 1616,
+              "totalKb": "2 KB",
+              "totalMs": "10ms"
+            },
+            {
+              "url": "/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+              "totalBytes": 1273,
               "totalKb": "1 KB",
               "totalMs": "10ms"
             },
             {
-              "url": "/dobetterweb/dbw_tester.css?delay=100",
-              "totalBytes": 859,
-              "totalKb": "1 KB",
-              "totalMs": "0ms"
-            },
-            {
-              "url": "/dobetterweb/dbw_tester.css?delay=2000&async=true",
-              "totalBytes": 859,
-              "totalKb": "1 KB",
-              "totalMs": "0ms"
-            },
-            {
               "url": "/dobetterweb/dbw_tester.css?delay=2200",
-              "totalBytes": 859,
+              "totalBytes": 984,
               "totalKb": "1 KB",
               "totalMs": "0ms"
             },
             {
               "url": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-              "totalBytes": 859,
+              "totalBytes": 984,
+              "totalKb": "1 KB",
+              "totalMs": "0ms"
+            },
+            {
+              "url": "/dobetterweb/dbw_tester.css?delay=3000&async=true",
+              "totalBytes": 984,
+              "totalKb": "1 KB",
+              "totalMs": "0ms"
+            },
+            {
+              "url": "/dobetterweb/dbw_tester.css?delay=2000&async=true",
+              "totalBytes": 984,
+              "totalKb": "1 KB",
+              "totalMs": "0ms"
+            },
+            {
+              "url": "/dobetterweb/dbw_partial_a.html?delay=200",
+              "totalBytes": 920,
               "totalKb": "1 KB",
               "totalMs": "0ms"
             }
@@ -1307,11 +1747,173 @@
         }
       },
       "scoringMode": "numeric",
-      "informative": true,
       "name": "total-byte-weight",
       "category": "Network",
       "description": "Avoids enormous network payloads",
-      "helpText": "Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. Try to find ways to reduce the size of required files."
+      "helpText": "Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. Try to find ways to reduce the size of required files.",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Total Size"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Transfer Time"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "…3.2.1/jquery.min.js"
+            },
+            {
+              "type": "text",
+              "text": "30 KB"
+            },
+            {
+              "type": "text",
+              "text": "130ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "10 KB"
+            },
+            {
+              "type": "text",
+              "text": "40ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.js"
+            },
+            {
+              "type": "text",
+              "text": "2 KB"
+            },
+            {
+              "type": "text",
+              "text": "10ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/favicon.ico"
+            },
+            {
+              "type": "text",
+              "text": "2 KB"
+            },
+            {
+              "type": "text",
+              "text": "10ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
+            },
+            {
+              "type": "text",
+              "text": "1 KB"
+            },
+            {
+              "type": "text",
+              "text": "10ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.css?delay=2200"
+            },
+            {
+              "type": "text",
+              "text": "1 KB"
+            },
+            {
+              "type": "text",
+              "text": "0ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+            },
+            {
+              "type": "text",
+              "text": "1 KB"
+            },
+            {
+              "type": "text",
+              "text": "0ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.css?delay=3000&async=true"
+            },
+            {
+              "type": "text",
+              "text": "1 KB"
+            },
+            {
+              "type": "text",
+              "text": "0ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.css?delay=2000&async=true"
+            },
+            {
+              "type": "text",
+              "text": "1 KB"
+            },
+            {
+              "type": "text",
+              "text": "0ms"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_partial_a.html?delay=200"
+            },
+            {
+              "type": "text",
+              "text": "1 KB"
+            },
+            {
+              "type": "text",
+              "text": "0ms"
+            }
+          ]
+        ]
+      }
     },
     "offscreen-images": {
       "score": 100,
@@ -1336,7 +1938,34 @@
       "name": "offscreen-images",
       "category": "Images",
       "description": "Offscreen images",
-      "helpText": "Images that are not above the fold should be lazily loaded after the page is interactive. Consider using the [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) API."
+      "helpText": "Images that are not above the fold should be lazily loaded after the page is interactive. Consider using the [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) API.",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "thumbnail",
+            "text": ""
+          },
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Original"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Potential Savings"
+          }
+        ],
+        "items": []
+      }
     },
     "uses-optimized-images": {
       "score": 100,
@@ -1352,8 +1981,8 @@
             "preview": "",
             "url": "URL",
             "totalKb": "Original",
-            "webpSavings": "WebP Savings",
-            "jpegSavings": "JPEG Savings"
+            "webpSavings": "Savings as WebP",
+            "jpegSavings": "Savings as JPEG"
           }
         }
       },
@@ -1361,40 +1990,61 @@
       "informative": true,
       "name": "uses-optimized-images",
       "category": "Images",
-      "description": "Unoptimized images",
-      "helpText": "Images should be optimized to save network bytes. The following images could have smaller file sizes when compressed with [WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. [Learn more about image optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization)."
+      "description": "Optimize images",
+      "helpText": "Images should be optimized to save network bytes. The following images could have smaller file sizes when compressed with [WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. [Learn more about image optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "thumbnail",
+            "text": ""
+          },
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Original"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Savings as WebP"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Savings as JPEG"
+          }
+        ],
+        "items": []
+      }
     },
     "uses-request-compression": {
-      "score": 65,
-      "displayValue": "Potential savings of 62 KB (~300ms)",
-      "rawValue": 300,
+      "score": 90,
+      "displayValue": "Potential savings of 7 KB (~30ms)",
+      "rawValue": 30,
       "extendedInfo": {
         "formatter": "table",
         "value": {
-          "wastedMs": 300,
-          "wastedKb": 62,
+          "wastedMs": 30,
+          "wastedKb": 7,
           "results": [
             {
-              "url": "/zone.js",
-              "totalBytes": 71501,
-              "wastedBytes": 56204,
-              "wastedPercent": 78.6058936238654,
-              "potentialSavings": "55 KB _79%_",
-              "wastedKb": "55 KB",
-              "wastedMs": "260ms",
-              "totalKb": "70 KB",
-              "totalMs": "340ms"
-            },
-            {
               "url": "/dobetterweb/dbw_tester.html",
-              "totalBytes": 10196,
-              "wastedBytes": 6792,
-              "wastedPercent": 66.61435857198902,
-              "potentialSavings": "7 KB _67%_",
+              "totalBytes": 10390,
+              "wastedBytes": 6935,
+              "wastedPercent": 66.74687199230029,
+              "potentialSavings": "7 KB (67%)",
               "wastedKb": "7 KB",
               "wastedMs": "30ms",
               "totalKb": "10 KB",
-              "totalMs": "50ms"
+              "totalMs": "40ms"
             }
           ],
           "tableHeadings": {
@@ -1408,8 +2058,45 @@
       "informative": true,
       "name": "uses-request-compression",
       "category": "Performance",
-      "description": "Compression enabled for server responses",
-      "helpText": "Text-based responses should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer)."
+      "description": "Enable text compression",
+      "helpText": "Text-based responses should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "Uncompressed resource URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Original"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "GZIP Savings"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "10 KB"
+            },
+            {
+              "type": "text",
+              "text": "7 KB (67%)"
+            }
+          ]
+        ]
+      }
     },
     "uses-responsive-images": {
       "score": 100,
@@ -1433,8 +2120,35 @@
       "informative": true,
       "name": "uses-responsive-images",
       "category": "Images",
-      "description": "Oversized images",
-      "helpText": "Image sizes served should be based on the device display size to save network bytes. Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) and [client hints](https://developers.google.com/web/updates/2015/09/automating-resource-selection-with-client-hints)."
+      "description": "Properly size images",
+      "helpText": "Image sizes served should be based on the device display size to save network bytes. Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) and [client hints](https://developers.google.com/web/updates/2015/09/automating-resource-selection-with-client-hints).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "thumbnail",
+            "text": ""
+          },
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Original"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Potential Savings"
+          }
+        ],
+        "items": []
+      }
     },
     "appcache-manifest": {
       "score": false,
@@ -1468,7 +2182,7 @@
           },
           {
             "title": "Maximum Children",
-            "value": "21",
+            "value": "22",
             "snippet": "Element with most children:\nhead",
             "target": "< 60 nodes"
           }
@@ -1499,7 +2213,7 @@
           },
           {
             "title": "Maximum Children",
-            "value": "21",
+            "value": "22",
             "snippet": "Element with most children:\nhead",
             "target": "< 60 nodes"
           }
@@ -1515,12 +2229,21 @@
         "formatter": "url-list",
         "value": [
           {
+            "href": "https://www.google.com/",
+            "target": "_blank",
+            "rel": "",
             "url": "<a href=\"https://www.google.com/\" target=\"_blank\">"
           },
           {
+            "href": "Unknown",
+            "target": "_blank",
+            "rel": "",
             "url": "<a target=\"_blank\">"
           },
           {
+            "href": "./doesnotexist",
+            "target": "_blank",
+            "rel": "",
             "url": "<a href=\"./doesnotexist\" target=\"_blank\">"
           }
         ]
@@ -1529,7 +2252,72 @@
       "name": "external-anchors-use-rel-noopener",
       "category": "Performance",
       "description": "Opens external anchors using `rel=\"noopener\"`",
-      "helpText": "Open new tabs using `rel=\"noopener\"` to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+      "helpText": "Open new tabs using `rel=\"noopener\"` to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Target"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Rel"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "https://www.google.com/"
+            },
+            {
+              "type": "text",
+              "text": "_blank"
+            },
+            {
+              "type": "text",
+              "text": ""
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "Unknown"
+            },
+            {
+              "type": "text",
+              "text": "_blank"
+            },
+            {
+              "type": "text",
+              "text": ""
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "./doesnotexist"
+            },
+            {
+              "type": "text",
+              "text": "_blank"
+            },
+            {
+              "type": "text",
+              "text": ""
+            }
+          ]
+        ]
+      }
     },
     "geolocation-on-start": {
       "score": false,
@@ -1539,26 +2327,58 @@
         "formatter": "url-list",
         "value": [
           {
-            "label": "line: 253, col: 25",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-            "args": [
-              null
-            ],
-            "line": 253,
-            "col": 25,
-            "isEval": false,
-            "isExtension": false
+            "label": "line: 254",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Only request geolocation information in response to a user gesture.",
+            "timestamp": 1494787235986.89,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 254,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "geolocationOnStartTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 254,
+                  "columnNumber": 24
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 309,
+                  "columnNumber": 2
+                }
+              ]
+            }
           },
           {
-            "label": "line: 257, col: 41",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-            "args": [
-              null
-            ],
-            "line": 257,
-            "col": 41,
-            "isEval": false,
-            "isExtension": false
+            "label": "line: 258",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Only request geolocation information in response to a user gesture.",
+            "timestamp": 1494787235990.42,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 258,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "geolocationOnStartTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 258,
+                  "columnNumber": 40
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 309,
+                  "columnNumber": 2
+                }
+              ]
+            }
           }
         ]
       },
@@ -1566,35 +2386,69 @@
       "name": "geolocation-on-start",
       "category": "UX",
       "description": "Avoids requesting the geolocation permission on page load",
-      "helpText": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+      "helpText": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Location"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 254"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 258"
+            }
+          ]
+        ]
+      }
     },
     "link-blocking-first-paint": {
-      "score": false,
-      "displayValue": "4 resources delayed first paint by 2212ms",
-      "rawValue": false,
+      "score": 90,
+      "displayValue": "3 resources delayed first paint by 180ms",
+      "rawValue": 180,
       "extendedInfo": {
         "formatter": "table",
         "value": {
+          "wastedMs": 180,
           "results": [
-            {
-              "url": "/dobetterweb/dbw_tester.css?delay=100",
-              "totalKb": "1 KB",
-              "totalMs": "108ms"
-            },
             {
               "url": "/dobetterweb/unknown404.css?delay=200",
               "totalKb": "0 KB",
-              "totalMs": "214ms"
+              "totalMs": "161ms"
             },
             {
               "url": "/dobetterweb/dbw_tester.css?delay=2200",
               "totalKb": "1 KB",
-              "totalMs": "2212ms"
+              "totalMs": "165ms"
             },
             {
               "url": "/dobetterweb/dbw_partial_a.html?delay=200",
               "totalKb": "1 KB",
-              "totalMs": "215ms"
+              "totalMs": "180ms"
             }
           ],
           "tableHeadings": {
@@ -1608,122 +2462,73 @@
       "informative": true,
       "name": "link-blocking-first-paint",
       "category": "Performance",
-      "description": "Render-blocking stylesheets",
-      "helpText": "Link elements are blocking the first paint of your page. Consider inlining critical links and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
-    },
-    "no-console-time": {
-      "score": false,
-      "displayValue": "",
-      "rawValue": false,
-      "extendedInfo": {
-        "formatter": "table",
-        "value": {
-          "results": [
+      "description": "Reduce render-blocking stylesheets",
+      "helpText": "Link elements are blocking the first paint of your page. Consider inlining critical links and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Size (KB)"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Delayed Paint By (ms)"
+          }
+        ],
+        "items": [
+          [
             {
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-              "args": [
-                "arg1"
-              ],
-              "line": 142,
-              "col": 11,
-              "isEval": false,
-              "isExtension": false
+              "type": "url",
+              "text": "/dobetterweb/unknown404.css?delay=200"
             },
             {
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-              "args": [
-                "arg2"
-              ],
-              "line": 145,
-              "col": 13,
-              "isEval": false,
-              "isExtension": false
+              "type": "text",
+              "text": "0 KB"
             },
             {
-              "url": "consoleTimeTest (http://localhost:10200/dobetterweb/dbw_tester.html:150:3)",
-              "args": [
-                "arg3"
-              ],
-              "line": 1,
-              "col": 9,
-              "isEval": true,
-              "isExtension": false
+              "type": "text",
+              "text": "161ms"
             }
           ],
-          "tableHeadings": {
-            "url": "URL",
-            "lineCol": "Line/Col",
-            "isEval": "Eval'd?"
-          }
-        }
-      },
-      "scoringMode": "binary",
-      "name": "no-console-time",
-      "category": "JavaScript",
-      "description": "Avoids `console.time()` in its own scripts",
-      "helpText": "Consider using `performance.mark()` and `performance.measure()` from the User Timing API instead. They provide high-precision timestamps, independent of the system clock, and are integrated in the Chrome DevTools Timeline. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/console-time)."
-    },
-    "no-datenow": {
-      "score": false,
-      "displayValue": "",
-      "rawValue": false,
-      "extendedInfo": {
-        "formatter": "table",
-        "value": {
-          "results": [
+          [
             {
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-              "args": [],
-              "line": 26,
-              "col": 18,
-              "isEval": false,
-              "isExtension": false
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.css?delay=2200"
             },
             {
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-              "args": [],
-              "line": 132,
-              "col": 17,
-              "isEval": false,
-              "isExtension": false
+              "type": "text",
+              "text": "1 KB"
             },
             {
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-              "args": [],
-              "line": 135,
-              "col": 18,
-              "isEval": false,
-              "isExtension": false
-            },
-            {
-              "url": "dateNowTest (http://localhost:10200/dobetterweb/dbw_tester.html:136:3)",
-              "args": [],
-              "line": 1,
-              "col": 6,
-              "isEval": true,
-              "isExtension": false
-            },
-            {
-              "url": "dateNowTest (http://localhost:10200/dobetterweb/dbw_tester.html:137:29)",
-              "args": [],
-              "line": 2,
-              "col": 6,
-              "isEval": true,
-              "isExtension": false
+              "type": "text",
+              "text": "165ms"
             }
           ],
-          "tableHeadings": {
-            "url": "URL",
-            "lineCol": "Line/Col",
-            "isEval": "Eval'd?"
-          }
-        }
-      },
-      "scoringMode": "binary",
-      "name": "no-datenow",
-      "category": "JavaScript",
-      "description": "Avoids `Date.now()` in its own scripts",
-      "helpText": "Consider using `performance.now()` from the User Timing API instead. It provides high-precision timestamps, independent of the system clock. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/date-now)."
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_partial_a.html?delay=200"
+            },
+            {
+              "type": "text",
+              "text": "1 KB"
+            },
+            {
+              "type": "text",
+              "text": "180ms"
+            }
+          ]
+        ]
+      }
     },
     "no-document-write": {
       "score": false,
@@ -1733,37 +2538,85 @@
         "formatter": "url-list",
         "value": [
           {
-            "label": "line: 154, col: 12",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-            "args": [
-              "Hi"
-            ],
-            "line": 154,
-            "col": 12,
-            "isEval": false,
-            "isExtension": false
+            "label": "line: 155",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Avoid using document.write().",
+            "timestamp": 1494787235948.6,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 155,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "documentWriteTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 155,
+                  "columnNumber": 11
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 303,
+                  "columnNumber": 2
+                }
+              ]
+            }
           },
           {
-            "label": "line: 155, col: 12",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-            "args": [
-              "There"
-            ],
-            "line": 155,
-            "col": 12,
-            "isEval": false,
-            "isExtension": false
+            "label": "line: 156",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Avoid using document.write().",
+            "timestamp": 1494787235949.37,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 156,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "documentWriteTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 156,
+                  "columnNumber": 11
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 303,
+                  "columnNumber": 2
+                }
+              ]
+            }
           },
           {
-            "label": "line: 156, col: 12",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-            "args": [
-              "2.0!"
-            ],
-            "line": 156,
-            "col": 12,
-            "isEval": false,
-            "isExtension": false
+            "label": "line: 157",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Avoid using document.write().",
+            "timestamp": 1494787235949.8,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 157,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "documentWriteTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 157,
+                  "columnNumber": 11
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 303,
+                  "columnNumber": 2
+                }
+              ]
+            }
           }
         ]
       },
@@ -1771,7 +2624,55 @@
       "name": "no-document-write",
       "category": "Performance",
       "description": "Avoids `document.write()`",
-      "helpText": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+      "helpText": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Location"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 155"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 156"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 157"
+            }
+          ]
+        ]
+      }
     },
     "no-mutation-events": {
       "score": false,
@@ -1782,52 +2683,52 @@
         "value": {
           "results": [
             {
-              "line": 175,
+              "line": 177,
               "col": 61,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
               "type": "DOMNodeInserted",
               "pre": "body.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-              "label": "line: 175, col: 61"
+              "label": "line: 177, col: 61"
             },
             {
-              "line": 181,
+              "line": 183,
               "col": 50,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
               "type": "DOMNodeInserted",
               "pre": "section#touchmove-section.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted on element');\n  })\n\n",
-              "label": "line: 181, col: 50"
+              "label": "line: 183, col: 50"
             },
             {
               "line": 31,
               "col": 56,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
               "type": "DOMNodeInserted",
               "pre": "document.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
               "label": "line: 31, col: 56"
             },
             {
-              "line": 165,
+              "line": 167,
               "col": 56,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
               "type": "DOMNodeInserted",
               "pre": "document.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-              "label": "line: 165, col: 56"
+              "label": "line: 167, col: 56"
             },
             {
-              "line": 170,
+              "line": 172,
               "col": 55,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
               "type": "DOMNodeRemoved",
               "pre": "document.addEventListener('DOMNodeRemoved', function (e) {\n    console.log('DOMNodeRemoved');\n  })\n\n",
-              "label": "line: 170, col: 55"
+              "label": "line: 172, col: 55"
             },
             {
-              "line": 186,
+              "line": 188,
               "col": 54,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
               "type": "DOMNodeInserted",
               "pre": "window.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-              "label": "line: 186, col: 54"
+              "label": "line: 188, col: 54"
             }
           ],
           "tableHeadings": {
@@ -1843,71 +2744,6 @@
       "category": "JavaScript",
       "description": "Avoids Mutation Events in its own scripts",
       "helpText": "Mutation Events are deprecated and harm performance. Consider using Mutation Observers instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/mutation-events)."
-    },
-    "no-old-flexbox": {
-      "score": false,
-      "displayValue": "",
-      "rawValue": false,
-      "extendedInfo": {
-        "formatter": "table",
-        "value": {
-          "results": [
-            {
-              "url": "inline",
-              "location": "4:17",
-              "startLine": 5,
-              "pre": "p,div {\n  display: box;\n}"
-            },
-            {
-              "url": "inline",
-              "location": "4:17",
-              "startLine": 10,
-              "pre": ".span {\n  display: box;\n}"
-            },
-            {
-              "url": "inline",
-              "location": "10:23",
-              "startLine": 14,
-              "pre": ".span2,.span3 {\n  display: box;\n}"
-            },
-            {
-              "url": "inline",
-              "location": "11:28",
-              "startLine": 18,
-              "pre": ".span4,.span5 {\n  display:     box;\n}"
-            },
-            {
-              "url": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-              "location": "2:19",
-              "startLine": 21,
-              "pre": ".doesnotapply {\n  display: flexbox;\n}"
-            },
-            {
-              "url": "inline",
-              "location": "4:24",
-              "startLine": 5,
-              "pre": ".failedselector {\n  -webkit-box-flex: 1;\n}"
-            },
-            {
-              "url": "inline",
-              "location": "4:16",
-              "startLine": 6,
-              "pre": ".failedselector {\n  box-flex: 1;\n}"
-            }
-          ],
-          "tableHeadings": {
-            "url": "URL",
-            "startLine": "Line in the stylesheet / <style>",
-            "location": "Column start/end",
-            "pre": "Snippet"
-          }
-        }
-      },
-      "scoringMode": "binary",
-      "name": "no-old-flexbox",
-      "category": "CSS",
-      "description": "Avoids old CSS flexbox",
-      "helpText": "The 2009 spec of Flexbox is deprecated and is 2.3x slower than the latest spec. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/old-flexbox)."
     },
     "no-websql": {
       "score": false,
@@ -1928,13 +2764,31 @@
         "formatter": "url-list",
         "value": [
           {
-            "label": "line: 263, col: 16",
-            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-            "args": [],
-            "line": 263,
-            "col": 16,
-            "isEval": false,
-            "isExtension": false
+            "label": "line: 264",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Only request notification permission in response to a user gesture.",
+            "timestamp": 1494787235993.33,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 264,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "notificationOnStartTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 264,
+                  "columnNumber": 15
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 310,
+                  "columnNumber": 2
+                }
+              ]
+            }
           }
         ]
       },
@@ -1942,20 +2796,49 @@
       "name": "notification-on-start",
       "category": "UX",
       "description": "Avoids requesting the notification permission on page load",
-      "helpText": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+      "helpText": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Location"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 264"
+            }
+          ]
+        ]
+      }
     },
     "script-blocking-first-paint": {
-      "score": false,
-      "displayValue": "1 resource delayed first paint by 215ms",
-      "rawValue": false,
+      "score": 65,
+      "displayValue": "1 resource delayed first paint by 318ms",
+      "rawValue": 318,
       "extendedInfo": {
         "formatter": "table",
         "value": {
+          "wastedMs": 318,
           "results": [
             {
               "url": "/dobetterweb/dbw_tester.js",
               "totalKb": "2 KB",
-              "totalMs": "215ms"
+              "totalMs": "318ms"
             }
           ],
           "tableHeadings": {
@@ -1969,12 +2852,49 @@
       "informative": true,
       "name": "script-blocking-first-paint",
       "category": "Performance",
-      "description": "Render-blocking scripts",
-      "helpText": "Script elements are blocking the first paint of your page. Consider inlining critical scripts and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+      "description": "Reduce render-blocking scripts",
+      "helpText": "Script elements are blocking the first paint of your page. Consider inlining critical scripts and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Size (KB)"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Delayed Paint By (ms)"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "/dobetterweb/dbw_tester.js"
+            },
+            {
+              "type": "text",
+              "text": "2 KB"
+            },
+            {
+              "type": "text",
+              "text": "318ms"
+            }
+          ]
+        ]
+      }
     },
     "uses-http2": {
       "score": false,
-      "displayValue": "13 requests were not handled over h2",
+      "displayValue": "14 requests were not handled over h2",
       "rawValue": false,
       "extendedInfo": {
         "formatter": "table",
@@ -1982,55 +2902,59 @@
           "results": [
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100"
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200"
+              "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200"
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200"
+              "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200"
+              "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.js"
+              "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/zone.js"
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true"
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.js"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200"
+              "url": "http://localhost:3000/zone.js"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+              "url": "http://localhost:3000/dobetterweb/dbw_tester.html"
             },
             {
               "protocol": "http/1.1",
-              "url": "http://localhost:10200/favicon.ico"
+              "url": "http://localhost:3000/zone.js"
+            },
+            {
+              "protocol": "http/1.1",
+              "url": "http://localhost:3000/favicon.ico"
             }
           ],
           "tableHeadings": {
@@ -2043,62 +2967,346 @@
       "name": "uses-http2",
       "category": "Performance",
       "description": "Uses HTTP/2 for its own resources",
-      "helpText": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+      "helpText": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Protocol"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/unknown404.css?delay=200"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.js"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/zone.js"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/zone.js"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/favicon.ico"
+            },
+            {
+              "type": "text",
+              "text": "http/1.1"
+            }
+          ]
+        ]
+      }
     },
     "uses-passive-event-listeners": {
       "score": false,
       "displayValue": "",
       "rawValue": false,
       "extendedInfo": {
-        "formatter": "table",
-        "value": {
-          "results": [
-            {
-              "line": 224,
-              "col": 44,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-              "type": "touchmove",
-              "pre": "section#touchmove-section.addEventListener('touchmove', function (e) {\n    console.log('touchmove');\n  })\n\n",
-              "label": "line: 224, col: 44"
-            },
-            {
-              "line": 38,
-              "col": 38,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-              "type": "wheel",
-              "pre": "document.addEventListener('wheel', e => {\n    console.log('wheel: arrow function');\n  })\n\n",
-              "label": "line: 38, col: 38"
-            },
-            {
-              "line": 198,
-              "col": 44,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-              "type": "wheel",
-              "pre": "window.addEventListener('wheel', function (e) {\n    console.log('wheel');\n  })\n\n",
-              "label": "line: 198, col: 44"
-            },
-            {
-              "line": 208,
-              "col": 49,
-              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-              "type": "mousewheel",
-              "pre": "window.addEventListener('mousewheel', function (e) {\n    console.log('mousewheel');\n  })\n\n",
-              "label": "line: 208, col: 49"
+        "formatter": "url-list",
+        "value": [
+          {
+            "label": "line: 37",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+            "timestamp": 1494787235458.1,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+            "lineNumber": 37,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "",
+                  "scriptId": "32",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                  "lineNumber": 37,
+                  "columnNumber": 11
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "32",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                  "lineNumber": 48,
+                  "columnNumber": 2
+                }
+              ]
             }
-          ],
-          "tableHeadings": {
-            "url": "URL",
-            "lineCol": "Line/Col",
-            "type": "Type",
-            "pre": "Snippet"
+          },
+          {
+            "label": "line: 199",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+            "timestamp": 1494787235980.47,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 199,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "passiveEventsListenerTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 199,
+                  "columnNumber": 9
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 308,
+                  "columnNumber": 2
+                }
+              ]
+            }
+          },
+          {
+            "label": "line: 209",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Added non-passive event listener to a scroll-blocking 'mousewheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+            "timestamp": 1494787235981.58,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 209,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "passiveEventsListenerTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 209,
+                  "columnNumber": 9
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 308,
+                  "columnNumber": 2
+                }
+              ]
+            }
+          },
+          {
+            "label": "line: 225",
+            "source": "violation",
+            "level": "verbose",
+            "text": "Added non-passive event listener to a scroll-blocking 'touchmove' event. Consider marking event handler as 'passive' to make the page more responsive.",
+            "timestamp": 1494787235982.36,
+            "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+            "lineNumber": 225,
+            "stackTrace": {
+              "callFrames": [
+                {
+                  "functionName": "passiveEventsListenerTest",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 225,
+                  "columnNumber": 5
+                },
+                {
+                  "functionName": "",
+                  "scriptId": "35",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 308,
+                  "columnNumber": 2
+                }
+              ]
+            }
           }
-        }
+        ]
       },
       "scoringMode": "binary",
       "name": "uses-passive-event-listeners",
       "category": "JavaScript",
       "description": "Uses passive listeners to improve scrolling performance",
-      "helpText": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+      "helpText": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).",
+      "details": {
+        "type": "table",
+        "header": "View Details",
+        "itemHeaders": [
+          {
+            "type": "text",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "type": "text",
+            "itemType": "text",
+            "text": "Location"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.js"
+            },
+            {
+              "type": "text",
+              "text": "line: 37"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 199"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 209"
+            }
+          ],
+          [
+            {
+              "type": "url",
+              "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+            },
+            {
+              "type": "text",
+              "text": "line: 225"
+            }
+          ]
+        ]
+      }
     }
   },
   "runtimeConfig": {
@@ -2126,7 +3334,7 @@
     {
       "name": "Progressive Web App",
       "weight": 1,
-      "description": "These audits validate the aspects of a Progressive Web App. They are a subset of the [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
+      "description": "These audits validate the aspects of a Progressive Web App. They are a subset¹ of the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
       "audits": [
         {
           "id": "service-worker",
@@ -2236,30 +3444,77 @@
               "value": {
                 "areLatenciesAll3G": true,
                 "allRequestLatencies": [
-                  150.8799999719483,
-                  154.82500000507596,
-                  203.930999996373,
-                  215.7330000190997,
-                  221.29199997289098,
-                  221.481999993557,
-                  163.90799998771402,
-                  158.19600000395462,
-                  177.923000010196,
-                  2010.1960000174572,
-                  2204.622999997808,
-                  155.95299997949056,
-                  207.00600001146103,
-                  154.0190000087024
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "latency": "151.95"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                    "latency": "155.11"
+                  },
+                  null,
+                  {
+                    "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+                    "latency": "156.48"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+                    "latency": "163.39"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                    "latency": "170.86"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+                    "latency": "177.25"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+                    "latency": "183.26"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                    "latency": "156.48"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                    "latency": "156.72"
+                  },
+                  {
+                    "url": "http://localhost:3000/zone.js",
+                    "latency": "164.22"
+                  },
+                  {
+                    "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
+                    "latency": "837.82"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+                    "latency": "153.81"
+                  },
+                  {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "latency": "157.18"
+                  },
+                  {
+                    "url": "http://localhost:3000/zone.js",
+                    "latency": "155.07"
+                  },
+                  {
+                    "url": "http://localhost:3000/favicon.ico",
+                    "latency": "154.19"
+                  }
                 ],
                 "isFast": true,
-                "timeToFirstInteractive": 3050.7450000047684
+                "timeToFirstInteractive": 1735.8040000166893
               }
             },
             "scoringMode": "binary",
             "name": "load-fast-enough-for-pwa",
             "category": "PWA",
             "description": "Page load is fast enough on 3G",
-            "helpText": "Satisfied if the _Time To Interactive_ duration is shorter than _10 seconds_, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected)."
+            "helpText": "Satisfied if the Time To Interactive duration is shorter than 10 seconds, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected)."
           },
           "score": 100
         },
@@ -2270,12 +3525,13 @@
             "score": false,
             "displayValue": "",
             "rawValue": false,
-            "debugString": "Failures: No manifest was fetched, Site registers a Service Worker.",
+            "debugString": "Failures: No manifest was fetched, Site does not register a Service Worker, Manifest start_url is not cached by a Service Worker.",
             "extendedInfo": {
               "value": {
                 "failures": [
                   "No manifest was fetched",
-                  "Site registers a Service Worker"
+                  "Site does not register a Service Worker",
+                  "Manifest start_url is not cached by a Service Worker"
                 ],
                 "manifestValues": {
                   "isParseFailure": true,
@@ -2384,6 +3640,60 @@
             "helpText": "If the width of your app's content doesn't match the width of the viewport, your app might not be optimized for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport)."
           },
           "score": 100
+        },
+        {
+          "id": "pwa-cross-browser",
+          "weight": 0,
+          "group": "manual-pwa-checks",
+          "result": {
+            "score": false,
+            "displayValue": "",
+            "rawValue": false,
+            "scoringMode": "binary",
+            "informative": true,
+            "manual": true,
+            "name": "pwa-cross-browser",
+            "category": "PWA",
+            "description": "Site works cross-browser",
+            "helpText": "To reach the most number of users, sites should work across every major browser."
+          },
+          "score": 0
+        },
+        {
+          "id": "pwa-page-transitions",
+          "weight": 0,
+          "group": "manual-pwa-checks",
+          "result": {
+            "score": false,
+            "displayValue": "",
+            "rawValue": false,
+            "scoringMode": "binary",
+            "informative": true,
+            "manual": true,
+            "name": "pwa-page-transitions",
+            "category": "PWA",
+            "description": "Page transitions don't feel like they block on the network",
+            "helpText": "Transitions should feel snappy as you tap around, even on a slow network, a key to perceived performance."
+          },
+          "score": 0
+        },
+        {
+          "id": "pwa-each-page-has-url",
+          "weight": 0,
+          "group": "manual-pwa-checks",
+          "result": {
+            "score": false,
+            "displayValue": "",
+            "rawValue": false,
+            "scoringMode": "binary",
+            "informative": true,
+            "manual": true,
+            "name": "pwa-each-page-has-url",
+            "category": "PWA",
+            "description": "Each page has a URL",
+            "helpText": "Ensure individual pages are deep linkable via the URLs and that URLs are unique for the purpose of shareability on social media."
+          },
+          "score": 0
         }
       ],
       "id": "pwa",
@@ -2398,21 +3708,21 @@
           "weight": 5,
           "group": "perf-metric",
           "result": {
-            "score": 70,
-            "displayValue": "3041.3ms",
-            "rawValue": 3041.3,
+            "score": 98,
+            "displayValue": "1422.4ms",
+            "rawValue": 1422.4,
             "optimalValue": "< 1,600 ms",
             "extendedInfo": {
               "value": {
                 "timestamps": {
-                  "navStart": 177804923477,
-                  "fCP": 177807964718,
-                  "fMP": 177807964730
+                  "navStart": 482337143550,
+                  "fCP": 482338565967,
+                  "fMP": 482338565978
                 },
                 "timings": {
                   "navStart": 0,
-                  "fCP": 3041.241,
-                  "fMP": 3041.253
+                  "fCP": 1422.417,
+                  "fMP": 1422.428
                 }
               },
               "formatter": "null"
@@ -2423,43 +3733,47 @@
             "description": "First meaningful paint",
             "helpText": "First meaningful paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
           },
-          "score": 70
+          "score": 98
         },
         {
           "id": "speed-index-metric",
           "weight": 1,
           "group": "perf-metric",
           "result": {
-            "score": 80,
-            "displayValue": "3051",
-            "rawValue": 3051,
+            "score": 97,
+            "displayValue": "1433",
+            "rawValue": 1433,
             "optimalValue": "< 1,250",
             "extendedInfo": {
               "formatter": "speedline",
               "value": {
                 "timings": {
-                  "firstVisualChange": 3051,
-                  "visuallyComplete": 3051,
-                  "speedIndex": 3051.097000002861,
-                  "perceptualSpeedIndex": 3051.097000002861
+                  "firstVisualChange": 1433,
+                  "visuallyComplete": 1433,
+                  "speedIndex": 1433.2870000004768,
+                  "perceptualSpeedIndex": 1433.2870000004768
                 },
                 "timestamps": {
-                  "firstVisualChange": 177807974477,
-                  "visuallyComplete": 177807974477,
-                  "speedIndex": 177807974574,
-                  "perceptualSpeedIndex": 177807974574
+                  "firstVisualChange": 482338576550,
+                  "visuallyComplete": 482338576550,
+                  "speedIndex": 482338576837,
+                  "perceptualSpeedIndex": 482338576837
                 },
                 "frames": [
                   {
-                    "timestamp": 177804923.477,
+                    "timestamp": 482337143.55,
                     "progress": 0
                   },
                   {
-                    "timestamp": 177807974.574,
+                    "timestamp": 482338576.837,
                     "progress": 100
                   },
                   {
-                    "timestamp": 177808039.717,
+                    "timestamp": 482338585.176,
+                    "progress": 100
+                  },
+                  {
+                    "timestamp": 482338897.487,
                     "progress": 100
                   }
                 ]
@@ -2471,7 +3785,7 @@
             "description": "Perceptual Speed Index",
             "helpText": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
           },
-          "score": 80
+          "score": 97
         },
         {
           "id": "estimated-input-latency",
@@ -2498,11 +3812,11 @@
                 },
                 {
                   "percentile": 0.99,
-                  "time": 16.349075434647187
+                  "time": 82.478669999472
                 },
                 {
                   "percentile": 1,
-                  "time": 24.238000000002103
+                  "time": 156.88399999999183
                 }
               ],
               "formatter": "null"
@@ -2520,51 +3834,91 @@
           "weight": 5,
           "group": "perf-metric",
           "result": {
-            "score": 81,
-            "displayValue": "3051.1ms",
-            "rawValue": 3051.1,
+            "score": 97,
+            "displayValue": "1683.3ms",
+            "rawValue": 1683.3,
             "optimalValue": "< 5,000 ms",
             "extendedInfo": {
               "value": {
                 "timings": {
-                  "onLoad": 3053.918000012636,
-                  "fMP": 3041.253,
-                  "visuallyReady": 3051.097,
-                  "timeToInteractive": 3051.097,
-                  "timeToInteractiveB": 3041.2529999911785,
-                  "timeToInteractiveC": 3041.2529999911785,
-                  "endOfTrace": 8754.877000004053
+                  "onLoad": 1729.5439999699593,
+                  "fMP": 1422.428,
+                  "visuallyReady": 1433.287,
+                  "timeToInteractive": 1683.287,
+                  "timeToInteractiveB": 1672.4279999732971,
+                  "timeToInteractiveC": 1422.4279999732971,
+                  "endOfTrace": 8858.657000005245
                 },
                 "timestamps": {
-                  "onLoad": 177807977395,
-                  "fMP": 177807964730,
-                  "visuallyReady": 177807974574,
-                  "timeToInteractive": 177807974574,
-                  "timeToInteractiveB": 177807964730,
-                  "timeToInteractiveC": 177807964730,
-                  "endOfTrace": 177813678354
+                  "onLoad": 482338873094,
+                  "fMP": 482338565978,
+                  "visuallyReady": 482338576837,
+                  "timeToInteractive": 482338826837,
+                  "timeToInteractiveB": 482338815978,
+                  "timeToInteractiveC": 482338565978,
+                  "endOfTrace": 482346002207
                 },
                 "latencies": {
                   "timeToInteractive": [
                     {
-                      "estLatency": 16,
-                      "startTime": "3051.1"
+                      "estLatency": 106.88399999999996,
+                      "startTime": "1433.3"
+                    },
+                    {
+                      "estLatency": 106.88399999999996,
+                      "startTime": "1483.3"
+                    },
+                    {
+                      "estLatency": 106.88400000000001,
+                      "startTime": "1533.3"
+                    },
+                    {
+                      "estLatency": 106.88400000000001,
+                      "startTime": "1583.3"
+                    },
+                    {
+                      "estLatency": 68.51700001621248,
+                      "startTime": "1633.3"
+                    },
+                    {
+                      "estLatency": 19.120666672070815,
+                      "startTime": "1683.3"
                     }
                   ],
                   "timeToInteractiveB": [
                     {
-                      "estLatency": 16,
-                      "startTime": "3041.3"
+                      "estLatency": 106.88400000000013,
+                      "startTime": "1422.4"
+                    },
+                    {
+                      "estLatency": 106.88399999999996,
+                      "startTime": "1472.4"
+                    },
+                    {
+                      "estLatency": 106.88399999999996,
+                      "startTime": "1522.4"
+                    },
+                    {
+                      "estLatency": 106.88400000000001,
+                      "startTime": "1572.4"
+                    },
+                    {
+                      "estLatency": 79.3760000433922,
+                      "startTime": "1622.4"
+                    },
+                    {
+                      "estLatency": 29.376000043392196,
+                      "startTime": "1672.4"
                     }
                   ],
                   "timeToInteractiveC": [
                     {
                       "estLatency": 16,
-                      "startTime": "3041.3"
+                      "startTime": "1422.4"
                     }
                   ]
                 },
-                "expectedLatencyAtTTI": 16
+                "expectedLatencyAtTTI": 19.121
               },
               "formatter": "null"
             },
@@ -2574,20 +3928,20 @@
             "description": "Time To Interactive (alpha)",
             "helpText": "Time to Interactive identifies the time at which your app appears to be ready enough to interact with. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive)."
           },
-          "score": 81
+          "score": 97
         },
         {
           "id": "first-interactive",
           "weight": 5,
           "group": "perf-metric",
           "result": {
-            "score": 93,
-            "displayValue": "3,050ms",
-            "rawValue": 3050.7450000047684,
+            "score": 99,
+            "displayValue": "1,740ms",
+            "rawValue": 1735.8040000166893,
             "extendedInfo": {
               "value": {
-                "timeInMs": 3050.7450000047684,
-                "timestamp": 177807974222
+                "timeInMs": 1735.8040000166893,
+                "timestamp": 482338879354.00006
               },
               "formatter": "null"
             },
@@ -2597,39 +3951,78 @@
             "description": "First Interactive (beta)",
             "helpText": "The first point at which necessary scripts of the page have loaded and the CPU is idle enough to handle most user input."
           },
-          "score": 93
+          "score": 99
+        },
+        {
+          "id": "consistently-interactive",
+          "weight": 5,
+          "group": "perf-metric",
+          "result": {
+            "score": 99,
+            "displayValue": "1,740ms",
+            "rawValue": 1735.8040000610351,
+            "extendedInfo": {
+              "value": {
+                "cpuQuietPeriod": {
+                  "start": 482338879.35400003,
+                  "end": 482346002.207
+                },
+                "networkQuietPeriod": {
+                  "start": 482338404.903,
+                  "end": 482346002.207
+                },
+                "cpuQuietPeriods": [
+                  {
+                    "start": 482338879.35400003,
+                    "end": 482346002.207
+                  }
+                ],
+                "networkQuietPeriods": [
+                  {
+                    "start": 482338404.903,
+                    "end": 482346002.207
+                  }
+                ],
+                "timestamp": 482338879354.00006,
+                "timeInMs": 1735.8040000610351
+              },
+              "formatter": "null"
+            },
+            "scoringMode": "numeric",
+            "name": "consistently-interactive",
+            "category": "Performance",
+            "description": "Consistently Interactive (beta)",
+            "helpText": "The point at which most network resources have finished loading and the CPU is idle for a prolonged period."
+          },
+          "score": 99
         },
         {
           "id": "link-blocking-first-paint",
           "weight": 0,
           "group": "perf-hint",
           "result": {
-            "score": false,
-            "displayValue": "4 resources delayed first paint by 2212ms",
-            "rawValue": false,
+            "score": 90,
+            "displayValue": "3 resources delayed first paint by 180ms",
+            "rawValue": 180,
             "extendedInfo": {
               "formatter": "table",
               "value": {
+                "wastedMs": 180,
                 "results": [
-                  {
-                    "url": "/dobetterweb/dbw_tester.css?delay=100",
-                    "totalKb": "1 KB",
-                    "totalMs": "108ms"
-                  },
                   {
                     "url": "/dobetterweb/unknown404.css?delay=200",
                     "totalKb": "0 KB",
-                    "totalMs": "214ms"
+                    "totalMs": "161ms"
                   },
                   {
                     "url": "/dobetterweb/dbw_tester.css?delay=2200",
                     "totalKb": "1 KB",
-                    "totalMs": "2212ms"
+                    "totalMs": "165ms"
                   },
                   {
                     "url": "/dobetterweb/dbw_partial_a.html?delay=200",
                     "totalKb": "1 KB",
-                    "totalMs": "215ms"
+                    "totalMs": "180ms"
                   }
                 ],
                 "tableHeadings": {
@@ -2643,27 +4036,93 @@
             "informative": true,
             "name": "link-blocking-first-paint",
             "category": "Performance",
-            "description": "Render-blocking stylesheets",
-            "helpText": "Link elements are blocking the first paint of your page. Consider inlining critical links and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+            "description": "Reduce render-blocking stylesheets",
+            "helpText": "Link elements are blocking the first paint of your page. Consider inlining critical links and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Size (KB)"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Delayed Paint By (ms)"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/unknown404.css?delay=200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "0 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "161ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.css?delay=2200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "1 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "165ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_partial_a.html?delay=200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "1 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "180ms"
+                  }
+                ]
+              ]
+            }
           },
-          "score": 0
+          "score": 90
         },
         {
           "id": "script-blocking-first-paint",
           "weight": 0,
           "group": "perf-hint",
           "result": {
-            "score": false,
-            "displayValue": "1 resource delayed first paint by 215ms",
-            "rawValue": false,
+            "score": 65,
+            "displayValue": "1 resource delayed first paint by 318ms",
+            "rawValue": 318,
             "extendedInfo": {
               "formatter": "table",
               "value": {
+                "wastedMs": 318,
                 "results": [
                   {
                     "url": "/dobetterweb/dbw_tester.js",
                     "totalKb": "2 KB",
-                    "totalMs": "215ms"
+                    "totalMs": "318ms"
                   }
                 ],
                 "tableHeadings": {
@@ -2677,10 +4136,47 @@
             "informative": true,
             "name": "script-blocking-first-paint",
             "category": "Performance",
-            "description": "Render-blocking scripts",
-            "helpText": "Script elements are blocking the first paint of your page. Consider inlining critical scripts and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+            "description": "Reduce render-blocking scripts",
+            "helpText": "Script elements are blocking the first paint of your page. Consider inlining critical scripts and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Size (KB)"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Delayed Paint By (ms)"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.js"
+                  },
+                  {
+                    "type": "text",
+                    "text": "2 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "318ms"
+                  }
+                ]
+              ]
+            }
           },
-          "score": 0
+          "score": 65
         },
         {
           "id": "uses-optimized-images",
@@ -2700,8 +4196,8 @@
                   "preview": "",
                   "url": "URL",
                   "totalKb": "Original",
-                  "webpSavings": "WebP Savings",
-                  "jpegSavings": "JPEG Savings"
+                  "webpSavings": "Savings as WebP",
+                  "jpegSavings": "Savings as JPEG"
                 }
               }
             },
@@ -2709,8 +4205,40 @@
             "informative": true,
             "name": "uses-optimized-images",
             "category": "Images",
-            "description": "Unoptimized images",
-            "helpText": "Images should be optimized to save network bytes. The following images could have smaller file sizes when compressed with [WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. [Learn more about image optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization)."
+            "description": "Optimize images",
+            "helpText": "Images should be optimized to save network bytes. The following images could have smaller file sizes when compressed with [WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. [Learn more about image optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "thumbnail",
+                  "text": ""
+                },
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Original"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Savings as WebP"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Savings as JPEG"
+                }
+              ],
+              "items": []
+            }
           },
           "score": 100
         },
@@ -2719,36 +4247,25 @@
           "weight": 0,
           "group": "perf-hint",
           "result": {
-            "score": 65,
-            "displayValue": "Potential savings of 62 KB (~300ms)",
-            "rawValue": 300,
+            "score": 90,
+            "displayValue": "Potential savings of 7 KB (~30ms)",
+            "rawValue": 30,
             "extendedInfo": {
               "formatter": "table",
               "value": {
-                "wastedMs": 300,
-                "wastedKb": 62,
+                "wastedMs": 30,
+                "wastedKb": 7,
                 "results": [
                   {
-                    "url": "/zone.js",
-                    "totalBytes": 71501,
-                    "wastedBytes": 56204,
-                    "wastedPercent": 78.6058936238654,
-                    "potentialSavings": "55 KB _79%_",
-                    "wastedKb": "55 KB",
-                    "wastedMs": "260ms",
-                    "totalKb": "70 KB",
-                    "totalMs": "340ms"
-                  },
-                  {
                     "url": "/dobetterweb/dbw_tester.html",
-                    "totalBytes": 10196,
-                    "wastedBytes": 6792,
-                    "wastedPercent": 66.61435857198902,
-                    "potentialSavings": "7 KB _67%_",
+                    "totalBytes": 10390,
+                    "wastedBytes": 6935,
+                    "wastedPercent": 66.74687199230029,
+                    "potentialSavings": "7 KB (67%)",
                     "wastedKb": "7 KB",
                     "wastedMs": "30ms",
                     "totalKb": "10 KB",
-                    "totalMs": "50ms"
+                    "totalMs": "40ms"
                   }
                 ],
                 "tableHeadings": {
@@ -2762,10 +4279,47 @@
             "informative": true,
             "name": "uses-request-compression",
             "category": "Performance",
-            "description": "Compression enabled for server responses",
-            "helpText": "Text-based responses should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer)."
+            "description": "Enable text compression",
+            "helpText": "Text-based responses should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "Uncompressed resource URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Original"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "GZIP Savings"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "10 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "7 KB (67%)"
+                  }
+                ]
+              ]
+            }
           },
-          "score": 65
+          "score": 90
         },
         {
           "id": "uses-responsive-images",
@@ -2793,8 +4347,35 @@
             "informative": true,
             "name": "uses-responsive-images",
             "category": "Images",
-            "description": "Oversized images",
-            "helpText": "Image sizes served should be based on the device display size to save network bytes. Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) and [client hints](https://developers.google.com/web/updates/2015/09/automating-resource-selection-with-client-hints)."
+            "description": "Properly size images",
+            "helpText": "Image sizes served should be based on the device display size to save network bytes. Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) and [client hints](https://developers.google.com/web/updates/2015/09/automating-resource-selection-with-client-hints).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "thumbnail",
+                  "text": ""
+                },
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Original"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Potential Savings"
+                }
+              ],
+              "items": []
+            }
           },
           "score": 100
         },
@@ -2804,70 +4385,70 @@
           "group": "perf-info",
           "result": {
             "score": 100,
-            "displayValue": "Total size was 129 KB",
-            "rawValue": 132075,
+            "displayValue": "Total size was 51 KB",
+            "rawValue": 52569,
             "optimalValue": "< 1,600 KB",
             "extendedInfo": {
               "formatter": "table",
               "value": {
                 "results": [
                   {
-                    "url": "/zone.js",
-                    "totalBytes": 71654,
-                    "totalKb": "70 KB",
-                    "totalMs": "340ms"
-                  },
-                  {
                     "url": "…3.2.1/jquery.min.js",
-                    "totalBytes": 31674,
-                    "totalKb": "31 KB",
-                    "totalMs": "150ms"
+                    "totalBytes": 30874,
+                    "totalKb": "30 KB",
+                    "totalMs": "130ms"
                   },
                   {
                     "url": "/dobetterweb/dbw_tester.html",
-                    "totalBytes": 10317,
+                    "totalBytes": 10664,
                     "totalKb": "10 KB",
-                    "totalMs": "50ms"
-                  },
-                  {
-                    "url": "/dobetterweb/dbw_tester.html",
-                    "totalBytes": 10317,
-                    "totalKb": "10 KB",
-                    "totalMs": "50ms"
+                    "totalMs": "40ms"
                   },
                   {
                     "url": "/dobetterweb/dbw_tester.js",
-                    "totalBytes": 1630,
+                    "totalBytes": 1749,
                     "totalKb": "2 KB",
                     "totalMs": "10ms"
                   },
                   {
-                    "url": "/dobetterweb/dbw_disabled.css?delay=200",
-                    "totalBytes": 1146,
+                    "url": "/favicon.ico",
+                    "totalBytes": 1616,
+                    "totalKb": "2 KB",
+                    "totalMs": "10ms"
+                  },
+                  {
+                    "url": "/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                    "totalBytes": 1273,
                     "totalKb": "1 KB",
                     "totalMs": "10ms"
                   },
                   {
-                    "url": "/dobetterweb/dbw_tester.css?delay=100",
-                    "totalBytes": 859,
-                    "totalKb": "1 KB",
-                    "totalMs": "0ms"
-                  },
-                  {
-                    "url": "/dobetterweb/dbw_tester.css?delay=2000&async=true",
-                    "totalBytes": 859,
-                    "totalKb": "1 KB",
-                    "totalMs": "0ms"
-                  },
-                  {
                     "url": "/dobetterweb/dbw_tester.css?delay=2200",
-                    "totalBytes": 859,
+                    "totalBytes": 984,
                     "totalKb": "1 KB",
                     "totalMs": "0ms"
                   },
                   {
                     "url": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-                    "totalBytes": 859,
+                    "totalBytes": 984,
+                    "totalKb": "1 KB",
+                    "totalMs": "0ms"
+                  },
+                  {
+                    "url": "/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                    "totalBytes": 984,
+                    "totalKb": "1 KB",
+                    "totalMs": "0ms"
+                  },
+                  {
+                    "url": "/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                    "totalBytes": 984,
+                    "totalKb": "1 KB",
+                    "totalMs": "0ms"
+                  },
+                  {
+                    "url": "/dobetterweb/dbw_partial_a.html?delay=200",
+                    "totalBytes": 920,
                     "totalKb": "1 KB",
                     "totalMs": "0ms"
                   }
@@ -2880,11 +4461,173 @@
               }
             },
             "scoringMode": "numeric",
-            "informative": true,
             "name": "total-byte-weight",
             "category": "Network",
             "description": "Avoids enormous network payloads",
-            "helpText": "Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. Try to find ways to reduce the size of required files."
+            "helpText": "Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. Try to find ways to reduce the size of required files.",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Total Size"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Transfer Time"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "…3.2.1/jquery.min.js"
+                  },
+                  {
+                    "type": "text",
+                    "text": "30 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "130ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "10 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "40ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.js"
+                  },
+                  {
+                    "type": "text",
+                    "text": "2 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "10ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/favicon.ico"
+                  },
+                  {
+                    "type": "text",
+                    "text": "2 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "10ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
+                  },
+                  {
+                    "type": "text",
+                    "text": "1 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "10ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.css?delay=2200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "1 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "0ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "1 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "0ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.css?delay=3000&async=true"
+                  },
+                  {
+                    "type": "text",
+                    "text": "1 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "0ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.css?delay=2000&async=true"
+                  },
+                  {
+                    "type": "text",
+                    "text": "1 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "0ms"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_partial_a.html?delay=200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "1 KB"
+                  },
+                  {
+                    "type": "text",
+                    "text": "0ms"
+                  }
+                ]
+              ]
+            }
           },
           "score": 100
         },
@@ -2913,7 +4656,7 @@
                 },
                 {
                   "title": "Maximum Children",
-                  "value": "21",
+                  "value": "22",
                   "snippet": "Element with most children:\nhead",
                   "target": "< 60 nodes"
                 }
@@ -2944,7 +4687,7 @@
                 },
                 {
                   "title": "Maximum Children",
-                  "value": "21",
+                  "value": "22",
                   "snippet": "Element with most children:\nhead",
                   "target": "< 60 nodes"
                 }
@@ -2959,129 +4702,149 @@
           "group": "perf-info",
           "result": {
             "score": false,
-            "displayValue": "11",
+            "displayValue": "13",
             "rawValue": false,
             "optimalValue": 0,
             "extendedInfo": {
               "formatter": "critical-request-chains",
               "value": {
                 "chains": {
-                  "75268.1": {
+                  "68289.1": {
                     "request": {
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                      "startTime": 177804.925661,
-                      "endTime": 177805.123481,
-                      "responseReceivedTime": 177805.080619,
-                      "transferSize": 10317
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                      "startTime": 482337.146085,
+                      "endTime": 482337.352812,
+                      "responseReceivedTime": 482337.302538,
+                      "transferSize": 10664
                     },
                     "children": {
-                      "75268.3": {
+                      "68289.2": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                          "startTime": 482337.376297,
+                          "endTime": 482337.532551,
+                          "responseReceivedTime": 482337.531899,
+                          "transferSize": 984
+                        },
+                        "children": {}
+                      },
+                      "68289.3": {
                         "request": {
                           "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
-                          "startTime": 177805.117895,
-                          "endTime": 177805.274093,
-                          "responseReceivedTime": 177805.273648,
-                          "transferSize": 859
+                          "startTime": 482337.379707,
+                          "endTime": 482337.39337,
+                          "responseReceivedTime": -1,
+                          "transferSize": 0
                         },
                         "children": {}
                       },
-                      "75268.4": {
+                      "68289.4": {
                         "request": {
-                          "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
-                          "startTime": 177805.118221,
-                          "endTime": 177805.324375,
-                          "responseReceivedTime": 177805.323597,
-                          "transferSize": 139
+                          "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+                          "startTime": 482337.380844,
+                          "endTime": 482337.541672,
+                          "responseReceivedTime": 482337.538673,
+                          "transferSize": 133
                         },
                         "children": {}
                       },
-                      "75268.6": {
+                      "68289.5": {
                         "request": {
-                          "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200",
-                          "startTime": 177805.119508,
-                          "endTime": 177805.338533,
-                          "responseReceivedTime": 177805.338083,
-                          "transferSize": 1146
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+                          "startTime": 482337.381144,
+                          "endTime": 482337.546151,
+                          "responseReceivedTime": 482337.545695,
+                          "transferSize": 984
                         },
                         "children": {}
                       },
-                      "75268.7": {
+                      "68289.6": {
                         "request": {
-                          "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200",
-                          "startTime": 177805.119977,
-                          "endTime": 177805.345399,
-                          "responseReceivedTime": 177805.345063,
-                          "transferSize": 770
+                          "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                          "startTime": 482337.381999,
+                          "endTime": 482337.55391,
+                          "responseReceivedTime": 482337.55344,
+                          "transferSize": 1273
                         },
                         "children": {}
                       },
-                      "75268.8": {
+                      "68289.7": {
                         "request": {
-                          "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200",
-                          "startTime": 177805.12127,
-                          "endTime": 177805.496218,
-                          "responseReceivedTime": 177805.495865,
-                          "transferSize": 767
+                          "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+                          "startTime": 482337.382781,
+                          "endTime": 482337.56081,
+                          "responseReceivedTime": 482337.560413,
+                          "transferSize": 920
                         },
                         "children": {}
                       },
-                      "75268.9": {
+                      "68289.8": {
                         "request": {
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-                          "startTime": 177805.122028,
-                          "endTime": 177805.509764,
-                          "responseReceivedTime": 177805.48814,
-                          "transferSize": 1630
+                          "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+                          "startTime": 482337.383554,
+                          "endTime": 482337.567984,
+                          "responseReceivedTime": 482337.567541,
+                          "transferSize": 917
                         },
                         "children": {}
                       },
-                      "75268.18": {
+                      "68289.9": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                          "startTime": 482337.384843,
+                          "endTime": 482337.689976,
+                          "responseReceivedTime": 482337.689377,
+                          "transferSize": 984
+                        },
+                        "children": {}
+                      },
+                      "68289.10": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                          "startTime": 482337.385661,
+                          "endTime": 482337.70328,
+                          "responseReceivedTime": 482337.69617,
+                          "transferSize": 1749
+                        },
+                        "children": {}
+                      },
+                      "68289.11": {
+                        "request": {
+                          "url": "http://localhost:3000/zone.js",
+                          "startTime": 482337.386495,
+                          "endTime": 482338.489729,
+                          "responseReceivedTime": 482337.710627,
+                          "transferSize": 133
+                        },
+                        "children": {}
+                      },
+                      "68289.12": {
                         "request": {
                           "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
-                          "startTime": 177805.129849,
-                          "endTime": 177805.524424,
-                          "responseReceivedTime": 177805.331196,
-                          "transferSize": 31674
+                          "startTime": 482337.386939,
+                          "endTime": 482338.369126,
+                          "responseReceivedTime": 482338.22519,
+                          "transferSize": 30874
                         },
                         "children": {}
                       },
-                      "75268.17": {
+                      "68289.22": {
                         "request": {
-                          "url": "http://localhost:10200/zone.js",
-                          "startTime": 177805.129377,
-                          "endTime": 177805.86017,
-                          "responseReceivedTime": 177805.516777,
-                          "transferSize": 71654
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+                          "startTime": 482338.24998,
+                          "endTime": 482338.404903,
+                          "responseReceivedTime": 482338.404314,
+                          "transferSize": 984
                         },
                         "children": {}
                       },
-                      "75268.2": {
+                      "68289.24": {
                         "request": {
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true",
-                          "startTime": 177805.115359,
-                          "endTime": 177807.12637,
-                          "responseReceivedTime": 177807.126014,
-                          "transferSize": 859
-                        },
-                        "children": {}
-                      },
-                      "75268.5": {
-                        "request": {
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
-                          "startTime": 177805.11908,
-                          "endTime": 177807.32654,
-                          "responseReceivedTime": 177807.326161,
-                          "transferSize": 859
-                        },
-                        "children": {}
-                      },
-                      "75268.21": {
-                        "request": {
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-                          "startTime": 177807.426194,
-                          "endTime": 177807.63423,
-                          "responseReceivedTime": 177807.633715,
-                          "transferSize": 859
+                          "url": "http://localhost:3000/zone.js",
+                          "startTime": 482338.577149,
+                          "endTime": 482338.735018,
+                          "responseReceivedTime": 482338.733016,
+                          "transferSize": 133
                         },
                         "children": {}
                       }
@@ -3089,9 +4852,9 @@
                   }
                 },
                 "longestChain": {
-                  "duration": 2708.5690000094473,
+                  "duration": 1588.9329999918118,
                   "length": 2,
-                  "transferSize": 859
+                  "transferSize": 133
                 }
               }
             },
@@ -3100,7 +4863,162 @@
             "name": "critical-request-chains",
             "category": "Performance",
             "description": "Critical Request Chains",
-            "helpText": "The Critical Request Chains below show you what resources are required for first render of this page. Improve page load by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+            "helpText": "The Critical Request Chains below show you what resources are required for first render of this page. Improve page load by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains).",
+            "details": {
+              "type": "criticalrequestchain",
+              "header": {
+                "type": "text",
+                "text": "View critical network waterfall:"
+              },
+              "chains": {
+                "68289.1": {
+                  "request": {
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "startTime": 482337.146085,
+                    "endTime": 482337.352812,
+                    "responseReceivedTime": 482337.302538,
+                    "transferSize": 10664
+                  },
+                  "children": {
+                    "68289.2": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                        "startTime": 482337.376297,
+                        "endTime": 482337.532551,
+                        "responseReceivedTime": 482337.531899,
+                        "transferSize": 984
+                      },
+                      "children": {}
+                    },
+                    "68289.3": {
+                      "request": {
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
+                        "startTime": 482337.379707,
+                        "endTime": 482337.39337,
+                        "responseReceivedTime": -1,
+                        "transferSize": 0
+                      },
+                      "children": {}
+                    },
+                    "68289.4": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+                        "startTime": 482337.380844,
+                        "endTime": 482337.541672,
+                        "responseReceivedTime": 482337.538673,
+                        "transferSize": 133
+                      },
+                      "children": {}
+                    },
+                    "68289.5": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+                        "startTime": 482337.381144,
+                        "endTime": 482337.546151,
+                        "responseReceivedTime": 482337.545695,
+                        "transferSize": 984
+                      },
+                      "children": {}
+                    },
+                    "68289.6": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                        "startTime": 482337.381999,
+                        "endTime": 482337.55391,
+                        "responseReceivedTime": 482337.55344,
+                        "transferSize": 1273
+                      },
+                      "children": {}
+                    },
+                    "68289.7": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+                        "startTime": 482337.382781,
+                        "endTime": 482337.56081,
+                        "responseReceivedTime": 482337.560413,
+                        "transferSize": 920
+                      },
+                      "children": {}
+                    },
+                    "68289.8": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+                        "startTime": 482337.383554,
+                        "endTime": 482337.567984,
+                        "responseReceivedTime": 482337.567541,
+                        "transferSize": 917
+                      },
+                      "children": {}
+                    },
+                    "68289.9": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                        "startTime": 482337.384843,
+                        "endTime": 482337.689976,
+                        "responseReceivedTime": 482337.689377,
+                        "transferSize": 984
+                      },
+                      "children": {}
+                    },
+                    "68289.10": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                        "startTime": 482337.385661,
+                        "endTime": 482337.70328,
+                        "responseReceivedTime": 482337.69617,
+                        "transferSize": 1749
+                      },
+                      "children": {}
+                    },
+                    "68289.11": {
+                      "request": {
+                        "url": "http://localhost:3000/zone.js",
+                        "startTime": 482337.386495,
+                        "endTime": 482338.489729,
+                        "responseReceivedTime": 482337.710627,
+                        "transferSize": 133
+                      },
+                      "children": {}
+                    },
+                    "68289.12": {
+                      "request": {
+                        "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
+                        "startTime": 482337.386939,
+                        "endTime": 482338.369126,
+                        "responseReceivedTime": 482338.22519,
+                        "transferSize": 30874
+                      },
+                      "children": {}
+                    },
+                    "68289.22": {
+                      "request": {
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+                        "startTime": 482338.24998,
+                        "endTime": 482338.404903,
+                        "responseReceivedTime": 482338.404314,
+                        "transferSize": 984
+                      },
+                      "children": {}
+                    },
+                    "68289.24": {
+                      "request": {
+                        "url": "http://localhost:3000/zone.js",
+                        "startTime": 482338.577149,
+                        "endTime": 482338.735018,
+                        "responseReceivedTime": 482338.733016,
+                        "transferSize": 133
+                      },
+                      "children": {}
+                    }
+                  }
+                }
+              },
+              "longestChain": {
+                "duration": 1588.9329999918118,
+                "length": 2,
+                "transferSize": 133
+              }
+            }
           },
           "score": 0
         },
@@ -3121,13 +5039,35 @@
             "name": "user-timings",
             "category": "Performance",
             "description": "User Timing marks and measures",
-            "helpText": "Consider instrumenting your app with the User Timing API to create custom, real-world measurements of key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+            "helpText": "Consider instrumenting your app with the User Timing API to create custom, real-world measurements of key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Name"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Type"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Time"
+                }
+              ],
+              "items": []
+            }
           },
           "score": 100
         }
       ],
       "id": "performance",
-      "score": 82.3529411764706
+      "score": 98.27272727272727
     },
     {
       "name": "Accessibility",
@@ -3319,7 +5259,7 @@
             "name": "button-name",
             "category": "Accessibility",
             "description": "Buttons have an accessible name.",
-            "helpText": "An accessible name helps convey the purpose of a button. Without one, a screen reader will only announce the word \"button\"."
+            "helpText": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/button-name)."
           },
           "score": 100
         },
@@ -3992,7 +5932,7 @@
           "weight": 1,
           "result": {
             "score": false,
-            "displayValue": "13 requests were not handled over h2",
+            "displayValue": "14 requests were not handled over h2",
             "rawValue": false,
             "extendedInfo": {
               "formatter": "table",
@@ -4000,55 +5940,59 @@
                 "results": [
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100"
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200"
+                    "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200"
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200"
+                    "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200"
+                    "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.js"
+                    "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/zone.js"
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true"
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.js"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200"
+                    "url": "http://localhost:3000/zone.js"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html"
                   },
                   {
                     "protocol": "http/1.1",
-                    "url": "http://localhost:10200/favicon.ico"
+                    "url": "http://localhost:3000/zone.js"
+                  },
+                  {
+                    "protocol": "http/1.1",
+                    "url": "http://localhost:3000/favicon.ico"
                   }
                 ],
                 "tableHeadings": {
@@ -4061,77 +6005,165 @@
             "name": "uses-http2",
             "category": "Performance",
             "description": "Uses HTTP/2 for its own resources",
-            "helpText": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2)."
-          },
-          "score": 0
-        },
-        {
-          "id": "no-old-flexbox",
-          "weight": 1,
-          "result": {
-            "score": false,
-            "displayValue": "",
-            "rawValue": false,
-            "extendedInfo": {
-              "formatter": "table",
-              "value": {
-                "results": [
+            "helpText": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Protocol"
+                }
+              ],
+              "items": [
+                [
                   {
-                    "url": "inline",
-                    "location": "4:17",
-                    "startLine": 5,
-                    "pre": "p,div {\n  display: box;\n}"
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
                   },
                   {
-                    "url": "inline",
-                    "location": "4:17",
-                    "startLine": 10,
-                    "pre": ".span {\n  display: box;\n}"
-                  },
-                  {
-                    "url": "inline",
-                    "location": "10:23",
-                    "startLine": 14,
-                    "pre": ".span2,.span3 {\n  display: box;\n}"
-                  },
-                  {
-                    "url": "inline",
-                    "location": "11:28",
-                    "startLine": 18,
-                    "pre": ".span4,.span5 {\n  display:     box;\n}"
-                  },
-                  {
-                    "url": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-                    "location": "2:19",
-                    "startLine": 21,
-                    "pre": ".doesnotapply {\n  display: flexbox;\n}"
-                  },
-                  {
-                    "url": "inline",
-                    "location": "4:24",
-                    "startLine": 5,
-                    "pre": ".failedselector {\n  -webkit-box-flex: 1;\n}"
-                  },
-                  {
-                    "url": "inline",
-                    "location": "4:16",
-                    "startLine": 6,
-                    "pre": ".failedselector {\n  box-flex: 1;\n}"
+                    "type": "text",
+                    "text": "http/1.1"
                   }
                 ],
-                "tableHeadings": {
-                  "url": "URL",
-                  "startLine": "Line in the stylesheet / <style>",
-                  "location": "Column start/end",
-                  "pre": "Snippet"
-                }
-              }
-            },
-            "scoringMode": "binary",
-            "name": "no-old-flexbox",
-            "category": "CSS",
-            "description": "Avoids old CSS flexbox",
-            "helpText": "The 2009 spec of Flexbox is deprecated and is 2.3x slower than the latest spec. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/old-flexbox)."
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/unknown404.css?delay=200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.js"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/zone.js"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/zone.js"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/favicon.ico"
+                  },
+                  {
+                    "type": "text",
+                    "text": "http/1.1"
+                  }
+                ]
+              ]
+            }
           },
           "score": 0
         },
@@ -4143,55 +6175,181 @@
             "displayValue": "",
             "rawValue": false,
             "extendedInfo": {
-              "formatter": "table",
-              "value": {
-                "results": [
-                  {
-                    "line": 224,
-                    "col": 44,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "type": "touchmove",
-                    "pre": "section#touchmove-section.addEventListener('touchmove', function (e) {\n    console.log('touchmove');\n  })\n\n",
-                    "label": "line: 224, col: 44"
-                  },
-                  {
-                    "line": 38,
-                    "col": 38,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-                    "type": "wheel",
-                    "pre": "document.addEventListener('wheel', e => {\n    console.log('wheel: arrow function');\n  })\n\n",
-                    "label": "line: 38, col: 38"
-                  },
-                  {
-                    "line": 198,
-                    "col": 44,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "type": "wheel",
-                    "pre": "window.addEventListener('wheel', function (e) {\n    console.log('wheel');\n  })\n\n",
-                    "label": "line: 198, col: 44"
-                  },
-                  {
-                    "line": 208,
-                    "col": 49,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "type": "mousewheel",
-                    "pre": "window.addEventListener('mousewheel', function (e) {\n    console.log('mousewheel');\n  })\n\n",
-                    "label": "line: 208, col: 49"
+              "formatter": "url-list",
+              "value": [
+                {
+                  "label": "line: 37",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+                  "timestamp": 1494787235458.1,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                  "lineNumber": 37,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "",
+                        "scriptId": "32",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                        "lineNumber": 37,
+                        "columnNumber": 11
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "32",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                        "lineNumber": 48,
+                        "columnNumber": 2
+                      }
+                    ]
                   }
-                ],
-                "tableHeadings": {
-                  "url": "URL",
-                  "lineCol": "Line/Col",
-                  "type": "Type",
-                  "pre": "Snippet"
+                },
+                {
+                  "label": "line: 199",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+                  "timestamp": 1494787235980.47,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 199,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "passiveEventsListenerTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 199,
+                        "columnNumber": 9
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 308,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
+                },
+                {
+                  "label": "line: 209",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Added non-passive event listener to a scroll-blocking 'mousewheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+                  "timestamp": 1494787235981.58,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 209,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "passiveEventsListenerTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 209,
+                        "columnNumber": 9
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 308,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
+                },
+                {
+                  "label": "line: 225",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Added non-passive event listener to a scroll-blocking 'touchmove' event. Consider marking event handler as 'passive' to make the page more responsive.",
+                  "timestamp": 1494787235982.36,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 225,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "passiveEventsListenerTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 225,
+                        "columnNumber": 5
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 308,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
                 }
-              }
+              ]
             },
             "scoringMode": "binary",
             "name": "uses-passive-event-listeners",
             "category": "JavaScript",
             "description": "Uses passive listeners to improve scrolling performance",
-            "helpText": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+            "helpText": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Location"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.js"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 37"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 199"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 209"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 225"
+                  }
+                ]
+              ]
+            }
           },
           "score": 0
         },
@@ -4207,52 +6365,52 @@
               "value": {
                 "results": [
                   {
-                    "line": 175,
+                    "line": 177,
                     "col": 61,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                     "type": "DOMNodeInserted",
                     "pre": "body.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-                    "label": "line: 175, col: 61"
+                    "label": "line: 177, col: 61"
                   },
                   {
-                    "line": 181,
+                    "line": 183,
                     "col": 50,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                     "type": "DOMNodeInserted",
                     "pre": "section#touchmove-section.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted on element');\n  })\n\n",
-                    "label": "line: 181, col: 50"
+                    "label": "line: 183, col: 50"
                   },
                   {
                     "line": 31,
                     "col": 56,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                     "type": "DOMNodeInserted",
                     "pre": "document.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
                     "label": "line: 31, col: 56"
                   },
                   {
-                    "line": 165,
+                    "line": 167,
                     "col": 56,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                     "type": "DOMNodeInserted",
                     "pre": "document.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-                    "label": "line: 165, col: 56"
+                    "label": "line: 167, col: 56"
                   },
                   {
-                    "line": 170,
+                    "line": 172,
                     "col": 55,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                     "type": "DOMNodeRemoved",
                     "pre": "document.addEventListener('DOMNodeRemoved', function (e) {\n    console.log('DOMNodeRemoved');\n  })\n\n",
-                    "label": "line: 170, col: 55"
+                    "label": "line: 172, col: 55"
                   },
                   {
-                    "line": 186,
+                    "line": 188,
                     "col": 54,
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                     "type": "DOMNodeInserted",
                     "pre": "window.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-                    "label": "line: 186, col: 54"
+                    "label": "line: 188, col: 54"
                   }
                 ],
                 "tableHeadings": {
@@ -4282,37 +6440,85 @@
               "formatter": "url-list",
               "value": [
                 {
-                  "label": "line: 154, col: 12",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "args": [
-                    "Hi"
-                  ],
-                  "line": 154,
-                  "col": 12,
-                  "isEval": false,
-                  "isExtension": false
+                  "label": "line: 155",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Avoid using document.write().",
+                  "timestamp": 1494787235948.6,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 155,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "documentWriteTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 155,
+                        "columnNumber": 11
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 303,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
                 },
                 {
-                  "label": "line: 155, col: 12",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "args": [
-                    "There"
-                  ],
-                  "line": 155,
-                  "col": 12,
-                  "isEval": false,
-                  "isExtension": false
+                  "label": "line: 156",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Avoid using document.write().",
+                  "timestamp": 1494787235949.37,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 156,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "documentWriteTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 156,
+                        "columnNumber": 11
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 303,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
                 },
                 {
-                  "label": "line: 156, col: 12",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "args": [
-                    "2.0!"
-                  ],
-                  "line": 156,
-                  "col": 12,
-                  "isEval": false,
-                  "isExtension": false
+                  "label": "line: 157",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Avoid using document.write().",
+                  "timestamp": 1494787235949.8,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 157,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "documentWriteTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 157,
+                        "columnNumber": 11
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 303,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
                 }
               ]
             },
@@ -4320,7 +6526,55 @@
             "name": "no-document-write",
             "category": "Performance",
             "description": "Avoids `document.write()`",
-            "helpText": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+            "helpText": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Location"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 155"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 156"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 157"
+                  }
+                ]
+              ]
+            }
           },
           "score": 0
         },
@@ -4336,12 +6590,21 @@
               "formatter": "url-list",
               "value": [
                 {
+                  "href": "https://www.google.com/",
+                  "target": "_blank",
+                  "rel": "",
                   "url": "<a href=\"https://www.google.com/\" target=\"_blank\">"
                 },
                 {
+                  "href": "Unknown",
+                  "target": "_blank",
+                  "rel": "",
                   "url": "<a target=\"_blank\">"
                 },
                 {
+                  "href": "./doesnotexist",
+                  "target": "_blank",
+                  "rel": "",
                   "url": "<a href=\"./doesnotexist\" target=\"_blank\">"
                 }
               ]
@@ -4350,7 +6613,72 @@
             "name": "external-anchors-use-rel-noopener",
             "category": "Performance",
             "description": "Opens external anchors using `rel=\"noopener\"`",
-            "helpText": "Open new tabs using `rel=\"noopener\"` to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+            "helpText": "Open new tabs using `rel=\"noopener\"` to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Target"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Rel"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "https://www.google.com/"
+                  },
+                  {
+                    "type": "text",
+                    "text": "_blank"
+                  },
+                  {
+                    "type": "text",
+                    "text": ""
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "Unknown"
+                  },
+                  {
+                    "type": "text",
+                    "text": "_blank"
+                  },
+                  {
+                    "type": "text",
+                    "text": ""
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "./doesnotexist"
+                  },
+                  {
+                    "type": "text",
+                    "text": "_blank"
+                  },
+                  {
+                    "type": "text",
+                    "text": ""
+                  }
+                ]
+              ]
+            }
           },
           "score": 0
         },
@@ -4365,26 +6693,58 @@
               "formatter": "url-list",
               "value": [
                 {
-                  "label": "line: 253, col: 25",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "args": [
-                    null
-                  ],
-                  "line": 253,
-                  "col": 25,
-                  "isEval": false,
-                  "isExtension": false
+                  "label": "line: 254",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Only request geolocation information in response to a user gesture.",
+                  "timestamp": 1494787235986.89,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 254,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "geolocationOnStartTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 254,
+                        "columnNumber": 24
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 309,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
                 },
                 {
-                  "label": "line: 257, col: 41",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "args": [
-                    null
-                  ],
-                  "line": 257,
-                  "col": 41,
-                  "isEval": false,
-                  "isExtension": false
+                  "label": "line: 258",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Only request geolocation information in response to a user gesture.",
+                  "timestamp": 1494787235990.42,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 258,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "geolocationOnStartTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 258,
+                        "columnNumber": 40
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 309,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
                 }
               ]
             },
@@ -4392,7 +6752,45 @@
             "name": "geolocation-on-start",
             "category": "UX",
             "description": "Avoids requesting the geolocation permission on page load",
-            "helpText": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+            "helpText": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Location"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 254"
+                  }
+                ],
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 258"
+                  }
+                ]
+              ]
+            }
           },
           "score": 0
         },
@@ -4407,13 +6805,31 @@
               "formatter": "url-list",
               "value": [
                 {
-                  "label": "line: 263, col: 16",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                  "args": [],
-                  "line": 263,
-                  "col": 16,
-                  "isEval": false,
-                  "isExtension": false
+                  "label": "line: 264",
+                  "source": "violation",
+                  "level": "verbose",
+                  "text": "Only request notification permission in response to a user gesture.",
+                  "timestamp": 1494787235993.33,
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                  "lineNumber": 264,
+                  "stackTrace": {
+                    "callFrames": [
+                      {
+                        "functionName": "notificationOnStartTest",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 264,
+                        "columnNumber": 15
+                      },
+                      {
+                        "functionName": "",
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 310,
+                        "columnNumber": 2
+                      }
+                    ]
+                  }
                 }
               ]
             },
@@ -4421,7 +6837,35 @@
             "name": "notification-on-start",
             "category": "UX",
             "description": "Avoids requesting the notification permission on page load",
-            "helpText": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+            "helpText": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Location"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "url",
+                    "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": "line: 264"
+                  }
+                ]
+              ]
+            }
           },
           "score": 0
         },
@@ -4437,26 +6881,26 @@
               "value": [
                 {
                   "label": "line: 45",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                   "code": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details.",
                   "source": "deprecation",
                   "level": "warning",
                   "text": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details.",
-                  "timestamp": 1493917811116.72,
+                  "timestamp": 1494787235458.94,
                   "lineNumber": 45,
                   "stackTrace": {
                     "callFrames": [
                       {
                         "functionName": "",
-                        "scriptId": "107",
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                        "scriptId": "32",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                         "lineNumber": 45,
                         "columnNumber": 6
                       },
                       {
                         "functionName": "",
-                        "scriptId": "107",
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                        "scriptId": "32",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                         "lineNumber": 48,
                         "columnNumber": 2
                       }
@@ -4464,56 +6908,56 @@
                   }
                 },
                 {
-                  "label": "line: 292",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                  "label": "line: 294",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                   "code": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.",
                   "source": "deprecation",
                   "level": "warning",
                   "text": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.",
-                  "timestamp": 1493917811174.34,
-                  "lineNumber": 292,
+                  "timestamp": 1494787236069.11,
+                  "lineNumber": 294,
                   "stackTrace": {
                     "callFrames": [
                       {
                         "functionName": "deprecationsTest",
-                        "scriptId": "110",
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                        "lineNumber": 292,
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 294,
                         "columnNumber": 6
                       },
                       {
                         "functionName": "",
-                        "scriptId": "110",
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                        "lineNumber": 312,
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 314,
                         "columnNumber": 2
                       }
                     ]
                   }
                 },
                 {
-                  "label": "line: 295",
-                  "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                  "label": "line: 297",
+                  "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                   "code": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead.",
                   "source": "deprecation",
                   "level": "warning",
                   "text": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead.",
-                  "timestamp": 1493917811178.06,
-                  "lineNumber": 295,
+                  "timestamp": 1494787236231.84,
+                  "lineNumber": 297,
                   "stackTrace": {
                     "callFrames": [
                       {
                         "functionName": "deprecationsTest",
-                        "scriptId": "110",
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                        "lineNumber": 295,
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 297,
                         "columnNumber": 8
                       },
                       {
                         "functionName": "",
-                        "scriptId": "110",
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                        "lineNumber": 312,
+                        "scriptId": "35",
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "lineNumber": 314,
                         "columnNumber": 2
                       }
                     ]
@@ -4526,7 +6970,7 @@
                   "source": "deprecation",
                   "level": "warning",
                   "text": "/deep/ combinator is deprecated and will be a no-op in M60, around August 2017. See https://www.chromestatus.com/features/4964279606312960 for more details.",
-                  "timestamp": 1493917811228.05
+                  "timestamp": 1494787236238.11
                 }
               ]
             },
@@ -4534,7 +6978,85 @@
             "name": "deprecations",
             "category": "Deprecations",
             "description": "Avoids deprecated APIs",
-            "helpText": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated)."
+            "helpText": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated).",
+            "details": {
+              "type": "table",
+              "header": "View Details",
+              "itemHeaders": [
+                {
+                  "type": "text",
+                  "itemType": "code",
+                  "text": "Deprecation / Warning"
+                },
+                {
+                  "type": "text",
+                  "itemType": "url",
+                  "text": "URL"
+                },
+                {
+                  "type": "text",
+                  "itemType": "text",
+                  "text": "Line"
+                }
+              ],
+              "items": [
+                [
+                  {
+                    "type": "code",
+                    "text": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details."
+                  },
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.js"
+                  },
+                  {
+                    "type": "text",
+                    "text": 45
+                  }
+                ],
+                [
+                  {
+                    "type": "code",
+                    "text": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/."
+                  },
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": 294
+                  }
+                ],
+                [
+                  {
+                    "type": "code",
+                    "text": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead."
+                  },
+                  {
+                    "type": "url",
+                    "text": "/dobetterweb/dbw_tester.html"
+                  },
+                  {
+                    "type": "text",
+                    "text": 297
+                  }
+                ],
+                [
+                  {
+                    "type": "code",
+                    "text": "/deep/ combinator is deprecated and will be a no-op in M60, around August 2017. See https://www.chromestatus.com/features/4964279606312960 for more details."
+                  },
+                  {
+                    "type": "url",
+                    "text": ""
+                  },
+                  {
+                    "type": "text"
+                  }
+                ]
+              ]
+            }
           },
           "score": 0
         },
@@ -4564,7 +7086,7 @@
       "description": "These metrics encapsulate your app's performance across a number of dimensions."
     },
     "perf-hint": {
-      "title": "Unoptimized Resources",
+      "title": "Opportunities",
       "description": "These are opportunities to speed up your application by optimizing the following resources."
     },
     "perf-info": {
@@ -4573,48 +7095,52 @@
     },
     "a11y-color-contrast": {
       "title": "Color Contrast Is Satisfactory",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-describe-contents": {
       "title": "Elements Describe Contents Well",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-well-structured": {
       "title": "Elements Are Well Structured",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-aria": {
       "title": "ARIA Attributes Follow Best Practices",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-correct-attributes": {
       "title": "Elements Use Attributes Correctly",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-element-names": {
       "title": "Elements Have Discernable Names",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-language": {
       "title": "Page Specifies Valid Language",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
     },
     "a11y-meta": {
       "title": "Meta Tags Used Properly",
-      "description": "Screen readers and other assitive technologies require annotations to understand otherwise ambiguous content."
+      "description": "Screen readers and other assistive technologies require annotations to understand otherwise ambiguous content."
+    },
+    "manual-pwa-checks": {
+      "title": "¹ Manual checks to verify",
+      "description": "These audits are required by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are not automatically checked by Lighthouse. They do not affect your score but please verify them manually."
     }
   },
   "aggregations": [
     {
       "name": "Progressive Web App",
-      "description": "These audits validate the aspects of a Progressive Web App. They are a subset of the [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
+      "description": "These audits validate the aspects of a Progressive Web App. They are a subset¹ of the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
       "categorizable": false,
       "scored": true,
       "total": 0.36363636363636365,
       "score": [
         {
           "name": "Progressive Web App",
-          "description": "These audits validate the aspects of a Progressive Web App. They are a subset of the [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
+          "description": "These audits validate the aspects of a Progressive Web App. They are a subset¹ of the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).",
           "overall": 0.36363636363636365,
           "subItems": [
             {
@@ -4697,41 +7223,89 @@
                 "value": {
                   "areLatenciesAll3G": true,
                   "allRequestLatencies": [
-                    150.8799999719483,
-                    154.82500000507596,
-                    203.930999996373,
-                    215.7330000190997,
-                    221.29199997289098,
-                    221.481999993557,
-                    163.90799998771402,
-                    158.19600000395462,
-                    177.923000010196,
-                    2010.1960000174572,
-                    2204.622999997808,
-                    155.95299997949056,
-                    207.00600001146103,
-                    154.0190000087024
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                      "latency": "151.95"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                      "latency": "155.11"
+                    },
+                    null,
+                    {
+                      "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+                      "latency": "156.48"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+                      "latency": "163.39"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                      "latency": "170.86"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+                      "latency": "177.25"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+                      "latency": "183.26"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                      "latency": "156.48"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                      "latency": "156.72"
+                    },
+                    {
+                      "url": "http://localhost:3000/zone.js",
+                      "latency": "164.22"
+                    },
+                    {
+                      "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
+                      "latency": "837.82"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+                      "latency": "153.81"
+                    },
+                    {
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                      "latency": "157.18"
+                    },
+                    {
+                      "url": "http://localhost:3000/zone.js",
+                      "latency": "155.07"
+                    },
+                    {
+                      "url": "http://localhost:3000/favicon.ico",
+                      "latency": "154.19"
+                    }
                   ],
                   "isFast": true,
-                  "timeToFirstInteractive": 3050.7450000047684
+                  "timeToFirstInteractive": 1735.8040000166893
                 }
               },
               "scoringMode": "binary",
               "name": "load-fast-enough-for-pwa",
               "category": "PWA",
               "description": "Page load is fast enough on 3G",
-              "helpText": "Satisfied if the _Time To Interactive_ duration is shorter than _10 seconds_, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected)."
+              "helpText": "Satisfied if the Time To Interactive duration is shorter than 10 seconds, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected)."
             },
             {
               "score": false,
               "displayValue": "",
               "rawValue": false,
-              "debugString": "Failures: No manifest was fetched, Site registers a Service Worker.",
+              "debugString": "Failures: No manifest was fetched, Site does not register a Service Worker, Manifest start_url is not cached by a Service Worker.",
               "extendedInfo": {
                 "value": {
                   "failures": [
                     "No manifest was fetched",
-                    "Site registers a Service Worker"
+                    "Site does not register a Service Worker",
+                    "Manifest start_url is not cached by a Service Worker"
                   ],
                   "manifestValues": {
                     "isParseFailure": true,
@@ -4818,6 +7392,42 @@
               "category": "Mobile Friendly",
               "description": "Content is sized correctly for the viewport",
               "helpText": "If the width of your app's content doesn't match the width of the viewport, your app might not be optimized for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport)."
+            },
+            {
+              "score": false,
+              "displayValue": "",
+              "rawValue": false,
+              "scoringMode": "binary",
+              "informative": true,
+              "manual": true,
+              "name": "pwa-cross-browser",
+              "category": "PWA",
+              "description": "Site works cross-browser",
+              "helpText": "To reach the most number of users, sites should work across every major browser."
+            },
+            {
+              "score": false,
+              "displayValue": "",
+              "rawValue": false,
+              "scoringMode": "binary",
+              "informative": true,
+              "manual": true,
+              "name": "pwa-page-transitions",
+              "category": "PWA",
+              "description": "Page transitions don't feel like they block on the network",
+              "helpText": "Transitions should feel snappy as you tap around, even on a slow network, a key to perceived performance."
+            },
+            {
+              "score": false,
+              "displayValue": "",
+              "rawValue": false,
+              "scoringMode": "binary",
+              "informative": true,
+              "manual": true,
+              "name": "pwa-each-page-has-url",
+              "category": "PWA",
+              "description": "Each page has a URL",
+              "helpText": "Ensure individual pages are deep linkable via the URLs and that URLs are unique for the purpose of shareability on social media."
             }
           ]
         }
@@ -4828,29 +7438,29 @@
       "description": "These encapsulate your app's performance.",
       "categorizable": false,
       "scored": false,
-      "total": 0.823529411764706,
+      "total": 0.9827272727272727,
       "score": [
         {
           "name": "Performance",
           "description": "These encapsulate your app's performance.",
-          "overall": 0.823529411764706,
+          "overall": 0.9827272727272727,
           "subItems": [
             {
-              "score": 70,
-              "displayValue": "3041.3ms",
-              "rawValue": 3041.3,
+              "score": 98,
+              "displayValue": "1422.4ms",
+              "rawValue": 1422.4,
               "optimalValue": "< 1,600 ms",
               "extendedInfo": {
                 "value": {
                   "timestamps": {
-                    "navStart": 177804923477,
-                    "fCP": 177807964718,
-                    "fMP": 177807964730
+                    "navStart": 482337143550,
+                    "fCP": 482338565967,
+                    "fMP": 482338565978
                   },
                   "timings": {
                     "navStart": 0,
-                    "fCP": 3041.241,
-                    "fMP": 3041.253
+                    "fCP": 1422.417,
+                    "fMP": 1422.428
                   }
                 },
                 "formatter": "null"
@@ -4862,36 +7472,40 @@
               "helpText": "First meaningful paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
             },
             {
-              "score": 80,
-              "displayValue": "3051",
-              "rawValue": 3051,
+              "score": 97,
+              "displayValue": "1433",
+              "rawValue": 1433,
               "optimalValue": "< 1,250",
               "extendedInfo": {
                 "formatter": "speedline",
                 "value": {
                   "timings": {
-                    "firstVisualChange": 3051,
-                    "visuallyComplete": 3051,
-                    "speedIndex": 3051.097000002861,
-                    "perceptualSpeedIndex": 3051.097000002861
+                    "firstVisualChange": 1433,
+                    "visuallyComplete": 1433,
+                    "speedIndex": 1433.2870000004768,
+                    "perceptualSpeedIndex": 1433.2870000004768
                   },
                   "timestamps": {
-                    "firstVisualChange": 177807974477,
-                    "visuallyComplete": 177807974477,
-                    "speedIndex": 177807974574,
-                    "perceptualSpeedIndex": 177807974574
+                    "firstVisualChange": 482338576550,
+                    "visuallyComplete": 482338576550,
+                    "speedIndex": 482338576837,
+                    "perceptualSpeedIndex": 482338576837
                   },
                   "frames": [
                     {
-                      "timestamp": 177804923.477,
+                      "timestamp": 482337143.55,
                       "progress": 0
                     },
                     {
-                      "timestamp": 177807974.574,
+                      "timestamp": 482338576.837,
                       "progress": 100
                     },
                     {
-                      "timestamp": 177808039.717,
+                      "timestamp": 482338585.176,
+                      "progress": 100
+                    },
+                    {
+                      "timestamp": 482338897.487,
                       "progress": 100
                     }
                   ]
@@ -4924,11 +7538,11 @@
                   },
                   {
                     "percentile": 0.99,
-                    "time": 16.349075434647187
+                    "time": 82.478669999472
                   },
                   {
                     "percentile": 1,
-                    "time": 24.238000000002103
+                    "time": 156.88399999999183
                   }
                 ],
                 "formatter": "null"
@@ -4940,51 +7554,91 @@
               "helpText": "The score above is an estimate of how long your app takes to respond to user input, in milliseconds. There is a 90% probability that a user encounters this amount of latency, or less. 10% of the time a user can expect additional latency. If your score is higher than Lighthouse's target score, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
             },
             {
-              "score": 81,
-              "displayValue": "3051.1ms",
-              "rawValue": 3051.1,
+              "score": 97,
+              "displayValue": "1683.3ms",
+              "rawValue": 1683.3,
               "optimalValue": "< 5,000 ms",
               "extendedInfo": {
                 "value": {
                   "timings": {
-                    "onLoad": 3053.918000012636,
-                    "fMP": 3041.253,
-                    "visuallyReady": 3051.097,
-                    "timeToInteractive": 3051.097,
-                    "timeToInteractiveB": 3041.2529999911785,
-                    "timeToInteractiveC": 3041.2529999911785,
-                    "endOfTrace": 8754.877000004053
+                    "onLoad": 1729.5439999699593,
+                    "fMP": 1422.428,
+                    "visuallyReady": 1433.287,
+                    "timeToInteractive": 1683.287,
+                    "timeToInteractiveB": 1672.4279999732971,
+                    "timeToInteractiveC": 1422.4279999732971,
+                    "endOfTrace": 8858.657000005245
                   },
                   "timestamps": {
-                    "onLoad": 177807977395,
-                    "fMP": 177807964730,
-                    "visuallyReady": 177807974574,
-                    "timeToInteractive": 177807974574,
-                    "timeToInteractiveB": 177807964730,
-                    "timeToInteractiveC": 177807964730,
-                    "endOfTrace": 177813678354
+                    "onLoad": 482338873094,
+                    "fMP": 482338565978,
+                    "visuallyReady": 482338576837,
+                    "timeToInteractive": 482338826837,
+                    "timeToInteractiveB": 482338815978,
+                    "timeToInteractiveC": 482338565978,
+                    "endOfTrace": 482346002207
                   },
                   "latencies": {
                     "timeToInteractive": [
                       {
-                        "estLatency": 16,
-                        "startTime": "3051.1"
+                        "estLatency": 106.88399999999996,
+                        "startTime": "1433.3"
+                      },
+                      {
+                        "estLatency": 106.88399999999996,
+                        "startTime": "1483.3"
+                      },
+                      {
+                        "estLatency": 106.88400000000001,
+                        "startTime": "1533.3"
+                      },
+                      {
+                        "estLatency": 106.88400000000001,
+                        "startTime": "1583.3"
+                      },
+                      {
+                        "estLatency": 68.51700001621248,
+                        "startTime": "1633.3"
+                      },
+                      {
+                        "estLatency": 19.120666672070815,
+                        "startTime": "1683.3"
                       }
                     ],
                     "timeToInteractiveB": [
                       {
-                        "estLatency": 16,
-                        "startTime": "3041.3"
+                        "estLatency": 106.88400000000013,
+                        "startTime": "1422.4"
+                      },
+                      {
+                        "estLatency": 106.88399999999996,
+                        "startTime": "1472.4"
+                      },
+                      {
+                        "estLatency": 106.88399999999996,
+                        "startTime": "1522.4"
+                      },
+                      {
+                        "estLatency": 106.88400000000001,
+                        "startTime": "1572.4"
+                      },
+                      {
+                        "estLatency": 79.3760000433922,
+                        "startTime": "1622.4"
+                      },
+                      {
+                        "estLatency": 29.376000043392196,
+                        "startTime": "1672.4"
                       }
                     ],
                     "timeToInteractiveC": [
                       {
                         "estLatency": 16,
-                        "startTime": "3041.3"
+                        "startTime": "1422.4"
                       }
                     ]
                   },
-                  "expectedLatencyAtTTI": 16
+                  "expectedLatencyAtTTI": 19.121
                 },
                 "formatter": "null"
               },
@@ -4995,13 +7649,13 @@
               "helpText": "Time to Interactive identifies the time at which your app appears to be ready enough to interact with. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive)."
             },
             {
-              "score": 93,
-              "displayValue": "3,050ms",
-              "rawValue": 3050.7450000047684,
+              "score": 99,
+              "displayValue": "1,740ms",
+              "rawValue": 1735.8040000166893,
               "extendedInfo": {
                 "value": {
-                  "timeInMs": 3050.7450000047684,
-                  "timestamp": 177807974222
+                  "timeInMs": 1735.8040000166893,
+                  "timestamp": 482338879354.00006
                 },
                 "formatter": "null"
               },
@@ -5012,32 +7666,65 @@
               "helpText": "The first point at which necessary scripts of the page have loaded and the CPU is idle enough to handle most user input."
             },
             {
-              "score": false,
-              "displayValue": "4 resources delayed first paint by 2212ms",
-              "rawValue": false,
+              "score": 99,
+              "displayValue": "1,740ms",
+              "rawValue": 1735.8040000610351,
+              "extendedInfo": {
+                "value": {
+                  "cpuQuietPeriod": {
+                    "start": 482338879.35400003,
+                    "end": 482346002.207
+                  },
+                  "networkQuietPeriod": {
+                    "start": 482338404.903,
+                    "end": 482346002.207
+                  },
+                  "cpuQuietPeriods": [
+                    {
+                      "start": 482338879.35400003,
+                      "end": 482346002.207
+                    }
+                  ],
+                  "networkQuietPeriods": [
+                    {
+                      "start": 482338404.903,
+                      "end": 482346002.207
+                    }
+                  ],
+                  "timestamp": 482338879354.00006,
+                  "timeInMs": 1735.8040000610351
+                },
+                "formatter": "null"
+              },
+              "scoringMode": "numeric",
+              "name": "consistently-interactive",
+              "category": "Performance",
+              "description": "Consistently Interactive (beta)",
+              "helpText": "The point at which most network resources have finished loading and the CPU is idle for a prolonged period."
+            },
+            {
+              "score": 90,
+              "displayValue": "3 resources delayed first paint by 180ms",
+              "rawValue": 180,
               "extendedInfo": {
                 "formatter": "table",
                 "value": {
+                  "wastedMs": 180,
                   "results": [
-                    {
-                      "url": "/dobetterweb/dbw_tester.css?delay=100",
-                      "totalKb": "1 KB",
-                      "totalMs": "108ms"
-                    },
                     {
                       "url": "/dobetterweb/unknown404.css?delay=200",
                       "totalKb": "0 KB",
-                      "totalMs": "214ms"
+                      "totalMs": "161ms"
                     },
                     {
                       "url": "/dobetterweb/dbw_tester.css?delay=2200",
                       "totalKb": "1 KB",
-                      "totalMs": "2212ms"
+                      "totalMs": "165ms"
                     },
                     {
                       "url": "/dobetterweb/dbw_partial_a.html?delay=200",
                       "totalKb": "1 KB",
-                      "totalMs": "215ms"
+                      "totalMs": "180ms"
                     }
                   ],
                   "tableHeadings": {
@@ -5051,21 +7738,87 @@
               "informative": true,
               "name": "link-blocking-first-paint",
               "category": "Performance",
-              "description": "Render-blocking stylesheets",
-              "helpText": "Link elements are blocking the first paint of your page. Consider inlining critical links and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+              "description": "Reduce render-blocking stylesheets",
+              "helpText": "Link elements are blocking the first paint of your page. Consider inlining critical links and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Size (KB)"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Delayed Paint By (ms)"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/unknown404.css?delay=200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "0 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "161ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.css?delay=2200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "1 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "165ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_partial_a.html?delay=200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "1 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "180ms"
+                    }
+                  ]
+                ]
+              }
             },
             {
-              "score": false,
-              "displayValue": "1 resource delayed first paint by 215ms",
-              "rawValue": false,
+              "score": 65,
+              "displayValue": "1 resource delayed first paint by 318ms",
+              "rawValue": 318,
               "extendedInfo": {
                 "formatter": "table",
                 "value": {
+                  "wastedMs": 318,
                   "results": [
                     {
                       "url": "/dobetterweb/dbw_tester.js",
                       "totalKb": "2 KB",
-                      "totalMs": "215ms"
+                      "totalMs": "318ms"
                     }
                   ],
                   "tableHeadings": {
@@ -5079,8 +7832,45 @@
               "informative": true,
               "name": "script-blocking-first-paint",
               "category": "Performance",
-              "description": "Render-blocking scripts",
-              "helpText": "Script elements are blocking the first paint of your page. Consider inlining critical scripts and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
+              "description": "Reduce render-blocking scripts",
+              "helpText": "Script elements are blocking the first paint of your page. Consider inlining critical scripts and deferring non-critical ones. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Size (KB)"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Delayed Paint By (ms)"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.js"
+                    },
+                    {
+                      "type": "text",
+                      "text": "2 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "318ms"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": 100,
@@ -5096,8 +7886,8 @@
                     "preview": "",
                     "url": "URL",
                     "totalKb": "Original",
-                    "webpSavings": "WebP Savings",
-                    "jpegSavings": "JPEG Savings"
+                    "webpSavings": "Savings as WebP",
+                    "jpegSavings": "Savings as JPEG"
                   }
                 }
               },
@@ -5105,40 +7895,61 @@
               "informative": true,
               "name": "uses-optimized-images",
               "category": "Images",
-              "description": "Unoptimized images",
-              "helpText": "Images should be optimized to save network bytes. The following images could have smaller file sizes when compressed with [WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. [Learn more about image optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization)."
+              "description": "Optimize images",
+              "helpText": "Images should be optimized to save network bytes. The following images could have smaller file sizes when compressed with [WebP](https://developers.google.com/speed/webp/) or JPEG at 80 quality. [Learn more about image optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "thumbnail",
+                    "text": ""
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Original"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Savings as WebP"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Savings as JPEG"
+                  }
+                ],
+                "items": []
+              }
             },
             {
-              "score": 65,
-              "displayValue": "Potential savings of 62 KB (~300ms)",
-              "rawValue": 300,
+              "score": 90,
+              "displayValue": "Potential savings of 7 KB (~30ms)",
+              "rawValue": 30,
               "extendedInfo": {
                 "formatter": "table",
                 "value": {
-                  "wastedMs": 300,
-                  "wastedKb": 62,
+                  "wastedMs": 30,
+                  "wastedKb": 7,
                   "results": [
                     {
-                      "url": "/zone.js",
-                      "totalBytes": 71501,
-                      "wastedBytes": 56204,
-                      "wastedPercent": 78.6058936238654,
-                      "potentialSavings": "55 KB _79%_",
-                      "wastedKb": "55 KB",
-                      "wastedMs": "260ms",
-                      "totalKb": "70 KB",
-                      "totalMs": "340ms"
-                    },
-                    {
                       "url": "/dobetterweb/dbw_tester.html",
-                      "totalBytes": 10196,
-                      "wastedBytes": 6792,
-                      "wastedPercent": 66.61435857198902,
-                      "potentialSavings": "7 KB _67%_",
+                      "totalBytes": 10390,
+                      "wastedBytes": 6935,
+                      "wastedPercent": 66.74687199230029,
+                      "potentialSavings": "7 KB (67%)",
                       "wastedKb": "7 KB",
                       "wastedMs": "30ms",
                       "totalKb": "10 KB",
-                      "totalMs": "50ms"
+                      "totalMs": "40ms"
                     }
                   ],
                   "tableHeadings": {
@@ -5152,8 +7963,45 @@
               "informative": true,
               "name": "uses-request-compression",
               "category": "Performance",
-              "description": "Compression enabled for server responses",
-              "helpText": "Text-based responses should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer)."
+              "description": "Enable text compression",
+              "helpText": "Text-based responses should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "Uncompressed resource URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Original"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "GZIP Savings"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "10 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "7 KB (67%)"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": 100,
@@ -5177,75 +8025,102 @@
               "informative": true,
               "name": "uses-responsive-images",
               "category": "Images",
-              "description": "Oversized images",
-              "helpText": "Image sizes served should be based on the device display size to save network bytes. Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) and [client hints](https://developers.google.com/web/updates/2015/09/automating-resource-selection-with-client-hints)."
+              "description": "Properly size images",
+              "helpText": "Image sizes served should be based on the device display size to save network bytes. Learn more about [responsive images](https://developers.google.com/web/fundamentals/design-and-ui/media/images) and [client hints](https://developers.google.com/web/updates/2015/09/automating-resource-selection-with-client-hints).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "thumbnail",
+                    "text": ""
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Original"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Potential Savings"
+                  }
+                ],
+                "items": []
+              }
             },
             {
               "score": 100,
-              "displayValue": "Total size was 129 KB",
-              "rawValue": 132075,
+              "displayValue": "Total size was 51 KB",
+              "rawValue": 52569,
               "optimalValue": "< 1,600 KB",
               "extendedInfo": {
                 "formatter": "table",
                 "value": {
                   "results": [
                     {
-                      "url": "/zone.js",
-                      "totalBytes": 71654,
-                      "totalKb": "70 KB",
-                      "totalMs": "340ms"
-                    },
-                    {
                       "url": "…3.2.1/jquery.min.js",
-                      "totalBytes": 31674,
-                      "totalKb": "31 KB",
-                      "totalMs": "150ms"
+                      "totalBytes": 30874,
+                      "totalKb": "30 KB",
+                      "totalMs": "130ms"
                     },
                     {
                       "url": "/dobetterweb/dbw_tester.html",
-                      "totalBytes": 10317,
+                      "totalBytes": 10664,
                       "totalKb": "10 KB",
-                      "totalMs": "50ms"
-                    },
-                    {
-                      "url": "/dobetterweb/dbw_tester.html",
-                      "totalBytes": 10317,
-                      "totalKb": "10 KB",
-                      "totalMs": "50ms"
+                      "totalMs": "40ms"
                     },
                     {
                       "url": "/dobetterweb/dbw_tester.js",
-                      "totalBytes": 1630,
+                      "totalBytes": 1749,
                       "totalKb": "2 KB",
                       "totalMs": "10ms"
                     },
                     {
-                      "url": "/dobetterweb/dbw_disabled.css?delay=200",
-                      "totalBytes": 1146,
+                      "url": "/favicon.ico",
+                      "totalBytes": 1616,
+                      "totalKb": "2 KB",
+                      "totalMs": "10ms"
+                    },
+                    {
+                      "url": "/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                      "totalBytes": 1273,
                       "totalKb": "1 KB",
                       "totalMs": "10ms"
                     },
                     {
-                      "url": "/dobetterweb/dbw_tester.css?delay=100",
-                      "totalBytes": 859,
-                      "totalKb": "1 KB",
-                      "totalMs": "0ms"
-                    },
-                    {
-                      "url": "/dobetterweb/dbw_tester.css?delay=2000&async=true",
-                      "totalBytes": 859,
-                      "totalKb": "1 KB",
-                      "totalMs": "0ms"
-                    },
-                    {
                       "url": "/dobetterweb/dbw_tester.css?delay=2200",
-                      "totalBytes": 859,
+                      "totalBytes": 984,
                       "totalKb": "1 KB",
                       "totalMs": "0ms"
                     },
                     {
                       "url": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-                      "totalBytes": 859,
+                      "totalBytes": 984,
+                      "totalKb": "1 KB",
+                      "totalMs": "0ms"
+                    },
+                    {
+                      "url": "/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                      "totalBytes": 984,
+                      "totalKb": "1 KB",
+                      "totalMs": "0ms"
+                    },
+                    {
+                      "url": "/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                      "totalBytes": 984,
+                      "totalKb": "1 KB",
+                      "totalMs": "0ms"
+                    },
+                    {
+                      "url": "/dobetterweb/dbw_partial_a.html?delay=200",
+                      "totalBytes": 920,
                       "totalKb": "1 KB",
                       "totalMs": "0ms"
                     }
@@ -5258,11 +8133,173 @@
                 }
               },
               "scoringMode": "numeric",
-              "informative": true,
               "name": "total-byte-weight",
               "category": "Network",
               "description": "Avoids enormous network payloads",
-              "helpText": "Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. Try to find ways to reduce the size of required files."
+              "helpText": "Network transfer size [costs users real dollars](https://whatdoesmysitecost.com/) and is [highly correlated](http://httparchive.org/interesting.php#onLoad) with long load times. Try to find ways to reduce the size of required files.",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Total Size"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Transfer Time"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "…3.2.1/jquery.min.js"
+                    },
+                    {
+                      "type": "text",
+                      "text": "30 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "130ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "10 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "40ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.js"
+                    },
+                    {
+                      "type": "text",
+                      "text": "2 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "10ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/favicon.ico"
+                    },
+                    {
+                      "type": "text",
+                      "text": "2 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "10ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
+                    },
+                    {
+                      "type": "text",
+                      "text": "1 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "10ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.css?delay=2200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "1 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "0ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "1 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "0ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.css?delay=3000&async=true"
+                    },
+                    {
+                      "type": "text",
+                      "text": "1 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "0ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.css?delay=2000&async=true"
+                    },
+                    {
+                      "type": "text",
+                      "text": "1 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "0ms"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_partial_a.html?delay=200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "1 KB"
+                    },
+                    {
+                      "type": "text",
+                      "text": "0ms"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": 100,
@@ -5285,7 +8322,7 @@
                   },
                   {
                     "title": "Maximum Children",
-                    "value": "21",
+                    "value": "22",
                     "snippet": "Element with most children:\nhead",
                     "target": "< 60 nodes"
                   }
@@ -5316,7 +8353,7 @@
                   },
                   {
                     "title": "Maximum Children",
-                    "value": "21",
+                    "value": "22",
                     "snippet": "Element with most children:\nhead",
                     "target": "< 60 nodes"
                   }
@@ -5325,129 +8362,149 @@
             },
             {
               "score": false,
-              "displayValue": "11",
+              "displayValue": "13",
               "rawValue": false,
               "optimalValue": 0,
               "extendedInfo": {
                 "formatter": "critical-request-chains",
                 "value": {
                   "chains": {
-                    "75268.1": {
+                    "68289.1": {
                       "request": {
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                        "startTime": 177804.925661,
-                        "endTime": 177805.123481,
-                        "responseReceivedTime": 177805.080619,
-                        "transferSize": 10317
+                        "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                        "startTime": 482337.146085,
+                        "endTime": 482337.352812,
+                        "responseReceivedTime": 482337.302538,
+                        "transferSize": 10664
                       },
                       "children": {
-                        "75268.3": {
+                        "68289.2": {
+                          "request": {
+                            "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                            "startTime": 482337.376297,
+                            "endTime": 482337.532551,
+                            "responseReceivedTime": 482337.531899,
+                            "transferSize": 984
+                          },
+                          "children": {}
+                        },
+                        "68289.3": {
                           "request": {
                             "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
-                            "startTime": 177805.117895,
-                            "endTime": 177805.274093,
-                            "responseReceivedTime": 177805.273648,
-                            "transferSize": 859
+                            "startTime": 482337.379707,
+                            "endTime": 482337.39337,
+                            "responseReceivedTime": -1,
+                            "transferSize": 0
                           },
                           "children": {}
                         },
-                        "75268.4": {
+                        "68289.4": {
                           "request": {
-                            "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
-                            "startTime": 177805.118221,
-                            "endTime": 177805.324375,
-                            "responseReceivedTime": 177805.323597,
-                            "transferSize": 139
+                            "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+                            "startTime": 482337.380844,
+                            "endTime": 482337.541672,
+                            "responseReceivedTime": 482337.538673,
+                            "transferSize": 133
                           },
                           "children": {}
                         },
-                        "75268.6": {
+                        "68289.5": {
                           "request": {
-                            "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200",
-                            "startTime": 177805.119508,
-                            "endTime": 177805.338533,
-                            "responseReceivedTime": 177805.338083,
-                            "transferSize": 1146
+                            "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+                            "startTime": 482337.381144,
+                            "endTime": 482337.546151,
+                            "responseReceivedTime": 482337.545695,
+                            "transferSize": 984
                           },
                           "children": {}
                         },
-                        "75268.7": {
+                        "68289.6": {
                           "request": {
-                            "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200",
-                            "startTime": 177805.119977,
-                            "endTime": 177805.345399,
-                            "responseReceivedTime": 177805.345063,
-                            "transferSize": 770
+                            "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                            "startTime": 482337.381999,
+                            "endTime": 482337.55391,
+                            "responseReceivedTime": 482337.55344,
+                            "transferSize": 1273
                           },
                           "children": {}
                         },
-                        "75268.8": {
+                        "68289.7": {
                           "request": {
-                            "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200",
-                            "startTime": 177805.12127,
-                            "endTime": 177805.496218,
-                            "responseReceivedTime": 177805.495865,
-                            "transferSize": 767
+                            "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+                            "startTime": 482337.382781,
+                            "endTime": 482337.56081,
+                            "responseReceivedTime": 482337.560413,
+                            "transferSize": 920
                           },
                           "children": {}
                         },
-                        "75268.9": {
+                        "68289.8": {
                           "request": {
-                            "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-                            "startTime": 177805.122028,
-                            "endTime": 177805.509764,
-                            "responseReceivedTime": 177805.48814,
-                            "transferSize": 1630
+                            "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+                            "startTime": 482337.383554,
+                            "endTime": 482337.567984,
+                            "responseReceivedTime": 482337.567541,
+                            "transferSize": 917
                           },
                           "children": {}
                         },
-                        "75268.18": {
+                        "68289.9": {
+                          "request": {
+                            "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                            "startTime": 482337.384843,
+                            "endTime": 482337.689976,
+                            "responseReceivedTime": 482337.689377,
+                            "transferSize": 984
+                          },
+                          "children": {}
+                        },
+                        "68289.10": {
+                          "request": {
+                            "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                            "startTime": 482337.385661,
+                            "endTime": 482337.70328,
+                            "responseReceivedTime": 482337.69617,
+                            "transferSize": 1749
+                          },
+                          "children": {}
+                        },
+                        "68289.11": {
+                          "request": {
+                            "url": "http://localhost:3000/zone.js",
+                            "startTime": 482337.386495,
+                            "endTime": 482338.489729,
+                            "responseReceivedTime": 482337.710627,
+                            "transferSize": 133
+                          },
+                          "children": {}
+                        },
+                        "68289.12": {
                           "request": {
                             "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
-                            "startTime": 177805.129849,
-                            "endTime": 177805.524424,
-                            "responseReceivedTime": 177805.331196,
-                            "transferSize": 31674
+                            "startTime": 482337.386939,
+                            "endTime": 482338.369126,
+                            "responseReceivedTime": 482338.22519,
+                            "transferSize": 30874
                           },
                           "children": {}
                         },
-                        "75268.17": {
+                        "68289.22": {
                           "request": {
-                            "url": "http://localhost:10200/zone.js",
-                            "startTime": 177805.129377,
-                            "endTime": 177805.86017,
-                            "responseReceivedTime": 177805.516777,
-                            "transferSize": 71654
+                            "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+                            "startTime": 482338.24998,
+                            "endTime": 482338.404903,
+                            "responseReceivedTime": 482338.404314,
+                            "transferSize": 984
                           },
                           "children": {}
                         },
-                        "75268.2": {
+                        "68289.24": {
                           "request": {
-                            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true",
-                            "startTime": 177805.115359,
-                            "endTime": 177807.12637,
-                            "responseReceivedTime": 177807.126014,
-                            "transferSize": 859
-                          },
-                          "children": {}
-                        },
-                        "75268.5": {
-                          "request": {
-                            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
-                            "startTime": 177805.11908,
-                            "endTime": 177807.32654,
-                            "responseReceivedTime": 177807.326161,
-                            "transferSize": 859
-                          },
-                          "children": {}
-                        },
-                        "75268.21": {
-                          "request": {
-                            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-                            "startTime": 177807.426194,
-                            "endTime": 177807.63423,
-                            "responseReceivedTime": 177807.633715,
-                            "transferSize": 859
+                            "url": "http://localhost:3000/zone.js",
+                            "startTime": 482338.577149,
+                            "endTime": 482338.735018,
+                            "responseReceivedTime": 482338.733016,
+                            "transferSize": 133
                           },
                           "children": {}
                         }
@@ -5455,9 +8512,9 @@
                     }
                   },
                   "longestChain": {
-                    "duration": 2708.5690000094473,
+                    "duration": 1588.9329999918118,
                     "length": 2,
-                    "transferSize": 859
+                    "transferSize": 133
                   }
                 }
               },
@@ -5466,7 +8523,162 @@
               "name": "critical-request-chains",
               "category": "Performance",
               "description": "Critical Request Chains",
-              "helpText": "The Critical Request Chains below show you what resources are required for first render of this page. Improve page load by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains)."
+              "helpText": "The Critical Request Chains below show you what resources are required for first render of this page. Improve page load by reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains).",
+              "details": {
+                "type": "criticalrequestchain",
+                "header": {
+                  "type": "text",
+                  "text": "View critical network waterfall:"
+                },
+                "chains": {
+                  "68289.1": {
+                    "request": {
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                      "startTime": 482337.146085,
+                      "endTime": 482337.352812,
+                      "responseReceivedTime": 482337.302538,
+                      "transferSize": 10664
+                    },
+                    "children": {
+                      "68289.2": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true",
+                          "startTime": 482337.376297,
+                          "endTime": 482337.532551,
+                          "responseReceivedTime": 482337.531899,
+                          "transferSize": 984
+                        },
+                        "children": {}
+                      },
+                      "68289.3": {
+                        "request": {
+                          "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
+                          "startTime": 482337.379707,
+                          "endTime": 482337.39337,
+                          "responseReceivedTime": -1,
+                          "transferSize": 0
+                        },
+                        "children": {}
+                      },
+                      "68289.4": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200",
+                          "startTime": 482337.380844,
+                          "endTime": 482337.541672,
+                          "responseReceivedTime": 482337.538673,
+                          "transferSize": 133
+                        },
+                        "children": {}
+                      },
+                      "68289.5": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200",
+                          "startTime": 482337.381144,
+                          "endTime": 482337.546151,
+                          "responseReceivedTime": 482337.545695,
+                          "transferSize": 984
+                        },
+                        "children": {}
+                      },
+                      "68289.6": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+                          "startTime": 482337.381999,
+                          "endTime": 482337.55391,
+                          "responseReceivedTime": 482337.55344,
+                          "transferSize": 1273
+                        },
+                        "children": {}
+                      },
+                      "68289.7": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200",
+                          "startTime": 482337.382781,
+                          "endTime": 482337.56081,
+                          "responseReceivedTime": 482337.560413,
+                          "transferSize": 920
+                        },
+                        "children": {}
+                      },
+                      "68289.8": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+                          "startTime": 482337.383554,
+                          "endTime": 482337.567984,
+                          "responseReceivedTime": 482337.567541,
+                          "transferSize": 917
+                        },
+                        "children": {}
+                      },
+                      "68289.9": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true",
+                          "startTime": 482337.384843,
+                          "endTime": 482337.689976,
+                          "responseReceivedTime": 482337.689377,
+                          "transferSize": 984
+                        },
+                        "children": {}
+                      },
+                      "68289.10": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                          "startTime": 482337.385661,
+                          "endTime": 482337.70328,
+                          "responseReceivedTime": 482337.69617,
+                          "transferSize": 1749
+                        },
+                        "children": {}
+                      },
+                      "68289.11": {
+                        "request": {
+                          "url": "http://localhost:3000/zone.js",
+                          "startTime": 482337.386495,
+                          "endTime": 482338.489729,
+                          "responseReceivedTime": 482337.710627,
+                          "transferSize": 133
+                        },
+                        "children": {}
+                      },
+                      "68289.12": {
+                        "request": {
+                          "url": "http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js",
+                          "startTime": 482337.386939,
+                          "endTime": 482338.369126,
+                          "responseReceivedTime": 482338.22519,
+                          "transferSize": 30874
+                        },
+                        "children": {}
+                      },
+                      "68289.22": {
+                        "request": {
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+                          "startTime": 482338.24998,
+                          "endTime": 482338.404903,
+                          "responseReceivedTime": 482338.404314,
+                          "transferSize": 984
+                        },
+                        "children": {}
+                      },
+                      "68289.24": {
+                        "request": {
+                          "url": "http://localhost:3000/zone.js",
+                          "startTime": 482338.577149,
+                          "endTime": 482338.735018,
+                          "responseReceivedTime": 482338.733016,
+                          "transferSize": 133
+                        },
+                        "children": {}
+                      }
+                    }
+                  }
+                },
+                "longestChain": {
+                  "duration": 1588.9329999918118,
+                  "length": 2,
+                  "transferSize": 133
+                }
+              }
             },
             {
               "score": true,
@@ -5481,7 +8693,29 @@
               "name": "user-timings",
               "category": "Performance",
               "description": "User Timing marks and measures",
-              "helpText": "Consider instrumenting your app with the User Timing API to create custom, real-world measurements of key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
+              "helpText": "Consider instrumenting your app with the User Timing API to create custom, real-world measurements of key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Name"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Type"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Time"
+                  }
+                ],
+                "items": []
+              }
             }
           ]
         }
@@ -5627,7 +8861,7 @@
               "name": "button-name",
               "category": "Accessibility",
               "description": "Buttons have an accessible name.",
-              "helpText": "An accessible name helps convey the purpose of a button. Without one, a screen reader will only announce the word \"button\"."
+              "helpText": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/button-name)."
             },
             {
               "score": true,
@@ -6138,7 +9372,7 @@
             },
             {
               "score": false,
-              "displayValue": "13 requests were not handled over h2",
+              "displayValue": "14 requests were not handled over h2",
               "rawValue": false,
               "extendedInfo": {
                 "formatter": "table",
@@ -6146,55 +9380,59 @@
                   "results": [
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100"
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200"
+                      "url": "http://localhost:3000/dobetterweb/unknown404.css?delay=200"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200"
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200"
+                      "url": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200"
+                      "url": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.js"
+                      "url": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/zone.js"
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true"
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.js"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200"
+                      "url": "http://localhost:3000/zone.js"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html"
                     },
                     {
                       "protocol": "http/1.1",
-                      "url": "http://localhost:10200/favicon.ico"
+                      "url": "http://localhost:3000/zone.js"
+                    },
+                    {
+                      "protocol": "http/1.1",
+                      "url": "http://localhost:3000/favicon.ico"
                     }
                   ],
                   "tableHeadings": {
@@ -6207,127 +9445,346 @@
               "name": "uses-http2",
               "category": "Performance",
               "description": "Uses HTTP/2 for its own resources",
-              "helpText": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2)."
+              "helpText": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Protocol"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2000&async=true"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/unknown404.css?delay=200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=2200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_partial_a.html?delay=200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_partial_b.html?delay=200&isasync"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.css?delay=3000&async=true"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.js"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/zone.js"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/zone.js"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/favicon.ico"
+                    },
+                    {
+                      "type": "text",
+                      "text": "http/1.1"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": false,
               "displayValue": "",
               "rawValue": false,
               "extendedInfo": {
-                "formatter": "table",
-                "value": {
-                  "results": [
-                    {
-                      "url": "inline",
-                      "location": "4:17",
-                      "startLine": 5,
-                      "pre": "p,div {\n  display: box;\n}"
-                    },
-                    {
-                      "url": "inline",
-                      "location": "4:17",
-                      "startLine": 10,
-                      "pre": ".span {\n  display: box;\n}"
-                    },
-                    {
-                      "url": "inline",
-                      "location": "10:23",
-                      "startLine": 14,
-                      "pre": ".span2,.span3 {\n  display: box;\n}"
-                    },
-                    {
-                      "url": "inline",
-                      "location": "11:28",
-                      "startLine": 18,
-                      "pre": ".span4,.span5 {\n  display:     box;\n}"
-                    },
-                    {
-                      "url": "/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
-                      "location": "2:19",
-                      "startLine": 21,
-                      "pre": ".doesnotapply {\n  display: flexbox;\n}"
-                    },
-                    {
-                      "url": "inline",
-                      "location": "4:24",
-                      "startLine": 5,
-                      "pre": ".failedselector {\n  -webkit-box-flex: 1;\n}"
-                    },
-                    {
-                      "url": "inline",
-                      "location": "4:16",
-                      "startLine": 6,
-                      "pre": ".failedselector {\n  box-flex: 1;\n}"
+                "formatter": "url-list",
+                "value": [
+                  {
+                    "label": "line: 37",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+                    "timestamp": 1494787235458.1,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                    "lineNumber": 37,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "",
+                          "scriptId": "32",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                          "lineNumber": 37,
+                          "columnNumber": 11
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "32",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
+                          "lineNumber": 48,
+                          "columnNumber": 2
+                        }
+                      ]
                     }
-                  ],
-                  "tableHeadings": {
-                    "url": "URL",
-                    "startLine": "Line in the stylesheet / <style>",
-                    "location": "Column start/end",
-                    "pre": "Snippet"
-                  }
-                }
-              },
-              "scoringMode": "binary",
-              "name": "no-old-flexbox",
-              "category": "CSS",
-              "description": "Avoids old CSS flexbox",
-              "helpText": "The 2009 spec of Flexbox is deprecated and is 2.3x slower than the latest spec. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/old-flexbox)."
-            },
-            {
-              "score": false,
-              "displayValue": "",
-              "rawValue": false,
-              "extendedInfo": {
-                "formatter": "table",
-                "value": {
-                  "results": [
-                    {
-                      "line": 224,
-                      "col": 44,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                      "type": "touchmove",
-                      "pre": "section#touchmove-section.addEventListener('touchmove', function (e) {\n    console.log('touchmove');\n  })\n\n",
-                      "label": "line: 224, col: 44"
-                    },
-                    {
-                      "line": 38,
-                      "col": 38,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-                      "type": "wheel",
-                      "pre": "document.addEventListener('wheel', e => {\n    console.log('wheel: arrow function');\n  })\n\n",
-                      "label": "line: 38, col: 38"
-                    },
-                    {
-                      "line": 198,
-                      "col": 44,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                      "type": "wheel",
-                      "pre": "window.addEventListener('wheel', function (e) {\n    console.log('wheel');\n  })\n\n",
-                      "label": "line: 198, col: 44"
-                    },
-                    {
-                      "line": 208,
-                      "col": 49,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                      "type": "mousewheel",
-                      "pre": "window.addEventListener('mousewheel', function (e) {\n    console.log('mousewheel');\n  })\n\n",
-                      "label": "line: 208, col: 49"
+                  },
+                  {
+                    "label": "line: 199",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+                    "timestamp": 1494787235980.47,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 199,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "passiveEventsListenerTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 199,
+                          "columnNumber": 9
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 308,
+                          "columnNumber": 2
+                        }
+                      ]
                     }
-                  ],
-                  "tableHeadings": {
-                    "url": "URL",
-                    "lineCol": "Line/Col",
-                    "type": "Type",
-                    "pre": "Snippet"
+                  },
+                  {
+                    "label": "line: 209",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Added non-passive event listener to a scroll-blocking 'mousewheel' event. Consider marking event handler as 'passive' to make the page more responsive.",
+                    "timestamp": 1494787235981.58,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 209,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "passiveEventsListenerTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 209,
+                          "columnNumber": 9
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 308,
+                          "columnNumber": 2
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "label": "line: 225",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Added non-passive event listener to a scroll-blocking 'touchmove' event. Consider marking event handler as 'passive' to make the page more responsive.",
+                    "timestamp": 1494787235982.36,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 225,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "passiveEventsListenerTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 225,
+                          "columnNumber": 5
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 308,
+                          "columnNumber": 2
+                        }
+                      ]
+                    }
                   }
-                }
+                ]
               },
               "scoringMode": "binary",
               "name": "uses-passive-event-listeners",
               "category": "JavaScript",
               "description": "Uses passive listeners to improve scrolling performance",
-              "helpText": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners)."
+              "helpText": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Location"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.js"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 37"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 199"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 209"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 225"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": false,
@@ -6338,52 +9795,52 @@
                 "value": {
                   "results": [
                     {
-                      "line": 175,
+                      "line": 177,
                       "col": 61,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                       "type": "DOMNodeInserted",
                       "pre": "body.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-                      "label": "line: 175, col: 61"
+                      "label": "line: 177, col: 61"
                     },
                     {
-                      "line": 181,
+                      "line": 183,
                       "col": 50,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                       "type": "DOMNodeInserted",
                       "pre": "section#touchmove-section.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted on element');\n  })\n\n",
-                      "label": "line: 181, col: 50"
+                      "label": "line: 183, col: 50"
                     },
                     {
                       "line": 31,
                       "col": 56,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                       "type": "DOMNodeInserted",
                       "pre": "document.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
                       "label": "line: 31, col: 56"
                     },
                     {
-                      "line": 165,
+                      "line": 167,
                       "col": 56,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                       "type": "DOMNodeInserted",
                       "pre": "document.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-                      "label": "line: 165, col: 56"
+                      "label": "line: 167, col: 56"
                     },
                     {
-                      "line": 170,
+                      "line": 172,
                       "col": 55,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                       "type": "DOMNodeRemoved",
                       "pre": "document.addEventListener('DOMNodeRemoved', function (e) {\n    console.log('DOMNodeRemoved');\n  })\n\n",
-                      "label": "line: 170, col: 55"
+                      "label": "line: 172, col: 55"
                     },
                     {
-                      "line": 186,
+                      "line": 188,
                       "col": 54,
-                      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                      "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                       "type": "DOMNodeInserted",
                       "pre": "window.addEventListener('DOMNodeInserted', function (e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-                      "label": "line: 186, col: 54"
+                      "label": "line: 188, col: 54"
                     }
                   ],
                   "tableHeadings": {
@@ -6408,37 +9865,85 @@
                 "formatter": "url-list",
                 "value": [
                   {
-                    "label": "line: 154, col: 12",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "args": [
-                      "Hi"
-                    ],
-                    "line": 154,
-                    "col": 12,
-                    "isEval": false,
-                    "isExtension": false
+                    "label": "line: 155",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Avoid using document.write().",
+                    "timestamp": 1494787235948.6,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 155,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "documentWriteTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 155,
+                          "columnNumber": 11
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 303,
+                          "columnNumber": 2
+                        }
+                      ]
+                    }
                   },
                   {
-                    "label": "line: 155, col: 12",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "args": [
-                      "There"
-                    ],
-                    "line": 155,
-                    "col": 12,
-                    "isEval": false,
-                    "isExtension": false
+                    "label": "line: 156",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Avoid using document.write().",
+                    "timestamp": 1494787235949.37,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 156,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "documentWriteTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 156,
+                          "columnNumber": 11
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 303,
+                          "columnNumber": 2
+                        }
+                      ]
+                    }
                   },
                   {
-                    "label": "line: 156, col: 12",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "args": [
-                      "2.0!"
-                    ],
-                    "line": 156,
-                    "col": 12,
-                    "isEval": false,
-                    "isExtension": false
+                    "label": "line: 157",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Avoid using document.write().",
+                    "timestamp": 1494787235949.8,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 157,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "documentWriteTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 157,
+                          "columnNumber": 11
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 303,
+                          "columnNumber": 2
+                        }
+                      ]
+                    }
                   }
                 ]
               },
@@ -6446,7 +9951,55 @@
               "name": "no-document-write",
               "category": "Performance",
               "description": "Avoids `document.write()`",
-              "helpText": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write)."
+              "helpText": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Location"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 155"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 156"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 157"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": false,
@@ -6457,12 +10010,21 @@
                 "formatter": "url-list",
                 "value": [
                   {
+                    "href": "https://www.google.com/",
+                    "target": "_blank",
+                    "rel": "",
                     "url": "<a href=\"https://www.google.com/\" target=\"_blank\">"
                   },
                   {
+                    "href": "Unknown",
+                    "target": "_blank",
+                    "rel": "",
                     "url": "<a target=\"_blank\">"
                   },
                   {
+                    "href": "./doesnotexist",
+                    "target": "_blank",
+                    "rel": "",
                     "url": "<a href=\"./doesnotexist\" target=\"_blank\">"
                   }
                 ]
@@ -6471,7 +10033,72 @@
               "name": "external-anchors-use-rel-noopener",
               "category": "Performance",
               "description": "Opens external anchors using `rel=\"noopener\"`",
-              "helpText": "Open new tabs using `rel=\"noopener\"` to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener)."
+              "helpText": "Open new tabs using `rel=\"noopener\"` to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Target"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Rel"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "https://www.google.com/"
+                    },
+                    {
+                      "type": "text",
+                      "text": "_blank"
+                    },
+                    {
+                      "type": "text",
+                      "text": ""
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "Unknown"
+                    },
+                    {
+                      "type": "text",
+                      "text": "_blank"
+                    },
+                    {
+                      "type": "text",
+                      "text": ""
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "./doesnotexist"
+                    },
+                    {
+                      "type": "text",
+                      "text": "_blank"
+                    },
+                    {
+                      "type": "text",
+                      "text": ""
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": false,
@@ -6481,26 +10108,58 @@
                 "formatter": "url-list",
                 "value": [
                   {
-                    "label": "line: 253, col: 25",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "args": [
-                      null
-                    ],
-                    "line": 253,
-                    "col": 25,
-                    "isEval": false,
-                    "isExtension": false
+                    "label": "line: 254",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Only request geolocation information in response to a user gesture.",
+                    "timestamp": 1494787235986.89,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 254,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "geolocationOnStartTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 254,
+                          "columnNumber": 24
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 309,
+                          "columnNumber": 2
+                        }
+                      ]
+                    }
                   },
                   {
-                    "label": "line: 257, col: 41",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "args": [
-                      null
-                    ],
-                    "line": 257,
-                    "col": 41,
-                    "isEval": false,
-                    "isExtension": false
+                    "label": "line: 258",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Only request geolocation information in response to a user gesture.",
+                    "timestamp": 1494787235990.42,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 258,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "geolocationOnStartTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 258,
+                          "columnNumber": 40
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 309,
+                          "columnNumber": 2
+                        }
+                      ]
+                    }
                   }
                 ]
               },
@@ -6508,7 +10167,45 @@
               "name": "geolocation-on-start",
               "category": "UX",
               "description": "Avoids requesting the geolocation permission on page load",
-              "helpText": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load)."
+              "helpText": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Location"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 254"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 258"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": false,
@@ -6518,13 +10215,31 @@
                 "formatter": "url-list",
                 "value": [
                   {
-                    "label": "line: 263, col: 16",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                    "args": [],
-                    "line": 263,
-                    "col": 16,
-                    "isEval": false,
-                    "isExtension": false
+                    "label": "line: 264",
+                    "source": "violation",
+                    "level": "verbose",
+                    "text": "Only request notification permission in response to a user gesture.",
+                    "timestamp": 1494787235993.33,
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                    "lineNumber": 264,
+                    "stackTrace": {
+                      "callFrames": [
+                        {
+                          "functionName": "notificationOnStartTest",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 264,
+                          "columnNumber": 15
+                        },
+                        {
+                          "functionName": "",
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 310,
+                          "columnNumber": 2
+                        }
+                      ]
+                    }
                   }
                 ]
               },
@@ -6532,7 +10247,35 @@
               "name": "notification-on-start",
               "category": "UX",
               "description": "Avoids requesting the notification permission on page load",
-              "helpText": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load)."
+              "helpText": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Location"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "url",
+                      "text": "http://localhost:3000/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": "line: 264"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": false,
@@ -6543,26 +10286,26 @@
                 "value": [
                   {
                     "label": "line: 45",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                     "code": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details.",
                     "source": "deprecation",
                     "level": "warning",
                     "text": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details.",
-                    "timestamp": 1493917811116.72,
+                    "timestamp": 1494787235458.94,
                     "lineNumber": 45,
                     "stackTrace": {
                       "callFrames": [
                         {
                           "functionName": "",
-                          "scriptId": "107",
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                          "scriptId": "32",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                           "lineNumber": 45,
                           "columnNumber": 6
                         },
                         {
                           "functionName": "",
-                          "scriptId": "107",
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+                          "scriptId": "32",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.js",
                           "lineNumber": 48,
                           "columnNumber": 2
                         }
@@ -6570,56 +10313,56 @@
                     }
                   },
                   {
-                    "label": "line: 292",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                    "label": "line: 294",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                     "code": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.",
                     "source": "deprecation",
                     "level": "warning",
                     "text": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.",
-                    "timestamp": 1493917811174.34,
-                    "lineNumber": 292,
+                    "timestamp": 1494787236069.11,
+                    "lineNumber": 294,
                     "stackTrace": {
                       "callFrames": [
                         {
                           "functionName": "deprecationsTest",
-                          "scriptId": "110",
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                          "lineNumber": 292,
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 294,
                           "columnNumber": 6
                         },
                         {
                           "functionName": "",
-                          "scriptId": "110",
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                          "lineNumber": 312,
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 314,
                           "columnNumber": 2
                         }
                       ]
                     }
                   },
                   {
-                    "label": "line: 295",
-                    "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+                    "label": "line: 297",
+                    "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
                     "code": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead.",
                     "source": "deprecation",
                     "level": "warning",
                     "text": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead.",
-                    "timestamp": 1493917811178.06,
-                    "lineNumber": 295,
+                    "timestamp": 1494787236231.84,
+                    "lineNumber": 297,
                     "stackTrace": {
                       "callFrames": [
                         {
                           "functionName": "deprecationsTest",
-                          "scriptId": "110",
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                          "lineNumber": 295,
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 297,
                           "columnNumber": 8
                         },
                         {
                           "functionName": "",
-                          "scriptId": "110",
-                          "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-                          "lineNumber": 312,
+                          "scriptId": "35",
+                          "url": "http://localhost:3000/dobetterweb/dbw_tester.html",
+                          "lineNumber": 314,
                           "columnNumber": 2
                         }
                       ]
@@ -6632,7 +10375,7 @@
                     "source": "deprecation",
                     "level": "warning",
                     "text": "/deep/ combinator is deprecated and will be a no-op in M60, around August 2017. See https://www.chromestatus.com/features/4964279606312960 for more details.",
-                    "timestamp": 1493917811228.05
+                    "timestamp": 1494787236238.11
                   }
                 ]
               },
@@ -6640,7 +10383,85 @@
               "name": "deprecations",
               "category": "Deprecations",
               "description": "Avoids deprecated APIs",
-              "helpText": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated)."
+              "helpText": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated).",
+              "details": {
+                "type": "table",
+                "header": "View Details",
+                "itemHeaders": [
+                  {
+                    "type": "text",
+                    "itemType": "code",
+                    "text": "Deprecation / Warning"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "url",
+                    "text": "URL"
+                  },
+                  {
+                    "type": "text",
+                    "itemType": "text",
+                    "text": "Line"
+                  }
+                ],
+                "items": [
+                  [
+                    {
+                      "type": "code",
+                      "text": "Calling Element.createShadowRoot() for an element which already hosts a shadow root is deprecated. See https://www.chromestatus.com/features/4668884095336448 for more details."
+                    },
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.js"
+                    },
+                    {
+                      "type": "text",
+                      "text": 45
+                    }
+                  ],
+                  [
+                    {
+                      "type": "code",
+                      "text": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/."
+                    },
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": 294
+                    }
+                  ],
+                  [
+                    {
+                      "type": "code",
+                      "text": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead."
+                    },
+                    {
+                      "type": "url",
+                      "text": "/dobetterweb/dbw_tester.html"
+                    },
+                    {
+                      "type": "text",
+                      "text": 297
+                    }
+                  ],
+                  [
+                    {
+                      "type": "code",
+                      "text": "/deep/ combinator is deprecated and will be a no-op in M60, around August 2017. See https://www.chromestatus.com/features/4964279606312960 for more details."
+                    },
+                    {
+                      "type": "url",
+                      "text": ""
+                    },
+                    {
+                      "type": "text"
+                    }
+                  ]
+                ]
+              }
             },
             {
               "score": false,
@@ -6656,5 +10477,8 @@
         }
       ]
     }
-  ]
+  ],
+  "timing": {
+    "total": 11882
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/2059

This PR adds the notion of a "manual" audit, an audit which does not require any artifacts but renders in the report like a normal audit.  We're using @patrickhulce's awesome report grouping to group the manual audits together (below passing audits).

I chose the grey "-" instead of the blue information "i" because we need some way to distinguish these audits from normal (automated) audits run by LH. But LMK what ya'll think.

<img width="826" alt="screen shot 2017-05-14 at 2 23 58 pm" src="https://cloud.githubusercontent.com/assets/238208/26036984/affad6e6-38b7-11e7-8ae2-ff2ba24ee1ec.png">
<img width="807" alt="screen shot 2017-05-14 at 2 24 07 pm" src="https://cloud.githubusercontent.com/assets/238208/26036985/b0018fea-38b7-11e7-96be-44f3c6ad9c97.png">

Also modernizes samples_v2.json 
