### PR TITLE
misc(jsconfig): Enable type checking for JavaScript

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,7 +6,8 @@
   "compilerOptions": {
     "target": "ES6",
     "noEmit": true,
-    "diagnostics": true
+    "diagnostics": true,
+    "checkJs": true
   },
   "exclude": [
     "lighthouse-cli",


### PR DESCRIPTION
Highlights errors in IDE, doesn't affect automatic linters.

<img width="221" alt="checkJS:true" src="https://user-images.githubusercontent.com/985504/31684140-1f5aea0c-b37f-11e7-8220-ae627529f781.png">


Doc: https://code.visualstudio.com/docs/languages/javascript
Can be disabled per file via `// @ts-nocheck`.

We could also add `strict: true`. I have hard time finding the docs for this, but from what I can see it doesn't allow implicit 'any' type and is able to recognize that function may return undefined while jsdoc says it should return a string.

<img width="207" alt="checkJS:true; strict:true" src="https://user-images.githubusercontent.com/985504/31684186-3c64b8bc-b37f-11e7-8cd8-81a8bc6ca923.png">