### PR TITLE
Warn users about perf numbers when report was created using headless chrome

### DIFF
--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -138,6 +138,12 @@ class ReportRenderer {
       categories.appendChild(this._categoryRenderer.render(category, report.reportGroups));
     }
 
+    // Render a warning that perf numbers may be off when using headless chrome.
+    if (/HeadlessChrome/.test(report.userAgent)) {
+      const warning = this._dom.cloneTemplate('#tmpl-lh-headless-warning', this._templateContext);
+      reportSection.insertBefore(warning, categories);
+    }
+
     reportSection.appendChild(this._renderReportFooter(report));
 
     return container;

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -719,6 +719,16 @@ span.lh-node:hover {
   top: 5px;
 }
 
+.lh-warning-banner {
+  font-size: var(--body-font-size);
+  margin: 0;
+  padding: var(--section-padding);
+  border-bottom: 1px solid var(--report-border-color);
+  line-height: var(--header-line-height);
+}
+.lh-warning-banner::before {
+  display: inline-block;
+}
 
 /* Report */
 

--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -1,3 +1,10 @@
+<!-- Lighthouse warning -->
+<template id="tmpl-lh-headless-warning">
+  <div class="lh-warning-banner lh-debug">
+    <b>Note</b>: Your site's mobile performance may be worse than the numbers presented in this report. Lighthouse could not test on a mobile connection because Headless Chrome does not support network throttling. See <a href="https://crbug.com/728451" target="_blank" rel="noopener">crbug.com/728451</a>.
+  </div>
+</template>
+
 <!-- Lighthouse category score -->
 <template id="tmpl-lh-category-score">
   <div class="lh-score">

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -103,6 +103,15 @@ describe('ReportRenderer V2', () => {
       });
     });
 
+    it('renders a warning when using headless chrome', () => {
+      const container = renderer._dom._document.body;
+      const reportJson = Object.assign(sampleResults, {
+        userAgent: 'HeadlessChrome/62.0.3180.0 Safari/537.36'
+      });
+      const output = renderer.renderReport(reportJson, container);
+      assert.ok(output.querySelector('.lh-warning-banner'), 'contains headless chrome warning');
+    });
+
     it('renders a left nav', () => {
       const header = renderer._renderReportNav(sampleResults);
       assert.equal(header.querySelectorAll('.lh-leftnav__item').length, 4);


### PR DESCRIPTION
Fixes #2675.

<img width="915" alt="screen shot 2017-08-09 at 2 21 45 pm" src="https://user-images.githubusercontent.com/238208/29145607-a17f091c-7d12-11e7-8370-94d32fe38da0.png">

Chose to put this at the top of the report instead of just the perf section for a couple of reasons:
1) makes it more visible
2) there are perf-related audits in other categories
3) we'd need to pipe `reportJSON` through a bunch of functions in report-renderer.

Should running the module also throw a warning?