### PR TITLE
core(font-size): make font size artifact serializable

### DIFF
--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -12,8 +12,8 @@ const CSSStyleDeclaration = require('../../lib/web-inspector').CSSStyleDeclarati
 const MINIMAL_PERCENTAGE_OF_LEGIBLE_TEXT = 75;
 
 /**
- * @param {Array<{cssRule: WebInspector.CSSStyleDeclaration, fontSize: number, textLength: number, node: Node}>} fontSizeArtifact
- * @returns {Array<{cssRule: WebInspector.CSSStyleDeclaration, fontSize: number, textLength: number, node: Node}>}
+ * @param {Array<{cssRule: SimplifiedStyleDeclaration, fontSize: number, textLength: number, node: Node}>} fontSizeArtifact
+ * @returns {Array<{cssRule: SimplifiedStyleDeclaration, fontSize: number, textLength: number, node: Node}>}
  */
 function getUniqueFailingRules(fontSizeArtifact) {
   const failingRules = new Map();
@@ -91,7 +91,7 @@ function nodeToTableNode(node) {
 
 /**
  * @param {string} baseURL
- * @param {WebInspector.CSSStyleDeclaration} styleDeclaration
+ * @param {SimplifiedStyleDeclaration} styleDeclaration
  * @param {Node} node
  * @returns {{source:!string, selector:string|object}}
  */
@@ -154,7 +154,7 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
 }
 
 /**
- * @param {WebInspector.CSSStyleDeclaration} styleDeclaration
+ * @param {SimplifiedStyleDeclaration} styleDeclaration
  * @param {Node} node
  * @return string
  */

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -190,7 +190,20 @@ class FontSize extends Gatherer {
           .map(info =>
             getFontSizeSourceRule(options.driver, info.node)
               .then(sourceRule => {
-                info.cssRule = sourceRule;
+                if (sourceRule) {
+                  info.cssRule = {
+                    type: sourceRule.type,
+                    range: sourceRule.range,
+                    styleSheetId: sourceRule.styleSheetId,
+                  };
+
+                  if (sourceRule.parentRule) {
+                    info.cssRule.parentRule = {
+                      origin: sourceRule.parentRule.origin,
+                      selectors: sourceRule.parentRule.selectors,
+                    };
+                  }
+                }
                 return info;
               })
           )

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -150,7 +150,7 @@ function isNonEmptyTextNode(node) {
 class FontSize extends Gatherer {
   /**
    * @param {{driver: !Object}} options Run options
-   * @return {!Promise<{totalTextLength: number, failingTextLength: number, visitedTextLength: number, analyzedFailingTextLength: number, analyzedFailingNodesData: Array<{fontSize: number, textLength: number, node: Node, cssRule: WebInspector.CSSStyleDeclaration}>}>} font-size analysis
+   * @return {!Promise<{totalTextLength: number, failingTextLength: number, visitedTextLength: number, analyzedFailingTextLength: number, analyzedFailingNodesData: Array<{fontSize: number, textLength: number, node: Node, cssRule: SimplifiedStyleDeclaration}>}>} font-size analysis
    */
   afterPass(options) {
     const stylesheets = new Map();
@@ -235,3 +235,12 @@ class FontSize extends Gatherer {
 
 module.exports = FontSize;
 
+/**
+ * Simplified, for serializability sake, WebInspector.CSSStyleDeclaration
+ * @typedef {Object} SimplifiedStyleDeclaration
+ * @property {string} type
+ * @property {{startLine: number, startColumn: number}} range
+ * @property {{origin: string, selectors: Array<{text: string}>}} parentRule
+ * @property {string} styleSheetId
+ * @property {WebInspector.CSSStyleSheetHeader} stylesheet
+ */

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -78,7 +78,6 @@ describe('Font size gatherer', () => {
         visitedTextLength: expectedVisitedTextLength,
         totalTextLength: expectedTotalTextLength,
         analyzedFailingNodesData: [{
-          cssRule: undefined,
           fontSize: 10,
           node: bodyNode,
           textLength: expectedFailingTextLength,


### PR DESCRIPTION
Fixes #4184

`WebInspector.CSSStyleDeclaration`s have circular structure making them non-serializable.

I created `SimplifiedStyleDeclaration` type definition to make jsdoc comments more readable.