### PR TITLE
PSI audit: hitting ideal target should give you 100 score

### DIFF
--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -9,8 +9,9 @@ const Audit = require('./audit');
 const Util = require('../report/v2/renderer/util');
 
 // Parameters (in ms) for log-normal CDF scoring. To see the curve:
-// https://www.desmos.com/calculator/mdgjzchijg
-const SCORING_POINT_OF_DIMINISHING_RETURNS = 1250;
+// https://www.desmos.com/calculator/rva61mekla
+const SCORING_POINT_OF_DIMINISHING_RETURNS = 1840;
+const SCORING_TARGET = 1250; // Ideal. Users receive score of 100.
 const SCORING_MEDIAN = 5500;
 
 class SpeedIndexMetric extends Audit {
@@ -24,7 +25,7 @@ class SpeedIndexMetric extends Audit {
       description: 'Perceptual Speed Index',
       helpText: 'Speed Index shows how quickly the contents of a page are visibly populated. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index).',
-      optimalValue: `< ${Util.formatNumber(SCORING_POINT_OF_DIMINISHING_RETURNS)}`,
+      optimalValue: `< ${Util.formatNumber(SCORING_TARGET)}`,
       scoringMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces']
     };
@@ -57,11 +58,12 @@ class SpeedIndexMetric extends Audit {
       });
 
       // Use the CDF of a log-normal distribution for scoring.
-      //  10th Percentile = 2,240
-      //  25th Percentile = 3,430
-      //  Median = 5,500
-      //  75th Percentile = 8,820
-      //  95th Percentile = 17,400
+      //   10th Percentile = 2,621
+      //   25th Percentile = 3,731
+      //   Median = 5,500
+      //   75th Percentile = 8,107
+      //   95th Percentile = 14,161
+      // Users receive a LH score of 100 if they achieve a PI <= 1250.
       const score = Audit.computeLogNormalScore(
         speedline.perceptualSpeedIndex,
         SCORING_POINT_OF_DIMINISHING_RETURNS,


### PR DESCRIPTION
@gauntface brought this to my attention and it's been confusing for a long time. TLDR is that users should get a score of 100/100 if you they hit the ideal target we suggest.

Example - Matt got 99/100 for having a PSI of 966. Lighthouse says the target is 1250:
"99 Perceptual Speed Index: 966 (target: < 1,250)"

So intuitively, he thought "why don't I have 100/100 for hitting the target!?!?"