### PR TITLE
core(predictive-perf): predict FCP

### DIFF
--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -19,6 +19,24 @@ const SCORING_MEDIAN = 10000;
 // Any CPU task of 20 ms or more will end up being a critical long task on mobile
 const CRITICAL_LONG_TASK_THRESHOLD = 20;
 
+const COEFFICIENTS = {
+  FCP: {
+    intercept: 1440,
+    optimistic: -1.75,
+    pessimistic: 2.73,
+  },
+  FMP: {
+    intercept: 1532,
+    optimistic: -.30,
+    pessimistic: 1.33,
+  },
+  TTCI: {
+    intercept: 1582,
+    optimistic: .97,
+    pessimistic: .49,
+  },
+};
+
 class PredictivePerf extends Audit {
   /**
    * @return {!AuditMeta}
@@ -102,8 +120,16 @@ class PredictivePerf extends Audit {
    */
   static getOptimisticFMPGraph(dependencyGraph, traceOfTab) {
     const fmp = traceOfTab.timestamps.firstMeaningfulPaint;
+    const requiredScriptUrls = PredictivePerf.getScriptUrls(dependencyGraph, node => {
+      return (
+        node.endTime <= fmp && node.hasRenderBlockingPriority() && node.initiatorType !== 'script'
+      );
+    });
+
     return dependencyGraph.cloneWithRelationships(node => {
-      if (node.endTime > fmp || node.type === Node.TYPES.CPU) return false;
+      if (node.endTime > fmp) return false;
+      // Include EvaluateScript tasks for blocking scripts
+      if (node.type === Node.TYPES.CPU) return node.isEvaluateScriptFor(requiredScriptUrls);
       // Include non-script-initiated network requests with a render-blocking priority
       return node.hasRenderBlockingPriority() && node.initiatorType !== 'script';
     });
@@ -116,10 +142,18 @@ class PredictivePerf extends Audit {
    */
   static getPessimisticFMPGraph(dependencyGraph, traceOfTab) {
     const fmp = traceOfTab.timestamps.firstMeaningfulPaint;
+    const requiredScriptUrls = PredictivePerf.getScriptUrls(dependencyGraph, node => {
+      return node.endTime <= fmp && node.hasRenderBlockingPriority();
+    });
+
     return dependencyGraph.cloneWithRelationships(node => {
       if (node.endTime > fmp) return false;
-      // Include CPU tasks that performed a layout
-      if (node.type === Node.TYPES.CPU) return node.didPerformLayout();
+
+      // Include CPU tasks that performed a layout or were evaluations of required scripts
+      if (node.type === Node.TYPES.CPU) {
+        return node.didPerformLayout() || node.isEvaluateScriptFor(requiredScriptUrls);
+      }
+
       // Include all network requests that had render-blocking priority (even script-initiated)
       return node.hasRenderBlockingPriority();
     });
@@ -185,7 +219,6 @@ class PredictivePerf extends Audit {
         pessimisticTTCI: PredictivePerf.getPessimisticTTCIGraph(graph, traceOfTab),
       };
 
-      let sum = 0;
       const values = {};
       Object.keys(graphs).forEach(key => {
         const estimate = new LoadSimulator(graphs[key]).simulate();
@@ -205,21 +238,33 @@ class PredictivePerf extends Audit {
             values[key] = Math.max(values.pessimisticFMP, lastLongTaskEnd);
             break;
         }
-
-        sum += values[key];
       });
 
-      const meanDuration = sum / Object.keys(values).length;
+      values.roughEstimateOfFCP = COEFFICIENTS.FCP.intercept +
+        COEFFICIENTS.FCP.optimistic * values.optimisticFCP +
+        COEFFICIENTS.FCP.pessimistic * values.pessimisticFCP;
+      values.roughEstimateOfFMP = COEFFICIENTS.FMP.intercept +
+        COEFFICIENTS.FMP.optimistic * values.optimisticFMP +
+        COEFFICIENTS.FMP.pessimistic * values.pessimisticFMP;
+      values.roughEstimateOfTTCI = COEFFICIENTS.TTCI.intercept +
+        COEFFICIENTS.TTCI.optimistic * values.optimisticTTCI +
+        COEFFICIENTS.TTCI.pessimistic * values.pessimisticTTCI;
+
+      // While the raw values will never be lower than following metric, the weights make this
+      // theoretically possible, so take the maximum if this happens.
+      values.roughEstimateOfFMP = Math.max(values.roughEstimateOfFCP, values.roughEstimateOfFMP);
+      values.roughEstimateOfTTCI = Math.max(values.roughEstimateOfFMP, values.roughEstimateOfTTCI);
+
       const score = Audit.computeLogNormalScore(
-        meanDuration,
+        values.roughEstimateOfTTCI,
         SCORING_POINT_OF_DIMINISHING_RETURNS,
         SCORING_MEDIAN
       );
 
       return {
         score,
-        rawValue: meanDuration,
-        displayValue: Util.formatMilliseconds(meanDuration),
+        rawValue: values.roughEstimateOfTTCI,
+        displayValue: Util.formatMilliseconds(values.roughEstimateOfTTCI),
         extendedInfo: {value: values},
       };
     });

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -121,6 +121,15 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       } else if (node !== rootNode) {
         rootNode.addDependent(node);
       }
+
+      const redirects = Array.from(node.record.redirects || []);
+      redirects.push(node.record);
+
+      for (let i = 1; i < redirects.length; i++) {
+        const redirectNode = networkNodeOutput.idToNodeMap.get(redirects[i - 1].requestId);
+        const actualNode = networkNodeOutput.idToNodeMap.get(redirects[i].requestId);
+        actualNode.addDependency(redirectNode);
+      }
     });
   }
 

--- a/lighthouse-core/lib/dependency-graph/cpu-node.js
+++ b/lighthouse-core/lib/dependency-graph/cpu-node.js
@@ -56,10 +56,24 @@ class CPUNode extends Node {
   }
 
   /**
+   * Returns true if this node contains a Layout task.
    * @return {boolean}
    */
   didPerformLayout() {
     return this._childEvents.some(evt => evt.name === 'Layout');
+  }
+
+  /**
+   * Returns true if this node contains the EvaluateScript task for a URL in the given set.
+   * @param {!Set<string>} urls
+   * @return {boolean}
+   */
+  isEvaluateScriptFor(urls) {
+    return this._childEvents.some(evt => {
+      return evt.name === 'EvaluateScript' &&
+        evt.args.data &&
+        urls.has(evt.args.data.url);
+    });
   }
 
   /**

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -26,12 +26,14 @@ describe('Performance: predictive performance audit', () => {
 
     return PredictivePerf.audit(artifacts).then(output => {
       assert.equal(output.score, 99);
-      assert.equal(Math.round(output.rawValue), 1513);
-      assert.equal(output.displayValue, '1,510\xa0ms');
+      assert.equal(Math.round(output.rawValue), 1333);
+      assert.equal(output.displayValue, '1,330\xa0ms');
 
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
       assert.equal(valueOf('optimisticFCP'), 607);
       assert.equal(valueOf('pessimisticFCP'), 607);
+      assert.equal(valueOf('optimisticFMP'), 754);
+      assert.equal(valueOf('pessimisticFMP'), 1191);
       assert.equal(valueOf('optimisticTTCI'), 2438);
       assert.equal(valueOf('pessimisticTTCI'), 2399);
     });

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -25,15 +25,18 @@ describe('Performance: predictive performance audit', () => {
     }, Runner.instantiateComputedArtifacts());
 
     return PredictivePerf.audit(artifacts).then(output => {
-      assert.equal(output.score, 99);
-      assert.equal(Math.round(output.rawValue), 1333);
-      assert.equal(output.displayValue, '1,330\xa0ms');
+      assert.equal(output.score, 80);
+      assert.equal(Math.round(output.rawValue), 5123);
+      assert.equal(output.displayValue, '5,120\xa0ms');
 
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
+      assert.equal(valueOf('roughEstimateOfFCP'), 2035);
       assert.equal(valueOf('optimisticFCP'), 607);
       assert.equal(valueOf('pessimisticFCP'), 607);
-      assert.equal(valueOf('optimisticFMP'), 754);
+      assert.equal(valueOf('roughEstimateOfFMP'), 2845);
+      assert.equal(valueOf('optimisticFMP'), 904);
       assert.equal(valueOf('pessimisticFMP'), 1191);
+      assert.equal(valueOf('roughEstimateOfTTCI'), 5123);
       assert.equal(valueOf('optimisticTTCI'), 2438);
       assert.equal(valueOf('pessimisticTTCI'), 2399);
     });

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -26,12 +26,12 @@ describe('Performance: predictive performance audit', () => {
 
     return PredictivePerf.audit(artifacts).then(output => {
       assert.equal(output.score, 99);
-      assert.equal(Math.round(output.rawValue), 1696);
-      assert.equal(output.displayValue, '1,700\xa0ms');
+      assert.equal(Math.round(output.rawValue), 1513);
+      assert.equal(output.displayValue, '1,510\xa0ms');
 
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
-      assert.equal(valueOf('optimisticFMP'), 754);
-      assert.equal(valueOf('pessimisticFMP'), 1191);
+      assert.equal(valueOf('optimisticFCP'), 607);
+      assert.equal(valueOf('pessimisticFCP'), 607);
       assert.equal(valueOf('optimisticTTCI'), 2438);
       assert.equal(valueOf('pessimisticTTCI'), 2399);
     });


### PR DESCRIPTION
closes #3671 
closes #3593 

Minimal changes required here for converting FMP to FCP, basically just move the time boundary to FCP, removing the CPU layout tasks, and adding in the EvaluateScript tasks of blocking scripts (which really could have been part of FMP prediction too).

I also added redirects support since FCP was more radically impacted by missing redirect support than FMP was. I dug into a lot of the larger error cases (where error was >1s) and at this point small differences should not be used for decision making. 

Some notable examples:

* DevTools throttling limitations and approximation of just adding 600ms delay to everything greatly exaggerates impact of redirects (i.e. 3 redirects = 1.8 s instead of the correct result of ~
* Server response time was measured in seconds and had variability i.e. returned in 5s for unthrottled case but only 3 seconds in throttled case

Overall, we're about as accurate as we were with FMP, higher error at the tail but lower error for most sites. Further progress on accuracy will need higher fidelity throttling like WPT.

### Accuracy comparison
| Metric | Value on 99% | Value on 95% | Value on 90% |
| -- | -- | -- | -- |
| FMP - spearman's rho | .805 | .833 | .854 |
| FCP - spearman's rho | .792 | .832 | .850 |
| FMP - MAPE % | 27.44% | 24.11% | 21.94% |
| FCP - MAPE % | 29.03% | 21.72% | 19.65% |



