### PR TITLE
core(aspect-ratio): skip aspect ratio audit for svg

### DIFF
--- a/lighthouse-core/audits/image-aspect-ratio.js
+++ b/lighthouse-core/audits/image-aspect-ratio.js
@@ -73,6 +73,7 @@ class ImageAspectRatio extends Audit {
       // filter out images that don't have following properties
       // networkRecord, width, height, images that use `object-fit`: `cover` or `contain`
       return image.networkRecord &&
+        image.networkRecord.mimeType !== 'image/svg+xml' &&
         image.width &&
         image.height &&
         !image.usesObjectFit;

--- a/lighthouse-core/audits/image-aspect-ratio.js
+++ b/lighthouse-core/audits/image-aspect-ratio.js
@@ -70,8 +70,9 @@ class ImageAspectRatio extends Audit {
     let debugString;
     const results = [];
     images.filter(image => {
-      // filter out images that don't have following properties
-      // networkRecord, width, height, images that use `object-fit`: `cover` or `contain`
+      // - filter out images that don't have following properties:
+      //   networkRecord, width, height, images that use `object-fit`: `cover` or `contain`
+      // - filter all svgs as they have no natural dimensions to audit
       return image.networkRecord &&
         image.networkRecord.mimeType !== 'image/svg+xml' &&
         image.width &&

--- a/lighthouse-core/test/audits/image-aspect-ratio-test.js
+++ b/lighthouse-core/test/audits/image-aspect-ratio-test.js
@@ -135,7 +135,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('is an svg image', {
-    mimeType: 'image/svg',
+    mimeType: 'image/svg+xml',
     rawValue: true,
     clientSize: [],
     naturalSize: [150, 150],

--- a/lighthouse-core/test/audits/image-aspect-ratio-test.js
+++ b/lighthouse-core/test/audits/image-aspect-ratio-test.js
@@ -32,7 +32,7 @@ describe('Images: aspect-ratio audit', () => {
           generateImage(
             {width: data.clientSize[0], height: data.clientSize[1]},
             {naturalWidth: data.naturalSize[0], naturalHeight: data.naturalSize[1]},
-            generateRecord({mimeType: data.mimeType}),
+            generateRecord(),
             data.props
           ),
         ],
@@ -134,14 +134,25 @@ describe('Images: aspect-ratio audit', () => {
     },
   });
 
-  testImage('is an svg image', {
-    mimeType: 'image/svg+xml',
-    rawValue: true,
-    clientSize: [],
-    naturalSize: [150, 150],
-    props: {
-      isCss: false,
-      usesObjectFit: false,
-    },
+  it('skips svg images', () => {
+    const result = ImageAspectRatioAudit.audit({
+      ImageUsage: [
+        generateImage(
+          {width: 150, height: 150},
+          {},
+          {
+            url: 'https://google.com/logo.png',
+            mimeType: 'image/svg+xml',
+          },
+          {
+            isCss: false,
+            usesObjectFit: false,
+          }
+        ),
+      ],
+    });
+
+    assert.strictEqual(result.rawValue, true, 'rawValue does not match');
+    assert.strictEqual(result.debugString, undefined, 'debugString does not match');
   });
 });

--- a/lighthouse-core/test/audits/image-aspect-ratio-test.js
+++ b/lighthouse-core/test/audits/image-aspect-ratio-test.js
@@ -32,7 +32,7 @@ describe('Images: aspect-ratio audit', () => {
           generateImage(
             {width: data.clientSize[0], height: data.clientSize[1]},
             {naturalWidth: data.naturalSize[0], naturalHeight: data.naturalSize[1]},
-            generateRecord(),
+            generateRecord({mimeType: data.mimeType}),
             data.props
           ),
         ],
@@ -128,6 +128,17 @@ describe('Images: aspect-ratio audit', () => {
     debugString: 'Invalid image sizing information https://google.com/logo.png',
     clientSize: [100, 100],
     naturalSize: [0, 0],
+    props: {
+      isCss: false,
+      usesObjectFit: false,
+    },
+  });
+
+  testImage('is an svg image', {
+    mimeType: 'image/svg',
+    rawValue: true,
+    clientSize: [],
+    naturalSize: [150, 150],
     props: {
       isCss: false,
       usesObjectFit: false,


### PR DESCRIPTION
I'm pretty confident that the code matches the suggestion in #3716. I made an attempt at a new test, but it isn't correct (passes with and without the new check); suggestions welcome.