### PR TITLE
fix: remove TTI (alpha) from performance category

### DIFF
--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -34,14 +34,8 @@ module.exports = [
           }
         }
       },
-      'time-to-interactive': {
+      'first-interactive': {
         score: 100,
-        extendedInfo: {
-          value: {
-            timings: {},
-            timestamps: {}
-          }
-        }
       }
     }
   },

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -675,7 +675,6 @@ module.exports = {
         {"id": "first-meaningful-paint", "weight": 5, "group": "perf-metric"},
         {"id": "speed-index-metric", "weight": 1, "group": "perf-metric"},
         {"id": "estimated-input-latency", "weight": 1, "group": "perf-metric"},
-        {"id": "time-to-interactive", "weight": 5, "group": "perf-metric"},
         {"id": "first-interactive", "weight": 5, "group": "perf-metric"},
         {"id": "consistently-interactive", "weight": 5, "group": "perf-metric"},
         {"id": "link-blocking-first-paint", "weight": 0, "group": "perf-hint"},


### PR DESCRIPTION
This hides TTI from being displayed but still leaves it in the audits so it will appear in the trace if `--save-assets` and you run with the default or with `onlyAudits: ['time-to-interactive']` 