### PR TITLE
fix: bump jpeg quality

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
@@ -51,7 +51,7 @@ function getOptimizedNumBytes(url) {
         canvas.width = img.width;
         context.drawImage(img, 0, 0);
 
-        const jpeg = getTypeStats('image/jpeg', 0.85);
+        const jpeg = getTypeStats('image/jpeg', 0.92);
         const webp = getTypeStats('image/webp', 0.85);
 
         resolve({jpeg, webp});


### PR DESCRIPTION
related #2217 

at some point recently the JPEG library used by chrome has changed so that the quality or file size is now much lower for the same quality setting which is causing smoke tests to fail if they don't use the cached download of Chrome (see https://travis-ci.org/GoogleChrome/lighthouse/jobs/235694158)

this bumps it to give roughly the same output as it does under Chrome stable but we should investigate this more and try to bisect for the cause or track it better