### PR TITLE
Docs: Eliminate integration with CI

### DIFF
--- a/chrome-launcher/README.md
+++ b/chrome-launcher/README.md
@@ -129,3 +129,5 @@ before_script:
 addons:
   chrome: stable
 ```
+
+> Since Travis can install Chrome at a run time you no longer need to install it manually. Read [more](https://docs.travis-ci.com/user/chrome).

--- a/chrome-launcher/README.md
+++ b/chrome-launcher/README.md
@@ -125,5 +125,7 @@ before_script:
   - export DISPLAY=:99.0
   - export CHROME_PATH="$(pwd)/chrome-linux/chrome"
   - sh -e /etc/init.d/xvfb start
-  - curl -L https://raw.githubusercontent.com/GoogleChrome/lighthouse/v2.1.0/lighthouse-core/scripts/download-chrome.sh | bash
+  - sleep 3 # wait for xvfb to boot
+addons:
+  chrome: stable
 ```

--- a/chrome-launcher/README.md
+++ b/chrome-launcher/README.md
@@ -111,9 +111,10 @@ chromeLauncher.launch({
 
 ### Continuous Integration
 
-In a CI environment like Travis, Chrome may not be installed. If you want to use `chrome-launcher`, you can install Chrome using Lighthouse's `download-chrome.sh` script:
+In a CI environment, Chrome may not be installed. If you want to use `chrome-launcher`, e.g. Travis can [install Chrome at run time with an addon](https://docs.travis-ci.com/user/chrome).
 
-`curl -L https://raw.githubusercontent.com/GoogleChrome/lighthouse/v2.1.0/lighthouse-core/scripts/download-chrome.sh | bash`
+> You can also install Chrome manually using Lighthouse's `download-chrome.sh` script:
+> `curl -L https://raw.githubusercontent.com/GoogleChrome/lighthouse/v2.1.0/lighthouse-core/scripts/download-chrome.sh | bash`
 
 Then in `.travis.yml`, use it like so:
 
@@ -129,5 +130,3 @@ before_script:
 addons:
   chrome: stable
 ```
-
-> Since Travis can install Chrome at a run time you no longer need to install it manually. Read [more](https://docs.travis-ci.com/user/chrome).

--- a/chrome-launcher/README.md
+++ b/chrome-launcher/README.md
@@ -111,7 +111,7 @@ chromeLauncher.launch({
 
 ### Continuous Integration
 
-In a CI environment, Chrome may not be installed. If you want to use `chrome-launcher`, e.g. Travis can [install Chrome at run time with an addon](https://docs.travis-ci.com/user/chrome).
+In a CI environment like Travis, Chrome may not be installed. If you want to use `chrome-launcher`, Travis can [install Chrome at run time with an addon](https://docs.travis-ci.com/user/chrome).
 
 > You can also install Chrome manually using Lighthouse's `download-chrome.sh` script:
 > `curl -L https://raw.githubusercontent.com/GoogleChrome/lighthouse/v2.1.0/lighthouse-core/scripts/download-chrome.sh | bash`


### PR DESCRIPTION
Since e.g. Travis has chrome under the hood https://docs.travis-ci.com/user/chrome so this section is no longer needed. I think ...