### PR TITLE
fix: Bump axe-core to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "zone.js": "^0.7.3"
   },
   "dependencies": {
-    "axe-core": "2.4.0",
+    "axe-core": "2.4.1",
     "chrome-devtools-frontend": "1.0.422034",
     "devtools-timeline-model": "1.1.6",
     "jpeg-js": "0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,9 +161,9 @@ aws4@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
 
-axe-core@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.4.0.tgz#7c5bed90641f6d2cf06cb7efafc2c4678744d7cc"
+axe-core@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.4.1.tgz#55b6ceaa847cb1eaef5d559b6c41035dc3e07dbf"
 
 axios@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
This fixes #3318 