### PR TITLE
test(smokehouse): Passive event listener violation doesn't report on passive:false now

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -209,7 +209,7 @@ function passiveEventsListenerTest() {
     console.log('touchstart');
   });
 
-  // FAIL
+  // PASS - passive:false doesn't get a warning now. crbug.com/770208
   window.addEventListener('mousewheel', function(e) {
     console.log('mousewheel');
   }, {passive: false});

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -158,7 +158,8 @@ module.exports = [
           value: {
             // Note: This would normally be 7 but M56 defaults document-level
             // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
-            length: 4,
+            // Note: Explicitly passive:false doesn't get a warning as of M63: crbug.com/770208
+            length: '>=3',
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -156,9 +156,10 @@ module.exports = [
         score: false,
         extendedInfo: {
           value: {
-            // Note: This would normally be 7 but M56 defaults document-level
+            // Note: Originally this was 7 but M56 defaults document-level
             // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
-            // Note: Explicitly passive:false doesn't get a warning as of M63: crbug.com/770208
+            // Note: It was 4, but {passive:false} doesn't get a warning as of M63: crbug.com/770208
+            // COMPAT: This can be set to 3 when m63 is stable.
             length: '>=3',
           },
         },


### PR DESCRIPTION
Fixes appveyor breakage