### PR TITLE
Add remote-device flag to test mobile devices

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -57,7 +57,7 @@ instance with an open debugging port.
 
 Lighthouse can run against a real mobile device. You can follow the [Remote Debugging on Android (Legacy Workflow)](https://developer.chrome.com/devtools/docs/remote-debugging-legacy) up through step 3.3, but the TL;DR is install & run adb, enable USB debugging, then port forward 9222 from the device to the machine with Lighthouse.
 
-You'll likely want to use the CLI flags `--disable-device-emulation --disable-cpu-throttling`, `--port=9222` and potentially `--disable-network-throttling`. If you want to test on a mobile device without dealing with those flags, you could use `--remote-device` instead, which enables these features by default.
+You'll likely want to use the `--remote-device` flag which disables CPU and network throttling, disables device emulation, and defaults the port to 9222.
 
 ```sh
 $ adb kill-server

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -57,7 +57,7 @@ instance with an open debugging port.
 
 Lighthouse can run against a real mobile device. You can follow the [Remote Debugging on Android (Legacy Workflow)](https://developer.chrome.com/devtools/docs/remote-debugging-legacy) up through step 3.3, but the TL;DR is install & run adb, enable USB debugging, then port forward 9222 from the device to the machine with Lighthouse.
 
-You'll likely want to use the CLI flags `--disable-device-emulation --disable-cpu-throttling`, `--port=9222` and potentially `--disable-network-throttling`. If you want to test on a mobile device without dealing with those flags, you could use `lighthouse --remote-device` instead, which enables these features by default.
+You'll likely want to use the CLI flags `--disable-device-emulation --disable-cpu-throttling`, `--port=9222` and potentially `--disable-network-throttling`. If you want to test on a mobile device without dealing with those flags, you could use `--remote-device` instead, which enables these features by default.
 
 ```sh
 $ adb kill-server
@@ -69,7 +69,7 @@ $ adb devices -l
 
 $ adb forward tcp:9222 localabstract:chrome_devtools_remote
 
-$ lighthouse --disable-device-emulation --disable-cpu-throttling https://mysite.com
+$ lighthouse --remote-device https://mysite.com
 ```
 
 ## Lighthouse as trace processor

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -57,7 +57,7 @@ instance with an open debugging port.
 
 Lighthouse can run against a real mobile device. You can follow the [Remote Debugging on Android (Legacy Workflow)](https://developer.chrome.com/devtools/docs/remote-debugging-legacy) up through step 3.3, but the TL;DR is install & run adb, enable USB debugging, then port forward 9222 from the device to the machine with Lighthouse.
 
-You'll likely want to use the CLI flags `--disable-device-emulation --disable-cpu-throttling` and potentially `--disable-network-throttling`.
+You'll likely want to use the CLI flags `--disable-device-emulation --disable-cpu-throttling`, `--port=9222` and potentially `--disable-network-throttling`. If you want to test on a mobile device without dealing with those flags, you could use `lighthouse --remote-device` instead, which enables these features by default.
 
 ```sh
 $ adb kill-server

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -47,10 +47,12 @@ const cliFlags = getFlags();
 
 if (cliFlags.remoteDevice) {
   cliFlags.port = defaults(cliFlags.port, 9222);
-  cliFlags.disableNetworkThrottling = defaults(cliFlags.disableNetworkThrottling, true);
-  console.log(cliFlags.disableNetworkThrottling)
-  cliFlags.disableCpuThrottling = defaults(cliFlags.disableCpuThrottling, true);
-  cliFlags.disableDeviceEmulation = defaults(cliFlags.disableDeviceEmulation, true);
+
+  cliFlags.disableNetworkThrottling =
+      cliFlags.disableNetworkThrottling ? cliFlags.disableNetworkThrottling : true;
+
+  cliFlags.disableDeviceEmulation =
+      cliFlags.disableDeviceEmulation ? cliFlags.disableDeviceEmulation : true;
 }
 
 // Process terminating command

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -44,6 +44,13 @@ interface LighthouseError extends Error {
 
 const cliFlags = getFlags();
 
+if (cliFlags.remoteDevice) {
+  cliFlags.port = 9222;
+  cliFlags.disableNetworkThrottling = true;
+  cliFlags.disableCpuThrottling = true;
+  cliFlags.disableDeviceEmulation = true;
+}
+
 // Process terminating command
 if (cliFlags.listAllAudits) {
   Commands.ListAudits();

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -22,6 +22,7 @@ const _PROTOCOL_TIMEOUT_EXIT_CODE = 67;
 const assetSaver = require('../lighthouse-core/lib/asset-saver.js');
 const getFilenamePrefix = require('../lighthouse-core/lib/file-namer.js').getFilenamePrefix;
 import {launch, LaunchedChrome} from '../chrome-launcher/chrome-launcher';
+import {defaults} from '../chrome-launcher/utils';
 import * as Commands from './commands/commands';
 import {getFlags, Flags} from './cli-flags';
 const lighthouse = require('../lighthouse-core');
@@ -45,7 +46,7 @@ interface LighthouseError extends Error {
 const cliFlags = getFlags();
 
 if (cliFlags.remoteDevice) {
-  cliFlags.port = 9222;
+  cliFlags.port = defaults(cliFlags.port, 9222);
   cliFlags.disableNetworkThrottling = true;
   cliFlags.disableCpuThrottling = true;
   cliFlags.disableDeviceEmulation = true;

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -47,9 +47,10 @@ const cliFlags = getFlags();
 
 if (cliFlags.remoteDevice) {
   cliFlags.port = defaults(cliFlags.port, 9222);
-  cliFlags.disableNetworkThrottling = true;
-  cliFlags.disableCpuThrottling = true;
-  cliFlags.disableDeviceEmulation = true;
+  cliFlags.disableNetworkThrottling = defaults(cliFlags.disableNetworkThrottling, true);
+  console.log(cliFlags.disableNetworkThrottling)
+  cliFlags.disableCpuThrottling = defaults(cliFlags.disableCpuThrottling, true);
+  cliFlags.disableDeviceEmulation = defaults(cliFlags.disableDeviceEmulation, true);
 }
 
 // Process terminating command

--- a/lighthouse-cli/cli-flags.ts
+++ b/lighthouse-cli/cli-flags.ts
@@ -45,6 +45,7 @@ export function getFlags() {
       .example(
           'lighthouse <url> --disable-device-emulation --disable-network-throttling',
           'Disable device emulation')
+      .example('lighthouse <url> --remote-device', 'Enable remote device emulation')
       .example(
           'lighthouse <url> --chrome-flags="--window-size=412,732"',
           'Launch Chrome with a specific window size')
@@ -72,6 +73,7 @@ export function getFlags() {
         'disable-device-emulation': 'Disable Nexus 5X emulation',
         'disable-cpu-throttling': 'Disable CPU throttling',
         'disable-network-throttling': 'Disable network throttling',
+        'remote-device': 'Enable remote device emulation',
         'save-assets': 'Save the trace contents & screenshots to disk',
         'save-artifacts': 'Save all gathered artifacts to disk',
         'list-all-audits': 'Prints a list of all available audits and exits',
@@ -104,10 +106,10 @@ Example: --output-path=./lighthouse-results.html`,
 
       // boolean values
       .boolean([
-        'disable-storage-reset', 'disable-device-emulation', 'disable-cpu-throttling',
-        'disable-network-throttling', 'save-assets', 'save-artifacts', 'list-all-audits',
-        'list-trace-categories', 'perf', 'view', 'skip-autolaunch', 'select-chrome', 'verbose',
-        'quiet', 'help', 'interactive'
+        'disable-storage-reset', 'remote-device', 'disable-device-emulation',
+        'disable-cpu-throttling', 'disable-network-throttling', 'save-assets', 'save-artifacts',
+        'list-all-audits', 'list-trace-categories', 'perf', 'view', 'skip-autolaunch',
+        'select-chrome', 'verbose', 'quiet', 'help', 'interactive'
       ])
       .choices('output', GetValidOutputOptions())
 

--- a/lighthouse-cli/cli-flags.ts
+++ b/lighthouse-cli/cli-flags.ts
@@ -73,7 +73,8 @@ export function getFlags() {
         'disable-device-emulation': 'Disable Nexus 5X emulation',
         'disable-cpu-throttling': 'Disable CPU throttling',
         'disable-network-throttling': 'Disable network throttling',
-        'remote-device': 'Enable remote device emulation',
+        'remote-device':
+            'Disables CPU/Network throttling, emulation, and defaults the protocol port to 9222',
         'save-assets': 'Save the trace contents & screenshots to disk',
         'save-artifacts': 'Save all gathered artifacts to disk',
         'list-all-audits': 'Prints a list of all available audits and exits',


### PR DESCRIPTION
Enables mobile emulation to be the default port `9222` instead of `0` on device emulations. This enables mobile emulations instead of defaulting to the browser. Users can also use the remote debug port to forward I assume, without this getting affected. Fixes #2368