### PR TITLE
fixes viewer CSS specificity and event listener removal

### DIFF
--- a/lighthouse-core/report/v2/renderer/report-ui-features.js
+++ b/lighthouse-core/report/v2/renderer/report-ui-features.js
@@ -235,6 +235,7 @@ class ReportUIFeatures {
     // after it's created. Normally, we could also listen for the popup window's
     // load event, however it is cross-domain and won't fire. Instead, listen
     // for a message from the target app saying "I'm open".
+    const json = this.json;
     window.addEventListener('message', function msgHandler(/** @type {!Event} */ e) {
       const messageEvent = /** @type {!MessageEvent<{opened: boolean}>} */ (e);
       if (messageEvent.origin !== VIEWER_ORIGIN) {
@@ -242,10 +243,10 @@ class ReportUIFeatures {
       }
 
       if (messageEvent.data.opened) {
-        popup.postMessage({lhresults: this.json}, VIEWER_ORIGIN);
+        popup.postMessage({lhresults: json}, VIEWER_ORIGIN);
         window.removeEventListener('message', msgHandler);
       }
-    }.bind(this));
+    });
 
     const popup = /** @type {!Window} */ (window.open(VIEWER_URL, '_blank'));
   }

--- a/lighthouse-viewer/app/styles/viewer.css
+++ b/lighthouse-viewer/app/styles/viewer.css
@@ -122,5 +122,5 @@
 
 /* open-in-gist option visible in Viewer */
 .lh-export__dropdown .lh-export--gist {
-  display: block;
+  display: block !important;
 }


### PR DESCRIPTION
sorry, two last viewer flubs
1) This was an existing issue with the old viewer too: binding the `message` handler to `this` meant that a newly created function was being passed to `addEventListener`, so later attempts to remove the handler via a reference to the original, non-bound function was having no effect. Noticed when refreshing the viewer kept loading the same report as long as the triggering html report was still open in a tab.

2) save-as-gist is hidden by the CSS in the `<template>`s, which is after viewer.css in the page, so they win. This !importants it. Why does anyone let me write CSS