### PR TITLE
deps(chrome-launcher): Upgrade chrome-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,14 +73,14 @@
     "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
     "npm-run-posix-or-windows": "^2.0.2",
-    "typescript": "^2.6.1",
     "sinon": "^2.3.5",
+    "typescript": "^2.6.1",
     "zone.js": "^0.7.3"
   },
   "dependencies": {
     "axe-core": "2.6.1",
     "chrome-devtools-frontend": "1.0.422034",
-    "chrome-launcher": "0.8.1",
+    "chrome-launcher": "^0.10.1",
     "configstore": "^3.1.1",
     "devtools-timeline-model": "1.1.6",
     "esprima": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "axe-core": "2.6.1",
     "chrome-devtools-frontend": "1.0.422034",
-    "chrome-launcher": "^0.10.1",
+    "chrome-launcher": "^0.10.2",
     "configstore": "^3.1.1",
     "devtools-timeline-model": "1.1.6",
     "esprima": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,7 +21,7 @@
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
 
-"@types/node@*", "@types/node@6.0.66":
+"@types/node@*", "@types/node@^9.3.0":
   version "8.0.49"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.49.tgz#417f86ab4829c629fe561779ee48751e0fe2a11b"
 
@@ -656,13 +656,13 @@ chrome-devtools-frontend@1.0.422034:
   version "1.0.422034"
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.422034.tgz#071c8ce14466b7653032fcd1ad1a4a68d5e3cbd9"
 
-chrome-launcher@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.10.1.tgz#70a8ba330f1cc831688c157baf6a7b4d794efb4b"
+chrome-launcher@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.10.2.tgz#f7d860ddec627b6f01015736b5ae1e33b3d165b1"
   dependencies:
     "@types/core-js" "^0.9.41"
     "@types/mkdirp" "^0.3.29"
-    "@types/node" "6.0.66"
+    "@types/node" "^9.3.0"
     "@types/rimraf" "^0.0.28"
     is-wsl "^1.1.0"
     lighthouse-logger "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -656,9 +656,9 @@ chrome-devtools-frontend@1.0.422034:
   version "1.0.422034"
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.422034.tgz#071c8ce14466b7653032fcd1ad1a4a68d5e3cbd9"
 
-chrome-launcher@0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.8.1.tgz#e275b738376d294b3228dc32caf3ed7ee0405e57"
+chrome-launcher@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.10.1.tgz#70a8ba330f1cc831688c157baf6a7b4d794efb4b"
   dependencies:
     "@types/core-js" "^0.9.41"
     "@types/mkdirp" "^0.3.29"


### PR DESCRIPTION
Upgrade chrome-launcher to 0.10.1.

I wasn't sure why chrome-launcher does not have a `^` in package.json so feel free to decline this PR.