### PR TITLE
fix: update plots-config to use newer quiet parameters

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ You can specify a custom config file when using Lighthouse through the CLI or co
 module.exports = {
   passes: [{
     recordTrace: true,
-    pauseBeforeTraceEndMs: 5000,
+    pauseAfterLoadMs: 5000,
     useThrottling: true,
     gatherers: [],
   }],

--- a/lighthouse-core/config/plots-config.js
+++ b/lighthouse-core/config/plots-config.js
@@ -8,7 +8,9 @@
 module.exports = {
   passes: [{
     recordTrace: true,
-    pauseBeforeTraceEndMs: 5000,
+    pauseAfterLoadMs: 5250,
+    networkQuietThresholdMs: 5250,
+    cpuQuietThresholdMs: 5250,
     useThrottling: true,
     gatherers: [],
   }],


### PR DESCRIPTION
we missed these when updating in #2220, #2473, et al, which leads to lots of null TTCIs in plots runs :S