### PR TITLE
Add 'link' type for markdown links

### DIFF
--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -35,6 +35,8 @@ class DetailsRenderer {
         return this._renderText(details);
       case 'url':
         return this._renderURL(details);
+      case 'link':
+        return this._renderLink(details);
       case 'thumbnail':
         return this._renderThumbnail(/** @type {!DetailsRenderer.ThumbnailDetails} */ (details));
       case 'filmstrip':
@@ -86,6 +88,17 @@ class DetailsRenderer {
       element.title = url;
     }
 
+    return element;
+  }
+
+  /**
+   * @param {!DetailsRenderer.DetailsJSON} text
+   * @return {!Element}
+   */
+  _renderLink(text) {
+    const snippet = text.text || '';
+    const element = this._dom.convertMarkdownLinkSnippets(snippet);
+    element.classList.add('lh-link');
     return element;
   }
 

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -40,6 +40,16 @@ describe('DetailsRenderer', () => {
       assert.ok(el.classList.contains('lh-text'), 'adds classes');
     });
 
+    it('renders links', () => {
+      const el = renderer.render({type: 'link', text: '[My text content](https://example.com)'});
+      const links = el.querySelectorAll('a');
+      assert.ok(el.localName === 'span', 'creates a wrapping span');
+      assert.ok(links.length, 'creates a link');
+      assert.equal(links[0].getAttribute('href'), 'https://example.com/');
+      assert.equal(links[0].textContent, 'My text content');
+      assert.ok(el.classList.contains('lh-link'), 'adds classes');
+    });
+
     it('renders lists with headers', () => {
       const el = renderer.render({
         type: 'list',


### PR DESCRIPTION
Adds a "link" type for content to be displayed in tables in the report. This type looks for a markdown link and renders it.

![Example of a link type displayed in audit table results](https://user-images.githubusercontent.com/66536/29755847-bf850614-8b63-11e7-9f3b-a4115dd933b7.png)