### PR TITLE
core(errors-in-console): If exception info is not present use exception text

### DIFF
--- a/lighthouse-core/audits/errors-in-console.js
+++ b/lighthouse-core/audits/errors-in-console.js
@@ -47,9 +47,12 @@ class ErrorLogs extends Audit {
     const runtimeExRows =
       runtimeExceptions.filter(entry => entry.exceptionDetails !== undefined)
       .map(entry => {
+        const description = entry.exceptionDetails.exception ?
+          entry.exceptionDetails.exception.description : entry.exceptionDetails.text;
+
         return {
           source: 'Runtime.exception',
-          description: entry.exceptionDetails.exception.description,
+          description,
           url: entry.exceptionDetails.url,
         };
       });

--- a/lighthouse-core/test/audits/errors-in-console-test.js
+++ b/lighthouse-core/test/audits/errors-in-console-test.js
@@ -147,9 +147,7 @@ describe('Console error logs audit', () => {
     assert.equal(auditResult.rawValue, 1);
     assert.equal(auditResult.score, false);
     assert.equal(auditResult.details.items.length, 1);
-    // url is undefined
     assert.strictEqual(auditResult.details.items[0][0].text, 'http://example.com/fancybox.js');
-    // text is undefined
     assert.strictEqual(auditResult.details.items[0][1].text,
       'TypeError: Cannot read property \'msie\' of undefined');
   });

--- a/lighthouse-core/test/audits/errors-in-console-test.js
+++ b/lighthouse-core/test/audits/errors-in-console-test.js
@@ -121,4 +121,36 @@ describe('Console error logs audit', () => {
     // text is undefined
     assert.strictEqual(auditResult.details.items[0][1].text, undefined);
   });
+
+  // Checks bug #4188
+  it('handle the case when exception info is not present', () => {
+    const auditResult = ErrorLogsAudit.audit({
+      ChromeConsoleMessages: [],
+      RuntimeExceptions: [{
+        'timestamp': 1506535813608.003,
+        'exceptionDetails': {
+          'url': 'http://example.com/fancybox.js',
+          'text': 'TypeError: Cannot read property \'msie\' of undefined',
+          'stackTrace': {
+            'callFrames': [
+              {
+                'url': 'http://example.com/fancybox.js',
+                'lineNumber': 28,
+                'columnNumber': 20,
+              },
+            ],
+          },
+          'executionContextId': 3,
+        },
+      }],
+    });
+    assert.equal(auditResult.rawValue, 1);
+    assert.equal(auditResult.score, false);
+    assert.equal(auditResult.details.items.length, 1);
+    // url is undefined
+    assert.strictEqual(auditResult.details.items[0][0].text, 'http://example.com/fancybox.js');
+    // text is undefined
+    assert.strictEqual(auditResult.details.items[0][1].text,
+      'TypeError: Cannot read property \'msie\' of undefined');
+  });
 });


### PR DESCRIPTION
Fixes #4188 

when looking at the [devtools protocol](https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#type-ExceptionDetails). Exeption is an optional property, when not present we should use text.

I also added an extra test to cover this case.