### PR TITLE
[chrome-launcher] Publish type definitions instead of source TypeScript files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ lighthouse-cli/*.js
 !chrome-launcher/compiled-check.js
 chrome-launcher/*.map
 chrome-launcher/*.js
+chrome-launcher/*.d.ts
 
 lighthouse-cli/commands/*.map
 lighthouse-cli/commands/*.js

--- a/chrome-launcher/.npmignore
+++ b/chrome-launcher/.npmignore
@@ -9,3 +9,9 @@ test/
 .eslintrc.js
 .travis.yml
 gulpfile.js
+
+# exclude source TypeScript files
+*.ts
+
+# allow TypeScript Declaration Files
+!*.d.ts

--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -7,12 +7,12 @@
 
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
+import * as net from 'net';
+import * as rimraf from 'rimraf';
 import * as chromeFinder from './chrome-finder';
 import {getRandomPort} from './random-port';
 import {DEFAULT_FLAGS} from './flags';
 import {makeTmpDir, defaults, delay} from './utils';
-import * as net from 'net';
-const rimraf = require('rimraf');
 const log = require('lighthouse-logger');
 const spawn = childProcess.spawn;
 const execSync = childProcess.execSync;

--- a/chrome-launcher/package.json
+++ b/chrome-launcher/package.json
@@ -7,7 +7,7 @@
     "test": "mocha --require ts-node/register --reporter=dot test/**/*-test.ts --timeout=10000",
     "coverage": "nyc yarn test && nyc report --reporter=text-lcov > lcov.info",
     "test-formatting": "test/check-formatting.sh",
-    "format": "clang-format -i -style=file **/*.ts *.ts"
+    "format": "scripts/format.sh"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.41",

--- a/chrome-launcher/package.json
+++ b/chrome-launcher/package.json
@@ -23,6 +23,7 @@
     "@types/core-js": "^0.9.41",
     "@types/mkdirp": "^0.3.29",
     "@types/node": "6.0.66",
+    "@types/rimraf": "^0.0.28",
     "lighthouse-logger": "^1.0.0",
     "mkdirp": "0.5.1",
     "rimraf": "^2.6.1"

--- a/chrome-launcher/scripts/format.sh
+++ b/chrome-launcher/scripts/format.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+FILES="`find . -type f \! -path '*node_modules*' \! -name '*.d.ts' -name '*.ts'`"
+
+./node_modules/.bin/clang-format -i -style=file $FILES

--- a/chrome-launcher/test/check-formatting.sh
+++ b/chrome-launcher/test/check-formatting.sh
@@ -12,5 +12,4 @@ check_formatting ()
   fi
 }
 
-check_formatting "*.ts"
-check_formatting "**/*.ts"
+check_formatting "`find . -type f \! -path '*node_modules*' \! -name '*.d.ts' -name '*.ts'`"

--- a/chrome-launcher/tsconfig.json
+++ b/chrome-launcher/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es2016",
+        "declaration": true,
         "noImplicitAny": true,
         "inlineSourceMap": true,
         "noEmitOnError": false,

--- a/chrome-launcher/yarn.lock
+++ b/chrome-launcher/yarn.lock
@@ -18,6 +18,10 @@
   version "6.0.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.66.tgz#5680b74a6135d33d4c00447e7c3dc691a4601625"
 
+"@types/rimraf@^0.0.28":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"
+
 "@types/sinon@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-2.3.1.tgz#5e214093e9e2345219ab0f31bf310c9790ad0712"


### PR DESCRIPTION
This _should_ fix #2896 and reduce errors caused by different ts versions, ts configs, and ts declaration file versions.

In general, this PR enables the option in chrome-launcher's tsconfig to produce declaration files and updates the .npmignore to ignore `.ts` files.

One additional change was the addition of the `@types/rimraf` package. This had to be done, as the compiler was complaining about exporting a private type.