### PR TITLE
polish: do not fail loadfast4pwa for internal redirects

### DIFF
--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -32,6 +32,8 @@ const Formatter = require('../report/formatter');
 //   https://developers.google.com/web/progressive-web-apps/checklist
 const MAXIMUM_TTFI = 10 * 1000;
 
+const WHITELISTED_STATUS_CODES = [307];
+
 class LoadFastEnough4Pwa extends Audit {
   /**
    * @return {!AuditMeta}
@@ -55,11 +57,12 @@ class LoadFastEnough4Pwa extends Audit {
     return artifacts.requestNetworkRecords(devtoolsLogs).then(networkRecords => {
       const firstRequestLatenciesByOrigin = new Map();
       networkRecords.forEach(record => {
-        // Ignore requests that don't have valid origin, timing data, came from the cache, or are
-        // not finished.
+        // Ignore requests that don't have valid origin, timing data, came from the cache, were
+        // redirected by Chrome without going to the network, or are not finished.
         const fromCache = record._fromDiskCache || record._fromMemoryCache;
         const origin = URL.getOrigin(record._url);
-        if (!origin || !record._timing || fromCache || !record.finished) {
+        if (!origin || !record._timing || fromCache ||
+            WHITELISTED_STATUS_CODES.includes(record.statusCode) || !record.finished) {
           return;
         }
 

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -82,6 +82,7 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     // latencies are very long
     const urlA = 'https://google.com';
     const urlB = 'https://example.com';
+    const urlC = 'https://example-c.com';
     const mockNetworkRecords = [
       {_timing: {sendEnd: 0, receiveHeadersEnd: 250}, finished: true, _url: urlA, _startTime: 0},
       {_timing: {sendEnd: 0, receiveHeadersEnd: 250}, finished: true, _url: urlB},
@@ -89,6 +90,9 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
       { },
       // ignored for not being the first of the origin
       {_timing: {sendEnd: 0, receiveHeadersEnd: 100}, finished: true, _url: urlA, _startTime: 100},
+      // ignored for being redirected internally
+      {_timing: {sendEnd: 0, receiveHeadersEnd: 100}, finished: true, _url: urlC, _startTime: 0,
+        statusCode: 307},
       // ignored for not finishing
       {_timing: {sendEnd: 0, receiveHeadersEnd: -1}, finished: false},
     ];


### PR DESCRIPTION
http://veerle.duoh.com/ used to fail the check because google analytics latency was 0 for being redirected internally to https (status code 307)