### PR TITLE
report: add LinkDetailsJSON to details renderer

### DIFF
--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* globals self CriticalRequestChainRenderer Util */
+/* globals self CriticalRequestChainRenderer Util URL */
 
 class DetailsRenderer {
   /**
@@ -35,6 +35,8 @@ class DetailsRenderer {
         return this._renderText(details);
       case 'url':
         return this._renderURL(details);
+      case 'link':
+        return this._renderLink(/** @type {!DetailsRenderer.LinkDetailsJSON} */ (details));
       case 'thumbnail':
         return this._renderThumbnail(/** @type {!DetailsRenderer.ThumbnailDetails} */ (details));
       case 'filmstrip':
@@ -87,6 +89,27 @@ class DetailsRenderer {
     }
 
     return element;
+  }
+
+  /**
+   * @param {!DetailsRenderer.LinkDetailsJSON} details
+   * @return {!Element}
+   */
+  _renderLink(details) {
+    const allowedProtocols = ['https:', 'http:'];
+    const url = new URL(details.url);
+    if (!allowedProtocols.includes(url.protocol)) {
+      // Fall back to text if protocol not allowed.
+      return this._renderText(details);
+    }
+
+    const a = /** @type {!HTMLAnchorElement} */ (this._dom.createElement('a'));
+    a.rel = 'noopener';
+    a.target = '_blank';
+    a.textContent = details.text;
+    a.href = url.href;
+
+    return a;
   }
 
   /**
@@ -338,6 +361,14 @@ DetailsRenderer.TableDetailsJSON; // eslint-disable-line no-unused-expressions
  * }}
  */
 DetailsRenderer.ThumbnailDetails; // eslint-disable-line no-unused-expressions
+
+/** @typedef {{
+ *     type: string,
+ *     url: string,
+ *     text: string
+ * }}
+ */
+DetailsRenderer.LinkDetailsJSON; // eslint-disable-line no-unused-expressions
 
 /** @typedef {{
  *     type: string,

--- a/lighthouse-core/report/v2/renderer/details-renderer.js
+++ b/lighthouse-core/report/v2/renderer/details-renderer.js
@@ -34,7 +34,7 @@ class DetailsRenderer {
       case 'text':
         return this._renderText(details);
       case 'url':
-        return this._renderURL(details);
+        return this._renderTextURL(details);
       case 'link':
         return this._renderLink(/** @type {!DetailsRenderer.LinkDetailsJSON} */ (details));
       case 'thumbnail':
@@ -63,7 +63,7 @@ class DetailsRenderer {
    * @param {!DetailsRenderer.DetailsJSON} text
    * @return {!Element}
    */
-  _renderURL(text) {
+  _renderTextURL(text) {
     const url = text.text || '';
 
     let displayedURL;

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -213,5 +213,18 @@ describe('DetailsRenderer', () => {
       assert.equal(el.textContent, linkText);
       assert.ok(el.classList.contains('lh-text'), 'adds classes');
     });
+
+    it.only('renders text URLs', () => {
+      const urlText = 'https://example.com/';
+      const displayUrlText = '/';
+      const el = renderer.render({
+        type: 'url',
+        text: urlText,
+      });
+
+      assert.equal(el.localName, 'div');
+      assert.equal(el.textContent, displayUrlText);
+      assert.ok(el.classList.contains('lh-text'), 'adds classes');
+    });
   });
 });

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -214,7 +214,7 @@ describe('DetailsRenderer', () => {
       assert.ok(el.classList.contains('lh-text'), 'adds classes');
     });
 
-    it.only('renders text URLs', () => {
+    it('renders text URLs', () => {
       const urlText = 'https://example.com/';
       const displayUrlText = '/';
       const el = renderer.render({

--- a/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/details-renderer-test.js
@@ -183,5 +183,35 @@ describe('DetailsRenderer', () => {
       assert.equal(el.querySelectorAll('.lh-table-column--thumbnail').length, 3,
           '--thumbnail not set');
     });
+
+    it('renders links', () => {
+      const linkText = 'Example Site';
+      const linkUrl = 'https://example.com/';
+      const el = renderer.render({
+        type: 'link',
+        text: linkText,
+        url: linkUrl
+      });
+
+      assert.equal(el.localName, 'a');
+      assert.equal(el.textContent, linkText);
+      assert.equal(el.href, linkUrl);
+      assert.equal(el.rel, 'noopener');
+      assert.equal(el.target, '_blank');
+    });
+
+    it('renders link as text if URL is not allowed', () => {
+      const linkText = 'Evil Link';
+      const linkUrl = 'javascript:alert(5)';
+      const el = renderer.render({
+        type: 'link',
+        text: linkText,
+        url: linkUrl
+      });
+
+      assert.equal(el.localName, 'div');
+      assert.equal(el.textContent, linkText);
+      assert.ok(el.classList.contains('lh-text'), 'adds classes');
+    });
   });
 });


### PR DESCRIPTION
alternative to #3154

this does unfortunately leave us with `renderUrl` and `renderLink`, but they were different enough that I didn't really want to merge them