### PR TITLE
Don't wait for Page.navigate's resolution

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -624,7 +624,8 @@ class Driver {
     return this._beginNetworkStatusMonitoring(url)
       .then(_ => {
         // These can 'race' and that's OK.
-        // We don't want to wait for Page.navigate's resolution, as it can happen _after_ onload.
+        // We don't want to wait for Page.navigate's resolution, as it can now
+        // happen _after_ onload: https://crbug.com/768961
         this.sendCommand('Page.enable');
         this.sendCommand('Emulation.setScriptExecutionDisabled', {value: disableJS});
         this.sendCommand('Page.navigate', {url});


### PR DESCRIPTION
to repro:

```sh
yarn start -- --disable-device-emulation --disable-cpu-throttling --disable-network-throttling "http://example.com" --verbose
```

this will always timeout at 30 waiting for example.com

that's because it fires loadEventFired before page.navigate ever resolves:

![image](https://user-images.githubusercontent.com/39191/30873287-8cf775a6-a2a1-11e7-8d1d-37bd581b4f2d.png)
