### PR TITLE
docs(results): describe audit result's notApplicable/error properties

### DIFF
--- a/docs/understanding-results.md
+++ b/docs/understanding-results.md
@@ -53,6 +53,7 @@ An object containing the results of the audits, keyed by their name.
 | description | `string` | The brief description of the audit's successful state. |
 | helpText | `string` | A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit, markdown links supported. |
 | debugString | <code>string&#124;undefined</code> | A string indicating some additional information to the user explaining an unusual circumstance or reason for failure. |
+| error | `boolean` | Set to true if there was an an exception thrown within the audit. The error message will be in `debugString`.
 | rawValue | <code>boolean&#124;number</code> | The unscored value determined by the audit. Typically this will match the score if there's no additional information to impart. For performance audits, this value is typically a number indicating the metric value. |
 | displayValue | `string` | The string to display in the report alongside audit results. If empty, nothing additional is shown. This is typically used to explain additional information such as the number and nature of failing items. |
 | score | <code>boolean&#124;number</code> | The scored value determined by the audit as either boolean or a number `0-100`. If the audit is a boolean, the implication is `score ? 100 : 0`. |
@@ -61,6 +62,8 @@ An object containing the results of the audits, keyed by their name.
 | extendedInfo | `Object` | Extra information found by the audit. The structure of this object varies from audit to audit and is generally for programmatic consumption and debugging, though there is typically overlap with `details`. *WARNING: The structure of this object is not stable and cannot be trusted to follow semver* |
 | manual | `boolean` | Indicator used for display that the audit does not have results and is a placeholder for the user to conduct manual testing. |
 | informative | `boolean` | Indicator used for display that the audit is intended to be informative only. It cannot be passed or failed. |
+| notApplicable | `boolean` | Indicator used for display that the audit doesn't apply to the page. (e.g. A images audit on a page without images). |
+
 
 ### Example
 ```json


### PR DESCRIPTION
  little bit of followup on #4052 ;)

cc @robdodson 