### PR TITLE
misc(package): scripts don't require "--" for options to be forwarded

### DIFF
--- a/lighthouse-cli/test/smokehouse/a11y/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/a11y/run-tests.sh
@@ -7,7 +7,7 @@ sleep 0.5s
 config="lighthouse-cli/test/smokehouse/a11y/a11y-config.js"
 expectations="lighthouse-cli/test/smokehouse/a11y/expectations.js"
 
-yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+yarn smokehouse --config-path=$config --expectations-path=$expectations
 exit_code=$?
 
 # kill test servers

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/run-tests.sh
@@ -7,7 +7,7 @@ sleep 0.5s
 config="lighthouse-cli/test/smokehouse/byte-config.js"
 expectations="lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js"
 
-yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+yarn smokehouse --config-path=$config --expectations-path=$expectations
 exit_code=$?
 
 # kill test servers

--- a/lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh
@@ -8,7 +8,7 @@ config="lighthouse-cli/test/smokehouse/dbw-config.js"
 expectations="lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js"
 
 # run smoketest on DBW test page.
-yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+yarn smokehouse --config-path=$config --expectations-path=$expectations
 exit_code=$?
 
 # kill test servers

--- a/lighthouse-cli/test/smokehouse/offline-local/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/offline-local/run-tests.sh
@@ -8,7 +8,7 @@ config="lighthouse-cli/test/smokehouse/offline-config.js"
 expectations="lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js"
 
 # run smoketest, expecting results found in offline-expectations
-yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+yarn smokehouse --config-path=$config --expectations-path=$expectations
 exit_code=$?
 
 # kill test servers

--- a/lighthouse-cli/test/smokehouse/perf/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/perf/run-tests.sh
@@ -7,7 +7,7 @@ sleep 0.5s
 config="lighthouse-core/config/perf.json"
 expectations="lighthouse-cli/test/smokehouse/perf/expectations.js"
 
-yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+yarn smokehouse --config-path=$config --expectations-path=$expectations
 exit_code=$?
 
 # kill test servers

--- a/lighthouse-cli/test/smokehouse/redirects/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/redirects/run-tests.sh
@@ -8,7 +8,7 @@ config="lighthouse-cli/test/smokehouse/redirects-config.js"
 expectations="lighthouse-cli/test/smokehouse/redirects/expectations.js"
 
 # run smoketest, expecting results found in offline-expectations
-yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+yarn smokehouse --config-path=$config --expectations-path=$expectations
 exit_code=$?
 
 # kill test servers

--- a/lighthouse-cli/test/smokehouse/seo/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/seo/run-tests.sh
@@ -7,7 +7,7 @@ sleep 0.5s
 config="lighthouse-cli/test/smokehouse/seo-config.js"
 expectations="lighthouse-cli/test/smokehouse/seo/expectations.js"
 
-yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+yarn smokehouse --config-path=$config --expectations-path=$expectations
 exit_code=$?
 
 # kill test servers

--- a/lighthouse-cli/test/smokehouse/tricky-ttci/run-tests.sh
+++ b/lighthouse-cli/test/smokehouse/tricky-ttci/run-tests.sh
@@ -7,7 +7,7 @@ sleep 0.5s
 config="lighthouse-core/config/default.js"
 expectations="lighthouse-cli/test/smokehouse/tricky-ttci/expectations.js"
 
-yarn smokehouse -- --config-path=$config --expectations-path=$expectations
+yarn smokehouse --config-path=$config --expectations-path=$expectations
 exit_code=$?
 
 # kill test servers

--- a/lighthouse-core/scripts/compile-against-devtools.sh
+++ b/lighthouse-core/scripts/compile-against-devtools.sh
@@ -42,7 +42,7 @@ cd "$protocol_path" && git reset --hard && git fetch origin master && git checko
 cd "$lhroot_path" || exit 1
 
 # copy renderer and lh backgrond into this devtools checkout
-yarn devtools -- "$frontend_path/front_end/"
+yarn devtools "$frontend_path/front_end/"
 
 #
 # monkeypatch the audits2 module.json to include any new files we're added that aren't present

--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -11,13 +11,13 @@
 #   yarn devtools
 
 # with a custom devtools front_end location:
-#   yarn devtools -- node_modules/temp-devtoolsfrontend/front_end/
+#   yarn devtools node_modules/temp-devtoolsfrontend/front_end/
 
 chromium_dir="$HOME/chromium/src"
 
 if [[ -n "$1" ]]; then
   frontend_dir="$1"
-else 
+else
   frontend_dir="$chromium_dir/third_party/WebKit/Source/devtools/front_end"
 fi
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "compile-devtools": "bash lighthouse-core/scripts/compile-against-devtools.sh",
     "watch": "bash lighthouse-core/scripts/run-mocha.sh --watch",
     "chrome": "node chrome-launcher/manual-chrome-launcher.js",
-    "fast": "yarn start -- --disable-device-emulation --disable-cpu-throttling --disable-network-throttling",
+    "fast": "yarn start --disable-device-emulation --disable-cpu-throttling --disable-network-throttling",
     "smokehouse": "node lighthouse-cli/test/smokehouse/smokehouse.js",
     "deploy-viewer": "cd lighthouse-viewer && gulp deploy",
     "bundlesize": "bundlesize",


### PR DESCRIPTION
This isn't required in Yarn 1.0+ or NPM.

And now we kill off this warning:
![image](https://user-images.githubusercontent.com/39191/35875257-86956372-0b23-11e8-8db1-01b0eb2bbf77.png)
