### PR TITLE
core(help-text-fix): Add link to docs for mixed-content audit

### DIFF
--- a/lighthouse-core/audits/mixed-content.js
+++ b/lighthouse-core/audits/mixed-content.js
@@ -28,7 +28,7 @@ class MixedContent extends Audit {
       failureDescription: 'Some insecure resources can be upgraded to HTTPS',
       helpText: `Mixed content warnings can prevent you from upgrading to HTTPS.
       This audit shows which insecure resources this page uses that can be
-      upgraded to HTTPS. [Learn more]`,
+      upgraded to HTTPS. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/mixed-content)`,
       requiredArtifacts: ['devtoolsLogs', 'MixedContent'],
     };
   }


### PR DESCRIPTION
This adds a link to the documentation in the helpText for the new mixed-content audit (#3953). The link should be live once the docs PR (google/WebFundamentals#5758) lands.