### PR TITLE
use a stable sort for trace events

### DIFF
--- a/lighthouse-core/gather/computed/speedline.js
+++ b/lighthouse-core/gather/computed/speedline.js
@@ -21,10 +21,13 @@ class Speedline extends ComputedArtifact {
     // speedline() may throw without a promise, so we resolve immediately
     // to get in a promise chain.
     return computedArtifacts.requestTraceOfTab(trace).then(traceOfTab => {
+      // Use a shallow copy of traceEvents so speedline can sort as it pleases.
+      // See https://github.com/GoogleChrome/lighthouse/issues/2333
+      const traceEvents = trace.traceEvents.slice();
       // Force use of nav start as reference point for speedline
       // See https://github.com/GoogleChrome/lighthouse/issues/2095
       const navStart = traceOfTab.timestamps.navigationStart;
-      return speedline(trace.traceEvents, {
+      return speedline(traceEvents, {
         timeOrigin: navStart,
         fastMode: true,
       });

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -31,7 +31,8 @@ class TraceOfTab extends ComputedArtifact {
    * @return {!TraceOfTabArtifact}
   */
   compute_(trace) {
-    // Parse the trace for our key events and sort them by timestamp.
+    // Parse the trace for our key events and sort them by timestamp. Note: sort
+    // *must* be stable to keep events correctly nested.
     const keyEvents = trace.traceEvents
       .filter(e => {
         return e.cat.includes('blink.user_timing') ||
@@ -39,7 +40,7 @@ class TraceOfTab extends ComputedArtifact {
           e.cat.includes('devtools.timeline') ||
           e.name === 'TracingStartedInPage';
       })
-      .sort((event0, event1) => event0.ts - event1.ts);
+      .stableSort((event0, event1) => event0.ts - event1.ts);
 
     // The first TracingStartedInPage in the trace is definitely our renderer thread of interest
     // Beware: the tracingStartedInPage event can appear slightly after a navigationStart
@@ -84,9 +85,10 @@ class TraceOfTab extends ComputedArtifact {
     );
 
     // subset all trace events to just our tab's process (incl threads other than main)
+    // stable-sort events to keep them correctly nested.
     const processEvents = trace.traceEvents
       .filter(e => e.pid === startedInPageEvt.pid)
-      .sort((event0, event1) => event0.ts - event1.ts);
+      .stableSort((event0, event1) => event0.ts - event1.ts);
 
     const mainThreadEvents = processEvents
       .filter(e => e.tid === startedInPageEvt.tid);

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -19,6 +19,11 @@
 const ComputedArtifact = require('./computed-artifact');
 const log = require('../../lib/log');
 
+// Bring in web-inspector for side effect of adding [].stableSort
+// See https://github.com/GoogleChrome/lighthouse/pull/2415
+// eslint-disable-next-line no-unused-vars
+const WebInspector = require('../../lib/web-inspector');
+
 class TraceOfTab extends ComputedArtifact {
   get name() {
     return 'TraceOfTab';

--- a/lighthouse-core/test/gather/computed/speedline-test.js
+++ b/lighthouse-core/test/gather/computed/speedline-test.js
@@ -8,6 +8,7 @@
 /* eslint-env mocha */
 
 const assert = require('assert');
+const fs = require('fs');
 const pwaTrace = require('../../fixtures/traces/progressive-app.json');
 const threeFrameTrace = require('../../fixtures/traces/threeframes-blank_content_more.json');
 const Runner = require('../../../runner.js');
@@ -59,6 +60,22 @@ describe('Speedline gatherer', () => {
         assert.equal(firstResult, speedline, 'Cache match matches');
 
         return assert.equal(Math.floor(speedline.speedIndex), 561);
+      });
+  });
+
+  it('does not change order of events in traces', () => {
+    // Use fresh trace in case it has been altered by other require()s.
+    const pwaJson = fs.readFileSync(__dirname +
+        '/../../fixtures/traces/progressive-app.json', 'utf8');
+    const pwaTrace = JSON.parse(pwaJson);
+    return computedArtifacts.requestSpeedline({traceEvents: pwaTrace})
+      .then(_ => {
+        // assert.deepEqual has issue with diffing large array, so manually loop.
+        const freshTrace = JSON.parse(pwaJson);
+        assert.strictEqual(pwaTrace.length, freshTrace.length);
+        for (let i = 0; i < pwaTrace.length; i++) {
+          assert.deepStrictEqual(pwaTrace[i], freshTrace[i]);
+        }
       });
   });
 });


### PR DESCRIPTION
fixes #2333. Ensures that nested trace events stay nested.

I'm loath to use the Devtools array extensions, but the easiest way to bring in a stable sort is to use the one we already pull in with `devtools-frontend`, and since it [writes it directly onto the Array prototype](https://github.com/ChromeDevTools/devtools-frontend/blob/c3d0c13c1ad36c71f2a9218d42ba3de760e5f9a3/front_end/platform/utilities.js#L549), the easiest way to use it is to just call it on the `traceEvents` array. Better than bringing in a new module, at least :S

For testing, I haven't yet been able to produce a trace that when sorted with the native v8 `[].sort` will put events from the same process and thread out of order. In #2333 @wwwillchen notes it may also rely on the poor resolution of the android timer, so I'll try grabbing a trace from a mobile device to see if that gets me what we'll need.