### PR TITLE
core(emulation): remove use of deprecated Emulation.setVisibleSize

### DIFF
--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -104,11 +104,6 @@ function enableNexus5X(driver) {
 
   return Promise.all([
     driver.sendCommand('Emulation.setDeviceMetricsOverride', NEXUS5X_EMULATION_METRICS),
-    // required for screenshotting emulated page size, rather than full size
-    driver.sendCommand('Emulation.setVisibleSize', {
-      width: NEXUS5X_EMULATION_METRICS.screenWidth,
-      height: NEXUS5X_EMULATION_METRICS.screenHeight,
-    }),
     // Network.enable must be called for UA overriding to work
     driver.sendCommand('Network.enable'),
     driver.sendCommand('Network.setUserAgentOverride', NEXUS5X_USERAGENT),


### PR DESCRIPTION
This protocol method was made redundant in 61.0.3155.0

It's a noop for us now. Trace screenshots are no different.

fixes #2831 
