### PR TITLE
docs: demo flags in example of programmatic use

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,20 +11,23 @@ assumes you've installed Lighthouse as a dependency (`yarn add --dev lighthouse`
 const lighthouse = require('lighthouse');
 const chromeLauncher = require('chrome-launcher');
 
-function launchChromeAndRunLighthouse(url, flags = {}, config = null) {
-  return chromeLauncher.launch(flags).then(chrome => {
-    flags.port = chrome.port;
-    return lighthouse(url, flags, config).then(results =>
+function launchChromeAndRunLighthouse(url, opts, config = null) {
+  return chromeLauncher.launch({chromeFlags: opts.chromeFlags}).then(chrome => {
+    opts.port = chrome.port;
+    return lighthouse(url, opts, config).then(results =>
       chrome.kill().then(() => results));
   });
 }
 
-const flags = {};
+const opts = {
+  chromeFlags: ['--show-paint-rects']
+};
 
 // Usage:
-launchChromeAndRunLighthouse('https://example.com', flags).then(results => {
+launchChromeAndRunLighthouse('https://example.com', opts).then(results => {
   // Use results!
 });
+
 ```
 
 ### Performance-only Lighthouse run

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -12,7 +12,7 @@ const lighthouse = require('lighthouse');
 const chromeLauncher = require('chrome-launcher');
 
 function launchChromeAndRunLighthouse(url, flags = {}, config = null) {
-  return chromeLauncher.launch().then(chrome => {
+  return chromeLauncher.launch(flags).then(chrome => {
     flags.port = chrome.port;
     return lighthouse(url, flags, config).then(results =>
       chrome.kill().then(() => results));


### PR DESCRIPTION
In the current documentation, the example given does not pass the flags argument to `chromeLauncher.launch` which caused some initial confusion when trying to leverage any of the chromeFlags. It is not intuitive that flags should also be passed into the launch method.