### PR TITLE
😈 Fix disconnect promise race.

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -118,10 +118,8 @@ class GatherRunner {
   }
 
   static disposeDriver(driver) {
-    // We dont need to hold up the reporting for the reload/disconnect,
-    // so we will not return a promise in here.
     log.log('status', 'Disconnecting from browser...');
-    driver.disconnect().catch(err => {
+    return driver.disconnect().catch(err => {
       // Ignore disconnecting error if browser was already closed.
       // See https://github.com/GoogleChrome/lighthouse/issues/1583
       if (!(/close\/.*status: 500$/.test(err.message))) {


### PR DESCRIPTION
It is possible that we were resolving the gather chain before we had
disconnected. When manually launching and killing chrome this can race
and result in an error to the user.

This fixes that problem. \o/.

Fixes #2337

---

Test plan:

Run launcher with:

```ts
const lighthouse = require('lighthouse');

import {launch} from './chrome-launcher';

async function runLighthouse(url: string) {
  const opts = {
    chromeFlags: ['--headless'],
  };
  const chrome = await launch(opts);
  const flags = {
    output: 'json',
    port: chrome.port,
  };

  const results = await lighthouse(url, flags);

  process.on('uncaughtException', (e: any) => {
    console.log(e);
  });

  await chrome.kill();
  return results;
}

runLighthouse('https://example.com');
```

Without this patch, and then run it with the patch. Observe it now working.