### PR TITLE
report(a11y): Don't count non-applicable a11y audits toward score

### DIFF
--- a/docs/hacking-tips.md
+++ b/docs/hacking-tips.md
@@ -16,7 +16,7 @@ node --trace-warnings lighthouse-cli http://example.com
 ## Updating fixture dumps
 
 `lighthouse-core/test/results/samples_v2.json` is generated from running LH against
-dbw_tester.html. To update this file, run:
+dbw_tester.html. To update this file, start a local server on port `8080` and serve the directory `lighthouse-cli/test/fixtures`. Then run:
 
 ```sh
 npm run start -- --output=json --output-path=lighthouse-core/test/results/sample_v2.json http://localhost:8080/dobetterweb/dbw_tester.html

--- a/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
@@ -51,22 +51,22 @@ module.exports = [
         score: false,
       },
       'aria-valid-attr': {
-        score: true,
+        notApplicable: true,
       },
       'aria-allowed-attr': {
-        score: true,
+        notApplicable: true,
       },
       'color-contrast': {
         score: true,
       },
       'image-alt': {
-        score: true,
+        notApplicable: true,
       },
       'label': {
-        score: true,
+        notApplicable: true,
       },
       'tabindex': {
-        score: true,
+        notApplicable: true,
       },
       'content-width': {
         score: true,
@@ -114,10 +114,10 @@ module.exports = [
         score: false,
       },
       'aria-valid-attr': {
-        score: true,
+        notApplicable: true,
       },
       'aria-allowed-attr': {
-        score: true,
+        notApplicable: true,
       },
       'color-contrast': {
         score: true,
@@ -126,10 +126,10 @@ module.exports = [
         score: false,
       },
       'label': {
-        score: true,
+        notApplicable: true,
       },
       'tabindex': {
-        score: true,
+        notApplicable: true,
       },
       'content-width': {
         score: true,

--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -28,15 +28,6 @@ class AxeAudit extends Audit {
       return {
         rawValue: false,
         notApplicable: true,
-        extendedInfo: {},
-        details: {
-          type: 'list',
-          header: {
-            type: 'text',
-            text: 'View failing elements',
-          },
-          items: [],
-        },
       };
     }
 

--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -22,27 +22,25 @@ class AxeAudit extends Audit {
     // Indicate if a test is not applicable.
     // This means aXe did not find any nodes which matched these checks.
     // Note in Lighthouse we use the phrasing "Not Applicable" (aXe uses "inapplicable", which sounds weird).
-    const notApplicables = artifacts.Accessibility.inapplicable;
-    if (notApplicables && notApplicables.length) {
-      const isNotApplicable = notApplicables.find(result => result.id === this.meta.name);
-      if (isNotApplicable) {
-        return {
-          rawValue: false,
-          notApplicable: true,
-          extendedInfo: {},
-          details: {
-            type: 'list',
-            header: {
-              type: 'text',
-              text: 'View failing elements',
-            },
-            items: [],
+    const notApplicables = artifacts.Accessibility.notApplicable || [];
+    const isNotApplicable = notApplicables.find(result => result.id === this.meta.name);
+    if (isNotApplicable) {
+      return {
+        rawValue: false,
+        notApplicable: true,
+        extendedInfo: {},
+        details: {
+          type: 'list',
+          header: {
+            type: 'text',
+            text: 'View failing elements',
           },
-        };
-      }
+          items: [],
+        },
+      };
     }
 
-    const violations = artifacts.Accessibility.violations;
+    const violations = artifacts.Accessibility.violations || [];
     const rule = violations.find(result => result.id === this.meta.name);
 
     let nodeDetails = [];

--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -19,6 +19,29 @@ class AxeAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
+    // Indicate if a test is not applicable.
+    // This means aXe did not find any nodes which matched these checks.
+    // Note in Lighthouse we use the phrasing "Not Applicable" (aXe uses "inapplicable", which sounds weird).
+    const notApplicables = artifacts.Accessibility.inapplicable;
+    if (notApplicables && notApplicables.length) {
+      const isNotApplicable = notApplicables.find(result => result.id === this.meta.name);
+      if (isNotApplicable) {
+        return {
+          rawValue: false,
+          notApplicable: true,
+          extendedInfo: {},
+          details: {
+            type: 'list',
+            header: {
+              type: 'text',
+              text: 'View failing elements',
+            },
+            items: [],
+          },
+        };
+      }
+    }
+
     const violations = artifacts.Accessibility.violations;
     const rule = violations.find(result => result.id === this.meta.name);
 

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -156,6 +156,7 @@ class Audit {
       scoringMode: audit.meta.scoringMode || Audit.SCORING_MODES.BINARY,
       informative: audit.meta.informative,
       manual: audit.meta.manual,
+      notApplicable: result.notApplicable,
       name: audit.meta.name,
       description: auditDescription,
       helpText: audit.meta.helpText,

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -43,7 +43,7 @@ function runA11yChecks() {
     }));
 
     // We only need violations, and circular references are possible outside of violations
-    axeResult = {violations: axeResult.violations};
+    axeResult = {violations: axeResult.violations, notApplicable: axeResult.inapplicable};
     return axeResult;
   });
 

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -237,7 +237,7 @@ class CategoryRenderer {
     elements.forEach(function(element) {
       scratch.appendChild(element);
     });
-    const subAudits = scratch.querySelectorAll('.lh-audit-group .lh-audit');
+    const subAudits = scratch.querySelectorAll('.lh-audit');
     if (subAudits.length) {
       return subAudits.length;
     } else {
@@ -266,7 +266,7 @@ class CategoryRenderer {
     const notApplicableElem = this._renderAuditGroup({
       title: `${this._getTotalAuditsLength(elements)} Not Applicable Audits`,
     }, {expandable: true});
-    notApplicableElem.classList.add('lh-passed-audits');
+    notApplicableElem.classList.add('lh-audit-group--notapplicable');
     elements.forEach(elem => notApplicableElem.appendChild(elem));
     return notApplicableElem;
   }
@@ -487,12 +487,10 @@ class CategoryRenderer {
 
       if (audit.result.notApplicable) {
         groups.notApplicable.push(audit);
+      } else if (audit.score === 100) {
+        groups.passed.push(audit);
       } else {
-        if (audit.score === 100) {
-          groups.passed.push(audit);
-        } else {
-          groups.failed.push(audit);
-        }
+        groups.failed.push(audit);
       }
 
       auditsGroupedByGroup[groupId] = groups;
@@ -523,17 +521,15 @@ class CategoryRenderer {
       }
     });
 
-    // don't create a passed section if there are no passed
-    if (!passedElements.length) return element;
+    if (passedElements.length) {
+      const passedElem = this._renderPassedAuditsSection(passedElements);
+      element.appendChild(passedElem);
+    }
 
-    const passedElem = this._renderPassedAuditsSection(passedElements);
-    element.appendChild(passedElem);
-
-    // don't create a not applicable section if there are no not applicables
-    if (!notApplicableElements.length) return element;
-
-    const notApplicableElem = this._renderNotApplicableAuditsSection(notApplicableElements);
-    element.appendChild(notApplicableElem);
+    if (notApplicableElements.length) {
+      const notApplicableElem = this._renderNotApplicableAuditsSection(notApplicableElements);
+      element.appendChild(notApplicableElem);
+    }
 
     // Render manual audits after passing.
     this._renderManualAudits(manualAudits, groupDefinitions, element);

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -183,6 +183,7 @@ if (typeof module !== 'undefined' && module.exports) {
  *       description: string,
  *       informative: boolean,
  *       manual: boolean,
+ *       notApplicable: boolean,
  *       debugString: string,
  *       displayValue: string,
  *       helpText: string,

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -44,26 +44,6 @@ class ReportGeneratorV2 {
     return REPORT_TEMPLATES;
   }
 
-<<<<<<< HEAD
-=======
-  /**
-   * Computes the weighted-average of the score of the list of items.
-   * @param {!Array<{score: number|undefined, weight: number|undefined}>} items
-   * @return {number}
-   */
-  static arithmeticMean(items) {
-    const results = items.reduce((result, item) => {
-      const score = Number(item.score) || 0;
-      const weight = Number(item.weight) || 0;
-      return {
-        weight: result.weight + weight,
-        sum: result.sum + score * weight,
-      };
-    }, {weight: 0, sum: 0});
-
-    return (results.sum / results.weight) || 0;
-  }
->>>>>>> Add non-applicable test reporting for a11y
 
   /**
    * Replaces all the specified strings in source without serial replacements.
@@ -84,47 +64,6 @@ class ReportGeneratorV2 {
         .join(firstReplacement.replacement);
   }
 
-<<<<<<< HEAD
-=======
-  /**
-   * Returns the report JSON object with computed scores.
-   * @param {{categories: !Object<string, {id: string|undefined, weight: number|undefined, audits: !Array<{id: string, weight: number|undefined}>}>}} config
-   * @param {!Object<{score: ?number|boolean|undefined}>} resultsByAuditId
-   * @return {{score: number, categories: !Array<{audits: !Array<{score: number, result: !Object}>}>}}
-   */
-  generateReportJson(config, resultsByAuditId) {
-    const categories = Object.keys(config.categories).map(categoryId => {
-      const category = config.categories[categoryId];
-      category.id = categoryId;
-
-      const audits = category.audits.map(audit => {
-        const result = resultsByAuditId[audit.id];
-        // Cast to number to catch `null` and undefined when audits error
-        let auditScore = Number(result.score) || 0;
-        if (typeof result.score === 'boolean') {
-          auditScore = result.score ? 100 : 0;
-        }
-        // If a result was not applicable, meaning its checks did not run against anything on
-        // the page, force it's weight to 0. It will not count during the arithmeticMean() but
-        // will still be included in the final report json and displayed in the report as
-        // "Not Applicable".
-        if (result.notApplicable) {
-          auditScore = 100;
-          audit.weight = 0;
-          result.informative = true;
-        }
-
-        return Object.assign({}, audit, {result, score: auditScore});
-      });
-
-      const categoryScore = ReportGeneratorV2.arithmeticMean(audits);
-      return Object.assign({}, category, {audits, score: categoryScore});
-    });
-
-    const overallScore = ReportGeneratorV2.arithmeticMean(categories);
-    return {score: overallScore, categories};
-  }
->>>>>>> wip not applicable reporting
 
   /**
    * Returns the report HTML as a string with the report JSON and renderer JS inlined.

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -52,7 +52,6 @@ class ReportGeneratorV2 {
    * @return {number}
    */
   static arithmeticMean(items) {
-    // debugger;
     const results = items.reduce((result, item) => {
       const score = Number(item.score) || 0;
       const weight = Number(item.weight) || 0;
@@ -110,9 +109,9 @@ class ReportGeneratorV2 {
         // will still be included in the final report json and displayed in the report as
         // "Not Applicable".
         if (result.notApplicable) {
+          auditScore = 100;
           audit.weight = 0;
           result.informative = true;
-          auditScore = 100;
         }
 
         return Object.assign({}, audit, {result, score: auditScore});

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -64,6 +64,41 @@ class ReportGeneratorV2 {
         .join(firstReplacement.replacement);
   }
 
+<<<<<<< HEAD
+=======
+  /**
+   * Returns the report JSON object with computed scores.
+   * @param {{categories: !Object<string, {id: string|undefined, weight: number|undefined, audits: !Array<{id: string, weight: number|undefined}>}>}} config
+   * @param {!Object<{score: ?number|boolean|undefined}>} resultsByAuditId
+   * @return {{score: number, categories: !Array<{audits: !Array<{score: number, result: !Object}>}>}}
+   */
+  generateReportJson(config, resultsByAuditId) {
+    const categories = Object.keys(config.categories).map(categoryId => {
+      const category = config.categories[categoryId];
+      category.id = categoryId;
+
+      const audits = category.audits.filter(audit => {
+        const result = resultsByAuditId[audit.id];
+        return !result.notApplicable;
+      }).map(audit => {
+        const result = resultsByAuditId[audit.id];
+        // Cast to number to catch `null` and undefined when audits error
+        let auditScore = Number(result.score) || 0;
+        if (typeof result.score === 'boolean') {
+          auditScore = result.score ? 100 : 0;
+        }
+
+        return Object.assign({}, audit, {result, score: auditScore});
+      });
+
+      const categoryScore = ReportGeneratorV2.arithmeticMean(audits);
+      return Object.assign({}, category, {audits, score: categoryScore});
+    });
+
+    const overallScore = ReportGeneratorV2.arithmeticMean(categories);
+    return {score: overallScore, categories};
+  }
+>>>>>>> wip not applicable reporting
 
   /**
    * Returns the report HTML as a string with the report JSON and renderer JS inlined.

--- a/lighthouse-core/report/v2/report-generator.js
+++ b/lighthouse-core/report/v2/report-generator.js
@@ -44,6 +44,27 @@ class ReportGeneratorV2 {
     return REPORT_TEMPLATES;
   }
 
+<<<<<<< HEAD
+=======
+  /**
+   * Computes the weighted-average of the score of the list of items.
+   * @param {!Array<{score: number|undefined, weight: number|undefined}>} items
+   * @return {number}
+   */
+  static arithmeticMean(items) {
+    // debugger;
+    const results = items.reduce((result, item) => {
+      const score = Number(item.score) || 0;
+      const weight = Number(item.weight) || 0;
+      return {
+        weight: result.weight + weight,
+        sum: result.sum + score * weight,
+      };
+    }, {weight: 0, sum: 0});
+
+    return (results.sum / results.weight) || 0;
+  }
+>>>>>>> Add non-applicable test reporting for a11y
 
   /**
    * Replaces all the specified strings in source without serial replacements.
@@ -77,15 +98,21 @@ class ReportGeneratorV2 {
       const category = config.categories[categoryId];
       category.id = categoryId;
 
-      const audits = category.audits.filter(audit => {
-        const result = resultsByAuditId[audit.id];
-        return !result.notApplicable;
-      }).map(audit => {
+      const audits = category.audits.map(audit => {
         const result = resultsByAuditId[audit.id];
         // Cast to number to catch `null` and undefined when audits error
         let auditScore = Number(result.score) || 0;
         if (typeof result.score === 'boolean') {
           auditScore = result.score ? 100 : 0;
+        }
+        // If a result was not applicable, meaning its checks did not run against anything on
+        // the page, force it's weight to 0. It will not count during the arithmeticMean() but
+        // will still be included in the final report json and displayed in the report as
+        // "Not Applicable".
+        if (result.notApplicable) {
+          audit.weight = 0;
+          result.informative = true;
+          auditScore = 100;
         }
 
         return Object.assign({}, audit, {result, score: auditScore});

--- a/lighthouse-core/scoring.js
+++ b/lighthouse-core/scoring.js
@@ -43,6 +43,15 @@ class ReportScoring {
         if (typeof result.score === 'boolean') {
           auditScore = result.score ? 100 : 0;
         }
+        // If a result was not applicable, meaning its checks did not run against anything on
+        // the page, force it's weight to 0. It will not count during the arithmeticMean() but
+        // will still be included in the final report json and displayed in the report as
+        // "Not Applicable".
+        if (result.notApplicable) {
+          auditScore = 100;
+          audit.weight = 0;
+          result.informative = true;
+        }
 
         return Object.assign({}, audit, {result, score: auditScore});
       });

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -126,6 +126,18 @@ describe('CategoryRenderer', () => {
     assert.ok(!categoryDOM2.querySelector('.lh-audit-group--manual'));
   });
 
+  it('renders not applicable audits if the category contains them', () => {
+    const a11yCategory = sampleResults.reportCategories.find(cat => cat.id === 'accessibility');
+    const categoryDOM = renderer.render(a11yCategory, sampleResults.reportGroups);
+    assert.ok(categoryDOM.querySelector('.lh-audit-group--notapplicable .lh-audit-group__summary'));
+    assert.equal(categoryDOM.querySelectorAll('.lh-score--informative').length, 1,
+        'score shows informative and dash icon');
+
+    const perfCategory = sampleResults.reportCategories.find(cat => cat.id === 'performance');
+    const categoryDOM2 = renderer.render(perfCategory, sampleResults.reportGroups);
+    assert.ok(!categoryDOM2.querySelector('.lh-audit-group--notapplicable'));
+  });
+
   describe('performance category', () => {
     const category = sampleResults.reportCategories.find(cat => cat.id === 'performance');
 
@@ -245,12 +257,13 @@ describe('CategoryRenderer', () => {
 
     it('renders the failed audits grouped by group', () => {
       const categoryDOM = renderer.render(category, sampleResults.reportGroups);
-
-      const failedAudits = category.audits.filter(audit => audit.score !== 100);
+      const failedAudits = category.audits.filter(audit => {
+        return audit.score !== 100 && !audit.result.notApplicable;
+      });
       const failedAuditTags = new Set(failedAudits.map(audit => audit.group));
 
-      const failedAuditGroups = categoryDOM.querySelectorAll('.lh-category > .lh-audit-group');
-      assert.equal(failedAuditGroups.length, failedAuditTags.size+1);
+      const failedAuditGroups = categoryDOM.querySelectorAll('.lh-category > div.lh-audit-group');
+      assert.equal(failedAuditGroups.length, failedAuditTags.size);
     });
 
     it('renders the passed audits grouped by group', () => {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -4964,6 +4964,8 @@
             "score": true,
             "displayValue": "",
             "rawValue": true,
+            "notApplicable": true,
+            "informative": true,
             "extendedInfo": {},
             "scoringMode": "binary",
             "name": "accesskeys",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "zone.js": "^0.7.3"
   },
   "dependencies": {
-    "axe-core": "2.4.1",
+    "axe-core": "2.6.1",
     "chrome-devtools-frontend": "1.0.422034",
     "chrome-launcher": "0.8.1",
     "configstore": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,9 +335,9 @@ aws4@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
 
-axe-core@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.4.1.tgz#55b6ceaa847cb1eaef5d559b6c41035dc3e07dbf"
+axe-core@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.6.1.tgz#28772c4f76966d373acda35b9a409299dc00d1b5"
 
 axios@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
This updates the accessibility report so it no longer counts non-applicable tests toward the user's score. Currently lighthouse gives folks an artificial "boost" to their a11y score because aXe was not filtering out tests which matched 0 nodes. That should be fixed in the next release of aXe (https://github.com/dequelabs/axe-core/pull/637).

This PR also updates how the number of passed/failed/notApplicable audits are reported by counting any grouped audits toward the total. Previously it was just counting the number of groups. So even though we have 35 non-manual a11y audits, it looked like we had far fewer. Here's the new look (note the 12 passed, 15 not applicable):

![image](https://user-images.githubusercontent.com/1066253/33972316-2628cb9e-e032-11e7-869c-adde5951455b.png)
