### PR TITLE
Eliminate number of launch arguments

### DIFF
--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -84,8 +84,7 @@ if (cliFlags.output === Printer.OutputMode[Printer.OutputMode.json] && !cliFlags
  * a debuggable instance.
  */
 async function getDebuggableChrome(flags: Flags) {
-  return await launch(
-      {port: flags.port, chromeFlags: flags.chromeFlags.split(' '), handleSIGINT: true});
+  return await launch({port: flags.port, chromeFlags: flags.chromeFlags.split(' ')});
 }
 
 function showConnectionError() {


### PR DESCRIPTION
Tiny nit. Since `handleSIGINT` is true by default - https://github.com/GoogleChrome/lighthouse/blob/master/chrome-launcher/chrome-launcher.ts#L53, so here it's not needed.