### PR TITLE
report: add help link icon

### DIFF
--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -80,7 +80,22 @@ class CategoryRenderer {
     this._dom.find('.lh-score__description', element)
         .appendChild(this._dom.convertMarkdownLinkSnippets(description));
 
+    this._populateHelpLink(element, description);
+
     return /** @type {!Element} **/ (element);
+  }
+
+  /**
+   * @param {!DocumentFragment|!Element} element
+   * @param {string} helpText
+   */
+  _populateHelpLink(element, helpText) {
+    const firstLinkMatch = helpText.match(/]\((http[^\)]+)/);
+    const helpLink = element.querySelector('.lh-help-link');
+    if (helpLink && firstLinkMatch) {
+      helpLink.href = firstLinkMatch[1];
+      helpLink.classList.add('lh-help-link--visible');
+    }
   }
 
   /**
@@ -159,6 +174,8 @@ class CategoryRenderer {
         'lh-expandable-details__summary');
     const titleEl = this._dom.createChildOf(summary, 'div', 'lh-perf-hint__title');
     titleEl.textContent = audit.result.description;
+    this._dom.createChildOf(summary, 'a', 'lh-help-link');
+    this._populateHelpLink(summary, audit.result.helpText);
 
     this._dom.createChildOf(summary, 'div', 'lh-toggle-arrow', {title: 'See resources'});
 

--- a/lighthouse-core/report/v2/report-styles.css
+++ b/lighthouse-core/report/v2/report-styles.css
@@ -338,6 +338,33 @@ span.lh-node:hover {
   flex: 1;
 }
 
+.lh-help-link {
+  color: var(--informative-color);
+  border: 1px solid var(--informative-color);
+  width: var(--caption-line-height);
+  height: var(--caption-line-height);
+  line-height: var(--caption-line-height);
+  font-size: var(--caption-font-size);
+  border-radius: 50%;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  display: none;
+}
+
+.lh-help-link:hover {
+  color: white;
+  background: var(--informative-color);
+}
+
+.lh-help-link::after {
+  content: "?";
+}
+
+.lh-help-link--visible {
+  display: block;
+}
+
 .lh-toggle-arrow {
   background: var(--collapsed-icon-url) no-repeat center center / 12px 12px;
   background-color: transparent;

--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -28,6 +28,7 @@
       <summary class="lh-score__snippet lh-expandable-details__summary">
         <span class="lh-score__title"><!-- fill me --></span>
         <div class="lh-toggle-arrow" title="See audits"></div>
+        <a class="lh-help-link"></a>
       </summary>
       <div class="lh-score__description"><!-- fill me --></div>
     </details>


### PR DESCRIPTION
closes #3696 

first pass at adding some help icons, a book might be better than a question mark?
not in love with the current placement, moving it right next to the text makes them jump around and feels a bit weird, at the beginning of the line seemed to increase the noise and hurts ability to easily see what failed. definitely open to other ideas

screenshot below, first one is in hover state
![image](https://user-images.githubusercontent.com/2301202/32965946-1a07290a-cb8d-11e7-9288-78f1e9a9f4c4.png)
