### PR TITLE
core(config): add silent seo audits to default config

### DIFF
--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -35,6 +35,7 @@ module.exports = {
       'dobetterweb/response-compression',
       'dobetterweb/tags-blocking-first-paint',
       'dobetterweb/websql',
+      'seo/meta-description',
     ],
   },
   {
@@ -144,6 +145,8 @@ module.exports = {
     'dobetterweb/script-blocking-first-paint',
     'dobetterweb/uses-http2',
     'dobetterweb/uses-passive-event-listeners',
+    'seo/meta-description',
+    'seo/http-status-code',
   ],
 
   groups: {


### PR DESCRIPTION
fixes #3521

These audit results will show up in the `audits` object on the LHR, but won't show up in the HTML report as no category includes them. They will be filtered out by any config that subsets the default config because of this, however.

We can add the other SEO audits as they land (probably as long as they don't have substantial cost) and/or make them visible in the report by bringing in the SEO report category if we're ready.

@kdzwinel @rviscomi 