### PR TITLE
Report app manifest errors

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -267,19 +267,20 @@ class Driver {
   getAppManifest() {
     return this.sendCommand('Page.getAppManifest')
       .then(response => {
-        // handle errors
+        // Handle JSON syntax errors and manifest correctness warnings
         if (response.errors) {
+          // Possible issues: https://cs.chromium.org/search/?q=f:manifest_parser.cc+AddErrorInfo&type=cs
           response.errors.forEach(error => {
             log.warn('driver', 'Manifest error', error.message);
           });
+          // Possible critical issues: invalid JSON (location reported) or manifest root is an array
           const criticalError = response.errors.find(error => error.critical);
           if (criticalError) {
-            return Promise.reject(new Error(`Manifest error: ${criticalError.message}`));
+            throw new Error(`Manifest error: ${criticalError.message}`);
           }
         }
-        // handle failed manifest request or 404
+        // Handle failed manifest request or 404
         if (!response.data) {
-          // If the data is empty, the page had no manifest.
           return null;
         }
 

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -189,7 +189,7 @@ class Runner {
           log.warn('Runner', `${artifactName} gatherer, required by audit ${audit.meta.name},` +
             ` encountered an error: ${artifactError.message}`);
           throw new Error(
-              `Required ${artifactName} gatherer encountered an error: ${artifactError.message}`);
+              `${artifactName} gatherer encountered an error: ${artifactError.message}`);
         }
       }
       // all required artifacts are in good shape, so we proceed


### PR DESCRIPTION
fixes #2348

If the manifest has JSON errors, it currently fails with something like this:
![](https://cloud.githubusercontent.com/assets/205226/26382613/4367964a-3fe2-11e7-85f2-ceb58deef6b1.png)

But we do have more useful errors coming from protocol we could share... for example.
![](https://cloud.githubusercontent.com/assets/39191/26383472/c11a3bb0-3fe7-11e7-83c9-416fea59862f.png)

This PR implements that.
Also driveby to remove superfluous word "required"

