### PR TITLE
fix(deps): add yargs-parser at 7.0.0

### DIFF
--- a/lighthouse-cli/package.json
+++ b/lighthouse-cli/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@types/node": "6.0.66",
-    "lighthouse-logger": "^1.0.0",
-    "yargs-parser": "7.0.0"
+    "lighthouse-logger": "^1.0.0"
   }
 }

--- a/lighthouse-cli/yarn.lock
+++ b/lighthouse-cli/yarn.lock
@@ -1316,17 +1316,17 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@7.0.0, yargs-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   dependencies:
     camelcase "^3.0.0"
+
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs@^8.0.1:
   version "8.0.2"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "update-notifier": "^2.1.0",
     "whatwg-url": "4.0.0",
     "ws": "1.1.2",
-    "yargs": "3.32.0"
+    "yargs": "3.32.0",
+    "yargs-parser": "7.0.0"
   },
   "repository": "GoogleChrome/lighthouse",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,6 +449,10 @@ camelcase@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.0.0.tgz#8b0f90d44be5e281b903b9887349b92595ef07f2"
 
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
 capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
@@ -3650,6 +3654,12 @@ y18n@^3.2.0:
 yallist@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yargs-parser@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs@3.32.0:
   version "3.32.0"


### PR DESCRIPTION
reverts previous PR to put package in root deps

time to ditch the non-package `package.json`s? :)