### PR TITLE
report(categories): performance first, then pwa, then the others

### DIFF
--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -221,7 +221,7 @@ module.exports = {
       description: 'These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).',
     },
     'manual-pwa-checks': {
-      title: 'Manual checks to verify',
+      title: 'Additional items to manually check',
       description: 'These checks are required by the baseline ' +
           '[PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are ' +
           'not automatically checked by Lighthouse. They do not affect your score but it\'s important that you verify them manually.',
@@ -241,27 +241,6 @@ module.exports = {
     },
   },
   categories: {
-    'pwa': {
-      name: 'Progressive Web App',
-      weight: 1,
-      description: 'These checks validate the aspects of a Progressive Web App, as specified by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).',
-      audits: [
-        {id: 'service-worker', weight: 1},
-        {id: 'works-offline', weight: 1},
-        {id: 'without-javascript', weight: 1},
-        {id: 'is-on-https', weight: 1},
-        {id: 'redirects-http', weight: 1},
-        {id: 'load-fast-enough-for-pwa', weight: 1},
-        {id: 'webapp-install-banner', weight: 1},
-        {id: 'splash-screen', weight: 1},
-        {id: 'themed-omnibox', weight: 1},
-        {id: 'viewport', weight: 1},
-        {id: 'content-width', weight: 1},
-        {id: 'pwa-cross-browser', weight: 0, group: 'manual-pwa-checks'},
-        {id: 'pwa-page-transitions', weight: 0, group: 'manual-pwa-checks'},
-        {id: 'pwa-each-page-has-url', weight: 0, group: 'manual-pwa-checks'},
-      ],
-    },
     'performance': {
       name: 'Performance',
       description: 'These encapsulate your app\'s current performance and opportunities to improve it.',
@@ -288,6 +267,27 @@ module.exports = {
         {id: 'bootup-time', weight: 0, group: 'perf-info'},
         {id: 'screenshot-thumbnails', weight: 0},
         {id: 'mainthread-work-breakdown', weight: 0, group: 'perf-info'},
+      ],
+    },
+    'pwa': {
+      name: 'Progressive Web App',
+      weight: 1,
+      description: 'These checks validate the aspects of a Progressive Web App, as specified by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist).',
+      audits: [
+        {id: 'service-worker', weight: 1},
+        {id: 'works-offline', weight: 1},
+        {id: 'without-javascript', weight: 1},
+        {id: 'is-on-https', weight: 1},
+        {id: 'redirects-http', weight: 1},
+        {id: 'load-fast-enough-for-pwa', weight: 1},
+        {id: 'webapp-install-banner', weight: 1},
+        {id: 'splash-screen', weight: 1},
+        {id: 'themed-omnibox', weight: 1},
+        {id: 'viewport', weight: 1},
+        {id: 'content-width', weight: 1},
+        {id: 'pwa-cross-browser', weight: 0, group: 'manual-pwa-checks'},
+        {id: 'pwa-page-transitions', weight: 0, group: 'manual-pwa-checks'},
+        {id: 'pwa-each-page-has-url', weight: 0, group: 'manual-pwa-checks'},
       ],
     },
     'accessibility': {


### PR DESCRIPTION
screenshot:
![image](https://user-images.githubusercontent.com/39191/34184119-f3bba348-e4d2-11e7-97f8-fc55ad07fcb3.png)

fixes #3599

The attached change already fixes's extension's order:
![image](https://user-images.githubusercontent.com/39191/34184212-5bbfa480-e4d3-11e7-8beb-142dcd8efcfc.png)

separately, i'm moving Perf to be first in DevTools' checkboxes. 

----------

Also a driveby fix on PWA's manual audits to match the manual audit text we used for a11y's.

