### PR TITLE
pass --enable-extensions on from manual-chrome-launcher

### DIFF
--- a/chrome-launcher/manual-chrome-launcher.js
+++ b/chrome-launcher/manual-chrome-launcher.js
@@ -6,10 +6,11 @@
  *
  * Assuming Lighthouse is installed globally or `npm link`ed, use via:
  *     chrome-debug
- * Optionally pass additional a port, chrome flags and/or a URL
+ * Optionally enable extensions or pass a port, additional chrome flags, and/or a URL
  *     chrome-debug --port=9222
  *     chrome-debug http://goat.com
  *     chrome-debug --show-paint-rects
+ *     chrome-debug --enable-extensions
  */
 
 require('./compiled-check.js')('chrome-launcher.js');
@@ -19,6 +20,7 @@ const args = process.argv.slice(2);
 let chromeFlags;
 let startingUrl;
 let port;
+let enableExtensions;
 
 if (args.length) {
   chromeFlags = args.filter(flag => flag.startsWith('--'));
@@ -26,11 +28,14 @@ if (args.length) {
   const portFlag = chromeFlags.find(flag => flag.startsWith('--port='));
   port = portFlag && portFlag.replace('--port=', '');
 
+  enableExtensions = !!chromeFlags.find(flag => flag === '--enable-extensions');
+
   startingUrl = args.find(flag => !flag.startsWith('--'));
 }
 
 launch({
   startingUrl,
   port,
+  enableExtensions,
   chromeFlags,
 }).then(v => console.log(`✨  Chrome debugging port: ${v.port}`));


### PR DESCRIPTION
followup to #2650

After that PR, `--enable-extensions` works for chrome-launcher-cli and `enableExtensions` works for calling `chrome-launcher` from within node.

This PR special cases `--enable-extensions` in `manual-chrome-launcher.js` (similar to `--port`) so that `chrome-debug --enable-extensions` and `yarn chrome -- --enable-extension` will also work.