### PR TITLE
report(redirects): reformat results, incl all requests and wasted time,

### DIFF
--- a/lighthouse-cli/test/smokehouse/redirects/expectations.js
+++ b/lighthouse-cli/test/smokehouse/redirects/expectations.js
@@ -20,7 +20,7 @@ module.exports = [
         rawValue: '>=500',
         details: {
           items: {
-            length: 2,
+            length: 3,
           },
         },
       },
@@ -32,10 +32,10 @@ module.exports = [
     audits: {
       'redirects': {
         score: 100,
-        rawValue: 0,
+        rawValue: '>=250',
         details: {
           items: {
-            length: 1,
+            length: 2,
           },
         },
       },

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -34,6 +34,7 @@ class GeolocationOnStart extends ViolationAudit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
+    // 'Only request geolocation information in response to a user gesture.'
     const results = ViolationAudit.getViolationResults(artifacts, /geolocation/);
 
     const headings = [

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -68,7 +68,7 @@ class Redirects extends Audit {
 
         return {
           // We award a passing grade if you only have 1 redirect
-          score: redirectRequests.length === 2 ? 100 : UnusedBytes.scoreForWastedMs(totalWastedMs),
+          score: redirectRequests.length <= 2 ? 100 : UnusedBytes.scoreForWastedMs(totalWastedMs),
           rawValue: totalWastedMs,
           displayValue: Util.formatMilliseconds(totalWastedMs, 1),
           extendedInfo: {

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -32,38 +32,48 @@ class Redirects extends Audit {
       .then(mainResource => {
         // redirects is only available when redirects happens
         const redirectRequests = Array.from(mainResource.redirects || []);
+
         // add main resource to redirectRequests so we can use it to calculate wastedMs
         redirectRequests.push(mainResource);
+
         let totalWastedMs = 0;
-
         const pageRedirects = [];
-        for (let i = 1; i < redirectRequests.length; i++) {
-          const request = redirectRequests[i - 1];
-          const nextRequest = redirectRequests[i];
-          const wastedMs = (nextRequest.startTime - request.startTime) * 1000;
 
-          // We skip the first redirect in our calculations but show it in the table below.
-          // We allow 1 redirect (www. => m.)
-          if (i > 1) {
-            totalWastedMs += wastedMs;
+        for (let i = 0; i < redirectRequests.length; i++) {
+          const initialRequest = redirectRequests[i - 1];
+          const redirectedRequest = redirectRequests[i];
+
+          // Only create a table (with the initial request) if there are > 1 redirects
+          if (!initialRequest) {
+            if (redirectRequests.length > 1) {
+              pageRedirects.push({
+                url: `(Initial: ${redirectedRequest.url})`,
+                wastedMs: 'n/a',
+              });
+            }
+            continue;
           }
 
+          const wastedMs = (redirectedRequest.startTime - initialRequest.startTime) * 1000;
+          totalWastedMs += wastedMs;
+
           pageRedirects.push({
-            url: request.url,
-            wastedMs: Util.formatMilliseconds(wastedMs),
+            url: redirectedRequest.url,
+            wastedMs: Util.formatMilliseconds(wastedMs, 1),
           });
         }
 
         const headings = [
-          {key: 'url', itemType: 'text', text: 'URL'},
+          {key: 'url', itemType: 'text', text: 'Redirected URL'},
           {key: 'wastedMs', itemType: 'text', text: 'Time for Redirect'},
         ];
         const details = Audit.makeTableDetails(headings, pageRedirects);
 
         return {
-          score: UnusedBytes.scoreForWastedMs(totalWastedMs),
+          // We award a passing grade if you only have 1 redirect
+          score: redirectRequests.length === 2 ? 100 : UnusedBytes.scoreForWastedMs(totalWastedMs),
           rawValue: totalWastedMs,
-          displayValue: Util.formatMilliseconds(totalWastedMs),
+          displayValue: Util.formatMilliseconds(totalWastedMs, 1),
           extendedInfo: {
             value: {
               wastedMs: totalWastedMs,

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -39,20 +39,17 @@ class Redirects extends Audit {
         let totalWastedMs = 0;
         const pageRedirects = [];
 
-        for (let i = 0; i < redirectRequests.length; i++) {
+        // Kickoff the results table (with the initial request) if there are > 1 redirects
+        if (redirectRequests.length > 1) {
+          pageRedirects.push({
+            url: `(Initial: ${redirectRequests[0].url})`,
+            wastedMs: 'n/a',
+          });
+        }
+
+        for (let i = 1; i < redirectRequests.length; i++) {
           const initialRequest = redirectRequests[i - 1];
           const redirectedRequest = redirectRequests[i];
-
-          // Only create a table (with the initial request) if there are > 1 redirects
-          if (!initialRequest) {
-            if (redirectRequests.length > 1) {
-              pageRedirects.push({
-                url: `(Initial: ${redirectedRequest.url})`,
-                wastedMs: 'n/a',
-              });
-            }
-            continue;
-          }
 
           const wastedMs = (redirectedRequest.startTime - initialRequest.startTime) * 1000;
           totalWastedMs += wastedMs;


### PR DESCRIPTION
##### Changes:

* The cost of each redirect is shown next to the new/redirected URL rather than initial URL. (Makes more sense to my brain). This also means we now show the final URL in the table, whereas before it wasn't there.
* The very first initial url is shown for completeness. 
* (If there's just 1 redirect we currently pass them. Nothing changes here.)
* All costs of redirects are kept and summed. We don't skip the first one. 
* Even if there's 1 redirect and you pass, we will still show the cost of the redirects to be clear.
* I updated the test cases to be slightly more realistic.

##### screenshots

failing with 2 redirects: 
![image](https://user-images.githubusercontent.com/39191/31257722-08387752-a9ef-11e7-878d-ac475d12aa8b.png)


passing with 1 redirect: 
![image](https://user-images.githubusercontent.com/39191/31257706-f93d3792-a9ee-11e7-9640-ca8b492d64d0.png)


passing with 0 redirects:
![image](https://user-images.githubusercontent.com/39191/31257737-2ef88cd8-a9ef-11e7-8ef2-25c1a1d8b661.png)

