### PR TITLE
release: Tagging 2.0.0-alpha.5

### DIFF
--- a/lighthouse-extension/app/manifest_canary.json
+++ b/lighthouse-extension/app/manifest_canary.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
-  "version": "2.0.0.4",
-  "version_name": "2.0.0-alpha.4 2017-05-09",
+  "version": "2.0.0.5",
+  "version_name": "2.0.0-alpha.5 2017-05-15",
   "minimum_chrome_version": "56",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-alpha.5",
   "description": "Lighthouse",
   "main": "./lighthouse-core/index.js",
   "bin": {


### PR DESCRIPTION
shipping these to npm & cws right now.