### PR TITLE
make save-as-gist css more specific

### DIFF
--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -215,7 +215,7 @@
       background-position: 9px 50%;
     }
     /* save-as-gist option hidden in report */
-    .lh-export--gist {
+    .lh-export__dropdown .lh-export--gist {
       display: none;
     }
     .lh-config {


### PR DESCRIPTION
The "Save as Gist" option was accidentally left visible in the regular report, even though it only works in viewer.

Followup to #2521