### PR TITLE
misc(sentry): update sampled errors list

### DIFF
--- a/lighthouse-core/lib/sentry.js
+++ b/lighthouse-core/lib/sentry.js
@@ -23,8 +23,12 @@ const sentryApi = {
 const SAMPLED_ERRORS = [
   {pattern: /Unable to load/, rate: 0.1},
   {pattern: /Failed to decode/, rate: 0.1},
-  {pattern: /No resource with given id/, rate: 0.01},
-  {pattern: /No node with given id/, rate: 0.01},
+  {pattern: /activity continued through the end/, rate: 0.1},
+  {pattern: /All image optimizations failed/, rate: 0.1},
+  {pattern: /No.*in trace/, rate: 0.1},
+  {pattern: /No firstMeaningfulPaint found/, rate: 0.1},
+  {pattern: /No.*resource with given/, rate: 0.01},
+  {pattern: /No.*node with given id/, rate: 0.01},
 ];
 
 /**


### PR DESCRIPTION
throttles our top remaining sentry errors