### PR TITLE
misc(error-reporting): report unhandled promise rejections

### DIFF
--- a/lighthouse-core/lib/sentry.js
+++ b/lighthouse-core/lib/sentry.js
@@ -50,6 +50,9 @@ sentryDelegate.init = function init(opts) {
         Sentry.captureException(...args, () => resolve());
       });
     };
+
+    // Report any rejections that are never caught
+    process.on('unhandledRejection', reason => sentryDelegate.captureException(reason));
   } catch (e) {
     log.warn(
       'sentry',


### PR DESCRIPTION
Since we have a catch() way back in CLI, it's unlikely we'll actually have an uncaught rejection, but this is insurance anyhow.

[Here's some reported unhandled rejections](https://github.com/GoogleChrome/lighthouse/issues?q=is%3Aissue+%22Unhandled+promise+rejections+are+deprecated%22+sort%3Acreated-desc)

Q: do we want to add any extra metadata to indicate this was unhandled?