### PR TITLE
Total byte audit reports full URL

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -22,7 +22,6 @@
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const Formatter = require('../../report/formatter');
 const TracingProcessor = require('../../lib/traces/tracing-processor');
-const URL = require('../../lib/url-shim');
 
 // Parameters for log-normal CDF scoring. See https://www.desmos.com/calculator/gpmjeykbwr
 // ~75th and ~90th percentiles http://httparchive.org/interesting.php?a=All&l=Feb%201%202017&s=All#bytesTotal

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -65,7 +65,7 @@ class TotalByteWeight extends ByteEfficiencyAudit {
           if (record.scheme === 'data' || !record.finished) return;
 
           const result = {
-            url: URL.getURLDisplayName(record.url),
+            url: record.url,
             totalBytes: record.transferSize,
             totalKb: this.bytesToKbString(record.transferSize),
             totalMs: this.bytesToMsString(record.transferSize, networkThroughput),

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -72,8 +72,10 @@ class DetailsRenderer {
    * @return {!Element}
    */
   _renderURL(text) {
-    const element = this._renderText(text);
+    const parsedURL = Util.parseURL(text.text);
+    const element = this._renderText({text: parsedURL.file});
     element.classList.add('lh-text__url');
+    element.title = text.text;
     return element;
   }
 

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -77,9 +77,9 @@ class DetailsRenderer {
     let displayedURL;
     let title;
     try {
-      displayedURL = Util.parseURL(text.text).file;
+      displayedURL = Util.parseURL(url).file;
       title = url;
-    } catch (e) {
+    } catch (/** @type {!Error} */ e) {
       if (!(e instanceof TypeError)) {
         throw e;
       }

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -72,10 +72,30 @@ class DetailsRenderer {
    * @return {!Element}
    */
   _renderURL(text) {
-    const parsedURL = Util.parseURL(text.text);
-    const element = this._renderText({text: parsedURL.file});
+    const url = text.text || '';
+
+    let displayedURL;
+    let title;
+    try {
+      displayedURL = Util.parseURL(text.text).file;
+      title = url;
+    } catch (e) {
+      if (!(e instanceof TypeError)) {
+        throw e;
+      }
+      displayedURL = url;
+    }
+
+    const element = this._renderText({
+      type: 'url',
+      text: displayedURL
+    });
     element.classList.add('lh-text__url');
-    element.title = text.text;
+
+    if (title) {
+      element.title = url;
+    }
+
     return element;
   }
 


### PR DESCRIPTION
Currently the `total-byte-weight` audit only reports `getURLDisplayName` for URLs.

This can make it challenging to understand what resource the audit is talking about, as sites we work with include 3rd party scripts with mystery names.

Without the complete URL, it is impossible to create detailed CI tests that fail if certain resources are bigger than a threshold. In our case, we often do not control the size of all assets on the page, so we don't want to fail on the overall threshold... just thing we have control on.

This change displays the full URL.

| Before | After |
|---|---|
| ![image](https://cloud.githubusercontent.com/assets/28967/26259780/70eb320e-3c7f-11e7-8634-8e466988a467.png) | ![image](https://cloud.githubusercontent.com/assets/28967/26259887/e954d524-3c7f-11e7-852a-eaebabdeccb4.png)|

I used the test page https://lighthouse-url-example.surge.sh/ with a few examples of URLs that we may encounter in the wild.

_With the longer URLs, the styling could probably use some love (I could also imagine terrible ideas like having the full URL available on hover) – happy to pursue that if this is a direction you'd like to head in. Assuming this is a direction you're looking at going in, also happy to update the relevant tests._

❤️ 