### PR TITLE
Add script to capture travis build durations

### DIFF
--- a/lighthouse-core/scripts/log-travis-durations.rb
+++ b/lighthouse-core/scripts/log-travis-durations.rb
@@ -1,0 +1,59 @@
+##
+# @license Copyright 2017 Google Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
+# @fileoverview This script logs durations of travis builds, for plotting
+
+# step 1. generate github token and and use in .netrc
+#   https://help.github.com/articles/creating-an-access-token-for-command-line-use/
+#   Leave all scope checkboxes unchecked.
+#   Place in your ~/.netrc file like so:
+#     machine github.com login <token>
+
+# step 2. install travis ruby library: https://github.com/travis-ci/travis.rb/
+#   gem install travis
+#   travis login --auto
+
+# step 3. run this script and output to a file
+#   ruby lighthouse-core/scripts/log-travis-durations.rb > results.txt
+# (it'll take a minute pending on how big days_of_builds_to_consider is)
+
+# step 4. paste into column 1 of this spreadsheet:
+#   https://docs.google.com/spreadsheets/d/197M4SRTdDbbpg4uRDCr-tI5l48L2qsAGkxIcIncKKew/edit#gid=247558940
+# view the chart in the second sheet
+
+require 'travis'
+require 'date'
+
+config_path = ENV.fetch('TRAVIS_CONFIG_PATH') { File.expand_path('.travis', Dir.home) }
+config = YAML.load_file(File.expand_path('config.yml', config_path))
+access_token = config['endpoints'].values[0]['access_token']
+
+Travis.access_token = access_token
+
+$days_of_builds_to_consider = 10
+
+puts "build, state, started_at, duration"
+
+def log_durations
+  repository = Travis::Repository.find('GoogleChrome/lighthouse')
+  repository.each_build do |build|
+    # next unless Integer(build.number) < 8283
+
+    next if build.started_at.nil?
+
+    # quit paginating at some point.
+    if build.started_at < Time.now.to_date.prev_day($days_of_builds_to_consider).to_time
+      exit 0
+    end
+
+    build.jobs.each do |job|
+      puts "#{job.number}, #{job.state}, #{job.started_at}, #{job.duration}"
+    end
+  end
+end
+
+
+log_durations

--- a/lighthouse-core/scripts/log-travis-durations.rb
+++ b/lighthouse-core/scripts/log-travis-durations.rb
@@ -33,9 +33,9 @@ access_token = config['endpoints'].values[0]['access_token']
 
 Travis.access_token = access_token
 
-$days_of_builds_to_consider = 10
+$days_of_builds_to_consider = 5
 
-puts "build, state, started_at, duration"
+puts "build, branch, state, started_at, duration"
 
 def log_durations
   repository = Travis::Repository.find('GoogleChrome/lighthouse')
@@ -50,7 +50,7 @@ def log_durations
     end
 
     build.jobs.each do |job|
-      puts "#{job.number}, #{job.state}, #{job.started_at}, #{job.duration}"
+      puts "#{job.number}, #{job.branch_info}, #{job.state}, #{job.started_at}, #{job.duration}"
     end
   end
 end


### PR DESCRIPTION
Here's the last 40 days of travis build durations:
![image](https://user-images.githubusercontent.com/39191/27314836-116d8808-552b-11e7-8578-4ddc7c4f826a.png)


Pretty cool data. Halfway down the X axis you'll see the variance kick off. AFAICT, this seems to be travis's fault. It starts right when the "fix appveyor" commits land on master. (around the #7972's of build numbers)  But these commits ONLY touch appveyor.yml, so they couldn't matter less to Travis. 
![image](https://user-images.githubusercontent.com/39191/27314766-a00e7c94-552a-11e7-8d31-086783309d21.png)



EDIT: i've amended the script to tag where the build is from so we can see just master branch builds too:
![image](https://user-images.githubusercontent.com/39191/27314810-fde9d19c-552a-11e7-97b3-bf3bc38111da.png)

spreadsheet: https://docs.google.com/spreadsheets/d/197M4SRTdDbbpg4uRDCr-tI5l48L2qsAGkxIcIncKKew/edit#gid=0

cc @wardpeet 