### PR TITLE
Appveyor fixes: fresh yarn, only node6 build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,10 @@ environment:
   matrix:
     - nodejs_version: "6"
       platform: x86
+    # node 7 is skipped, as appveyor only allows 1 concurrent job
+    # and we want appveyor finishing ASAP. see #2382
+    # - nodejs_version: "7"
+    #   platform: x86
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,9 +5,7 @@ version: "{build}"
 environment:
   fast_finish: true
   matrix:
-    - nodejs_version: "6.9.1"
-      platform: x86
-    - nodejs_version: "7"
+    - nodejs_version: "6"
       platform: x86
 
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,8 +26,10 @@ test_script:
   - node --version
   - npm --version
   - yarn --version
-  - yarn lint
-  - yarn unit
+  - which yarn
+  - npm install yarn -g
+  - which yarn
+  - yarn install-all
   - yarn smoke
   - yarn smokehouse
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,7 @@ clone_depth: 10
 version: "{build}"
 
 environment:
+  fast_finish: true
   matrix:
     - nodejs_version: "6.9.1"
       platform: x86
@@ -13,6 +14,7 @@ build: off
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm install yarn -g
   - yarn
   - yarn install-all
 
@@ -27,9 +29,8 @@ test_script:
   - npm --version
   - yarn --version
   - which yarn
-  - npm install yarn -g
-  - which yarn
-  - yarn install-all
+  - yarn lint
+  - yarn unit
   - yarn smoke
   - yarn smokehouse
 


### PR DESCRIPTION
We were seeing this error in the appveyor logs:
![image](https://cloud.githubusercontent.com/assets/39191/26524985/a6463498-42fc-11e7-8446-01a5f5ccfabc.png)

It seemed to point at this yarn bug: https://github.com/yarnpkg/yarn/issues/2591

Appveyor has an older build of Yarn on the bots by default (0.21.3), so i've installed a fresh version of yarn (>= 0.24.5) in the build script. It sorts it out.

cc @XhmikosR 

-------

As a driveby: enabled `fast_finish` which means "immediately finish build once one of the jobs fails." We wanted this for travis too, but they don't have it. odd.

------

_Update_

Two more drivebys:

1. Our OSS free plan only allows 1 concurrent job at a time. Since appveyor VMs are so slow, i dont think its worth it to always wait for 2 back-to-back builds with node 6 and node 7. So i've ditched the node7 build.
2. I enabled the ["rolling builds" option](http://help.appveyor.com/discussions/problems/586-cancel-queued-builds-for-old-commits-of-the-same-branch) in the appveyor settings UI. It cancels queued builds if there's a fresh commit on the branch, must like the recently added travis beta experiment.
