### PR TITLE
core(assets): json stringify devtools log

### DIFF
--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -286,7 +286,7 @@ function saveAssets(artifacts, audits, pathWithBasename) {
 function logAssets(artifacts, audits) {
   return prepareAssets(artifacts, audits).then(assets => {
     assets.map(data => {
-      log.log(`devtoolslog-${data.passName}.json`, data.devtoolsLog);
+      log.log(`devtoolslog-${data.passName}.json`, JSON.stringify(data.devtoolsLog));
       const traceIter = traceJsonGenerator(data.traceData);
       let traceJson = '';
       for (const trace of traceIter) {


### PR DESCRIPTION
@patrickhulce

This fix that the logged out devtools log string is empty.