### PR TITLE
Add chrome hostname to CriConnection & eslint fix

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -13,7 +13,6 @@ const chromeLauncher = require('lighthouse/chrome-launcher');
 
 function launchChromeAndRunLighthouse(url, flags = {}, config = null) {
   return chromeLauncher.launch().then(chrome => {
-    flags.host = 'localhost';
     flags.port = chrome.port;
     return lighthouse(url, flags, config).then(results =>
       chrome.kill().then(() => results));

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -13,6 +13,7 @@ const chromeLauncher = require('lighthouse/chrome-launcher');
 
 function launchChromeAndRunLighthouse(url, flags = {}, config = null) {
   return chromeLauncher.launch().then(chrome => {
+    flags.host = 'localhost';
     flags.port = chrome.port;
     return lighthouse(url, flags, config).then(results =>
       chrome.kill().then(() => results));

--- a/lighthouse-cli/cli-flags.ts
+++ b/lighthouse-cli/cli-flags.ts
@@ -12,9 +12,9 @@ const Driver = require('../lighthouse-core/gather/driver.js');
 import {GetValidOutputOptions, OutputMode} from './printer';
 
 export interface Flags {
-  port: number, chromeFlags: string, output: any, outputPath: string,
-      interactive: boolean, saveArtifacts: boolean, saveAssets: boolean, view: boolean,
-      maxWaitForLoad: number, logLevel: string, host: string
+  port: number, chromeFlags: string, output: any, outputPath: string, interactive: boolean,
+      saveArtifacts: boolean, saveAssets: boolean, view: boolean, maxWaitForLoad: number,
+      logLevel: string, host: string
 }
 
 export function getFlags(manualArgv?: string) {

--- a/lighthouse-cli/cli-flags.ts
+++ b/lighthouse-cli/cli-flags.ts
@@ -12,9 +12,9 @@ const Driver = require('../lighthouse-core/gather/driver.js');
 import {GetValidOutputOptions, OutputMode} from './printer';
 
 export interface Flags {
-  port: number, chromeFlags: string, output: any, outputPath: string, interactive: boolean,
-      saveArtifacts: boolean, saveAssets: boolean, view: boolean, maxWaitForLoad: number,
-      logLevel: string
+  port: number, host: string, chromeFlags: string, output: any, outputPath: string,
+      interactive: boolean, saveArtifacts: boolean, saveAssets: boolean, view: boolean,
+      maxWaitForLoad: number, logLevel: string
 }
 
 export function getFlags(manualArgv?: string) {
@@ -53,7 +53,7 @@ export function getFlags(manualArgv?: string) {
       .group(
           [
             'save-assets', 'save-artifacts', 'list-all-audits', 'list-trace-categories',
-            'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port',
+            'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port', 'host',
             'max-wait-for-load'
           ],
           'Configuration:')
@@ -77,6 +77,7 @@ export function getFlags(manualArgv?: string) {
             CHROME_PATH: Explicit path of intended Chrome binary. If set must point to an executable of a build of Chromium version 54.0 or later. By default, any detected Chrome Canary or Chrome (stable) will be launched.
             `,
         'perf': 'Use a performance-test-only configuration',
+        'host': 'The host to use for the debugging protocol.',
         'port': 'The port to use for the debugging protocol. Use 0 for a random port',
         'max-wait-for-load':
             'The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue. WARNING: Very high values can lead to large traces and instability',
@@ -107,6 +108,7 @@ Example: --output-path=./lighthouse-results.html`,
       .default('disable-cpu-throttling', false)
       .default('output', GetValidOutputOptions()[OutputMode.domhtml])
       .default('port', 0)
+      .default('host', 'localhost')
       .default('max-wait-for-load', Driver.MAX_WAIT_FOR_FULLY_LOADED)
       .check((argv: {listAllAudits?: boolean, listTraceCategories?: boolean, _: Array<any>}) => {
         // Make sure lighthouse has been passed a url, or at least one of --list-all-audits

--- a/lighthouse-cli/cli-flags.ts
+++ b/lighthouse-cli/cli-flags.ts
@@ -14,7 +14,7 @@ import {GetValidOutputOptions, OutputMode} from './printer';
 export interface Flags {
   port: number, chromeFlags: string, output: any, outputPath: string, interactive: boolean,
       saveArtifacts: boolean, saveAssets: boolean, view: boolean, maxWaitForLoad: number,
-      logLevel: string, host: string
+      logLevel: string, hostname: string
 }
 
 export function getFlags(manualArgv?: string) {
@@ -53,8 +53,8 @@ export function getFlags(manualArgv?: string) {
       .group(
           [
             'save-assets', 'save-artifacts', 'list-all-audits', 'list-trace-categories',
-            'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port', 'host',
-            'max-wait-for-load'
+            'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port',
+            'hostname', 'max-wait-for-load'
           ],
           'Configuration:')
       .describe({
@@ -77,7 +77,7 @@ export function getFlags(manualArgv?: string) {
             CHROME_PATH: Explicit path of intended Chrome binary. If set must point to an executable of a build of Chromium version 54.0 or later. By default, any detected Chrome Canary or Chrome (stable) will be launched.
             `,
         'perf': 'Use a performance-test-only configuration',
-        'host': 'The host to use for the debugging protocol.',
+        'hostname': 'The hostname to use for the debugging protocol.',
         'port': 'The port to use for the debugging protocol. Use 0 for a random port',
         'max-wait-for-load':
             'The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue. WARNING: Very high values can lead to large traces and instability',
@@ -108,7 +108,7 @@ Example: --output-path=./lighthouse-results.html`,
       .default('disable-cpu-throttling', false)
       .default('output', GetValidOutputOptions()[OutputMode.domhtml])
       .default('port', 0)
-      .default('host', 'localhost')
+      .default('hostname', 'localhost')
       .default('max-wait-for-load', Driver.MAX_WAIT_FOR_FULLY_LOADED)
       .check((argv: {listAllAudits?: boolean, listTraceCategories?: boolean, _: Array<any>}) => {
         // Make sure lighthouse has been passed a url, or at least one of --list-all-audits

--- a/lighthouse-cli/cli-flags.ts
+++ b/lighthouse-cli/cli-flags.ts
@@ -12,9 +12,9 @@ const Driver = require('../lighthouse-core/gather/driver.js');
 import {GetValidOutputOptions, OutputMode} from './printer';
 
 export interface Flags {
-  port: number, host: string, chromeFlags: string, output: any, outputPath: string,
+  port: number, chromeFlags: string, output: any, outputPath: string,
       interactive: boolean, saveArtifacts: boolean, saveAssets: boolean, view: boolean,
-      maxWaitForLoad: number, logLevel: string
+      maxWaitForLoad: number, logLevel: string, host: string
 }
 
 export function getFlags(manualArgv?: string) {

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -17,7 +17,7 @@ const DEFAULT_PORT = 9222;
 class CriConnection extends Connection {
   /**
    * @param {number=} port Optional port number. Defaults to 9222;
-   * @param {string} hostname Optional hostname. Defaults to localhost.
+   * @param {string=} hostname Optional hostname. Defaults to localhost.
    * @constructor
    */
   constructor(port, hostname) {

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -22,6 +22,8 @@ class CriConnection extends Connection {
    */
   constructor(port = DEFAULT_PORT, hostname = DEFAULT_HOSTNAME) {
     super();
+    this.port = port;
+    this.hostname = hostname;
   }
 
   /**

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -20,11 +20,8 @@ class CriConnection extends Connection {
    * @param {string=} hostname Optional hostname. Defaults to localhost.
    * @constructor
    */
-  constructor(port, hostname) {
+  constructor(port = DEFAULT_PORT, hostname = DEFAULT_HOSTNAME) {
     super();
-
-    this.hostname = hostname || DEFAULT_HOSTNAME;
-    this.port = port || DEFAULT_PORT;
   }
 
   /**

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -10,18 +10,20 @@ const WebSocket = require('ws');
 const http = require('http');
 const log = require('lighthouse-logger');
 
-const hostname = 'localhost';
+const DEFAULT_HOSTNAME = 'localhost';
 const CONNECT_TIMEOUT = 10000;
 const DEFAULT_PORT = 9222;
 
 class CriConnection extends Connection {
   /**
    * @param {number=} port Optional port number. Defaults to 9222;
+   * @param {string} hostname Optional hostname. Defaults to localhost.
    * @constructor
    */
-  constructor(port) {
+  constructor(port, hostname) {
     super();
 
+    this.hostname = hostname || DEFAULT_HOSTNAME;
     this.port = port || DEFAULT_PORT;
   }
 
@@ -77,7 +79,7 @@ class CriConnection extends Connection {
   _runJsonCommand(command) {
     return new Promise((resolve, reject) => {
       const request = http.get({
-        hostname: hostname,
+        hostname: this.hostname,
         port: this.port,
         path: '/json/' + command
       }, response => {

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -35,7 +35,7 @@ module.exports = function(url, flags = {}, configJSON) {
     // Use ConfigParser to generate a valid config file
     const config = new Config(configJSON, flags.configPath);
 
-    const connection = new ChromeProtocol(flags.port);
+    const connection = new ChromeProtocol(flags.port, flags.host);
 
     // kick off a lighthouse run
     return Runner.run(connection, {url, flags, config})

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -35,7 +35,7 @@ module.exports = function(url, flags = {}, configJSON) {
     // Use ConfigParser to generate a valid config file
     const config = new Config(configJSON, flags.configPath);
 
-    const connection = new ChromeProtocol(flags.port, flags.host);
+    const connection = new ChromeProtocol(flags.port, flags.hostname);
 
     // kick off a lighthouse run
     return Runner.run(connection, {url, flags, config})

--- a/lighthouse-viewer/app/src/github-api.js
+++ b/lighthouse-viewer/app/src/github-api.js
@@ -116,8 +116,9 @@ class GithubApi {
             const filename = Object.keys(json.files)
                 .find(filename => filename.endsWith(GithubApi.LH_JSON_EXT));
             if (!filename) {
-              throw new Error(`Failed to find a Lighthouse report
-                (*${GithubApi.LH_JSON_EXT}) in gist ${id}`);
+              throw new Error(
+                `Failed to find a Lighthouse report (*${GithubApi.LH_JSON_EXT}) in gist ${id}`
+              );
             }
             const f = json.files[filename];
             if (f.truncated) {

--- a/lighthouse-viewer/app/src/github-api.js
+++ b/lighthouse-viewer/app/src/github-api.js
@@ -116,7 +116,8 @@ class GithubApi {
             const filename = Object.keys(json.files)
                 .find(filename => filename.endsWith(GithubApi.LH_JSON_EXT));
             if (!filename) {
-              throw new Error(`Failed to find a Lighthouse report (*${GithubApi.LH_JSON_EXT}) in gist ${id}`);
+              throw new Error(`Failed to find a Lighthouse report
+                (*${GithubApi.LH_JSON_EXT}) in gist ${id}`);
             }
             const f = json.files[filename];
             if (f.truncated) {

--- a/readme.md
+++ b/readme.md
@@ -58,8 +58,7 @@ Configuration:
                                  http://peter.sh/experiments/chromium-command-line-switches/.                                          [default: ""]
   --perf                         Use a performance-test-only configuration                                                                 [boolean]
   --port                         The port to use for the debugging protocol. Use 0 for a random port                                 [default: 9222]
-  --host                         The host to use for the debugging protocol.
-  host                                 [default: localhost]
+  --hostname                     The hostname to use for the debugging protocol.                                                [default: localhost]
   --max-wait-for-load            The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue.
                                  WARNING: Very high values can lead to large traces and instability                                 [default: 25000]
 

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,8 @@ Configuration:
                                  http://peter.sh/experiments/chromium-command-line-switches/.                                          [default: ""]
   --perf                         Use a performance-test-only configuration                                                                 [boolean]
   --port                         The port to use for the debugging protocol. Use 0 for a random port                                 [default: 9222]
+  --host                         The host to use for the debugging protocol.
+  host                                 [default: localhost]
   --max-wait-for-load            The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue.
                                  WARNING: Very high values can lead to large traces and instability                                 [default: 25000]
 


### PR DESCRIPTION
This issue fulfills the request made in issue #2727. This change should allow for Chrome to be located on a hostname other than `localhost`, as outlined in the issue. It may be noted that I added the hostname parameter to be the second parameter in the constructor so that it does not break any previous implementations of CriConnection.

Additionally, I made a small change that allowed for the yarn tests to be passed. No functionality was changed in this (the second) commit.