### PR TITLE
Added CHROME_PATH to readme

### DIFF
--- a/chrome-launcher/README.md
+++ b/chrome-launcher/README.md
@@ -41,7 +41,8 @@ npm install chrome-launcher
   handleSIGINT: boolean;
 
   // (optional) Explicit path of intended Chrome binary
-  // If the `LIGHTHOUSE_CHROMIUM_PATH` env variable is set, that will be used
+  // If the `CHROME_PATH` env variable is set, that will be used
+  // Usage of `LIGHTHOUSE_CHROMIUM_PATH` env variable is deprecated
   // By default, any detected Chrome Canary or Chrome (stable) will be launched
   chromePath: string;
 


### PR DESCRIPTION
Updated the readme to this commit https://github.com/GoogleChrome/lighthouse/commit/41df647f1b88b95980c03b2364d222a1e6804e58

I've added the deprecation note about `LIGHTHOUSE_CHROMIUM_PATH ` because it used in [other files](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/scripts/download-chrome.sh).