### PR TITLE
fix(travis): unset _JAVA_OPTIONS for compile_frontend.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ script:
   - yarn closure
   - yarn smoke
   - yarn smokehouse
+  # _JAVA_OPTIONS is breaking parsing of compiler output. See #3338.
+  - unset _JAVA_OPTIONS
   - yarn compile-devtools
 before_cache:
   # the `yarn compile-devtools` task adds these to node_modules, which slows down caching


### PR DESCRIPTION
fixes #3338 

Unfortunately https://github.com/ChromeDevTools/devtools-frontend/commit/5e7e9ca0a01c880f5aae5123d3242591a86d8c3c wasn't successful. Something else in `compile_frontend.py` is dependent on the exact output of the compiler and is breaking the build.

In the [Travis bug for this](https://github.com/travis-ci/travis-ci/issues/8408), unsetting the variable is mentioned as working, and though there is a concern that the new default JVM will run out of memory, it appears to work for us so let's go with it for now unless it ends up flaky.

https://github.com/travis-ci/travis-cookbooks/issues/895 suggests Travis may move to using `JAVA_TOOL_OPTIONS` which *won't* get printed to stdout, so we may be able to remove this line again in the future.