### PR TITLE
fix(is-https): consider chrome:// URLs safe

### DIFF
--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -20,7 +20,7 @@ const Audit = require('./audit');
 const Formatter = require('../report/formatter');
 const URL = require('../lib/url-shim');
 
-const SECURE_SCHEMES = ['data', 'https', 'wss'];
+const SECURE_SCHEMES = ['data', 'https', 'wss', 'chrome', 'chrome-extension'];
 const SECURE_DOMAINS = ['localhost', '127.0.0.1'];
 
 class HTTPS extends Audit {


### PR DESCRIPTION
since the change to how https is handled to support Android (#1918), chrome-extension URLs get flagged as insecure requests this considers chrome and chrome-extension schemes secure