### PR TITLE
link remaining a11y audits to aXe docs

### DIFF
--- a/lighthouse-core/audits/accessibility/aria-allowed-attr.js
+++ b/lighthouse-core/audits/accessibility/aria-allowed-attr.js
@@ -24,7 +24,7 @@ class ARIAAllowedAttr extends AxeAudit {
       failureDescription: '`[aria-*]` attributes do not match their roles.',
       helpText: 'Each ARIA `role` supports a specific subset of `aria-*` attributes. ' +
           'Mismatching these invalidates the `aria-*` attributes. [Learn ' +
-          'more](https://developers.google.com/web/tools/lighthouse/audits/aria-allowed-attributes).',
+          'more](https://dequeuniversity.com/rules/axe/1.1/aria-allowed-attr).',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/accessibility/aria-required-attr.js
+++ b/lighthouse-core/audits/accessibility/aria-required-attr.js
@@ -23,7 +23,7 @@ class ARIARequiredAttr extends AxeAudit {
       description: '`[role]`s have all required `[aria-*]` attributes.',
       failureDescription: '`[role]`s do not have all required `[aria-*]` attributes.',
       helpText: 'Some ARIA roles have required attributes that describe the state ' +
-          'of the element to screen readers. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/required-aria-attributes).',
+          'of the element to screen readers. [Learn more](https://dequeuniversity.com/rules/axe/1.1/aria-required-attr).',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/accessibility/aria-valid-attr-value.js
+++ b/lighthouse-core/audits/accessibility/aria-valid-attr-value.js
@@ -24,7 +24,7 @@ class ARIAValidAttr extends AxeAudit {
       failureDescription: '`[aria-*]` attributes do not have valid values.',
       helpText: 'Assistive technologies, like screen readers, can\'t interpret ARIA ' +
           'attributes with invalid values. [Learn ' +
-          'more](https://developers.google.com/web/tools/lighthouse/audits/valid-aria-values).',
+          'more](https://dequeuniversity.com/rules/axe/1.1/aria-valid-attr-value).',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/accessibility/aria-valid-attr.js
+++ b/lighthouse-core/audits/accessibility/aria-valid-attr.js
@@ -24,7 +24,7 @@ class ARIAValidAttr extends AxeAudit {
       failureDescription: '`[aria-*]` attributes are not valid or misspelled.',
       helpText: 'Assistive technologies, like screen readers, can\'t interpret ARIA ' +
           'attributes with invalid names. [Learn ' +
-          'more](https://developers.google.com/web/tools/lighthouse/audits/valid-aria-attributes).',
+          'more](https://dequeuniversity.com/rules/axe/1.1/aria-valid-attr).',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/accessibility/button-name.js
+++ b/lighthouse-core/audits/accessibility/button-name.js
@@ -24,7 +24,7 @@ class ButtonName extends AxeAudit {
       failureDescription: 'Buttons do not have an accessible name.',
       helpText: 'When a button doesn\'t have an accessible name, screen readers announce it as ' +
           '"button", making it unusable for users who rely on screen readers. ' +
-          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/button-name).',
+          '[Learn more](https://dequeuniversity.com/rules/axe/1.1/button-name).',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/accessibility/color-contrast.js
+++ b/lighthouse-core/audits/accessibility/color-contrast.js
@@ -25,7 +25,7 @@ class ColorContrast extends AxeAudit {
       failureDescription: 'Background and foreground colors do not have a ' +
           'sufficient contrast ratio.',
       helpText: 'Low-contrast text is difficult or impossible for many users to read. ' +
-          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/contrast-ratio).',
+          '[Learn more](https://dequeuniversity.com/rules/axe/1.1/color-contrast).',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/accessibility/image-alt.js
+++ b/lighthouse-core/audits/accessibility/image-alt.js
@@ -24,7 +24,7 @@ class ImageAlt extends AxeAudit {
       failureDescription: 'Image elements do not have `[alt]` attributes.',
       helpText: 'Informative elements should aim for short, descriptive alternate text. ' +
           'Decorative elements can be ignored with an empty alt attribute.' +
-          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/alt-attribute).',
+          '[Learn more](https://dequeuniversity.com/rules/axe/1.1/image-alt).',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/accessibility/label.js
+++ b/lighthouse-core/audits/accessibility/label.js
@@ -24,7 +24,7 @@ class Label extends AxeAudit {
       failureDescription: 'Form elements do not have associated labels.',
       helpText: 'Labels ensure that form controls are announced properly by assistive ' +
           'technologies, like screen readers. [Learn ' +
-          'more](https://developers.google.com/web/tools/lighthouse/audits/form-labels).',
+          'more](https://dequeuniversity.com/rules/axe/1.1/label).',
       requiredArtifacts: ['Accessibility']
     };
   }

--- a/lighthouse-core/audits/accessibility/tabindex.js
+++ b/lighthouse-core/audits/accessibility/tabindex.js
@@ -24,7 +24,7 @@ class TabIndex extends AxeAudit {
       failureDescription: 'Some elements have a `[tabindex]` value greater than 0.',
       helpText: 'A value greater than 0 implies an explicit navigation ordering. ' +
           'Although technically valid, this often creates frustrating experiences ' +
-          'for users who rely on assistive technologies. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/tabindex).',
+          'for users who rely on assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/1.1/tabindex).',
       requiredArtifacts: ['Accessibility']
     };
   }


### PR DESCRIPTION
The current plan is to link all of the a11y audits to their respective sources in the aXe docs.

These audits currently link to references I wrote before the a11y category ballooned to 50+ audits.

Deprecating the a11y docs I wrote reduces my workload while also ensuring a consistent UX (if you click on "Learn more" in an a11y doc now, you can always expect to land on an aXe doc)