### PR TITLE
new_audit(plugins): avoid plugins

### DIFF
--- a/lighthouse-cli/test/fixtures/seo/seo-failure-cases.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-failure-cases.html
@@ -25,5 +25,25 @@
   <a href='https://example.com'>click this</a>
   <a href='/test.html'> click this </a>
   <a href='/test.html'>CLICK THIS</a>
+
+  <!-- FAIL(plugins): java applet on page -->
+  <applet code=HelloWorld.class width="200" height="200" id='applet'>
+    Your browser does not support the <code>applet</code> tag.
+  </applet>
+
+  <!-- FAIL(plugins): flash content on page -->
+  <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="590" height="90" id="adobe-embed" align="middle">
+    <param name="movie" value="movie_name.swf"/>
+    <!--[if !IE]>-->
+    <object type="application/x-shockwave-flash" data="movie_name.swf" width="590" height="90">
+      <param name="movie" value="movie_name.swf"/>
+    <!--<![endif]-->
+      <a href="http://www.adobe.com/go/getflash">
+        <img src="http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash player"/>
+      </a>
+    <!--[if !IE]>-->
+    </object>
+    <!--<![endif]-->
+  </object>
 </body>
 </html>

--- a/lighthouse-cli/test/fixtures/seo/seo-tester.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester.html
@@ -42,5 +42,7 @@
   <script class='small'>
     // text from SCRIPT tags should be ignored by the font-size audit
   </script>
+  <!-- PASS(plugins): external content does not require java, flash or silverlight -->
+  <object data="test.pdf" type="application/pdf" width="300" height="200"></object>
 </body>
 </html>

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -57,6 +57,9 @@ module.exports = [
       'hreflang': {
         score: true,
       },
+      'plugins': {
+        score: true,
+      },
     },
   },
   {
@@ -103,6 +106,14 @@ module.exports = [
         },
       },
       'hreflang': {
+        score: false,
+        details: {
+          items: {
+            length: 3,
+          },
+        },
+      },
+      'plugins': {
         score: false,
         details: {
           items: {

--- a/lighthouse-core/audits/seo/plugins.js
+++ b/lighthouse-core/audits/seo/plugins.js
@@ -66,7 +66,6 @@ class Plugins extends Audit {
    */
   static get meta() {
     return {
-      category: 'Content Best Practices',
       name: 'plugins',
       description: 'Document avoids plugins.',
       failureDescription: 'Document uses plugins',

--- a/lighthouse-core/audits/seo/plugins.js
+++ b/lighthouse-core/audits/seo/plugins.js
@@ -12,10 +12,10 @@ const JAVA_APPLET_TYPE = 'application/x-java-applet';
 const JAVA_BEAN_TYPE = 'application/x-java-bean';
 const TYPE_BLOCKLIST = new Set([
   'application/x-shockwave-flash',
-  // https://docs.oracle.com/cd/E19683-01/816-0378/using_tags/index.html
+  // See https://docs.oracle.com/cd/E19683-01/816-0378/using_tags/index.html
   JAVA_APPLET_TYPE,
   JAVA_BEAN_TYPE,
-  // https://msdn.microsoft.com/es-es/library/cc265156(v=vs.95).aspx
+  // See https://msdn.microsoft.com/es-es/library/cc265156(v=vs.95).aspx
   'application/x-silverlight',
   'application/x-silverlight-2',
 ]);
@@ -50,6 +50,7 @@ function isPluginType(type) {
  */
 function isPluginURL(url) {
   try {
+    // in order to support relative URLs we need to provied a base URL
     const filePath = new URL(url, 'http://example.com').pathname;
     const parts = filePath.split('.');
 
@@ -68,10 +69,10 @@ class Plugins extends Audit {
       category: 'Content Best Practices',
       name: 'plugins',
       description: 'Document avoids plugins.',
-      failureDescription: 'Document doesn\'t avoid plugins',
+      failureDescription: 'Document uses plugins',
       helpText: 'Some types of media or content are not playable on mobile devices. ' +
       '[Learn more](https://developers.google.com/speed/docs/insights/AvoidPlugins).',
-      requiredArtifacts: ['ExternalContent'],
+      requiredArtifacts: ['EmbeddedContent'],
     };
   }
 
@@ -80,7 +81,7 @@ class Plugins extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const plugins = artifacts.ExternalContent
+    const plugins = artifacts.EmbeddedContent
       .filter(item => {
         if (item.tagName === 'APPLET') {
           return true;

--- a/lighthouse-core/audits/seo/plugins.js
+++ b/lighthouse-core/audits/seo/plugins.js
@@ -1,0 +1,147 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Audit = require('../audit');
+const URL = require('../../lib/url-shim');
+
+const JAVA_APPLET_TYPE = 'application/x-java-applet';
+const JAVA_BEAN_TYPE = 'application/x-java-bean';
+const TYPE_BLOCKLIST = new Set([
+  'application/x-shockwave-flash',
+  // https://docs.oracle.com/cd/E19683-01/816-0378/using_tags/index.html
+  JAVA_APPLET_TYPE,
+  JAVA_BEAN_TYPE,
+  // https://msdn.microsoft.com/es-es/library/cc265156(v=vs.95).aspx
+  'application/x-silverlight',
+  'application/x-silverlight-2',
+]);
+const FILE_EXTENSION_BLOCKLIST = new Set([
+  'swf',
+  'flv',
+  'class',
+  'xap',
+]);
+const SOURCE_PARAMS = new Set([
+  'code',
+  'movie',
+  'source',
+  'src',
+]);
+
+/**
+ * Verifies if given MIME type matches any known plugin MIME type
+ * @param {string} type
+ */
+function isPluginType(type) {
+  type = type.trim().toLowerCase();
+
+  return TYPE_BLOCKLIST.has(type) ||
+    type.startsWith(JAVA_APPLET_TYPE) || // e.g. "application/x-java-applet;jpi-version=1.4"
+    type.startsWith(JAVA_BEAN_TYPE);
+}
+
+/**
+ * Verifies if given url points to a file that has a known plugin extension
+ * @param {string} url
+ */
+function isPluginURL(url) {
+  try {
+    const filePath = new URL(url, 'http://example.com').pathname;
+    const parts = filePath.split('.');
+
+    return parts.length > 1 && FILE_EXTENSION_BLOCKLIST.has(parts.pop().trim().toLowerCase());
+  } catch (e) {
+    return false;
+  }
+}
+
+class Plugins extends Audit {
+  /**
+   * @return {!AuditMeta}
+   */
+  static get meta() {
+    return {
+      category: 'Content Best Practices',
+      name: 'plugins',
+      description: 'Document avoids plugins.',
+      failureDescription: 'Document doesn\'t avoid plugins',
+      helpText: 'Some types of media or content are not playable on mobile devices. ' +
+      '[Learn more](https://developers.google.com/speed/docs/insights/AvoidPlugins).',
+      requiredArtifacts: ['ExternalContent'],
+    };
+  }
+
+  /**
+   * @param {!Artifacts} artifacts
+   * @return {!AuditResult}
+   */
+  static audit(artifacts) {
+    const plugins = artifacts.ExternalContent
+      .filter(item => {
+        if (item.tagName === 'APPLET') {
+          return true;
+        }
+
+        if (
+          (item.tagName === 'EMBED' || item.tagName === 'OBJECT') &&
+          item.type &&
+          isPluginType(item.type)
+        ) {
+          return true;
+        }
+
+        const embedSrc = item.src || item.code;
+        if (item.tagName === 'EMBED' && embedSrc && isPluginURL(embedSrc)) {
+          return true;
+        }
+
+        if (item.tagName === 'OBJECT' && item.data && isPluginURL(item.data)) {
+          return true;
+        }
+
+        const failingParams = item.params.filter(param =>
+          SOURCE_PARAMS.has(param.name.trim().toLowerCase()) && isPluginURL(param.value)
+        );
+
+        return failingParams.length > 0;
+      })
+      .map(plugin => {
+        const tagName = plugin.tagName.toLowerCase();
+        const attributes = ['src', 'data', 'code', 'type']
+          .reduce((result, attr) => {
+            if (plugin[attr] !== null) {
+              result += ` ${attr}="${plugin[attr]}"`;
+            }
+            return result;
+          }, '');
+        const params = plugin.params
+          .filter(param => SOURCE_PARAMS.has(param.name.trim().toLowerCase()))
+          .map(param => `<param ${param.name}="${param.value}" />`)
+          .join('');
+
+        return {
+          source: {
+            type: 'node',
+            snippet: `<${tagName}${attributes}>${params}</${tagName}>`,
+          },
+        };
+      });
+
+    const headings = [
+      {key: 'source', itemType: 'code', text: 'Source'},
+    ];
+
+    const details = Audit.makeTableDetails(headings, plugins);
+
+    return {
+      rawValue: plugins.length === 0,
+      details,
+    };
+  }
+}
+
+module.exports = Plugins;

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -42,6 +42,7 @@ module.exports = {
       'seo/crawlable-links',
       'seo/meta-robots',
       'seo/hreflang',
+      'seo/external-content',
     ],
   },
   {
@@ -171,6 +172,7 @@ module.exports = {
     'seo/link-text',
     'seo/is-crawlable',
     'seo/hreflang',
+    'seo/plugins',
     'seo/manual/mobile-friendly',
     'seo/manual/structured-data',
   ],
@@ -386,6 +388,7 @@ module.exports = {
         {id: 'is-crawlable', weight: 1, group: 'seo-crawl'},
         {id: 'hreflang', weight: 1, group: 'seo-content'},
         {id: 'font-size', weight: 1, group: 'seo-mobile'},
+        {id: 'plugins', weight: 1, group: 'seo-content'},
         {id: 'mobile-friendly', weight: 0, group: 'manual-seo-checks'},
         {id: 'structured-data', weight: 0, group: 'manual-seo-checks'},
       ],

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -42,7 +42,7 @@ module.exports = {
       'seo/crawlable-links',
       'seo/meta-robots',
       'seo/hreflang',
-      'seo/external-content',
+      'seo/embedded-content',
     ],
   },
   {

--- a/lighthouse-core/gather/gatherers/seo/embedded-content.js
+++ b/lighthouse-core/gather/gatherers/seo/embedded-content.js
@@ -8,10 +8,10 @@
 const Gatherer = require('../gatherer');
 const DOMHelpers = require('../../../lib/dom-helpers.js');
 
-class ExternalContent extends Gatherer {
+class EmbeddedContent extends Gatherer {
   /**
    * @param {{driver: !Driver}} options Run options
-   * @return {!Promise<Array<{tagName: string, type: ?string, src: ?string, data: ?string, code: ?string, params: Array<{name: ?string, value: ?string}>}>>} All objects, embeds and applets with list of relevant attributes and child properties
+   * @return {!Promise<Array<{tagName: string, type: ?string, src: ?string, data: ?string, code: ?string, params: Array<{name: string, value: string}>}>>} All <object>s, <embed>s and <applet>s with list of relevant attributes and child properties
    */
   afterPass(options) {
     const expression = `(function() {
@@ -28,8 +28,8 @@ class ExternalContent extends Gatherer {
           params: Array.from(node.children)
             .filter(el => el.tagName === 'PARAM')
             .map(el => ({
-              name: el.getAttribute('name'),
-              value: el.getAttribute('value'),
+              name: el.getAttribute('name') || '',
+              value: el.getAttribute('value') || '',
             })),
         }));
     })()`;
@@ -38,4 +38,4 @@ class ExternalContent extends Gatherer {
   }
 }
 
-module.exports = ExternalContent;
+module.exports = EmbeddedContent;

--- a/lighthouse-core/gather/gatherers/seo/external-content.js
+++ b/lighthouse-core/gather/gatherers/seo/external-content.js
@@ -1,0 +1,41 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Gatherer = require('../gatherer');
+const DOMHelpers = require('../../../lib/dom-helpers.js');
+
+class ExternalContent extends Gatherer {
+  /**
+   * @param {{driver: !Driver}} options Run options
+   * @return {!Promise<Array<{tagName: string, type: ?string, src: ?string, data: ?string, code: ?string, params: Array<{name: ?string, value: ?string}>}>>} All objects, embeds and applets with list of relevant attributes and child properties
+   */
+  afterPass(options) {
+    const expression = `(function() {
+      ${DOMHelpers.getElementsInDocumentFnString}; // define function on page
+      const selector = 'object, embed, applet';
+      const elements = getElementsInDocument(selector);
+      return elements
+        .map(node => ({
+          tagName: node.tagName,
+          type: node.getAttribute('type'),
+          src: node.getAttribute('src'),
+          data: node.getAttribute('data'),
+          code: node.getAttribute('code'),
+          params: Array.from(node.children)
+            .filter(el => el.tagName === 'PARAM')
+            .map(el => ({
+              name: el.getAttribute('name'),
+              value: el.getAttribute('value'),
+            })),
+        }));
+    })()`;
+
+    return options.driver.evaluateAsync(expression);
+  }
+}
+
+module.exports = ExternalContent;

--- a/lighthouse-core/test/audits/seo/plugins.js
+++ b/lighthouse-core/test/audits/seo/plugins.js
@@ -1,0 +1,141 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const PluginsAudit = require('../../../audits/seo/plugins.js');
+const assert = require('assert');
+
+/* eslint-env mocha */
+
+describe('SEO: Avoids plugins', () => {
+  it('fails when page contains java, silverlight or flash content', () => {
+    const externalContentValues = [
+      [{
+        tagName: 'APPLET',
+        params: [],
+      }],
+      [{
+        tagName: 'OBJECT',
+        type: 'application/x-shockwave-flash',
+        params: [],
+      }],
+      [{
+        tagName: 'EMBED',
+        type: 'application/x-java-applet;jpi-version=1.4',
+        params: [],
+      }],
+      [{
+        tagName: 'OBJECT',
+        type: 'application/x-silverlight-2',
+        params: [],
+      }],
+      [{
+        tagName: 'OBJECT',
+        data: 'https://example.com/movie_name.swf?uid=123',
+        params: [],
+      }],
+      [{
+        tagName: 'EMBED',
+        src: '/path/to/movie_name.latest.swf',
+        params: [],
+      }],
+      [{
+        tagName: 'OBJECT',
+        params: [
+          {name: 'quality', value: 'low'},
+          {name: 'movie', value: 'movie.swf?id=123'},
+        ],
+      }],
+      [{
+        tagName: 'OBJECT',
+        params: [
+          {name: 'code', value: '../HelloWorld.class'},
+        ],
+      }],
+    ];
+
+    externalContentValues.forEach(externalContent => {
+      const artifacts = {
+        ExternalContent: externalContent,
+      };
+
+      const auditResult = PluginsAudit.audit(artifacts);
+      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.details.items.length, 1);
+    });
+  });
+
+  it('returns multiple results when there are multiple failing items', () => {
+    const artifacts = {
+      ExternalContent: [
+        {
+          tagName: 'EMBED',
+          type: 'application/x-java-applet;jpi-version=1.4',
+          params: [],
+        },
+        {
+          tagName: 'OBJECT',
+          type: 'application/x-silverlight-2',
+          params: [],
+        },
+        {
+          tagName: 'APPLET',
+          params: [],
+        },
+      ],
+    };
+
+    const auditResult = PluginsAudit.audit(artifacts);
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.details.items.length, 3);
+  });
+
+  it('succeeds when there is no external content found on page', () => {
+    const artifacts = {
+      ExternalContent: [],
+    };
+
+    const auditResult = PluginsAudit.audit(artifacts);
+    assert.equal(auditResult.rawValue, true);
+  });
+
+  it('succeeds when all external content is valid', () => {
+    const artifacts = {
+      ExternalContent: [
+        {
+          tagName: 'OBJECT',
+          type: 'image/svg+xml',
+          data: 'https://example.com/test.svg',
+          params: [],
+        },
+        {
+          tagName: 'OBJECT',
+          data: 'https://example.com',
+          params: [],
+        },
+        {
+          tagName: 'EMBED',
+          type: 'video/quicktime',
+          src: 'movie.mov',
+          params: [],
+        },
+        {
+          tagName: 'OBJECT',
+          params: [{
+            name: 'allowFullScreen',
+            value: 'true',
+          }, {
+            name: 'movie',
+            value: 'http://www.youtube.com/v/example',
+          }],
+        },
+      ],
+    };
+
+    const auditResult = PluginsAudit.audit(artifacts);
+    assert.equal(auditResult.rawValue, true);
+  });
+});

--- a/lighthouse-core/test/audits/seo/plugins.js
+++ b/lighthouse-core/test/audits/seo/plugins.js
@@ -12,7 +12,7 @@ const assert = require('assert');
 
 describe('SEO: Avoids plugins', () => {
   it('fails when page contains java, silverlight or flash content', () => {
-    const externalContentValues = [
+    const embeddedContentValues = [
       [{
         tagName: 'APPLET',
         params: [],
@@ -57,9 +57,9 @@ describe('SEO: Avoids plugins', () => {
       }],
     ];
 
-    externalContentValues.forEach(externalContent => {
+    embeddedContentValues.forEach(embeddedContent => {
       const artifacts = {
-        ExternalContent: externalContent,
+        EmbeddedContent: embeddedContent,
       };
 
       const auditResult = PluginsAudit.audit(artifacts);
@@ -70,7 +70,7 @@ describe('SEO: Avoids plugins', () => {
 
   it('returns multiple results when there are multiple failing items', () => {
     const artifacts = {
-      ExternalContent: [
+      EmbeddedContent: [
         {
           tagName: 'EMBED',
           type: 'application/x-java-applet;jpi-version=1.4',
@@ -95,7 +95,7 @@ describe('SEO: Avoids plugins', () => {
 
   it('succeeds when there is no external content found on page', () => {
     const artifacts = {
-      ExternalContent: [],
+      EmbeddedContent: [],
     };
 
     const auditResult = PluginsAudit.audit(artifacts);
@@ -104,7 +104,7 @@ describe('SEO: Avoids plugins', () => {
 
   it('succeeds when all external content is valid', () => {
     const artifacts = {
-      ExternalContent: [
+      EmbeddedContent: [
         {
           tagName: 'OBJECT',
           type: 'image/svg+xml',


### PR DESCRIPTION
Fixes #3180 

Success:
<img width="793" alt="plugins_success" src="https://user-images.githubusercontent.com/985504/34732468-af804280-f565-11e7-93bf-807eea959fbf.png">

Failure:
<img width="789" alt="screen shot 2018-01-09 at 01 36 16" src="https://user-images.githubusercontent.com/985504/34732473-b42a1a86-f565-11e7-99a1-300f2eb02846.png">

As I found out, world of embedding external content is very messy. There are many non-standard ways of embedding that still work (multiplied by the number of different browsers 😵).

My approach here was to focus on documented ways of embedding (docs from adobe, ms, oracle, mdn) and real-life uses on popular sites (video, games, showcases). It should cover most of the real-life uses, but I'm pretty sure there are some false positives and false negatives.

Some notes:
- it's common to do feature detection when embedding such content (esp. for flash with `swfobject.js`, but there is also `silverlight.js` and some code from oracle doing the same for java). We won't be able to detect that unless user has these plugins enabled.
- flash is often embedded as `<object …><embed …></object>`. I'm listing both the `object` and `embed` as separate entries on the details list as they potentially can have different contents.
  
  
  