### PR TITLE
fix: better debug message for missing network times

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -78,6 +78,10 @@ class UnusedBytes extends Audit {
    * @return {!AuditResult}
    */
   static createAuditResult(result, networkThroughput) {
+    if (!Number.isFinite(networkThroughput) && result.results.length) {
+      throw new Error('Invalid network timing information');
+    }
+
     const debugString = result.debugString;
     const results = result.results
         .map(item => {

--- a/lighthouse-core/gather/computed/network-throughput.js
+++ b/lighthouse-core/gather/computed/network-throughput.js
@@ -15,6 +15,7 @@ class NetworkThroughput extends ComputedArtifact {
   /**
    * Computes the average throughput for the given records in bytes/second.
    * Excludes data URI, failed or otherwise incomplete, and cached requests.
+   * Returns Infinity if there were no analyzable network records.
    *
    * @param {?Array<!WebInspector.NetworkRequest>} networkRecords
    * @return {number}

--- a/lighthouse-core/gather/computed/network-throughput.js
+++ b/lighthouse-core/gather/computed/network-throughput.js
@@ -20,9 +20,7 @@ class NetworkThroughput extends ComputedArtifact {
    * @return {number}
    */
   compute_(networkRecords) {
-    if (!networkRecords || !networkRecords.length) {
-      return 0;
-    }
+    networkRecords = networkRecords || [];
 
     let totalBytes = 0;
     const timeBoundaries = networkRecords.reduce((boundaries, record) => {
@@ -37,6 +35,10 @@ class NetworkThroughput extends ComputedArtifact {
       boundaries.push({time: record.endTime, isStart: false});
       return boundaries;
     }, []).sort((a, b) => a.time - b.time);
+
+    if (!timeBoundaries.length) {
+      return Infinity;
+    }
 
     let inflight = 0;
     let currentStart = 0;

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -193,6 +193,12 @@ class CategoryRenderer {
     const descriptionEl = this._dom.createChildOf(element, 'div', 'lh-perf-hint__description');
     descriptionEl.appendChild(this._dom.convertMarkdownLinkSnippets(audit.result.helpText));
 
+    if (audit.result.debugString) {
+      const debugStrEl = this._dom.createChildOf(element, 'div', 'lh-debug');
+      debugStrEl.textContent = audit.result.debugString;
+      element.open = true;
+    }
+
     if (audit.result.details) {
       element.appendChild(this._detailsRenderer.render(audit.result.details));
     }

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -61,7 +61,7 @@ describe('Byte efficiency base audit', () => {
     const result = ByteEfficiencyAudit.createAuditResult({
       headings: [{key: 'value', text: 'Label'}],
       results: [{wastedBytes: 2048, totalBytes: 4096, wastedPercent: 50}],
-    });
+    }, 1000);
 
     assert.equal(result.extendedInfo.value.results[0].wastedKb, '2 KB');
     assert.equal(result.extendedInfo.value.results[0].totalKb, '4 KB');
@@ -85,7 +85,7 @@ describe('Byte efficiency base audit', () => {
         {wastedBytes: 450, totalBytes: 1000, wastedPercent: 50},
         {wastedBytes: 400, totalBytes: 450, wastedPercent: 50},
       ],
-    });
+    }, 1000);
 
     assert.equal(result.extendedInfo.value.results[0].wastedBytes, 450);
     assert.equal(result.extendedInfo.value.results[1].wastedBytes, 400);

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -57,6 +57,15 @@ describe('Byte efficiency base audit', () => {
     assert.ok(failingResult.score < 50, 'scores failing wastedMs');
   });
 
+  it('should throw on invalid network throughput', () => {
+    assert.throws(() => {
+      ByteEfficiencyAudit.createAuditResult({
+        headings: [{key: 'value', text: 'Label'}],
+        results: [{wastedBytes: 350, totalBytes: 700, wastedPercent: 50}],
+      }, Infinity);
+    });
+  });
+
   it('should populate Kb', () => {
     const result = ByteEfficiencyAudit.createAuditResult({
       headings: [{key: 'value', text: 'Label'}],

--- a/lighthouse-core/test/gather/computed/network-throughput-test.js
+++ b/lighthouse-core/test/gather/computed/network-throughput-test.js
@@ -25,6 +25,13 @@ describe('NetworkThroughput', () => {
     }, extras);
   }
 
+  it('should return Infinity for no/missing records', () => {
+    assert.equal(compute(undefined), Infinity);
+    assert.equal(compute(null), Infinity);
+    assert.equal(compute([]), Infinity);
+    assert.equal(compute([createRecord(0, 0, {finished: false})]), Infinity);
+  });
+
   it('should compute correctly for a basic waterfall', () => {
     const result = compute([
       createRecord(0, 1),

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -174,6 +174,21 @@ describe('CategoryRenderer', () => {
       assert.ok(hintSparklineElement.title, 'did not render tooltip');
     });
 
+    it('renders the performance hints with a debug string', () => {
+      const auditWithDebug = {
+        score: 0,
+        group: 'perf-hint',
+        result: {rawValue: 100, debugString: 'Yikes!', description: 'Bug'},
+      };
+
+      const fakeAudits = category.audits.concat(auditWithDebug);
+      const fakeCategory = Object.assign({}, category, {audits: fakeAudits});
+      const categoryDOM = renderer.render(fakeCategory, sampleResults.reportGroups);
+
+      const debugEl = categoryDOM.querySelector('.lh-perf-hint .lh-debug');
+      assert.ok(debugEl, 'did not render debug');
+    });
+
     it('renders the performance hints with no extended info', () => {
       const buggyAudit = {
         score: 0,


### PR DESCRIPTION
Improves the debug information when network throughput can't be computed and defaults the result to Infinity instead of 0 which makes more sense since the only use of networkThroughput is to be the divisor (the computed artifact is also used by total byte weight which makes sense to say 0 ms time and still report the byte savings)

This was affecting chrome URLs which don't have any timing information, results from before and after for `chrome://version` below (the optimized images error is for tainting canvas which apparently all chrome images do)

**Before**
![image](https://user-images.githubusercontent.com/2301202/26858029-e4b2c978-4ae3-11e7-9fad-a25b240b4de1.png)

**After**
![image](https://user-images.githubusercontent.com/2301202/26858106-53824a90-4ae4-11e7-8d15-d91bf68c024b.png)
