### PR TITLE
cli(sentry): handle configstore errors by not enabling error reporting

### DIFF
--- a/lighthouse-cli/sentry-prompt.js
+++ b/lighthouse-cli/sentry-prompt.js
@@ -61,18 +61,21 @@ function prompt() {
  * @return {!Promise<boolean>}
  */
 function askPermission() {
-  const configstore = new Configstore('lighthouse');
-  let isErrorReportingEnabled = configstore.get('isErrorReportingEnabled');
-  if (typeof isErrorReportingEnabled === 'boolean') {
-    return Promise.resolve(isErrorReportingEnabled);
-  }
+  return Promise.resolve().then(_ => {
+    const configstore = new Configstore('lighthouse');
+    let isErrorReportingEnabled = configstore.get('isErrorReportingEnabled');
+    if (typeof isErrorReportingEnabled === 'boolean') {
+      return Promise.resolve(isErrorReportingEnabled);
+    }
 
-  return prompt()
-    .then(response => {
-      isErrorReportingEnabled = response;
-      configstore.set('isErrorReportingEnabled', isErrorReportingEnabled);
-      return isErrorReportingEnabled;
-    });
+    return prompt()
+      .then(response => {
+        isErrorReportingEnabled = response;
+        configstore.set('isErrorReportingEnabled', isErrorReportingEnabled);
+        return isErrorReportingEnabled;
+      });
+  // Error accessing configstore; default to false.
+  }).catch(_ => false);
 }
 
 module.exports = {


### PR DESCRIPTION
fixes #3873

Lighthouse shouldn't fail when `configstore` hits an `EACCES` error. We also don't want to make a user who can't use `configstore` hit the 20 second timeout every time, so it seems like defaulting to false is the thing to do here.

Seemed better to have this handled within `askPermission` than by the caller. Promise wrapper will get a bit nicer when we can do async/await, but note that it's the `get` and `set` calls that try to access the file, not the `Configstore` constructor, and wrapping the two individually made a bit of a mess.