### PR TITLE
tests: remove global timeout, set timeouts individually

### DIFF
--- a/lighthouse-core/lib/traces/trace-parser.js
+++ b/lighthouse-core/lib/traces/trace-parser.js
@@ -14,6 +14,7 @@ const WebInspector = require('../web-inspector');
  * streaming JSON parser.
  * The resulting trace doesn't include the "metadata" property, as it's excluded via DevTools'
  * implementation.
+ * FIXME: This can be removed once Node 8 support is dropped. https://stackoverflow.com/a/47781288/89484
  */
 class TraceParser {
   constructor() {

--- a/lighthouse-core/scripts/run-mocha.sh
+++ b/lighthouse-core/scripts/run-mocha.sh
@@ -9,7 +9,7 @@
 flag=$1
 
 function _runmocha() {
-  mocha $2 $(find $1/test -name '*-test.js');
+  mocha --reporter dot $2 $(find $1/test -name '*-test.js');
 }
 
 if [ "$flag" == '--watch' ]; then

--- a/lighthouse-core/scripts/run-mocha.sh
+++ b/lighthouse-core/scripts/run-mocha.sh
@@ -9,7 +9,7 @@
 flag=$1
 
 function _runmocha() {
-  mocha --reporter dot $2 $(find $1/test -name '*-test.js') --timeout 60000;
+  mocha --reporter dot $2 $(find $1/test -name '*-test.js');
 }
 
 if [ "$flag" == '--watch' ]; then

--- a/lighthouse-core/scripts/run-mocha.sh
+++ b/lighthouse-core/scripts/run-mocha.sh
@@ -9,7 +9,7 @@
 flag=$1
 
 function _runmocha() {
-  mocha --reporter dot $2 $(find $1/test -name '*-test.js');
+  mocha $2 $(find $1/test -name '*-test.js');
 }
 
 if [ "$flag" == '--watch' ]; then

--- a/lighthouse-core/test/audits/bootup-time-test.js
+++ b/lighthouse-core/test/audits/bootup-time-test.js
@@ -43,7 +43,7 @@ describe('Performance: bootup-time audit', () => {
       assert.deepEqual(roundedValueOf('https://pwa.rocks/'), {[groupIdToName.parseHTML]: 14.2, [groupIdToName.scripting]: 6.1, [groupIdToName.scriptParseCompile]: 1.2});
       assert.deepEqual(roundedValueOf('https://pwa.rocks/0ff789bf.js'), {[groupIdToName.parseHTML]: 0});
     });
-  });
+  }).timeout(10000);
 
   it('should get no data when no events are present', () => {
     const artifacts = Object.assign({

--- a/lighthouse-core/test/audits/screenshot-thumbnails-test.js
+++ b/lighthouse-core/test/audits/screenshot-thumbnails-test.js
@@ -63,7 +63,7 @@ describe('Screenshot thumbnails', () => {
       assert.equal(results.details.items[9].timing, 818);
       assert.equal(results.details.items[0].timestamp, 225414253815);
     });
-  });
+  }).timeout(10000);
 
   it('should scale the timeline to TTFI', () => {
     const artifacts = Object.assign({

--- a/lighthouse-core/test/audits/speed-index-metric-test.js
+++ b/lighthouse-core/test/audits/speed-index-metric-test.js
@@ -49,7 +49,7 @@ describe('Performance: speed-index-metric audit', () => {
       assert.equal(Math.round(result.extendedInfo.value.timings.visuallyComplete), 1105);
       assert.equal(Math.round(result.extendedInfo.value.timings.perceptualSpeedIndex), 609);
     });
-  });
+  }).timeout(10000);
 
   it('throws an error if no frames', () => {
     const artifacts = mockArtifactsWithSpeedlineResult({frames: []});

--- a/lighthouse-core/test/gather/computed/dtm-model-test.js
+++ b/lighthouse-core/test/gather/computed/dtm-model-test.js
@@ -77,5 +77,5 @@ describe('DTM Model gatherer', () => {
           assert.deepStrictEqual(pwaTrace[i], freshTrace[i]);
         }
       });
-  });
+  }).timeout(20000);
 });

--- a/lighthouse-core/test/gather/computed/speedline-test.js
+++ b/lighthouse-core/test/gather/computed/speedline-test.js
@@ -34,14 +34,14 @@ describe('Speedline gatherer', () => {
       assert.equal(speedline.speedIndex, undefined);
       assert.equal(Math.floor(speedline.perceptualSpeedIndex), 609);
     });
-  });
+  }).timeout(10000);
 
   it('measures SI of 3 frame trace (blank @1s, content @2s, more content @3s)', () => {
     return computedArtifacts.requestSpeedline(threeFrameTrace).then(speedline => {
       assert.equal(speedline.speedIndex, undefined);
       assert.equal(Math.floor(speedline.perceptualSpeedIndex), 2030);
     });
-  });
+  }).timeout(10000);
 
   it('uses a cache', () => {
     let start;
@@ -62,7 +62,7 @@ describe('Speedline gatherer', () => {
 
         return assert.equal(Math.floor(speedline.perceptualSpeedIndex), 609);
       });
-  });
+  }).timeout(10000);
 
   it('does not change order of events in traces', () => {
     // Use fresh trace in case it has been altered by other require()s.
@@ -78,5 +78,5 @@ describe('Speedline gatherer', () => {
           assert.deepStrictEqual(pwaTrace[i], freshTrace[i]);
         }
       });
-  });
+  }).timeout(10000);
 });

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -65,7 +65,7 @@ describe('asset-saver helper', () => {
       const traceEventsFromDisk = JSON.parse(traceFileContents).traceEvents;
       assertTraceEventsEqual(traceEventsFromDisk, traceEvents);
       fs.unlinkSync(traceFilename);
-    }).timeout(10000);
+    });
 
     it('devtools log file saved to disk with data', () => {
       const filename = 'the_file-0.devtoolslog.json';
@@ -124,7 +124,7 @@ describe('asset-saver helper', () => {
           const traceEventsFromDisk = JSON.parse(traceFileContents).traceEvents;
           assertTraceEventsEqual(traceEventsFromDisk, fullTraceObj.traceEvents);
         });
-    }).timeout(5000);
+    }).timeout(10000);
 
     it('correctly saves a trace with no trace events to disk', () => {
       const trace = {
@@ -165,7 +165,7 @@ describe('asset-saver helper', () => {
           const traceEventsFromDisk = JSON.parse(traceFileContents).traceEvents;
           assertTraceEventsEqual(traceEventsFromDisk, trace.traceEvents);
         });
-    }).timeout(10000);
+    });
 
     it('can save traces over 256MB (slow)', () => {
       // Create a trace that wil be longer than 256MB when stringified, the hard

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -65,7 +65,7 @@ describe('asset-saver helper', () => {
       const traceEventsFromDisk = JSON.parse(traceFileContents).traceEvents;
       assertTraceEventsEqual(traceEventsFromDisk, traceEvents);
       fs.unlinkSync(traceFilename);
-    });
+    }).timeout(10000);
 
     it('devtools log file saved to disk with data', () => {
       const filename = 'the_file-0.devtoolslog.json';
@@ -124,7 +124,7 @@ describe('asset-saver helper', () => {
           const traceEventsFromDisk = JSON.parse(traceFileContents).traceEvents;
           assertTraceEventsEqual(traceEventsFromDisk, fullTraceObj.traceEvents);
         });
-    });
+    }).timeout(5000);
 
     it('correctly saves a trace with no trace events to disk', () => {
       const trace = {
@@ -165,7 +165,7 @@ describe('asset-saver helper', () => {
           const traceEventsFromDisk = JSON.parse(traceFileContents).traceEvents;
           assertTraceEventsEqual(traceEventsFromDisk, trace.traceEvents);
         });
-    });
+    }).timeout(10000);
 
     it('can save traces over 256MB (slow)', () => {
       // Create a trace that wil be longer than 256MB when stringified, the hard
@@ -186,6 +186,6 @@ describe('asset-saver helper', () => {
           const fileStats = fs.lstatSync(traceFilename);
           assert.ok(fileStats.size > Math.pow(2, 28));
         });
-    }).timeout(20000);
+    }).timeout(40 * 1000);
   });
 });

--- a/lighthouse-core/test/lib/asset-saver-test.js
+++ b/lighthouse-core/test/lib/asset-saver-test.js
@@ -186,6 +186,6 @@ describe('asset-saver helper', () => {
           const fileStats = fs.lstatSync(traceFilename);
           assert.ok(fileStats.size > Math.pow(2, 28));
         });
-    });
+    }).timeout(20000);
   });
 });

--- a/lighthouse-core/test/lib/traces/trace-parser-test.js
+++ b/lighthouse-core/test/lib/traces/trace-parser-test.js
@@ -35,7 +35,7 @@ describe('traceParser parser', () => {
 
       done();
     });
-  });
+  }).timeout(10000);
 
 
   it('parses a trace > 256mb (slow)', () => {
@@ -89,5 +89,5 @@ describe('traceParser parser', () => {
     assert.deepStrictEqual(
         streamedTrace.traceEvents[events.length - 2],
         events[0]);
-  }).timeout(20000);
+  }).timeout(40 * 1000);
 });

--- a/lighthouse-core/test/lib/traces/trace-parser-test.js
+++ b/lighthouse-core/test/lib/traces/trace-parser-test.js
@@ -89,5 +89,5 @@ describe('traceParser parser', () => {
     assert.deepStrictEqual(
         streamedTrace.traceEvents[events.length - 2],
         events[0]);
-  });
+  }).timeout(20000);
 });


### PR DESCRIPTION
This should make unexpected hangs more obvious and potentially failing/long tests will fail faster.