### PR TITLE
handle Page.handleJavaScriptDialog rejection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,11 @@ before_script:
   - export LIGHTHOUSE_CHROMIUM_PATH="$(pwd)/chrome-linux/chrome"
   - sh -e /etc/init.d/xvfb start
   - ./lighthouse-core/scripts/download-chrome.sh
-  - yarn build-all
 script:
-  - yarn test-cli-formatting
-  - yarn test-launcher-formatting
-  - yarn lint
-  - yarn unit
-  - yarn closure
-  - yarn smoke
-  - yarn smokehouse
-  - yarn compile-devtools
+  - bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh
+  - bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh
+  - bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh
+  - bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh
 after_success:
   - yarn coveralls
 after_failure:

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -121,10 +121,27 @@
   property the e.stack inside the gatherer won't be in the correct format
   https://github.com/GoogleChrome/lighthouse/issues/1194 -->
 <script>window.Error = function(error) { this.stack = 'stacktrace'; };</script>
+<script>
+window.confirm('Is DBW Mega Tester the best site?');
 
-<!--The javascriptDialogOpening test is disabled as we hit a platform bug frequently on travis-->
-<!--<script>window.confirm('Is DBW Mega Tester the best site?')</script>-->
+window.confirm('Is DBW Mega Tester the best site?');
 
+window.confirm('Is DBW Mega Tester the best site?');
+
+window.confirm('Is DBW Mega Tester the best site?');
+window.confirm('Is DBW Mega Tester the best site?');
+
+window.confirm('Is DBW Mega Tester the best site?');
+
+window.confirm('Is DBW Mega Tester the best site?');
+
+window.confirm('Is DBW Mega Tester the best site?');
+
+window.confirm('Is DBW Mega Tester the best site?');
+
+window.confirm('Is DBW Mega Tester the best site?');
+
+</script>
 <script>
 function stampTemplate(id, location) {
   const template = document.querySelector('#' + id);

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -60,6 +60,7 @@ function resolveLocalOrCwd(payloadPath) {
 function runLighthouse(url, configPath, saveAssetsPath) {
   const command = 'node';
   const args = [
+    '--trace-warnings',
     'lighthouse-cli/index.js',
     url,
     `--config-path=${configPath}`,

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -65,7 +65,7 @@ function runLighthouse(url, configPath, saveAssetsPath) {
     url,
     `--config-path=${configPath}`,
     '--output=json',
-    '--quiet',
+    '--verbose',
     '--port=0'
   ];
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -929,13 +929,8 @@ class Driver {
       // No need to wait for this event bind to complete, so no promise returned
       this.on('Page.javascriptDialogOpening', data => {
         log.warn('Driver', `${data.type} dialog opened by the page automatically suppressed.`);
-        // In some cases, handleJavaScriptDialog will reject, but it appears to only happen when the
-        // the dialog already dismissed.
-        // Since it's handled and no longer blocking the page, we're happy.
-        this.sendCommand('Page.handleJavaScriptDialog', {
-          accept: true,
-          promptText: 'Lighthouse prompt response',
-        }).catch(err => log.warn('Driver', err.message));
+        this.sendCommand('Page.handleJavaScriptDialog', {accept: false}, {silent: true})
+        .catch(_ => this.sendCommand('Page.handleJavaScriptDialog', {accept: true}, {silent: true}));
       });
     });
   }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -938,9 +938,8 @@ class Driver {
    * @return {!Promise}
    */
   dismissJavaScriptDialogs() {
-    const waitForDismiss = 300;
+    const waitForDismiss = 2000;
     const silent = {silent: true};
-
 
     return this.sendCommand('Page.enable').then(_ => {
       // No need to wait for this event bind to complete, so no promise returned

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -926,13 +926,16 @@ class Driver {
    */
   dismissJavaScriptDialogs() {
     return this.sendCommand('Page.enable').then(_ => {
+      // No need to wait for this event bind to complete, so no promise returned
       this.on('Page.javascriptDialogOpening', data => {
         log.warn('Driver', `${data.type} dialog opened by the page automatically suppressed.`);
-
+        // In some cases, handleJavaScriptDialog will reject, but it appears to only happen when the
+        // the dialog already dismissed.
+        // Since it's handled and no longer blocking the page, we're happy.
         this.sendCommand('Page.handleJavaScriptDialog', {
           accept: true,
           promptText: 'Lighthouse prompt response',
-        }).catch(err => log.error('driver', err.message));
+        }).catch(err => log.warn('Driver', err.message));
       });
     });
   }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -929,11 +929,10 @@ class Driver {
       this.on('Page.javascriptDialogOpening', data => {
         log.warn('Driver', `${data.type} dialog opened by the page automatically suppressed.`);
 
-        // rejection intentionally unhandled
         this.sendCommand('Page.handleJavaScriptDialog', {
           accept: true,
           promptText: 'Lighthouse prompt response',
-        });
+        }).catch(err => log.error('driver', err.message));
       });
     });
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -272,7 +272,7 @@ class GatherRunner {
     });
 
     // Disable throttling so the afterPass analysis isn't throttled
-    pass = pass.then(_ => driver.setThrottling(options.flags, {useThrottling: false}));
+    // pass = pass.then(_ => driver.setThrottling(options.flags, {useThrottling: false}));
 
     pass = gatherers.reduce((chain, gatherer) => {
       const status = `Retrieving: ${gatherer.name}`;

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -37,6 +37,12 @@ const Config = require('./config/config');
  *
  */
 
+process.on('unhandledRejection', function(err) {
+  log.error('promise', 'Unhandled rejection.');
+  log.error('promise', err.message, err.stack);
+  throw new Error('unhandled rejection, terminating');
+});
+
 module.exports = function(url, flags = {}, configJSON) {
   const startTime = Date.now();
   return Promise.resolve().then(_ => {

--- a/lighthouse-core/scripts/restart-travis-builds.rb
+++ b/lighthouse-core/scripts/restart-travis-builds.rb
@@ -37,7 +37,7 @@ def restart_builds
   repository = Travis::Repository.find('GoogleChrome/lighthouse')
   repository.each_build do |build|
     # failed builds are failed. errored = timed out, or another problem.
-    next unless build.errored? or build.failed? or build.started?
+    next unless build.errored? or build.failed?
 
     # only consider builds from the last 3 days
     next if build.started_at.nil?
@@ -56,13 +56,6 @@ def restart_builds
     puts "  Build #{build.number} #{build.state} #{to_pretty(build.started_at)}. Looking at jobs..."
 
     build.jobs.each do |job|
-
-      if job.started? and job.log.body.include? "Could not handle JavaScript dialog"
-        puts "  👺  Job #{job.number} started to fail because of handleJavaScriptDialog 🔳  "
-        puts "      Restarting job #{job.number}"
-        job.restart
-        next
-      end
 
       if job.failed? and job.log.body.include? "Could not handle JavaScript dialog"
         puts "  👺  Job #{job.number} failed because of handleJavaScriptDialog 🔳  "


### PR DESCRIPTION
Here's how to repro this bug:

1. open dbw_tester and find the `window.confirm()` call.
2. repeat it like 7 times.
2. comment out the "--quiet" flag in smokehouse.js to see output
3. run `bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh`
4. when the page loads for the first time, you should see these confirm prompts.
5. hit space bar frequently to try to dismiss the prompt before the protocol dismisses them.

 
--------------------

AFAICT, this rejection was unhandled because it's unexpected and we wanted it to tank the run... is that right?

Anyway, I handle it here and log it as an error:

![image](https://cloud.githubusercontent.com/assets/39191/26611945/70889f0a-4566-11e7-892b-4cd127e3c53f.png)


---------



fixes #2141
related issues: #2120, #1939, #2106 