### PR TITLE
swap math.round with util.formatNumber

### DIFF
--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -127,7 +127,7 @@ class ReportRenderer {
       this._dom.find('.leftnav-item__category', navItem).textContent = category.name;
       const score = this._dom.find('.leftnav-item__score', navItem);
       score.classList.add(`lh-score__value--${Util.calculateRating(category.score)}`);
-      score.textContent = Util.formatNumber(Math.round(category.score));
+      score.textContent = Math.round(category.score);
       nav.appendChild(navItem);
     }
     return leftNav;

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -127,7 +127,7 @@ class ReportRenderer {
       this._dom.find('.leftnav-item__category', navItem).textContent = category.name;
       const score = this._dom.find('.leftnav-item__score', navItem);
       score.classList.add(`lh-score__value--${Util.calculateRating(category.score)}`);
-      score.textContent = Math.round(Util.formatNumber(category.score));
+      score.textContent = Util.formatNumber(Math.round(category.score));
       nav.appendChild(navItem);
     }
     return leftNav;


### PR DESCRIPTION
Fixes #2320 
---
#### Previously:

`formatNumber` returns a string value from `Number.toLocaleString`, and `math.round` can't round the number.

#### Currently:

`math.round` receives an integer instead of a string, which makes the conversion complete, not returning `NaN`. Note that we first do `math.round` and then use `formatNumber` instead of the opposite, as prior.

--- 
Didn't change test for `Utils.formatNumber`, as I didn't touch it. Furthermore, I'd prefer a common conversion point for [this](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/report/v2/renderer/category-renderer.js#L105) in relation to the line I've changed, as we're basically doing the same thing. This ensures that scores are persistent and co-reliant.

---

## Before:
![skjermbilde 2017-05-25 kl 11 06 01](https://cloud.githubusercontent.com/assets/16735925/26443798/2cf6e9a2-413a-11e7-8540-dc86b3d934ce.png)
![skjermbilde 2017-05-25 kl 11 07 41](https://cloud.githubusercontent.com/assets/16735925/26443873/6f4978ce-413a-11e7-9f4e-052daf49f913.png)



## After:
![skjermbilde 2017-05-25 kl 10 59 27](https://cloud.githubusercontent.com/assets/16735925/26443581/523a3bac-4139-11e7-9fce-16b2601006d1.png)

![skjermbilde 2017-05-25 kl 11 10 22](https://cloud.githubusercontent.com/assets/16735925/26443997/cf0d3a16-413a-11e7-978d-92c511a495eb.png)


