### PR TITLE
Viewer: log expected URL

### DIFF
--- a/lighthouse-viewer/app/src/github-api.js
+++ b/lighthouse-viewer/app/src/github-api.js
@@ -116,7 +116,7 @@ class GithubApi {
             const filename = Object.keys(json.files)
                 .find(filename => filename.endsWith(GithubApi.LH_JSON_EXT));
             if (!filename) {
-              throw new Error(`gist ${id} does not contain a Lighthouse report`);
+              throw new Error(`Failed to find a Lighthouse report (*${GithubApi.LH_JSON_EXT}) in gist ${id}`);
             }
             const f = json.files[filename];
             if (f.truncated) {


### PR DESCRIPTION
Log the expected URL to prevent confusion.

Fixes #2722 

Because I think if the user then renamed the file to match, it would then give a proper error saying the version is incorrect. 