### PR TITLE
polish: handle traces with base64 encoded args

### DIFF
--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -4,7 +4,7 @@ module.exports = {
   "passes": [{
     "passName": "defaultPass",
     "recordTrace": true,
-    "pauseAfterLoadMs": 5000,
+    "pauseAfterLoadMs": 5250,
     "networkQuietThresholdMs": 5000,
     "pauseAfterNetworkQuietMs": 2500,
     "useThrottling": true,

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -54,6 +54,7 @@ global.HTMLImportsLoader.hrefToAbsolutePath = function(path) {
 require('../../third_party/traceviewer-js/');
 const traceviewer = global.tr;
 if (typeof atob === 'undefined') {
+  // Node doesn't have base64 encode/decode functions available globally so polyfill with buffer
   traceviewer.b.Base64.atob = input => new Buffer(input).toString('base64')
   traceviewer.b.Base64.btoa = input => new Buffer(input, 'base64').toString()
 }

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -53,6 +53,10 @@ global.HTMLImportsLoader.hrefToAbsolutePath = function(path) {
 
 require('../../third_party/traceviewer-js/');
 const traceviewer = global.tr;
+if (typeof atob === 'undefined') {
+  traceviewer.b.Base64.atob = input => new Buffer(input).toString('base64')
+  traceviewer.b.Base64.btoa = input => new Buffer(input, 'base64').toString()
+}
 
 class TraceProcessor {
   get RESPONSE() {

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -55,8 +55,8 @@ require('../../third_party/traceviewer-js/');
 const traceviewer = global.tr;
 if (typeof atob === 'undefined') {
   // Node doesn't have base64 encode/decode functions available globally so polyfill with buffer
-  traceviewer.b.Base64.atob = input => new Buffer(input).toString('base64')
-  traceviewer.b.Base64.btoa = input => new Buffer(input, 'base64').toString()
+  traceviewer.b.Base64.atob = input => new Buffer(input).toString('base64');
+  traceviewer.b.Base64.btoa = input => new Buffer(input, 'base64').toString();
 }
 
 class TraceProcessor {

--- a/lighthouse-core/test/lib/traces/tracing-processor-test.js
+++ b/lighthouse-core/test/lib/traces/tracing-processor-test.js
@@ -49,16 +49,16 @@ describe('TracingProcessor lib', () => {
     assert.doesNotThrow(_ => {
       new TracingProcessor().init([
         {
-          "pid": 15256,
-          "tid": 1295,
-          "ts": 668545368880,
-          "ph": "e",
-          "id": "fake-event",
-          "cat": "blink.user_timing",
-          "name": "Zone:ZonePromise",
-          "dur": 64,
-          "tdur": 61,
-          "tts": 881373
+          'pid': 15256,
+          'tid': 1295,
+          'ts': 668545368880,
+          'ph': 'e',
+          'id': 'fake-event',
+          'cat': 'blink.user_timing',
+          'name': 'Zone:ZonePromise',
+          'dur': 64,
+          'tdur': 61,
+          'tts': 881373
         },
       ]);
     });

--- a/lighthouse-core/test/lib/traces/tracing-processor-test.js
+++ b/lighthouse-core/test/lib/traces/tracing-processor-test.js
@@ -45,6 +45,25 @@ describe('TracingProcessor lib', () => {
     });
   });
 
+  it('doesn\'t throw when user_timing events have a colon', () => {
+    assert.doesNotThrow(_ => {
+      new TracingProcessor().init([
+        {
+          "pid": 15256,
+          "tid": 1295,
+          "ts": 668545368880,
+          "ph": "e",
+          "id": "fake-event",
+          "cat": "blink.user_timing",
+          "name": "Zone:ZonePromise",
+          "dur": 64,
+          "tdur": 61,
+          "tts": 881373
+        },
+      ]);
+    });
+  });
+
   describe('riskPercentiles calculation', () => {
     it('correctly calculates percentiles of no tasks', () => {
       const results = TracingProcessor._riskPercentiles([], 100, defaultPercentiles);


### PR DESCRIPTION
fixes the `atob is not defined` error on https://plustimer.firebaseapp.com/ that results from the traceviewer trying to parse base64 encoded args embeded in a trace event used by Zone 

actually surprised we haven't run into this yet, it only happens when calling from node

also includes a drive by fix to increase the wait after load to 5250 since I've seen a couple traces where the trace ended 4999 or 4990 ms after quiet when the site was `onLoad` bound