### PR TITLE
core: remove optimalValue

### DIFF
--- a/docs/understanding-results.md
+++ b/docs/understanding-results.md
@@ -61,7 +61,6 @@ An object containing the results of the audits, keyed by their name.
 | extendedInfo | `Object` | Extra information found by the audit. The structure of this object varies from audit to audit and is generally for programmatic consumption and debugging, though there is typically overlap with `details`. *WARNING: The structure of this object is not stable and cannot be trusted to follow semver* |
 | manual | `boolean` | Indicator used for display that the audit does not have results and is a placeholder for the user to conduct manual testing. |
 | informative | `boolean` | Indicator used for display that the audit is intended to be informative only. It cannot be passed or failed. |
-| category | `string` | No longer used. *WARNING: Deprecated, will be removed in Lighthouse 3.0* |
 
 ### Example
 ```json

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -151,7 +151,6 @@ class Audit {
       rawValue: result.rawValue,
       error: result.error,
       debugString: result.debugString,
-      optimalValue: result.optimalValue,
       extendedInfo: result.extendedInfo,
       scoringMode: audit.meta.scoringMode || Audit.SCORING_MODES.BINARY,
       informative: audit.meta.informative,

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -9,7 +9,6 @@ const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 
 // Parameters for log-normal CDF scoring. See https://www.desmos.com/calculator/gpmjeykbwr
 // ~75th and ~90th percentiles http://httparchive.org/interesting.php?a=All&l=Feb%201%202017&s=All#bytesTotal
-const OPTIMAL_VALUE = 1600 * 1024;
 const SCORING_POINT_OF_DIMINISHING_RETURNS = 2500 * 1024;
 const SCORING_MEDIAN = 4000 * 1024;
 
@@ -20,7 +19,6 @@ class TotalByteWeight extends ByteEfficiencyAudit {
   static get meta() {
     return {
       name: 'total-byte-weight',
-      optimalValue: `< ${this.bytesToKbString(OPTIMAL_VALUE)}`,
       description: 'Avoids enormous network payloads',
       failureDescription: 'Has enormous network payloads',
       helpText:
@@ -84,7 +82,6 @@ class TotalByteWeight extends ByteEfficiencyAudit {
       return {
         score,
         rawValue: totalBytes,
-        optimalValue: this.meta.optimalValue,
         displayValue: `Total size was ${ByteEfficiencyAudit.bytesToKbString(totalBytes)}`,
         extendedInfo: {
           value: {

--- a/lighthouse-core/audits/consistently-interactive.js
+++ b/lighthouse-core/audits/consistently-interactive.js
@@ -236,7 +236,6 @@ class ConsistentlyInteractiveMetric extends Audit {
           ),
           rawValue: timeInMs,
           displayValue: Util.formatMilliseconds(timeInMs),
-          optimalValue: this.meta.optimalValue,
           extendedInfo: {
             value: extendedInfo,
           },

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -17,7 +17,6 @@ class CriticalRequestChains extends Audit {
       name: 'critical-request-chains',
       description: 'Critical Request Chains',
       informative: true,
-      optimalValue: 0,
       helpText: 'The Critical Request Chains below show you what resources are ' +
           'required for first render of this page. Improve page load by reducing ' +
           'the length of chains, reducing the download size of resources, or ' +
@@ -113,9 +112,8 @@ class CriticalRequestChains extends Audit {
       const longestChain = CriticalRequestChains._getLongestChain(chains);
 
       return {
-        rawValue: chainCount <= this.meta.optimalValue,
+        rawValue: chainCount === 0,
         displayValue: Util.formatNumber(chainCount),
-        optimalValue: this.meta.optimalValue,
         extendedInfo: {
           value: {
             chains,

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -36,7 +36,6 @@ class DOMSize extends Audit {
       name: 'dom-size',
       description: 'Avoids an excessive DOM size',
       failureDescription: 'Uses an excessive DOM size',
-      optimalValue: `< ${DOMSize.MAX_DOM_NODES.toLocaleString()} nodes`,
       helpText: 'Browser engineers recommend pages contain fewer than ' +
         `~${Util.formatNumber(DOMSize.MAX_DOM_NODES)} DOM nodes. The sweet spot is a tree ` +
         `depth < ${MAX_DOM_TREE_DEPTH} elements and fewer than ${MAX_DOM_TREE_WIDTH} ` +
@@ -96,7 +95,6 @@ class DOMSize extends Audit {
     return {
       score,
       rawValue: stats.totalDOMNodes,
-      optimalValue: this.meta.optimalValue,
       displayValue: `${Util.formatNumber(stats.totalDOMNodes)} nodes`,
       extendedInfo: {
         value: cards,

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -22,7 +22,6 @@ class EstimatedInputLatency extends Audit {
     return {
       name: 'estimated-input-latency',
       description: 'Estimated Input Latency',
-      optimalValue: `< ${Util.formatMilliseconds(SCORING_POINT_OF_DIMINISHING_RETURNS, 1)}`,
       helpText: 'The score above is an estimate of how long your app takes to respond to user ' +
           'input, in milliseconds. There is a 90% probability that a user encounters this amount ' +
           'of latency, or less. 10% of the time a user can expect additional latency. If your ' +
@@ -57,7 +56,6 @@ class EstimatedInputLatency extends Audit {
 
     return {
       score,
-      optimalValue: EstimatedInputLatency.meta.optimalValue,
       rawValue,
       displayValue: Util.formatMilliseconds(rawValue, 1),
       extendedInfo: {

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -22,7 +22,6 @@ class FirstMeaningfulPaint extends Audit {
     return {
       name: 'first-meaningful-paint',
       description: 'First meaningful paint',
-      optimalValue: `< ${Util.formatMilliseconds(SCORING_POINT_OF_DIMINISHING_RETURNS, 1)}`,
       helpText: 'First meaningful paint measures when the primary content of a page is visible. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint).',
       scoringMode: Audit.SCORING_MODES.NUMERIC,
@@ -57,7 +56,6 @@ class FirstMeaningfulPaint extends Audit {
         rawValue: parseFloat(result.duration),
         displayValue: Util.formatMilliseconds(result.duration),
         debugString: result.debugString,
-        optimalValue: this.meta.optimalValue,
         extendedInfo: {
           value: result.extendedInfo,
         },

--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -23,7 +23,6 @@ class SpeedIndexMetric extends Audit {
       description: 'Perceptual Speed Index',
       helpText: 'Speed Index shows how quickly the contents of a page are visibly populated. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index).',
-      optimalValue: `< ${Util.formatNumber(SCORING_POINT_OF_DIMINISHING_RETURNS)}`,
       scoringMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces'],
     };
@@ -96,7 +95,6 @@ class SpeedIndexMetric extends Audit {
         score,
         rawValue,
         displayValue: Util.formatNumber(rawValue),
-        optimalValue: this.meta.optimalValue,
         extendedInfo: {
           value: extendedInfo,
         },

--- a/lighthouse-core/closure/typedefs/Audit.js
+++ b/lighthouse-core/closure/typedefs/Audit.js
@@ -21,8 +21,5 @@ AuditMeta.prototype.name;
 /** @type {string} */
 AuditMeta.prototype.description;
 
-/** @type {?(boolean|number|string|undefined)} */
-AuditMeta.prototype.optimalValue;
-
 /** @type {!Array<string>} */
 AuditMeta.prototype.requiredArtifacts;

--- a/lighthouse-core/closure/typedefs/AuditResult.js
+++ b/lighthouse-core/closure/typedefs/AuditResult.js
@@ -34,9 +34,6 @@ AuditResult.prototype.displayValue;
  */
 AuditResult.prototype.debugString;
 
-/** @type {(boolean|number|string|undefined|null)} */
-AuditResult.prototype.optimalValue;
-
 /** @type {(AuditExtendedInfo|undefined|null)} */
 AuditResult.prototype.extendedInfo;
 
@@ -73,9 +70,6 @@ AuditFullResult.prototype.error;
 
 /** @type {(string|undefined)} */
 AuditFullResult.prototype.debugString;
-
-/** @type {(boolean|number|string|undefined|null)} */
-AuditFullResult.prototype.optimalValue;
 
 /** @type {(AuditExtendedInfo|undefined|null)} */
 AuditFullResult.prototype.extendedInfo;

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -37,9 +37,6 @@ class CategoryRenderer {
     if (audit.result.displayValue) {
       title += `:  ${audit.result.displayValue}`;
     }
-    if (audit.result.optimalValue) {
-      title += ` (target: ${audit.result.optimalValue})`;
-    }
 
     if (audit.result.debugString) {
       const debugStrEl = tmpl.appendChild(this._dom.createElement('div', 'lh-debug'));

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -188,7 +188,6 @@ if (typeof module !== 'undefined' && module.exports) {
  *       helpText: string,
  *       score: (number|boolean),
  *       scoringMode: string,
- *       optimalValue: number,
  *       extendedInfo: Object,
  *       details: (!DetailsRenderer.DetailsJSON|undefined)
  *     }

--- a/lighthouse-core/test/audits/dobetterweb/dom-size-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/dom-size-test.js
@@ -29,7 +29,6 @@ describe('Num DOM nodes audit', () => {
     const auditResult = DOMSize.audit(artifact);
     assert.equal(auditResult.score, 100);
     assert.equal(auditResult.rawValue, numNodes);
-    assert.equal(auditResult.optimalValue, `< ${DOMSize.MAX_DOM_NODES.toLocaleString()} nodes`);
     assert.equal(auditResult.displayValue, `${numNodes.toLocaleString()} nodes`);
     assert.equal(auditResult.details.items[0].title, 'Total DOM Nodes');
     assert.equal(auditResult.details.items[0].value, numNodes.toLocaleString());

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -124,7 +124,6 @@ describe('Config', () => {
     configJSON.auditResults = [{
       value: 1,
       rawValue: 1.0,
-      optimalValue: 1.0,
       name: 'Test Audit',
       details: {
         items: {


### PR DESCRIPTION
closes #2812 

I'd normally oppose removing this without a major version bump, but the value was almost always an english string like `< 1,000` rather than a number that people likely relied on, we also just removed the similarly useless `category` property without a major bump so blocking this seems inconsistent

I kept the existing target references in dom-size audit since those are explicitly in the description as to why you care and its just for making sense of the data in the cards. Still removed the overall optimalValue display.