### PR TITLE
harden security of static-server

### DIFF
--- a/lighthouse-cli/performance-experiment/server.js
+++ b/lighthouse-cli/performance-experiment/server.js
@@ -45,7 +45,7 @@ function hostExperiment(params, results) {
     fallbackReportId = id;
 
     const server = http.createServer(requestHandler);
-    server.listen(0);
+    server.listen(0, 'localhost');
     server.on('listening', () => opn(`http://localhost:${server.address().port}/?id=${id}`));
     server.on('error', err => log.error('PerformanceXServer', err.code, err));
     server.on('close', resolve);

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -13,6 +13,8 @@ const fs = require('fs');
 const parseQueryString = require('querystring').parse;
 const parseURL = require('url').parse;
 
+const lhRootDirPath = path.join(__dirname, '../../../');
+
 function requestHandler(request, response) {
   const requestUrl = parseURL(request.url);
   const filePath = requestUrl.pathname;
@@ -24,6 +26,11 @@ function requestHandler(request, response) {
     // We bring in an aggressive Promise polyfill (zone) to ensure we don't still fail.
     const zonePath = '../../../node_modules/zone.js';
     absoluteFilePath = path.join(__dirname, `${zonePath}/dist/zone.js`);
+  }
+
+  // Disallow file requests outside of LH folder
+  if (!path.parse(absoluteFilePath).dir.startsWith(lhRootDirPath)) {
+    return readFileCallback(new Error('Disallowed path'));
   }
 
   fs.exists(absoluteFilePath, fsExistsCallback);
@@ -76,5 +83,5 @@ serverForOnline.on('error', e => console.error(e.code, e));
 serverForOffline.on('error', e => console.error(e.code, e));
 
 // Listen
-serverForOnline.listen(10200);
-serverForOffline.listen(10503);
+serverForOnline.listen(10200, 'localhost');
+serverForOffline.listen(10503, 'localhost');


### PR DESCRIPTION
1. we only allow localhost to connect to our static-server
2. extra protection of not allowing requests beyond the LH folder