### PR TITLE
Fix number type chrome flags

### DIFF
--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -36,7 +36,7 @@ function formatArg(arg: string, value: any): string {
   }
 
   // Only quote the value if it contains spaces
-  if (value.indexOf(' ') !== -1) {
+  if (typeof(value) === 'string' && value.indexOf(' ') !== -1) {
     value = `"${value}"`
   }
 

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -54,6 +54,10 @@ describe('Parsing --chrome-flags', () => {
     assert.deepStrictEqual(['--debug=false'], parseChromeFlags('--debug=false'));
   });
 
+  it('returns int flags that correctly', () => {
+    assert.deepStrictEqual(['--log-level=0'], parseChromeFlags('--log-level=0'));
+  });
+
   it('returns boolean flags that empty when passed undefined', () => {
     assert.deepStrictEqual([], parseChromeFlags());
   });


### PR DESCRIPTION
This PR fixes an issue where non-string and non-boolean `--chrome-flags` break. For example `--log-level=0`

I have not been able to get tests to run locally, so I am hoping that they run correctly on CI!