### PR TITLE
refactor(critical-request-chains): split out critical request chains

### DIFF
--- a/lighthouse-core/gather/computed/critical-request-chains.js
+++ b/lighthouse-core/gather/computed/critical-request-chains.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const ComputedArtifact = require('./computed-artifact');
+const RequestChains = require('./request-chains');
 const WebInspector = require('../../lib/web-inspector');
 
 class CriticalRequestChains extends ComputedArtifact {
@@ -38,91 +39,8 @@ class CriticalRequestChains extends ComputedArtifact {
     return ['VeryHigh', 'High', 'Medium'].includes(request.priority());
   }
 
-  static extractChain(networkRecords) {
-    networkRecords = networkRecords.filter(req => req.finished);
-
-    // Build a map of requestID -> Node.
-    const requestIdToRequests = new Map();
-    for (const request of networkRecords) {
-      requestIdToRequests.set(request.requestId, request);
-    }
-
-    // Get all the critical requests.
-    /** @type {!Array<NetworkRequest>} */
-    const criticalRequests = networkRecords.filter(CriticalRequestChains.isCritical);
-
-    const flattenRequest = request => {
-      return {
-        url: request._url,
-        startTime: request.startTime,
-        endTime: request.endTime,
-        responseReceivedTime: request.responseReceivedTime,
-        transferSize: request.transferSize
-      };
-    };
-
-    // Create a tree of critical requests.
-    const criticalRequestChains = {};
-    for (const request of criticalRequests) {
-      // Work back from this request up to the root. If by some weird quirk we are giving request D
-      // here, which has ancestors C, B and A (where A is the root), we will build array [C, B, A]
-      // during this phase.
-      const ancestors = [];
-      let ancestorRequest = request.initiatorRequest();
-      let node = criticalRequestChains;
-      while (ancestorRequest) {
-        const ancestorIsCritical = CriticalRequestChains.isCritical(ancestorRequest);
-
-        // If the parent request isn't a high priority request it won't be in the
-        // requestIdToRequests map, and so we can break the chain here. We should also
-        // break it if we've seen this request before because this is some kind of circular
-        // reference, and that's bad.
-        if (!ancestorIsCritical || ancestors.includes(ancestorRequest.requestId)) {
-          // Set the ancestors to an empty array and unset node so that we don't add
-          // the request in to the tree.
-          ancestors.length = 0;
-          node = undefined;
-          break;
-        }
-        ancestors.push(ancestorRequest.requestId);
-        ancestorRequest = ancestorRequest.initiatorRequest();
-      }
-
-      // With the above array we can work from back to front, i.e. A, B, C, and during this process
-      // we can build out the tree for any nodes that have yet to be created.
-      let ancestor = ancestors.pop();
-      while (ancestor) {
-        const parentRequest = requestIdToRequests.get(ancestor);
-        const parentRequestId = parentRequest.requestId;
-        if (!node[parentRequestId]) {
-          node[parentRequestId] = {
-            request: flattenRequest(parentRequest),
-            children: {}
-          };
-        }
-
-        // Step to the next iteration.
-        ancestor = ancestors.pop();
-        node = node[parentRequestId].children;
-      }
-
-      if (!node) {
-        continue;
-      }
-
-      // If the node already exists, bail.
-      if (node[request.requestId]) {
-        continue;
-      }
-
-      // node should now point to the immediate parent for this request.
-      node[request.requestId] = {
-        request: flattenRequest(request),
-        children: {}
-      };
-    }
-
-    return criticalRequestChains;
+  static extractChain(records) {
+    return RequestChains.extractChain(records, CriticalRequestChains.isCritical);
   }
 
   /**

--- a/lighthouse-core/gather/computed/request-chains.js
+++ b/lighthouse-core/gather/computed/request-chains.js
@@ -29,6 +29,8 @@ class RequestChains extends ComputedArtifact {
 
   /**
    * Links together network requests (filtered by predicate) with their initiator, building a DAG.
+   * When the predicate function returns false for a network request, that request and all of its children
+   * will be excluded from the graph. If no predicate is provided, all requests are included.
    *
    * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
    * @param {function(!WebInspector.NetworkRequest):boolean=} predicate

--- a/lighthouse-core/gather/computed/request-chains.js
+++ b/lighthouse-core/gather/computed/request-chains.js
@@ -14,8 +14,8 @@ class RequestChains extends ComputedArtifact {
   }
 
   /**
-   *
-   * @param {!} record
+   * @param {!WebInspector.NetworkRequest} record
+   * @return {{url: string, startTime: number, endTime: number, responseReceivedTime: number, transferSize: number}}
    */
   static flattenRecord(record) {
     return {
@@ -28,10 +28,11 @@ class RequestChains extends ComputedArtifact {
   }
 
   /**
+   * Links together network requests (filtered by predicate) with their initiator, building a DAG.
    *
    * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
    * @param {function(!WebInspector.NetworkRequest):boolean=} predicate
-   * @return {!ComputedArtifacts}
+   * @return {{request: !Object, children: !Object}}
    */
   static extractChain(networkRecords, predicate) {
     predicate = predicate || (() => true);

--- a/lighthouse-core/gather/computed/request-chains.js
+++ b/lighthouse-core/gather/computed/request-chains.js
@@ -15,10 +15,11 @@ class RequestChains extends ComputedArtifact {
 
   /**
    * @param {!WebInspector.NetworkRequest} record
-   * @return {{url: string, startTime: number, endTime: number, responseReceivedTime: number, transferSize: number}}
+   * @return {!CriticalRequestChainRenderer.CRCRequest}
    */
   static flattenRecord(record) {
     return {
+      requestId: record.requestId,
       url: record._url,
       startTime: record.startTime,
       endTime: record.endTime,
@@ -58,10 +59,9 @@ class RequestChains extends ComputedArtifact {
       let ancestorRequest = request.initiatorRequest();
       let node = requestChains;
       while (ancestorRequest) {
-        // If the parent request isn't a high priority request it won't be in the
-        // requestIdToRequests map, and so we can break the chain here. We should also
-        // break it if we've seen this request before because this is some kind of circular
-        // reference, and that's bad.
+        // If the parent request doesn't match the predicate it won't be in requestIdToRequests,
+        // and so we can break the chain here. We should also break it if we've seen this request
+        // before because this is some kind of circular reference, and that's bad.
         if (!predicate(ancestorRequest) || ancestors.includes(ancestorRequest.requestId)) {
           // Set the ancestors to an empty array and unset node so that we don't add
           // the request in to the tree.
@@ -113,7 +113,7 @@ class RequestChains extends ComputedArtifact {
   /**
    * @param {!DevtoolsLog} devtoolsLog
    * @param {!ComputedArtifacts} artifacts
-   * @return {!Promise<!Object>}
+   * @return {!Promise<!CriticalRequestChainRenderer.RequestNode>}
    */
   compute_(devtoolsLog, artifacts) {
     return artifacts.requestNetworkRecords(devtoolsLog)

--- a/lighthouse-core/gather/computed/request-chains.js
+++ b/lighthouse-core/gather/computed/request-chains.js
@@ -1,0 +1,121 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const ComputedArtifact = require('./computed-artifact');
+
+class RequestChains extends ComputedArtifact {
+
+  get name() {
+    return 'RequestChains';
+  }
+
+  /**
+   *
+   * @param {!} record
+   */
+  static flattenRecord(record) {
+    return {
+      url: record._url,
+      startTime: record.startTime,
+      endTime: record.endTime,
+      responseReceivedTime: record.responseReceivedTime,
+      transferSize: record.transferSize
+    };
+  }
+
+  /**
+   *
+   * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
+   * @param {function(!WebInspector.NetworkRequest):boolean=} predicate
+   * @return {!ComputedArtifacts}
+   */
+  static extractChain(networkRecords, predicate) {
+    predicate = predicate || (() => true);
+    networkRecords = networkRecords.filter(req => req.finished);
+
+    // Build a map of requestID -> Node.
+    const requestIdToRequests = new Map();
+    for (const request of networkRecords) {
+      requestIdToRequests.set(request.requestId, request);
+    }
+
+    const requestsToExamine = networkRecords.filter(predicate);
+
+    // Create a tree of critical requests.
+    const requestChains = {};
+    for (const request of requestsToExamine) {
+      // Work back from this request up to the root. If by some weird quirk we are giving request D
+      // here, which has ancestors C, B and A (where A is the root), we will build array [C, B, A]
+      // during this phase.
+      const ancestors = [];
+      let ancestorRequest = request.initiatorRequest();
+      let node = requestChains;
+      while (ancestorRequest) {
+        // If the parent request isn't a high priority request it won't be in the
+        // requestIdToRequests map, and so we can break the chain here. We should also
+        // break it if we've seen this request before because this is some kind of circular
+        // reference, and that's bad.
+        if (!predicate(ancestorRequest) || ancestors.includes(ancestorRequest.requestId)) {
+          // Set the ancestors to an empty array and unset node so that we don't add
+          // the request in to the tree.
+          ancestors.length = 0;
+          node = undefined;
+          break;
+        }
+        ancestors.push(ancestorRequest.requestId);
+        ancestorRequest = ancestorRequest.initiatorRequest();
+      }
+
+      // With the above array we can work from back to front, i.e. A, B, C, and during this process
+      // we can build out the tree for any nodes that have yet to be created.
+      let ancestor = ancestors.pop();
+      while (ancestor) {
+        const parentRequest = requestIdToRequests.get(ancestor);
+        const parentRequestId = parentRequest.requestId;
+        if (!node[parentRequestId]) {
+          node[parentRequestId] = {
+            request: RequestChains.flattenRecord(parentRequest),
+            children: {}
+          };
+        }
+
+        // Step to the next iteration.
+        ancestor = ancestors.pop();
+        node = node[parentRequestId].children;
+      }
+
+      if (!node) {
+        continue;
+      }
+
+      // If the node already exists, bail.
+      if (node[request.requestId]) {
+        continue;
+      }
+
+      // node should now point to the immediate parent for this request.
+      node[request.requestId] = {
+        request: RequestChains.flattenRecord(request),
+        children: {}
+      };
+    }
+
+    return requestChains;
+  }
+
+  /**
+   * @param {!DevtoolsLog} devtoolsLog
+   * @param {!ComputedArtifacts} artifacts
+   * @return {!Promise<!Object>}
+   */
+  compute_(devtoolsLog, artifacts) {
+    return artifacts.requestNetworkRecords(devtoolsLog)
+      .then(RequestChains.extractChain);
+  }
+}
+
+module.exports = RequestChains;

--- a/lighthouse-core/report/v2/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/crc-details-renderer.js
@@ -15,8 +15,8 @@
 class CriticalRequestChainRenderer {
   /**
    * Create render context for critical-request-chain tree display.
-   * @param {!Object<string, !CriticalRequestChainRenderer.CRCNode>} tree
-   * @return {{tree: !Object<string, !CriticalRequestChainRenderer.CRCNode>, startTime: number, transferSize: number}}
+   * @param {!Object<string, !CriticalRequestChainRenderer.RequestNode>} tree
+   * @return {{tree: !Object<string, !CriticalRequestChainRenderer.RequestNode>, startTime: number, transferSize: number}}
    */
   static initTree(tree) {
     let startTime = 0;
@@ -34,7 +34,7 @@ class CriticalRequestChainRenderer {
    * parent. Calculates if this node is the last child, whether it has any
    * children itself and what the tree looks like all the way back up to the root,
    * so the tree markers can be drawn correctly.
-   * @param {!Object<string, !CriticalRequestChainRenderer.CRCNode>} parent
+   * @param {!Object<string, !CriticalRequestChainRenderer.RequestNode>} parent
    * @param {string} id
    * @param {number} startTime
    * @param {number} transferSize
@@ -187,7 +187,7 @@ if (typeof module !== 'undefined' && module.exports) {
  *     type: string,
  *     header: {text: string},
  *     longestChain: {duration: number, length: number, transferSize: number},
- *     chains: !Object<string, !CriticalRequestChainRenderer.CRCNode>
+ *     chains: !Object<string, !CriticalRequestChainRenderer.RequestNode>
  * }}
  */
 CriticalRequestChainRenderer.CRCDetailsJSON; // eslint-disable-line no-unused-expressions
@@ -203,20 +203,20 @@ CriticalRequestChainRenderer.CRCDetailsJSON; // eslint-disable-line no-unused-ex
 CriticalRequestChainRenderer.CRCRequest; // eslint-disable-line no-unused-expressions
 
 /**
- * Record type so children can circularly have CRCNode values.
+ * Record type so children can circularly have RequestNode values.
  * @struct
  * @record
  */
-CriticalRequestChainRenderer.CRCNode = function() {};
+CriticalRequestChainRenderer.RequestNode = function() {};
 
-/** @type {!Object<string, !CriticalRequestChainRenderer.CRCNode>} */
-CriticalRequestChainRenderer.CRCNode.prototype.children; // eslint-disable-line no-unused-expressions
+/** @type {!Object<string, !CriticalRequestChainRenderer.RequestNode>} */
+CriticalRequestChainRenderer.RequestNode.prototype.children; // eslint-disable-line no-unused-expressions
 
 /** @type {!CriticalRequestChainRenderer.CRCRequest} */
-CriticalRequestChainRenderer.CRCNode.prototype.request; // eslint-disable-line no-unused-expressions
+CriticalRequestChainRenderer.RequestNode.prototype.request; // eslint-disable-line no-unused-expressions
 
 /** @typedef {{
- *     node: !CriticalRequestChainRenderer.CRCNode,
+ *     node: !CriticalRequestChainRenderer.RequestNode,
  *     isLastChild: boolean,
  *     hasChildren: boolean,
  *     startTime: number,


### PR DESCRIPTION
preparing to do some predictive perf analysis and need access to the full request chains, this PR separates out the criticality filter from the wiring of 'initiator'