### PR TITLE
core(driver): increase default timeout to 45s

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -26,7 +26,7 @@ const _uniq = arr => Array.from(new Set(arr));
 
 class Driver {
   static get MAX_WAIT_FOR_FULLY_LOADED() {
-    return 30 * 1000;
+    return 45 * 1000;
   }
 
   /**


### PR DESCRIPTION
closes #3733 

things to consider:
* this might break folks who were running on bad hardware and needed to keep traces small (counter: it currently breaks for plenty of these sites at 30s already)
* scores will change from 0 to ~8 at sites with TTI at 30s