### PR TITLE
Add hostname as parameter for GoogleChrome/lighthouse#2727

### DIFF
--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -10,19 +10,22 @@ const WebSocket = require('ws');
 const http = require('http');
 const log = require('lighthouse-logger');
 
-const hostname = 'localhost';
 const CONNECT_TIMEOUT = 10000;
 const DEFAULT_PORT = 9222;
+const DEFAULT_HOSTNAME = 'localhost';
 
 class CriConnection extends Connection {
   /**
-   * @param {number=} port Optional port number. Defaults to 9222;
+   * @param connectionParams Information about the connection.
+   * @param {string=} connectionParams.hostname Optional host address. Defaults to 'localhost';
+   * @param {number=} connectionParams.port Optional port number. Defaults to 9222;
    * @constructor
    */
-  constructor(port) {
+  constructor({hostname = DEFAULT_HOSTNAME, port = DEFAULT_PORT}) {
     super();
 
-    this.port = port || DEFAULT_PORT;
+    this.hostname = hostname;
+    this.port = port;
   }
 
   /**
@@ -77,7 +80,7 @@ class CriConnection extends Connection {
   _runJsonCommand(command) {
     return new Promise((resolve, reject) => {
       const request = http.get({
-        hostname: hostname,
+        hostname: this.hostname,
         port: this.port,
         path: '/json/' + command
       }, response => {

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -36,7 +36,7 @@ module.exports = function(url, flags = {}, configJSON) {
     const config = new Config(configJSON, flags.configPath);
 
     const connection = new ChromeProtocol({
-      hostname: flags.hostnae,
+      hostname: flags.hostname,
       port: flags.port,
     });
 

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -36,8 +36,8 @@ module.exports = function(url, flags = {}, configJSON) {
     const config = new Config(configJSON, flags.configPath);
 
     const connection = new ChromeProtocol({
-        hostname: flags.hostname,
-        port: flags.port,
+      hostname: flags.hostnae,
+      port: flags.port,
     });
 
     // kick off a lighthouse run

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -35,7 +35,10 @@ module.exports = function(url, flags = {}, configJSON) {
     // Use ConfigParser to generate a valid config file
     const config = new Config(configJSON, flags.configPath);
 
-    const connection = new ChromeProtocol(flags.port);
+    const connection = new ChromeProtocol({
+        hostname: flags.hostname,
+        port: flags.port,
+    });
 
     // kick off a lighthouse run
     return Runner.run(connection, {url, flags, config})


### PR DESCRIPTION
Convert the parameter configs to object to make it more extensible and add the hostname parameter.
This is actually in conflict with https://github.com/GoogleChrome/lighthouse/pull/2728
Whichever makes more sense, as long as we can have a host param :)
