### PR TITLE
launcher: support enabling extension loading (#2594)

### DIFF
--- a/chrome-launcher/README.md
+++ b/chrome-launcher/README.md
@@ -56,6 +56,10 @@ npm install chrome-launcher
   // (optional) Logging level: verbose, info, error, silent
   // Default: 'info'
   logLevel: string;
+
+  // (optional) Enable extension loading
+  // Default: false
+  enableExtensions: boolean
 };
 ```
 

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -31,6 +31,7 @@ export interface Options {
   chromePath?: string;
   userDataDir?: string;
   logLevel?: string;
+  enableExtensions?: boolean;
 }
 
 export interface LaunchedChrome {
@@ -71,6 +72,7 @@ export class Launcher {
   private outFile?: number;
   private errFile?: number;
   private chromePath?: string;
+  private enableExtensions?: boolean;
   private chromeFlags: string[];
   private requestedPort?: number;
   private chrome?: childProcess.ChildProcess;
@@ -94,14 +96,19 @@ export class Launcher {
     this.chromeFlags = defaults(this.opts.chromeFlags, []);
     this.requestedPort = defaults(this.opts.port, 0);
     this.chromePath = this.opts.chromePath;
+    this.enableExtensions = defaults(this.opts.enableExtensions, false);
   }
 
   private get flags() {
-    const flags = DEFAULT_FLAGS.concat([
+    let flags = DEFAULT_FLAGS.concat([
       `--remote-debugging-port=${this.port}`,
       // Place Chrome profile in a custom location we'll rm -rf later
       `--user-data-dir=${this.userDataDir}`
     ]);
+
+    if (this.enableExtensions) {
+      flags = flags.filter(flag => flag !== '--disable-extensions');
+    }
 
     if (process.platform === 'linux') {
       flags.push('--disable-setuid-sandbox');

--- a/chrome-launcher/test/chrome-launcher-test.ts
+++ b/chrome-launcher/test/chrome-launcher-test.ts
@@ -102,4 +102,24 @@ describe('Launcher', () => {
     assert.strictEqual(pid, chromeInstance.pid);
     await chromeInstance.kill();
   });
+
+  it('removes --disable-extensions from flags on enableExtensions', async () => {
+    const spawnStub = stub().returns({pid: 'some_pid'});
+
+    const chromeInstance = new Launcher(
+        {enableExtensions: true},
+        {fs: fsMock as any, rimraf: spy() as any, spawn: spawnStub as any});
+    stub(chromeInstance, 'waitUntilReady').returns(Promise.resolve());
+
+    chromeInstance.prepare();
+
+    try {
+      await chromeInstance.launch();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    const chromeFlags = spawnStub.getCall(0).args[1] as string[];
+    assert.ok(!chromeFlags.includes('--disable-extensions'));
+  });
 });

--- a/chrome-launcher/tsconfig.json
+++ b/chrome-launcher/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2016",
         "noImplicitAny": true,
         "inlineSourceMap": true,
         "noEmitOnError": false,


### PR DESCRIPTION
fixes #2594

I've tested flag status by mocha and running test by [chrome-launcher-cli@extension-enable](https://github.com/ragingwind/chrome-launcher-cli/tree/extension-enable) in manually:

```
chrome --app=file:///Users/ragingwind/Workspace/chrome-extension/extended/test/index.html --system-developer-mode --load-ex
tension=/Users/ragingwind/Workspace/chrome-extension/extended/test/extension --enable-extensions
```