### PR TITLE
Convert code snippets in audit titles

### DIFF
--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -88,7 +88,8 @@ class CategoryRenderer {
     valueEl.classList.add(`lh-score__value--${Util.calculateRating(score)}`,
         `lh-score__value--${scoringMode}`);
 
-    this._dom.find('.lh-score__title', element).textContent = title;
+    this._dom.find('.lh-score__title', element).appendChild(
+        this._dom.convertMarkdownCodeSnippets(title));
     this._dom.find('.lh-score__description', element)
         .appendChild(this._dom.createSpanFromMarkdown(description));
 

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -91,7 +91,7 @@ class CategoryRenderer {
     this._dom.find('.lh-score__title', element).appendChild(
         this._dom.convertMarkdownCodeSnippets(title));
     this._dom.find('.lh-score__description', element)
-        .appendChild(this._dom.createSpanFromMarkdown(description));
+        .appendChild(this._dom.convertMarkdownLinkSnippets(description));
 
     return /** @type {!Element} **/ (element);
   }
@@ -201,7 +201,7 @@ class CategoryRenderer {
     }
 
     const descriptionEl = this._dom.createChildOf(element, 'div', 'lh-perf-hint__description');
-    descriptionEl.appendChild(this._dom.createSpanFromMarkdown(audit.result.helpText));
+    descriptionEl.appendChild(this._dom.convertMarkdownLinkSnippets(audit.result.helpText));
 
     if (audit.result.details) {
       element.appendChild(this._detailsRenderer.render(audit.result.details));
@@ -224,7 +224,7 @@ class CategoryRenderer {
     auditGroupHeader.textContent = group.title;
 
     const auditGroupDescription = this._dom.createElement('div', 'lh-audit-group__description');
-    auditGroupDescription.appendChild(this._dom.createSpanFromMarkdown(group.description));
+    auditGroupDescription.appendChild(this._dom.convertMarkdownLinkSnippets(group.description));
 
     const auditGroupSummary = this._dom.createElement('summary',
           'lh-audit-group__summary lh-expandable-details__summary');

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -151,7 +151,7 @@ class CategoryRenderer {
 
     const descriptionEl = this._dom.createChildOf(element, 'div',
         'lh-timeline-metric__description');
-    descriptionEl.appendChild(this._dom.createSpanFromMarkdown(audit.result.helpText));
+    descriptionEl.appendChild(this._dom.convertMarkdownLinkSnippets(audit.result.helpText));
 
     return element;
   }

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -101,7 +101,7 @@ class DOM {
    * @param {string} text
    * @return {!Element}
    */
-  createSpanFromMarkdown(text) {
+  convertMarkdownLinkSnippets(text) {
     const element = this.createElement('span');
 
     // Split on markdown links (e.g. [some link](https://...)).

--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -127,6 +127,28 @@ class DOM {
   }
 
   /**
+   * @param {string} text
+   * @return {!Element}
+   */
+  convertMarkdownCodeSnippets(text) {
+    const element = this.createElement('span');
+
+    const parts = text.split(/`(.*?)`/g); // Split on markdown code slashes
+    while (parts.length) {
+      // Pop off the same number of elements as there are capture groups.
+      const [preambleText, codeText] = parts.splice(0, 2);
+      element.appendChild(this._document.createTextNode(preambleText));
+      if (codeText) {
+        const pre = /** @type {!HTMLPreElement} */ (this.createElement('code'));
+        pre.textContent = codeText;
+        element.appendChild(pre);
+      }
+    }
+
+    return element;
+  }
+
+  /**
    * @return {!Document}
    */
   document() {

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -69,12 +69,12 @@ describe('CategoryRenderer', () => {
   it('renders an audit debug str when appropriate', () => {
     const audit1 = renderer._renderAudit({
       scoringMode: 'binary', score: 0,
-      result: {helpText: '', debugString: 'Debug string'},
+      result: {helpText: '', debugString: 'Debug string', description: 'Audit title'},
     });
     assert.ok(audit1.querySelector('.lh-debug'));
 
     const audit2 = renderer._renderAudit({
-      scoringMode: 'binary', score: 0, result: {helpText: ''},
+      scoringMode: 'binary', score: 0, result: {helpText: '', description: 'Audit title'},
     });
     assert.ok(!audit2.querySelector('.lh-debug'));
   });

--- a/lighthouse-core/test/report/v2/renderer/dom-test.js
+++ b/lighthouse-core/test/report/v2/renderer/dom-test.js
@@ -117,4 +117,13 @@ describe('DOM', () => {
       assert.equal(result.innerHTML, text);
     });
   });
+
+  describe('convertMarkdownCodeSnippets', () => {
+    it('correctly converts links', () => {
+      const result = dom.convertMarkdownCodeSnippets(
+          'Here is some `code`, and then some `more code`, and yet event `more`.');
+      assert.equal(result.innerHTML, 'Here is some <code>code</code>, and then some ' +
+          '<code>more code</code>, and yet event <code>more</code>.');
+    });
+  });
 });

--- a/lighthouse-core/test/report/v2/renderer/dom-test.js
+++ b/lighthouse-core/test/report/v2/renderer/dom-test.js
@@ -84,20 +84,20 @@ describe('DOM', () => {
     });
   });
 
-  describe('createSpanFromMarkdown', () => {
+  describe('convertMarkdownLinkSnippets', () => {
     it('correctly converts links', () => {
-      let result = dom.createSpanFromMarkdown(
+      let result = dom.convertMarkdownLinkSnippets(
           'Some [link](https://example.com/foo). [Learn more](http://example.com).');
       assert.equal(result.innerHTML,
           'Some <a rel="noopener" target="_blank" href="https://example.com/foo">link</a>. ' +
           '<a rel="noopener" target="_blank" href="http://example.com/">Learn more</a>.');
 
-      result = dom.createSpanFromMarkdown('[link](https://example.com/foo)');
+      result = dom.convertMarkdownLinkSnippets('[link](https://example.com/foo)');
       assert.equal(result.innerHTML,
           '<a rel="noopener" target="_blank" href="https://example.com/foo">link</a>',
           'just a link');
 
-      result = dom.createSpanFromMarkdown(
+      result = dom.convertMarkdownLinkSnippets(
           '[ Link ](https://example.com/foo) and some text afterwards.');
       assert.equal(result.innerHTML,
           '<a rel="noopener" target="_blank" href="https://example.com/foo"> Link </a> ' +
@@ -107,13 +107,13 @@ describe('DOM', () => {
     it('handles invalid urls', () => {
       const text = 'Text has [bad](https:///) link.';
       assert.throws(() => {
-        dom.createSpanFromMarkdown(text);
+        dom.convertMarkdownLinkSnippets(text);
       });
     });
 
     it('ignores links that do not start with http', () => {
       const text = 'Sentence with [link](/local/path).';
-      const result = dom.createSpanFromMarkdown(text);
+      const result = dom.convertMarkdownLinkSnippets(text);
       assert.equal(result.innerHTML, text);
     });
   });


### PR DESCRIPTION
This converts markdown ticks in audit titles.

Esp. makes the a11y audits look better.

![screen shot 2017-05-16 at 8 32 43 pm](https://cloud.githubusercontent.com/assets/238208/26137681/a0656094-3a78-11e7-9288-98c6254d0d24.png)

