### PR TITLE
fix: hide violations with no URL information

### DIFF
--- a/lighthouse-core/audits/violation-audit.js
+++ b/lighthouse-core/audits/violation-audit.js
@@ -27,7 +27,7 @@ class ViolationAudit extends Audit {
   static getViolationResults(artifacts, pattern) {
     return artifacts.ChromeConsoleMessages
         .map(message => message.entry)
-        .filter(entry => entry.source === 'violation' && pattern.test(entry.text))
+        .filter(entry => entry.url && entry.source === 'violation' && pattern.test(entry.text))
         .map(entry => Object.assign({label: `line: ${entry.lineNumber}`}, entry));
   }
 }


### PR DESCRIPTION
since switching to using violations, entries would appear in the table that had no actionable information, this filters those out