### PR TITLE
Disable the dismissJavaScriptDialogs smoketest. 

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -121,7 +121,10 @@
   property the e.stack inside the gatherer won't be in the correct format
   https://github.com/GoogleChrome/lighthouse/issues/1194 -->
 <script>window.Error = function(error) { this.stack = 'stacktrace'; };</script>
-<script>window.confirm('Is DBW Mega Tester the best site?')</script>
+
+<!--The javascriptDialogOpening test is disabled as we hit a platform bug frequently on travis-->
+<!--<script>window.confirm('Is DBW Mega Tester the best site?')</script>-->
+
 <script>
 function stampTemplate(id, location) {
   const template = document.querySelector('#' + id);


### PR DESCRIPTION
A proactive commit to sort out our tests.
I'm improving the fix in #2402 and will be landing that soon


fixes #2141 
ref #2423