### PR TITLE
perf(optimized-images): use Audits.getEncodedResponse

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -64,6 +64,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
 
       results.push({
         url,
+        fromProtocol: image.fromProtocol,
         isCrossOrigin: !image.isSameOrigin,
         preview: {url: image.url, mimeType: image.mimeType, type: 'thumbnail'},
         totalBytes: image.originalSize,

--- a/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
@@ -53,6 +53,7 @@ class UsesWebPImages extends ByteEfficiencyAudit {
 
       results.push({
         url,
+        fromProtocol: image.fromProtocol,
         isCrossOrigin: !image.isSameOrigin,
         preview: {url: image.url, mimeType: image.mimeType, type: 'thumbnail'},
         totalBytes: image.originalSize,

--- a/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
@@ -13,6 +13,11 @@
 const Gatherer = require('../gatherer');
 const URL = require('../../../lib/url-shim');
 
+const JPEG_QUALITY = 0.92;
+const WEBP_QUALITY = 0.85;
+
+const MINIMUM_IMAGE_SIZE = 4096; // savings of <4 KB will be ignored in the audit anyway
+
 /* global document, Image, atob */
 
 /**
@@ -71,7 +76,7 @@ class OptimizedImages extends Gatherer {
       const isSameOrigin = URL.originsMatch(pageUrl, record._url);
       const isBase64DataUri = /^data:.{2,40}base64\s*,/.test(record._url);
 
-      if (isOptimizableImage) {
+      if (isOptimizableImage && record._resourceSize > MINIMUM_IMAGE_SIZE) {
         prev.push({
           isSameOrigin,
           isBase64DataUri,
@@ -88,24 +93,49 @@ class OptimizedImages extends Gatherer {
 
   /**
    * @param {!Object} driver
+   * @param {string} requestId
+   * @param {string} encoding
+   * @return {!Promise<{encodedSize: number}>}
+   */
+  _getEncodedResponse(driver, requestId, encoding) {
+    const quality = encoding === 'jpeg' ? JPEG_QUALITY : WEBP_QUALITY;
+    const params = {requestId, encoding, quality, sizeOnly: true};
+    return driver.sendCommand('Audits.getEncodedResponse', params);
+  }
+
+  /**
+   * @param {!Object} driver
    * @param {{url: string, isBase64DataUri: boolean, resourceSize: number}} networkRecord
    * @return {!Promise<?{originalSize: number, jpegSize: number, webpSize: number}>}
    */
   calculateImageStats(driver, networkRecord) {
-    if (!networkRecord.isSameOrigin && !networkRecord.isBase64DataUri) {
-      // Processing of cross-origin images is buggy and very slow, disable for now
-      // See https://github.com/GoogleChrome/lighthouse/issues/1853
-      // See https://github.com/GoogleChrome/lighthouse/issues/2146
-      return Promise.resolve(null);
-    }
-
-    return Promise.resolve(networkRecord.url).then(uri => {
-      const script = `(${getOptimizedNumBytes.toString()})(${JSON.stringify(uri)})`;
-      return driver.evaluateAsync(script).then(stats => {
-        if (!stats) {
-          return null;
+    // TODO(phulce): remove this dance of trying _getEncodedResponse with a fallback when Audits
+    // domain hits stable in Chrome 62
+    return Promise.resolve(networkRecord.requestId).then(requestId => {
+      if (this._getEncodedResponseUnsupported) return;
+      return this._getEncodedResponse(driver, requestId, 'jpeg').then(jpegData => {
+        return this._getEncodedResponse(driver, requestId, 'webp').then(webpData => {
+          return {
+            originalSize: networkRecord.resourceSize,
+            jpegSize: jpegData.encodedSize,
+            webpSize: webpData.encodedSize,
+          };
+        });
+      }).catch(err => {
+        if (/wasn't found/.test(err.message)) {
+          // Mark non-support so we don't keep attempting the protocol method over and over
+          this._getEncodedResponseUnsupported = true;
         }
+      });
+    }).then(result => {
+      if (result) return result;
 
+      // Take the slower/same-origin-limited fallback path if getEncodedResponse isn't available yet
+      if (!networkRecord.isSameOrigin && !networkRecord.isBase64DataUri) return null;
+
+      const script = `(${getOptimizedNumBytes.toString()})(${JSON.stringify(networkRecord.url)})`;
+      return driver.evaluateAsync(script).then(stats => {
+        if (!stats) return null;
         const isBase64DataUri = networkRecord.isBase64DataUri;
         const base64Length = networkRecord.url.length - networkRecord.url.indexOf(',') - 1;
         return {


### PR DESCRIPTION
Uses the new Audits.getEncodedResponse method to determine the size savings. Time savings varies since the canvas method was more variable than outright slow but some runs went from ~6s to ~500ms. Also enables fast checking of cross-origin images which was previously impossible.