### PR TITLE
fix(report): tame greedy markdown link regex

### DIFF
--- a/lighthouse-core/report/v2/renderer/dom.js
+++ b/lighthouse-core/report/v2/renderer/dom.js
@@ -95,7 +95,7 @@ class DOM {
     const element = this.createElement('span');
 
     // Split on markdown links (e.g. [some link](https://...)).
-    const parts = text.split(/\[(.*?)\]\((https?:\/\/.*?)\)/g);
+    const parts = text.split(/\[([^\]]*?)\]\((https?:\/\/.*?)\)/g);
 
     while (parts.length) {
       // Pop off the same number of elements as there are capture groups.

--- a/lighthouse-core/test/report/v2/renderer/dom-test.js
+++ b/lighthouse-core/test/report/v2/renderer/dom-test.js
@@ -106,6 +106,14 @@ describe('DOM', () => {
       const result = dom.convertMarkdownLinkSnippets(text);
       assert.equal(result.innerHTML, text);
     });
+
+    it('handles the case of [text]... [text](url)', () => {
+      const text = 'Ensuring `<td>` cells using the `[headers]` are good. ' +
+          '[Learn more](https://dequeuniversity.com/rules/axe/2.2/td-headers-attr).';
+      const result = dom.convertMarkdownLinkSnippets(text);
+      assert.equal(result.innerHTML, 'Ensuring `&lt;td&gt;` cells using the `[headers]` are ' +
+          'good. <a rel="noopener" target="_blank" href="https://dequeuniversity.com/rules/axe/2.2/td-headers-attr">Learn more</a>.');
+    });
   });
 
   describe('convertMarkdownCodeSnippets', () => {


### PR DESCRIPTION
encountered in the `td-headers-attr` [`helpText`](https://github.com/GoogleChrome/lighthouse/blob/da9f7893b84851a914b59058202455e1cc072a86/lighthouse-core/audits/accessibility/td-headers-attr.js#L28-L31)

fixes https://bugs.chromium.org/p/chromium/issues/detail?id=762936