### PR TITLE
move computed artifacts dependent on networkRecords to devtoolsLog

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -62,14 +62,13 @@ class UnusedBytes extends Audit {
    * @return {!Promise<!AuditResult>}
    */
   static audit(artifacts) {
-    const devtoolsLogs = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    return artifacts.requestNetworkRecords(devtoolsLogs).then(networkRecords => {
-      return artifacts.requestNetworkThroughput(networkRecords).then(networkThroughput =>
-        Promise.resolve(this.audit_(artifacts, networkRecords)).then(result =>
-          this.createAuditResult(result, networkThroughput)
-        )
-      );
-    });
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    return artifacts.requestNetworkRecords(devtoolsLog)
+      .then(networkRecords => this.audit_(artifacts, networkRecords))
+      .then(result => {
+        return artifacts.requestNetworkThroughput(devtoolsLog)
+          .then(networkThroughput => this.createAuditResult(result, networkThroughput));
+      });
   }
 
   /**

--- a/lighthouse-core/closure/typedefs/ComputedArtifacts.js
+++ b/lighthouse-core/closure/typedefs/ComputedArtifacts.js
@@ -53,7 +53,7 @@ ComputedArtifacts.prototype.requestNetworkRecords;
 /** @type {function(ManifestNode<(!Manifest|undefined)>): !Promise<{isParseFailure: boolean, parseFailureReason: string, allChecks: !Array<{passing: boolean, failureText: string}>}>} */
 ComputedArtifacts.prototype.requestManifestValues;
 
-/** @type {function(!Array): !Promise<number>} */
+/** @type {function(!DevtoolsLog): !Promise<number>} */
 ComputedArtifacts.prototype.requestNetworkThroughput;
 
 // ComputedArtifacts.prototype.requestPushedRequests;

--- a/lighthouse-core/closure/typedefs/ComputedArtifacts.js
+++ b/lighthouse-core/closure/typedefs/ComputedArtifacts.js
@@ -44,7 +44,7 @@ let TraceOfTabArtifact;
  */
 function ComputedArtifacts() {}
 
-/** @type {function(!Array): !Promise<!Object>} */
+/** @type {function(!DevtoolsLog): !Promise<!Object>} */
 ComputedArtifacts.prototype.requestCriticalRequestChains;
 
 /** @type {function(!DevtoolsLog): !Promise<!Array<!WebInspector.NetworkRequest>>} */

--- a/lighthouse-core/gather/computed/critical-request-chains.js
+++ b/lighthouse-core/gather/computed/critical-request-chains.js
@@ -20,7 +20,7 @@ class CriticalRequestChains extends ComputedArtifact {
    * @see https://docs.google.com/document/d/1bCDuq9H1ih9iNjgzyAL0gpwNFiEP4TZS-YLRp_RuMlc
    * @param  {any} request
    */
-  isCritical(request) {
+  static isCritical(request) {
     const resourceTypeCategory = request._resourceType && request._resourceType._category;
 
     // XHRs are fetched at High priority, but we exclude them, as they are unlikely to be critical
@@ -38,7 +38,7 @@ class CriticalRequestChains extends ComputedArtifact {
     return ['VeryHigh', 'High', 'Medium'].includes(request.priority());
   }
 
-  compute_(networkRecords) {
+  static extractChains(networkRecords) {
     networkRecords = networkRecords.filter(req => req.finished);
 
     // Build a map of requestID -> Node.
@@ -49,7 +49,7 @@ class CriticalRequestChains extends ComputedArtifact {
 
     // Get all the critical requests.
     /** @type {!Array<NetworkRequest>} */
-    const criticalRequests = networkRecords.filter(req => this.isCritical(req));
+    const criticalRequests = networkRecords.filter(CriticalRequestChains.isCritical);
 
     const flattenRequest = request => {
       return {
@@ -71,7 +71,7 @@ class CriticalRequestChains extends ComputedArtifact {
       let ancestorRequest = request.initiatorRequest();
       let node = criticalRequestChains;
       while (ancestorRequest) {
-        const ancestorIsCritical = this.isCritical(ancestorRequest);
+        const ancestorIsCritical = CriticalRequestChains.isCritical(ancestorRequest);
 
         // If the parent request isn't a high priority request it won't be in the
         // requestIdToRequests map, and so we can break the chain here. We should also
@@ -123,6 +123,16 @@ class CriticalRequestChains extends ComputedArtifact {
     }
 
     return criticalRequestChains;
+  }
+
+  /**
+   * @param {!DevtoolsLog} devtoolsLog
+   * @param {!ComputedArtifacts} artifacts
+   * @return {!Promise<!Object>}
+   */
+  compute_(devtoolsLog, artifacts) {
+    return artifacts.requestNetworkRecords(devtoolsLog)
+      .then(CriticalRequestChains.extractChains);
   }
 }
 

--- a/lighthouse-core/gather/computed/critical-request-chains.js
+++ b/lighthouse-core/gather/computed/critical-request-chains.js
@@ -38,7 +38,7 @@ class CriticalRequestChains extends ComputedArtifact {
     return ['VeryHigh', 'High', 'Medium'].includes(request.priority());
   }
 
-  static extractChains(networkRecords) {
+  static extractChain(networkRecords) {
     networkRecords = networkRecords.filter(req => req.finished);
 
     // Build a map of requestID -> Node.
@@ -132,7 +132,7 @@ class CriticalRequestChains extends ComputedArtifact {
    */
   compute_(devtoolsLog, artifacts) {
     return artifacts.requestNetworkRecords(devtoolsLog)
-      .then(CriticalRequestChains.extractChains);
+      .then(CriticalRequestChains.extractChain);
   }
 }
 

--- a/lighthouse-core/gather/computed/network-throughput.js
+++ b/lighthouse-core/gather/computed/network-throughput.js
@@ -17,12 +17,10 @@ class NetworkThroughput extends ComputedArtifact {
    * Excludes data URI, failed or otherwise incomplete, and cached requests.
    * Returns Infinity if there were no analyzable network records.
    *
-   * @param {?Array<!WebInspector.NetworkRequest>} networkRecords
+   * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
    * @return {number}
    */
-  compute_(networkRecords) {
-    networkRecords = networkRecords || [];
-
+  static getThroughput(networkRecords) {
     let totalBytes = 0;
     const timeBoundaries = networkRecords.reduce((boundaries, record) => {
       const scheme = record.parsedURL && record.parsedURL.scheme;
@@ -59,6 +57,16 @@ class NetworkThroughput extends ComputedArtifact {
     });
 
     return totalBytes / totalDuration;
+  }
+
+  /**
+   * @param {!DevtoolsLog} devtoolsLog
+   * @param {!ComputedArtifacts} artifacts
+   * @return {!Promise<!Object>}
+   */
+  compute_(devtoolsLog, artifacts) {
+    return artifacts.requestNetworkRecords(devtoolsLog)
+      .then(NetworkThroughput.getThroughput);
   }
 }
 

--- a/lighthouse-core/gather/computed/pushed-requests.js
+++ b/lighthouse-core/gather/computed/pushed-requests.js
@@ -15,12 +15,15 @@ class PushedRequests extends ComputedArtifact {
 
   /**
    * Return list of network requests that were pushed.
-   * @param {!Array<!WebInspector.NetworkRequest>} records
-   * @return {!Array<!WebInspector.NetworkRequest>}
+   * @param {!DevtoolsLog} devtoolsLog
+   * @param {!ComputedArtifacts} artifacts
+   * @return {!Promise<!Array<!WebInspector.NetworkRequest>>}
    */
-  compute_(records) {
-    const pushedRecords = records.filter(r => r._timing && !!r._timing.pushStart);
-    return pushedRecords;
+  compute_(devtoolsLog, artifacts) {
+    return artifacts.requestNetworkRecords(devtoolsLog).then(records => {
+      const pushedRecords = records.filter(r => r._timing && !!r._timing.pushStart);
+      return pushedRecords;
+    });
   }
 }
 

--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -7,7 +7,7 @@
 
 /* eslint-env mocha */
 
-const Audit = require('../../audits/critical-request-chains.js');
+const CriticalRequestChains = require('../../audits/critical-request-chains.js');
 const assert = require('assert');
 
 const FAILING_REQUEST_CHAIN = {
@@ -72,7 +72,7 @@ const EMPTY_REQUEST_CHAIN = {};
 const mockArtifacts = (mockChain) => {
   return {
     devtoolsLogs: {
-      [Audit.DEFAULT_PASS]: []
+      [CriticalRequestChains.DEFAULT_PASS]: []
     },
     requestNetworkRecords: () => {
       return Promise.resolve([]);
@@ -85,7 +85,7 @@ const mockArtifacts = (mockChain) => {
 
 describe('Performance: critical-request-chains audit', () => {
   it('calculates the correct chain result for failing example', () => {
-    return Audit.audit(mockArtifacts(FAILING_REQUEST_CHAIN)).then(output => {
+    return CriticalRequestChains.audit(mockArtifacts(FAILING_REQUEST_CHAIN)).then(output => {
       assert.equal(output.displayValue, 2);
       assert.equal(output.rawValue, false);
       assert.ok(output.details);
@@ -93,7 +93,7 @@ describe('Performance: critical-request-chains audit', () => {
   });
 
   it('calculates the correct chain result for passing example', () => {
-    return Audit.audit(mockArtifacts(PASSING_REQUEST_CHAIN)).then(output => {
+    return CriticalRequestChains.audit(mockArtifacts(PASSING_REQUEST_CHAIN)).then(output => {
       assert.equal(output.details.longestChain.duration, 1000);
       assert.equal(output.displayValue, 0);
       assert.equal(output.rawValue, true);
@@ -101,14 +101,14 @@ describe('Performance: critical-request-chains audit', () => {
   });
 
   it('calculates the correct chain result for passing example (no 2.)', () => {
-    return Audit.audit(mockArtifacts(PASSING_REQUEST_CHAIN_2)).then(output => {
+    return CriticalRequestChains.audit(mockArtifacts(PASSING_REQUEST_CHAIN_2)).then(output => {
       assert.equal(output.displayValue, 0);
       assert.equal(output.rawValue, true);
     });
   });
 
   it('calculates the correct chain result for empty example', () => {
-    return Audit.audit(mockArtifacts(EMPTY_REQUEST_CHAIN)).then(output => {
+    return CriticalRequestChains.audit(mockArtifacts(EMPTY_REQUEST_CHAIN)).then(output => {
       assert.equal(output.displayValue, 0);
       assert.equal(output.rawValue, true);
     });

--- a/lighthouse-core/test/fixtures/wikipedia-redirect.critical-request-chains.json
+++ b/lighthouse-core/test/fixtures/wikipedia-redirect.critical-request-chains.json
@@ -1,0 +1,26 @@
+{
+  "33097.1:redirected.0": {
+    "request": {"url":"http://en.wikipedia.org/","startTime":496649.559583,"endTime":496649.560558,"responseReceivedTime":496649.559597,"transferSize":0},
+    "children": {
+      "33097.1:redirected.1": {
+        "request": {"url":"https://en.wikipedia.org/","startTime":496649.561058,"endTime":496649.863606,"responseReceivedTime":496649.860002,"transferSize":992},
+        "children": {
+          "33097.1:redirected.2": {
+            "request": {"url":"https://en.wikipedia.org/wiki/Main_Page","startTime":496649.864273,"endTime":496650.019583,"responseReceivedTime":496650.017331,"transferSize":293},
+            "children": {
+              "33097.1": {
+                "request": {"url":"https://en.m.wikipedia.org/wiki/Main_Page","startTime":496650.020124,"endTime":496650.267975,"responseReceivedTime":496650.232022,"transferSize":8315},
+                "children": {
+                  "33097.3": {
+                    "request": {"url":"https://en.m.wikipedia.org/w/load.php?debug=false&lang=en&modules=mediawiki.ui.button%2Cicon%7Cskins.minerva.base.reset%2Cstyles%7Cskins.minerva.content.styles%7Cskins.minerva.icons.images%7Cskins.minerva.mainPage.styles%7Cskins.minerva.tablet.styles&only=styles&skin=minerva","startTime":496650.292339,"endTime":496650.53995,"responseReceivedTime":496650.45365,"transferSize":9085},
+                    "children": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lighthouse-core/test/gather/computed/network-throughput-test.js
+++ b/lighthouse-core/test/gather/computed/network-throughput-test.js
@@ -11,7 +11,7 @@ const NetworkThroughput = require('../../../gather/computed/network-throughput')
 const assert = require('assert');
 
 describe('NetworkThroughput', () => {
-  const compute = new NetworkThroughput().compute_;
+  const compute = NetworkThroughput.getThroughput;
   function createRecord(responseReceivedTime, endTime, extras) {
     return Object.assign({
       responseReceivedTime,
@@ -26,8 +26,6 @@ describe('NetworkThroughput', () => {
   }
 
   it('should return Infinity for no/missing records', () => {
-    assert.equal(compute(undefined), Infinity);
-    assert.equal(compute(null), Infinity);
     assert.equal(compute([]), Infinity);
     assert.equal(compute([createRecord(0, 0, {finished: false})]), Infinity);
   });

--- a/lighthouse-core/test/gather/computed/pushed-requests-test.js
+++ b/lighthouse-core/test/gather/computed/pushed-requests-test.js
@@ -7,15 +7,17 @@
 
 /* eslint-env mocha */
 
-const GathererClass = require('../../../gather/computed/pushed-requests');
+const Runner = require('../../../runner.js');
 const mockNetworkRecords = require('../../fixtures/networkRecords-h2push.json');
 
 const assert = require('assert');
-const Gatherer = new GathererClass();
 
 describe('PushedRequests computed artifact', () => {
   it('filters networkRecords down to the pushed ones', () => {
-    return Gatherer.request(mockNetworkRecords).then(records => {
+    const computedArtifacts = Runner.instantiateComputedArtifacts();
+    computedArtifacts.requestNetworkRecords = _ => Promise.resolve(mockNetworkRecords);
+
+    return computedArtifacts.requestPushedRequests({}).then(records => {
       assert.ok(records.length < mockNetworkRecords.length, 'We filtered out the non-push records');
       assert.equal(records.length, 3, 'There are 3 pushed responses in the recording');
       return;

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -420,12 +420,10 @@ describe('Runner', () => {
       const devtoolsLogs = artifacts.devtoolsLogs['firstPass'];
       assert.equal(Array.isArray(devtoolsLogs), true, 'devtoolsLogs is not an array');
 
-      return artifacts.requestNetworkRecords(devtoolsLogs).then(networkRecords => {
-        return artifacts.requestCriticalRequestChains(networkRecords).then(chains => {
-          assert.ok(chains['93149.1']);
-          assert.ok(chains['93149.1'].request);
-          assert.ok(chains['93149.1'].children);
-        });
+      return artifacts.requestCriticalRequestChains(devtoolsLogs).then(chains => {
+        assert.ok(chains['93149.1']);
+        assert.ok(chains['93149.1'].request);
+        assert.ok(chains['93149.1'].children);
       });
     });
   });


### PR DESCRIPTION
followup to #2062 and #2133 (specifically https://github.com/GoogleChrome/lighthouse/pull/2062#discussion_r113811358)

really just a convenience thing. Since computed artifacts can request other computed artifacts, callers of e.g. criticalRequestChains shouldn't have to construct networkRecords, CRC can just do it itself.