### PR TITLE
config rebuild: keep defaultPass

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -540,6 +540,8 @@ class Config {
     }).filter(pass => {
       // remove any passes lacking concrete gatherers, unless they are dependent on the trace
       if (pass.recordTrace) return true;
+      // Always keep defaultPass
+      if (pass.passName === 'defaultPass') return true;
       return pass.gatherers.length > 0;
     });
     return filteredPasses;


### PR DESCRIPTION
example config:

```js
module.exports = {
  "extends": "lighthouse:default",
  "settings": {
    "onlyAudits": [
      "is-on-https"
    ]
  }
}
```

This ends up filtering out the defaultPass as there are no audits consuming a trace from it.
There are other ways to fix this. 
This is but one.