### PR TITLE
upgrade rimraf to latest

### DIFF
--- a/chrome-launcher/package.json
+++ b/chrome-launcher/package.json
@@ -25,7 +25,7 @@
     "@types/node": "6.0.66",
     "lighthouse-logger": "^1.0.0",
     "mkdirp": "0.5.1",
-    "rimraf": "2.2.8"
+    "rimraf": "^2.6.1"
   },
   "version": "0.3.0",
   "description": "Launch latest Chrome with the devtools-protocol port open",

--- a/chrome-launcher/yarn.lock
+++ b/chrome-launcher/yarn.lock
@@ -1182,10 +1182,6 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2.2.8:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
-
 rimraf@^2.3.3, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "metaviewport-parser": "0.0.1",
     "mkdirp": "0.5.1",
     "opn": "4.0.2",
-    "rimraf": "2.2.8",
+    "rimraf": "^2.6.1",
     "speedline": "1.2.0",
     "update-notifier": "^2.1.0",
     "whatwg-url": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,7 +1207,7 @@ glob@^5.0.15, glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2771,9 +2771,11 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2.2.8, rimraf@^2.2.8:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+rimraf@^2.2.8, rimraf@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  dependencies:
+    glob "^7.0.5"
 
 run-async@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
fixes #2618, https://github.com/isaacs/rimraf/issues/155, https://github.com/facebook/jest/issues/3942

I bisected and rimraf did fix this EPERM bug as of 2.3.0. it was one of these commits: https://github.com/isaacs/rimraf/compare/v2.2.8...v2.3.0

but i'm bumping all the way to 2.6.1 because why not