### PR TITLE
Add DOM.enable to the event-listeners gatherers

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
@@ -117,7 +117,7 @@ class EventListeners extends Gatherer {
     return options.driver.sendCommand('DOM.enable')
       .then(() => this.listenForScriptParsedEvents())
       .then(() => this.unlistenForScriptParsedEvents())
-      .then(_ => options.driver.getElementsInDocument())
+      .then(() => options.driver.getElementsInDocument())
       .then(nodes => {
         nodes.push('document', 'window');
         return this.collectListeners(nodes);

--- a/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
@@ -114,7 +114,7 @@ class EventListeners extends Gatherer {
   afterPass(options) {
     this.driver = options.driver;
     this._parsedScripts = new Map();
-    return Promise.resolve()
+    return options.driver.sendCommand('DOM.enable')
       .then(() => this.listenForScriptParsedEvents())
       .then(() => this.unlistenForScriptParsedEvents())
       .then(_ => options.driver.getElementsInDocument())

--- a/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/all-event-listeners.js
@@ -121,6 +121,9 @@ class EventListeners extends Gatherer {
       .then(nodes => {
         nodes.push('document', 'window');
         return this.collectListeners(nodes);
+      }).then(listeners => {
+        return options.driver.sendCommand('DOM.disable')
+          .then(() => listeners);
       });
   }
 }


### PR DESCRIPTION
When speeding up travis I found a bug when I try to load only a subset of gatherers.

![image](https://user-images.githubusercontent.com/1120926/27698971-0e4f8f60-5cf9-11e7-98d9-e60abc57fdc4.png)
