### PR TITLE
fix(extension): Restore status logging to extension

### DIFF
--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -24,7 +24,5 @@
     "run-sequence": "^1.1.5",
     "through2": "^2.0.1"
   },
-  "dependencies": {
-    "lighthouse-logger": "^1.0.0"
-  }
+  "dependencies": {}
 }

--- a/lighthouse-extension/yarn.lock
+++ b/lighthouse-extension/yarn.lock
@@ -584,7 +584,7 @@ dateformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
 
-debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.6.8:
+debug@^2.1.0, debug@^2.1.1, debug@^2.2.0:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -1737,12 +1737,6 @@ liftoff@^2.1.0:
     lodash.mapvalues "^4.4.0"
     rechoir "^0.6.2"
     resolve "^1.1.7"
-
-lighthouse-logger@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lighthouse-logger/-/lighthouse-logger-1.0.0.tgz#c6abdfbbbf0b4a541ab33864802cbad8944bcc8c"
-  dependencies:
-    debug "^2.6.8"
 
 livereload-js@^2.2.0:
   version "2.2.2"


### PR DESCRIPTION
When extension had it's own lh-logger, it didn't share state with core's logger. With this changes,
the extension require's in core's logger.

Fixes bug introduced in #2528 
See https://github.com/GoogleChrome/lighthouse/pull/2528/files#diff-1d5287b2468c222ed5562ae5015485db