### PR TITLE
Clarification of hasOfflineStartUrl rule

### DIFF
--- a/lighthouse-core/audits/webapp-install-banner.js
+++ b/lighthouse-core/audits/webapp-install-banner.js
@@ -81,7 +81,7 @@ class WebappInstallBanner extends MultiCheckAudit {
     const hasOfflineStartUrl = artifacts.StartUrl.statusCode === 200;
 
     if (!hasOfflineStartUrl) {
-      result.failures.push('Manifest start_url is not cached and returned by a service worker');
+      result.failures.push('Service worker does not successfully serve the manifest\'s start_url');
     }
 
     if (artifacts.StartUrl.debugString) {

--- a/lighthouse-core/audits/webapp-install-banner.js
+++ b/lighthouse-core/audits/webapp-install-banner.js
@@ -81,7 +81,7 @@ class WebappInstallBanner extends MultiCheckAudit {
     const hasOfflineStartUrl = artifacts.StartUrl.statusCode === 200;
 
     if (!hasOfflineStartUrl) {
-      result.failures.push('Manifest start_url is not cached by a service worker');
+      result.failures.push('Manifest start_url is not cached and returned by a service worker');
     }
 
     if (artifacts.StartUrl.debugString) {


### PR DESCRIPTION
Error message is confusing for some users (https://stackoverflow.com/questions/45330087/manifest-start-url-is-not-cached-by-a-service-worker) and technically it's not true. There's check if the start_url is returned, and if not the message that it's not cached is returned. There's possibility for service worker to cache it but not return it and receive this error message.