### PR TITLE
core(rel=noopener-audit): Only test http/https links

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -106,10 +106,18 @@
   <!-- FAIL - does not use rel="noopener" and has no href attribute, giving an
     href value of '' when read, which will throw in a `new URL('')` constructor -->
   <a target="_blank">external link</a>
-  <!-- PASS -->
+  <!-- FAIL - external link that does have a rel attribute but it is not "noopener" -->
+  <a href="https://www.google.com/" target="_blank" rel="nofollow">external link</a>
+  <!-- PASS - external link correctly uses rel="noopener" and an additional rel value -->
   <a href="https://www.google.com/" target="_blank" rel="noopener nofollow">external link that uses rel noopener and another unrelated rel attribute</a>
-  <!-- PASS -->
+  <!-- PASS - external link correctly uses rel="noopener" -->
+  <a href="https://www.google.com/" target="_blank" rel="noopener">external link that uses rel noopener</a>
+  <!-- PASS - internal link without rel="noopener" -->
   <a href="./doesnotexist" target="_blank">internal link is ok</a>
+  <!-- PASS - href uses javascript: -->
+  <a href="javascript:void(0)" target="_blank"></a>
+  <!-- PASS - href uses mailto: -->
+  <a href="mailto:inbox@email.com" target="_blank"></a>
 </template>
 
 <template id="password-inputs-can-be-pasted-into">

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -53,12 +53,12 @@ module.exports = [
                      'If they are not used as hyperlinks, consider removing the _blank target.',
         extendedInfo: {
           value: {
-            length: 2,
+            length: 3,
           },
         },
         details: {
           items: {
-            length: 2,
+            length: 3,
           },
         },
       },

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -46,10 +46,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
           return true;
         }
       })
-      .filter(anchor => {
-        // Ignore href's that are not real links
-        return !anchor.href || !anchor.href.toLowerCase().startsWith('javascript:');
-      })
+      .filter(anchor => anchor.href.toLowerCase().startsWith('http'))
       .map(anchor => {
         return {
           href: anchor.href || 'Unknown',

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -46,7 +46,9 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
           return true;
         }
       })
-      .filter(anchor => anchor.href.toLowerCase().startsWith('http'))
+      .filter(anchor => {
+        return !anchor.href || anchor.href.toLowerCase().startsWith('http');
+      })
       .map(anchor => {
         return {
           href: anchor.href || 'Unknown',

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -27,6 +27,30 @@ describe('External anchors use rel="noopener"', () => {
     assert.equal(auditResult.details.items.length, 0);
   });
 
+  it('passes when links have javascript in href attribute', () => {
+    const auditResult = ExternalAnchorsAudit.audit({
+      AnchorsWithNoRelNoopener: [
+        {href: 'javascript:void(0)'},
+        {href: 'JAVASCRIPT:void(0)'},
+      ],
+      URL: {finalUrl: URL},
+    });
+    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.details.items.length, 0);
+  });
+
+  it('passes when links have mailto in href attribute', () => {
+    const auditResult = ExternalAnchorsAudit.audit({
+      AnchorsWithNoRelNoopener: [
+        {href: 'mailto:inbox@email.com'},
+        {href: 'MAILTO:INBOX@EMAIL.COM'},
+      ],
+      URL: {finalUrl: URL},
+    });
+    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.details.items.length, 0);
+  });
+
   it('fails when links are from different hosts than the page host', () => {
     const auditResult = ExternalAnchorsAudit.audit({
       AnchorsWithNoRelNoopener: [
@@ -40,42 +64,32 @@ describe('External anchors use rel="noopener"', () => {
     assert.equal(auditResult.details.items.length, 2);
   });
 
-  it('handles links with no href attribute', () => {
+  it('fails when links have no href attribute', () => {
     const auditResult = ExternalAnchorsAudit.audit({
       AnchorsWithNoRelNoopener: [
         {href: ''},
-        {href: 'http://'},
-        {href: 'http:'},
       ],
       URL: {finalUrl: URL},
     });
     assert.equal(auditResult.rawValue, false);
-    assert.equal(auditResult.details.items.length, 3);
-    assert.equal(auditResult.details.items.length, 3);
+    assert.equal(auditResult.details.items.length, 1);
+    assert.equal(auditResult.details.items.length, 1);
     assert.ok(auditResult.debugString, 'includes debugString');
   });
 
-  it('does not fail for links with javascript in href attribute', () => {
+  it('fails when links have href attribute starting with a protocol', () => {
     const auditResult = ExternalAnchorsAudit.audit({
       AnchorsWithNoRelNoopener: [
-        {href: 'javascript:void(0)'},
-        {href: 'JAVASCRIPT:void(0)'},
+        {href: 'http://'},
+        {href: 'http:'},
+        {href: 'https://'},
+        {href: 'https:'},
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, true);
-    assert.equal(auditResult.details.items.length, 0);
-  });
-
-  it('does not fail for links with mailto in href attribute', () => {
-    const auditResult = ExternalAnchorsAudit.audit({
-      AnchorsWithNoRelNoopener: [
-        {href: 'mailto:inbox@email.com'},
-        {href: 'MAILTO:INBOX@EMAIL.COM'},
-      ],
-      URL: {finalUrl: URL},
-    });
-    assert.equal(auditResult.rawValue, true);
-    assert.equal(auditResult.details.items.length, 0);
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.details.items.length, 4);
+    assert.equal(auditResult.details.items.length, 4);
+    assert.ok(auditResult.debugString, 'includes debugString');
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -66,4 +66,16 @@ describe('External anchors use rel="noopener"', () => {
     assert.equal(auditResult.rawValue, true);
     assert.equal(auditResult.details.items.length, 0);
   });
+
+  it('does not fail for links with mailto in href attribute', () => {
+    const auditResult = ExternalAnchorsAudit.audit({
+      AnchorsWithNoRelNoopener: [
+        {href: 'mailto:inbox@email.com'},
+        {href: 'MAILTO:INBOX@EMAIL.COM'},
+      ],
+      URL: {finalUrl: URL},
+    });
+    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.details.items.length, 0);
+  });
 });


### PR DESCRIPTION
Closes #3714 

Only filter anchor links that start with an http protocol for the `rel=noopener` audit.