### PR TITLE
Fix: Allow template literals in linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,6 @@ module.exports = {
       "argsIgnorePattern": "(^reject$|^_$)",
       "varsIgnorePattern": "(^_$)"
     }],
-    "quotes": [2, "single", {"allowTemplateLiterals": true}],
     "strict": [2, "global"],
     "prefer-const": 2,
     "curly": [2, "multi-line"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,10 +35,10 @@ module.exports = {
       "argsIgnorePattern": "(^reject$|^_$)",
       "varsIgnorePattern": "(^_$)"
     }],
-    "quotes": [2, "single"],
+    "quotes": [2, "single", {"allowTemplateLiterals": true}],
     "strict": [2, "global"],
     "prefer-const": 2,
-    curly: [2, "multi-line"],
+    "curly": [2, "multi-line"],
 
     // Disabled rules
     "require-jsdoc": 0,


### PR DESCRIPTION
Not sure if it was left out for a reason or just missed. Google's default preset has this exact quotes setting so I think it could just be removed.