### PR TITLE
adopt yargsParser directly for chromeFlags parsing

### DIFF
--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -12,7 +12,7 @@ import {Results} from './types/types';
 import {Flags} from './cli-flags';
 import {launch, LaunchedChrome} from '../chrome-launcher/chrome-launcher';
 
-const yargs = require('yargs');
+const yargsParser = require("yargs-parser")
 const lighthouse = require('../lighthouse-core');
 const log = require('lighthouse-logger');
 const getFilenamePrefix = require('../lighthouse-core/lib/file-namer.js').getFilenamePrefix;
@@ -29,28 +29,22 @@ interface LighthouseError extends Error {
   code?: string
 }
 
-// Boolean values that are true are rendered without a value (--debug vs. --debug=true)
-function formatArg(arg: string, value: any): string {
-  if (value === true) {
-    return `--${arg}`
-  }
-
-  // Only quote the value if it contains spaces
-  if (value.indexOf(' ') !== -1) {
-    value = `"${value}"`
-  }
-
-  return `--${arg}=${value}`
-}
-
 // exported for testing
 export function parseChromeFlags(flags: string) {
-  let args = yargs(flags).argv;
-  const allKeys = Object.keys(args);
+  const parsed = yargsParser(flags || '', {
+    configuration: {
+      'camel-case-expansion': false,
+      'boolean-negation': false
+    }
+  });
 
-  // Remove unneeded arguments (yargs includes a _ arg, $-prefixed args, and camelCase dupes)
-  return allKeys.filter(k => k !== '_' && !k.startsWith('$') && !/[A-Z]/.test(k))
-      .map(k => formatArg(k, args[k]));
+  const addQuotes = (str:String) => (typeof str === 'string' && str.includes(' ')) ? `"${str}"` : str;
+
+  return Object.keys(parsed)
+    // Remove unnecessary _ item provided by yargs,
+    .filter(key => key !== '_')
+    // Avoid '=true', then reintroduce quotes if required
+    .map(key => `--${key}` + (parsed[key] === true ? '' : `=${addQuotes(parsed[key])}`));
 }
 
 /**

--- a/lighthouse-cli/run.ts
+++ b/lighthouse-cli/run.ts
@@ -12,7 +12,7 @@ import {Results} from './types/types';
 import {Flags} from './cli-flags';
 import {launch, LaunchedChrome} from '../chrome-launcher/chrome-launcher';
 
-const yargsParser = require("yargs-parser")
+const yargsParser = require('yargs-parser');
 const lighthouse = require('../lighthouse-core');
 const log = require('lighthouse-logger');
 const getFilenamePrefix = require('../lighthouse-core/lib/file-namer.js').getFilenamePrefix;
@@ -31,20 +31,21 @@ interface LighthouseError extends Error {
 
 // exported for testing
 export function parseChromeFlags(flags: string) {
-  const parsed = yargsParser(flags || '', {
-    configuration: {
-      'camel-case-expansion': false,
-      'boolean-negation': false
-    }
-  });
+  const parsed = yargsParser(
+      flags || '', {configuration: {'camel-case-expansion': false, 'boolean-negation': false}});
 
-  const addQuotes = (str:String) => (typeof str === 'string' && str.includes(' ')) ? `"${str}"` : str;
+  const addQuotes = (str: String) =>
+      (typeof str === 'string' && str.includes(' ')) ? `"${str}"` : str;
 
-  return Object.keys(parsed)
-    // Remove unnecessary _ item provided by yargs,
-    .filter(key => key !== '_')
-    // Avoid '=true', then reintroduce quotes if required
-    .map(key => `--${key}` + (parsed[key] === true ? '' : `=${addQuotes(parsed[key])}`));
+  return Object
+      .keys(parsed)
+      // Remove unnecessary _ item provided by yargs,
+      .filter(key => key !== '_')
+      // Avoid '=true', then reintroduce quotes if required
+      .map(key => {
+        if (parsed[key] === true) return `--${key}`;
+        return `--${key}=${addQuotes(parsed[key])}`;
+      });
 }
 
 /**

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -58,7 +58,20 @@ describe('Parsing --chrome-flags', () => {
     assert.deepStrictEqual([], parseChromeFlags());
   });
 
+  it('keeps --no-flags untouched, #3003', () => {
+    assert.deepStrictEqual(['--no-sandbox'], parseChromeFlags('--no-sandbox'));
+  });
+
+  it('handles numeric values', () => {
+    assert.deepStrictEqual(['--log-level=0'], parseChromeFlags('--log-level=0'));
+  });
+
   it('returns flags correctly for issue 2817', () => {
+    assert.deepStrictEqual(
+      ['--user-agent="iPhone UA Test"'],
+      parseChromeFlags('--user-agent="iPhone UA Test"')
+    );
+
     assert.deepStrictEqual(
       ['--host-resolver-rules="MAP www.example.org:443 127.0.0.1:8443"'],
       parseChromeFlags('--host-resolver-rules="MAP www.example.org:443 127.0.0.1:8443"')


### PR DESCRIPTION
yargs has some overzealous parsing. by using yargs-parser directly, we can turn off boolean & camelCasing. Still have to add back quotes, but it doesn't seem too bad.

basically the alternative impl of #2754 (which was for #2753)

fixes #3003