### PR TITLE
report: Update vulnerability links

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -91,7 +91,7 @@ class NoVulnerableLibrariesAudit extends Audit {
       return vulns;
     }
 
-    lib.pkgLink = `https://snyk.io/vuln/npm:${lib.npmPkgName}#lh@${lib.version}`;
+    lib.pkgLink = `https://snyk.io/vuln/npm:${lib.npmPkgName}?lh@${lib.version}`;
     const snykInfo = snykDB.npm[lib.npmPkgName];
     snykInfo.forEach(vuln => {
       if (semver.satisfies(lib.version, vuln.semver.vulnerable[0])) {

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -39,7 +39,7 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
     assert.equal(auditResult.extendedInfo.jsLibs.length, 3);
     assert.equal(auditResult.details.items[0][2].text, 'High');
     assert.equal(auditResult.details.items[0][0].text, 'angular@1.1.4');
-    assert.equal(auditResult.details.items[0][0].url, 'https://snyk.io/vuln/npm:angular#lh@1.1.4');
+    assert.equal(auditResult.details.items[0][0].url, 'https://snyk.io/vuln/npm:angular?lh@1.1.4');
   });
 
   it('handles ill-specified versions', () => {


### PR DESCRIPTION
Quick change to vulnerability links so that Snyk can serve up a version of the vuln pages with information specific to the versions Lighthouse found.