### PR TITLE
cli(lighthouse): Add --mixed-content flag for triggering the mixed content audit

### DIFF
--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -60,6 +60,12 @@ if (cliFlags.configPath) {
   config = /** @type {!LH.Config} */ (perfOnlyConfig);
 } else if (cliFlags.mixedContent) {
   config = /** @type {!LH.Config} */ (mixedContentConfig);
+  // The mixed-content audits require headless Chrome (https://crbug.com/764505).
+  if (!cliFlags.chromeFlags) {
+    cliFlags.chromeFlags = '--headless';
+  } else {
+    cliFlags.chromeFlags = cliFlags.chromeFlags.concat(' --headless');
+  }
 }
 
 // set logging preferences

--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -17,6 +17,8 @@ const log = require('lighthouse-logger');
 // @ts-ignore
 const perfOnlyConfig = require('../lighthouse-core/config/perf.json');
 // @ts-ignore
+const mixedContentConfig = require('../lighthouse-core/config/mixed-content.js');
+// @ts-ignore
 const pkg = require('../package.json');
 const Sentry = require('../lighthouse-core/lib/sentry');
 
@@ -56,6 +58,8 @@ if (cliFlags.configPath) {
   config = /** @type {!LH.Config} */ (require(cliFlags.configPath));
 } else if (cliFlags.perf) {
   config = /** @type {!LH.Config} */ (perfOnlyConfig);
+} else if (cliFlags.mixedContent) {
+  config = /** @type {!LH.Config} */ (mixedContentConfig);
 }
 
 // set logging preferences

--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -61,11 +61,7 @@ if (cliFlags.configPath) {
 } else if (cliFlags.mixedContent) {
   config = /** @type {!LH.Config} */ (mixedContentConfig);
   // The mixed-content audits require headless Chrome (https://crbug.com/764505).
-  if (!cliFlags.chromeFlags) {
-    cliFlags.chromeFlags = '--headless';
-  } else {
-    cliFlags.chromeFlags = cliFlags.chromeFlags.concat(' --headless');
-  }
+  cliFlags.chromeFlags = `${cliFlags.chromeFlags} --headless`;
 }
 
 // set logging preferences

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -58,9 +58,9 @@ function getFlags(manualArgv) {
 
       .group(
         [
-          'save-assets', 'list-all-audits', 'list-trace-categories',
-          'additional-trace-categories', 'config-path', 'chrome-flags', 'perf', 'port',
-          'hostname', 'max-wait-for-load', 'enable-error-reporting', 'gather-mode', 'audit-mode',
+          'save-assets', 'list-all-audits', 'list-trace-categories', 'additional-trace-categories',
+          'config-path', 'mixed-content', 'chrome-flags', 'perf', 'port', 'hostname',
+          'max-wait-for-load', 'enable-error-reporting', 'gather-mode', 'audit-mode',
         ],
         'Configuration:')
       .describe({
@@ -81,6 +81,7 @@ function getFlags(manualArgv) {
         'additional-trace-categories':
             'Additional categories to capture with the trace (comma-delimited).',
         'config-path': 'The path to the config JSON.',
+        'mixed-content': 'Use the mixed-content auditing config.',
         'chrome-flags':
             `Custom flags to pass to Chrome (space-delimited). For a full list of flags, see http://bit.ly/chrome-flags
             Additionally, use the CHROME_PATH environment variable to use a specific Chrome binary. Requires Chromium version 54.0 or later. If omitted, any detected Chrome Canary or Chrome stable will be used.`,
@@ -110,7 +111,7 @@ function getFlags(manualArgv) {
         'disable-storage-reset', 'disable-device-emulation', 'disable-cpu-throttling',
         'disable-network-throttling', 'save-assets', 'list-all-audits',
         'list-trace-categories', 'perf', 'view', 'verbose', 'quiet', 'help',
-        'gather-mode', 'audit-mode',
+        'gather-mode', 'audit-mode', 'mixed-content',
       ])
       .choices('output', printer.getValidOutputOptions())
       // force as an array

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -81,7 +81,7 @@ function getFlags(manualArgv) {
         'additional-trace-categories':
             'Additional categories to capture with the trace (comma-delimited).',
         'config-path': 'The path to the config JSON.',
-        'mixed-content': 'Use the mixed-content auditing config.',
+        'mixed-content': 'Use the mixed-content auditing configuration.',
         'chrome-flags':
             `Custom flags to pass to Chrome (space-delimited). For a full list of flags, see http://bit.ly/chrome-flags
             Additionally, use the CHROME_PATH environment variable to use a specific Chrome binary. Requires Chromium version 54.0 or later. If omitted, any detected Chrome Canary or Chrome stable will be used.`,

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -59,7 +59,7 @@ function getFlags(manualArgv) {
       .group(
         [
           'save-assets', 'list-all-audits', 'list-trace-categories', 'additional-trace-categories',
-          'config-path', 'mixed-content', 'chrome-flags', 'perf', 'port', 'hostname',
+          'config-path', 'chrome-flags', 'perf', 'mixed-content', 'port', 'hostname',
           'max-wait-for-load', 'enable-error-reporting', 'gather-mode', 'audit-mode',
         ],
         'Configuration:')

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -30,7 +30,7 @@ const _PROTOCOL_TIMEOUT_EXIT_CODE = 67;
  */
 function parseChromeFlags(flags = '') {
   const parsed = yargsParser(
-      flags, {configuration: {'camel-case-expansion': false, 'boolean-negation': false}});
+      flags.trim(), {configuration: {'camel-case-expansion': false, 'boolean-negation': false}});
 
   return Object
       .keys(parsed)

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -40,8 +40,8 @@ function lighthouse(url, flags = {}, configJSON) {
     log.setLevel(flags.logLevel);
 
     // Use ConfigParser to generate a valid config file
-    const config = new Config(configJSON, flags.configPath);
-
+    const config = flags.mixedContent ? new Config(require('./config/mixed-content.js'), null)
+      : new Config(configJSON, flags.configPath);
     const connection = new ChromeProtocol(flags.port, flags.hostname);
 
     // kick off a lighthouse run

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -40,8 +40,7 @@ function lighthouse(url, flags = {}, configJSON) {
     log.setLevel(flags.logLevel);
 
     // Use ConfigParser to generate a valid config file
-    const config = flags.mixedContent ? new Config(require('./config/mixed-content.js'), null)
-      : new Config(configJSON, flags.configPath);
+    const config = new Config(configJSON, flags.configPath);
     const connection = new ChromeProtocol(flags.port, flags.hostname);
 
     // kick off a lighthouse run

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -26,6 +26,7 @@ export interface Flags {
   gatherMode: boolean;
   configPath?: string;
   perf: boolean;
+  mixedContent: boolean;
   verbose: boolean;
   quiet: boolean;
 }


### PR DESCRIPTION
Per discussion on #4344, it may be simpler to add a flag to lighthouse itself for the mixed content scan configuration rather than trying to do it through yarn/npm (as the yarn/npm invocations get unwieldy very fast).

This is an initial attempt at adding a `--mixed-content` flag that loads the mixed-content.js config if passed (essentially simplifying passing a custom config path to an included configuration file).

@paulirish WDYT?