### PR TITLE
core(is-crawlable): make sure that page is not blocked by robots.txt file

### DIFF
--- a/lighthouse-core/audits/seo/is-crawlable.js
+++ b/lighthouse-core/audits/seo/is-crawlable.js
@@ -113,7 +113,7 @@ class IsCrawlable extends Audit {
         }
 
         const headings = [
-          {key: 'source', itemType: 'code', text: 'Source'},
+          {key: 'source', itemType: 'code', text: 'Blocking Directive Source'},
         ];
         const details = Audit.makeTableDetails(headings, blockingDirectives);
 

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -45,6 +45,7 @@ module.exports = {
       'seo/hreflang',
       'seo/embedded-content',
       'seo/canonical',
+      'seo/robots-txt',
       'fonts',
     ],
   },

--- a/lighthouse-core/gather/gatherers/seo/robots-txt.js
+++ b/lighthouse-core/gather/gatherers/seo/robots-txt.js
@@ -7,7 +7,7 @@
 
 const Gatherer = require('../gatherer');
 
-/* global fetch, URL */
+/* global fetch, URL, location */
 
 function getRobotsTxtContent() {
   return fetch(new URL('/robots.txt', location.href))

--- a/lighthouse-core/gather/gatherers/seo/robots-txt.js
+++ b/lighthouse-core/gather/gatherers/seo/robots-txt.js
@@ -1,0 +1,36 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Gatherer = require('../gatherer');
+
+/* global fetch, URL */
+
+function getRobotsTxtContent() {
+  return fetch(new URL('/robots.txt', location.href))
+    .then(response => {
+      if (!response.ok) {
+        return {status: response.status, content: null};
+      }
+
+      return response.text()
+        .then(content => ({status: response.status, content}));
+    })
+    .catch(_ => ({status: null, content: null}));
+}
+
+
+class RobotsTxt extends Gatherer {
+  /**
+   * @param {{driver: !Driver}} options Run options
+   * @return {!Promise<!{code: number, content: string}>}
+   */
+  afterPass(options) {
+    return options.driver.evaluateAsync(`(${getRobotsTxtContent.toString()}())`);
+  }
+}
+
+module.exports = RobotsTxt;

--- a/lighthouse-core/test/audits/seo/is-crawlable-test.js
+++ b/lighthouse-core/test/audits/seo/is-crawlable-test.js
@@ -26,12 +26,11 @@ describe('SEO: Is page crawlable audit', () => {
       const mainResource = {
         responseHeaders: [],
       };
-      const robotsTxt = {};
       const artifacts = {
         devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
         requestMainResource: () => Promise.resolve(mainResource),
         MetaRobots: robotsValue,
-        RobotsTxt: robotsTxt,
+        RobotsTxt: {},
       };
 
       return IsCrawlableAudit.audit(artifacts).then(auditResult => {
@@ -47,12 +46,11 @@ describe('SEO: Is page crawlable audit', () => {
     const mainResource = {
       responseHeaders: [],
     };
-    const robotsTxt = {};
     const artifacts = {
       devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
       requestMainResource: () => Promise.resolve(mainResource),
       MetaRobots: 'all, noarchive',
-      RobotsTxt: robotsTxt,
+      RobotsTxt: {},
     };
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
@@ -64,12 +62,11 @@ describe('SEO: Is page crawlable audit', () => {
     const mainResource = {
       responseHeaders: [],
     };
-    const robotsTxt = {};
     const artifacts = {
       devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
       requestMainResource: () => Promise.resolve(mainResource),
       MetaRobots: null,
-      RobotsTxt: robotsTxt,
+      RobotsTxt: {},
     };
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
@@ -104,12 +101,11 @@ describe('SEO: Is page crawlable audit', () => {
       const mainResource = {
         responseHeaders: headers,
       };
-      const robotsTxt = {};
       const artifacts = {
         devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
         requestMainResource: () => Promise.resolve(mainResource),
         MetaRobots: null,
-        RobotsTxt: robotsTxt,
+        RobotsTxt: {},
       };
 
       return IsCrawlableAudit.audit(artifacts).then(auditResult => {
@@ -128,12 +124,11 @@ describe('SEO: Is page crawlable audit', () => {
         {name: 'X-Robots-Tag', value: 'unavailable_after: 25 Jun 2045 15:00:00 PST'},
       ],
     };
-    const robotsTxt = {};
     const artifacts = {
       devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
       requestMainResource: () => Promise.resolve(mainResource),
       MetaRobots: null,
-      RobotsTxt: robotsTxt,
+      RobotsTxt: {},
     };
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
@@ -145,12 +140,11 @@ describe('SEO: Is page crawlable audit', () => {
     const mainResource = {
       responseHeaders: [],
     };
-    const robotsTxt = {};
     const artifacts = {
       devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
       requestMainResource: () => Promise.resolve(mainResource),
       MetaRobots: null,
-      RobotsTxt: robotsTxt,
+      RobotsTxt: {},
     };
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
@@ -165,12 +159,11 @@ describe('SEO: Is page crawlable audit', () => {
         {name: 'x-robots-tag', value: 'unavailable_after: 25 Jun 2045 15:00:00 PST'},
       ],
     };
-    const robotsTxt = {};
     const artifacts = {
       devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
       requestMainResource: () => Promise.resolve(mainResource),
       MetaRobots: null,
-      RobotsTxt: robotsTxt,
+      RobotsTxt: {},
     };
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "parse-cache-control": "1.0.1",
     "raven": "^2.2.1",
     "rimraf": "^2.6.1",
+    "robots-parser": "^1.0.2",
     "semver": "^5.3.0",
     "speedline": "1.3.0",
     "update-notifier": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,6 +3602,10 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
+robots-parser@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/robots-parser/-/robots-parser-1.0.2.tgz#9ebe25b1a2c52773cbe6f1dbe90ebc9518089009"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"


### PR DESCRIPTION
First part of #4356

Extends is-crawlable audit, so that it also verifies robots.txt file (besides meta tag and header).

<img width="798" alt="screen shot 2018-02-15 at 14 37 51" src="https://user-images.githubusercontent.com/985504/36260936-2035a0a0-1263-11e8-8972-92c1a77bbc5c.png">

This change adds a new dependency - [robots-parser](https://github.com/samclarke/robots-parser). It's a lightweight, well tested robots.txt parser with no dependencies.