### PR TITLE
really yarn install-all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ cache:
     - lighthouse-extension/node_modules
     - lighthouse-viewer/node_modules
 install:
-  - yarn
   - yarn install-all
 before_script:
   - gem install travis-artifacts

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=6"
   },
   "scripts": {
-    "install-all": "yarn install-launcher && yarn install-cli && yarn install-extension && yarn install-viewer",
+    "install-all": "yarn && yarn install-launcher && yarn install-cli && yarn install-extension && yarn install-viewer",
     "install-launcher": "cd ./chrome-launcher && yarn install && yarn build",
     "install-cli": "cd ./lighthouse-cli && yarn install && yarn build",
     "install-extension": "cd ./lighthouse-extension && yarn install",


### PR DESCRIPTION
`yarn install-all` currently doesn't call `yarn install` in the base directory, so when `yarn build-all` is called, it immediately errors on `gulp: command not found`