### PR TITLE
extension: Fix formatting of bug reports

### DIFF
--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -60,24 +60,21 @@ function hideRunningSubpage() {
 }
 
 function buildReportErrorLink(err) {
-  let qsBody = '**Lighthouse Version**: ' + getLighthouseVersion() + '\n';
-  qsBody += '**Chrome Version**: ' + getChromeVersion() + '\n';
-
-  if (siteURL) {
-    qsBody += '**URL**: ' + siteURL + '\n';
-  }
-
-  qsBody += '**Error Message**: ' + err.message + '\n';
-  qsBody += '**Stack Trace**:\n ```' + err.stack + '```';
+  const issueBody = `
+**Lighthouse Version**: ${getLighthouseVersion()}
+**Chrome Version**: ${getChromeVersion()}
+**Initial URL**: ${siteURL}
+**Error Message**: ${err.message}
+**Stack Trace**:
+\`\`\`
+${err.stack}
+\`\`\`
+    `;
 
   const base = 'https://github.com/GoogleChrome/lighthouse/issues/new?';
-  let titleError = err.message;
-
-  if (titleError.length > MAX_ISSUE_ERROR_LENGTH) {
-    titleError = `${titleError.substring(0, MAX_ISSUE_ERROR_LENGTH - 3)}...`;
-  }
-  const title = encodeURI('title=Extension Error: ' + titleError);
-  const body = '&body=' + encodeURI(qsBody);
+  const errorTitle = err.message.substring(0, MAX_ISSUE_ERROR_LENGTH);
+  const title = encodeURI('title=Extension Error: ' + errorTitle);
+  const body = '&body=' + encodeURI(issueBody.trim());
 
   const reportErrorEl = document.createElement('a');
   reportErrorEl.className = 'button button--report-error';

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -71,14 +71,15 @@ ${err.stack}
 \`\`\`
     `;
 
-  const base = 'https://github.com/GoogleChrome/lighthouse/issues/new?';
+  const url = new URL('https://github.com/GoogleChrome/lighthouse/issues/new');
+
   const errorTitle = err.message.substring(0, MAX_ISSUE_ERROR_LENGTH);
-  const title = encodeURI('title=Extension Error: ' + errorTitle);
-  const body = '&body=' + encodeURI(issueBody.trim());
+  url.searchParams.append('title', `Extension Error: ${errorTitle}`);
+  url.searchParams.append('body', issueBody.trim());
 
   const reportErrorEl = document.createElement('a');
   reportErrorEl.className = 'button button--report-error';
-  reportErrorEl.href = base + title + body;
+  reportErrorEl.href = url;
   reportErrorEl.textContent = 'Report Error';
   reportErrorEl.target = '_blank';
 


### PR DESCRIPTION
Reusing the refactor [that's on the devtools side](https://codereview.chromium.org/2888263002/diff/50001/third_party/WebKit/Source/devtools/front_end/audits2/Audits2Panel.js).

This fixes the incorrect triple-tick we currently have (with no newlines inbetween).

It also simplifies this bit.