### PR TITLE
test(smokehouse): add basic smoke test for SEO audits

### DIFF
--- a/lighthouse-cli/test/fixtures/seo/seo-failure-cases.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-failure-cases.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<!--
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+
+<html>
+<head>
+  <!-- no <title>SEO audit bad page</title> -->
+  <meta charset="utf-8">
+  <meta name="viewport" content="invalid-content=should_have_looked_it_up">
+  <!-- no <meta name="description" content=""> -->
+</head>
+<body>
+  bad crawlz
+</body>
+</html>

--- a/lighthouse-cli/test/fixtures/seo/seo-failure-cases.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-failure-cases.html
@@ -17,7 +17,7 @@
 
 <html>
 <head>
-  <!-- no <title>SEO audit bad page</title> -->
+  <!-- no <title>SEO audit failures page</title> -->
   <meta charset="utf-8">
   <meta name="viewport" content="invalid-content=should_have_looked_it_up">
   <!-- no <meta name="description" content=""> -->

--- a/lighthouse-cli/test/fixtures/seo/seo-failure-cases.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-failure-cases.html
@@ -1,18 +1,8 @@
 <!doctype html>
 <!--
- * Copyright 2017 Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 -->
 
 <html>

--- a/lighthouse-cli/test/fixtures/seo/seo-tester.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<!--
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+
+<html>
+<head>
+  <title>SEO audit tester</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <meta name="description" content="The premiere destination for testing your SEO audit gathering">
+</head>
+<body>
+  crawlz me
+</body>
+</html>

--- a/lighthouse-cli/test/fixtures/seo/seo-tester.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester.html
@@ -1,18 +1,8 @@
 <!doctype html>
 <!--
- * Copyright 2017 Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 -->
 
 <html>

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * Expected Lighthouse audit values for seo tests
+ */
+module.exports = [
+  {
+    initialUrl: 'http://localhost:10200/seo/seo-tester.html',
+    url: 'http://localhost:10200/seo/seo-tester.html',
+    audits: {
+      'meta-viewport': {
+        score: true,
+      },
+      'document-title': {
+        score: true,
+      },
+    }
+  },
+];

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -19,6 +19,9 @@ module.exports = [
       'document-title': {
         score: true,
       },
+      'meta-description': {
+        score: true,
+      }
     }
   },
   {
@@ -36,6 +39,9 @@ module.exports = [
           }
         }
       },
+      'meta-description': {
+        score: false,
+      }
     }
   },
 ];

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -13,7 +13,7 @@ module.exports = [
     initialUrl: 'http://localhost:10200/seo/seo-tester.html',
     url: 'http://localhost:10200/seo/seo-tester.html',
     audits: {
-      'meta-viewport': {
+      'viewport': {
         score: true,
       },
       'document-title': {
@@ -28,7 +28,7 @@ module.exports = [
     initialUrl: 'http://localhost:10200/seo/seo-failure-cases.html',
     url: 'http://localhost:10200/seo/seo-failure-cases.html',
     audits: {
-      'meta-viewport': {
+      'viewport': {
         score: false,
       },
       'document-title': {

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -21,4 +21,21 @@ module.exports = [
       },
     }
   },
+  {
+    initialUrl: 'http://localhost:10200/seo/seo-failure-cases.html',
+    url: 'http://localhost:10200/seo/seo-failure-cases.html',
+    audits: {
+      'meta-viewport': {
+        score: false,
+      },
+      'document-title': {
+        score: false,
+        extendedInfo: {
+          value: {
+            id: 'document-title'
+          }
+        }
+      },
+    }
+  },
 ];

--- a/lighthouse-cli/test/smokehouse/seo/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/seo/run-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+node lighthouse-cli/test/fixtures/static-server.js &
+
+sleep 0.5s
+
+config="lighthouse-core/config/seo.js"
+expectations="lighthouse-cli/test/smokehouse/seo/expectations.js"
+
+yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+exit_code=$?
+
+# kill test servers
+kill $(jobs -p)
+
+exit "$exit_code"

--- a/lighthouse-core/config/seo.js
+++ b/lighthouse-core/config/seo.js
@@ -36,7 +36,7 @@ module.exports = {
       name: 'SEO',
       description: 'These ensure your app is able to be understood by search engine crawlers.',
       audits: [
-        {id: 'meta-viewport', weight: 1, group: 'seo-mobile'},
+        {id: 'viewport', weight: 1, group: 'seo-mobile'},
         {id: 'document-title', weight: 1, group: 'seo-content'},
         {id: 'meta-description', weight: 1, group: 'seo-content'},
       ]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build-viewer": "cd ./lighthouse-viewer && yarn build",
     "clean": "rimraf *.report.html *.report.dom.html *.report.json *.screenshots.html *.devtoolslog.json *.trace.json || true",
     "lint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .",
-    "smoke": "bash lighthouse-cli/test/smokehouse/offline-local/run-tests.sh && bash lighthouse-cli/test/smokehouse/perf/run-tests.sh && bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh && bash lighthouse-cli/test/smokehouse/byte-efficiency/run-tests.sh && bash lighthouse-cli/test/smokehouse/tricky-ttci/run-tests.sh",
+    "smoke": "bash lighthouse-cli/test/smokehouse/offline-local/run-tests.sh && bash lighthouse-cli/test/smokehouse/perf/run-tests.sh && bash lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh && bash lighthouse-cli/test/smokehouse/byte-efficiency/run-tests.sh && bash lighthouse-cli/test/smokehouse/tricky-ttci/run-tests.sh && bash lighthouse-cli/test/smokehouse/seo/run-tests.sh",
     "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*-test.js') --timeout 10000 --reporter progress --report lcovonly",
     "start": "node ./lighthouse-cli/index.js",
     "test": "yarn lint --silent && yarn unit && yarn closure && yarn test-cli-formatting && yarn test-launcher-formatting",


### PR DESCRIPTION
@kdzwinel FYI

this adds a starting point for SEO audit integration tests. Right now this tests only the two a11y audits that are also being used as SEO audits, but since they're a11y audits they don't have many details to test beyond the score

as new SEO audits get added:
- add audits to the expectations file (obviously :)
- new audits may have a lot more detail in `extendedInfo`/`details` that can be tested ([example](https://github.com/GoogleChrome/lighthouse/blob/a9b02a948b579be1a0667b69627f6d1f831d30ca/lighthouse-cli/test/smokehouse/pwa-expectations.js#L40-L56))
- could add a second html tester file that fails some/all of these audits and asserts proper failure output in those cases