### PR TITLE
core(dbw response compression): Exclude non binary files from auditing

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -8,95 +8,94 @@
   * @fileoverview Determines optimized gzip/br/deflate filesizes for all responses by
   *   checking the content-encoding header.
   */
-  'use strict';
+'use strict';
 
-  const Gatherer = require('../gatherer');
-  const gzip = require('zlib').gzip;
-  
-  const compressionTypes = ['gzip', 'br', 'deflate'];
-  const mediaTypes = ['mp3', 'wav', 'wma', 'webm', 'jpg', 'gif', 'png', 'webp',
-    'svg', 'mkv', 'flv', 'gif', 'avi', 'mov', 'mpg', '3gp', 'mpeg', 'avi', 'wmv'];
-  
-  const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
-  
-  class ResponseCompression extends Gatherer {
-    /**
+const Gatherer = require('../gatherer');
+const gzip = require('zlib').gzip;
+
+const compressionTypes = ['gzip', 'br', 'deflate'];
+const mediaTypes = ['mp3', 'wav', 'wma', 'webm', 'jpg', 'gif', 'png', 'webp',
+  'svg', 'mkv', 'flv', 'gif', 'avi', 'mov', 'mpg', '3gp', 'mpeg', 'avi', 'wmv'];
+
+const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
+
+class ResponseCompression extends Gatherer {
+  /**
      * @param {!NetworkRecords} networkRecords
      * @return {!Array<{url: string, isBase64DataUri: boolean, mimeType: string, resourceSize: number}>}
      */
-    static filterUnoptimizedResponses(networkRecords) {
-      const unoptimizedResponses = [];
-  
-      networkRecords.forEach(record => {
-        const isTextBasedResource = record.resourceType() && record.resourceType().isTextType();
-        const url = record.url.toLowerCase();
-        let isMediaResource;
-  
-        for (let i = 0; i < mediaTypes.length; i+=1) {
-          if (url.endsWith(mediaTypes[i])) {
-            isMediaResource = true;
-            break;
-          }
+  static filterUnoptimizedResponses(networkRecords) {
+    const unoptimizedResponses = [];
+
+    networkRecords.forEach(record => {
+      const isTextBasedResource = record.resourceType() && record.resourceType().isTextType();
+      const url = record.url.toLowerCase();
+      let isMediaResource;
+
+      for (let i = 0; i < mediaTypes.length; i+=1) {
+        if (url.endsWith(mediaTypes[i])) {
+          isMediaResource = true;
+          break;
         }
-        const isChromeExtensionResource = record.url.startsWith(CHROME_EXTENSION_PROTOCOL);
-  
-        if (!isTextBasedResource || !record.resourceSize || !record.finished ||
+      }
+      const isChromeExtensionResource = record.url.startsWith(CHROME_EXTENSION_PROTOCOL);
+
+      if (!isTextBasedResource || !record.resourceSize || !record.finished ||
           isChromeExtensionResource || !record.transferSize || record.statusCode === 304
           ||isMediaResource) {
-          return;
-        }
-  
-        const isContentEncoded = record.responseHeaders.find(header =>
+        return;
+      }
+
+      const isContentEncoded = record.responseHeaders.find(header =>
           header.name.toLowerCase() === 'content-encoding' &&
           compressionTypes.includes(header.value)
-        );
-  
-        if (!isContentEncoded) {
-          unoptimizedResponses.push({
-            requestId: record.requestId,
-            url: record.url,
-            mimeType: record.mimeType,
-            transferSize: record.transferSize,
-            resourceSize: record.resourceSize,
-          });
+      );
+
+      if (!isContentEncoded) {
+        unoptimizedResponses.push({
+          requestId: record.requestId,
+          url: record.url,
+          mimeType: record.mimeType,
+          transferSize: record.transferSize,
+          resourceSize: record.resourceSize,
+        });
+      }
+    });
+
+    return unoptimizedResponses;
+  }
+
+  afterPass(options, traceData) {
+    const networkRecords = traceData.networkRecords;
+    const textRecords = ResponseCompression.filterUnoptimizedResponses(networkRecords);
+
+    const driver = options.driver;
+    return Promise.all(textRecords.map(record => {
+      const contentPromise = driver.getRequestContent(record.requestId);
+      const timeoutPromise = new Promise(resolve => setTimeout(resolve, 3000));
+      return Promise.race([contentPromise, timeoutPromise]).then(content => {
+        // if we don't have any content gzipSize is set to 0
+        if (!content) {
+          record.gzipSize = 0;
+
+          return record;
         }
-      });
-  
-      return unoptimizedResponses;
-    }
-  
-    afterPass(options, traceData) {
-      const networkRecords = traceData.networkRecords;
-      const textRecords = ResponseCompression.filterUnoptimizedResponses(networkRecords);
-  
-      const driver = options.driver;
-      return Promise.all(textRecords.map(record => {
-        const contentPromise = driver.getRequestContent(record.requestId);
-        const timeoutPromise = new Promise(resolve => setTimeout(resolve, 3000));
-        return Promise.race([contentPromise, timeoutPromise]).then(content => {
-          // if we don't have any content gzipSize is set to 0
-          if (!content) {
-            record.gzipSize = 0;
-  
-            return record;
-          }
-  
-          return new Promise((resolve, reject) => {
-            return gzip(content, (err, res) => {
-              if (err) {
-                return reject(err);
-              }
-  
-              // get gzip size
-              record.gzipSize = Buffer.byteLength(res, 'utf8');
-  
-              resolve(record);
-            });
+
+        return new Promise((resolve, reject) => {
+          return gzip(content, (err, res) => {
+            if (err) {
+              return reject(err);
+            }
+
+            // get gzip size
+            record.gzipSize = Buffer.byteLength(res, 'utf8');
+
+            resolve(record);
           });
         });
-      }));
-    }
+      });
+    }));
   }
-  
-  module.exports = ResponseCompression;
-  
+}
+
+module.exports = ResponseCompression;

--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -19,9 +19,9 @@ const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
 
 class ResponseCompression extends Gatherer {
   /**
-     * @param {!NetworkRecords} networkRecords
-     * @return {!Array<{url: string, isBase64DataUri: boolean, mimeType: string, resourceSize: number}>}
-     */
+   * @param {!NetworkRecords} networkRecords
+   * @return {!Array<{url: string, isBase64DataUri: boolean, mimeType: string, resourceSize: number}>}
+   */
   static filterUnoptimizedResponses(networkRecords) {
     const unoptimizedResponses = [];
 
@@ -33,13 +33,13 @@ class ResponseCompression extends Gatherer {
       const isChromeExtensionResource = record.url.startsWith(CHROME_EXTENSION_PROTOCOL);
 
       if (!isTextBasedResource || !record.resourceSize || !record.finished ||
-          isChromeExtensionResource || !record.transferSize || record.statusCode === 304) {
+        isChromeExtensionResource || !record.transferSize || record.statusCode === 304) {
         return;
       }
 
       const isContentEncoded = record.responseHeaders.find(header =>
-          header.name.toLowerCase() === 'content-encoding' &&
-          compressionTypes.includes(header.value)
+        header.name.toLowerCase() === 'content-encoding' &&
+        compressionTypes.includes(header.value)
       );
 
       if (!isContentEncoded) {

--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -8,84 +8,85 @@
   * @fileoverview Determines optimized gzip/br/deflate filesizes for all responses by
   *   checking the content-encoding header.
   */
-  'use strict';
+'use strict';
 
-  const Gatherer = require('../gatherer');
-  const gzip = require('zlib').gzip;
-  
-  const compressionTypes = ['gzip', 'br', 'deflate'];
-  const binaryMimeTypes = ['image', 'audio', 'video'];
-  const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
-  
-  class ResponseCompression extends Gatherer {
-    /**
+const Gatherer = require('../gatherer');
+const gzip = require('zlib').gzip;
+
+const compressionTypes = ['gzip', 'br', 'deflate'];
+const binaryMimeTypes = ['image', 'audio', 'video'];
+const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
+
+class ResponseCompression extends Gatherer {
+  /**
      * @param {!NetworkRecords} networkRecords
      * @return {!Array<{url: string, isBase64DataUri: boolean, mimeType: string, resourceSize: number}>}
      */
-    static filterUnoptimizedResponses(networkRecords) {
-      const unoptimizedResponses = [];
-  
-      networkRecords.forEach(record => {
-        const isBinaryResource = record.mimeType && binaryMimeTypes.some(mimeType => record.mimeType.startsWith(mimeType));
-        const isTextBasedResource = !isBinaryResource && record.resourceType() && record.resourceType().isTextType();
-        const isChromeExtensionResource = record.url.startsWith(CHROME_EXTENSION_PROTOCOL);
-  
-        if (!isTextBasedResource || !record.resourceSize || !record.finished ||
+  static filterUnoptimizedResponses(networkRecords) {
+    const unoptimizedResponses = [];
+
+    networkRecords.forEach(record => {
+      const isBinaryResource = record.mimeType &&
+      binaryMimeTypes.some(mimeType => record.mimeType.startsWith(mimeType));
+      const isTextBasedResource = !isBinaryResource && record.resourceType() &&
+      record.resourceType().isTextType();
+      const isChromeExtensionResource = record.url.startsWith(CHROME_EXTENSION_PROTOCOL);
+
+      if (!isTextBasedResource || !record.resourceSize || !record.finished ||
           isChromeExtensionResource || !record.transferSize || record.statusCode === 304) {
-          return;
-        }
-  
-        const isContentEncoded = record.responseHeaders.find(header =>
+        return;
+      }
+
+      const isContentEncoded = record.responseHeaders.find(header =>
           header.name.toLowerCase() === 'content-encoding' &&
           compressionTypes.includes(header.value)
-        );
-  
-        if (!isContentEncoded) {
-          unoptimizedResponses.push({
-            requestId: record.requestId,
-            url: record.url,
-            mimeType: record.mimeType,
-            transferSize: record.transferSize,
-            resourceSize: record.resourceSize,
-          });
+      );
+
+      if (!isContentEncoded) {
+        unoptimizedResponses.push({
+          requestId: record.requestId,
+          url: record.url,
+          mimeType: record.mimeType,
+          transferSize: record.transferSize,
+          resourceSize: record.resourceSize,
+        });
+      }
+    });
+
+    return unoptimizedResponses;
+  }
+
+  afterPass(options, traceData) {
+    const networkRecords = traceData.networkRecords;
+    const textRecords = ResponseCompression.filterUnoptimizedResponses(networkRecords);
+
+    const driver = options.driver;
+    return Promise.all(textRecords.map(record => {
+      const contentPromise = driver.getRequestContent(record.requestId);
+      const timeoutPromise = new Promise(resolve => setTimeout(resolve, 3000));
+      return Promise.race([contentPromise, timeoutPromise]).then(content => {
+        // if we don't have any content gzipSize is set to 0
+        if (!content) {
+          record.gzipSize = 0;
+
+          return record;
         }
-      });
-  
-      return unoptimizedResponses;
-    }
-  
-    afterPass(options, traceData) {
-      const networkRecords = traceData.networkRecords;
-      const textRecords = ResponseCompression.filterUnoptimizedResponses(networkRecords);
-  
-      const driver = options.driver;
-      return Promise.all(textRecords.map(record => {
-        const contentPromise = driver.getRequestContent(record.requestId);
-        const timeoutPromise = new Promise(resolve => setTimeout(resolve, 3000));
-        return Promise.race([contentPromise, timeoutPromise]).then(content => {
-          // if we don't have any content gzipSize is set to 0
-          if (!content) {
-            record.gzipSize = 0;
-  
-            return record;
-          }
-  
-          return new Promise((resolve, reject) => {
-            return gzip(content, (err, res) => {
-              if (err) {
-                return reject(err);
-              }
-  
-              // get gzip size
-              record.gzipSize = Buffer.byteLength(res, 'utf8');
-  
-              resolve(record);
-            });
+
+        return new Promise((resolve, reject) => {
+          return gzip(content, (err, res) => {
+            if (err) {
+              return reject(err);
+            }
+
+            // get gzip size
+            record.gzipSize = Buffer.byteLength(res, 'utf8');
+
+            resolve(record);
           });
         });
-      }));
-    }
+      });
+    }));
   }
-  
-  module.exports = ResponseCompression;
-  
+}
+
+module.exports = ResponseCompression;

--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -26,10 +26,11 @@ class ResponseCompression extends Gatherer {
     const unoptimizedResponses = [];
 
     networkRecords.forEach(record => {
-      const isBinaryResource = record.mimeType &&
-      binaryMimeTypes.some(mimeType => record.mimeType.startsWith(mimeType));
-      const isTextBasedResource = !isBinaryResource && record.resourceType() &&
-      record.resourceType().isTextType();
+      const mimeType = record.mimeType;
+      const resourceType = record.resourceType();
+
+      const isBinaryResource = mimeType && binaryMimeTypes.some(type => mimeType.startsWith(type));
+      const isTextBasedResource = !isBinaryResource && resourceType && resourceType.isTextType();
       const isChromeExtensionResource = record.url.startsWith(CHROME_EXTENSION_PROTOCOL);
 
       if (!isTextBasedResource || !record.resourceSize || !record.finished ||

--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -8,81 +8,95 @@
   * @fileoverview Determines optimized gzip/br/deflate filesizes for all responses by
   *   checking the content-encoding header.
   */
-'use strict';
+  'use strict';
 
-const Gatherer = require('../gatherer');
-const gzip = require('zlib').gzip;
-
-const compressionTypes = ['gzip', 'br', 'deflate'];
-const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
-
-class ResponseCompression extends Gatherer {
-  /**
-   * @param {!NetworkRecords} networkRecords
-   * @return {!Array<{url: string, isBase64DataUri: boolean, mimeType: string, resourceSize: number}>}
-   */
-  static filterUnoptimizedResponses(networkRecords) {
-    const unoptimizedResponses = [];
-
-    networkRecords.forEach(record => {
-      const isTextBasedResource = record.resourceType() && record.resourceType().isTextType();
-      const isChromeExtensionResource = record.url.startsWith(CHROME_EXTENSION_PROTOCOL);
-
-      if (!isTextBasedResource || !record.resourceSize || !record.finished ||
-        isChromeExtensionResource || !record.transferSize || record.statusCode === 304) {
-        return;
-      }
-
-      const isContentEncoded = record.responseHeaders.find(header =>
-        header.name.toLowerCase() === 'content-encoding' &&
-        compressionTypes.includes(header.value)
-      );
-
-      if (!isContentEncoded) {
-        unoptimizedResponses.push({
-          requestId: record.requestId,
-          url: record.url,
-          mimeType: record.mimeType,
-          transferSize: record.transferSize,
-          resourceSize: record.resourceSize,
-        });
-      }
-    });
-
-    return unoptimizedResponses;
-  }
-
-  afterPass(options, traceData) {
-    const networkRecords = traceData.networkRecords;
-    const textRecords = ResponseCompression.filterUnoptimizedResponses(networkRecords);
-
-    const driver = options.driver;
-    return Promise.all(textRecords.map(record => {
-      const contentPromise = driver.getRequestContent(record.requestId);
-      const timeoutPromise = new Promise(resolve => setTimeout(resolve, 3000));
-      return Promise.race([contentPromise, timeoutPromise]).then(content => {
-        // if we don't have any content gzipSize is set to 0
-        if (!content) {
-          record.gzipSize = 0;
-
-          return record;
+  const Gatherer = require('../gatherer');
+  const gzip = require('zlib').gzip;
+  
+  const compressionTypes = ['gzip', 'br', 'deflate'];
+  const mediaTypes = ['mp3', 'wav', 'wma', 'webm', 'jpg', 'gif', 'png', 'webp',
+    'svg', 'mkv', 'flv', 'gif', 'avi', 'mov', 'mpg', '3gp', 'mpeg', 'avi', 'wmv'];
+  
+  const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
+  
+  class ResponseCompression extends Gatherer {
+    /**
+     * @param {!NetworkRecords} networkRecords
+     * @return {!Array<{url: string, isBase64DataUri: boolean, mimeType: string, resourceSize: number}>}
+     */
+    static filterUnoptimizedResponses(networkRecords) {
+      const unoptimizedResponses = [];
+  
+      networkRecords.forEach(record => {
+        const isTextBasedResource = record.resourceType() && record.resourceType().isTextType();
+        const url = record.url.toLowerCase();
+        let isMediaResource;
+  
+        for (let i = 0; i < mediaTypes.length; i+=1) {
+          if (url.endsWith(mediaTypes[i])) {
+            isMediaResource = true;
+            break;
+          }
         }
-
-        return new Promise((resolve, reject) => {
-          return gzip(content, (err, res) => {
-            if (err) {
-              return reject(err);
-            }
-
-            // get gzip size
-            record.gzipSize = Buffer.byteLength(res, 'utf8');
-
-            resolve(record);
+        const isChromeExtensionResource = record.url.startsWith(CHROME_EXTENSION_PROTOCOL);
+  
+        if (!isTextBasedResource || !record.resourceSize || !record.finished ||
+          isChromeExtensionResource || !record.transferSize || record.statusCode === 304
+          ||isMediaResource) {
+          return;
+        }
+  
+        const isContentEncoded = record.responseHeaders.find(header =>
+          header.name.toLowerCase() === 'content-encoding' &&
+          compressionTypes.includes(header.value)
+        );
+  
+        if (!isContentEncoded) {
+          unoptimizedResponses.push({
+            requestId: record.requestId,
+            url: record.url,
+            mimeType: record.mimeType,
+            transferSize: record.transferSize,
+            resourceSize: record.resourceSize,
+          });
+        }
+      });
+  
+      return unoptimizedResponses;
+    }
+  
+    afterPass(options, traceData) {
+      const networkRecords = traceData.networkRecords;
+      const textRecords = ResponseCompression.filterUnoptimizedResponses(networkRecords);
+  
+      const driver = options.driver;
+      return Promise.all(textRecords.map(record => {
+        const contentPromise = driver.getRequestContent(record.requestId);
+        const timeoutPromise = new Promise(resolve => setTimeout(resolve, 3000));
+        return Promise.race([contentPromise, timeoutPromise]).then(content => {
+          // if we don't have any content gzipSize is set to 0
+          if (!content) {
+            record.gzipSize = 0;
+  
+            return record;
+          }
+  
+          return new Promise((resolve, reject) => {
+            return gzip(content, (err, res) => {
+              if (err) {
+                return reject(err);
+              }
+  
+              // get gzip size
+              record.gzipSize = Buffer.byteLength(res, 'utf8');
+  
+              resolve(record);
+            });
           });
         });
-      });
-    }));
+      }));
+    }
   }
-}
-
-module.exports = ResponseCompression;
+  
+  module.exports = ResponseCompression;
+  

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/response-compression-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/response-compression-test.js
@@ -65,7 +65,7 @@ const traceData = {
       _url: 'http://google.com/index.json',
       _statusCode: 304, // ignore for being a cache not modified response
       _mimeType: 'application/json',
-      _requestId: 2,
+      _requestId: 22,
       _resourceSize: 7,
       _transferSize: 7,
       _resourceType: {
@@ -79,7 +79,7 @@ const traceData = {
       _url: 'http://google.com/other.json',
       _statusCode: 200,
       _mimeType: 'application/json',
-      _requestId: 2,
+      _requestId: 23,
       _resourceSize: 7,
       _transferSize: 8,
       _resourceType: {
@@ -92,7 +92,7 @@ const traceData = {
     {
       _url: 'http://google.com/index.jpg',
       _statusCode: 200,
-      _mimeType: 'images/jpg',
+      _mimeType: 'image/jpg',
       _requestId: 3,
       _resourceSize: 10,
       _transferSize: 10,
@@ -101,6 +101,20 @@ const traceData = {
       },
       _responseHeaders: [],
       content: 'aaaaaaaaaa',
+      finished: true,
+    },
+    {
+      _url: 'http://google.com/helloworld.mp4',
+      _statusCode: 200,
+      _mimeType: 'video/mp4',
+      _requestId: 4,
+      _resourceSize: 100,
+      _transferSize: 100,
+      _resourceType: {
+        _isTextType: false,
+      },
+      _responseHeaders: [],
+      content: 'bbbbbbbb',
       finished: true,
     },
   ],


### PR DESCRIPTION
I have followed the recommended approach but I am wondering if there is a better way to know the type of the file and if the extensions I added are enough and if not what can I refer to in order to get a full list of extensions.
#4039