### PR TITLE
chore: bump canary to 2.0.0-alpha.7

### DIFF
--- a/lighthouse-extension/app/manifest_canary.json
+++ b/lighthouse-extension/app/manifest_canary.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
-  "version": "2.0.0.6",
-  "version_name": "2.0.0-alpha.6 2017-05-15",
+  "version": "2.0.0.7",
+  "version_name": "2.0.0-alpha.7 2017-05-16",
   "minimum_chrome_version": "56",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "2.0.0-alpha.6",
+  "version": "2.0.0-alpha.7",
   "description": "Lighthouse",
   "main": "./lighthouse-core/index.js",
   "bin": {


### PR DESCRIPTION
* **chrome extension canary** `2.0.0-alpha.7 2017-05-16` published:
  * https://chrome.google.com/webstore/detail/gcladjiblfghhokpimgadfdmblkocoae
  * can be run alongside the 1.x extension.
* **npm prerelease** `lighthouse@2.0.0-alpha.7`
  * `npm install -g lighthouse@canary`
  * caution: this will replaces your globally installed lighthouse

cut from master @ 603c92031eaae868293d5a4300ca61703d4cc67f