### PR TITLE
docs(api): generate API docs from source

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,0 +1,35 @@
+{
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc", "closure"]
+    },
+    "source": {
+        "include": [
+            "lighthouse-cli/commands",
+            "lighthouse-core/audits",
+            "lighthouse-core/closue",
+            "lighthouse-core/gather",
+            "lighthouse-logger",
+            "package.json",
+            "README.md"
+        ],
+        "includePattern": ".+\\.(js|ts)$",
+        "excludePattern": "(node_modules/|docs|test|types)"
+    },
+    "plugins": [
+      "plugins/markdown"
+    ],
+    "templates": {
+        "cleverLinks": true,
+        "monospaceLinks": true,
+        "useLongnameInNav": false,
+        "showInheritedInNav": true
+    },
+    "opts": {
+        "destination": "./docs/api/",
+        "encoding": "utf8",
+        "private": true,
+        "recurse": true,
+        "template": "./node_modules/minami"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "smokehouse": "node lighthouse-cli/test/smokehouse/smokehouse.js",
     "deploy-viewer": "cd lighthouse-viewer && gulp deploy",
     "bundlesize": "bundlesize",
-    "plots-smoke": "bash plots/test/smoke.sh"
+    "plots-smoke": "bash plots/test/smoke.sh",
+    "generate-docs": "jsdoc --configure .jsdoc.json --verbose"
   },
   "devDependencies": {
     "@types/node": "^6.0.45",
@@ -67,7 +68,9 @@
     "lcov-result-merger": "^1.2.0",
     "mocha": "^3.2.0",
     "npm-run-posix-or-windows": "^2.0.2",
-    "zone.js": "^0.7.3"
+    "zone.js": "^0.7.3",
+    "minami": "^1.2.3",
+    "jsdoc": "^3.5.5"
   },
   "dependencies": {
     "axe-core": "2.4.1",


### PR DESCRIPTION
FIX #2463

The generated documentation looks like this:
![image](https://user-images.githubusercontent.com/1699357/31744403-e8a53194-b45e-11e7-953c-383fe00a4e23.png)

You can generate the api doc using the npm command: `npm run generate-docs`

I set the output folder in `docs/api` (this is configurable in `.jsdoc.json`)

However, it seems that some jsdocs comments are valid like this:

```
ERROR: Unable to parse a tag's type expression for source file 
lighthouse/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js in line 181 with tag title "return" and text "{!Promise<!Array<!Object>}": Invalid type expression "!Promise<!Array<!Object>": Expected ",", "=", ">" or "|" but end of input found.
```

TBH, I'm not familiar with this syntax. any idea how to fix this?
