### PR TITLE
tests(smokehouse): improve smokehouse failure output

### DIFF
--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -209,23 +209,34 @@ function collateResults(actual, expected) {
  * @param {{category: string, equal: boolean, diff: ?Object, actual: boolean, expected: boolean}} assertion
  */
 function reportAssertion(assertion) {
+  const _toJSON = RegExp.prototype.toJSON;
+  // eslint-disable-next-line no-extend-native
+  RegExp.prototype.toJSON = RegExp.prototype.toString;
+
   if (assertion.equal) {
     console.log(`  ${log.greenify(log.tick)} ${assertion.category}: ` +
         log.greenify(assertion.actual));
   } else {
     if (assertion.diff) {
       const diff = assertion.diff;
-      let msg = `  ${log.redify(log.cross)} difference at ${diff.path}: `;
-      msg += log.redify(`found ${diff.actual}, expected ${diff.expected}\n`);
-
       const fullActual = JSON.stringify(assertion.actual, null, 2).replace(/\n/g, '\n      ');
-      msg += log.redify('      full found result: ' + fullActual);
+      const msg = `
+  ${log.redify(log.cross)} difference at ${log.bold}${diff.path}${log.reset}
+              expected: ${JSON.stringify(diff.expected)}
+                 found: ${JSON.stringify(diff.actual)}
+          found result: ${log.redify(fullActual)}
+`;
       console.log(msg);
     } else {
-      console.log(`  ${log.redify(log.cross)} ${assertion.category}: ` +
-          log.redify(`found ${assertion.actual}, expected ${assertion.expected}`));
+      console.log(`  ${log.redify(log.cross)} ${assertion.category}:
+              expected: ${JSON.stringify(assertion.expected)}
+                 found: ${JSON.stringify(assertion.actual)}
+`);
     }
   }
+
+  // eslint-disable-next-line no-extend-native
+  RegExp.prototype.toJSON = _toJSON;
 }
 
 /**


### PR DESCRIPTION
Based on recently having to poke around the output, here's a proposal to improve the readability of failures.

Two before & after examples, taken from recent failures:

![image](https://user-images.githubusercontent.com/39191/35995594-b7dbdee2-0cc8-11e8-8d0e-7177521a01f1.png)

![image](https://user-images.githubusercontent.com/39191/35995686-029b23b6-0cc9-11e8-8372-e26a9762e95b.png)

changes

* display expected & found on top of eachother
* switch order so found comes next to "full found result"
* serialize objects, including regular expressions. no more `[Object object]`
* formatting
