### PR TITLE
fix: deprecate old HTML report

### DIFF
--- a/lighthouse-cli/printer.ts
+++ b/lighthouse-cli/printer.ts
@@ -34,7 +34,6 @@ type Mode = 'json'|'html'|'domhtml';
 import {Results} from './types/types';
 
 const fs = require('fs');
-const ReportGenerator = require('../lighthouse-core/report/report-generator');
 const ReportGeneratorV2 = require('../lighthouse-core/report/v2/report-generator');
 const log = require('../lighthouse-core/lib/log');
 
@@ -55,14 +54,8 @@ function checkOutputPath(path: string): string {
  * Creates the results output in a format based on the `mode`.
  */
 function createOutput(results: Results, outputMode: OutputMode): string {
-  const reportGenerator = new ReportGenerator();
-
   // HTML report.
-  if (outputMode === OutputMode.html) {
-    return reportGenerator.generateHTML(results, 'cli');
-  }
-
-  if (outputMode === OutputMode.domhtml) {
+  if (outputMode === OutputMode.domhtml || outputMode === OutputMode.html) {
     return new ReportGeneratorV2().generateReportHtml(results);
   }
 

--- a/lighthouse-cli/test/cli/printer-test.js
+++ b/lighthouse-cli/test/cli/printer-test.js
@@ -45,7 +45,7 @@ describe('Printer', () => {
     const mode = Printer.OutputMode.html;
     const htmlOutput = Printer.createOutput(sampleResults, mode);
     assert.ok(/<!doctype/gim.test(htmlOutput));
-    assert.ok(/<html lang="en" data-report-context="cli"/gim.test(htmlOutput));
+    assert.ok(/<html lang="en"/gim.test(htmlOutput));
   });
 
   it('writes file for results', () => {


### PR DESCRIPTION
closes #2344 and opens the door to fully remove the old report code, users who request --output html will receive the current report instead (including WPT)