### PR TITLE
core(main-resource): adjust main resource identification logic

### DIFF
--- a/lighthouse-core/gather/computed/main-resource.js
+++ b/lighthouse-core/gather/computed/main-resource.js
@@ -24,17 +24,7 @@ class MainResource extends ComputedArtifact {
   compute_(devtoolsLog, artifacts) {
     return artifacts.requestNetworkRecords(devtoolsLog)
       .then(requests => {
-        let mainResource = null;
-
-        for (/** @type {WebInspector.NetworkRequest} */const request of requests) {
-          if (mainResource === null) {
-            mainResource = request;
-          }
-
-          if (request.redirectSource && request.redirectSource.url === mainResource.url) {
-            mainResource = request;
-          }
-        }
+        const mainResource = requests.find(request => request.url === artifacts.URL.finalUrl);
 
         if (!mainResource) {
           throw new Error('Unable to identify the main resource');

--- a/lighthouse-core/test/gather/computed/critical-request-chains-test.js
+++ b/lighthouse-core/test/gather/computed/critical-request-chains-test.js
@@ -50,6 +50,7 @@ function replaceChain(chains, networkRecords) {
 describe('CriticalRequestChain gatherer: extractChain function', () => {
   it('returns correct data for chain from a devtoolsLog', () => {
     const computedArtifacts = Runner.instantiateComputedArtifacts();
+    computedArtifacts.URL = {finalUrl: 'https://en.m.wikipedia.org/wiki/Main_Page'};
     const wikiDevtoolsLog = require('../../fixtures/wikipedia-redirect.devtoolslog.json');
     const wikiChains = require('../../fixtures/wikipedia-redirect.critical-request-chains.json');
 

--- a/lighthouse-core/test/gather/computed/main-resource-test.js
+++ b/lighthouse-core/test/gather/computed/main-resource-test.js
@@ -19,7 +19,7 @@ describe('MainResource computed artifact', () => {
 
   it('returns an artifact', () => {
     const record = {
-      statusCode: 404,
+      url: 'https://example.com',
     };
     const networkRecords = [
       record,
@@ -33,9 +33,6 @@ describe('MainResource computed artifact', () => {
 
   it('thows when main resource can\'t be found', () => {
     const networkRecords = [
-      {
-        statusCode: 302,
-      },
     ];
     computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
 
@@ -48,16 +45,31 @@ describe('MainResource computed artifact', () => {
 
   it('should ignore redirects', () => {
     const record = {
-      statusCode: 404,
+      url: 'http://example.com/3',
+      redirectSource: {
+        url: 'http://example.com/2',
+      },
     };
     const networkRecords = [
       {
-        statusCode: 301,
+        url: 'http://example.com/1',
       },
       {
-        statusCode: 302,
+        url: 'http://example.com/2',
+        redirectSource: {
+          url: 'http://example.com/1',
+        },
       },
       record,
+      {
+        url: 'http://example.com/someimage.jpg',
+      },
+      {
+        url: 'https://example.com/someimage.jpg',
+        redirectSource: {
+          url: 'http://example.com/someimage.jpg',
+        },
+      },
     ];
     computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
 

--- a/lighthouse-core/test/gather/computed/main-resource-test.js
+++ b/lighthouse-core/test/gather/computed/main-resource-test.js
@@ -22,9 +22,11 @@ describe('MainResource computed artifact', () => {
       url: 'https://example.com',
     };
     const networkRecords = [
+      {url: 'http://example.com'},
       record,
     ];
     computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
+    computedArtifacts.URL = {finalUrl: 'https://example.com'};
 
     return computedArtifacts.requestMainResource({}).then(output => {
       assert.equal(output, record);
@@ -33,8 +35,10 @@ describe('MainResource computed artifact', () => {
 
   it('thows when main resource can\'t be found', () => {
     const networkRecords = [
+      {url: 'https://example.com'},
     ];
     computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
+    computedArtifacts.URL = {finalUrl: 'https://m.example.com'};
 
     return computedArtifacts.requestMainResource({}).then(() => {
       assert.ok(false, 'should have thrown');
@@ -43,43 +47,9 @@ describe('MainResource computed artifact', () => {
     });
   });
 
-  it('should ignore redirects', () => {
-    const record = {
-      url: 'http://example.com/3',
-      redirectSource: {
-        url: 'http://example.com/2',
-      },
-    };
-    const networkRecords = [
-      {
-        url: 'http://example.com/1',
-      },
-      {
-        url: 'http://example.com/2',
-        redirectSource: {
-          url: 'http://example.com/1',
-        },
-      },
-      record,
-      {
-        url: 'http://example.com/someimage.jpg',
-      },
-      {
-        url: 'https://example.com/someimage.jpg',
-        redirectSource: {
-          url: 'http://example.com/someimage.jpg',
-        },
-      },
-    ];
-    computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
-
-    return computedArtifacts.requestMainResource({}).then(output => {
-      assert.equal(output, record);
-    });
-  });
-
   it('should identify correct main resource in the wikipedia fixture', () => {
     const wikiDevtoolsLog = require('../../fixtures/wikipedia-redirect.devtoolslog.json');
+    computedArtifacts.URL = {finalUrl: 'https://en.m.wikipedia.org/wiki/Main_Page'};
 
     return computedArtifacts.requestMainResource(wikiDevtoolsLog).then(output => {
       assert.equal(output.url, 'https://en.m.wikipedia.org/wiki/Main_Page');

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -16,7 +16,7 @@ module.exports = {
     return Promise.resolve();
   },
   gotoURL() {
-    return Promise.resolve('https://example.com');
+    return Promise.resolve('https://www.reddit.com/r/nba');
   },
   waitForLoadEvent() {
     return Promise.resolve();

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -330,6 +330,9 @@ describe('Runner', () => {
       ],
 
       artifacts: {
+        URL: {
+          finalUrl: 'https://www.reddit.com/r/nba',
+        },
         devtoolsLogs: {
           defaultPass: path.join(__dirname, '/fixtures/perflog.json'),
         },
@@ -473,7 +476,7 @@ describe('Runner', () => {
     const config = new Config({
       passes: [{
         passName: 'firstPass',
-        gatherers: ['viewport-dimensions'],
+        gatherers: ['url', 'viewport-dimensions'],
       }],
 
       audits: [


### PR DESCRIPTION
this PR aligns main-resource gatherer logic with final URL logic from driver.js

https://github.com/GoogleChrome/lighthouse/blob/3030b4f0651fc4eb2634600d7cf0dbca43972b32/lighthouse-core/gather/driver.js#L611-L622

Fixes #4454
Fixes #4440