### PR TITLE
add flag to FMP to indicate if it fell back to FMP candidate

### DIFF
--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -83,7 +83,7 @@ class FirstMeaningfulPaint extends Audit {
         onLoad: traceOfTab.timings.onLoad,
         endOfTrace: traceOfTab.timings.traceEnd,
       },
-      fmpIsFallback: traceOfTab.fmpIsFallback
+      fmpFellBack: traceOfTab.fmpFellBack
     };
 
     Object.keys(extendedInfo.timings).forEach(key => {

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -82,7 +82,8 @@ class FirstMeaningfulPaint extends Audit {
         fMP: traceOfTab.timings.firstMeaningfulPaint,
         onLoad: traceOfTab.timings.onLoad,
         endOfTrace: traceOfTab.timings.traceEnd,
-      }
+      },
+      fmpIsFallback: traceOfTab.fmpIsFallback
     };
 
     Object.keys(extendedInfo.timings).forEach(key => {

--- a/lighthouse-core/closure/typedefs/ComputedArtifacts.js
+++ b/lighthouse-core/closure/typedefs/ComputedArtifacts.js
@@ -34,7 +34,7 @@ let TraceTimes;
     firstContentfulPaintEvt: TraceEvent,
     firstMeaningfulPaintEvt: TraceEvent,
     onLoadEvt: TraceEvent,
-    fmpIsFallback: boolean,
+    fmpFellBack: boolean,
   }} */
 let TraceOfTabArtifact;
 

--- a/lighthouse-core/closure/typedefs/ComputedArtifacts.js
+++ b/lighthouse-core/closure/typedefs/ComputedArtifacts.js
@@ -34,6 +34,7 @@ let TraceTimes;
     firstContentfulPaintEvt: TraceEvent,
     firstMeaningfulPaintEvt: TraceEvent,
     onLoadEvt: TraceEvent,
+    fmpIsFallback: boolean,
   }} */
 let TraceOfTabArtifact;
 

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -69,6 +69,7 @@ class TraceOfTab extends ComputedArtifact {
     let firstMeaningfulPaint = frameEvents.find(
       e => e.name === 'firstMeaningfulPaint' && e.ts > navigationStart.ts
     );
+    let fmpIsFallback = false;
 
     // If there was no firstMeaningfulPaint event found in the trace, the network idle detection
     // may have not been triggered before Lighthouse finished tracing.
@@ -76,6 +77,7 @@ class TraceOfTab extends ComputedArtifact {
     // However, if no candidates were found (a bogus trace, likely), we fail.
     if (!firstMeaningfulPaint) {
       const fmpCand = 'firstMeaningfulPaintCandidate';
+      fmpIsFallback = true;
       log.verbose('trace-of-tab', `No firstMeaningfulPaint found, falling back to last ${fmpCand}`);
       const lastCandidate = frameEvents.filter(e => e.name === fmpCand).pop();
       if (!lastCandidate) {
@@ -131,6 +133,7 @@ class TraceOfTab extends ComputedArtifact {
       firstContentfulPaintEvt: firstContentfulPaint,
       firstMeaningfulPaintEvt: firstMeaningfulPaint,
       onLoadEvt: onLoad,
+      fmpIsFallback,
     };
   }
 }

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -69,7 +69,7 @@ class TraceOfTab extends ComputedArtifact {
     let firstMeaningfulPaint = frameEvents.find(
       e => e.name === 'firstMeaningfulPaint' && e.ts > navigationStart.ts
     );
-    let fmpIsFallback = false;
+    let fmpFellBack = false;
 
     // If there was no firstMeaningfulPaint event found in the trace, the network idle detection
     // may have not been triggered before Lighthouse finished tracing.
@@ -77,7 +77,7 @@ class TraceOfTab extends ComputedArtifact {
     // However, if no candidates were found (a bogus trace, likely), we fail.
     if (!firstMeaningfulPaint) {
       const fmpCand = 'firstMeaningfulPaintCandidate';
-      fmpIsFallback = true;
+      fmpFellBack = true;
       log.verbose('trace-of-tab', `No firstMeaningfulPaint found, falling back to last ${fmpCand}`);
       const lastCandidate = frameEvents.filter(e => e.name === fmpCand).pop();
       if (!lastCandidate) {
@@ -133,7 +133,7 @@ class TraceOfTab extends ComputedArtifact {
       firstContentfulPaintEvt: firstContentfulPaint,
       firstMeaningfulPaintEvt: firstMeaningfulPaint,
       onLoadEvt: onLoad,
-      fmpIsFallback,
+      fmpFellBack,
     };
   }
 }

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -59,6 +59,10 @@ describe('Performance: first-meaningful-paint audit', () => {
     it('scores the fMP correctly', () => {
       assert.equal(fmpResult.score, 99);
     });
+
+    it('did not fall back to an FMP candidate event', () => {
+      assert.ok(!fmpResult.extendedInfo.value.fmpIsFallback);
+    });
   });
 
   describe('finds correct FMP', () => {
@@ -68,6 +72,7 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.rawValue, 529.9);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 29343540951);
         assert.equal(result.extendedInfo.value.timings.fCP, 80.054);
+        assert.ok(!result.extendedInfo.value.fmpIsFallback);
         assert.ok(!result.debugString);
       });
     });
@@ -78,6 +83,7 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.rawValue, 632.4);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 8885424467);
         assert.equal(result.extendedInfo.value.timings.fCP, 632.419);
+        assert.ok(!result.extendedInfo.value.fmpIsFallback);
         assert.ok(!result.debugString);
       });
     });
@@ -88,6 +94,7 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.rawValue, 878.4);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 1805796384607);
         assert.equal(result.extendedInfo.value.timings.fCP, 879.046);
+        assert.ok(!result.extendedInfo.value.fmpIsFallback);
         assert.ok(!result.debugString);
       });
     });
@@ -97,6 +104,7 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.displayValue, '4,460\xa0ms');
         assert.equal(result.rawValue, 4460.9);
         assert.equal(result.extendedInfo.value.timings.fCP, 1494.73);
+        assert.ok(result.extendedInfo.value.fmpIsFallback);
         assert.ok(!result.debugString);
       });
     });
@@ -111,6 +119,8 @@ describe('Performance: first-meaningful-paint audit', () => {
       assert.strictEqual(result.extendedInfo.value.timings.fMP, 482.318);
       assert.strictEqual(result.extendedInfo.value.timestamps.fCP, undefined);
       assert.strictEqual(result.extendedInfo.value.timestamps.fMP, 2149509604903);
+      // NOTE: falls back to candidate FMP
+      assert.ok(result.extendedInfo.value.fmpIsFallback);
     });
   });
 });

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -61,7 +61,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     });
 
     it('did not fall back to an FMP candidate event', () => {
-      assert.ok(!fmpResult.extendedInfo.value.fmpIsFallback);
+      assert.ok(!fmpResult.extendedInfo.value.fmpFellBack);
     });
   });
 
@@ -72,7 +72,7 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.rawValue, 529.9);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 29343540951);
         assert.equal(result.extendedInfo.value.timings.fCP, 80.054);
-        assert.ok(!result.extendedInfo.value.fmpIsFallback);
+        assert.ok(!result.extendedInfo.value.fmpFellBack);
         assert.ok(!result.debugString);
       });
     });
@@ -83,7 +83,7 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.rawValue, 632.4);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 8885424467);
         assert.equal(result.extendedInfo.value.timings.fCP, 632.419);
-        assert.ok(!result.extendedInfo.value.fmpIsFallback);
+        assert.ok(!result.extendedInfo.value.fmpFellBack);
         assert.ok(!result.debugString);
       });
     });
@@ -94,7 +94,7 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.rawValue, 878.4);
         assert.equal(result.extendedInfo.value.timestamps.navStart, 1805796384607);
         assert.equal(result.extendedInfo.value.timings.fCP, 879.046);
-        assert.ok(!result.extendedInfo.value.fmpIsFallback);
+        assert.ok(!result.extendedInfo.value.fmpFellBack);
         assert.ok(!result.debugString);
       });
     });
@@ -104,7 +104,7 @@ describe('Performance: first-meaningful-paint audit', () => {
         assert.equal(result.displayValue, '4,460\xa0ms');
         assert.equal(result.rawValue, 4460.9);
         assert.equal(result.extendedInfo.value.timings.fCP, 1494.73);
-        assert.ok(result.extendedInfo.value.fmpIsFallback);
+        assert.ok(result.extendedInfo.value.fmpFellBack);
         assert.ok(!result.debugString);
       });
     });
@@ -120,7 +120,7 @@ describe('Performance: first-meaningful-paint audit', () => {
       assert.strictEqual(result.extendedInfo.value.timestamps.fCP, undefined);
       assert.strictEqual(result.extendedInfo.value.timestamps.fMP, 2149509604903);
       // NOTE: falls back to candidate FMP
-      assert.ok(result.extendedInfo.value.fmpIsFallback);
+      assert.ok(result.extendedInfo.value.fmpFellBack);
     });
   });
 });

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -58,6 +58,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 29343540951);
       assert.equal(trace.firstContentfulPaintEvt.ts, 29343621005);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 29344070867);
+      assert.ok(!trace.fmpIsFallback);
     });
 
     it('if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
@@ -66,6 +67,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 8885424467);
       assert.equal(trace.firstContentfulPaintEvt.ts, 8886056886);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 8886056891);
+      assert.ok(!trace.fmpIsFallback);
     });
 
     it('if it appears slightly before the fCP', () => {
@@ -74,6 +76,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 1805796384607);
       assert.equal(trace.firstContentfulPaintEvt.ts, 1805797263653);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 1805797262960);
+      assert.ok(!trace.fmpIsFallback);
     });
 
     it('from candidates if no defined FMP exists', () => {
@@ -82,6 +85,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 2146735807738);
       assert.equal(trace.firstContentfulPaintEvt.ts, 2146737302468);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 2146740268666);
+      assert.ok(trace.fmpIsFallback);
     });
   });
 
@@ -91,6 +95,7 @@ describe('Trace of Tab computed artifact:', () => {
     assert.equal(trace.navigationStartEvt.ts, 2149509122585, 'bad navStart');
     assert.equal(trace.firstContentfulPaintEvt, undefined, 'bad fcp');
     assert.equal(trace.firstMeaningfulPaintEvt.ts, 2149509604903, 'bad fmp');
+    assert.ok(trace.fmpIsFallback);
   });
 
   it('handles traces missing a paints (captured in background tab)', () => {

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -58,7 +58,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 29343540951);
       assert.equal(trace.firstContentfulPaintEvt.ts, 29343621005);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 29344070867);
-      assert.ok(!trace.fmpIsFallback);
+      assert.ok(!trace.fmpFellBack);
     });
 
     it('if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
@@ -67,7 +67,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 8885424467);
       assert.equal(trace.firstContentfulPaintEvt.ts, 8886056886);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 8886056891);
-      assert.ok(!trace.fmpIsFallback);
+      assert.ok(!trace.fmpFellBack);
     });
 
     it('if it appears slightly before the fCP', () => {
@@ -76,7 +76,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 1805796384607);
       assert.equal(trace.firstContentfulPaintEvt.ts, 1805797263653);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 1805797262960);
-      assert.ok(!trace.fmpIsFallback);
+      assert.ok(!trace.fmpFellBack);
     });
 
     it('from candidates if no defined FMP exists', () => {
@@ -85,7 +85,7 @@ describe('Trace of Tab computed artifact:', () => {
       assert.equal(trace.navigationStartEvt.ts, 2146735807738);
       assert.equal(trace.firstContentfulPaintEvt.ts, 2146737302468);
       assert.equal(trace.firstMeaningfulPaintEvt.ts, 2146740268666);
-      assert.ok(trace.fmpIsFallback);
+      assert.ok(trace.fmpFellBack);
     });
   });
 
@@ -95,7 +95,7 @@ describe('Trace of Tab computed artifact:', () => {
     assert.equal(trace.navigationStartEvt.ts, 2149509122585, 'bad navStart');
     assert.equal(trace.firstContentfulPaintEvt, undefined, 'bad fcp');
     assert.equal(trace.firstMeaningfulPaintEvt.ts, 2149509604903, 'bad fmp');
-    assert.ok(trace.fmpIsFallback);
+    assert.ok(trace.fmpFellBack);
   });
 
   it('handles traces missing a paints (captured in background tab)', () => {


### PR DESCRIPTION
there's no way to tell from the LH results that `trace-of-tab` fell back to a `firstMeaningfulPaintCandidate` event for the FMP event.  #2420 will generate a Sentry entry for that case, but it would be handy to have it in the report so that e.g. the HTTPArchive data can be queried to get frequency numbers on this as well.

Happy to bikeshed on this and/or change so that it will also work for logging when/if we turn on #2244