### PR TITLE
Revert "Switch to containerized Trusty"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
   include:
     - node_js: "6.9.1"
     - node_js: "7"
+sudo: required
 dist: trusty
 env:
   global:


### PR DESCRIPTION
Been seeing a lot more travis flakey failures (12/12 recent failures of known green branches), want to give this branch a try to see if it improves.

Reverts GoogleChrome/lighthouse#2234