### PR TITLE
CRC audit: child chain renders using its own transfersize. Fixes #2597

### DIFF
--- a/lighthouse-core/report/v2/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/crc-details-renderer.js
@@ -117,7 +117,7 @@ class CriticalRequestChainRenderer {
       span.textContent = ' - ' + Util.chainDuration(
           segment.node.request.startTime, segment.node.request.endTime) + 'ms, ';
       const span2 = dom.createElement('span', 'crc-node__chain-duration');
-      span2.textContent = Util.formatBytesToKB(segment.node.request.transferSize) + 'KB';
+      span2.textContent = Util.formatBytesToKB(segment.node.request.transferSize);
 
       treevalEl.appendChild(span);
       treevalEl.appendChild(span2);

--- a/lighthouse-core/report/v2/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/crc-details-renderer.js
@@ -71,10 +71,9 @@ class CriticalRequestChainRenderer {
    * @param {!DOM} dom
    * @param {!DocumentFragment} tmpl
    * @param {!CriticalRequestChainRenderer.CRCSegment} segment
-   * @param {!CriticalRequestChainRenderer.CRCDetailsJSON} details
    * @return {!Node}
    */
-  static createChainNode(dom, tmpl, segment, details) {
+  static createChainNode(dom, tmpl, segment) {
     const chainsEl = dom.cloneTemplate('#tmpl-lh-crc__chains', tmpl);
 
     // Hovering over request shows full URL.
@@ -118,7 +117,7 @@ class CriticalRequestChainRenderer {
       span.textContent = ' - ' + Util.chainDuration(
           segment.node.request.startTime, segment.node.request.endTime) + 'ms, ';
       const span2 = dom.createElement('span', 'crc-node__chain-duration');
-      span2.textContent = Util.formatBytesToKB(details.longestChain.transferSize);
+      span2.textContent = Util.formatBytesToKB(segment.node.request.transferSize) + 'KB';
 
       treevalEl.appendChild(span);
       treevalEl.appendChild(span2);
@@ -136,8 +135,7 @@ class CriticalRequestChainRenderer {
    * @param {!CriticalRequestChainRenderer.CRCDetailsJSON} details
    */
   static buildTree(dom, tmpl, segment, detailsEl, details) {
-    detailsEl.appendChild(CriticalRequestChainRenderer.createChainNode(dom, tmpl, segment,
-        details));
+    detailsEl.appendChild(CriticalRequestChainRenderer.createChainNode(dom, tmpl, segment));
 
     for (const key of Object.keys(segment.node.children)) {
       const childSegment = CriticalRequestChainRenderer.createSegment(segment.node.children, key,

--- a/lighthouse-core/test/report/v2/renderer/crc-details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/crc-details-renderer-test.js
@@ -104,6 +104,7 @@ describe('DetailsRenderer', () => {
     assert.equal(chains[1].querySelector('.crc-node__tree-hostname').textContent, '(example.com)');
     const durationNodes = chains[1].querySelectorAll('.crc-node__chain-duration');
     assert.equal(durationNodes[0].textContent, ' - 5,000ms, ');
+    // Note: actual transferSize is 2000 bytes but formatter displays as KB.
     assert.equal(durationNodes[1].textContent, '1.95KB');
   });
 });

--- a/lighthouse-core/test/report/v2/renderer/crc-details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/crc-details-renderer-test.js
@@ -30,7 +30,7 @@ const DETAILS = {
         responseReceivedTime: 5,
         startTime: 0,
         url: 'https://example.com/',
-        transferSize: 1
+        transferSize: 1000
       },
       children: {
         1: {
@@ -39,7 +39,7 @@ const DETAILS = {
             responseReceivedTime: 14,
             startTime: 11,
             url: 'https://example.com/b.js',
-            transferSize: 1
+            transferSize: 2000
           },
           children: {}
         },
@@ -49,7 +49,7 @@ const DETAILS = {
             responseReceivedTime: 15,
             startTime: 12,
             url: superLongURL,
-            transferSize: 1
+            transferSize: 3000
           },
           children: {}
         },
@@ -59,7 +59,7 @@ const DETAILS = {
             responseReceivedTime: 16,
             startTime: 13,
             url: 'about:blank',
-            transferSize: 1
+            transferSize: 4000
           },
           children: {}
         }
@@ -92,37 +92,18 @@ describe('DetailsRenderer', () => {
     const el = CriticalRequestChainRenderer.render(dom, dom.document(), DETAILS);
     const details = el.querySelector('.lh-details');
     const chains = details.querySelectorAll('.crc-node');
+
+    // Main request
     assert.equal(chains.length, 4, 'generates correct number of chain nodes');
+    assert.equal(chains[0].querySelector('.crc-node__tree-hostname').textContent, '(example.com)');
 
-    const div = dom.createElement('div');
-    div.innerHTML = `<span class="crc-node__tree-marker">
-        <!-- fill me -->
-        <span class="tree-marker up-right"></span>
-        <span class="tree-marker right"></span>
-        <span class="tree-marker horiz-down"></span>
-      </span>
-      <span class="crc-node__tree-value">
-        <span class="crc-node__tree-file">/</span>
-        <span class="crc-node__tree-hostname">(example.com)</span>
-        <!-- fill me -->
-      </span>`;
-    assert.ok(chains[0].innerHTML, div.innerHTML);
-
-    div.innerHTML = `<span class="crc-node__tree-marker">
-        <!-- fill me -->
-        <span class="tree-marker"></span>
-        <span class="tree-marker"></span>
-        <span class="tree-marker vert-right"></span>
-        <span class="tree-marker right"></span>
-        <span class="tree-marker right"></span>
-      </span>
-      <span class="crc-node__tree-value">
-        <span class="crc-node__tree-file">/b.js</span>
-        <span class="crc-node__tree-hostname">(example.com)</span>
-        <!-- fill me -->
-        <span class="crc-node__chain-duration"> - 5,000ms, </span>
-        <span class="crc-node__chain-duration">0KB</span>
-      </span>`;
-    assert.ok(chains[1].innerHTML, div.innerHTML);
+    // Children
+    assert.ok(chains[1].querySelector('.crc-node__tree-marker .vert-right'));
+    assert.equal(chains[1].querySelectorAll('.crc-node__tree-marker .right').length, 2);
+    assert.equal(chains[1].querySelector('.crc-node__tree-file').textContent, '/b.js');
+    assert.equal(chains[1].querySelector('.crc-node__tree-hostname').textContent, '(example.com)');
+    const durationNodes = chains[1].querySelectorAll('.crc-node__chain-duration');
+    assert.equal(durationNodes[0].textContent, ' - 5,000ms, ');
+    assert.equal(durationNodes[1].textContent, '1.95KB');
   });
 });

--- a/lighthouse-core/test/report/v2/renderer/crc-details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/crc-details-renderer-test.js
@@ -104,7 +104,7 @@ describe('DetailsRenderer', () => {
     assert.equal(chains[1].querySelector('.crc-node__tree-hostname').textContent, '(example.com)');
     const durationNodes = chains[1].querySelectorAll('.crc-node__chain-duration');
     assert.equal(durationNodes[0].textContent, ' - 5,000ms, ');
-    // Note: actual transferSize is 2000 bytes but formatter displays as KB.
-    assert.equal(durationNodes[1].textContent, '1.95KB');
+    // Note: actual transferSize is 2000 bytes but formatter formats to KBs.
+    assert.equal(durationNodes[1].textContent, '1.95\xa0KB');
   });
 });


### PR DESCRIPTION
Children chains were using the overall `longestChain.transferSize` instead of their own size. 

Also updated the renderer test to actually be useful.

Fixes #2597