### PR TITLE
misc(viewer): retain /plots/ when deploying new viewer version

### DIFF
--- a/lighthouse-viewer/gulpfile.js
+++ b/lighthouse-viewer/gulpfile.js
@@ -173,6 +173,7 @@ gulp.task('create-dir-for-gh-pages', () => {
 gulp.task('deploy', cb => {
   runSequence('clean', 'build', 'create-dir-for-gh-pages', function() {
     ghpages.publish(`dist/viewer`, {
+      add: true, // keep existing files (like `./plots/`)
       logger: $.util.log,
     }, err => {
       if (err) {


### PR DESCRIPTION
now we have both:

* https://googlechrome.github.io/lighthouse/plots/
* https://googlechrome.github.io/lighthouse/viewer/ (updated to 2.7.0!)