### PR TITLE
deps: bump js-library-detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "http-link-header": "^0.8.0",
     "inquirer": "^3.3.0",
     "jpeg-js": "0.1.2",
-    "js-library-detector": "^4.0.0",
+    "js-library-detector": "^4.3.1",
     "json-stringify-safe": "5.0.1",
     "lighthouse-logger": "^1.0.0",
     "metaviewport-parser": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,9 +2375,9 @@ jpeg-js@0.1.2, jpeg-js@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
 
-js-library-detector@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-4.0.0.tgz#7ebb02ae20f97ad61e4527b97011c409aec318ba"
+js-library-detector@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-4.3.1.tgz#6d34f55002813bc0a7543deef53faa4e2e79767b"
 
 js-tokens@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
one of the juicier bits we get out of this for HTTPArchive https://github.com/johnmichel/Library-Detector-for-Chrome/pull/102 (better react detection :D)