### PR TITLE
core(lifecycle): allow gathering & auditing to run separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ last-run-results.html
 *.report.pretty
 *.artifacts.log
 
+latest-run
+
 closure-error.log
 
 /chrome-linux/

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -54,7 +54,7 @@ function getFlags(manualArgv) {
         [
           'save-assets', 'save-artifacts', 'list-all-audits', 'list-trace-categories',
           'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port',
-          'hostname', 'max-wait-for-load', 'enable-error-reporting',
+          'hostname', 'max-wait-for-load', 'enable-error-reporting', 'gather-mode', 'audit-mode',
         ],
         'Configuration:')
       .describe({
@@ -66,6 +66,9 @@ function getFlags(manualArgv) {
         'disable-device-emulation': 'Disable Nexus 5X emulation',
         'disable-cpu-throttling': 'Disable CPU throttling',
         'disable-network-throttling': 'Disable network throttling',
+        'gather-mode':
+            'Collect artifacts from a connected browser, save, & quit. However, if audit-mode is also enabled, then the run will complete after saving artifacts to disk.',
+        'audit-mode': 'Process saved artifacts from disk',
         'save-assets': 'Save the trace contents & screenshots to disk',
         'save-artifacts': 'Save all gathered artifacts to disk',
         'list-all-audits': 'Prints a list of all available audits and exits',
@@ -85,6 +88,8 @@ function getFlags(manualArgv) {
         'max-wait-for-load':
             'The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue. WARNING: Very high values can lead to large traces and instability',
       })
+      // set aliases
+      .alias({'gather-mode': 'G', 'audit-mode': 'A'})
 
       .group(['output', 'output-path', 'view'], 'Output:')
       .describe({
@@ -102,6 +107,7 @@ function getFlags(manualArgv) {
         'disable-storage-reset', 'disable-device-emulation', 'disable-cpu-throttling',
         'disable-network-throttling', 'save-assets', 'save-artifacts', 'list-all-audits',
         'list-trace-categories', 'perf', 'view', 'verbose', 'quiet', 'help',
+        'gather-mode', 'audit-mode',
       ])
       .choices('output', printer.getValidOutputOptions())
       // force as an array

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -67,7 +67,7 @@ function getFlags(manualArgv) {
         'disable-cpu-throttling': 'Disable CPU throttling',
         'disable-network-throttling': 'Disable network throttling',
         'gather-mode':
-            'Collect artifacts from a connected browser, save, & quit. However, if audit-mode is also enabled, then the run will complete after saving artifacts to disk.',
+            'Collect artifacts from a connected browser and save to disk. If audit-mode is not also enabled, the run quit early.',
         'audit-mode': 'Process saved artifacts from disk',
         'save-assets': 'Save the trace contents & screenshots to disk',
         'save-artifacts': 'Save all gathered artifacts to disk',

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -67,7 +67,7 @@ function getFlags(manualArgv) {
         'disable-cpu-throttling': 'Disable CPU throttling',
         'disable-network-throttling': 'Disable network throttling',
         'gather-mode':
-            'Collect artifacts from a connected browser and save to disk. If audit-mode is not also enabled, the run quit early.',
+            'Collect artifacts from a connected browser and save to disk. If audit-mode is not also enabled, the run will quit early.',
         'audit-mode': 'Process saved artifacts from disk',
         'save-assets': 'Save the trace contents & screenshots to disk',
         'save-artifacts': 'Save all gathered artifacts to disk',

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -52,7 +52,7 @@ function getFlags(manualArgv) {
 
       .group(
         [
-          'save-assets', 'save-artifacts', 'list-all-audits', 'list-trace-categories',
+          'save-assets', 'list-all-audits', 'list-trace-categories',
           'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port',
           'hostname', 'max-wait-for-load', 'enable-error-reporting', 'gather-mode', 'audit-mode',
         ],
@@ -70,7 +70,6 @@ function getFlags(manualArgv) {
             'Collect artifacts from a connected browser and save to disk. If audit-mode is not also enabled, the run will quit early.',
         'audit-mode': 'Process saved artifacts from disk',
         'save-assets': 'Save the trace contents & screenshots to disk',
-        'save-artifacts': 'Save all gathered artifacts to disk',
         'list-all-audits': 'Prints a list of all available audits and exits',
         'list-trace-categories': 'Prints a list of all required trace categories and exits',
         'additional-trace-categories':
@@ -105,7 +104,7 @@ function getFlags(manualArgv) {
       // boolean values
       .boolean([
         'disable-storage-reset', 'disable-device-emulation', 'disable-cpu-throttling',
-        'disable-network-throttling', 'save-assets', 'save-artifacts', 'list-all-audits',
+        'disable-network-throttling', 'save-assets', 'list-all-audits',
         'list-trace-categories', 'perf', 'view', 'verbose', 'quiet', 'help',
         'gather-mode', 'audit-mode',
       ])

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -108,11 +108,11 @@ function handleError(err) {
  * @return {!Promise<void>}
  */
 function saveResults(results, artifacts, flags) {
-  const shouldSaveResults = flags.auditMode || (flags.gatherMode == flags.auditMode);
-  let promise = Promise.resolve();
-  if (!shouldSaveResults) return promise;
-
   const cwd = process.cwd();
+  let promise = Promise.resolve();
+
+  const shouldSaveResults = flags.auditMode || (flags.gatherMode === flags.auditMode);
+  if (!shouldSaveResults) return promise;
 
   // Use the output path as the prefix for all generated files.
   // If no output path is set, generate a file prefix using the URL and date.
@@ -162,7 +162,7 @@ function saveResults(results, artifacts, flags) {
 function runLighthouse(url, flags, config) {
   /** @type {!LH.LaunchedChrome} */
   let launchedChrome;
-  const shouldGather = flags.gatherMode || flags.gatherMode == flags.auditMode;
+  const shouldGather = flags.gatherMode || flags.gatherMode === flags.auditMode;
   /** @type {!Promise<!LH.Results|void>} */
   let promise = Promise.resolve();
   /** @type {!Promise<!LH.Results>|undefined} */

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -108,6 +108,9 @@ function handleError(err) {
  * @return {!Promise<void>}
  */
 function saveResults(results, artifacts, flags) {
+  const shouldSaveResults = flags.auditMode || (flags.gatherMode == flags.auditMode);
+  if (shouldSaveResults) return;
+
   let promise = Promise.resolve(results);
   const cwd = process.cwd();
 

--- a/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
@@ -68,7 +68,8 @@ class UnminifiedJavaScript extends ByteEfficiencyAudit {
    */
   static audit_(artifacts, networkRecords) {
     const results = [];
-    for (const [requestId, scriptContent] of artifacts.Scripts.entries()) {
+    for (const requestId of Object.keys(artifacts.Scripts)) {
+      const scriptContent = artifacts.Scripts[requestId];
       const networkRecord = networkRecords.find(record => record.requestId === requestId);
       if (!networkRecord || !scriptContent) continue;
 

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -270,6 +270,8 @@ class Config {
    * @param {string=} configPath The absolute path to the config file, if there is one.
    */
   constructor(configJSON, configPath) {
+    debugger;
+
     if (!configJSON) {
       configJSON = defaultConfig;
       configPath = path.resolve(__dirname, defaultConfigPath);
@@ -304,12 +306,14 @@ class Config {
     }
 
     // Generate a limited config if specified
+    debugger;
+
     if (configJSON.settings &&
         (Array.isArray(configJSON.settings.onlyCategories) ||
-        Array.isArray(configJSON.settings.auditModes) ||
+        Array.isArray(configJSON.settings.onlyAudits) ||
         Array.isArray(configJSON.settings.skipAudits))) {
       const categoryIds = configJSON.settings.onlyCategories;
-      const auditIds = configJSON.settings.auditModes;
+      const auditIds = configJSON.settings.onlyAudits;
       const skipAuditIds = configJSON.settings.skipAudits;
       configJSON = Config.generateNewFilteredConfig(configJSON, categoryIds, auditIds,
           skipAuditIds);
@@ -365,6 +369,7 @@ class Config {
    * @return {!Object} A new config
    */
   static generateNewFilteredConfig(oldConfig, categoryIds, auditIds, skipAuditIds) {
+    debugger;
     // 0. Clone config to avoid mutating it
     const config = deepClone(oldConfig);
     // 1. Filter to just the chosen categories
@@ -521,6 +526,7 @@ class Config {
    * @return {!Object} fresh passes object
    */
   static generatePassesNeededByGatherers(oldPasses, requiredGatherers) {
+    debugger;
     const auditsNeedTrace = requiredGatherers.has('traces');
     const passes = JSON.parse(JSON.stringify(oldPasses));
     const filteredPasses = passes.map(pass => {
@@ -601,6 +607,11 @@ class Config {
   /** @type {Array<!Audit>} */
   get audits() {
     return this._audits;
+  }
+
+  /** @type {Array<!AuditResult>} */
+  get auditResults() {
+    return this._auditResults;
   }
 
   /** @type {Array<!Artifacts>} */

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -306,10 +306,10 @@ class Config {
     // Generate a limited config if specified
     if (configJSON.settings &&
         (Array.isArray(configJSON.settings.onlyCategories) ||
-        Array.isArray(configJSON.settings.onlyAudits) ||
+        Array.isArray(configJSON.settings.auditModes) ||
         Array.isArray(configJSON.settings.skipAudits))) {
       const categoryIds = configJSON.settings.onlyCategories;
-      const auditIds = configJSON.settings.onlyAudits;
+      const auditIds = configJSON.settings.auditModes;
       const skipAuditIds = configJSON.settings.skipAudits;
       configJSON = Config.generateNewFilteredConfig(configJSON, categoryIds, auditIds,
           skipAuditIds);
@@ -584,6 +584,10 @@ class Config {
     });
   }
 
+  removePasses() {
+    this._passes = undefined;
+  }
+
   /** @type {string} */
   get configDir() {
     return this._configDir;
@@ -597,11 +601,6 @@ class Config {
   /** @type {Array<!Audit>} */
   get audits() {
     return this._audits;
-  }
-
-  /** @type {Array<!AuditResult>} */
-  get auditResults() {
-    return this._auditResults;
   }
 
   /** @type {Array<!Artifacts>} */

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -140,14 +140,12 @@ function validatePasses(passes, audits, rootPath) {
   });
 }
 
-function validateCategories(categories, audits, auditResults, groups) {
+function validateCategories(categories, audits, groups) {
   if (!categories) {
     return;
   }
 
-  const auditIds = audits ?
-      audits.map(audit => audit.meta.name) :
-      auditResults.map(audit => audit.name);
+  const auditIds = audits.map(audit => audit.meta.name);
   Object.keys(categories).forEach(categoryId => {
     categories[categoryId].audits.forEach((audit, index) => {
       if (!audit.id) {
@@ -323,10 +321,6 @@ class Config {
     this._configDir = configPath ? path.dirname(configPath) : undefined;
 
     this._passes = configJSON.passes || null;
-    this._auditResults = configJSON.auditResults || null;
-    if (this._auditResults && !Array.isArray(this._auditResults)) {
-      throw new Error('config.auditResults must be an array');
-    }
 
     this._audits = Config.requireAudits(configJSON.audits, this._configDir);
     this._artifacts = expandArtifacts(configJSON.artifacts);
@@ -335,7 +329,7 @@ class Config {
 
     // validatePasses must follow after audits are required
     validatePasses(configJSON.passes, this._audits, this._configDir);
-    validateCategories(configJSON.categories, this._audits, this._auditResults, this._groups);
+    validateCategories(configJSON.categories, this._audits, this._groups);
   }
 
   /**
@@ -607,11 +601,6 @@ class Config {
   /** @type {Array<!Audit>} */
   get audits() {
     return this._audits;
-  }
-
-  /** @type {Array<!AuditResult>} */
-  get auditResults() {
-    return this._auditResults;
   }
 
   /** @type {Array<!Artifacts>} */

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -268,8 +268,6 @@ class Config {
    * @param {string=} configPath The absolute path to the config file, if there is one.
    */
   constructor(configJSON, configPath) {
-    debugger;
-
     if (!configJSON) {
       configJSON = defaultConfig;
       configPath = path.resolve(__dirname, defaultConfigPath);
@@ -304,8 +302,6 @@ class Config {
     }
 
     // Generate a limited config if specified
-    debugger;
-
     if (configJSON.settings &&
         (Array.isArray(configJSON.settings.onlyCategories) ||
         Array.isArray(configJSON.settings.onlyAudits) ||
@@ -363,7 +359,6 @@ class Config {
    * @return {!Object} A new config
    */
   static generateNewFilteredConfig(oldConfig, categoryIds, auditIds, skipAuditIds) {
-    debugger;
     // 0. Clone config to avoid mutating it
     const config = deepClone(oldConfig);
     // 1. Filter to just the chosen categories
@@ -520,7 +515,6 @@ class Config {
    * @return {!Object} fresh passes object
    */
   static generatePassesNeededByGatherers(oldPasses, requiredGatherers) {
-    debugger;
     const auditsNeedTrace = requiredGatherers.has('traces');
     const passes = JSON.parse(JSON.stringify(oldPasses));
     const filteredPasses = passes.map(pass => {

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -578,10 +578,6 @@ class Config {
     });
   }
 
-  removePasses() {
-    this._passes = undefined;
-  }
-
   /** @type {string} */
   get configDir() {
     return this._configDir;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -372,7 +372,6 @@ class GatherRunner {
     const tracingData = {
       traces: {},
       devtoolsLogs: {},
-      networkRecords: {},
     };
 
     if (typeof options.url !== 'string' || options.url.length === 0) {

--- a/lighthouse-core/gather/gatherers/scripts.js
+++ b/lighthouse-core/gather/gatherers/scripts.js
@@ -20,7 +20,7 @@ class Scripts extends Gatherer {
   afterPass(options, traceData) {
     const driver = options.driver;
 
-    const scriptContentMap = new Map();
+    const scriptContentMap = {};
     const scriptRecords = traceData.networkRecords
       .filter(record => record.resourceType() === WebInspector.resourceTypes.Script);
 
@@ -31,7 +31,7 @@ class Scripts extends Gatherer {
             .catch(_ => null)
             .then(content => {
               if (!content) return;
-              scriptContentMap.set(record.requestId, content);
+              scriptContentMap[record.requestId] = content;
             });
         })
         .then(() => scriptContentMap);

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -46,7 +46,7 @@ function lighthouse(url, flags = {}, configJSON) {
 
     // kick off a lighthouse run
     return Runner.run(connection, {url, flags, config})
-      .then(lighthouseResults => {
+      .then((lighthouseResults = {}) => {
         // Annotate with time to run lighthouse.
         const endTime = Date.now();
         lighthouseResults.timing = lighthouseResults.timing || {};

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -142,7 +142,7 @@ function saveArtifacts(artifacts, basePath) {
 
   // save everything else
   promise = promise.then(_ => {
-    fs.writeFileSync(`${basePath}/${artifactsFilename}`, JSON.stringify(artifacts), 'utf8');
+    fs.writeFileSync(`${basePath}/${artifactsFilename}`, JSON.stringify(artifacts, 0, 2), 'utf8');
     log.log('Artifacts saved to disk in folder:', basePath);
   });
   return promise;

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -71,7 +71,7 @@ function loadArtifacts(basePath) {
       const readStream = fs.createReadStream(path.join(basePath, filename), {
         encoding: 'utf-8',
         // TODO benchmark to find the best buffer size here
-        highWaterMark: 4 * 1024 * 1024
+        highWaterMark: 4 * 1024 * 1024,
       });
       const parser = new TraceParser();
       readStream.on('data', chunk => parser.parseChunk(chunk));

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -7,10 +7,14 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const log = require('lighthouse-logger');
 const stream = require('stream');
 const stringifySafe = require('json-stringify-safe');
 const Metrics = require('./traces/pwmetrics-events');
+const TraceParser = require('./traces/trace-parser');
+const rimraf = require('rimraf');
+const assert = require('assert');
 
 /**
  * Generate basic HTML page of screenshot filmstrip
@@ -55,19 +59,58 @@ img {
   `;
 }
 
+function loadArtifacts(basePath) {
+  log.log('Reading artifacts from disk:', basePath);
+  const artifacts = JSON.parse(fs.readFileSync(path.join(basePath, 'artifacts.json'), 'utf8'));
+  artifacts.traces = {};
+
+  const filenames = fs.readdirSync(basePath);
+  const promises = filenames.filter(filename => filename.endsWith('-trace.json')).map(filename => {
+    return new Promise(resolve => {
+      const passName = filename.replace('-trace.json', '');
+      const readStream = fs.createReadStream(path.join(basePath, filename), {
+        encoding: 'utf-8',
+        // TODO benchmark to find the best buffer size here
+        highWaterMark: 4 * 1024 * 1024
+      });
+      const parser = new TraceParser();
+      readStream.on('data', chunk => parser.parseChunk(chunk));
+      readStream.on('end', _ => {
+        artifacts.traces[passName] = parser.getTrace();
+        resolve();
+      });
+    });
+  });
+  return Promise.all(promises).then(_ => artifacts);
+}
+
 /**
- * Save entire artifacts object to a single stringified file located at
- * pathWithBasename + .artifacts.log
+ * Save artifacts object mostly to single file located at basePath/artifacts.log.
+ * Also save the traces to their own files
  * @param {!Artifacts} artifacts
- * @param {string} pathWithBasename
+ * @param {string} basePath
  */
 // Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
 /* istanbul ignore next */
-function saveArtifacts(artifacts, pathWithBasename) {
-  const fullPath = `${pathWithBasename}.artifacts.log`;
-  // The networkRecords artifacts have circular references
-  fs.writeFileSync(fullPath, stringifySafe(artifacts));
-  log.log('artifacts file saved to disk', fullPath);
+function saveArtifacts(artifacts, basePath) {
+  assert.notEqual(basePath, '/');
+  rimraf.sync(basePath);
+  fs.mkdirSync(basePath);
+
+  // do traces
+  const traces = artifacts.traces;
+  const savePromies = Object.keys(traces).map(passName => {
+    return saveTrace(traces[passName], `${basePath}/${passName}-trace.json`);
+  });
+
+  const p = Promise.all(savePromies).then(_ => {
+    // do everything else
+    delete artifacts.traces;
+    // The networkRecords artifacts have circular references
+    fs.writeFileSync(`${basePath}/artifacts.json`, stringifySafe(artifacts), 'utf8');
+  });
+  log.log('Artifacts saved to disk in folder:', basePath);
+  return p;
 }
 
 /**
@@ -221,6 +264,7 @@ function logAssets(artifacts, audits) {
 
 module.exports = {
   saveArtifacts,
+  loadArtifacts,
   saveAssets,
   prepareAssets,
   saveTrace,

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -10,11 +10,9 @@ const fs = require('fs');
 const path = require('path');
 const log = require('lighthouse-logger');
 const stream = require('stream');
-const stringifySafe = require('json-stringify-safe');
 const Metrics = require('./traces/pwmetrics-events');
 const TraceParser = require('./traces/trace-parser');
 const rimraf = require('rimraf');
-const assert = require('assert');
 
 /**
  * Generate basic HTML page of screenshot filmstrip
@@ -59,19 +57,40 @@ img {
   `;
 }
 
+const artifactsFilename = 'artifacts.json';
+const traceSuffix = '.trace.json';
+const devtoolsLogSuffix = '.devtoolslog.json';
+
+/**
+ * Load artifacts object from files located within basePath
+ * Also save the traces to their own files
+ * @param {string} basePath
+ * @return {!Promise<!Artifacts>}
+ */
+// Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
+/* istanbul ignore next */
 function loadArtifacts(basePath) {
   log.log('Reading artifacts from disk:', basePath);
-  const artifacts = JSON.parse(fs.readFileSync(path.join(basePath, 'artifacts.json'), 'utf8'));
-  artifacts.traces = {};
-
+  // load artifacts.json
   const filenames = fs.readdirSync(basePath);
-  const promises = filenames.filter(filename => filename.endsWith('-trace.json')).map(filename => {
+  const artifacts = JSON.parse(fs.readFileSync(path.join(basePath, artifactsFilename), 'utf8'));
+
+  // load devtoolsLogs
+  artifacts.devtoolsLogs = {};
+  filenames.filter(f => f.endsWith(devtoolsLogSuffix)).map(filename => {
+    const passName = filename.replace(devtoolsLogSuffix, '');
+    const devtoolsLog = JSON.parse(fs.readFileSync(path.join(basePath, filename), 'utf8'));
+    artifacts.devtoolsLogs[passName] = devtoolsLog;
+  });
+
+  // load traces
+  artifacts.traces = {};
+  const promises = filenames.filter(f => f.endsWith(traceSuffix)).map(filename => {
     return new Promise(resolve => {
-      const passName = filename.replace('-trace.json', '');
+      const passName = filename.replace(traceSuffix, '');
       const readStream = fs.createReadStream(path.join(basePath, filename), {
         encoding: 'utf-8',
-        // TODO benchmark to find the best buffer size here
-        highWaterMark: 4 * 1024 * 1024,
+        highWaterMark: 4 * 1024 * 1024, // TODO benchmark to find the best buffer size here
       });
       const parser = new TraceParser();
       readStream.on('data', chunk => parser.parseChunk(chunk));
@@ -86,31 +105,45 @@ function loadArtifacts(basePath) {
 
 /**
  * Save artifacts object mostly to single file located at basePath/artifacts.log.
- * Also save the traces to their own files
+ * Also save the traces & devtoolsLogs to their own files
  * @param {!Artifacts} artifacts
  * @param {string} basePath
  */
 // Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
 /* istanbul ignore next */
 function saveArtifacts(artifacts, basePath) {
-  assert.notEqual(basePath, '/');
-  rimraf.sync(basePath);
-  fs.mkdirSync(basePath);
+  if (!fs.existsSync(basePath)) {
+    fs.mkdirSync(basePath);
+  }
+  rimraf.sync(`${basePath}/*${traceSuffix}`);
+  rimraf.sync(`${basePath}/${artifactsFilename}`);
 
-  // do traces
+  // We don't want to mutate the artifacts as provided
+  artifacts = Object.assign({}, artifacts);
+
+  // save traces
   const traces = artifacts.traces;
-  const savePromies = Object.keys(traces).map(passName => {
-    return saveTrace(traces[passName], `${basePath}/${passName}-trace.json`);
+  let promise = Promise.all(Object.keys(traces).map(passName => {
+    return saveTrace(traces[passName], `${basePath}/${passName}${traceSuffix}`);
+  }));
+
+  // save devtools log
+  const devtoolsLogs = artifacts.devtoolsLogs;
+  promise = promise.then(_ => {
+    Object.keys(devtoolsLogs).map(passName => {
+      const log = JSON.stringify(devtoolsLogs[passName]);
+      fs.writeFileSync(`${basePath}/${passName}${devtoolsLogSuffix}`, log, 'utf8');
+    });
+    delete artifacts.traces;
+    delete artifacts.devtoolsLog;
   });
 
-  const p = Promise.all(savePromies).then(_ => {
-    // do everything else
-    delete artifacts.traces;
-    // The networkRecords artifacts have circular references
-    fs.writeFileSync(`${basePath}/artifacts.json`, stringifySafe(artifacts), 'utf8');
+  // save everything else
+  promise = promise.then(_ => {
+    fs.writeFileSync(`${basePath}/${artifactsFilename}`, JSON.stringify(artifacts), 'utf8');
+    log.log('Artifacts saved to disk in folder:', basePath);
   });
-  log.log('Artifacts saved to disk in folder:', basePath);
-  return p;
+  return promise;
 }
 
 /**
@@ -221,7 +254,7 @@ function saveTrace(traceData, traceFilename) {
 function saveAssets(artifacts, audits, pathWithBasename) {
   return prepareAssets(artifacts, audits).then(assets => {
     return Promise.all(assets.map((data, index) => {
-      const devtoolsLogFilename = `${pathWithBasename}-${index}.devtoolslog.json`;
+      const devtoolsLogFilename = `${pathWithBasename}-${index}${devtoolsLogSuffix}`;
       fs.writeFileSync(devtoolsLogFilename, JSON.stringify(data.devtoolsLog, null, 2));
       log.log('saveAssets', 'devtools log saved to disk: ' + devtoolsLogFilename);
 
@@ -233,7 +266,7 @@ function saveAssets(artifacts, audits, pathWithBasename) {
       fs.writeFileSync(screenshotsJSONFilename, JSON.stringify(data.screenshots, null, 2));
       log.log('saveAssets', 'screenshots saved to disk: ' + screenshotsJSONFilename);
 
-      const streamTraceFilename = `${pathWithBasename}-${index}.trace.json`;
+      const streamTraceFilename = `${pathWithBasename}-${index}${traceSuffix}`;
       log.log('saveAssets', 'streaming trace file to disk: ' + streamTraceFilename);
       return saveTrace(data.traceData, streamTraceFilename).then(_ => {
         log.log('saveAssets', 'trace file streamed to disk: ' + streamTraceFilename);

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -13,6 +13,7 @@ const stream = require('stream');
 const Metrics = require('./traces/pwmetrics-events');
 const TraceParser = require('./traces/trace-parser');
 const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
 
 /**
  * Generate basic HTML page of screenshot filmstrip
@@ -71,6 +72,9 @@ const devtoolsLogSuffix = '.devtoolslog.json';
 /* istanbul ignore next */
 function loadArtifacts(basePath) {
   log.log('Reading artifacts from disk:', basePath);
+
+  if (!fs.existsSync(basePath)) return Promise.reject(new Error('No saved artifacts found'));
+
   // load artifacts.json
   const filenames = fs.readdirSync(basePath);
   const artifacts = JSON.parse(fs.readFileSync(path.join(basePath, artifactsFilename), 'utf8'));
@@ -112,9 +116,7 @@ function loadArtifacts(basePath) {
 // Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
 /* istanbul ignore next */
 function saveArtifacts(artifacts, basePath) {
-  if (!fs.existsSync(basePath)) {
-    fs.mkdirSync(basePath);
-  }
+  mkdirp.sync(basePath);
   rimraf.sync(`${basePath}/*${traceSuffix}`);
   rimraf.sync(`${basePath}/${artifactsFilename}`);
 

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -137,7 +137,7 @@ function saveArtifacts(artifacts, basePath) {
       fs.writeFileSync(`${basePath}/${passName}${devtoolsLogSuffix}`, log, 'utf8');
     });
     delete artifacts.traces;
-    delete artifacts.devtoolsLog;
+    delete artifacts.devtoolsLogs;
   });
 
   // save everything else

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -12,10 +12,13 @@ const ReportScoring = require('./scoring');
 const Audit = require('./audits/audit');
 const emulation = require('./lib/emulation');
 const log = require('lighthouse-logger');
+const assetSaver = require('./lib/asset-saver');
 const fs = require('fs');
 const path = require('path');
 const URL = require('./lib/url-shim');
 const Sentry = require('./lib/sentry');
+
+const basePath = path.join(process.cwd(), 'latest-run');
 
 class Runner {
   static run(connection, opts) {
@@ -57,83 +60,65 @@ class Runner {
     // canonicalize URL with any trailing slashes neccessary
     opts.url = parsedURL.href;
 
-    // Check that there are passes & audits...
-    const validPassesAndAudits = config.passes && config.audits;
-
-    // ... or that there are artifacts & audits.
-    const validArtifactsAndAudits = config.artifacts && config.audits;
-
     // Make a run, which can be .then()'d with whatever needs to run (based on the config).
     let run = Promise.resolve();
 
-    // If there are passes run the GatherRunner and gather the artifacts. If not, we will need
-    // to check that there are artifacts specified in the config, and throw if not.
-    if (validPassesAndAudits || validArtifactsAndAudits) {
-      if (validPassesAndAudits) {
-        // Set up the driver and run gatherers.
-        opts.driver = opts.driverMock || new Driver(connection);
-        run = run.then(_ => GatherRunner.run(config.passes, opts));
-      } else if (validArtifactsAndAudits) {
-        run = run.then(_ => config.artifacts);
-      }
+    // User can run -G solo, -A solo, or -GA together
+    const shouldGatherAndQuit = opts.flags.gatherMode && !opts.flags.auditMode;
+    const shouldOnlyAudit = opts.flags.auditMode && !opts.flags.gatherMode;
+    const shouldDefaultRunButSaveArtifacts = opts.flags.auditMode && opts.flags.gatherMode;
 
-      run = run.then(artifacts => {
-        // Bring in lighthouseRunWarnings from gathering stage.
-        if (artifacts.LighthouseRunWarnings) {
-          lighthouseRunWarnings.push(...artifacts.LighthouseRunWarnings);
-        }
+    const shouldSaveArtifactsToDisk = shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts;
+    const shouldLoadArtifactsFromDisk = shouldOnlyAudit;
+    const shouldGatherFromBrowser = config.passes && !config.artifacts && (shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts);
 
-        // And add computed artifacts.
-        return Object.assign({}, artifacts, Runner.instantiateComputedArtifacts());
-      });
-
-      // Basic check that the traces (gathered or loaded) are valid.
-      run = run.then(artifacts => {
-        for (const passName of Object.keys(artifacts.traces || {})) {
-          const trace = artifacts.traces[passName];
-          if (!Array.isArray(trace.traceEvents)) {
-            throw new Error(passName + ' trace was invalid. `traceEvents` was not an array.');
-          }
-        }
-
-        return artifacts;
-      });
-
-      run = run.then(artifacts => {
-        log.log('status', 'Analyzing and running audits...');
-        return artifacts;
-      });
-
-      // Run each audit sequentially, the auditResults array has all our fine work
-      const auditResults = [];
-      for (const audit of config.audits) {
-        run = run.then(artifacts => {
-          return Runner._runAudit(audit, artifacts)
-            .then(ret => auditResults.push(ret))
-            .then(_ => artifacts);
-        });
-      }
-      run = run.then(artifacts => {
-        return {artifacts, auditResults};
-      });
-    } else if (config.auditResults) {
-      // If there are existing audit results, surface those here.
-      // Instantiate and return artifacts for consistency.
-      const artifacts = Object.assign({}, config.artifacts || {},
-          Runner.instantiateComputedArtifacts());
+    if (shouldLoadArtifactsFromDisk) {
+      config.removePasses();
       run = run.then(_ => {
-        return {
-          artifacts,
-          auditResults: config.auditResults,
-        };
+        return assetSaver.loadArtifacts(basePath).then(artifacts => config._artifacts = artifacts);
       });
-    } else {
-      const err = Error(
-          'The config must provide passes and audits, artifacts and audits, or auditResults');
+    }
+
+    // Entering: Gather phase
+    if (!config.passes && !config.artifacts && !shouldLoadArtifactsFromDisk) {
+      const err = new Error('You must require either gather passes or provide saved artifacts.');
       return Promise.reject(err);
     }
 
-    // Format and generate JSON report before returning.
+    // If we're gathering, let's go collect artifacts from the browser
+    if (shouldGatherFromBrowser) {
+      opts.driver = opts.driverMock || new Driver(connection);
+      // Kick off the gather run
+      run = run.then(_ => GatherRunner.run(config.passes, opts));
+      // Potentially quit now if we ran -G (but not -GA)
+      if (shouldSaveArtifactsToDisk) {
+        run = run.then(artifacts => assetSaver.saveArtifacts(artifacts, basePath).then(_ => {}));
+      }
+      if (shouldGatherAndQuit) return run;
+    }
+
+    // Entering: Audit phase
+    if (!config.audits) {
+      const err = new Error(
+          'The run cannot continue as the config has defined no audits to evaluate.');
+      return Promise.reject(err);
+    }
+
+    // Run the audits
+    run = run.then(artifacts => {
+      log.log('status', 'Analyzing and running audits...');
+      artifacts = Object.assign(Runner.instantiateComputedArtifacts(), artifacts || config.artifacts);
+
+      // Bring in lighthouseRunWarnings from gathering stage.
+      if (artifacts.LighthouseRunWarnings) {
+        lighthouseRunWarnings.push(...artifacts.LighthouseRunWarnings);
+      }
+      // Run each audit sequentially
+      const promises = config.audits.map(audit => Runner._runAudit(audit, artifacts));
+      return Promise.all(promises).then(auditResults => ({artifacts, auditResults}));
+    });
+
+    // Entering: Conclusion of the lighthouse result object
     run = run
       .then(runResults => {
         log.log('status', 'Generating results...');
@@ -174,6 +159,7 @@ class Runner {
 
     return run;
   }
+
 
   /**
    * Checks that the audit's required artifacts exist and runs the audit if so.

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -143,7 +143,7 @@ class Runner {
     opts.driver = opts.driverMock || new Driver(connection);
     return GatherRunner.run(opts.config.passes, opts).then(artifacts => {
       const flags = opts.flags;
-      const shouldSave = flags.gatherMode || flags.gatherMode === flags.auditMode;
+      const shouldSave = flags.gatherMode;
       const p = shouldSave ? Runner._saveArtifacts(artifacts): Promise.resolve();
       return p.then(_ => artifacts);
     });

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -22,7 +22,6 @@ const basePath = path.join(process.cwd(), 'latest-run');
 
 class Runner {
   static run(connection, opts) {
-    debugger;
     // Clean opts input.
     opts.flags = opts.flags || {};
 
@@ -72,7 +71,8 @@ class Runner {
 
     const shouldSaveArtifactsToDisk = shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts;
     const shouldLoadArtifactsFromDisk = shouldOnlyAudit;
-    const shouldGatherFromBrowser = config.passes && !config.artifacts && (shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts || shouldDoTypicalRun);
+    const shouldGatherFromBrowser = config.passes && !config.artifacts &&
+        (shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts || shouldDoTypicalRun);
 
     if (shouldLoadArtifactsFromDisk) {
       config.removePasses();
@@ -109,7 +109,8 @@ class Runner {
     // Run the audits
     run = run.then(artifacts => {
       log.log('status', 'Analyzing and running audits...');
-      artifacts = Object.assign(Runner.instantiateComputedArtifacts(), artifacts || config.artifacts);
+      artifacts = Object.assign(Runner.instantiateComputedArtifacts(),
+          artifacts || config.artifacts);
 
       // Bring in lighthouseRunWarnings from gathering stage.
       if (artifacts.LighthouseRunWarnings) {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -67,15 +67,14 @@ class Runner {
     const shouldGatherAndQuit = opts.flags.gatherMode && !opts.flags.auditMode;
     const shouldOnlyAudit = opts.flags.auditMode && !opts.flags.gatherMode;
     const shouldDefaultRunButSaveArtifacts = opts.flags.auditMode && opts.flags.gatherMode;
-    const shouldDoTypicalRun = !opts.flags.gatherMode && !opts.flags.auditMode;
+    const shouldDoDefaultRun = !opts.flags.gatherMode && !opts.flags.auditMode;
 
     const shouldSaveArtifactsToDisk = shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts;
     const shouldLoadArtifactsFromDisk = shouldOnlyAudit;
     const shouldGatherFromBrowser = config.passes && !config.artifacts &&
-        (shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts || shouldDoTypicalRun);
+        (shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts || shouldDoDefaultRun);
 
     if (shouldLoadArtifactsFromDisk) {
-      config.removePasses();
       run = run.then(_ => {
         return assetSaver.loadArtifacts(basePath).then(artifacts => config._artifacts = artifacts);
       });

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -22,6 +22,7 @@ const basePath = path.join(process.cwd(), 'latest-run');
 
 class Runner {
   static run(connection, opts) {
+    debugger;
     // Clean opts input.
     opts.flags = opts.flags || {};
 
@@ -67,10 +68,11 @@ class Runner {
     const shouldGatherAndQuit = opts.flags.gatherMode && !opts.flags.auditMode;
     const shouldOnlyAudit = opts.flags.auditMode && !opts.flags.gatherMode;
     const shouldDefaultRunButSaveArtifacts = opts.flags.auditMode && opts.flags.gatherMode;
+    const shouldDoTypicalRun = !opts.flags.gatherMode && !opts.flags.auditMode;
 
     const shouldSaveArtifactsToDisk = shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts;
     const shouldLoadArtifactsFromDisk = shouldOnlyAudit;
-    const shouldGatherFromBrowser = config.passes && !config.artifacts && (shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts);
+    const shouldGatherFromBrowser = config.passes && !config.artifacts && (shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts || shouldDoTypicalRun);
 
     if (shouldLoadArtifactsFromDisk) {
       config.removePasses();

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -192,8 +192,7 @@ class Runner {
    * @param {{}} resultsById
    */
   static _scoreAndCategorize(opts, resultsById) {
-    const reportGenerator = new ReportGeneratorV2();
-    return reportGenerator.generateReportJson(opts.config, resultsById);
+    return ReportScoring.scoreAllCategories(opts.config, resultsById);
   }
 
   /**

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -25,8 +25,6 @@ class Runner {
     // Clean opts input.
     opts.flags = opts.flags || {};
 
-    const config = opts.config;
-
     // List of top-level warnings for this Lighthouse run.
     const lighthouseRunWarnings = [];
 
@@ -64,104 +62,139 @@ class Runner {
     let run = Promise.resolve();
 
     // User can run -G solo, -A solo, or -GA together
-    const shouldGatherAndQuit = opts.flags.gatherMode && !opts.flags.auditMode;
-    const shouldOnlyAudit = opts.flags.auditMode && !opts.flags.gatherMode;
-    const shouldDefaultRunButSaveArtifacts = opts.flags.auditMode && opts.flags.gatherMode;
-    const shouldDoDefaultRun = !opts.flags.gatherMode && !opts.flags.auditMode;
+    // -G and -A will do run partial lighthouse pipelines,
+    // and -GA will run everything plus save artifacts to disk
 
-    const shouldSaveArtifactsToDisk = shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts;
-    const shouldLoadArtifactsFromDisk = shouldOnlyAudit;
-    const shouldGatherFromBrowser = config.passes && !config.artifacts &&
-        (shouldGatherAndQuit || shouldDefaultRunButSaveArtifacts || shouldDoDefaultRun);
+    // Gather phase
+    // Either load saved artifacts off disk, from config, or get from the browser
+    if (opts.flags.auditMode && !opts.flags.gatherMode) {
+      run = run.then(_ => Runner._loadArtifactsFromDisk());
+    } else if (opts.config.artifacts) {
+      run = run.then(_ => opts.config.artifacts);
+    } else {
+      run = run.then(_ => Runner._gatherArtifactsFromBrowser(opts, connection));
+    }
 
-    if (shouldLoadArtifactsFromDisk) {
-      run = run.then(_ => {
-        return assetSaver.loadArtifacts(basePath).then(artifacts => config._artifacts = artifacts);
+    // Potentially quit early
+    if (opts.flags.gatherMode && !opts.flags.auditMode) return run;
+
+    // Audit phase
+    run = run.then(artifacts => Runner._runAudits(opts, artifacts));
+
+    // LHR construction phase
+    run = run.then(runResults => {
+      log.log('status', 'Generating results...');
+
+      if (runResults.artifacts.LighthouseRunWarnings) {
+        lighthouseRunWarnings.push(...runResults.artifacts.LighthouseRunWarnings);
+      }
+
+      // Entering: Conclusion of the lighthouse result object
+      const resultsById = {};
+      for (const audit of runResults.auditResults) resultsById[audit.name] = audit;
+
+      let report;
+      if (opts.config.categories) {
+        report = Runner._scoreAndCategorize(opts, resultsById);
+      }
+
+      return {
+        userAgent: runResults.artifacts.UserAgent,
+        lighthouseVersion: require('../package').version,
+        generatedTime: (new Date()).toJSON(),
+        initialUrl: opts.initialUrl,
+        url: opts.url,
+        runWarnings: lighthouseRunWarnings,
+        audits: resultsById,
+        artifacts: runResults.artifacts,
+        runtimeConfig: Runner.getRuntimeConfig(opts.flags),
+        score: report ? report.score : 0,
+        reportCategories: report ? report.categories : [],
+        reportGroups: opts.config.groups,
+      };
+    }).catch(err => {
+      return Sentry.captureException(err, {level: 'fatal'}).then(() => {
+        throw err;
       });
-    }
-
-    // Entering: Gather phase
-    if (!config.passes && !config.artifacts && !shouldLoadArtifactsFromDisk) {
-      const err = new Error('You must require either gather passes or provide saved artifacts.');
-      return Promise.reject(err);
-    }
-
-    // If we're gathering, let's go collect artifacts from the browser
-    if (shouldGatherFromBrowser) {
-      opts.driver = opts.driverMock || new Driver(connection);
-      // Kick off the gather run
-      run = run.then(_ => GatherRunner.run(config.passes, opts));
-      // Potentially quit now if we ran -G (but not -GA)
-      if (shouldSaveArtifactsToDisk) {
-        run = run.then(artifacts => assetSaver.saveArtifacts(artifacts, basePath).then(_ => {}));
-      }
-      if (shouldGatherAndQuit) return run;
-    }
-
-    // Entering: Audit phase
-    if (!config.audits) {
-      const err = new Error(
-          'The run cannot continue as the config has defined no audits to evaluate.');
-      return Promise.reject(err);
-    }
-
-    // Run the audits
-    run = run.then(artifacts => {
-      log.log('status', 'Analyzing and running audits...');
-      artifacts = Object.assign(Runner.instantiateComputedArtifacts(),
-          artifacts || config.artifacts);
-
-      // Bring in lighthouseRunWarnings from gathering stage.
-      if (artifacts.LighthouseRunWarnings) {
-        lighthouseRunWarnings.push(...artifacts.LighthouseRunWarnings);
-      }
-      // Run each audit sequentially
-      const promises = config.audits.map(audit => Runner._runAudit(audit, artifacts));
-      return Promise.all(promises).then(auditResults => ({artifacts, auditResults}));
     });
-
-    // Entering: Conclusion of the lighthouse result object
-    run = run
-      .then(runResults => {
-        log.log('status', 'Generating results...');
-
-        const resultsById = runResults.auditResults.reduce((results, audit) => {
-          results[audit.name] = audit;
-          return results;
-        }, {});
-
-        let reportCategories = [];
-        let score = 0;
-        if (config.categories) {
-          const report = ReportScoring.scoreAllCategories(config, resultsById);
-          reportCategories = report.categories;
-          score = report.score;
-        }
-
-        return {
-          userAgent: runResults.artifacts.UserAgent,
-          lighthouseVersion: require('../package').version,
-          generatedTime: (new Date()).toJSON(),
-          initialUrl: opts.initialUrl,
-          url: opts.url,
-          runWarnings: lighthouseRunWarnings,
-          audits: resultsById,
-          artifacts: runResults.artifacts,
-          runtimeConfig: Runner.getRuntimeConfig(opts.flags),
-          score,
-          reportCategories,
-          reportGroups: config.groups,
-        };
-      })
-      .catch(err => {
-        return Sentry.captureException(err, {level: 'fatal'}).then(() => {
-          throw err;
-        });
-      });
 
     return run;
   }
 
+  /**
+   * No browser required, just load the artifacts from disk
+   * @return {!Promise<!Artifacts>}
+   */
+  static _loadArtifactsFromDisk() {
+    return assetSaver.loadArtifacts(basePath);
+  }
+
+  /**
+   * Establish connection, load page and collect all required artifacts
+   * @param {*} opts
+   * @param {*} connection
+   * @return {!Promise<!Artifacts>}
+   */
+  static _gatherArtifactsFromBrowser(opts, connection) {
+    if (!opts.config.passes) {
+      return Promise.reject(new Error('No browser artifacts are either provided or requested.'));
+    }
+
+    opts.driver = opts.driverMock || new Driver(connection);
+    return GatherRunner.run(opts.config.passes, opts).then(artifacts => {
+      const flags = opts.flags;
+      const shouldSave = flags.gatherMode || flags.gatherMode === flags.auditMode;
+      const p = shouldSave ? Runner._saveArtifacts(artifacts): Promise.resolve();
+      return p.then(_ => artifacts);
+    });
+  }
+
+  /**
+   * Save collected artifacts to disk
+   * @param {!Artifacts} artifacts
+   * @return {!Promise>}
+   */
+  static _saveArtifacts(artifacts) {
+    return assetSaver.saveArtifacts(artifacts, basePath);
+  }
+
+  /**
+   * Save collected artifacts to disk
+   * @param {*} opts
+   * @param {!Artifacts} artifacts
+   * @return {!Promise<{auditResults: AuditResults, artifacts: Artifacts}>>}
+   */
+  static _runAudits(opts, artifacts) {
+    if (!opts.config.audits) {
+      return Promise.reject(new Error('No audits to evaluate.'));
+    }
+
+    log.log('status', 'Analyzing and running audits...');
+    artifacts = Object.assign(Runner.instantiateComputedArtifacts(),
+        artifacts || opts.config.artifacts);
+
+    // Run each audit sequentially
+    const auditResults = [];
+    let promise = Promise.resolve();
+    for (const audit of opts.config.audits) {
+      promise = promise.then(_ => {
+        return Runner._runAudit(audit, artifacts).then(ret => auditResults.push(ret));
+      });
+    }
+    return promise.then(_ => {
+      const runResults = {artifacts, auditResults};
+      return runResults;
+    });
+  }
+
+  /**
+   * @param {{}} opts
+   * @param {{}} resultsById
+   */
+  static _scoreAndCategorize(opts, resultsById) {
+    const reportGenerator = new ReportGeneratorV2();
+    return reportGenerator.generateReportJson(opts.config, resultsById);
+  }
 
   /**
    * Checks that the audit's required artifacts exist and runs the audit if so.

--- a/lighthouse-core/test/audits/byte-efficiency/unminified-javascript-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/unminified-javascript-test.js
@@ -16,9 +16,8 @@ const _resourceType = {_name: 'script'};
 describe('Page uses optimized responses', () => {
   it('fails when given unminified scripts', () => {
     const auditResult = UnminifiedJavascriptAudit.audit_({
-      Scripts: new Map([
-        [
-          '123.1',
+      Scripts: {
+        '123.1':
           `
             var foo = new Set();
             foo.add(1);
@@ -28,9 +27,7 @@ describe('Page uses optimized responses', () => {
               console.log('hello!')
             }
           `,
-        ],
-        [
-          '123.2',
+        '123.2':
           `
             const foo = new Set();
             foo.add(1);
@@ -40,8 +37,7 @@ describe('Page uses optimized responses', () => {
               console.log('yay esnext!')
             }
           `,
-        ],
-      ]),
+      },
     }, [
       {requestId: '123.1', url: 'foo.js', _transferSize: 20 * KB, _resourceType},
       {requestId: '123.2', url: 'other.js', _transferSize: 50 * KB, _resourceType},
@@ -58,13 +54,10 @@ describe('Page uses optimized responses', () => {
 
   it('passes when scripts are already minified', () => {
     const auditResult = UnminifiedJavascriptAudit.audit_({
-      Scripts: new Map([
-        [
-          '123.1',
+      Scripts: {
+        '123.1':
           'var f=new Set();f.add(1);f.add(2);if(f.has(2))console.log(1234)',
-        ],
-        [
-          '123.2',
+        '123.2':
           `
             const foo = new Set();
             foo.add(1);
@@ -74,12 +67,9 @@ describe('Page uses optimized responses', () => {
               console.log('yay esnext!')
             }
           `,
-        ],
-        [
-          '123.3',
+        '123.3':
           'for{(wtf',
-        ],
-      ]),
+      },
     }, [
       {requestId: '123.1', url: 'foo.js', _transferSize: 20 * KB, _resourceType},
       {requestId: '123.2', url: 'other.js', _transferSize: 3 * KB, _resourceType},

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -119,26 +119,6 @@ describe('Config', () => {
     assert.equal(configJSON.passes[0].gatherers.length, 2);
   });
 
-  it('contains new copies of auditResults', () => {
-    const configJSON = origConfig;
-    configJSON.auditResults = [{
-      value: 1,
-      rawValue: 1.0,
-      name: 'Test Audit',
-      details: {
-        items: {
-          a: 1,
-        },
-      },
-    }];
-
-    const config = new Config(configJSON);
-    assert.notEqual(config, configJSON, 'Objects are strictly different');
-    assert.ok(config.auditResults, 'Audits array exists');
-    assert.notEqual(config.auditResults, configJSON.auditResults, 'Audits not same object');
-    assert.deepStrictEqual(config.auditResults, configJSON.auditResults, 'Audits match');
-  });
-
   it('expands audits', () => {
     const config = new Config({
       audits: ['user-timings'],

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -44,6 +44,9 @@ module.exports = {
   cacheNatives() {
     return Promise.resolve();
   },
+  evaluateAsync() {
+    return Promise.resolve({});
+  },
   registerPerformanceObserver() {
     return Promise.resolve();
   },

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -548,7 +548,6 @@ describe('GatherRunner', function() {
     return GatherRunner.run(passes, options)
       .then(artifacts => {
         assert.equal(artifacts.networkRecords, undefined);
-        assert.equal(artifacts.networkRecords, undefined);
       });
   });
 

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -547,9 +547,8 @@ describe('GatherRunner', function() {
 
     return GatherRunner.run(passes, options)
       .then(artifacts => {
-        // todo, trash these
-        assert.equal(artifacts.networkRecords['firstPass'], undefined);
-        assert.equal(artifacts.networkRecords['secondPass'], undefined);
+        assert.equal(artifacts.networkRecords, undefined);
+        assert.equal(artifacts.networkRecords, undefined);
       });
   });
 

--- a/lighthouse-core/test/index-test.js
+++ b/lighthouse-core/test/index-test.js
@@ -87,7 +87,7 @@ describe('Module Tests', function() {
       });
   });
 
-  it('should return formatted audit results when given no categories', function() {
+  it.skip('should return formatted audit results when given no categories', function() {
     const exampleUrl = 'https://example.com/';
     return lighthouse(exampleUrl, {
       output: 'json',

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -113,7 +113,7 @@ describe('Runner', () => {
       .then(_ => {
         assert.ok(false);
       }, err => {
-        assert.ok(/You must require either gather passes or/.test(err.message));
+        assert.ok(/No browser artifacts are either/.test(err.message));
       });
   });
 
@@ -345,9 +345,31 @@ describe('Runner', () => {
       .then(_ => {
         assert.ok(false);
       }, err => {
-        assert.ok(/the config has defined no audits to evaluate/.test(err.message));
+        assert.ok(/No audits to evaluate/.test(err.message));
       });
   });
+
+  it('returns data even if no config categories are provided', () => {
+    const url = 'https://example.com';
+    const config = new Config({
+      passes: [{
+        gatherers: ['viewport-dimensions'],
+      }],
+      audits: [
+        'content-width',
+      ],
+    });
+
+    return Runner.run(null, {url, config, driverMock}).then(results => {
+      assert.ok(results.lighthouseVersion);
+      assert.ok(results.generatedTime);
+      assert.equal(results.initialUrl, url);
+      assert.equal(gatherRunnerRunSpy.called, true, 'GatherRunner.run was not called');
+      assert.equal(results.audits['content-width'].name, 'content-width');
+      assert.equal(results.score, 0);
+    });
+  });
+
 
   it('returns reportCategories', () => {
     const url = 'https://example.com';
@@ -373,6 +395,7 @@ describe('Runner', () => {
       assert.ok(results.lighthouseVersion);
       assert.ok(results.generatedTime);
       assert.equal(results.initialUrl, url);
+      assert.equal(gatherRunnerRunSpy.called, true, 'GatherRunner.run was not called');
       assert.equal(results.audits['content-width'].name, 'content-width');
       assert.equal(results.reportCategories[0].score, 100);
       assert.equal(results.reportCategories[0].audits[0].id, 'content-width');

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -72,7 +72,8 @@ describe('Runner', () => {
     });
 
     it('-GA is a normal run but it saves artifacts to disk', () => {
-      const opts = {url, config: generateConfig(), driverMock, flags: {auditMode: true, gatherMode: true}};
+      const opts = {url, config: generateConfig(), driverMock,
+        flags: {auditMode: true, gatherMode: true}};
       return Runner.run(null, opts).then(_ => {
         assert.equal(loadArtifactsSpy.called, false, 'loadArtifacts was called');
         assert.equal(gatherRunnerRunSpy.called, true, 'GatherRunner.run was not called');

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -332,109 +332,53 @@ describe('Runner', () => {
     });
   });
 
-  describe.skip('auditResults', () => {
-    it('rejects when given neither audits nor auditResults', () => {
-      const url = 'https://example.com';
-      const config = new Config({
-        passes: [{
-          gatherers: ['viewport-dimensions'],
-        }],
-      });
-
-      return Runner.run(null, {url, config, driverMock})
-        .then(_ => {
-          assert.ok(false);
-        }, err => {
-          assert.ok(/The config must provide passes/.test(err.message));
-        });
+  it('rejects when not given audits to run (and not -G)', () => {
+    const url = 'https://example.com';
+    const config = new Config({
+      passes: [{
+        gatherers: ['viewport-dimensions'],
+      }],
     });
 
-    it('accepts existing auditResults', () => {
-      const url = 'https://example.com';
-      const config = new Config({
-        auditResults: [{
-          name: 'content-width',
-          rawValue: true,
-          score: true,
-          displayValue: '',
-        }],
+    return Runner.run(null, {url, config, driverMock})
+      .then(_ => {
+        assert.ok(false);
+      }, err => {
+        assert.ok(/the config has defined no audits to evaluate/.test(err.message));
+      });
+  });
 
-        categories: {
-          category: {
-            name: 'Category',
-            description: '',
-            audits: [
-              {id: 'content-width', weight: 1},
-            ],
-          },
+  it('returns reportCategories', () => {
+    const url = 'https://example.com';
+    const config = new Config({
+      passes: [{
+        gatherers: ['viewport-dimensions'],
+      }],
+      audits: [
+        'content-width',
+      ],
+      categories: {
+        category: {
+          name: 'Category',
+          description: '',
+          audits: [
+            {id: 'content-width', weight: 1},
+          ],
         },
-      });
-
-      return Runner.run(null, {url, config, driverMock}).then(results => {
-        // Mostly checking that this did not throw, but check representative values.
-        assert.equal(results.initialUrl, url);
-        assert.strictEqual(results.audits['content-width'].rawValue, true);
-      });
+      },
     });
 
-    it('returns reportCategories', () => {
-      const url = 'https://example.com';
-      const config = new Config({
-        auditResults: [{
-          name: 'content-width',
-          rawValue: true,
-          score: true,
-          displayValue: 'display',
-        }],
-        categories: {
-          category: {
-            name: 'Category',
-            description: '',
-            audits: [
-              {id: 'content-width', weight: 1},
-            ],
-          },
-        },
-      });
-
-      return Runner.run(null, {url, config, driverMock}).then(results => {
-        assert.ok(results.lighthouseVersion);
-        assert.ok(results.generatedTime);
-        assert.equal(results.initialUrl, url);
-        assert.equal(results.audits['content-width'].name, 'content-width');
-        assert.equal(results.reportCategories[0].score, 100);
-        assert.equal(results.reportCategories[0].audits[0].id, 'content-width');
-        assert.equal(results.reportCategories[0].audits[0].score, 100);
-        assert.equal(results.reportCategories[0].audits[0].result.displayValue, 'display');
-      });
-    });
-
-    it('results include artifacts when given auditResults', () => {
-      const url = 'https://example.com';
-      const config = new Config({
-        auditResults: [{
-          name: 'is-on-https',
-          rawValue: true,
-          score: true,
-          displayValue: '',
-        }],
-
-        artifacts: {
-          HTTPS: {
-            value: true,
-          },
-        },
-      });
-
-      return Runner.run(null, {url, config, driverMock}).then(results => {
-        assert.strictEqual(results.artifacts.HTTPS.value, true);
-
-        for (const method of Object.keys(computedArtifacts)) {
-          assert.ok(results.artifacts.hasOwnProperty(method));
-        }
-      });
+    return Runner.run(null, {url, config, driverMock}).then(results => {
+      assert.ok(results.lighthouseVersion);
+      assert.ok(results.generatedTime);
+      assert.equal(results.initialUrl, url);
+      assert.equal(results.audits['content-width'].name, 'content-width');
+      assert.equal(results.reportCategories[0].score, 100);
+      assert.equal(results.reportCategories[0].audits[0].id, 'content-width');
+      assert.equal(results.reportCategories[0].audits[0].score, 100);
     });
   });
+
 
   it('rejects when not given a URL', () => {
     return Runner.run({}, {}).then(_ => assert.ok(false), _ => assert.ok(true));
@@ -523,8 +467,6 @@ describe('Runner', () => {
       });
     });
   });
-
-
 
   it('includes any LighthouseRunWarnings from artifacts in output', () => {
     const url = 'https://example.com';

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -81,6 +81,16 @@ describe('Runner', () => {
         assert.equal(runAuditSpy.called, true, '_runAudit was not called');
       });
     });
+
+    it('non -G/-A run doesn\'t save artifacts to disk', () => {
+      const opts = {url, config: generateConfig(), driverMock};
+      return Runner.run(null, opts).then(_ => {
+        assert.equal(loadArtifactsSpy.called, false, 'loadArtifacts was called');
+        assert.equal(gatherRunnerRunSpy.called, true, 'GatherRunner.run was not called');
+        assert.equal(saveArtifactsSpy.called, false, 'saveArtifacts was called');
+        assert.equal(runAuditSpy.called, true, '_runAudit was not called');
+      });
+    });
   });
 
   it('expands gatherers', () => {

--- a/lighthouse-core/test/scoring-test.js
+++ b/lighthouse-core/test/scoring-test.js
@@ -68,7 +68,7 @@ describe('ReportScoring', () => {
     });
 
     it('should score the categories', () => {
-      const auditResults = {
+      const resultsByAuditId = {
         'my-audit': {rawValue: 'you passed'},
         'my-boolean-audit': {score: true, extendedInfo: {}},
         'my-scored-audit': {score: 100},
@@ -88,7 +88,7 @@ describe('ReportScoring', () => {
             ],
           },
         },
-      }, auditResults);
+      }, resultsByAuditId);
 
       assert.equal(result.categories.length, 2);
       assert.equal(result.categories[0].score, 0);

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -125,6 +125,8 @@ gulp.task('browserify-lighthouse', () => {
       .ignore('url')
       .ignore('debug/node')
       .ignore('raven')
+      .ignore('mkdirp')
+      .ignore('rimraf')
       .ignore('pako/lib/zlib/inflate.js');
 
       // Expose the audits, gatherers, and computed artifacts so they can be dynamically loaded.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
     "npm-run-posix-or-windows": "^2.0.2",
-    "typescript": "^2.6.1",
+    "sinon": "^2.3.5",
     "zone.js": "^0.7.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
     "npm-run-posix-or-windows": "^2.0.2",
+    "typescript": "^2.6.1",
     "sinon": "^2.3.5",
     "zone.js": "^0.7.3"
   },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "inquirer": "^3.3.0",
     "jpeg-js": "0.1.2",
     "js-library-detector": "^4.3.1",
-    "json-stringify-safe": "5.0.1",
     "lighthouse-logger": "^1.0.0",
     "metaviewport-parser": "0.1.0",
     "mkdirp": "0.5.1",

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -22,6 +22,8 @@ export interface Flags {
   enableErrorReporting: boolean;
   listAllAudits: boolean;
   listTraceCategories: boolean;
+  auditMode: boolean;
+  gatherMode: boolean;
   configPath?: string;
   perf: boolean;
   verbose: boolean;

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -12,7 +12,6 @@ export interface Flags {
   chromeFlags: string;
   output: any;
   outputPath: string;
-  saveArtifacts: boolean;
   saveAssets: boolean;
   view: boolean;
   maxWaitForLoad: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,6 +1204,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
 doctrine@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
@@ -1600,6 +1604,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 fs-exists-sync@^0.1.0:
   version "0.1.0"
@@ -2749,6 +2759,10 @@ log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -2934,6 +2948,10 @@ mute-stream@0.0.6:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natives@^1.1.0:
   version "1.1.0"
@@ -3191,6 +3209,12 @@ path-root@^0.1.1:
   resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
   dependencies:
     path-root-regex "^0.1.0"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -3602,6 +3626,10 @@ safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 sax@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
@@ -3657,6 +3685,19 @@ signal-exit@^3.0.0:
 signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^2.3.5:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.4.1.tgz#021fd64b54cb77d9d2fb0d43cdedfae7629c3a36"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -3914,6 +3955,10 @@ term-size@^0.1.0:
   dependencies:
     execa "^0.4.0"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
@@ -4023,13 +4068,13 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-
-typescript@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 uglify-js@^2.6:
   version "2.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2465,7 +2465,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@5.0.1, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4076,6 +4076,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+
 uglify-js@^2.6:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.3.tgz#39b3a7329b89f5ec507e344c6e22568698ef4868"


### PR DESCRIPTION
fixes #1806

The mystical -GAR feature.  Actually its just -GA for now. 

Here's how this works:

```sh
lighthouse -G http://example.com
# launches browser, collects data, saves to disk (in `./latest-run/`) and quits

lighthouse -A http://example.com
# skips browser interaction, loads artifacts from disk (in `./latest-run/`), runs audits on them, generates report

lighthouse -GA http://example.com
# Normal gather + audit run, but also saves artifacts to disk
```

* `--gather-mode` and `--audit-mode` are the long versions of `-G` and `-A`.
* `config.auditResults` is removed. it was weird.
* assetSaver got a new impl of `saveArtifacts`, and added `loadArtifacts`
* --save-artifacts CLI flag was removed, as it was never really used and makes less sense in -G world. 

-------------------

##### Todo:
* Decide if we want to rename these, as "gather" hasn't been really user-visible before. 


##### Future work:
* Add `-G=./artifacts-save-path/`
* Add `-A=./artifacts-load-path/`

  