### PR TITLE
core: record top-level warnings in LHR and display in report

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -301,6 +301,9 @@ class GatherRunner {
   static collectArtifacts(gathererResults) {
     const artifacts = {};
 
+    // Nest LighthouseRunWarnings, if any, so they will be collected into artifact.
+    gathererResults.LighthouseRunWarnings = [gathererResults.LighthouseRunWarnings || []];
+
     return Object.keys(gathererResults).reduce((chain, gathererName) => {
       return chain.then(_ => {
         const phaseResultsPromises = gathererResults[gathererName];
@@ -349,7 +352,9 @@ class GatherRunner {
 
     passes = this.instantiateGatherers(passes, options.config.configDir);
 
-    const gathererResults = {};
+    const gathererResults = {
+      LighthouseRunWarnings: [],
+    };
 
     return driver.connect()
       .then(_ => GatherRunner.loadBlank(driver))

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -100,6 +100,7 @@ class GatherRunner {
     // Enable emulation based on flags
     return driver.assertNoSameOriginServiceWorkerClients(options.url)
       .then(_ => gathererResults.UserAgent = [driver.getUserAgent()])
+      .then(_ => GatherRunner.warnOnHeadless(driver, gathererResults))
       .then(_ => driver.beginEmulation(options.flags))
       .then(_ => driver.enableRuntimeEvents())
       .then(_ => driver.cacheNatives())
@@ -160,6 +161,23 @@ class GatherRunner {
       error.code = 'PAGE_LOAD_ERROR';
       throw error;
     }
+  }
+
+  /**
+   * Add run warning if running in Headless Chrome.
+   * @param {!Driver} driver
+   * @param {!GathererResults} gathererResults
+   * @return {!Promise<undefined>}
+   */
+  static warnOnHeadless(driver, gathererResults) {
+    return driver.getUserAgent()
+      .then(userAgent => {
+        if (userAgent.startsWith('HeadlessChrome')) {
+          gathererResults.LighthouseRunWarnings.push('Your site\'s mobile performance may be ' +
+              'worse than the numbers presented in this report. Lighthouse could not test on a ' +
+              'mobile connection because Headless Chrome does not support network throttling.');
+        }
+      });
   }
 
   /**

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -115,6 +115,26 @@ class ReportRenderer {
   }
 
   /**
+   * Returns a div with a list of top-level warnings, or null if no warnings.
+   * @param {!ReportRenderer.ReportJSON} report
+   * @return {?DocumentFragment}
+   */
+  _renderReportWarnings(report) {
+    if (!report.lighthouseRunWarnings || report.lighthouseRunWarnings.length === 0) {
+      return null;
+    }
+
+    const container = this._dom.cloneTemplate('#tmpl-lh-run-warnings', this._templateContext);
+    const warnings = this._dom.find('ul', container);
+    for (const warningString of report.lighthouseRunWarnings) {
+      const warning = warnings.appendChild(this._dom.createElement('li'));
+      warning.textContent = warningString;
+    }
+
+    return container;
+  }
+
+  /**
    * @param {!ReportRenderer.ReportJSON} report
    * @return {!Element}
    */
@@ -123,6 +143,11 @@ class ReportRenderer {
     container.appendChild(this._renderReportHeader(report)); // sticky header goes at the top.
     container.appendChild(this._renderReportNav(report));
     const reportSection = container.appendChild(this._dom.createElement('div', 'lh-report'));
+
+    const warnings = this._renderReportWarnings(report);
+    if (warnings) {
+      reportSection.appendChild(warnings);
+    }
 
     let scoreHeader;
     const isSoloCategory = report.reportCategories.length === 1;
@@ -202,6 +227,7 @@ ReportRenderer.GroupJSON; // eslint-disable-line no-unused-expressions
  *     timing: {total: number},
  *     initialUrl: string,
  *     url: string,
+ *     lighthouseRunWarnings: !Array<string>,
  *     artifacts: {traces: !Object},
  *     reportCategories: !Array<!ReportRenderer.CategoryJSON>,
  *     reportGroups: !Object<string, !ReportRenderer.GroupJSON>,

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -117,7 +117,7 @@ class ReportRenderer {
   /**
    * Returns a div with a list of top-level warnings, or an empty div if no warnings.
    * @param {!ReportRenderer.ReportJSON} report
-   * @return {!DocumentFragment}
+   * @return {!Node}
    */
   _renderReportWarnings(report) {
     if (!report.runWarnings || report.runWarnings.length === 0) {

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -115,18 +115,18 @@ class ReportRenderer {
   }
 
   /**
-   * Returns a div with a list of top-level warnings, or null if no warnings.
+   * Returns a div with a list of top-level warnings, or an empty div if no warnings.
    * @param {!ReportRenderer.ReportJSON} report
-   * @return {?DocumentFragment}
+   * @return {!DocumentFragment}
    */
   _renderReportWarnings(report) {
-    if (!report.lighthouseRunWarnings || report.lighthouseRunWarnings.length === 0) {
-      return null;
+    if (!report.runWarnings || report.runWarnings.length === 0) {
+      return this._dom.createElement('div');
     }
 
     const container = this._dom.cloneTemplate('#tmpl-lh-run-warnings', this._templateContext);
     const warnings = this._dom.find('ul', container);
-    for (const warningString of report.lighthouseRunWarnings) {
+    for (const warningString of report.runWarnings) {
       const warning = warnings.appendChild(this._dom.createElement('li'));
       warning.textContent = warningString;
     }
@@ -144,10 +144,7 @@ class ReportRenderer {
     container.appendChild(this._renderReportNav(report));
     const reportSection = container.appendChild(this._dom.createElement('div', 'lh-report'));
 
-    const warnings = this._renderReportWarnings(report);
-    if (warnings) {
-      reportSection.appendChild(warnings);
-    }
+    reportSection.appendChild(this._renderReportWarnings(report));
 
     let scoreHeader;
     const isSoloCategory = report.reportCategories.length === 1;
@@ -227,7 +224,7 @@ ReportRenderer.GroupJSON; // eslint-disable-line no-unused-expressions
  *     timing: {total: number},
  *     initialUrl: string,
  *     url: string,
- *     lighthouseRunWarnings: !Array<string>,
+ *     runWarnings: (!Array<string>|undefined),
  *     artifacts: {traces: !Object},
  *     reportCategories: !Array<!ReportRenderer.CategoryJSON>,
  *     reportGroups: !Object<string, !ReportRenderer.GroupJSON>,

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -756,10 +756,13 @@ span.lh-node:hover {
 
 .lh-run-warnings {
   font-size: var(--body-font-size);
-  margin: 0;
+  margin: var(--section-padding);
   padding: var(--section-padding);
-  border-bottom: 1px solid var(--report-border-color);
-  line-height: var(--header-line-height);
+  background-color: hsla(40, 100%, 91%, 1);
+  color: var(--secondary-text-color);
+}
+.lh-run-warnings li {
+  margin-bottom: calc(var(--header-line-height) / 2);
 }
 .lh-run-warnings::before {
   display: inline-block;

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -754,6 +754,17 @@ span.lh-node:hover {
   margin-top: 0;
 }
 
+.lh-run-warnings {
+  font-size: var(--body-font-size);
+  margin: 0;
+  padding: var(--section-padding);
+  border-bottom: 1px solid var(--report-border-color);
+  line-height: var(--header-line-height);
+}
+.lh-run-warnings::before {
+  display: inline-block;
+}
+
 .lh-scores-header {
   display: flex;
   justify-content: center;

--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -1,3 +1,11 @@
+<!-- Lighthouse run warnings -->
+<template id="tmpl-lh-run-warnings">
+  <div class="lh-run-warnings lh-debug">
+    <b>There were issues affecting this run of Lighthouse:</b>
+    <ul></ul>
+  </div>
+</template>
+
 <!-- Lighthouse category score -->
 <template id="tmpl-lh-category-score">
   <div class="lh-score">

--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -1,7 +1,7 @@
 <!-- Lighthouse run warnings -->
 <template id="tmpl-lh-run-warnings">
   <div class="lh-run-warnings lh-debug">
-    <b>There were issues affecting this run of Lighthouse:</b>
+    <strong>There were issues affecting this run of Lighthouse:</strong>
     <ul></ul>
   </div>
 </template>

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -157,7 +157,7 @@ class Runner {
           generatedTime: (new Date()).toJSON(),
           initialUrl: opts.initialUrl,
           url: opts.url,
-          lighthouseRunWarnings,
+          runWarnings: lighthouseRunWarnings,
           audits: resultsById,
           artifacts: runResults.artifacts,
           runtimeConfig: Runner.getRuntimeConfig(opts.flags),

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -23,6 +23,9 @@ class Runner {
 
     const config = opts.config;
 
+    // List of top-level warnings for this Lighthouse run.
+    const lighthouseRunWarnings = [];
+
     // save the initialUrl provided by the user
     opts.initialUrl = opts.url;
     if (typeof opts.initialUrl !== 'string' || opts.initialUrl.length === 0) {
@@ -73,8 +76,13 @@ class Runner {
         run = run.then(_ => config.artifacts);
       }
 
-      // Add computed artifacts.
       run = run.then(artifacts => {
+        // Bring in lighthouseRunWarnings from gathering stage.
+        if (artifacts.LighthouseRunWarnings) {
+          lighthouseRunWarnings.push(...artifacts.LighthouseRunWarnings);
+        }
+
+        // And add computed artifacts.
         return Object.assign({}, artifacts, Runner.instantiateComputedArtifacts());
       });
 
@@ -89,7 +97,6 @@ class Runner {
 
         return artifacts;
       });
-
 
       run = run.then(artifacts => {
         log.log('status', 'Analyzing and running audits...');
@@ -150,6 +157,7 @@ class Runner {
           generatedTime: (new Date()).toJSON(),
           initialUrl: opts.initialUrl,
           url: opts.url,
+          lighthouseRunWarnings,
           audits: resultsById,
           artifacts: runResults.artifacts,
           runtimeConfig: Runner.getRuntimeConfig(opts.flags),

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -255,7 +255,7 @@ describe('GatherRunner', function() {
       cleanBrowserCaches: createCheck('calledCleanBrowserCaches'),
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
-      getUserAgent: asyncFunc,
+      getUserAgent: () => Promise.resolve('Fake user agent'),
     };
 
     return GatherRunner.setupDriver(driver, {}, {flags: {}}).then(_ => {
@@ -313,7 +313,7 @@ describe('GatherRunner', function() {
       cleanBrowserCaches: createCheck('calledCleanBrowserCaches'),
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
-      getUserAgent: asyncFunc,
+      getUserAgent: () => Promise.resolve('Fake user agent'),
     };
 
     return GatherRunner.setupDriver(driver, {}, {
@@ -938,5 +938,21 @@ describe('GatherRunner', function() {
           assert.ok(true);
         });
     });
+  });
+
+  it('issues a lighthouseRunWarnings if running in Headless', () => {
+    const mockDriver = {
+      getUserAgent: () => Promise.resolve('HeadlessChrome/64.0.3240.0'),
+    };
+    const gathererResults = {
+      LighthouseRunWarnings: [],
+    };
+
+    return GatherRunner.warnOnHeadless(mockDriver, gathererResults)
+      .then(_ => {
+        assert.strictEqual(gathererResults.LighthouseRunWarnings.length, 1);
+        const warning = gathererResults.LighthouseRunWarnings[0];
+        assert.ok(/Headless Chrome/.test(warning));
+      });
   });
 });

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -739,6 +739,8 @@ describe('GatherRunner', function() {
           Promise.reject(someOtherError),
           Promise.resolve(1729),
         ],
+
+        LighthouseRunWarnings: [],
       };
 
       return GatherRunner.collectArtifacts(gathererResults).then(artifacts => {
@@ -941,18 +943,14 @@ describe('GatherRunner', function() {
   });
 
   it('issues a lighthouseRunWarnings if running in Headless', () => {
-    const mockDriver = {
-      getUserAgent: () => Promise.resolve('HeadlessChrome/64.0.3240.0'),
-    };
+    const userAgent = 'HeadlessChrome/64.0.3240.0';
     const gathererResults = {
       LighthouseRunWarnings: [],
     };
 
-    return GatherRunner.warnOnHeadless(mockDriver, gathererResults)
-      .then(_ => {
-        assert.strictEqual(gathererResults.LighthouseRunWarnings.length, 1);
-        const warning = gathererResults.LighthouseRunWarnings[0];
-        assert.ok(/Headless Chrome/.test(warning));
-      });
+    GatherRunner.warnOnHeadless(userAgent, gathererResults);
+    assert.strictEqual(gathererResults.LighthouseRunWarnings.length, 1);
+    const warning = gathererResults.LighthouseRunWarnings[0];
+    assert.ok(/Headless Chrome/.test(warning));
   });
 });

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -749,6 +749,22 @@ describe('GatherRunner', function() {
       });
     });
 
+    it('produces a LighthouseRunWarnings artifact from array of warnings', () => {
+      const LighthouseRunWarnings = [
+        'warning0',
+        'warning1',
+        'warning2',
+      ];
+
+      const gathererResults = {
+        LighthouseRunWarnings,
+      };
+
+      return GatherRunner.collectArtifacts(gathererResults).then(artifacts => {
+        assert.deepStrictEqual(artifacts.LighthouseRunWarnings, LighthouseRunWarnings);
+      });
+    });
+
     it('supports sync and async throwing of non-fatal errors from gatherers', () => {
       const gatherers = [
         // sync

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -122,20 +122,20 @@ describe('ReportRenderer V2', () => {
     });
 
     it('renders a warning section', () => {
-      const lighthouseRunWarnings = [
+      const runWarnings = [
         'Less bad thing',
         'Really bad thing',
         'LH should maybe just retire now',
       ];
-      const warningResults = Object.assign({}, sampleResults, {lighthouseRunWarnings});
+      const warningResults = Object.assign({}, sampleResults, {runWarnings});
       const container = renderer._dom._document.body;
       const output = renderer.renderReport(warningResults, container);
 
       const warningEls = output.querySelectorAll('.lh-run-warnings > ul > li');
-      assert.strictEqual(warningEls.length, lighthouseRunWarnings.length);
+      assert.strictEqual(warningEls.length, runWarnings.length);
       warningEls.forEach((warningEl, index) => {
         const warningText = warningEl.textContent;
-        assert.strictEqual(warningText, lighthouseRunWarnings[index]);
+        assert.strictEqual(warningText, runWarnings[index]);
       });
     });
 

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -115,6 +115,30 @@ describe('ReportRenderer V2', () => {
       });
     });
 
+    it('renders no warning section when no lighthouseRunWarnings occur', () => {
+      const container = renderer._dom._document.body;
+      const output = renderer.renderReport(sampleResults, container);
+      assert.strictEqual(output.querySelector('.lh-run-warnings'), null);
+    });
+
+    it('renders a warning section', () => {
+      const lighthouseRunWarnings = [
+        'Less bad thing',
+        'Really bad thing',
+        'LH should maybe just retire now',
+      ];
+      const warningResults = Object.assign({}, sampleResults, {lighthouseRunWarnings});
+      const container = renderer._dom._document.body;
+      const output = renderer.renderReport(warningResults, container);
+
+      const warningEls = output.querySelectorAll('.lh-run-warnings > ul > li');
+      assert.strictEqual(warningEls.length, lighthouseRunWarnings.length);
+      warningEls.forEach((warningEl, index) => {
+        const warningText = warningEl.textContent;
+        assert.strictEqual(warningText, lighthouseRunWarnings[index]);
+      });
+    });
+
     it('renders a footer', () => {
       const footer = renderer._renderReportFooter(sampleResults);
       const footerContent = footer.querySelector('.lh-footer').textContent;

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -468,7 +468,7 @@ describe('Runner', () => {
     });
 
     return Runner.run(null, {url, config, driverMock}).then(results => {
-      assert.deepStrictEqual(results.lighthouseRunWarnings, LighthouseRunWarnings);
+      assert.deepStrictEqual(results.runWarnings, LighthouseRunWarnings);
     });
   });
 });

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -453,4 +453,22 @@ describe('Runner', () => {
       }
     });
   });
+
+  it('includes any LighthouseRunWarnings from artifacts in output', () => {
+    const url = 'https://example.com';
+    const LighthouseRunWarnings = [
+      'warning0',
+      'warning1',
+    ];
+    const config = new Config({
+      artifacts: {
+        LighthouseRunWarnings,
+      },
+      audits: [],
+    });
+
+    return Runner.run(null, {url, config, driverMock}).then(results => {
+      assert.deepStrictEqual(results.lighthouseRunWarnings, LighthouseRunWarnings);
+    });
+  });
 });


### PR DESCRIPTION
Adds a `LighthouseRunWarnings` artifact in `gather-runner` and a `lighthouseRunWarnings` in `runner` (which `LighthouseRunWarnings` is folded into when `gather-runner` is complete) to collect top-level warnings worthy of bringing to the user's attention (e.g. ran in Headless which doesn't support throttling). For now only `gather-runner` and `runner` can add to these, but should be easy to extend if we want to e.g. let gatherers or audits emit warnings they think are worthy of floating to the top. Happy to bikeshed on naming and exact flow of warning strings.

~steals the styling in the HTML report from #2920, but not remotely attached to it :)~

<img width="1124" alt="screen shot 2017-10-30 at 15 52 23" src="https://user-images.githubusercontent.com/316891/32199569-5a5d464e-bd8a-11e7-9df4-775bed9348f0.png">

closes #2920 by adding a warning when running in Headless