### PR TITLE
fix(report): prevents unicode newline from breaking the report

### DIFF
--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -116,7 +116,9 @@ class ReportGeneratorV2 {
    * @return {string}
    */
   generateReportHtml(reportAsJson) {
-    const sanitizedJson = JSON.stringify(reportAsJson).replace(/</g, '\\u003c');
+    const sanitizedJson = JSON.stringify(reportAsJson)
+      .replace(/</g, '\\u003c') // replaces opening script tags
+      .replace(/\u2028/g, '\\n'); // replaces line separators
     const sanitizedJavascript = REPORT_JAVASCRIPT.replace(/<\//g, '\\u003c/');
 
     return ReportGeneratorV2.replaceStrings(REPORT_TEMPLATE, [

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -118,7 +118,8 @@ class ReportGeneratorV2 {
   generateReportHtml(reportAsJson) {
     const sanitizedJson = JSON.stringify(reportAsJson)
       .replace(/</g, '\\u003c') // replaces opening script tags
-      .replace(/\u2028/g, '\\n'); // replaces line separators
+      .replace(/\u2028/g, '\\u2028') // replaces line separators ()
+      .replace(/\u2029/g, '\\u2029'); // replaces paragraph separators
     const sanitizedJavascript = REPORT_JAVASCRIPT.replace(/<\//g, '\\u003c/');
 
     return ReportGeneratorV2.replaceStrings(REPORT_TEMPLATE, [

--- a/lighthouse-core/test/report/v2/report-generator-test.js
+++ b/lighthouse-core/test/report/v2/report-generator-test.js
@@ -129,9 +129,9 @@ describe('ReportGeneratorV2', () => {
     });
 
     it('should inject the report JSON', () => {
-      const code = 'hax</script><script>console.log("pwned");%%LIGHTHOUSE_JAVASCRIPT%%';
+      const code = 'hax\u2028</script><script>console.log("pwned");%%LIGHTHOUSE_JAVASCRIPT%%';
       const result = new ReportGeneratorV2().generateReportHtml({code});
-      assert.ok(result.includes('"code":"hax'), 'injects the json');
+      assert.ok(result.includes('"code":"hax\\n'), 'injects the json');
       assert.ok(result.includes('\\u003c/script'), 'escapes HTML tags');
       assert.ok(result.includes('LIGHTHOUSE_JAVASCRIPT'), 'cannot be tricked');
     });

--- a/lighthouse-core/test/report/v2/report-generator-test.js
+++ b/lighthouse-core/test/report/v2/report-generator-test.js
@@ -129,10 +129,10 @@ describe('ReportGeneratorV2', () => {
     });
 
     it('should inject the report JSON', () => {
-      const code = 'hax\u2028</script><script>console.log("pwned");%%LIGHTHOUSE_JAVASCRIPT%%';
+      const code = 'hax\u2028hax</script><script>console.log("pwned");%%LIGHTHOUSE_JAVASCRIPT%%';
       const result = new ReportGeneratorV2().generateReportHtml({code});
-      assert.ok(result.includes('"code":"hax\\n'), 'injects the json');
-      assert.ok(result.includes('\\u003c/script'), 'escapes HTML tags');
+      assert.ok(result.includes('"code":"hax\\u2028'), 'injects the json');
+      assert.ok(result.includes('hax\\u003c/script'), 'escapes HTML tags');
       assert.ok(result.includes('LIGHTHOUSE_JAVASCRIPT'), 'cannot be tricked');
     });
 
@@ -152,6 +152,7 @@ describe('ReportGeneratorV2', () => {
     it('should inject the report renderer javascript', () => {
       const result = new ReportGeneratorV2().generateReportHtml({});
       assert.ok(result.includes('ReportRenderer'), 'injects the script');
+      assert.ok(result.includes('robustness: \\u003c/script'), 'escapes HTML tags in javascript');
       assert.ok(result.includes('pre$`post'), 'does not break from String.replace');
       assert.ok(result.includes('LIGHTHOUSE_JSON'), 'cannot be tricked');
     });


### PR DESCRIPTION
fixes #3093 