### PR TITLE
misc(commitizen): new-audit => new_audit

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -10,7 +10,7 @@ module.exports = {
   allowCustomScopes: true,
   scopes: [],
   types: [
-    {value: 'new-audit',  name: 'new-audit: A new audit'},
+    {value: 'new_audit',  name: 'new_audit: A new audit'},
     {value: 'core',       name: 'core:      Driver, gather, (non-new) audits, LHR JSON, etc'},
     {value: 'tests',      name: 'tests:     Tests, smokehouse, etc'},
     {value: 'docs',       name: 'docs:      Documentation'},


### PR DESCRIPTION
konrad discovered that 'new-audit' wasn't being handled correctly

root issue: `conventional-commits-parser` package has `headerPattern: /^(\w*)(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$/,`  and this regex of `(\w*)` doesn't include dashes.

underscore works and kinda looks better anyway, so we'll move to that, ya?