### PR TITLE
cli: remove legacy domhtml output

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -74,11 +74,8 @@ function getFlags(manualArgv) {
             'Additional categories to capture with the trace (comma-delimited).',
         'config-path': 'The path to the config JSON.',
         'chrome-flags':
-            `Custom flags to pass to Chrome (space-delimited). For a full list of flags, see http://peter.sh/experiments/chromium-command-line-switches/.
-
-            Environment variables:
-            CHROME_PATH: Explicit path of intended Chrome binary. If set must point to an executable of a build of Chromium version 54.0 or later. By default, any detected Chrome Canary or Chrome (stable) will be launched.
-            `,
+            `Custom flags to pass to Chrome (space-delimited). For a full list of flags, see http://bit.ly/chrome-flags
+            Additionally, use the CHROME_PATH environment variable to use a specific Chrome binary. Requires Chromium version 54.0 or later. If omitted, any detected Chrome Canary or Chrome stable will be used.`,
         'perf': 'Use a performance-test-only configuration',
         'hostname': 'The hostname to use for the debugging protocol.',
         'port': 'The port to use for the debugging protocol. Use 0 for a random port',
@@ -110,7 +107,7 @@ function getFlags(manualArgv) {
       // default values
       .default('chrome-flags', '')
       .default('disable-cpu-throttling', false)
-      .default('output', 'domhtml')
+      .default('output', 'html')
       .default('port', 0)
       .default('hostname', 'localhost')
       .default('max-wait-for-load', Driver.MAX_WAIT_FOR_FULLY_LOADED)

--- a/lighthouse-cli/printer.js
+++ b/lighthouse-cli/printer.js
@@ -13,12 +13,10 @@ const log = require('lighthouse-logger');
  * An enumeration of acceptable output modes:
  *   'json': JSON formatted results
  *   'html': An HTML report
- *   'domhtml': Alias for 'html' report
  */
 const OutputMode = {
   json: 'json',
   html: 'html',
-  domhtml: 'domhtml',
 };
 
 /**
@@ -42,7 +40,7 @@ function checkOutputPath(path) {
  */
 function createOutput(results, outputMode) {
   // HTML report.
-  if (outputMode === OutputMode.domhtml || outputMode === OutputMode.html) {
+  if (outputMode === OutputMode.html) {
     return new ReportGenerator().generateReportHtml(results);
   }
   // JSON report.

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -128,17 +128,16 @@ function saveResults(results, artifacts, flags) {
   return promise.then(_ => {
     if (Array.isArray(flags.output)) {
       return flags.output.reduce((innerPromise, outputType) => {
-        const extension = outputType === 'domhtml' ? 'html' : outputType;
+        const extension = outputType;
         const outputPath = `${resolvedPath}.report.${extension}`;
         return innerPromise.then(() => Printer.write(results, outputType, outputPath));
       }, Promise.resolve());
     } else {
-      const extension = flags.output === 'domhtml' ? 'html' : flags.output;
+      const extension = flags.output;
       const outputPath =
           flags.outputPath || `${resolvedPath}.report.${extension}`;
       return Printer.write(results, flags.output, outputPath).then(_ => {
-        if (flags.output === Printer.OutputMode[Printer.OutputMode.html] ||
-            flags.output === Printer.OutputMode[Printer.OutputMode.domhtml]) {
+        if (flags.output === Printer.OutputMode[Printer.OutputMode.html]) {
           if (flags.view) {
             opn(outputPath, {wait: false});
           } else {


### PR DESCRIPTION
This was still hanging around. We can nuke it nowadays.