### PR TITLE
tests(travis): test on Node 9, drop testing on Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 matrix:
   include:
     - node_js: "6.9.1"
-    - node_js: "7"
     - node_js: "8"
+    - node_js: "9"
 dist: trusty
 env:
   global:


### PR DESCRIPTION
yarn started issuing this warning for node 7:

> warning You are using Node "7.10.1" which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: "^4.8.0 || ^5.7.0 || ^6.2.2 || >=8.0.0"

seems like a good time to cover our bases on 9. 