### PR TITLE
Report coverage to codecov.io

### DIFF
--- a/lighthouse-core/scripts/generate-combined-coverage.sh
+++ b/lighthouse-core/scripts/generate-combined-coverage.sh
@@ -6,6 +6,11 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 ##
 
+# run tests with coverage in both root and launcher
 yarn run coverage
 cd chrome-launcher && yarn run coverage && cd ..
+
+# report to coveralls
 ./node_modules/.bin/lcov-result-merger '**/lcov.info' | ./node_modules/.bin/coveralls
+# report to codecov
+./node_modules/codecov/bin/codecov

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "lint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .",
     "smoke": "bash lighthouse-cli/test/smokehouse/offline-local/run-tests.sh && bash lighthouse-cli/test/smokehouse/perf/run-tests.sh && bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh && bash lighthouse-cli/test/smokehouse/byte-efficiency/run-tests.sh",
     "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*-test.js') --timeout 10000 --reporter progress --report lcovonly",
-    "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "codecov": "codecov",
     "start": "gulp && node ./lighthouse-cli/index.js",
     "test": "yarn lint --silent && gulp && yarn unit && yarn closure && yarn test-cli-formatting && yarn test-launcher-formatting",
     "unit-core": "bash lighthouse-core/scripts/run-mocha.sh --core",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "clean": "rimraf *.report.html *.report.dom.html *.report.json *.screenshots.html *.devtoolslog.json *.trace.json || true",
     "lint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .",
     "smoke": "bash lighthouse-cli/test/smokehouse/offline-local/run-tests.sh && bash lighthouse-cli/test/smokehouse/perf/run-tests.sh && bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh && bash lighthouse-cli/test/smokehouse/byte-efficiency/run-tests.sh",
-    "coverage": "node $(yarn bin)/istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*-test.js') --timeout 10000 --reporter progress",
+    "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*-test.js') --timeout 10000 --reporter progress --report lcovonly",
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "codecov": "codecov",
     "start": "gulp && node ./lighthouse-cli/index.js",
     "test": "yarn lint --silent && gulp && yarn unit && yarn closure && yarn test-cli-formatting && yarn test-launcher-formatting",
     "unit-core": "bash lighthouse-core/scripts/run-mocha.sh --core",
@@ -55,6 +57,7 @@
   "devDependencies": {
     "@types/node": "^6.0.45",
     "babel-core": "^6.16.0",
+    "codecov": "^2.2.0",
     "coveralls": "^2.11.9",
     "eslint": "^3.12.0",
     "eslint-config-google": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -496,6 +500,14 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.0.1.tgz#1104cd34f9b5b45d3eba88f1babc1924e1ce35fb"
   dependencies:
     number-is-nan "^1.0.0"
+
+codecov@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-2.2.0.tgz#2d06817ceb8891eca6368836d4fb6bf6cc04ffd1"
+  dependencies:
+    argv "0.0.2"
+    request "2.79.0"
+    urlgrey "0.4.4"
 
 colors@~0.6.2:
   version "0.6.2"
@@ -2618,6 +2630,10 @@ qs@~6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.1.tgz#ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
 
+qs@~6.3.0:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
@@ -2803,6 +2819,31 @@ request@2.75.0:
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
+
+request@2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+    uuid "^3.0.0"
 
 request@^2.79.0:
   version "2.81.0"
@@ -3309,6 +3350,10 @@ url-parse-lax@^1.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
+
+urlgrey@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 user-home@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Example report: https://codecov.io/gh/GoogleChrome/lighthouse/tree/8851e9313eac1c5b1f6d4369da81b2598da7100f

![image](https://user-images.githubusercontent.com/39191/27246075-0d9719ee-52a4-11e7-87fd-6792bfc4b1a8.png)

Still reporting to coveralls for the moment, too.

FWIW, The typescript tests in chrome-launcher arent included because of the different (`ts-node`) mocha call. cc @samccone 