### PR TITLE
tests(smokehouse): disable multiple shadow root deprecation test

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
@@ -32,7 +32,9 @@ if (location.search === '' || params.has('passiveEvents')) {
 if (location.search === '' || params.has('deprecations')) {
   const div = document.createElement('div');
   div.createShadowRoot();
-  div.createShadowRoot(); // FAIL - multiple shadow v0 roots.
+  // FAIL(errors-in-console) - multiple shadow v0 roots.
+  // TODO: disabled until m64 is stable (when moved from deprecation warning to error)
+  // div.createShadowRoot();
 }
 
 })();

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -15,6 +15,7 @@ module.exports = [
     audits: {
       'errors-in-console': {
         score: false,
+        // TODO: should be 5 after m64 (see note in dbw_tester.js)
         rawValue: 4,
         displayValue: '4',
         details: {
@@ -168,12 +169,12 @@ module.exports = [
         score: false,
         extendedInfo: {
           value: {
-            length: 4,
+            length: 3,
           },
         },
         details: {
           items: {
-            length: 4,
+            length: 3,
           },
         },
       },


### PR DESCRIPTION
Fixes broken appveyor tests.

In m64 the multiple shadow root deprecation warning has turned into an error, so `deprecations--` and `errors-in-console++`. However, Travis runs stable while Appveyor runs Canary, so there's no great way to get these two to play along nicely short of just disabling that particular error in `dbw_tester` until m64 hits stable (which is what this does).

I investigated checking the `details.items` strings more directly (something we should probably do more often rather than just checking `length`), which would allow only checking a subset of `items` and ignoring the shadow root error in either list, but since these two audits' results are sorted by the order the error messages are emitted in, they weren't listed in a reliable order and so can't be addressed by index.