### PR TITLE
tests(coverage): minimize impact of timeout due to istanbul's instrumentation

### DIFF
--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -25,7 +25,8 @@ describe('CLI run', function() {
   it('runLighthouse completes a LH round trip', () => {
     const url = 'chrome://version';
     const filename = path.join(process.cwd(), 'run.ts.results.json');
-    const flags = getFlags(`--output=json --output-path=${filename} ${url}`);
+    const timeoutFlag = `--max-wait-for-load=${9000}`;
+    const flags = getFlags(`--output=json --output-path=${filename} ${timeoutFlag} ${url}`);
     return run.runLighthouse(url, flags, fastConfig).then(passedResults => {
       assert.ok(fs.existsSync(filename));
       const results = JSON.parse(fs.readFileSync(filename, 'utf-8'));
@@ -42,7 +43,7 @@ describe('CLI run', function() {
 
       fs.unlinkSync(filename);
     });
-  }).timeout(60000);
+  }).timeout(20 * 1000);
 });
 
 describe('Parsing --chrome-flags', () => {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1096,6 +1096,7 @@ class Driver {
  *     on the global object.
  * @return {function(...*): *} A wrapper around the original function.
  */
+/* istanbul ignore next */
 function captureJSCallUsage(funcRef, set) {
   /* global window */
   const __nativeError = window.__nativeError || Error;
@@ -1158,8 +1159,8 @@ function captureJSCallUsage(funcRef, set) {
  * information such as name, message, and stack trace of the error when it's wrapped in a
  * promise. Instead, map to a successful object that contains this information.
  * @param {string|Error} err The error to convert
- * istanbul ignore next
  */
+/* istanbul ignore next */
 function wrapRuntimeEvalErrorInBrowser(err) {
   err = err || new Error();
   const fallbackMessage = typeof err === 'string' ? err : 'unknown error';
@@ -1175,8 +1176,8 @@ function wrapRuntimeEvalErrorInBrowser(err) {
 /**
  * Used by _waitForCPUIdle and executed in the context of the page, updates the ____lastLongTask
  * property on window to the end time of the last long task.
- * instanbul ignore next
  */
+/* istanbul ignore next */
 function registerPerformanceObserverInPage() {
   window.____lastLongTask = window.performance.now();
   const observer = new window.PerformanceObserver(entryList => {
@@ -1201,8 +1202,8 @@ function registerPerformanceObserverInPage() {
 
 /**
  * Used by _waitForCPUIdle and executed in the context of the page, returns time since last long task.
- * instanbul ignore next
  */
+/* istanbul ignore next */
 function checkTimeSinceLastLongTask() {
   // Wait for a delta before returning so that we're sure the PerformanceObserver
   // has had time to register the last longtask

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf *.report.html *.report.dom.html *.report.json *.screenshots.html *.devtoolslog.json *.trace.json || true",
     "lint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .",
     "smoke": "bash lighthouse-cli/test/smokehouse/run-all-tests.sh",
-    "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*-test.js') --timeout 10000 --reporter progress --report lcovonly",
+    "coverage": "istanbul cover -x \"**/third_party/**\" _mocha -- $(find */test -name '*-test.js') --reporter progress --report lcovonly",
     "coveralls": "yarn coverage && cat ./coverage/lcov.info | coveralls && ./node_modules/codecov/bin/codecov",
     "debug": "node --inspect-brk ./lighthouse-cli/index.js",
     "start": "node ./lighthouse-cli/index.js",


### PR DESCRIPTION
Issue #4395 has the backstory. This PR has a few things going on:

* **primary fix:** wait only 9s load during run-test's roundtrip. No need to wait 45s if there's a problem loading the page.
* **driveby:** remove explicit timeout from istanbul's mocha call. (finishing #4224)
* **moot:** fix `istanbul ignore` statements. as detailed in #4395 they must be standalone (and spelled right). 

As a result of this PR, `yarn coverage` should be 36s faster, and no timeout error in the travis log. However the code coverage stats for the CLI are still incorrect and the roundtrip run is still not truly  successful.

This leads to a followup question: Should we have other success criteria for the run-test.js roundtrip test, like calculating TTI, etc?

Ref #4395 but doesn't close it.