### PR TITLE
fix(extension): collect better fallback error message

### DIFF
--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -109,7 +109,7 @@ class ExtensionConnection extends Connection {
           try {
             errorMessage = JSON.parse(message).message;
           } catch (e) {}
-          errorMessage = errorMessage || 'Unknown debugger protocol error.';
+          errorMessage = errorMessage || message || 'Unknown debugger protocol error.';
 
           log.formatProtocol('method <= browser ERR', {method: command}, 'error');
           return reject(new Error(`Protocol error (${command}): ${errorMessage}`));


### PR DESCRIPTION
falls back to the raw lastError message if we couldn't parse it, hopefully we can get something useful to figure out what's going on with #3468 and related