### PR TITLE
test(smokehouse): adjust unused css expectations

### DIFF
--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -17,7 +17,7 @@ module.exports = [
         score: '<100',
         extendedInfo: {
           value: {
-            wastedKb: 26,
+            wastedKb: 39,
             results: {
               length: 2
             }


### PR DESCRIPTION
forgot to update #2518 smokehouse expectations for the new last second multiplier change 3x -> 2x