### PR TITLE
track number of completed requests in total-byte-weight extendedInfo

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -64,6 +64,7 @@ class TotalByteWeight extends ByteEfficiencyAudit {
         totalBytes += result.totalBytes;
         results.push(result);
       });
+      const totalCompletedRequests = results.length;
       results = results.sort((itemA, itemB) => itemB.totalBytes - itemA.totalBytes).slice(0, 10);
 
 
@@ -91,6 +92,7 @@ class TotalByteWeight extends ByteEfficiencyAudit {
         extendedInfo: {
           value: {
             results,
+            totalCompletedRequests
           }
         },
         details: tableDetails

--- a/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
@@ -45,6 +45,7 @@ describe('Total byte weight audit', () => {
       assert.strictEqual(result.score, 100);
       const results = result.details.items;
       assert.strictEqual(results.length, 3);
+      assert.strictEqual(result.extendedInfo.value.totalCompletedRequests, 3);
       assert.strictEqual(results[0][1].text, `70${NBSP}KB`, 'results are sorted');
     });
   });
@@ -69,6 +70,7 @@ describe('Total byte weight audit', () => {
       assert.strictEqual(result.rawValue, 4180 * 1024);
       const results = result.details.items;
       assert.strictEqual(results.length, 10, 'results are clipped at top 10');
+      assert.strictEqual(result.extendedInfo.value.totalCompletedRequests, 11);
     });
   });
 


### PR DESCRIPTION
AFAICT we don't record the raw number of network requests made by a page anywhere, since the total-byte-weight array of assets is limited to the top 10.

There are some interesting patterns with that number, apparently regardless of content/size of the requests (though details there may offer even more interesting stuff). The pattern doesn't end at 10, which is as far as the array length will reveal, so this keeps the raw number around in the `extendedInfo` (neatly sidestepping the central question of #2668 for now :) so the investigation can continue.

If we do record that number in the report, let me know and we can close instead.