### PR TITLE
Added CHROME_PATH description from CLI help in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,12 @@ Configuration:
   --additional-trace-categories  Additional categories to capture with the trace (comma-delimited).
   --config-path                  The path to the config JSON.
   --chrome-flags                 Custom flags to pass to Chrome (space-delimited). For a full list of flags, see
-                                 http://peter.sh/experiments/chromium-command-line-switches/.                                          [default: ""]
+                                 http://peter.sh/experiments/chromium-command-line-switches/.
+
+                                 Environment variables:
+                                 CHROME_PATH: Explicit path of intended Chrome binary. If set must point to an executable of a build of
+                                 Chromium version 54.0 or later. By default, any detected Chrome Canary or Chrome (stable) will be launched.
+                                                                                                                                       [default: ""]
   --perf                         Use a performance-test-only configuration                                                                 [boolean]
   --port                         The port to use for the debugging protocol. Use 0 for a random port                                 [default: 9222]
   --max-wait-for-load            The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue.


### PR DESCRIPTION
I noticed that project's README file which contains CLI help is missing CHROME_PATH description that was added during work on #2617 so this PR is about to fix that.