### PR TITLE
cli(yarn): Add mixed-content yarn script

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "bundlesize": "bundlesize",
     "plots-smoke": "bash plots/test/smoke.sh",
     "changelog": "conventional-changelog --config ./build/changelog-generator/index.js --infile changelog.md --same-file",
-    "type-check": "tsc -p ."
+    "type-check": "tsc -p .",
+    "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --config-path=./lighthouse-core/config/mixed-content.js"
   },
   "devDependencies": {
     "@types/configstore": "^2.1.1",


### PR DESCRIPTION
This adds a new yarn script (as discussed in #3953) which simplifies running the custom configuration required for the mixed-content audit.

@paulirish Could you PTAL to see if this is what you had in mind?