### PR TITLE
cli(lifecycle): introduce report-only runs

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -55,6 +55,7 @@ function getFlags(manualArgv) {
           'save-assets', 'list-all-audits', 'list-trace-categories',
           'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port',
           'hostname', 'max-wait-for-load', 'enable-error-reporting', 'gather-mode', 'audit-mode',
+          'report-mode',
         ],
         'Configuration:')
       .describe({
@@ -69,6 +70,7 @@ function getFlags(manualArgv) {
         'gather-mode':
             'Collect artifacts from a connected browser and save to disk. If audit-mode is not also enabled, the run will quit early.',
         'audit-mode': 'Process saved artifacts from disk',
+        'report-mode': 'Generate report from saved Lighthouse results file',
         'save-assets': 'Save the trace contents & screenshots to disk',
         'list-all-audits': 'Prints a list of all available audits and exits',
         'list-trace-categories': 'Prints a list of all required trace categories and exits',
@@ -85,7 +87,7 @@ function getFlags(manualArgv) {
             'The timeout (in milliseconds) to wait before the page is considered done loading and the run should continue. WARNING: Very high values can lead to large traces and instability',
       })
       // set aliases
-      .alias({'gather-mode': 'G', 'audit-mode': 'A'})
+      .alias({'gather-mode': 'G', 'audit-mode': 'A', 'report-mode': 'R'})
 
       .group(['output', 'output-path', 'view'], 'Output:')
       .describe({
@@ -103,7 +105,7 @@ function getFlags(manualArgv) {
         'disable-storage-reset', 'disable-device-emulation', 'disable-cpu-throttling',
         'disable-network-throttling', 'save-assets', 'list-all-audits',
         'list-trace-categories', 'perf', 'view', 'verbose', 'quiet', 'help',
-        'gather-mode', 'audit-mode',
+        'gather-mode', 'audit-mode', 'report-mode',
       ])
       .choices('output', printer.getValidOutputOptions())
       // force as an array

--- a/lighthouse-cli/printer.js
+++ b/lighthouse-cli/printer.js
@@ -90,22 +90,16 @@ function writeFile(filePath, output, outputMode) {
  * @param {!LH.Results} results
  * @param {string} mode
  * @param {string} path
- * @return {!Promise<!LH.Results>}
+ * @return {!Promise<void>}
  */
 function write(results, mode, path) {
-  return new Promise((resolve, reject) => {
-    const outputPath = checkOutputPath(path);
-    const output = createOutput(results, mode);
+  const outputPath = checkOutputPath(path);
+  const output = createOutput(results, mode);
 
-    if (outputPath === 'stdout') {
-      return writeToStdout(output).then(_ => resolve(results));
-    }
-    return writeFile(outputPath, output, mode)
-      .then(_ => {
-        resolve(results);
-      })
-      .catch(err => reject(err));
-  });
+  if (outputPath === 'stdout') {
+    return writeToStdout(output);
+  }
+  return writeFile(outputPath, output, mode);
 }
 
 /**

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -123,6 +123,9 @@ function saveResults(results, artifacts, flags) {
 
   if (flags.saveAssets) {
     promise = promise.then(_ => assetSaver.saveAssets(artifacts, results.audits, resolvedPath));
+  } else if (flags.gatherMode || flags.auditMode) {
+    const latestPath = path.join(cwd, 'latest-run', 'lhr.json');
+    promise = promise.then(_ => Printer.write(results, Printer.OutputMode.json, latestPath));
   }
 
   return promise.then(_ => {

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -162,6 +162,12 @@ function saveResults(results, artifacts, flags) {
  * @return {!Promise<!LH.Results|void>}
  */
 function runLighthouse(url, flags, config) {
+  if (flags.reportMode) {
+    return Promise.resolve()
+        .then(_ => saveResults(assetSaver.loadResults(), {}, flags))
+        .catch(err => handleError(err));
+  }
+
   /** @type {!LH.LaunchedChrome} */
   let launchedChrome;
   const shouldGather = flags.gatherMode || flags.gatherMode === flags.auditMode;

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -59,6 +59,18 @@ img {
   `;
 }
 
+/**
+ * @return {!LH.Results}
+ */
+function loadResults() {
+  const filePath = path.join(latestRunPath, 'lhr.json');
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+  return JSON.parse(fs.readFileSync(filePath));
+}
+
+
 const artifactsFilename = 'artifacts.json';
 const traceSuffix = '.trace.json';
 const devtoolsLogSuffix = '.devtoolslog.json';
@@ -301,6 +313,7 @@ function logAssets(artifacts, audits) {
 }
 
 module.exports = {
+  loadResults,
   saveArtifacts,
   loadArtifacts,
   saveAssets,

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -15,6 +15,7 @@ const TraceParser = require('./traces/trace-parser');
 const rimraf = require('rimraf');
 const mkdirp = require('mkdirp');
 
+const latestRunPath = path.join(process.cwd(), 'latest-run');
 /**
  * Generate basic HTML page of screenshot filmstrip
  * @param {!Array<{timestamp: number, datauri: string}>} screenshots
@@ -70,7 +71,8 @@ const devtoolsLogSuffix = '.devtoolslog.json';
  */
 // Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
 /* istanbul ignore next */
-function loadArtifacts(basePath) {
+function loadArtifacts() {
+  const basePath = latestRunPath;
   log.log('Reading artifacts from disk:', basePath);
 
   if (!fs.existsSync(basePath)) return Promise.reject(new Error('No saved artifacts found'));
@@ -115,7 +117,8 @@ function loadArtifacts(basePath) {
  */
 // Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
 /* istanbul ignore next */
-function saveArtifacts(artifacts, basePath) {
+function saveArtifacts(artifacts) {
+  const basePath = latestRunPath;
   mkdirp.sync(basePath);
   rimraf.sync(`${basePath}/*${traceSuffix}`);
   rimraf.sync(`${basePath}/${artifactsFilename}`);

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -18,8 +18,6 @@ const path = require('path');
 const URL = require('./lib/url-shim');
 const Sentry = require('./lib/sentry');
 
-const basePath = path.join(process.cwd(), 'latest-run');
-
 class Runner {
   static run(connection, opts) {
     // Clean opts input.
@@ -126,7 +124,7 @@ class Runner {
    * @return {!Promise<!Artifacts>}
    */
   static _loadArtifactsFromDisk() {
-    return assetSaver.loadArtifacts(basePath);
+    return assetSaver.loadArtifacts();
   }
 
   /**
@@ -155,7 +153,7 @@ class Runner {
    * @return {!Promise>}
    */
   static _saveArtifacts(artifacts) {
-    return assetSaver.saveArtifacts(artifacts, basePath);
+    return assetSaver.saveArtifacts(artifacts);
   }
 
   /**

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -23,6 +23,7 @@ export interface Flags {
   listTraceCategories: boolean;
   auditMode: boolean;
   gatherMode: boolean;
+  reportMode: boolean;
   configPath?: string;
   perf: boolean;
   verbose: boolean;


### PR DESCRIPTION
1. If you run lighthouse with `-GA` or `-A` either one of the following, it will also save the LHR results json to disk within the `./latest-run/` folder, alongside the artifacts.
2. When running lighthouse with `-R`, it'll read that `latest-run/lhr.json` file and then generate a report and save that to disk. (It'll abide your output options or our defaults).

Also

* it turned out Printer.write() was more complicated than necessary. 
  * update: okay, [maybe previous paulirish says it _was_ necessary](https://github.com/GoogleChrome/lighthouse/commit/c9ab75dca68c1907ace71ed334db7d88c10487fa#diff-babd7547389c6ecb7aeb1ce64c8aab97L160). Will investigate! :)
* runner.js doesn't need to know about the 'latest-run' path. Moved that to be private to asset-saver.
* Unlike -G and -A, the -R flag is CLI only, and lighthouse-core is unaware of it completely. there's something nice about that.
* todo: readme update, tests

**GAR!**



  
  