### PR TITLE
misc(error-reporting): tweak sentry levels and ignore list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,12 +93,19 @@ NOTE: If the message you're capturing is dynamic/based on user data or you need 
 const Sentry = require('./lighthouse-core/lib/sentry');
 
 if (networkRecords.length === 1) {
-  Sentry.captureMessage('Site only had 1 network request');
+  Sentry.captureMessage('Site only had 1 network request', {level: 'info'});
   return null;
 } else {
   // do your thang
 }
 ```
+
+#### Level Guide
+
+- `info` for events that don't indicate a bug but should be tracked
+- `warning` for events that might indicate unexpected behavior but is recoverable
+- `error` for events that caused an audit/gatherer failure but were not fatal
+- `fatal` for events that caused Lighthouse to exit early and not produce a report
 
 # For Maintainers
 

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const Audit = require('../audit');
-const Sentry = require('../../lib/sentry');
 const Util = require('../../report/v2/renderer/util');
 
 const KB_IN_BYTES = 1024;
@@ -134,15 +133,6 @@ class UnusedBytes extends Audit {
     }
 
     const tableDetails = Audit.makeTableDetails(result.headings, results);
-
-    if (debugString) {
-      // Track these with Sentry since we don't want to fail the entire audit for a single image failure.
-      // Use captureException to preserve the stack and take advantage of Sentry grouping.
-      Sentry.captureException(new Error(debugString), {
-        tags: {audit: this.meta.name},
-        level: 'warning',
-      });
-    }
 
     return {
       debugString,

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
+const Sentry = require('../../lib/sentry');
 const URL = require('../../lib/url-shim');
 
 const ALLOWABLE_OFFSCREEN_X = 100;
@@ -101,6 +102,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
       const processed = OffscreenImages.computeWaste(image, viewportDimensions);
       if (processed instanceof Error) {
         debugString = processed.message;
+        Sentry.captureException(processed, {tags: {audit: this.meta.name}, level: 'warning'});
         return results;
       }
 

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -14,6 +14,7 @@
 'use strict';
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
+const Sentry = require('../../lib/sentry');
 const URL = require('../../lib/url-shim');
 
 const IGNORE_THRESHOLD_IN_BYTES = 2048;
@@ -86,6 +87,7 @@ class UsesResponsiveImages extends ByteEfficiencyAudit {
       const processed = UsesResponsiveImages.computeWaste(image, DPR);
       if (processed instanceof Error) {
         debugString = processed.message;
+        Sentry.captureException(processed, {tags: {audit: this.meta.name}, level: 'warning'});
         return;
       }
 

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -78,7 +78,7 @@ class TraceOfTab extends ComputedArtifact {
     // However, if no candidates were found (a bogus trace, likely), we fail.
     if (!firstMeaningfulPaint) {
       // Track this with Sentry since it's likely a bug we should investigate.
-      Sentry.captureMessage('No firstMeaningfulPaint found, using fallback');
+      Sentry.captureMessage('No firstMeaningfulPaint found, using fallback', {level: 'warning'});
 
       const fmpCand = 'firstMeaningfulPaintCandidate';
       fmpFellBack = true;

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -8,7 +8,6 @@
 
 const EventEmitter = require('events').EventEmitter;
 const log = require('lighthouse-logger');
-const Sentry = require('../../lib/sentry');
 
 class Connection {
   constructor() {

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -8,6 +8,7 @@
 
 const EventEmitter = require('events').EventEmitter;
 const log = require('lighthouse-logger');
+const Sentry = require('../../lib/sentry');
 
 class Connection {
   constructor() {
@@ -101,7 +102,10 @@ class Connection {
           log.formatProtocol('method <= browser ERR', {method: callback.method}, logLevel);
           let errMsg = `(${callback.method}): ${object.error.message}`;
           if (object.error.data) errMsg += ` (${object.error.data})`;
-          throw new Error(`Protocol error ${errMsg}`);
+          const error = new Error(`Protocol error ${errMsg}`);
+          error.protocolMethod = callback.method;
+          error.protocolError = object.error.message;
+          throw error;
         }
 
         log.formatProtocol('method <= browser OK',

--- a/lighthouse-core/lib/sentry.js
+++ b/lighthouse-core/lib/sentry.js
@@ -20,9 +20,11 @@ const sentryApi = {
   getContext: noop,
 };
 
-const IGNORED_ERRORS = [
-  /Unable to load/, // see https://github.com/GoogleChrome/lighthouse/issues/2784
-  /Tracing already started/, // see https://github.com/GoogleChrome/lighthouse/issues/1091
+const SAMPLED_ERRORS = [
+  {pattern: /Unable to load/, rate: 0.1},
+  {pattern: /Failed to decode/, rate: 0.1},
+  {pattern: /No resource with given id/, rate: 0.01},
+  {pattern: /No node with given id/, rate: 0.01},
 ];
 
 /**
@@ -37,7 +39,6 @@ sentryDelegate.init = function init(opts) {
   }
 
   const environmentData = opts.environmentData || {};
-  const isDevelopment = environmentData.environment === 'development';
   const sentryConfig = Object.assign({}, environmentData, {allowSecretKey: true});
 
   try {
@@ -49,23 +50,24 @@ sentryDelegate.init = function init(opts) {
     });
 
     // Special case captureException to return a Promise so we don't process.exit too early
-    sentryDelegate.captureException = (...args) => {
+    sentryDelegate.captureException = (err, opts) => {
+      opts = opts || {};
+
       const empty = Promise.resolve();
+      // Ignore if there wasn't an error
+      if (!err) return empty;
       // Ignore expected errors
-      if (args[0] && args[0].expected) return empty;
-      // Ignore errors matching our shortlist
-      if (args[0] && IGNORED_ERRORS.some(regex => regex.test(args[0].message))) return empty;
-      // Only report 25% of production errors
-      if (!isDevelopment && Math.random() > 0.25) return empty;
+      if (err.expected) return empty;
+      // Sample known errors that occurr at a high frequency
+      const sampledErrorMatch = SAMPLED_ERRORS.find(sample => sample.pattern.test(err.message));
+      if (sampledErrorMatch && sampledErrorMatch.rate <= Math.random()) return empty;
       // Protocol errors all share same stack trace, so add more to fingerprint
-      if (args[0] && args[0].protocolMethod) {
-        const opts = args[1] || {};
-        opts.fingerprint = ['{{ default }}', args[0].protocolMethod, args[0].protocolError];
-        args = [args[0], opts];
+      if (err.protocolMethod) {
+        opts.fingerprint = ['{{ default }}', err.protocolMethod, err.protocolError];
       }
 
       return new Promise(resolve => {
-        Sentry.captureException(...args, () => resolve());
+        Sentry.captureException(err, opts, () => resolve());
       });
     };
   } catch (e) {

--- a/lighthouse-core/lib/sentry.js
+++ b/lighthouse-core/lib/sentry.js
@@ -58,7 +58,7 @@ sentryDelegate.init = function init(opts) {
       if (!err) return empty;
       // Ignore expected errors
       if (err.expected) return empty;
-      // Sample known errors that occurr at a high frequency
+      // Sample known errors that occur at a high frequency
       const sampledErrorMatch = SAMPLED_ERRORS.find(sample => sample.pattern.test(err.message));
       if (sampledErrorMatch && sampledErrorMatch.rate <= Math.random()) return empty;
       // Protocol errors all share same stack trace, so add more to fingerprint

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -168,7 +168,7 @@ class Runner {
         };
       })
       .catch(err => {
-        return Sentry.captureException(err).then(() => {
+        return Sentry.captureException(err, {level: 'fatal'}).then(() => {
           throw err;
         });
       });
@@ -210,7 +210,7 @@ class Runner {
           const artifactError = artifacts[artifactName];
           Sentry.captureException(artifactError, {
             tags: {gatherer: artifactName},
-            level: 'warning',
+            level: 'error',
           });
 
           log.warn('Runner', `${artifactName} gatherer, required by audit ${audit.meta.name},` +
@@ -233,7 +233,7 @@ class Runner {
         throw err;
       }
 
-      Sentry.captureException(err, {tags: {audit: audit.meta.name}, level: 'warning'});
+      Sentry.captureException(err, {tags: {audit: audit.meta.name}, level: 'error'});
       // Non-fatal error become error audit result.
       return Audit.generateErrorAuditResult(audit, 'Audit error: ' + err.message);
     }).then(result => {


### PR DESCRIPTION
now that we've had sentry in WPT and the volume shot up this makes some tweaks to make it a little more manageable

* adjusts error levels to more clearly see which are failed audits/which are warnings/which are fatal errors
* adds fingerprint to distinguish different protocol errors
* samples a few known errors that happen *a lot*