### PR TITLE
core(devtools-model): fix missing `Runtime.experiments` object

### DIFF
--- a/lighthouse-core/lib/traces/devtools-timeline-model.js
+++ b/lighthouse-core/lib/traces/devtools-timeline-model.js
@@ -36,11 +36,14 @@ class TimelineModel {
     // populate with events
     this._tracingModel.reset();
 
-    ConsoleQuieter.mute({prefix: 'timelineModel'});
-    this._tracingModel.addEvents(events);
-    this._tracingModel.tracingComplete();
-    this._timelineModel.setEvents(this._tracingModel);
-    ConsoleQuieter.unmuteAndFlush();
+    try {
+      ConsoleQuieter.mute({prefix: 'timelineModel'});
+      this._tracingModel.addEvents(events);
+      this._tracingModel.tracingComplete();
+      this._timelineModel.setEvents(this._tracingModel);
+    } finally {
+      ConsoleQuieter.unmuteAndFlush();
+    }
 
     return this;
   }

--- a/lighthouse-core/lib/web-inspector.js
+++ b/lighthouse-core/lib/web-inspector.js
@@ -26,6 +26,10 @@ module.exports = (function() {
 
   global.Runtime = global.Runtime || {};
 
+  // Required for devtools-timeline-model
+  global.Runtime.experiments = global.Runtime.experiments || {};
+  global.Runtime.experiments.isEnabled = global.Runtime.experiments.isEnabled || (_ => false);
+
   const _queryParam = global.Runtime.queryParam;
   global.Runtime.queryParam = function(arg) {
     switch (arg) {


### PR DESCRIPTION
1. The changes in web-inspector fix #3509 and the current `yarn test` breakage on master due to changes in #3497
2. The DTM changes handle the silent failure coming from mocha. One alternative to this fix is removing consoleQuieter entirely, which I'm open to. It was introduced to handle cases like https://github.com/paulirish/pwmetrics/issues/3. @brendankenny thoughts?