### PR TITLE
polish: listen for network idle after DCL

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -397,7 +397,7 @@ class Driver {
     const promise = new Promise((resolve, reject) => {
       const onIdle = () => {
         // eslint-disable-next-line no-use-before-define
-        this._networkStatusMonitor.once('networkbusy', onBusy);
+        this._networkStatusMonitor.once('network-2-busy', onBusy);
         idleTimeout = setTimeout(_ => {
           cancel();
           resolve();
@@ -405,17 +405,17 @@ class Driver {
       };
 
       const onBusy = () => {
-        this._networkStatusMonitor.once('networkidle', onIdle);
+        this._networkStatusMonitor.once('network-2-idle', onIdle);
         clearTimeout(idleTimeout);
       };
 
       cancel = () => {
         clearTimeout(idleTimeout);
-        this._networkStatusMonitor.removeListener('networkbusy', onBusy);
-        this._networkStatusMonitor.removeListener('networkidle', onIdle);
+        this._networkStatusMonitor.removeListener('network-2-busy', onBusy);
+        this._networkStatusMonitor.removeListener('network-2-idle', onIdle);
       };
 
-      if (this._networkStatusMonitor.isIdle()) {
+      if (this._networkStatusMonitor.is2Idle()) {
         onIdle();
       } else {
         onBusy();

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -397,7 +397,7 @@ class Driver {
     const promise = new Promise((resolve, reject) => {
       const onIdle = () => {
         // eslint-disable-next-line no-use-before-define
-        this._networkStatusMonitor.once('network-2-busy', onBusy);
+        this._networkStatusMonitor.once('networkbusy', onBusy);
         idleTimeout = setTimeout(_ => {
           cancel();
           resolve();
@@ -405,17 +405,17 @@ class Driver {
       };
 
       const onBusy = () => {
-        this._networkStatusMonitor.once('network-2-idle', onIdle);
+        this._networkStatusMonitor.once('networkidle', onIdle);
         clearTimeout(idleTimeout);
       };
 
       cancel = () => {
         clearTimeout(idleTimeout);
-        this._networkStatusMonitor.removeListener('network-2-busy', onBusy);
-        this._networkStatusMonitor.removeListener('network-2-idle', onIdle);
+        this._networkStatusMonitor.removeListener('networkbusy', onBusy);
+        this._networkStatusMonitor.removeListener('networkidle', onIdle);
       };
 
-      if (this._networkStatusMonitor.is2Idle()) {
+      if (this._networkStatusMonitor.isIdle()) {
         onIdle();
       } else {
         onBusy();


### PR DESCRIPTION
~~@brendankenny has observed flakiness of TTCI and TTFI on simpler sites since we've switched to waiting on 2-quiet, my hypothesis is that under the new harsher throttling, we'll see this even more frequently because 2-idle is true as soon as we request the initial page (which if it takes too long 2-quiet could fire before we even load any other content!). Worst case sites already run up to the timeout, so this shouldn't impact them as much. Simpler sites see longer times, but that's the goal since we're ending the trace too early in some cases.~~

UPDATE: waits for DCL before listening for network idle per @deepanjanroy 's suggestion, this seems to mostly fix the issue for sites like vevo and NASA who were reaching "network idle" while the primary script request was in-flight