### PR TITLE
Fix errors inside spawnPromise being ignored

### DIFF
--- a/chrome-launcher/chrome-launcher.ts
+++ b/chrome-launcher/chrome-launcher.ts
@@ -177,10 +177,10 @@ export class Launcher {
 
   private async spawnProcess(execPath: string) {
     // Typescript is losing track of the return type without the explict typing.
-    const spawnPromise: Promise<number> = new Promise(async (resolve) => {
+    const spawnPromise: Promise<number> = (async () => {
       if (this.chrome) {
         log.log('ChromeLauncher', `Chrome already running with pid ${this.chrome.pid}.`);
-        return resolve(this.chrome.pid);
+        return this.chrome.pid;
       }
 
 
@@ -201,8 +201,8 @@ export class Launcher {
       this.fs.writeFileSync(this.pidFile, chrome.pid.toString());
 
       log.verbose('ChromeLauncher', `Chrome running with pid ${chrome.pid} on port ${this.port}.`);
-      resolve(chrome.pid);
-    });
+      return chrome.pid;
+    })();
 
     const pid = await spawnPromise;
     await this.waitUntilReady();

--- a/chrome-launcher/test/chrome-launcher-test.ts
+++ b/chrome-launcher/test/chrome-launcher-test.ts
@@ -122,4 +122,11 @@ describe('Launcher', () => {
     const chromeFlags = spawnStub.getCall(0).args[1] as string[];
     assert.ok(!chromeFlags.includes('--disable-extensions'));
   });
+
+  it('throws an error when chromePath is empty', (done) => {
+    const chromeInstance = new Launcher({
+      chromePath: ''
+    });
+    chromeInstance.launch().catch(() => done());
+  });
 });

--- a/chrome-launcher/test/chrome-launcher-test.ts
+++ b/chrome-launcher/test/chrome-launcher-test.ts
@@ -124,9 +124,7 @@ describe('Launcher', () => {
   });
 
   it('throws an error when chromePath is empty', (done) => {
-    const chromeInstance = new Launcher({
-      chromePath: ''
-    });
+    const chromeInstance = new Launcher({chromePath: ''});
     chromeInstance.launch().catch(() => done());
   });
 });


### PR DESCRIPTION
If an error inside spawnPromise occurs it is being ignored as the async function is passed to new Promise(...) as a regular function.

This leads to the following output if you pass an empty string for chromePath:
```
(node:19352) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Bad argument
(node:19352) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
