### PR TITLE
Throw better error message when url is not auditable

### DIFF
--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -22,8 +22,8 @@ const NON_BUG_ERROR_MESSAGES = {
   // The user tries to review an error page or has network issues
   'Unable to load the page': 'Unable to load the page. Please verify the url you ' +
       'are trying to review.',
-  'Cannot access contents of the page': 'The Lighthouse extension can only audit ' +
-      ' http & https pages.',
+  'Cannot access contents of the page': 'Lighthouse can only audit URLs that start' +
+      ' with http:// or https://.',
 };
 
 const MAX_ISSUE_ERROR_LENGTH = 60;

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -21,7 +21,9 @@ const NON_BUG_ERROR_MESSAGES = {
       'Chrome-specific urls. If necessary, use the Lighthouse CLI to do so.',
   // The user tries to review an error page or has network issues
   'Unable to load the page': 'Unable to load the page. Please verify the url you ' +
-      'are trying to review.'
+      'are trying to review.',
+  'Cannot access contents of the page': 'The Lighthouse extension can only audit ' +
+      ' http & https pages.',
 };
 
 const MAX_ISSUE_ERROR_LENGTH = 60;


### PR DESCRIPTION
should throw a message that don't support non auditable pages like view-source, ...
Fixes #2525

Not sure it's the best solution though 