### PR TITLE
tests(smoke): add long task to byte-efficiency tester to deflake appveyor

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -31,11 +31,17 @@ function generateInlineScriptWithSize(sizeInBytes, firstContent = '', used = fal
   document.head.appendChild(style);
 }
 
+// Add a long task to delay FI
+setTimeout(() => {
+  const start = Date.now();
+  while (Date.now() < start + 100) ;
+}, 2000);
+
 // Lazily load the image
 setTimeout(() => {
   const template = document.getElementById('lazily-loaded-image');
   document.body.appendChild(template.content.cloneNode(true));
-}, 6000);
+}, 7000);
 </script>
 <style>
   .onscreen {

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -40,9 +40,15 @@ module.exports = [
         score: '<100',
         extendedInfo: {
           value: {
-            results: {
-              length: 3,
-            },
+            results: [
+              {
+                url: /lighthouse-unoptimized.jpg$/,
+              }, {
+                url: /lighthouse-480x320.webp$/,
+              }, {
+                url: /large.svg$/,
+              },
+            ],
           },
         },
       },


### PR DESCRIPTION
`large.svg` starts loading almost exactly at FI on appveyor, leading to it to be pretty flakey since `offscreen-images` doesn't count images that start loading after FI. This PR just adds an artificial long task to push FI out a few more seconds to deflake things.

So far it's been passing consistently on appveyor over a few loads; will rerun multiple more times.

Also: since the `extendedInfo` is sorted by image size, added more useful expectations using the image file names, which should hopefully make the diff a little clearer for any future errors.