### PR TITLE
log protocol error data field

### DIFF
--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -90,7 +90,7 @@ class Connection {
         if (object.error) {
           const logLevel = callback.options && callback.options.silent ? 'verbose' : 'error';
           log.formatProtocol('method <= browser ERR', {method: callback.method}, logLevel);
-          throw new Error(`Protocol error (${callback.method}): ${object.error.message}`);
+          throw new Error(`Protocol error (${callback.method}): ${object.error.message} ${object.error.data}`);
         }
 
         log.formatProtocol('method <= browser OK',

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -90,7 +90,8 @@ class Connection {
         if (object.error) {
           const logLevel = callback.options && callback.options.silent ? 'verbose' : 'error';
           log.formatProtocol('method <= browser ERR', {method: callback.method}, logLevel);
-          throw new Error(`Protocol error (${callback.method}): ${object.error.message} ${object.error.data}`);
+          const errMsg = `(${callback.method}): ${object.error.message} (${object.error.data})`;
+          throw new Error(`Protocol error ${errMsg}`);
         }
 
         log.formatProtocol('method <= browser OK',

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -90,7 +90,8 @@ class Connection {
         if (object.error) {
           const logLevel = callback.options && callback.options.silent ? 'verbose' : 'error';
           log.formatProtocol('method <= browser ERR', {method: callback.method}, logLevel);
-          const errMsg = `(${callback.method}): ${object.error.message} (${object.error.data})`;
+          let errMsg = `(${callback.method}): ${object.error.message}`;
+          if (object.error.data) errMsg += ` (${object.error.data})`;
           throw new Error(`Protocol error ${errMsg}`);
         }
 


### PR DESCRIPTION
We just found a case (outside of Lighthouse) where we were getting this error:

     Error: Protocol error (Network.continueInterceptedRequest): Invalid parameters

however there were extra details once `error.data` was logged as well:

    Error: Protocol error (Network.continueInterceptedRequest): Invalid parameters (interceptionId: string value expected)

cc @aslushnikov