### PR TITLE
Log Chrome's stderr in case of failure

### DIFF
--- a/chrome-launcher/README.md
+++ b/chrome-launcher/README.md
@@ -51,6 +51,10 @@ npm install chrome-launcher
   // (optional) Starting URL to open the browser with
   // Default: `about:blank`
   startingUrl: string;
+
+  // (optional) Logging level: verbose, info, error, silent
+  // Default: 'info'
+  logLevel: string;
 };
 ```
 

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -30,6 +30,7 @@ export interface Options {
   handleSIGINT?: boolean;
   chromePath?: string;
   userDataDir?: string;
+  logLevel?: string;
 }
 
 export interface LaunchedChrome {
@@ -79,6 +80,8 @@ export class Launcher {
   constructor(private opts: Options = {}, moduleOverrides: ModuleOverrides = {}) {
     this.fs = moduleOverrides.fs || fs;
     this.rimraf = moduleOverrides.rimraf || rimraf;
+
+    log.setLevel(defaults(this.opts.logLevel, 'info'));
 
     // choose the first one (default)
     this.startingUrl = defaults(this.opts.startingUrl, 'about:blank');

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -225,7 +225,8 @@ export class Launcher {
     return new Promise((resolve, reject) => {
       let retries = 0;
       let waitStatus = 'Waiting for browser.';
-      (function poll() {
+
+      const poll = () => {
         if (retries === 0) {
           log.log('ChromeLauncher', waitStatus);
         }
@@ -240,11 +241,19 @@ export class Launcher {
             })
             .catch(err => {
               if (retries > 10) {
+                log.error('ChromeLauncher', err.message);
+                const stderr =
+                    this.fs.readFileSync(`${this.userDataDir}/chrome-err.log`, {encoding: 'utf-8'});
+                log.error(
+                    'ChromeLauncher', `Logging contents of ${this.userDataDir}/chrome-err.log`);
+                log.error('ChromeLauncher', stderr);
                 return reject(err);
               }
               delay(launcher.pollInterval).then(poll);
             });
-      })();
+      };
+      poll();
+
     });
   }
 

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -73,7 +73,8 @@ if (cliFlags.output === Printer.OutputMode[Printer.OutputMode.json] && !cliFlags
  * a debuggable instance.
  */
 async function getDebuggableChrome(flags: Flags) {
-  return await launch({port: flags.port, chromeFlags: flags.chromeFlags.split(' '), logLevel: cliFlags.logLevel});
+  return await launch(
+      {port: flags.port, chromeFlags: flags.chromeFlags.split(' '), logLevel: cliFlags.logLevel});
 }
 
 function showConnectionError() {

--- a/lighthouse-cli/bin.ts
+++ b/lighthouse-cli/bin.ts
@@ -73,7 +73,7 @@ if (cliFlags.output === Printer.OutputMode[Printer.OutputMode.json] && !cliFlags
  * a debuggable instance.
  */
 async function getDebuggableChrome(flags: Flags) {
-  return await launch({port: flags.port, chromeFlags: flags.chromeFlags.split(' ')});
+  return await launch({port: flags.port, chromeFlags: flags.chromeFlags.split(' '), logLevel: cliFlags.logLevel});
 }
 
 function showConnectionError() {


### PR DESCRIPTION
To improve debugging of #2556, #2544, #2462 , this PR will log out the contents of Chrome's stderr.

It was only through this technique that I found that Chrome had a fatal crash when I was trying to run it in a docker container:

> `[0627/002609.343419:FATAL:zygote_host_impl_linux.cc(107)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.`

We'll see if this will uncover the travis flake (which I presume to be unrelated to `--no-sandbox`)

---------

Also in this PR: we add the `logLevel` option to chrome-launcher. 