### PR TITLE
extension(devtools): restore listenForStatus method for devtools build

### DIFF
--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -63,3 +63,7 @@ window.runLighthouseInWorker = function(port, url, options, categoryIDs) {
 window.getDefaultCategories = function() {
   return Config.getCategories(defaultConfig);
 };
+
+window.listenForStatus = function(listenCallback) {
+  log.events.addListener('status', listenCallback);
+};


### PR DESCRIPTION
Missed this when I did https://github.com/GoogleChrome/lighthouse/pull/4162

But luckily we get to simplify the method in the devtools case.