### PR TITLE
polish: show audits with debug string, don't fail loadfast4pwa on network latencies, works-offline change

### DIFF
--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -63,6 +63,12 @@ class LoadFastEnough4Pwa extends Audit {
           return;
         }
 
+        // Disregard requests with an invalid start time, (H2 request start times are sometimes less
+        // than issue time and even negative which throws off timing)
+        if (record._startTime < record._issueTime) {
+          return;
+        }
+
         // Use DevTools' definition of Waiting latency: https://github.com/ChromeDevTools/devtools-frontend/blob/66595b8a73a9c873ea7714205b828866630e9e82/front_end/network/RequestTimingView.js#L164
         const latency = record._timing.receiveHeadersEnd - record._timing.sendEnd;
         const latencyInfo = {

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -41,7 +41,7 @@ class LoadFastEnough4Pwa extends Audit {
       category: 'PWA',
       name: 'load-fast-enough-for-pwa',
       description: 'Page load is fast enough on 3G',
-      helpText: 'Satisfied if the Time To Interactive duration is shorter than 10 seconds, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected).',
+      helpText: 'Satisfied if First Interactive is less than 10 seconds, as defined by the [PWA Baseline Checklist](https://developers.google.com/web/progressive-web-apps/checklist). Network throttling is required (specifically: RTT latencies >= 150 RTT are expected).',
       requiredArtifacts: ['traces', 'devtoolsLogs']
     };
   }
@@ -60,12 +60,6 @@ class LoadFastEnough4Pwa extends Audit {
         const fromCache = record._fromDiskCache || record._fromMemoryCache;
         const origin = URL.getOrigin(record._url);
         if (!origin || !record._timing || fromCache || !record.finished) {
-          return;
-        }
-
-        // Disregard requests with an invalid start time, (H2 request start times are sometimes less
-        // than issue time and even negative which throws off timing)
-        if (record._startTime < record._issueTime) {
           return;
         }
 
@@ -109,22 +103,22 @@ class LoadFastEnough4Pwa extends Audit {
           {key: 'latency', itemType: 'text', text: 'Latency (ms)'},
         ], firstRequestLatencies);
 
-        if (!areLatenciesAll3G) {
-          return {
-            rawValue: false,
-            // eslint-disable-next-line max-len
-            debugString: `First Interactive was found at ${timeToFirstInteractive.toLocaleString()}, however, the network request latencies were not sufficiently realistic, so the performance measurements cannot be trusted.`,
-            extendedInfo,
-            details
-          };
-        }
-
         if (!isFast) {
           return {
             rawValue: false,
             // eslint-disable-next-line max-len
-            debugString: `Under 3G conditions, First Interactive was at ${timeToFirstInteractive.toLocaleString()}. More details in the "Performance" section.`,
+            debugString: `First Interactive was at ${timeToFirstInteractive.toLocaleString()}. More details in the "Performance" section.`,
             extendedInfo
+          };
+        }
+
+        if (!areLatenciesAll3G) {
+          return {
+            rawValue: true,
+            // eslint-disable-next-line max-len
+            debugString: `First Interactive was found at ${timeToFirstInteractive.toLocaleString()}, however, the network request latencies were not sufficiently realistic, so the performance measurements cannot be trusted.`,
+            extendedInfo,
+            details
           };
         }
 

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -41,7 +41,8 @@ class WorksOffline extends Audit {
    */
   static audit(artifacts) {
     let debugString;
-    if (!URL.equalWithExcludedFragments(artifacts.URL.initialUrl, artifacts.URL.finalUrl)) {
+    if (artifacts.Offline !== 200 &&
+        !URL.equalWithExcludedFragments(artifacts.URL.initialUrl, artifacts.URL.finalUrl)) {
       debugString = 'WARNING: You may be failing this check because your test URL ' +
           `(${artifacts.URL.initialUrl}) was redirected to "${artifacts.URL.finalUrl}". ` +
           'Try testing the second URL directly.';

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -42,11 +42,11 @@ class WorksOffline extends Audit {
   static audit(artifacts) {
     let debugString;
     const passed = artifacts.Offline === 200;
-    if (!URL.equalWithExcludedFragments(artifacts.URL.initialUrl, artifacts.URL.finalUrl)) {
-      const explanation = passed ? 'Your test URL' :
-          'You may be failing this check because your test URL';
-      debugString = `WARNING: ${explanation} (${artifacts.URL.initialUrl}) was redirected to ` +
-          `"${artifacts.URL.finalUrl}". Try testing the second URL directly.`;
+    if (!passed &&
+        !URL.equalWithExcludedFragments(artifacts.URL.initialUrl, artifacts.URL.finalUrl)) {
+      debugString = 'WARNING: You may be failing this check because your test URL ' +
+          `(${artifacts.URL.initialUrl}) was redirected to "${artifacts.URL.finalUrl}". ` +
+          'Try testing the second URL directly.';
     }
 
     return {

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -41,15 +41,16 @@ class WorksOffline extends Audit {
    */
   static audit(artifacts) {
     let debugString;
-    if (artifacts.Offline !== 200 &&
-        !URL.equalWithExcludedFragments(artifacts.URL.initialUrl, artifacts.URL.finalUrl)) {
-      debugString = 'WARNING: You may be failing this check because your test URL ' +
-          `(${artifacts.URL.initialUrl}) was redirected to "${artifacts.URL.finalUrl}". ` +
-          'Try testing the second URL directly.';
+    const passed = artifacts.Offline === 200;
+    if (!URL.equalWithExcludedFragments(artifacts.URL.initialUrl, artifacts.URL.finalUrl)) {
+      const explanation = passed ? 'Your test URL' :
+          'You may be failing this check because your test URL';
+      debugString = `WARNING: ${explanation} (${artifacts.URL.initialUrl}) was redirected to ` +
+          `"${artifacts.URL.finalUrl}". Try testing the second URL directly to verify .`;
     }
 
     return {
-      rawValue: artifacts.Offline === 200,
+      rawValue: passed,
       debugString
     };
   }

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -46,7 +46,7 @@ class WorksOffline extends Audit {
       const explanation = passed ? 'Your test URL' :
           'You may be failing this check because your test URL';
       debugString = `WARNING: ${explanation} (${artifacts.URL.initialUrl}) was redirected to ` +
-          `"${artifacts.URL.finalUrl}". Try testing the second URL directly to verify .`;
+          `"${artifacts.URL.finalUrl}". Try testing the second URL directly.`;
     }
 
     return {

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -343,7 +343,8 @@ class CategoryRenderer {
 
     const manualAudits = category.audits.filter(audit => audit.result.manual);
     const nonManualAudits = category.audits.filter(audit => !manualAudits.includes(audit));
-    const passedAudits = nonManualAudits.filter(audit => audit.score === 100);
+    const passedAudits = nonManualAudits.filter(audit => audit.score === 100 &&
+        !audit.result.debugString);
     const nonPassedAudits = nonManualAudits.filter(audit => !passedAudits.includes(audit));
 
     for (const audit of nonPassedAudits) {

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -53,7 +53,7 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     });
   });
 
-  it('fails a good TTI value with no throttling', () => {
+  it('warns on a good TTI value with no throttling', () => {
     // latencies are very short
     const mockNetworkRecords = [
       {_timing: {sendEnd: 0, receiveHeadersEnd: 50}, finished: true, _url: 'https://google.com/'},
@@ -62,7 +62,7 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
       {_timing: {sendEnd: 0, receiveHeadersEnd: 50}, finished: true, _url: 'https://google.com/b'},
     ];
     return FastPWAAudit.audit(generateArtifacts(5000, mockNetworkRecords)).then(result => {
-      assert.equal(result.rawValue, false);
+      assert.equal(result.rawValue, true);
       assert.ok(result.debugString.includes('network request latencies'));
       assert.ok(result.details, 'contains details when latencies were not realistic');
     });

--- a/lighthouse-core/test/audits/works-offline-test.js
+++ b/lighthouse-core/test/audits/works-offline-test.js
@@ -35,11 +35,11 @@ describe('Offline: works-offline audit', () => {
 
   it('warns if initial url does not match final url', () => {
     const output = Audit.audit({
-      Offline: 200,
+      Offline: 404,
       URL: {initialUrl: URL, finalUrl: `${URL}/features`}
     });
 
-    assert.equal(output.rawValue, true);
+    assert.equal(output.rawValue, false);
     assert.ok(output.debugString);
   });
 

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -110,6 +110,20 @@ describe('CategoryRenderer', () => {
     assert.equal(audits.length, category.audits.length, 'renders correct number of audits');
   });
 
+  it('renders audits with debugString as failed', () => {
+    const auditResult = {
+      description: 'Audit',
+      helpText: 'Learn more',
+      debugString: 'It may not have worked!',
+      score: 100,
+    };
+    const audit = {result: auditResult, score: 100};
+    const category = {title: 'Fake', description: '', score: 100, audits: [audit]};
+    const categoryDOM = renderer.render(category, sampleResults.reportGroups);
+    assert.ok(categoryDOM.querySelector('.lh-category > .lh-audit'), 'did not render as failed');
+    assert.ok(categoryDOM.querySelector('.lh-debug'), 'did not render debug message');
+  });
+
   it('renders manual audits if the category contains them', () => {
     const pwaCategory = sampleResults.reportCategories.find(cat => cat.id === 'pwa');
     const categoryDOM = renderer.render(pwaCategory, sampleResults.reportGroups);

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -118,7 +118,7 @@ describe('CategoryRenderer', () => {
       score: 100,
     };
     const audit = {result: auditResult, score: 100};
-    const category = {title: 'Fake', description: '', score: 100, audits: [audit]};
+    const category = {name: 'Fake', description: '', score: 100, audits: [audit]};
     const categoryDOM = renderer.render(category, sampleResults.reportGroups);
     assert.ok(categoryDOM.querySelector('.lh-category > .lh-audit'), 'did not render as failed');
     assert.ok(categoryDOM.querySelector('.lh-debug'), 'did not render debug message');


### PR DESCRIPTION
* doesn't hide passed audits with a debug string in "passed audits" section
* only shows debug string on `works-offline` if the audit failed
* flips loadfast4pwa to pass (but still show debug string) when latencies seem unrealistic
* drive by text fix for loadfast4pwa TTI -> TTFI
![image](https://cloud.githubusercontent.com/assets/2301202/26167558/e941a78c-3aeb-11e7-966f-3a935ac4619e.png)

 