### PR TITLE
Theme Color wording fixes

### DIFF
--- a/lighthouse-core/audits/themed-omnibox.js
+++ b/lighthouse-core/audits/themed-omnibox.js
@@ -27,7 +27,7 @@ class ThemedOmnibox extends MultiCheckAudit {
     return {
       category: 'PWA',
       name: 'themed-omnibox',
-      description: 'Address bar matches brand colors',
+      description: 'Address bar has been themed',
       helpText: 'The browser address bar can be themed to match your site. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/address-bar).',
       requiredArtifacts: ['Manifest', 'ThemeColor']

--- a/lighthouse-core/test/results/sample.json
+++ b/lighthouse-core/test/results/sample.json
@@ -1612,8 +1612,8 @@
         },
         {
           "overall": 0,
-          "name": "Address bar matches brand colors",
-          "description": "The browser address bar can be themed to match your site. A `theme-color` [meta tag](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android) will upgrade the address bar when a user browses the site, and the [manifest theme-color](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color) will apply the same theme site-wide once it's been added to homescreen.",
+          "name": "Address bar has been themed",
+          "description": "The browser address bar can be themed to match your site. Adding the `theme-color` [meta tag](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android) to a web page will colorize the address bar when a user browses the site, while adding the `theme_color` [attribute](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color) to your web app's manifest will colorize the address bar once the app has been added to homescreen.",
           "subItems": [
             "manifest-exists",
             "theme-color-meta",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -855,8 +855,8 @@
       "scoringMode": "binary",
       "name": "themed-omnibox",
       "category": "PWA",
-      "description": "Address bar matches brand colors",
-      "helpText": "The browser address bar can be themed to match your site. A `theme-color` [meta tag](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android) will upgrade the address bar when a user browses the site, and the [manifest theme-color](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color) will apply the same theme site-wide once it's been added to homescreen."
+      "description": "Address bar has been themed",
+      "helpText": "The browser address bar can be themed to match your site. Adding the `theme-color` [meta tag](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android) to a web page will colorize the address bar when a user browses the site, while adding the `theme_color` [attribute](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color) to your web app's manifest will colorize the address bar once the app has been added to homescreen."
     },
     "manifest-short-name-length": {
       "score": false,
@@ -3604,8 +3604,8 @@
             "scoringMode": "binary",
             "name": "themed-omnibox",
             "category": "PWA",
-            "description": "Address bar matches brand colors",
-            "helpText": "The browser address bar can be themed to match your site. A `theme-color` [meta tag](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android) will upgrade the address bar when a user browses the site, and the [manifest theme-color](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color) will apply the same theme site-wide once it's been added to homescreen."
+            "description": "Address bar has been themed",
+            "helpText": "The browser address bar can be themed to match your site. Adding the `theme-color` [meta tag](https://developers.google.com/web/updates/2014/11/Support-for-theme-color-in-Chrome-39-for-Android) to a web page will colorize the address bar when a user browses the site, while adding the `theme_color` [attribute](https://developers.google.com/web/updates/2015/08/using-manifest-to-set-sitewide-theme-color) to your web app's manifest will colorize the address bar once the app has been added to homescreen."
           },
           "score": 0
         },


### PR DESCRIPTION
Updated description
- Lighthouse has no idea what your brand colors are - it's really just checking to see whether the address bar has been themed in any way.

Corrected reference to manifest theme color ("theme_color" vs. "theme-color")

Changes for clarity:
- I think "apply the same theme site-wide" could be misinterpreted as altering the web site appearance (vs. the browser) in some way. It's also slightly ambiguous as to whether "applying a theme" is the same thing as "upgrading the address bar", or whether it represents a larger subset of functionalities.