### PR TITLE
core(a11y): aXe perf: only collect provided resultTypes

### DIFF
--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -25,6 +25,7 @@ function runA11yChecks() {
         'wcag2aa',
       ],
     },
+    resultTypes: ['violations', 'inapplicable'],
     rules: {
       'tabindex': {enabled: true},
       'table-fake-caption': {enabled: true},


### PR DESCRIPTION
[A new axe document on performance](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#section-4-performance) suggests safelisting the resultTypes you're interested in. This saves time generating unique selectors (which on mlb.com can take 4s). 

cc @dylanb

This reduces about a 1 second of runtime cost of axe on mlb.com. (13s to 12s with the https://github.com/dequelabs/axe-core/pull/699 PR)