### PR TITLE
Manually check protocol for http -> https redirect

### DIFF
--- a/lighthouse-core/audits/redirects-http.js
+++ b/lighthouse-core/audits/redirects-http.js
@@ -38,6 +38,7 @@ class RedirectsHTTP extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
+    .
     return {
       rawValue: artifacts.HTTPRedirect.value,
       debugString: artifacts.HTTPRedirect.debugString

--- a/lighthouse-core/audits/redirects-http.js
+++ b/lighthouse-core/audits/redirects-http.js
@@ -38,7 +38,6 @@ class RedirectsHTTP extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-
     return {
       rawValue: artifacts.HTTPRedirect.value,
       debugString: artifacts.HTTPRedirect.debugString

--- a/lighthouse-core/audits/redirects-http.js
+++ b/lighthouse-core/audits/redirects-http.js
@@ -38,7 +38,7 @@ class RedirectsHTTP extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    .
+
     return {
       rawValue: artifacts.HTTPRedirect.value,
       debugString: artifacts.HTTPRedirect.debugString

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -71,13 +71,6 @@ class Driver {
      */
     this._httpsArr = [];
 
-    /**
-     * Used for monitoring url redirects to https
-     * at _beginNetworkStatusMonitoring.
-     * @private {Array}
-     */
-    this._httpArr = [];
-
     connection.on('notification', event => {
       this._devtoolsLog.record(event);
       if (this._networkStatusMonitor) {
@@ -549,9 +542,6 @@ class Driver {
       // register URLs to later validate against redirect
       if(redirectRequest.parsedURL.scheme === 'https') {
         this._httpsArr.push(redirectRequest.parsedURL);
-      }
-      if(redirectRequest.parsedURL.scheme === 'http') {
-        this._httpArr.push(redirectRequest.parsedURL);
       }
       // Ignore if this is not a redirected request.
       if (!redirectRequest.redirectSource) {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -64,6 +64,20 @@ class Driver {
      */
     this._monitoredUrl = null;
 
+    /**
+     * Used for monitoring initial route before httpsRedirect at
+     * _beginNetworkStatusMonitoring
+     * @private {Array}
+     */
+    this._httpsArr = [];
+
+    /**
+     * Used for monitoring url redirects to https
+     * at _beginNetworkStatusMonitoring.
+     * @private {Array}
+     */
+    this._httpArr = [];
+
     connection.on('notification', event => {
       this._devtoolsLog.record(event);
       if (this._networkStatusMonitor) {
@@ -532,6 +546,13 @@ class Driver {
     // Update startingUrl if it's ever redirected.
     this._monitoredUrl = startingUrl;
     this._networkStatusMonitor.on('requestloaded', redirectRequest => {
+      // register URLs to later validate against redirect
+      if(redirectRequest.parsedURL.scheme === 'https') {
+        this._httpsArr.push(redirectRequest.parsedURL);
+      }
+      if(redirectRequest.parsedURL.scheme === 'http') {
+        this._httpArr.push(redirectRequest.parsedURL);
+      }
       // Ignore if this is not a redirected request.
       if (!redirectRequest.redirectSource) {
         return;

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const Gatherer = require('./gatherer');
+const URL = require('../../lib/url-shim');
 
 /**
  * This gatherer changes the options.url so that its pass loads the http page.
@@ -39,9 +40,13 @@ class HTTPRedirect extends Gatherer {
     let isRedirect = false;
 
     if(options.driver._httpsArr.length !== 0) {
-      const httpsExpectURL = options.url.replace(/^http/, 'https');
       options.driver._httpsArr.forEach( (httpsUrl) => {
-        if(httpsUrl.url === httpsExpectURL) {
+        if(new URL(options.url).protocol === 'http:') {
+          const RedirectURL = options.url.replace(/^http/, 'https');
+          if(RedirectURL === httpsUrl.url) {
+            isRedirect = true;
+          }
+        } else if(httpsUrl.url === options.url) {
           isRedirect = true;
         } else if(httpsUrl.path === '/') {
           isRedirect = true;

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -38,8 +38,15 @@ class HTTPRedirect extends Gatherer {
   afterPass(options) {
     let isRedirect = false;
 
-    if(options.driver._httpsArr.length !== 0 && options.driver._httpsArr[0].scheme === 'https') {
-      isRedirect = true;
+    if(options.driver._httpsArr.length !== 0) {
+      const httpsExpectURL = options.url.replace(/^http/, 'https');
+      options.driver._httpsArr.forEach( (httpsUrl) => {
+        if(httpsUrl.url === httpsExpectURL) {
+          isRedirect = true;
+        } else if(httpsUrl.path === '/') {
+          isRedirect = true;
+        }
+      });
     }
     options.url = this._preRedirectURL;
     return {value: isRedirect};

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -17,7 +17,6 @@
 'use strict';
 
 const Gatherer = require('./gatherer');
-const URL = require('../../lib/url-shim');
 
 /**
  * This gatherer changes the options.url so that its pass loads the http page.
@@ -37,11 +36,20 @@ class HTTPRedirect extends Gatherer {
   }
 
   afterPass(options) {
-    const checkURLAfterDelay = new Promise(resolve => {
-      resolve({value: new URL(options.url).protocol === 'https:'});
-    });
+    let isRedirect;
+
+    if(options.driver._httpArr[0].url === options.url) {
+      isRedirect = false;
+    }
+    if(options.driver._httpsArr[0].scheme === 'https') {
+      isRedirect = true;
+    }
+    if(!isRedirect) {
+      isRedirect = false;
+    }
     options.url = this._preRedirectURL;
-    return checkURLAfterDelay.then(result => result);
+
+    return {value: isRedirect};
   }
 }
 

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -36,19 +36,12 @@ class HTTPRedirect extends Gatherer {
   }
 
   afterPass(options) {
-    let isRedirect;
+    let isRedirect = false;
 
-    if(options.driver._httpArr[0].url === options.url) {
-      isRedirect = false;
-    }
     if(options.driver._httpsArr[0].scheme === 'https') {
       isRedirect = true;
     }
-    if(!isRedirect) {
-      isRedirect = false;
-    }
     options.url = this._preRedirectURL;
-
     return {value: isRedirect};
   }
 }

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -38,7 +38,7 @@ class HTTPRedirect extends Gatherer {
   afterPass(options) {
     let isRedirect = false;
 
-    if(options.driver._httpsArr[0].scheme === 'https') {
+    if(options.driver._httpsArr.length !== 0 && options.driver._httpsArr[0].scheme === 'https') {
       isRedirect = true;
     }
     options.url = this._preRedirectURL;

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -37,15 +37,8 @@ class HTTPRedirect extends Gatherer {
   }
 
   afterPass(options) {
-    // explicitly use this._ to make test pass
-    this._url = options.url;
     const checkURLAfterDelay = new Promise(resolve => {
-      setTimeout(resolve, 5000);
-    }).then(_ => {
-      this._url = options.url;
-      return {value: new URL(this._url).protocol === 'https:'};
-    }).catch(_ => {
-      throw new Error('Couldn\'t resolve redirect');
+      resolve({value: new URL(options.url).protocol === 'https:'});
     });
     options.url = this._preRedirectURL;
     return checkURLAfterDelay.then(result => result);

--- a/lighthouse-core/gather/gatherers/http-redirect.js
+++ b/lighthouse-core/gather/gatherers/http-redirect.js
@@ -37,7 +37,7 @@ class HTTPRedirect extends Gatherer {
   }
 
   afterPass(options) {
-    let isRedirect = false;
+    let isRedirect = new URL(options.url).protocol === 'https:' ? true : false;
 
     if(options.driver._httpsArr.length !== 0) {
       options.driver._httpsArr.forEach( (httpsUrl) => {

--- a/lighthouse-core/test/gather/gatherers/http-redirect-test.js
+++ b/lighthouse-core/test/gather/gatherers/http-redirect-test.js
@@ -33,21 +33,4 @@ describe('HTTP Redirect gatherer', () => {
     httpRedirectGather.beforePass(opts);
     return assert.equal(opts.url, 'http://example.com');
   });
-
-  it('returns true for https', () => {
-    return httpRedirectGather.afterPass({
-      url: 'https://example.com'
-    })
-    .then(artifact => {
-      assert.equal(artifact.value, true);
-    });
-  });
-
-  it('returns false for non-https', () => {
-    return httpRedirectGather.afterPass({
-      url: 'http://vg.no'
-    }).then(artifact => {
-      assert.equal(artifact.value, false);
-    });
-  });
 });

--- a/lighthouse-core/test/gather/gatherers/http-redirect-test.js
+++ b/lighthouse-core/test/gather/gatherers/http-redirect-test.js
@@ -26,7 +26,6 @@ describe('HTTP Redirect gatherer', () => {
   beforeEach(() => {
     httpRedirectGather = new HTTPRedirectGather();
   });
-
   it('sets the URL to HTTP', () => {
     const opts = {
       url: 'https://example.com'
@@ -35,72 +34,20 @@ describe('HTTP Redirect gatherer', () => {
     return assert.equal(opts.url, 'http://example.com');
   });
 
-  it('resets the URL', () => {
-    const opts = {
-      url: 'https://example.com',
-      driver: {
-        getSecurityState() {
-          return Promise.resolve({
-            schemeIsCryptographic: true
-          });
-        }
-      }
-    };
-
-    httpRedirectGather.beforePass(opts);
-    return httpRedirectGather
-        .afterPass(opts)
-        .then(_ => {
-          assert.equal(opts.url, 'https://example.com');
-        });
-  });
-
-  it('returns an artifact', () => {
+  it('returns true for https', () => {
     return httpRedirectGather.afterPass({
-      driver: {
-        getSecurityState() {
-          return Promise.resolve({
-            schemeIsCryptographic: true
-          });
-        }
-      }
-    }).then(artifact => {
-      assert.ok(artifact.value);
+      url: 'https://example.com'
+    })
+    .then(artifact => {
+      assert.equal(artifact.value, true);
     });
   });
 
-  it('throws an error on driver failure', () => {
+  it('returns false for non-https', () => {
     return httpRedirectGather.afterPass({
-      driver: {
-        getSecurityState() {
-          return Promise.reject('such a fail');
-        }
-      }
-    }).then(
-      _ => assert.ok(false),
-      _ => assert.ok(true));
-  });
-
-  it('handles driver timeout', () => {
-    const fastTimeout = 50;
-    const slowResolve = 200;
-
-    return httpRedirectGather.afterPass({
-      driver: {
-        getSecurityState() {
-          return new Promise((resolve, reject) => {
-            // Resolve slowly, after the timeout for waiting on the security
-            // state has fired.
-            setTimeout(_ => resolve({
-              schemeIsCryptographic: true
-            }), slowResolve);
-          });
-        }
-      },
-
-      _testTimeout: fastTimeout
-    }).then(
-      _ => assert.ok(false),
-      _ => assert.ok(true));
+      url: 'http://vg.no'
+    }).then(artifact => {
+      assert.equal(artifact.value, false);
+    });
   });
 });

--- a/lighthouse-core/test/gather/gatherers/http-redirect-test.js
+++ b/lighthouse-core/test/gather/gatherers/http-redirect-test.js
@@ -33,4 +33,24 @@ describe('HTTP Redirect gatherer', () => {
     httpRedirectGather.beforePass(opts);
     return assert.equal(opts.url, 'http://example.com');
   });
+
+  it('returns true for https', () => {
+    const trueHTTPSRedirectResult = httpRedirectGather.afterPass({
+      url: 'https://example.com',
+      driver: {
+        _httpsArr: [{url: 'https://example.com'}]
+      }
+    });
+    assert.equal(trueHTTPSRedirectResult.value, true);
+  });
+
+  it('returns false for non-https', () => {
+    const trueHTTPSRedirectResult = httpRedirectGather.afterPass({
+      url: 'http://vg.no',
+      driver: {
+        _httpsArr: []
+      }
+    });
+    assert.equal(trueHTTPSRedirectResult.value, false);
+  });
 });

--- a/lighthouse-core/test/report/v2/renderer/format-helpers-test.js
+++ b/lighthouse-core/test/report/v2/renderer/format-helpers-test.js
@@ -29,7 +29,11 @@ describe('util helpers', () => {
 
   it('formats a date', () => {
     const timestamp = Util.formatDateTime('2017-04-28T23:07:51.189Z');
-    assert.ok(timestamp.includes('Apr 28, 2017'));
+    assert.ok(
+      timestamp.includes('Apr 27, 2017') ||
+      timestamp.includes('Apr 28, 2017') ||
+      timestamp.includes('Apr 29, 2017')
+    );
   });
 
   it('calculates a score ratings', () => {


### PR DESCRIPTION
fixes #2363

I’m not sure if I did this right. Seems too simple, but may be my lack of knowledge of what `afterPass` is doing behind the scenes. 