### PR TITLE
Remove outline from active clicks & show green bar on successful audits

### DIFF
--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -73,10 +73,6 @@ a {
   color: #0c50c7;
 }
 
-summary:active {
-  outline: none;
-}
-
 summary {
   cursor: pointer;
 }

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -73,6 +73,10 @@ a {
   color: #0c50c7;
 }
 
+summary:active {
+  outline: none;
+}
+
 summary {
   cursor: pointer;
 }
@@ -691,7 +695,12 @@ span.lh-node:hover {
 }
 
 .lh-passed-audits[open] summary.lh-passed-audits-summary {
-  margin-bottom: calc(var(--default-padding) * 2);
+  outline: none;
+  background: var(--pass-color);
+  margin-right: 0;
+  padding: 6px 0px 6px 4px;
+  color: white;
+  border-radius: 2px;
 }
 
 summary.lh-passed-audits-summary {


### PR DESCRIPTION
## Before 
![skjermbilde 2017-05-26 kl 21 40 55](https://cloud.githubusercontent.com/assets/16735925/26510167/4cbe35d8-425c-11e7-9118-422baf21bbad.png)
## After

![skjermbilde 2017-05-27 kl 01 41 03](https://cloud.githubusercontent.com/assets/16735925/26515697/98a823a2-427d-11e7-8f02-cb36d38a5976.png)


Optional merge. Fixing svg-icons issue right in mozilla ( might exist in IE too), seems to be related to `details` and `summary` not being correctly set in relation to the `::-webkit-details-marker` selector.
