### PR TITLE
perf(ImageUsage): use PaintImage trace events when available

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -129,9 +129,9 @@ setTimeout(() => {
   <!-- PASS(responsive): image is used numerous times in sprite-fashion -->
   <!-- PASS(offscreen): image is onscreen -->
   <div class="onscreen" style="width: 30px; height: 30px; background: 0% 50% url(lighthouse-480x320.jpg?sprite);"></div>
-  <div class="onscreen" style="width: 30px; height: 30px; background: 25% 50% url(lighthouse-480x320.jpg?sprite);"></div>
-  <div class="onscreen" style="width: 30px; height: 30px; background: 50% 50% url(lighthouse-480x320.jpg?sprite);"></div>
-  <div class="onscreen" style="width: 30px; height: 30px; background: 75% 50% url(lighthouse-480x320.jpg?sprite);"></div>
+  <div class="onscreen" style="left: 10px; width: 30px; height: 30px; background: 25% 50% url(lighthouse-480x320.jpg?sprite);"></div>
+  <div class="onscreen" style="left: 20px; width: 30px; height: 30px; background: 50% 50% url(lighthouse-480x320.jpg?sprite);"></div>
+  <div class="onscreen" style="left: 30px; width: 30px; height: 30px; background: 75% 50% url(lighthouse-480x320.jpg?sprite);"></div>
 </div>
 
 <template id="lazily-loaded-image">

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -59,8 +59,14 @@ class OffscreenImages extends ByteEfficiencyAudit {
    */
   static computeWaste(image, viewportDimensions) {
     const url = URL.elideDataURI(image.src);
-    const totalPixels = image.clientWidth * image.clientHeight;
-    const visiblePixels = this.computeVisiblePixels(image.clientRect, viewportDimensions);
+
+    let totalPixels = 0;
+    let visiblePixels = 0;
+    if (typeof image.clientWidth === 'number') {
+      totalPixels = image.clientWidth * image.clientHeight;
+      visiblePixels = this.computeVisiblePixels(image.clientRect, viewportDimensions);
+    }
+
     // Treat images with 0 area as if they're offscreen. See https://github.com/GoogleChrome/lighthouse/issues/1914
     const wastedRatio = totalPixels === 0 ? 1 : 1 - visiblePixels / totalPixels;
     const totalBytes = image.networkRecord.resourceSize;

--- a/lighthouse-core/gather/gatherers/image-usage.js
+++ b/lighthouse-core/gather/gatherers/image-usage.js
@@ -123,7 +123,7 @@ class ImageUsage extends Gatherer {
    */
   afterPass(options, passData) {
     const traceResults = this._traceMethod(options, passData);
-    if (traceResults.length) return traceResults;
+    if (traceResults.length) return Promise.resolve(traceResults);
     return this._fallbackMethod(options, passData);
   }
 
@@ -193,7 +193,7 @@ class ImageUsage extends Gatherer {
   _indexNetworkRecords(passData) {
     return passData.networkRecords.reduce((map, record) => {
       if (/^image/.test(record._mimeType) && record.finished) {
-        map.set(record._url, {
+        map.set(record.url, {
           url: record.url,
           resourceSize: record.resourceSize,
           startTime: record.startTime,

--- a/lighthouse-core/gather/gatherers/image-usage.js
+++ b/lighthouse-core/gather/gatherers/image-usage.js
@@ -63,9 +63,6 @@ function collectImageElementInfo() {
     const imageMatch = style.backgroundImage.match(CSS_URL_REGEX);
     const url = imageMatch[1];
 
-    // Heuristic to filter out sprite sheets
-    const differentImages = images.filter(image => image.src !== url);
-
     images.push({
       src: url,
       clientWidth: element.clientWidth,
@@ -76,11 +73,15 @@ function collectImageElementInfo() {
       naturalHeight: Number.MAX_VALUE,
       isCss: true,
       isPicture: false,
-      isLikelySprite: images.length - differentImages.length > 2,
     });
 
     return images;
   }, []);
+
+  // Find likely sprite sheets in css image usage records
+  for (const image of cssImages) {
+    image.isLikelySprite = cssImages.filter(candidate => candidate.src === image.src).length > 2;
+  }
 
   return htmlImages.concat(cssImages);
 }

--- a/lighthouse-core/test/gather/gatherers/image-usage-test.js
+++ b/lighthouse-core/test/gather/gatherers/image-usage-test.js
@@ -1,0 +1,112 @@
+/**
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env mocha */
+
+const ImageUsage = require('../../../gather/gatherers/image-usage');
+const assert = require('assert');
+
+function generateNetworkRecord(data) {
+  return Object.assign({
+    mimeType: 'image/jpeg',
+    _mimeType: 'image/jpeg',
+    finished: true,
+    resourceSize: 100,
+    startTime: 0,
+    endTime: 200,
+    responseReceivedTime: 100,
+  }, data);
+}
+
+function omit(obj, omitKeys) {
+  const outObj = {};
+  Object.keys(obj).forEach(key => {
+    if (omitKeys.includes(key)) return;
+    outObj[key] = obj[key];
+  });
+
+  return outObj;
+}
+
+
+describe('ImageUsage', () => {
+  let gatherer;
+  let driver;
+  let trace;
+  let networkRecords;
+  let mockEvaluateAsync;
+
+  beforeEach(() => {
+    gatherer = new ImageUsage();
+    mockEvaluateAsync = () => Promise.resolve();
+    driver = {evaluateAsync: (...args) => mockEvaluateAsync(...args)};
+    trace = {traceEvents: []};
+    networkRecords = [];
+  });
+
+  it('should find image information in trace', () => {
+    trace.traceEvents = [
+      {
+        name: 'PaintImage',
+        args: {
+          data: {
+            url: 'file://image.jpg',
+            x: 0, y: 0,
+            width: 202, height: 101,
+            srcWidth: 600, srcHeight: 300,
+          }
+        }
+      },
+      {
+        name: 'PaintImage',
+        args: {
+          data: {
+            url: 'file://image-2.jpg',
+            x: 200, y: 0,
+            width: 202, height: 101,
+            srcWidth: 600, srcHeight: 300,
+          }
+        }
+      },
+    ];
+
+    const usedRecord = generateNetworkRecord({url: 'file://image-2.jpg'});
+    const unusedRecord = generateNetworkRecord({url: 'file://missing.jpg'});
+    networkRecords = [
+      usedRecord,
+      unusedRecord,
+      generateNetworkRecord({url: 'file://image.jpg', finished: false}),
+      generateNetworkRecord({url: 'file://data.json', _mimeType: 'application/json'}),
+    ];
+
+    return gatherer.afterPass({driver}, {trace, networkRecords})
+      .then(results => {
+        assert.deepEqual(results, [
+          {
+            src: 'file://image.jpg',
+            clientRect: {top: 0, left: 0, bottom: 101, right: 202},
+            clientWidth: 202, clientHeight: 101,
+            naturalWidth: 600, naturalHeight: 300,
+            isLikelySprite: false,
+            networkRecord: undefined,
+          },
+          {
+            src: 'file://image-2.jpg',
+            clientRect: {top: 0, left: 200, bottom: 101, right: 402},
+            clientWidth: 202, clientHeight: 101,
+            naturalWidth: 600, naturalHeight: 300,
+            isLikelySprite: false,
+            networkRecord: omit(usedRecord, ['_mimeType', 'finished']),
+          },
+          {
+            src: 'file://missing.jpg',
+            networkRecord: omit(unusedRecord, ['_mimeType', 'finished']),
+          },
+        ]);
+      });
+  });
+});


### PR DESCRIPTION
eliminates the need to execute the in page listener and re-evaluate the image for natural size data if paintimage data is available in the trace events

fixes #2407