### PR TITLE
update eslint `curly` rule to google js style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     "quotes": [2, "single"],
     "strict": [2, "global"],
     "prefer-const": 2,
+    curly: [2, "multi-line"],
 
     // Disabled rules
     "require-jsdoc": 0,

--- a/plots/ab-screenshot/screenshot-viewer.js
+++ b/plots/ab-screenshot/screenshot-viewer.js
@@ -292,8 +292,9 @@ function createScreenshotImageElement(screenshot) {
   image.addEventListener('mouseleave', () => {
     shouldHidePopover = true;
     setTimeout(_ => {
-      if (shouldHidePopover)
+      if (shouldHidePopover) {
         imagePopoverElement.classList.add('hidden');
+      }
     }, 200);
   });
   return image;


### PR DESCRIPTION
surprised we weren't enforcing this, but turns out it's a [TODO in `eslint-config-google`](https://github.com/google/eslint-config-google/blob/d13ead768dd81492640eeffe85c35e3eb32c5c21/index.js#L81-L82)

change is simple and supports our current usage pattern