### PR TITLE
report(perf-audits): adjust presentation of runtime cost audits

### DIFF
--- a/lighthouse-core/audits/bootup-time.js
+++ b/lighthouse-core/audits/bootup-time.js
@@ -18,7 +18,7 @@ class BootupTime extends Audit {
     return {
       category: 'Performance',
       name: 'bootup-time',
-      description: 'JavaScript boot-up time is high (> 4s)',
+      description: 'JavaScript boot-up time',
       failureDescription: 'JavaScript boot-up time is too high',
       helpText: 'Consider reducing the time spent parsing, compiling and executing JS. ' +
         'You may find delivering smaller JS payloads helps with this.',
@@ -93,7 +93,7 @@ class BootupTime extends Audit {
       const tableDetails = BootupTime.makeTableDetails(headings, results);
 
       return {
-        score: totalBootupTime < 4000,
+        score: totalBootupTime < 2000,
         rawValue: totalBootupTime,
         displayValue: Util.formatMilliseconds(totalBootupTime),
         details: tableDetails,

--- a/lighthouse-core/audits/mainthread-work-breakdown.js
+++ b/lighthouse-core/audits/mainthread-work-breakdown.js
@@ -85,7 +85,7 @@ class PageExecutionTimings extends Audit {
         const tableDetails = PageExecutionTimings.makeTableDetails(headings, results);
 
         return {
-          score: false,
+          score: totalExecutionTime < 3000,
           rawValue: totalExecutionTime,
           displayValue: Util.formatMilliseconds(totalExecutionTime),
           details: tableDetails,

--- a/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
+++ b/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
@@ -92,7 +92,7 @@ describe('Performance: page execution timings audit', () => {
     return PageExecutionTimings.audit(artifacts).then(output => {
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
       assert.equal(output.details.items.length, 13);
-      assert.equal(output.score, false);
+      assert.equal(output.score, true);
       assert.equal(Math.round(output.rawValue), 596);
 
       for (const category in output.extendedInfo.value) {
@@ -113,7 +113,7 @@ describe('Performance: page execution timings audit', () => {
     return PageExecutionTimings.audit(artifacts).then(output => {
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
       assert.equal(output.details.items.length, 12);
-      assert.equal(output.score, false);
+      assert.equal(output.score, true);
       assert.equal(Math.round(output.rawValue), 524);
 
       for (const category in output.extendedInfo.value) {
@@ -133,7 +133,7 @@ describe('Performance: page execution timings audit', () => {
 
     return PageExecutionTimings.audit(artifacts).then(output => {
       assert.equal(output.details.items.length, 0);
-      assert.equal(output.score, false);
+      assert.equal(output.score, true);
       assert.equal(Math.round(output.rawValue), 0);
     });
   });

--- a/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
+++ b/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
@@ -71,7 +71,7 @@ describe('Performance: page execution timings audit', () => {
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
 
       assert.equal(output.details.items.length, 12);
-      assert.equal(output.score, false);
+      assert.equal(output.score, true);
       assert.equal(Math.round(output.rawValue), 611);
 
       for (const category in output.extendedInfo.value) {


### PR DESCRIPTION
I noticed and fixed some inconsistencies

* main thread work breakdown was always showing in diagnostics, even if total cost was just 40ms. 
* bootup time audit was saying "is high" but only when  the audit was passing.
* now the failure threshold for the two audits is adjusted. 
   - just JS bootup times costing more than 2s, show it. total main thread time costing more than 4s, show that.
