### PR TITLE
Bump chrome-launcher dep to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "axe-core": "2.4.1",
     "chrome-devtools-frontend": "1.0.422034",
-    "chrome-launcher": "0.8.0",
+    "chrome-launcher": "0.8.1",
     "devtools-timeline-model": "1.1.6",
     "jpeg-js": "0.1.2",
     "js-library-detector": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,9 +494,9 @@ chrome-devtools-frontend@1.0.422034:
   version "1.0.422034"
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.422034.tgz#071c8ce14466b7653032fcd1ad1a4a68d5e3cbd9"
 
-chrome-launcher@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.8.0.tgz#5cdf3089015a441faeb36388489ab5494742f00f"
+chrome-launcher@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.8.1.tgz#e275b738376d294b3228dc32caf3ed7ee0405e57"
   dependencies:
     "@types/core-js" "^0.9.41"
     "@types/mkdirp" "^0.3.29"


### PR DESCRIPTION
has the `google-emacs` fix.