### PR TITLE
is-on-https: check record.protocol for blob urls

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -316,6 +316,13 @@ function deprecationsTest() {
   window.webkitStorageInfo.PERSISTENT // FAIL
 }
 
+function isOnHttps() {
+  // Check blob URL.
+  const img = document.createElement('img');
+  img.src = URL.createObjectURL(blob);
+  document.body.appendChild(img); // PASS
+}
+
 // Figure out which tests to fun.
 const params = new URLSearchParams(location.search);
 if (location.search === '') {
@@ -332,6 +339,7 @@ if (location.search === '') {
   // oldCSSFlexboxTest();
   deprecationsTest();
   passwordInputsCanBePastedIntoTest();
+  isOnHttps();
 } else {
   if (params.has('documentWrite')) {
     documentWriteTest();
@@ -371,6 +379,9 @@ if (location.search === '') {
   }
   if (params.has('passwordinputs')) {
     passwordInputsCanBePastedIntoTest();
+  }
+  if (params.has('isonhttps')) {
+    isOnHttps();
   }
 }
 </script>

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -14,7 +14,12 @@ module.exports = [
     url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
     audits: {
       'is-on-https': {
-        score: false
+        score: false,
+        extendedInfo: {
+          value: {
+            length: 1
+          }
+        }
       },
       'uses-http2': {
         score: false,

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -35,7 +35,9 @@ class HTTPS extends Audit {
    * @return {boolean}
    */
   static isSecureRecord(record) {
-    return SECURE_SCHEMES.includes(record.scheme) || SECURE_DOMAINS.includes(record.domain);
+    return SECURE_SCHEMES.includes(record.scheme) ||
+           SECURE_SCHEMES.includes(record.protocol) ||
+           SECURE_DOMAINS.includes(record.domain);
   }
 
   /**

--- a/lighthouse-core/test/audits/is-on-https-test.js
+++ b/lighthouse-core/test/audits/is-on-https-test.js
@@ -67,6 +67,7 @@ describe('Security: HTTPS audit', () => {
       assert.strictEqual(Audit.isSecureRecord({scheme: 'wss', domain: 'my-service.com'}), true);
       assert.strictEqual(Audit.isSecureRecord({scheme: 'data', domain: ''}), true);
       assert.strictEqual(Audit.isSecureRecord({scheme: 'blob', domain: ''}), true);
+      assert.strictEqual(Audit.isSecureRecord({scheme: '', protocol: 'blob', domain: ''}), true);
       assert.strictEqual(Audit.isSecureRecord({scheme: 'chrome', domain: ''}), true);
       assert.strictEqual(Audit.isSecureRecord({scheme: 'chrome-extension', domain: ''}), true);
     });


### PR DESCRIPTION
Fixes #2523.

Adds an additional check for the protocol/scheme. FWIW, `record.scheme` isn't populated for `blob:` urls but `.protocol` is!