### PR TITLE
Fix dbw tester error

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -318,6 +318,7 @@ function deprecationsTest() {
 
 function isOnHttps() {
   // Check blob URL.
+  const blob = new Blob(['fake'])
   const img = document.createElement('img');
   img.src = URL.createObjectURL(blob);
   document.body.appendChild(img); // PASS


### PR DESCRIPTION
fixes https://github.com/GoogleChrome/lighthouse/pull/2538#discussion_r123076291

JS error prevented the image from being added to the dom, so the smoketest wasn't testing anything. The expectations remain the same b/c we're ignoring `blob` urls.