### PR TITLE
Expose LHR to modules consuming cli/run.ts

### DIFF
--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -87,7 +87,7 @@ export class Launcher {
     this.rimraf = moduleOverrides.rimraf || rimraf;
     this.spawn = moduleOverrides.spawn || spawn;
 
-    log.setLevel(defaults(this.opts.logLevel, 'info'));
+    log.setLevel(defaults(this.opts.logLevel, 'silent'));
 
     // choose the first one (default)
     this.startingUrl = defaults(this.opts.startingUrl, 'about:blank');

--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -138,7 +138,9 @@ export async function runLighthouse(
       await performanceXServer.hostExperiment({url, flags, config}, results);
     }
 
-    return await launchedChrome.kill();
+    await launchedChrome.kill();
+
+    return results;
   } catch (err) {
     if (typeof launchedChrome !== 'undefined') {
       await launchedChrome!.kill();

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -25,11 +25,18 @@ describe('CLI run', function() {
     const url = 'chrome://version';
     const filename = path.join(process.cwd(), 'run.ts.results.json');
     const flags = getFlags(`--output=json --output-path=${filename} ${url}`);
-    return run.runLighthouse(url, flags, fastConfig).then(_ => {
+    return run.runLighthouse(url, flags, fastConfig).then(passedResults => {
       assert.ok(fs.existsSync(filename));
       const results = JSON.parse(fs.readFileSync(filename, 'utf-8'));
       assert.equal(results.audits.viewport.rawValue, false);
+
+      // passed results match saved results
+      assert.strictEqual(results.generatedTime, passedResults.generatedTime);
+      assert.strictEqual(results.url, passedResults.url);
+      assert.strictEqual(results.audits.viewport.rawValue, passedResults.audits.viewport.rawValue);
+      assert.deepStrictEqual(results.timing, passedResults.timing);
+
       fs.unlinkSync(filename);
     });
-  });
+  }).timeout(60000);
 });

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -34,6 +34,9 @@ describe('CLI run', function() {
       assert.strictEqual(results.generatedTime, passedResults.generatedTime);
       assert.strictEqual(results.url, passedResults.url);
       assert.strictEqual(results.audits.viewport.rawValue, passedResults.audits.viewport.rawValue);
+      assert.strictEqual(
+          Object.keys(results.audits).length,
+          Object.keys(passedResults.audits).length);
       assert.deepStrictEqual(results.timing, passedResults.timing);
 
       fs.unlinkSync(filename);


### PR DESCRIPTION
Ran into this while writing https://github.com/GoogleChrome/lighthouse/pull/1832#issuecomment-313823375

If you just want the whole sequence and then want the LHR, it's really awkward. Adding this return at the end seems harmless. Sg?

----------------


Driveby fix to not log by default in launcher. Doesn't change LH usecases, just solo-launcher cases.