### PR TITLE
fix(anchors-with-no-rel): ignore same origin links

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -42,12 +42,12 @@ module.exports = [
                      'If they are not used as hyperlinks, consider removing the _blank target.',
         extendedInfo: {
           value: {
-            length: 3
+            length: 2
           }
         },
         details: {
           items: {
-            length: 3
+            length: 2
           }
         }
       },

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -163,7 +163,7 @@ function findDifference(path, actual, expected) {
     const expectedValue = expected[key];
 
     if (!(key in actual)) {
-      return {keyPath, undefined, expectedValue};
+      return {path: keyPath, actual: undefined, expected: expectedValue};
     }
 
     const actualValue = actual[key];

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -39,7 +39,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     const failingAnchors = artifacts.AnchorsWithNoRelNoopener
       .filter(anchor => {
         try {
-          return anchor.href === '' || new URL(anchor.href).host !== pageHost;
+          return new URL(anchor.href).host !== pageHost;
         } catch (err) {
           debugString = 'Lighthouse was unable to determine the destination ' +
               'of some anchor tags. If they are not used as hyperlinks, ' +

--- a/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
@@ -19,7 +19,7 @@ class AnchorsWithNoRelNoopener extends Gatherer {
       const selector = 'a[target="_blank"]:not([rel~="noopener"])';
       const elements = getElementsInDocument(selector);
       return elements.map(node => ({
-        href: node.getAttribute('href'),
+        href: node.href,
         rel: node.getAttribute('rel'),
         target: node.getAttribute('target')
       }));


### PR DESCRIPTION
fixes #2743

we actually already had the smoketest to catch this but it was updated without catching it in review last time, also fixes a rather humorous smokehouse bug where we said `difference at undefined, found undefined but expected undefined` 