### PR TITLE
core(audit): Ignore href=javascript:.* for rel=noopener audit

### DIFF
--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -49,7 +49,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       })
       .filter(anchor => {
         // Ignore href's that do not redirect to a new url
-        return !/^javascript:/.test(anchor.href);
+        return !anchor.href.startsWith('javascript:');
       })
       .map(anchor => {
         return {

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -49,7 +49,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       })
       .filter(anchor => {
         // Ignore href's that do not redirect to a new url
-        return !/javascript:.*/.test(anchor.href);
+        return !/^javascript:/.test(anchor.href);
       })
       .map(anchor => {
         return {

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -47,6 +47,10 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
           return true;
         }
       })
+      .filter(anchor => {
+        // Ignore href's that do not redirect to a new url
+        return !/javascript:.*/.test(anchor.href);
+      })
       .map(anchor => {
         return {
           href: anchor.href || 'Unknown',

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -49,11 +49,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       })
       .filter(anchor => {
         // Ignore href's that are not real links
-        return (
-          anchor.href
-            ? !anchor.href.toLowerCase().startsWith('javascript:')
-            : true
-        );
+        return !anchor.href || !anchor.href.toLowerCase().startsWith('javascript:');
       })
       .map(anchor => {
         return {

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -49,7 +49,11 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
       })
       .filter(anchor => {
         // Ignore href's that are not real links
-        return !anchor.href.startsWith('javascript:');
+        return (
+          anchor.href
+            ? !anchor.href.toLowerCase().startsWith('javascript:')
+            : true
+        );
       })
       .map(anchor => {
         return {

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -48,7 +48,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
         }
       })
       .filter(anchor => {
-        // Ignore href's that do not redirect to a new url
+        // Ignore href's that are not real links
         return !anchor.href.startsWith('javascript:');
       })
       .map(anchor => {

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -59,6 +59,7 @@ describe('External anchors use rel="noopener"', () => {
     const auditResult = ExternalAnchorsAudit.audit({
       AnchorsWithNoRelNoopener: [
         {href: 'javascript:void(0)'},
+        {href: 'JAVASCRIPT:void(0)'},
       ],
       URL: {finalUrl: URL},
     });

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -54,4 +54,15 @@ describe('External anchors use rel="noopener"', () => {
     assert.equal(auditResult.details.items.length, 3);
     assert.ok(auditResult.debugString, 'includes debugString');
   });
+
+  it('does not fail for links with javascript in href attribute', () => {
+    const auditResult = ExternalAnchorsAudit.audit({
+      AnchorsWithNoRelNoopener: [
+        {href: 'javascript:void(0)'},
+      ],
+      URL: {finalUrl: URL},
+    });
+    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.details.items.length, 0);
+  });
 });


### PR DESCRIPTION
Fixes #3079 

---

~PS: Happy to close this if @akonchady has another implementation in place already.~ https://github.com/GoogleChrome/lighthouse/issues/3079#issuecomment-336839105