### PR TITLE
Fix: Basic chrome-flags parsing for embedded quotes

### DIFF
--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -30,34 +30,23 @@ interface LighthouseError extends Error {
 }
 
 function parseChromeFlags(flags: string) {
-  let args = yargs(flags).argv
-  let allKeys = Object.keys(args)
+  let args = yargs(flags).argv;
+  const allKeys = Object.keys(args);
 
   // Remove any "mangled" arguments (args that contain dashes are duplicated as
   // camelCased variants, but the dashed version remains)
-  let keysToFilter = allKeys
-    .filter(k => k.indexOf('-') !== -1)
-    .map(k => { return k.replace(/-(\w)/, (_, p1) => p1.toUpperCase())})
+  let keysToFilter = allKeys.filter(k => k.indexOf('-') !== -1)
+                         .map(k => k.replace(/-(\w)/, (_, p1) => p1.toUpperCase()));
 
-  const keysToDelete = allKeys.filter(key => {
-    return (
-      key === '_' ||
-      key.startsWith('$') ||
-      keysToFilter.indexOf(key) !== -1
-    )
-  })
+  const keysToDelete = allKeys.filter(
+      key => (key === '_' || key.startsWith('$') || keysToFilter.indexOf(key) !== -1))
 
-  keysToDelete.forEach(key => {
-    delete args[key]
-  })
+  keysToDelete.forEach(key => delete args[key]);
 
   // Render the args back out as command-line arguments.
   // Boolean values that are true are rendered without a value (--debug vs. --debug=true)
-  return Object.keys(args)
-    .map(k => typeof args[k] === 'boolean' && args[k] === true
-      ? `--${k}`
-      : `--${k}="${args[k]}"`
-    )
+  return Object.keys(args).map(
+      k => typeof args[k] === 'boolean' && args[k] === true ? `--${k}` : `--${k}="${args[k]}"`);
 }
 
 /**

--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -28,32 +28,32 @@ interface LighthouseError extends Error {
 }
 
 function parseChromeFlags(flags: string) {
-  const result: Array<string> = []
-  let index = 0
-  let currentFlag = ''
-  let isInNestedString = false
+  const result: Array<string> = [];
+  let index = 0;
+  let currentFlag = '';
+  let isInNestedString = false;
 
-  const consumeNextChar = () => {
-    const c = flags[index++]
+  function consumeNextChar() {
+    const c = flags[index++];
 
     // Check if we're entering/existing a nested string
     if (c === '"' && index > 0 && flags[index - 1] !== '\\') {
-      isInNestedString = !isInNestedString
+      isInNestedString = !isInNestedString;
     }
 
     if ((c === ' ' && !isInNestedString) || index === flags.length) {
-      result.push(currentFlag)
-      currentFlag = ''
+      result.push(currentFlag);
+      currentFlag = '';
     } else {
-      currentFlag += c
+      currentFlag += c;
     }
   }
 
   while (index < flags.length) {
-    consumeNextChar()
+    consumeNextChar();
   }
 
-  return result
+  return result;
 }
 
 /**
@@ -61,8 +61,11 @@ function parseChromeFlags(flags: string) {
  * port. If none is found, launches a debuggable instance.
  */
 async function getDebuggableChrome(flags: Flags) {
-  return await launch(
-      {port: flags.port, chromeFlags: parseChromeFlags(flags.chromeFlags), logLevel: flags.logLevel});
+  return await launch({
+    port: flags.port,
+    chromeFlags: parseChromeFlags(flags.chromeFlags),
+    logLevel: flags.logLevel
+  });
 }
 
 function showConnectionError() {

--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -29,15 +29,28 @@ interface LighthouseError extends Error {
   code?: string
 }
 
-function parseChromeFlags(flags: string) {
+function formatArg(arg: string, value: any): string {
+  if (typeof value === 'boolean' && value === true) {
+    return `--${arg}`
+  }
+
+  // Only quote the value if it contains spaces
+  if (value.indexOf(' ') !== -1) {
+    value = `"${value}"`
+  }
+
+  return `--${arg}=${value}`
+}
+
+// exported for testing
+export function parseChromeFlags(flags: string) {
   let args = yargs(flags).argv;
   const allKeys = Object.keys(args);
 
   // Remove unneeded arguments and then render back out as command-line arguments.
   // Boolean values that are true are rendered without a value (--debug vs. --debug=true)
   return allKeys.filter(k => k !== '_' && !k.startsWith('$') && !/[A-Z]/.test(k))
-      .map(
-          k => typeof args[k] === 'boolean' && args[k] === true ? `--${k}` : `--${k}="${args[k]}"`);
+      .map(k => formatArg(k, args[k]));
 }
 
 /**

--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -29,8 +29,9 @@ interface LighthouseError extends Error {
   code?: string
 }
 
+// Boolean values that are true are rendered without a value (--debug vs. --debug=true)
 function formatArg(arg: string, value: any): string {
-  if (typeof value === 'boolean' && value === true) {
+  if (value === true) {
     return `--${arg}`
   }
 
@@ -47,8 +48,7 @@ export function parseChromeFlags(flags: string) {
   let args = yargs(flags).argv;
   const allKeys = Object.keys(args);
 
-  // Remove unneeded arguments and then render back out as command-line arguments.
-  // Boolean values that are true are rendered without a value (--debug vs. --debug=true)
+  // Remove unneeded arguments (yargs includes a _ arg, $-prefixed args, and camelCase dupes)
   return allKeys.filter(k => k !== '_' && !k.startsWith('$') && !/[A-Z]/.test(k))
       .map(k => formatArg(k, args[k]));
 }

--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -33,20 +33,11 @@ function parseChromeFlags(flags: string) {
   let args = yargs(flags).argv;
   const allKeys = Object.keys(args);
 
-  // Remove any "mangled" arguments (args that contain dashes are duplicated as
-  // camelCased variants, but the dashed version remains)
-  let keysToFilter = allKeys.filter(k => k.indexOf('-') !== -1)
-                         .map(k => k.replace(/-(\w)/, (_, p1) => p1.toUpperCase()));
-
-  const keysToDelete = allKeys.filter(
-      key => (key === '_' || key.startsWith('$') || keysToFilter.indexOf(key) !== -1))
-
-  keysToDelete.forEach(key => delete args[key]);
-
-  // Render the args back out as command-line arguments.
+  // Remove unneeded arguments and then render back out as command-line arguments.
   // Boolean values that are true are rendered without a value (--debug vs. --debug=true)
-  return Object.keys(args).map(
-      k => typeof args[k] === 'boolean' && args[k] === true ? `--${k}` : `--${k}="${args[k]}"`);
+  return allKeys.filter(k => k !== '_' && !k.startsWith('$') && !/[A-Z]/.test(k))
+      .map(
+          k => typeof args[k] === 'boolean' && args[k] === true ? `--${k}` : `--${k}="${args[k]}"`);
 }
 
 /**

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -11,6 +11,7 @@ const path = require('path');
 const fs = require('fs');
 
 const run = require('../../run');
+const parseChromeFlags = require('../../run').parseChromeFlags;
 const fastConfig = {
   'extends': 'lighthouse:default',
   'settings': {
@@ -42,4 +43,28 @@ describe('CLI run', function() {
       fs.unlinkSync(filename);
     });
   }).timeout(60000);
+});
+
+describe('Parsing --chrome-flags', () => {
+  it('returns boolean flags that are true as a bare flag', () => {
+    assert.deepStrictEqual(['--debug'], parseChromeFlags('--debug'));
+  });
+
+  it('returns boolean flags that are false with value', () => {
+    assert.deepStrictEqual(['--debug=false'], parseChromeFlags('--debug=false'));
+  });
+
+  it('returns flags correctly for issue 2817', () => {
+    assert.deepStrictEqual(
+      ['--host-resolver-rules="MAP www.example.org:443 127.0.0.1:8443"'],
+      parseChromeFlags('--host-resolver-rules="MAP www.example.org:443 127.0.0.1:8443"')
+    );
+  });
+
+  it('returns all flags as provided', () => {
+    assert.deepStrictEqual(
+      ['--spaces="1 2 3 4"', '--debug=false', '--verbose', '--more-spaces="9 9 9"'],
+      parseChromeFlags('--spaces="1 2 3 4" --debug=false --verbose --more-spaces="9 9 9"')
+    );
+  });
 });

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -54,6 +54,10 @@ describe('Parsing --chrome-flags', () => {
     assert.deepStrictEqual(['--debug=false'], parseChromeFlags('--debug=false'));
   });
 
+  it('returns boolean flags that empty when passed undefined', () => {
+    assert.deepStrictEqual([], parseChromeFlags());
+  });
+
   it('returns flags correctly for issue 2817', () => {
     assert.deepStrictEqual(
       ['--host-resolver-rules="MAP www.example.org:443 127.0.0.1:8443"'],


### PR DESCRIPTION
Related Issue: https://github.com/GoogleChrome/lighthouse/issues/2753

This PR fixes `--chrome-flags` parsing so that the flags can contain spaces if quoted properly.

## TODO
- [x] Handle other methods of embedding quotes (single quotes)
    - Arguments are now handled by `yargs`
- [x] Unit tests
