### PR TITLE
report(grammar): do not finalize audit titles with a period

### DIFF
--- a/lighthouse-core/audits/accessibility/accesskeys.js
+++ b/lighthouse-core/audits/accessibility/accesskeys.js
@@ -19,8 +19,8 @@ class Accesskeys extends AxeAudit {
   static get meta() {
     return {
       name: 'accesskeys',
-      description: '`[accesskey]` values are unique.',
-      failureDescription: '`[accesskey]` values are not unique.',
+      description: '`[accesskey]` values are unique',
+      failureDescription: '`[accesskey]` values are not unique',
       helpText: 'Access keys let users quickly focus a part of the page. For proper ' +
           'navigation, each access key must be unique. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/accesskeys?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/aria-allowed-attr.js
+++ b/lighthouse-core/audits/accessibility/aria-allowed-attr.js
@@ -19,8 +19,8 @@ class ARIAAllowedAttr extends AxeAudit {
   static get meta() {
     return {
       name: 'aria-allowed-attr',
-      description: '`[aria-*]` attributes match their roles.',
-      failureDescription: '`[aria-*]` attributes do not match their roles.',
+      description: '`[aria-*]` attributes match their roles',
+      failureDescription: '`[aria-*]` attributes do not match their roles',
       helpText: 'Each ARIA `role` supports a specific subset of `aria-*` attributes. ' +
           'Mismatching these invalidates the `aria-*` attributes. [Learn ' +
           'more](https://dequeuniversity.com/rules/axe/2.2/aria-allowed-attr?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/aria-required-attr.js
+++ b/lighthouse-core/audits/accessibility/aria-required-attr.js
@@ -19,8 +19,8 @@ class ARIARequiredAttr extends AxeAudit {
   static get meta() {
     return {
       name: 'aria-required-attr',
-      description: '`[role]`s have all required `[aria-*]` attributes.',
-      failureDescription: '`[role]`s do not have all required `[aria-*]` attributes.',
+      description: '`[role]`s have all required `[aria-*]` attributes',
+      failureDescription: '`[role]`s do not have all required `[aria-*]` attributes',
       helpText: 'Some ARIA roles have required attributes that describe the state ' +
           'of the element to screen readers. [Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-required-attr?application=lighthouse).',
       requiredArtifacts: ['Accessibility'],

--- a/lighthouse-core/audits/accessibility/aria-required-children.js
+++ b/lighthouse-core/audits/accessibility/aria-required-children.js
@@ -20,7 +20,7 @@ class AriaRequiredChildren extends AxeAudit {
   static get meta() {
     return {
       name: 'aria-required-children',
-      description: 'Elements with `[role]` that require specific children `[role]`s, are present.',
+      description: 'Elements with `[role]` that require specific children `[role]`s, are present',
       failureDescription: 'Elements with `[role]` that require specific children `[role]`s, ' +
           'are missing.',
       helpText: 'Some ARIA parent roles must contain specific child roles to perform ' +

--- a/lighthouse-core/audits/accessibility/aria-required-parent.js
+++ b/lighthouse-core/audits/accessibility/aria-required-parent.js
@@ -20,8 +20,8 @@ class AriaRequiredParent extends AxeAudit {
   static get meta() {
     return {
       name: 'aria-required-parent',
-      description: '`[role]`s are contained by their required parent element.',
-      failureDescription: '`[role]`s are not contained by their required parent element.',
+      description: '`[role]`s are contained by their required parent element',
+      failureDescription: '`[role]`s are not contained by their required parent element',
       helpText: 'Some ARIA child roles must be contained by specific parent roles to ' +
           'properly perform their intended accessibility functions. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-required-parent?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/aria-roles.js
+++ b/lighthouse-core/audits/accessibility/aria-roles.js
@@ -19,8 +19,8 @@ class AriaRoles extends AxeAudit {
   static get meta() {
     return {
       name: 'aria-roles',
-      description: '`[role]` values are valid.',
-      failureDescription: '`[role]` values are not valid.',
+      description: '`[role]` values are valid',
+      failureDescription: '`[role]` values are not valid',
       helpText: 'ARIA roles must have valid values in order to perform their ' +
           'intended accessibility functions. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-roles?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/aria-valid-attr-value.js
+++ b/lighthouse-core/audits/accessibility/aria-valid-attr-value.js
@@ -19,8 +19,8 @@ class ARIAValidAttr extends AxeAudit {
   static get meta() {
     return {
       name: 'aria-valid-attr-value',
-      description: '`[aria-*]` attributes have valid values.',
-      failureDescription: '`[aria-*]` attributes do not have valid values.',
+      description: '`[aria-*]` attributes have valid values',
+      failureDescription: '`[aria-*]` attributes do not have valid values',
       helpText: 'Assistive technologies, like screen readers, can\'t interpret ARIA ' +
           'attributes with invalid values. [Learn ' +
           'more](https://dequeuniversity.com/rules/axe/2.2/aria-valid-attr-value?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/aria-valid-attr.js
+++ b/lighthouse-core/audits/accessibility/aria-valid-attr.js
@@ -19,8 +19,8 @@ class ARIAValidAttr extends AxeAudit {
   static get meta() {
     return {
       name: 'aria-valid-attr',
-      description: '`[aria-*]` attributes are valid and not misspelled.',
-      failureDescription: '`[aria-*]` attributes are not valid or misspelled.',
+      description: '`[aria-*]` attributes are valid and not misspelled',
+      failureDescription: '`[aria-*]` attributes are not valid or misspelled',
       helpText: 'Assistive technologies, like screen readers, can\'t interpret ARIA ' +
           'attributes with invalid names. [Learn ' +
           'more](https://dequeuniversity.com/rules/axe/2.2/aria-valid-attr?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/audio-caption.js
+++ b/lighthouse-core/audits/accessibility/audio-caption.js
@@ -19,7 +19,7 @@ class AudioCaption extends AxeAudit {
   static get meta() {
     return {
       name: 'audio-caption',
-      description: '`<audio>` elements contain a `<track>` element with `[kind="captions"]`.',
+      description: '`<audio>` elements contain a `<track>` element with `[kind="captions"]`',
       failureDescription: '`<audio>` elements are missing a `<track>` element with ' +
           '`[kind="captions"]`.',
       helpText: 'Captions make audio elements usable for deaf or hearing-impaired users, ' +

--- a/lighthouse-core/audits/accessibility/button-name.js
+++ b/lighthouse-core/audits/accessibility/button-name.js
@@ -19,8 +19,8 @@ class ButtonName extends AxeAudit {
   static get meta() {
     return {
       name: 'button-name',
-      description: 'Buttons have an accessible name.',
-      failureDescription: 'Buttons do not have an accessible name.',
+      description: 'Buttons have an accessible name',
+      failureDescription: 'Buttons do not have an accessible name',
       helpText: 'When a button doesn\'t have an accessible name, screen readers announce it as ' +
           '"button", making it unusable for users who rely on screen readers. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/button-name?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/bypass.js
+++ b/lighthouse-core/audits/accessibility/bypass.js
@@ -20,8 +20,8 @@ class Bypass extends AxeAudit {
   static get meta() {
     return {
       name: 'bypass',
-      description: 'The page contains a heading, skip link, or landmark region.',
-      failureDescription: 'The page does not contain a heading, skip link, or landmark region.',
+      description: 'The page contains a heading, skip link, or landmark region',
+      failureDescription: 'The page does not contain a heading, skip link, or landmark region',
       helpText: 'Adding ways to bypass repetitive content lets keyboard users navigate the page ' +
           'more efficiently. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/bypass?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/color-contrast.js
+++ b/lighthouse-core/audits/accessibility/color-contrast.js
@@ -20,7 +20,7 @@ class ColorContrast extends AxeAudit {
   static get meta() {
     return {
       name: 'color-contrast',
-      description: 'Background and foreground colors have a sufficient contrast ratio.',
+      description: 'Background and foreground colors have a sufficient contrast ratio',
       failureDescription: 'Background and foreground colors do not have a ' +
           'sufficient contrast ratio.',
       helpText: 'Low-contrast text is difficult or impossible for many users to read. ' +

--- a/lighthouse-core/audits/accessibility/dlitem.js
+++ b/lighthouse-core/audits/accessibility/dlitem.js
@@ -19,8 +19,8 @@ class DLItem extends AxeAudit {
   static get meta() {
     return {
       name: 'dlitem',
-      description: 'Definition list items are wrapped in `<dl>` elements.',
-      failureDescription: 'Definition list items are not wrapped in `<dl>` elements.',
+      description: 'Definition list items are wrapped in `<dl>` elements',
+      failureDescription: 'Definition list items are not wrapped in `<dl>` elements',
       helpText: 'Definition list items (`<dt>` and `<dd>`) must be wrapped in a ' +
           'parent `<dl>` element to ensure that screen readers can properly announce them. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/dlitem?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/document-title.js
+++ b/lighthouse-core/audits/accessibility/document-title.js
@@ -19,8 +19,8 @@ class DocumentTitle extends AxeAudit {
   static get meta() {
     return {
       name: 'document-title',
-      description: 'Document has a `<title>` element.',
-      failureDescription: 'Document does not have a `<title>` element.',
+      description: 'Document has a `<title>` element',
+      failureDescription: 'Document does not have a `<title>` element',
       helpText: 'Screen reader users use page titles to get an overview of the contents of ' +
           'the page. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/document-title?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/duplicate-id.js
+++ b/lighthouse-core/audits/accessibility/duplicate-id.js
@@ -19,8 +19,8 @@ class DuplicateId extends AxeAudit {
   static get meta() {
     return {
       name: 'duplicate-id',
-      description: '`[id]` attributes on the page are unique.',
-      failureDescription: '`[id]` attributes on the page are not unique.',
+      description: '`[id]` attributes on the page are unique',
+      failureDescription: '`[id]` attributes on the page are not unique',
       helpText: 'The value of an id attribute must be unique to prevent ' +
           'other instances from being overlooked by assistive technologies. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/duplicate-id?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/frame-title.js
+++ b/lighthouse-core/audits/accessibility/frame-title.js
@@ -19,8 +19,8 @@ class FrameTitle extends AxeAudit {
   static get meta() {
     return {
       name: 'frame-title',
-      description: '`<frame>` or `<iframe>` elements have a title.',
-      failureDescription: '`<frame>` or `<iframe>` elements do not have a title.',
+      description: '`<frame>` or `<iframe>` elements have a title',
+      failureDescription: '`<frame>` or `<iframe>` elements do not have a title',
       helpText: 'Screen reader users rely on frame titles to describe the contents of frames. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/frame-title?application=lighthouse).',
       requiredArtifacts: ['Accessibility'],

--- a/lighthouse-core/audits/accessibility/html-has-lang.js
+++ b/lighthouse-core/audits/accessibility/html-has-lang.js
@@ -19,8 +19,8 @@ class HTMLHasLang extends AxeAudit {
   static get meta() {
     return {
       name: 'html-has-lang',
-      description: '`<html>` element has a `[lang]` attribute.',
-      failureDescription: '`<html>` element does not have a `[lang]` attribute.',
+      description: '`<html>` element has a `[lang]` attribute',
+      failureDescription: '`<html>` element does not have a `[lang]` attribute',
       helpText: 'If a page doesn\'t specify a lang attribute, a screen reader assumes ' +
           'that the page is in the default language that the user chose when setting up the ' +
           'screen reader. If the page isn\'t actually in the default language, then the screen ' +

--- a/lighthouse-core/audits/accessibility/html-lang-valid.js
+++ b/lighthouse-core/audits/accessibility/html-lang-valid.js
@@ -19,7 +19,7 @@ class HTMLLangValid extends AxeAudit {
   static get meta() {
     return {
       name: 'html-lang-valid',
-      description: '`<html>` element has a valid value for its `[lang]` attribute.',
+      description: '`<html>` element has a valid value for its `[lang]` attribute',
       failureDescription: '`<html>` element does not have a valid value for ' +
           'its `[lang]` attribute.',
       helpText: 'Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ' +

--- a/lighthouse-core/audits/accessibility/image-alt.js
+++ b/lighthouse-core/audits/accessibility/image-alt.js
@@ -19,8 +19,8 @@ class ImageAlt extends AxeAudit {
   static get meta() {
     return {
       name: 'image-alt',
-      description: 'Image elements have `[alt]` attributes.',
-      failureDescription: 'Image elements do not have `[alt]` attributes.',
+      description: 'Image elements have `[alt]` attributes',
+      failureDescription: 'Image elements do not have `[alt]` attributes',
       helpText: 'Informative elements should aim for short, descriptive alternate text. ' +
           'Decorative elements can be ignored with an empty alt attribute.' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/image-alt?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/input-image-alt.js
+++ b/lighthouse-core/audits/accessibility/input-image-alt.js
@@ -19,8 +19,8 @@ class InputImageAlt extends AxeAudit {
   static get meta() {
     return {
       name: 'input-image-alt',
-      description: '`<input type="image">` elements have `[alt]` text.',
-      failureDescription: '`<input type="image">` elements do not have `[alt]` text.',
+      description: '`<input type="image">` elements have `[alt]` text',
+      failureDescription: '`<input type="image">` elements do not have `[alt]` text',
       helpText: 'When an image is being used as an `<input>` button, providing alternative text ' +
           'can help screen reader users understand the purpose of the button. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/input-image-alt?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/label.js
+++ b/lighthouse-core/audits/accessibility/label.js
@@ -19,8 +19,8 @@ class Label extends AxeAudit {
   static get meta() {
     return {
       name: 'label',
-      description: 'Form elements have associated labels.',
-      failureDescription: 'Form elements do not have associated labels.',
+      description: 'Form elements have associated labels',
+      failureDescription: 'Form elements do not have associated labels',
       helpText: 'Labels ensure that form controls are announced properly by assistive ' +
           'technologies, like screen readers. [Learn ' +
           'more](https://dequeuniversity.com/rules/axe/2.2/label?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/link-name.js
+++ b/lighthouse-core/audits/accessibility/link-name.js
@@ -19,8 +19,8 @@ class LinkName extends AxeAudit {
   static get meta() {
     return {
       name: 'link-name',
-      description: 'Links have a discernible name.',
-      failureDescription: 'Links do not have a discernable name.',
+      description: 'Links have a discernible name',
+      failureDescription: 'Links do not have a discernable name',
       helpText: 'Link text (and alternate text for images, when used as links) that is ' +
           'discernible, unique, and focusable improves the navigation experience for ' +
           'screen reader users. ' +

--- a/lighthouse-core/audits/accessibility/listitem.js
+++ b/lighthouse-core/audits/accessibility/listitem.js
@@ -19,7 +19,7 @@ class ListItem extends AxeAudit {
   static get meta() {
     return {
       name: 'listitem',
-      description: 'List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements.',
+      description: 'List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements',
       failureDescription: 'List items (`<li>`) are not contained within `<ul>` ' +
           'or `<ol>` parent elements.',
       helpText: 'Screen readers require list items (`<li>`) to be contained within a ' +

--- a/lighthouse-core/audits/accessibility/meta-refresh.js
+++ b/lighthouse-core/audits/accessibility/meta-refresh.js
@@ -19,8 +19,8 @@ class MetaRefresh extends AxeAudit {
   static get meta() {
     return {
       name: 'meta-refresh',
-      description: 'The document does not use `<meta http-equiv="refresh">`.',
-      failureDescription: 'The document uses `<meta http-equiv="refresh">`.',
+      description: 'The document does not use `<meta http-equiv="refresh">`',
+      failureDescription: 'The document uses `<meta http-equiv="refresh">`',
       helpText: 'Users do not expect a page to refresh automatically, and doing so will move ' +
           'focus back to the top of the page. This may create a frustrating or ' +
           'confusing experience. ' +

--- a/lighthouse-core/audits/accessibility/object-alt.js
+++ b/lighthouse-core/audits/accessibility/object-alt.js
@@ -19,8 +19,8 @@ class ObjectAlt extends AxeAudit {
   static get meta() {
     return {
       name: 'object-alt',
-      description: '`<object>` elements have `[alt]` text.',
-      failureDescription: '`<object>` elements do not have `[alt]` text.',
+      description: '`<object>` elements have `[alt]` text',
+      failureDescription: '`<object>` elements do not have `[alt]` text',
       helpText: 'Screen readers cannot translate non-text content. Adding alt text to `<object>` ' +
           'elements helps screen readers convey meaning to users. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/object-alt?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/tabindex.js
+++ b/lighthouse-core/audits/accessibility/tabindex.js
@@ -19,8 +19,8 @@ class TabIndex extends AxeAudit {
   static get meta() {
     return {
       name: 'tabindex',
-      description: 'No element has a `[tabindex]` value greater than 0.',
-      failureDescription: 'Some elements have a `[tabindex]` value greater than 0.',
+      description: 'No element has a `[tabindex]` value greater than 0',
+      failureDescription: 'Some elements have a `[tabindex]` value greater than 0',
       helpText: 'A value greater than 0 implies an explicit navigation ordering. ' +
           'Although technically valid, this often creates frustrating experiences ' +
           'for users who rely on assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/2.2/tabindex?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/valid-lang.js
+++ b/lighthouse-core/audits/accessibility/valid-lang.js
@@ -19,8 +19,8 @@ class ValidLang extends AxeAudit {
   static get meta() {
     return {
       name: 'valid-lang',
-      description: '`[lang]` attributes have a valid value.',
-      failureDescription: '`[lang]` attributes do not have a valid value.',
+      description: '`[lang]` attributes have a valid value',
+      failureDescription: '`[lang]` attributes do not have a valid value',
       helpText: 'Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) ' +
           'on elements helps ensure that text is pronounced correctly by a screen reader. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/valid-lang?application=lighthouse).',

--- a/lighthouse-core/audits/accessibility/video-caption.js
+++ b/lighthouse-core/audits/accessibility/video-caption.js
@@ -19,7 +19,7 @@ class VideoCaption extends AxeAudit {
   static get meta() {
     return {
       name: 'video-caption',
-      description: '`<video>` elements contain a `<track>` element with `[kind="captions"]`.',
+      description: '`<video>` elements contain a `<track>` element with `[kind="captions"]`',
       failureDescription: '`<video>` elements do not contain a `<track>` element ' +
           'with `[kind="captions"]`.',
       helpText: 'When a video provides a caption it is easier for deaf and hearing impaired ' +

--- a/lighthouse-core/audits/accessibility/video-description.js
+++ b/lighthouse-core/audits/accessibility/video-description.js
@@ -19,7 +19,7 @@ class VideoDescription extends AxeAudit {
   static get meta() {
     return {
       name: 'video-description',
-      description: '`<video>` elements contain a `<track>` element with `[kind="description"]`.',
+      description: '`<video>` elements contain a `<track>` element with `[kind="description"]`',
       failureDescription: '`<video>` elements do not contain a `<track>` element with ' +
           '`[kind="description"]`.',
       helpText: 'Audio descriptions provide relevant information for videos that dialogue ' +

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -175,8 +175,8 @@ class FontSize extends Audit {
   static get meta() {
     return {
       name: 'font-size',
-      description: 'Document uses legible font sizes.',
-      failureDescription: 'Document doesn\'t use legible font sizes.',
+      description: 'Document uses legible font sizes',
+      failureDescription: 'Document doesn\'t use legible font sizes',
       helpText: 'Font sizes less than 16px are too small to be legible and require mobile ' +
       'visitors to “pinch to zoom” in order to read. Strive to have >75% of page text ≥16px. ' +
       '[Learn more](https://developers.google.com/speed/docs/insights/UseLegibleFontSizes).',

--- a/lighthouse-core/audits/seo/http-status-code.js
+++ b/lighthouse-core/audits/seo/http-status-code.js
@@ -16,7 +16,7 @@ class HTTPStatusCode extends Audit {
   static get meta() {
     return {
       name: 'http-status-code',
-      description: 'Page has successful HTTP status code.',
+      description: 'Page has successful HTTP status code',
       failureDescription: 'Page has unsuccessful HTTP status code',
       helpText: 'Pages with unsuccessful HTTP status codes may not be indexed properly. ' +
       '[Learn more]' +

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -27,7 +27,7 @@ class LinkText extends Audit {
     return {
       category: 'Content Best Practices',
       name: 'link-text',
-      description: 'Links have descriptive text.',
+      description: 'Links have descriptive text',
       failureDescription: 'Links do not have descriptive text',
       helpText: 'Descriptive link text helps search engines understand your content. ' +
       '[Learn more](https://webmasters.googleblog.com/2008/10/importance-of-link-architecture.html)',

--- a/lighthouse-core/test/audits/accessibility/axe-audit-test.js
+++ b/lighthouse-core/test/audits/accessibility/axe-audit-test.js
@@ -17,7 +17,7 @@ describe('Accessibility: axe-audit', () => {
         static get meta() {
           return {
             name: 'fake-aria-fail',
-            description: 'You have an aria-* issue.',
+            description: 'You have an aria-* issue',
             requiredArtifacts: ['Accessibility'],
           };
         }


### PR DESCRIPTION
Currently we're very inconsistent when it comes to the trailing period on audit titles:

![image](https://user-images.githubusercontent.com/39191/34798540-601cc0d6-f611-11e7-9de0-e2e0ded78fbd.png)

Kayce sez no period on these. So this PR removes them.