### PR TITLE
Gather-runner: Get useragent before emulating

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -30,7 +30,6 @@ let GathererResults; // eslint-disable-line no-unused-vars
  *     v. register a performance observer
  *     vi. register dialog dismisser
  *     vii. clearDataForOrigin
- *     viii. ignore the user's input events
  *
  * 2. For each pass in the config:
  *   A. GatherRunner.beforePass()
@@ -106,8 +105,7 @@ class GatherRunner {
       .then(_ => driver.cacheNatives())
       .then(_ => driver.registerPerformanceObserver())
       .then(_ => driver.dismissJavaScriptDialogs())
-      .then(_ => resetStorage && driver.clearDataForOrigin(options.url))
-      .then(_ => driver.sendCommand('Input.setIgnoreInputEvents', {ignore: true}));
+      .then(_ => resetStorage && driver.clearDataForOrigin(options.url));
   }
 
   static disposeDriver(driver) {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -30,8 +30,7 @@ let GathererResults; // eslint-disable-line no-unused-vars
  *     v. register a performance observer
  *     vi. register dialog dismisser
  *     vii. clearDataForOrigin
- *     viii. getUserAgent
- *     ix. ignore the user's input events
+ *     viii. ignore the user's input events
  *
  * 2. For each pass in the config:
  *   A. GatherRunner.beforePass()
@@ -101,13 +100,13 @@ class GatherRunner {
     const resetStorage = !options.flags.disableStorageReset;
     // Enable emulation based on flags
     return driver.assertNoSameOriginServiceWorkerClients(options.url)
+      .then(_ => gathererResults.UserAgent = [driver.getUserAgent()])
       .then(_ => driver.beginEmulation(options.flags))
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
       .then(_ => driver.registerPerformanceObserver())
       .then(_ => driver.dismissJavaScriptDialogs())
       .then(_ => resetStorage && driver.clearDataForOrigin(options.url))
-      .then(_ => gathererResults.UserAgent = [driver.getUserAgent()])
       .then(_ => driver.sendCommand('Input.setIgnoreInputEvents', {ignore: true}));
   }
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -27,8 +27,11 @@ let GathererResults; // eslint-disable-line no-unused-vars
  *     ii. beginEmulation
  *     iii. enableRuntimeEvents
  *     iv. evaluateScriptOnLoad rescue native Promise from potential polyfill
- *     v. cleanBrowserCaches
- *     vi. clearDataForOrigin
+ *     v. register a performance observer
+ *     vi. register dialog dismisser
+ *     vii. clearDataForOrigin
+ *     viii. getUserAgent
+ *     ix. ignore the user's input events
  *
  * 2. For each pass in the config:
  *   A. GatherRunner.beforePass()
@@ -104,7 +107,8 @@ class GatherRunner {
       .then(_ => driver.registerPerformanceObserver())
       .then(_ => driver.dismissJavaScriptDialogs())
       .then(_ => resetStorage && driver.clearDataForOrigin(options.url))
-      .then(_ => gathererResults.UserAgent = [driver.getUserAgent()]);
+      .then(_ => gathererResults.UserAgent = [driver.getUserAgent()])
+      .then(_ => driver.sendCommand('Input.setIgnoreInputEvents', {ignore: true}));
   }
 
   static disposeDriver(driver) {


### PR DESCRIPTION
fixes #2612


~Pavel introduced [`Input.setIgnoreInputEvents`](https://chromedevtools.github.io/devtools-protocol/tot/Input/#method-setIgnoreInputEvents) so that the user can't click or interact with the page while it's being audited.~

~It's been [injected into the lighthouse connection](https://github.com/ChromeDevTools/devtools-frontend/blob/f55402717f7f73fdb75b3d33d7587d9e92ab6447/front_end/audits2/Audits2Panel.js#L543-L546) in the devtools case for 2 months now.  And obviously it makes more sense to not have it hacked in there like that. :)~

