### PR TITLE
core(config): add category weight to perf config

### DIFF
--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -222,7 +222,6 @@ module.exports = {
     },
     'performance': {
       name: 'Performance',
-      weight: 1,
       description: 'These encapsulate your app\'s current performance and opportunities to improve it.',
       audits: [
         {id: 'first-meaningful-paint', weight: 5, group: 'perf-metric'},
@@ -248,7 +247,6 @@ module.exports = {
     },
     'accessibility': {
       name: 'Accessibility',
-      weight: 1,
       description: 'These checks highlight opportunities to [improve the accessibility of your app](https://developers.google.com/web/fundamentals/accessibility).',
       audits: [
         {id: 'accesskeys', weight: 1, group: 'a11y-correct-attributes'},
@@ -290,7 +288,6 @@ module.exports = {
     },
     'best-practices': {
       name: 'Best Practices',
-      weight: 1,
       description: 'We\'ve compiled some recommendations for modernizing your web app and avoiding performance pitfalls.',
       audits: [
         {id: 'appcache-manifest', weight: 1},

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -222,6 +222,7 @@ module.exports = {
     },
     'performance': {
       name: 'Performance',
+      weight: 1,
       description: 'These encapsulate your app\'s current performance and opportunities to improve it.',
       audits: [
         {id: 'first-meaningful-paint', weight: 5, group: 'perf-metric'},
@@ -247,6 +248,7 @@ module.exports = {
     },
     'accessibility': {
       name: 'Accessibility',
+      weight: 1,
       description: 'These checks highlight opportunities to [improve the accessibility of your app](https://developers.google.com/web/fundamentals/accessibility).',
       audits: [
         {id: 'accesskeys', weight: 1, group: 'a11y-correct-attributes'},
@@ -288,6 +290,7 @@ module.exports = {
     },
     'best-practices': {
       name: 'Best Practices',
+      weight: 1,
       description: 'We\'ve compiled some recommendations for modernizing your web app and avoiding performance pitfalls.',
       audits: [
         {id: 'appcache-manifest', weight: 1},

--- a/lighthouse-core/config/perf.json
+++ b/lighthouse-core/config/perf.json
@@ -2,5 +2,10 @@
   "extends": "lighthouse:default",
   "settings": {
     "onlyCategories": ["performance"]
+  },
+  "categories": {
+    "performance": {
+      "weight": 1
+    }
   }
 }


### PR DESCRIPTION
I noticed that when running the Lighthouse with the `--perf` flag, the top level `score` value in the generated json report is `0` even when the `score` of the `performance` category is higher than `0`. I expected these values to be the same when `performance` is the only category being evaluated.

This pull request simply adds default weights to `performance`, `accessibility`, and `best-practices`. `pwa` already had a weight.

Here's one way I tested this change.

```
git checkout master
/lighthouse-cli/index.js --chrome-flags="--headless --disable-gpu" https://www.github.com --perf  --output=json   --output-path=report.json  && cat report.json | jq '{TopLevelScore:  .score, PerfScore: .reportCategories[].score}'
{
  "TopLevelScore": 0,
  "PerfScore": 75.94117647058823
}

git checkout default-weight-value
./lighthouse-cli/index.js --chrome-flags="--headless --disable-gpu" https://www.github.com --perf  --output=json   --output-path=report.json  && cat report.json | jq '{TopLevelScore:  .score, PerfScore: .reportCategories[].score}'
{
  "TopLevelScore": 79.94117647058823,
  "PerfScore": 79.94117647058823
}
```

I encountered this problem when I was walking through https://github.com/ebidel/lighthouse-ci from @ebidel which relies on the top level `score` value of the json report generated by lighthouse.