### PR TITLE
fix(npm): remove lighthouse-logger/ from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ lighthouse-core/third_party/src/
 lighthouse-viewer/
 lighthouse-extension/
 lighthouse-cli/results/
+lighthouse-logger/
 
 # excluding cli/test minus smokehouse
 lighthouse-cli/test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,10 @@ echo "Test the extension"
 
 echo "Test a fresh local install"
 # (starting from lighthouse root...)
+# npm pack
 # cd ..; trash tmp; mkdir tmp; cd tmp
 # npm init -y
-# npm install ../lighthouse
+# npm install ../lighthouse/lighthouse-<version>.tgz
 # npm explore lighthouse -- npm run smoke
 # npm explore lighthouse -- npm run smokehouse
 # npm explore lighthouse -- npm run chrome # try the manual launcher


### PR DESCRIPTION
since lighthouse-logger is now its own package. Saves a whole 17KB!

Also update CONTRIBUTING on local testing of the npm package due to `npm install <file>` now just creating a symlink (https://github.com/npm/npm/pull/15900) instead of a real install