### PR TITLE
Ship new canary

### DIFF
--- a/lighthouse-extension/app/manifest_canary.json
+++ b/lighthouse-extension/app/manifest_canary.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
-  "version": "2.0.0.5",
-  "version_name": "2.0.0-alpha.5 2017-05-15",
+  "version": "2.0.0.6",
+  "version_name": "2.0.0-alpha.6 2017-05-15",
   "minimum_chrome_version": "56",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "2.0.0-alpha.5",
+  "version": "2.0.0-alpha.6",
   "description": "Lighthouse",
   "main": "./lighthouse-core/index.js",
   "bin": {


### PR DESCRIPTION
* **chrome extension canary** `2.0.0-alpha.6 2017-05-15` published:
  * https://chrome.google.com/webstore/detail/gcladjiblfghhokpimgadfdmblkocoae
  * can be run alongside the 1.x extension.
* **npm prerelease** `lghthouse@2.0.0-alpha.6`
  * `npm install -g lighthouse@canary`
  * caution: this will replaces your globally installed lighthouse

cut from master @ 72b06e422869c62d38815330751085acb5160cd9