### PR TITLE
open extension's report in new window

### DIFF
--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -129,7 +129,7 @@ window.runLighthouseInExtension = function(options, categoryIDs) {
       filterOutArtifacts(results);
       // return enableOtherChromeExtensions(true).then(_ => {
       const blobURL = window.createReportPageAsBlob(results, 'extension');
-      chrome.tabs.create({url: blobURL});
+      chrome.windows.create({url: blobURL});
       // });
     }).catch(err => {
       // return enableOtherChromeExtensions(true).then(_ => {


### PR DESCRIPTION
fixes #1177

allows opening the report when Lighthouse was run on an incognito tab.

(if folks hate always opening in a new window, we could try opening in a new window only when run in incognito or something)