### PR TITLE
core(trace-of-tab): throw error when TracingStartedInPage event is missing

### DIFF
--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -51,6 +51,7 @@ class TraceOfTab extends ComputedArtifact {
     // The first TracingStartedInPage in the trace is definitely our renderer thread of interest
     // Beware: the tracingStartedInPage event can appear slightly after a navigationStart
     const startedInPageEvt = keyEvents.find(e => e.name === 'TracingStartedInPage');
+    if (!startedInPageEvt) throw new Error('TracingStartedInPage was not found in the trace');
     // Filter to just events matching the frame ID for sanity
     const frameEvents = keyEvents.filter(e => e.args.frame === startedInPageEvt.args.data.page);
 


### PR DESCRIPTION
@patrickhulce: Add the error message when TracingStartedInPage event is missing. Otherwise the error message would be: Cannot read property 'args' of undefined.

PTAL.

