### PR TITLE
 core(lantern): improve RTT estimates

### DIFF
--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -52,6 +52,13 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
 
     networkRecords.forEach(record => {
       if (IGNORED_MIME_TYPES_REGEX.test(record.mimeType)) return;
+
+      // Network record requestIds can be duplicated for an unknown reason
+      // Suffix all subsequent records with `:duplicate` until it's unique
+      while (idToNodeMap.has(record.requestId)) {
+        record._requestId += ':duplicate';
+      }
+
       const node = new NetworkNode(record);
       nodes.push(node);
 

--- a/lighthouse-core/lib/dependency-graph/network-node.js
+++ b/lighthouse-core/lib/dependency-graph/network-node.js
@@ -42,6 +42,13 @@ class NetworkNode extends Node {
    * @return {!WebInspector.NetworkRequest}
    */
   get record() {
+    // Ensure that the record has an origin value
+    if (this._record.origin === undefined) {
+      this._record.origin = this._record.parsedURL
+        ? `${this._record.parsedURL.scheme}://${this._record.parsedURL.host}`
+        : null;
+    }
+
     return this._record;
   }
 

--- a/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
@@ -1,0 +1,104 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const NetworkAnalyzer = require('./network-analyzer');
+const TcpConnection = require('./tcp-connection');
+
+const DEFAULT_SERVER_RESPONSE_TIME = 30;
+const TLS_SCHEMES = ['https', 'wss'];
+
+module.exports = class ConnectionPool {
+  constructor(records, options) {
+    this._options = Object.assign(
+      {
+        rtt: undefined,
+        throughput: undefined,
+        additionalRttByOrigin: new Map(),
+        serverResponseTimeByOrigin: new Map(),
+      },
+      options
+    );
+
+    if (!this._options.rtt || !this._options.throughput) {
+      throw new Error('Cannot create pool with no rtt or throughput');
+    }
+
+    this._records = records;
+    this._connectionsByOrigin = new Map();
+    this._connectionsByRecord = new Map();
+    this._connectionsInUse = new Set();
+    this._connectionReusedByRequestId = NetworkAnalyzer.estimateIfConnectionWasReused(records, {
+      forceCoarseEstimates: true,
+    });
+
+    this._initializeConnections();
+  }
+
+  connectionsInUse() {
+    return Array.from(this._connectionsInUse);
+  }
+
+  _initializeConnections() {
+    const connectionReused = this._connectionReusedByRequestId;
+    const additionalRttByOrigin = this._options.additionalRttByOrigin;
+    const serverResponseTimeByOrigin = this._options.serverResponseTimeByOrigin;
+
+    const recordsByOrigin = NetworkAnalyzer.groupByOrigin(this._records);
+    for (const [origin, records] of recordsByOrigin.entries()) {
+      const connections = [];
+      const additionalRtt = additionalRttByOrigin.get(origin) || 0;
+      const responseTime = serverResponseTimeByOrigin.get(origin) || DEFAULT_SERVER_RESPONSE_TIME;
+
+      for (const record of records) {
+        if (connectionReused.get(record.requestId)) continue;
+
+        const isTLS = TLS_SCHEMES.includes(record.parsedURL.scheme);
+        const isH2 = record.protocol === 'h2';
+        const connection = new TcpConnection(
+          this._options.rtt + additionalRtt,
+          this._options.throughput,
+          responseTime,
+          isTLS,
+          isH2
+        );
+
+        connections.push(connection);
+      }
+
+      if (!connections.length) {
+        throw new Error(`Could not find a connection for origin: ${origin}`);
+      }
+
+      this._connectionsByOrigin.set(origin, connections);
+    }
+  }
+
+  acquire(record) {
+    if (this._connectionsByRecord.has(record)) {
+      return this._connectionsByRecord.get(record);
+    }
+
+    const origin = record.origin;
+    const connections = this._connectionsByOrigin.get(origin);
+    const wasConnectionWarm = !!this._connectionReusedByRequestId.get(record.requestId);
+    const connection = connections.find(connection => {
+      const meetsWarmRequirement = wasConnectionWarm === connection.isWarm();
+      return meetsWarmRequirement && !this._connectionsInUse.has(connection);
+    });
+
+    if (!connection) return null;
+    this._connectionsInUse.add(connection);
+    this._connectionsByRecord.set(record, connection);
+    return connection;
+  }
+
+  release(record) {
+    const connection = this._connectionsByRecord.get(record);
+    this._connectionsByRecord.delete(record);
+    this._connectionsInUse.delete(connection);
+  }
+};

--- a/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
@@ -12,6 +12,10 @@ const DEFAULT_SERVER_RESPONSE_TIME = 30;
 const TLS_SCHEMES = ['https', 'wss'];
 
 module.exports = class ConnectionPool {
+  /**
+   * @param {!Array<!WebInspector.NetworkRequest>} records
+   * @param {Object=} options
+   */
   constructor(records, options) {
     this._options = Object.assign(
       {
@@ -38,6 +42,9 @@ module.exports = class ConnectionPool {
     this._initializeConnections();
   }
 
+  /**
+   * @return {!Array<!WebInspector.NetworkRequest>}
+   */
   connectionsInUse() {
     return Array.from(this._connectionsInUse);
   }
@@ -77,6 +84,10 @@ module.exports = class ConnectionPool {
     }
   }
 
+  /**
+   * @param {!WebInspector.NetworkRequest} record
+   * @return {?TcpConnection}
+   */
   acquire(record) {
     if (this._connectionsByRecord.has(record)) {
       return this._connectionsByRecord.get(record);
@@ -96,6 +107,9 @@ module.exports = class ConnectionPool {
     return connection;
   }
 
+  /**
+   * @param {!WebInspector.NetworkRequest} record
+   */
   release(record) {
     const connection = this._connectionsByRecord.get(record);
     this._connectionsByRecord.delete(record);

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -1,0 +1,225 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const URL = require('../../url-shim');
+const INITIAL_CWD = 14 * 1024;
+
+module.exports = class NetworkAnalyzer {
+  static groupByOrigin(records) {
+    const grouped = new Map();
+    records.forEach(item => {
+      const key = new URL(item.url).origin;
+      const group = grouped.get(key) || [];
+      group.push(item);
+      grouped.set(key, group);
+    });
+    return grouped;
+  }
+
+  static summary(values) {
+    if (values instanceof Map) {
+      const summaryByKey = new Map();
+      const allEstimates = [];
+      for (const [key, estimates] of values) {
+        summaryByKey.set(key, NetworkAnalyzer.summary(estimates));
+        allEstimates.push(...estimates);
+      }
+
+      summaryByKey.set(NetworkAnalyzer.SUMMARY, NetworkAnalyzer.summary(allEstimates));
+      return summaryByKey;
+    }
+
+    values.sort((a, b) => a - b);
+
+    return {
+      min: values[0],
+      max: values[values.length - 1],
+      avg: values.reduce((a, b) => a + b, 0) / values.length,
+      median: values[Math.floor((values.length - 1) / 2)],
+    };
+  }
+
+  static _estimateValueByOrigin(records, iteratee) {
+    const connectionWasReused = NetworkAnalyzer.estimateIfConnectionWasReused(records);
+    const groupedByOrigin = NetworkAnalyzer.groupByOrigin(records);
+
+    const estimates = new Map();
+    for (const [origin, originRecords] of groupedByOrigin.entries()) {
+      let originEstimates = [];
+
+      for (const record of originRecords) {
+        const timing = record._timing;
+        if (!timing) continue;
+
+        const value = iteratee({
+          record,
+          timing,
+          connectionReused: connectionWasReused.get(record.requestId),
+        });
+        if (typeof value !== 'undefined') {
+          originEstimates = originEstimates.concat(value);
+        }
+      }
+
+      if (!originEstimates.length) continue;
+      estimates.set(origin, originEstimates);
+    }
+
+    return estimates;
+  }
+
+  static _estimateRTTByOriginViaTCPTiming(records) {
+    return NetworkAnalyzer._estimateValueByOrigin(records, ({record, timing, connectionReused}) => {
+      if (connectionReused) return;
+
+      if (timing.sslStart > 0 && timing.sslEnd > 0) {
+        return [timing.connectEnd - timing.sslStart, timing.sslStart - timing.connectStart];
+      } else if (timing.connectStart > 0 && timing.connectEnd > 0) {
+        return timing.connectEnd - timing.connectStart;
+      }
+    });
+  }
+
+  static _estimateRTTByOriginViaDownloadTiming(records, options) {
+    return NetworkAnalyzer._estimateValueByOrigin(records, ({record, timing, connectionReused}) => {
+      if (connectionReused) return;
+      if (record.transferSize <= INITIAL_CWD) return;
+      if (!Number.isFinite(timing.receiveHeadersEnd) || timing.receiveHeadersEnd < 0) return;
+
+      const totalTime = (record.endTime - record.startTime) * 1000;
+      const downloadTimeAfterFirstByte = totalTime - timing.receiveHeadersEnd;
+      const numberOfRoundTrips = Math.log2(record.transferSize / INITIAL_CWD);
+      return downloadTimeAfterFirstByte / numberOfRoundTrips;
+    });
+  }
+
+  static _estimateRTTByOriginViaSendStartTiming(records) {
+    return NetworkAnalyzer._estimateValueByOrigin(records, ({record, timing, connectionReused}) => {
+      if (connectionReused) return;
+      if (!Number.isFinite(timing.sendStart) || timing.sendStart < 0) return;
+
+      let roundTrips = 1;
+      if (record.parsedURL.scheme === 'https') roundTrips += 1;
+      return timing.sendStart / roundTrips;
+    });
+  }
+
+  static _estimateResponseTimeByOrigin(records, rttByOrigin) {
+    return NetworkAnalyzer._estimateValueByOrigin(records, ({record, timing}) => {
+      if (!Number.isFinite(timing.receiveHeadersEnd) || timing.receiveHeadersEnd < 0) return;
+      if (!Number.isFinite(timing.sendEnd) || timing.sendEnd < 0) return;
+
+      const ttfb = timing.receiveHeadersEnd - timing.sendEnd;
+      const origin = new URL(record.url).origin;
+      const rtt = rttByOrigin.get(origin) || rttByOrigin.get(NetworkAnalyzer.SUMMARY);
+      return Math.max(ttfb - rtt, 0);
+    });
+  }
+
+  /**
+   * Returns a map of requestId -> connectionReused, estimating the information if the information
+   * available in the records themselves appears untrustworthy.
+   *
+   * @param {!WebInspector.NetworkRequest} records
+   * @return {!Map<string, boolean>}
+   */
+  static estimateIfConnectionWasReused(records) {
+    const connectionIds = new Set(records.map(record => record.connectionId));
+    // If the records actually have distinct connectionIds we can reuse these.
+    if (connectionIds.size > 1 || records.size < 2) {
+      return new Map(records.map(record => [record.requestId, record.connectionReused]));
+    }
+
+    // Otherwise we're on our own, arecord may not have needed a fresh connection if...
+    //   - It was not the first request to the domain
+    //   - It was H2
+    //   - It was after the first request to the domain ended
+    const connectionWasReused = new Map();
+    const groupedByOrigin = NetworkAnalyzer.groupByOrigin(records);
+    for (const [origin, originRecords] of groupedByOrigin.entries()) {
+      const earliestReusePossible = originRecords
+        .map(record => record.endTime)
+        .reduce((a, b) => Math.min(a, b), Infinity);
+
+      for (const record of originRecords) {
+        connectionWasReused.set(
+          record.requestId,
+          record.startTime >= earliestReusePossible || record.protocol === 'h2'
+        );
+      }
+
+      const firstRecord = originRecords.reduce((a, b) => (a.startTime > b.startTime ? b : a), {
+        startTime: Infinity,
+      });
+      connectionWasReused.set(firstRecord.requestId, false);
+    }
+
+    return connectionWasReused;
+  }
+
+  static estimateRTTByOrigin(records, options) {
+    options = Object.assign(
+      {
+        // TCP connection handshake information will be used when available, but for testing
+        // it's useful to see how the coarse estimates compare with higher fidelity data
+        forceCoarseEstimates: false,
+        // coarse estimates include lots of extra time and noise
+        // multiply by some factor to deflate the RTT estimates a bit
+        coarseEstimateMultiplier: 0.5,
+      },
+      options
+    );
+
+    let estimatesByOrigin = NetworkAnalyzer._estimateRTTByOriginViaTCPTiming(records);
+    if (!estimatesByOrigin.size || options.forceCoarseEstimates) {
+      estimatesByOrigin = new Map();
+      const estimatesViaDownload = NetworkAnalyzer._estimateRTTByOriginViaDownloadTiming(records);
+      const estimatesViaSendStart = NetworkAnalyzer._estimateRTTByOriginViaSendStartTiming(
+        records,
+        options.estimateResponseTime
+      );
+
+      for (const [origin, estimates] of estimatesViaDownload.entries()) {
+        estimatesByOrigin.set(origin, estimates);
+      }
+
+      for (const [origin, estimates] of estimatesViaSendStart.entries()) {
+        const existing = estimatesByOrigin.get(origin) || [];
+        estimatesByOrigin.set(origin, existing.concat(estimates));
+      }
+
+      for (const estimates of estimatesByOrigin.values()) {
+        estimates.forEach((x, i) => (estimates[i] = x * options.coarseEstimateMultiplier));
+      }
+    }
+
+    if (!estimatesByOrigin.size) throw new Error('No timing information available');
+    return NetworkAnalyzer.summary(estimatesByOrigin);
+  }
+
+  static estimateServerResponseTimeByOrigin(records, options) {
+    options = Object.assign(
+      {
+        rttByOrigin: null,
+      },
+      options
+    );
+
+    let rttByOrigin = options.rttByOrigin;
+    if (!rttByOrigin) {
+      rttByOrigin = NetworkAnalyzer.estimateRTTByOrigin(records, options);
+      for (const [origin, summary] of rttByOrigin.entries()) {
+        rttByOrigin.set(origin, summary.min);
+      }
+    }
+
+    const estimatesByOrigin = NetworkAnalyzer._estimateResponseTimeByOrigin(records, rttByOrigin);
+    return NetworkAnalyzer.summary(estimatesByOrigin);
+  }
+};
+
+module.exports.SUMMARY = Symbol('__SUMMARY__');

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -6,15 +6,14 @@
 'use strict';
 
 const Node = require('../node');
-const URL = require('../../url-shim');
 const TcpConnection = require('./tcp-connection');
+const ConnectionPool = require('./connection-pool');
 const emulation = require('../../emulation').settings;
 
 // see https://cs.chromium.org/search/?q=kDefaultMaxNumDelayableRequestsPerClient&sq=package:chromium&type=cs
 const DEFAULT_MAXIMUM_CONCURRENT_REQUESTS = 10;
 
 // Fast 3G emulation target from DevTools, WPT 3G - Fast setting
-const DEFAULT_FALLBACK_TTFB = 30;
 const DEFAULT_RTT = emulation.TYPICAL_MOBILE_THROTTLING_METRICS.targetLatency;
 const DEFAULT_THROUGHPUT = emulation.TYPICAL_MOBILE_THROTTLING_METRICS.targetDownloadThroughput * 8; // 1.6 Mbps
 
@@ -24,8 +23,6 @@ const DEFAULT_CPU_TASK_MULTIPLIER = emulation.CPU_THROTTLE_METRICS.rate;
 const DEFAULT_LAYOUT_TASK_MULTIPLIER = DEFAULT_CPU_TASK_MULTIPLIER / 2;
 // if a task takes more than 10 seconds it's usually a sign it isn't actually CPU bound and we're overestimating
 const DEFAULT_MAXIMUM_CPU_TASK_DURATION = 10000;
-
-const TLS_SCHEMES = ['https', 'wss'];
 
 const NodeState = {
   NotReadyToStart: 0,
@@ -46,19 +43,15 @@ class Simulator {
       {
         rtt: DEFAULT_RTT,
         throughput: DEFAULT_THROUGHPUT,
-        fallbackTTFB: DEFAULT_FALLBACK_TTFB,
         maximumConcurrentRequests: DEFAULT_MAXIMUM_CONCURRENT_REQUESTS,
         cpuTaskMultiplier: DEFAULT_CPU_TASK_MULTIPLIER,
         layoutTaskMultiplier: DEFAULT_LAYOUT_TASK_MULTIPLIER,
-        latencyByOrigin: new Map(),
       },
       options
     );
 
     this._rtt = this._options.rtt;
     this._throughput = this._options.throughput;
-    this._fallbackTTFB = this._options.fallbackTTFB;
-    this._latencyByOrigin = this._options.latencyByOrigin;
     this._maximumConcurrentRequests = Math.min(
       TcpConnection.maximumSaturatedConnections(this._rtt, this._throughput),
       this._options.maximumConcurrentRequests
@@ -68,66 +61,17 @@ class Simulator {
   }
 
   /**
-   * Computes the time to first byte of a network record. Returns Infinity if not available.
-   * @param {!WebInspector.NetworkRequest} record
-   * @return {number}
+   *
    */
-  static getTTFB(record) {
-    const timing = record._timing;
-    return (timing && timing.receiveHeadersEnd - timing.sendEnd) || Infinity;
-  }
-
-  /**
-   * Initializes this._networkRecords with the array of network records from the graph.
-   */
-  _initializeNetworkRecords() {
-    this._networkRecords = [];
-
+  _initializeConnectionPool() {
+    const records = [];
     this._graph.getRootNode().traverse(node => {
       if (node.type === Node.TYPES.NETWORK) {
-        this._networkRecords.push(node.record);
+        records.push(node.record);
       }
     });
-  }
 
-  /**
-   * Initializes this._connections with the map of available TcpConnections by connectionId.
-   */
-  _initializeNetworkConnections() {
-    const connections = new Map();
-    const recordsByConnection = groupBy(this._networkRecords, record => record.connectionId);
-
-    for (const [connectionId, records] of recordsByConnection.entries()) {
-      console.log(new URL(records[0].url).origin);
-      const isTLS = TLS_SCHEMES.includes(records[0].parsedURL.scheme);
-      const isH2 = records[0].protocol === 'h2';
-
-      // We'll approximate how much time the server for a connection took to respond after receiving
-      // the request by computing the minimum TTFB time for requests on that connection.
-      //    TTFB = one way latency + server response time + one way latency
-      // Even though TTFB is greater than server response time, the RTT is underaccounted for by
-      // not varying per-server and so the difference roughly evens out.
-      // TODO(patrickhulce): investigate a way to identify per-server RTT
-      let estimatedResponseTime = Math.min(...records.map(Simulator.getTTFB));
-
-      // If we couldn't find a TTFB for the requests, use the fallback TTFB instead.
-      if (!Number.isFinite(estimatedResponseTime)) {
-        estimatedResponseTime = this._fallbackTTFB;
-      }
-
-      const connection = new TcpConnection(
-        this._rtt,
-        this._throughput,
-        estimatedResponseTime,
-        isTLS,
-        isH2
-      );
-
-      connections.set(connectionId, connection);
-    }
-
-    this._connections = connections;
-    return connections;
+    this._connectionPool = new ConnectionPool(records, this._options);
   }
 
   /**
@@ -135,7 +79,6 @@ class Simulator {
    */
   _initializeAuxiliaryData() {
     this._nodeTiming = new Map();
-    this._connectionsInUse = new Set();
     this._numberInProgressByType = new Map();
 
     this._nodes = [];
@@ -150,14 +93,6 @@ class Simulator {
    */
   _numberInProgress(type) {
     return this._numberInProgressByType.get(type) || 0;
-  }
-
-  /**
-   * @param {!WebInspector.NetworkRequest} record
-   * @return {?TcpConnection}
-   */
-  _getAvailableConnectionForRecord(record) {
-
   }
 
   /**
@@ -229,16 +164,11 @@ class Simulator {
 
     if (node.type !== Node.TYPES.NETWORK) throw new Error('Unsupported');
 
-    const connection = this._connections.get(node.record.connectionId);
+    // Start a network request if we're not at max requests and a connection is available
     const numberOfActiveRequests = this._numberInProgress(node.type);
-
-    // Start a network request if the connection isn't in use and we're not at max requests
-    if (
-      numberOfActiveRequests >= this._maximumConcurrentRequests ||
-      this._connectionsInUse.has(connection)
-    ) {
-      return;
-    }
+    if (numberOfActiveRequests >= this._maximumConcurrentRequests) return;
+    const connection = this._connectionPool.acquire(node.record);
+    if (!connection) return;
 
     this._markNodeAsInProgress(node, totalElapsedTime);
     this._setTimingData(node, {
@@ -246,8 +176,6 @@ class Simulator {
       timeElapsedOvershoot: 0,
       bytesDownloaded: 0,
     });
-
-    this._connectionsInUse.add(connection);
   }
 
   /**
@@ -255,7 +183,7 @@ class Simulator {
    * currently in flight.
    */
   _updateNetworkCapacity() {
-    for (const connection of this._connectionsInUse) {
+    for (const connection of this._connectionPool.connectionsInUse()) {
       connection.setThroughput(this._throughput / this._nodes[NodeState.InProgress].size);
     }
   }
@@ -283,7 +211,7 @@ class Simulator {
     if (node.type !== Node.TYPES.NETWORK) throw new Error('Unsupported');
 
     const timingData = this._nodeTiming.get(node);
-    const connection = this._connections.get(node.record.connectionId);
+    const connection = this._connectionPool.acquire(node.record);
     const calculation = connection.simulateDownloadUntil(
       node.record.transferSize - timingData.bytesDownloaded,
       {timeAlreadyElapsed: timingData.timeElapsed}
@@ -325,7 +253,7 @@ class Simulator {
 
     if (node.type !== Node.TYPES.NETWORK) throw new Error('Unsupported');
 
-    const connection = this._connections.get(node.record.connectionId);
+    const connection = this._connectionPool.acquire(node.record);
     const calculation = connection.simulateDownloadUntil(
       node.record.transferSize - timingData.bytesDownloaded,
       {
@@ -339,7 +267,7 @@ class Simulator {
 
     if (isFinished) {
       connection.setWarmed(true);
-      this._connectionsInUse.delete(connection);
+      this._connectionPool.release(node.record);
       this._markNodeAsComplete(node, totalElapsedTime);
     } else {
       timingData.timeElapsed += calculation.timeElapsed;
@@ -353,9 +281,8 @@ class Simulator {
    * @return {{timeInMs: number, nodeTiming: !Map<!Node, !NodeTimingData>}}
    */
   simulate() {
-    // initialize all the necessary data containers
-    this._initializeNetworkRecords();
-    this._initializeNetworkConnections();
+    // initialize the necessary data containers
+    this._initializeConnectionPool();
     this._initializeAuxiliaryData();
 
     const nodesNotReadyToStart = this._nodes[NodeState.NotReadyToStart];
@@ -366,6 +293,7 @@ class Simulator {
     rootNode.traverse(node => nodesNotReadyToStart.add(node));
 
     let totalElapsedTime = 0;
+    let iteration = 0;
 
     // root node is always ready to start
     this._markNodeAsReadyToStart(rootNode, totalElapsedTime);
@@ -384,6 +312,12 @@ class Simulator {
       const minimumTime = this._findNextNodeCompletionTime();
       totalElapsedTime += minimumTime;
 
+      // While this is no longer strictly necessary, it's always better than LH hanging
+      if (!Number.isFinite(minimumTime) || iteration > 100000) {
+        throw new Error('Graph creation failed, depth exceeded');
+      }
+
+      iteration++;
       // update how far each node will progress until that point
       for (const node of nodesInProgress) {
         this._updateProgressMadeInTimePeriod(node, minimumTime, totalElapsedTime);

--- a/lighthouse-core/lib/dependency-graph/simulator/tcp-connection.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/tcp-connection.js
@@ -72,6 +72,13 @@ class TcpConnection {
   }
 
   /**
+   * @return {boolean}
+   */
+  isWarm() {
+    return this._warmed;
+  }
+
+  /**
    * Sets the number of excess bytes that are available to this connection on future downloads, only
    * applies to H2 connections.
    * @param {number} bytes

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -25,20 +25,20 @@ describe('Performance: predictive performance audit', () => {
     }, Runner.instantiateComputedArtifacts());
 
     return PredictivePerf.audit(artifacts).then(output => {
-      assert.equal(output.score, 80);
-      assert.equal(Math.round(output.rawValue), 5123);
-      assert.equal(output.displayValue, '5,120\xa0ms');
+      assert.equal(output.score, 79);
+      assert.equal(Math.round(output.rawValue), 5308);
+      assert.equal(output.displayValue, '5,310\xa0ms');
 
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
-      assert.equal(valueOf('roughEstimateOfFCP'), 2035);
-      assert.equal(valueOf('optimisticFCP'), 607);
-      assert.equal(valueOf('pessimisticFCP'), 607);
-      assert.equal(valueOf('roughEstimateOfFMP'), 2845);
-      assert.equal(valueOf('optimisticFMP'), 904);
-      assert.equal(valueOf('pessimisticFMP'), 1191);
-      assert.equal(valueOf('roughEstimateOfTTCI'), 5123);
-      assert.equal(valueOf('optimisticTTCI'), 2438);
-      assert.equal(valueOf('pessimisticTTCI'), 2399);
+      assert.equal(valueOf('roughEstimateOfFCP'), 2038);
+      assert.equal(valueOf('optimisticFCP'), 611);
+      assert.equal(valueOf('pessimisticFCP'), 611);
+      assert.equal(valueOf('roughEstimateOfFMP'), 2851);
+      assert.equal(valueOf('optimisticFMP'), 911);
+      assert.equal(valueOf('pessimisticFMP'), 1198);
+      assert.equal(valueOf('roughEstimateOfTTCI'), 5308);
+      assert.equal(valueOf('optimisticTTCI'), 2451);
+      assert.equal(valueOf('pessimisticTTCI'), 2752);
     });
   });
 });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -1,0 +1,195 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const assert = require('assert');
+
+// eslint-disable-next-line
+const NetworkAnalyzer = require('../../../../lib/dependency-graph/simulator/network-analyzer');
+const Runner = require('../../../../runner');
+const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtools.log.json');
+// const devtoolsLog = require('../../../../../plots/out-tmp/out-0-300/weather.com-./2017-12-06T17.38.32.470Z/assets-0.devtoolslog.json');
+// const devtoolsLog = require('../../../../../plots/out-tmp/from-lightrider/www.weather.com.cn/devtoolslog-defaultPass.json');
+
+/* eslint-env mocha */
+describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
+  let computedArtifacts, recordId;
+
+  function createRecord(opts) {
+    const url = opts.url || 'https://example.com';
+    return Object.assign({
+      url,
+      requestId: recordId++,
+      connectionId: 0,
+      connectionReused: false,
+      startTime: 0.01,
+      endTime: 0.01,
+      transferSize: 0,
+      protocol: 'http/1.1',
+      parsedURL: {scheme: url.match(/https?/)[0]},
+      _timing: opts.timing || null,
+    }, opts);
+  }
+
+  beforeEach(() => {
+    recordId = 1;
+    computedArtifacts = Runner.instantiateComputedArtifacts();
+  });
+
+  function assertCloseEnough(valueA, valueB, threshold = 1) {
+    const message = `${valueA} was not close enough to ${valueB}`;
+    assert.ok(Math.abs(valueA - valueB) < threshold, message)
+  }
+
+  describe('#estimateIfConnectionWasReused', () => {
+    it('should use built-in value when trustworthy', () => {
+      const records = [
+        {requestId: 1, connectionId: 1, connectionReused: false},
+        {requestId: 2, connectionId: 1, connectionReused: true},
+        {requestId: 3, connectionId: 2, connectionReused: false},
+        {requestId: 4, connectionId: 3, connectionReused: false},
+        {requestId: 5, connectionId: 2, connectionReused: true},
+      ];
+
+      const result = NetworkAnalyzer.estimateIfConnectionWasReused(records);
+      const expected = new Map([[1, false], [2, true], [3, false], [4, false], [5, true]]);
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it('should estimate values when not trustworthy', () => {
+      const records = [
+        createRecord({requestId: 1, startTime: 0, endTime: 15}),
+        createRecord({requestId: 2, startTime: 10, endTime: 25}),
+        createRecord({requestId: 3, startTime: 20, endTime: 40}),
+        createRecord({requestId: 4, startTime: 30, endTime: 40}),
+      ];
+
+      const result = NetworkAnalyzer.estimateIfConnectionWasReused(records);
+      const expected = new Map([[1, false], [2, false], [3, true], [4, true]]);
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it('should estimate with earliest allowed reuse', () => {
+      const records = [
+        createRecord({requestId: 1, startTime: 0, endTime: 40}),
+        createRecord({requestId: 2, startTime: 10, endTime: 15}),
+        createRecord({requestId: 3, startTime: 20, endTime: 30}),
+        createRecord({requestId: 4, startTime: 35, endTime: 40}),
+      ];
+
+      const result = NetworkAnalyzer.estimateIfConnectionWasReused(records);
+      const expected = new Map([[1, false], [2, false], [3, true], [4, true]]);
+      assert.deepStrictEqual(result, expected);
+    });
+
+    it('should work on a real devtoolsLog', () => {
+      return computedArtifacts.requestNetworkRecords(devtoolsLog).then(records => {
+        const result = NetworkAnalyzer.estimateIfConnectionWasReused(records);
+        const distinctConnections = Array.from(result.values()).filter(item => !item).length;
+        assert.equal(result.size, 66);
+        assert.equal(distinctConnections, 3);
+      });
+    });
+  });
+
+  describe('#estimateRTTByOrigin', () => {
+    it('should infer from tcp timing when available', () => {
+      const timing = {connectStart: 1, connectEnd: 100};
+      const record = createRecord({startTime: 0, endTime: 1, timing});
+      const result = NetworkAnalyzer.estimateRTTByOrigin([record]);
+      const expected = {min: 99, max: 99, avg: 99, median: 99};
+      assert.deepStrictEqual(result.get('https://example.com'), expected);
+    });
+
+    it('should infer from sendStart when available', () => {
+      const timing = {sendStart: 100};
+      // this record took 100ms before Chrome could send the request
+      // i.e. DNS (maybe) + queuing (maybe) + TCP handshake took ~100ms
+      // 100ms / 2 round trips ~= 50ms RTT
+      const record = createRecord({startTime: 0, endTime: 1, timing});
+      const result = NetworkAnalyzer.estimateRTTByOrigin([record], {coarseEstimateMultiplier: 1});
+      const expected = {min: 50, max: 50, avg: 50, median: 50};
+      assert.deepStrictEqual(result.get('https://example.com'), expected);
+    });
+
+    it('should infer from download timing when available', () => {
+      const timing = {receiveHeadersEnd: 100};
+      // this record took 1000ms after the first byte was received to download the payload
+      // i.e. it took at least one full additional roundtrip after first byte to download the rest
+      // 1000ms / 1 round trip ~= 1000ms RTT
+      const record = createRecord({startTime: 0, endTime: 1.1, transferSize: 28 * 1024, timing});
+      const result = NetworkAnalyzer.estimateRTTByOrigin([record], {coarseEstimateMultiplier: 1});
+      const expected = {min: 1000, max: 1000, avg: 1000, median: 1000};
+      assert.deepStrictEqual(result.get('https://example.com'), expected);
+    });
+
+    it('should work on a real devtoolsLog', () => {
+      return computedArtifacts.requestNetworkRecords(devtoolsLog).then(records => {
+        const result = NetworkAnalyzer.estimateRTTByOrigin(records);
+        assertCloseEnough(result.get('https://pwa.rocks').min, 3);
+        assertCloseEnough(result.get('https://www.googletagmanager.com').min, 3);
+        assertCloseEnough(result.get('https://www.google-analytics.com').min, 4);
+      });
+    });
+
+    it('should approximate well with either method', () => {
+      return computedArtifacts.requestNetworkRecords(devtoolsLog).then(records => {
+        const result = NetworkAnalyzer.estimateRTTByOrigin(records).get(NetworkAnalyzer.SUMMARY);
+        const resultApprox = NetworkAnalyzer.estimateRTTByOrigin(records, {forceCoarseEstimates: true}).get(NetworkAnalyzer.SUMMARY);
+        assertCloseEnough(result.min, resultApprox.min, 20);
+        assertCloseEnough(result.avg, resultApprox.avg, 30);
+        assertCloseEnough(result.median, resultApprox.median, 30);
+      });
+    });
+  });
+
+  describe('#estimateServerResponseTimeByOrigin', () => {
+    it('should estimate server response time using ttfb times', () => {
+      const timing = {sendEnd: 100, receiveHeadersEnd: 200};
+      const record = createRecord({startTime: 0, endTime: 1, timing});
+      const rttByOrigin = new Map([[NetworkAnalyzer.SUMMARY, 0]]);
+      const result = NetworkAnalyzer.estimateServerResponseTimeByOrigin([record], {rttByOrigin});
+      const expected = {min: 100, max: 100, avg: 100, median: 100};
+      assert.deepStrictEqual(result.get('https://example.com'), expected);
+    });
+
+    it('should subtract out rtt', () => {
+      const timing = {sendEnd: 100, receiveHeadersEnd: 200};
+      const record = createRecord({startTime: 0, endTime: 1, timing});
+      const rttByOrigin = new Map([[NetworkAnalyzer.SUMMARY, 50]]);
+      const result = NetworkAnalyzer.estimateServerResponseTimeByOrigin([record], {rttByOrigin});
+      const expected = {min: 50, max: 50, avg: 50, median: 50};
+      assert.deepStrictEqual(result.get('https://example.com'), expected);
+    });
+
+    it('should compute rtts when not provided', () => {
+      const timing = {connectStart: 5, connectEnd: 55, sendEnd: 100, receiveHeadersEnd: 200};
+      const record = createRecord({startTime: 0, endTime: 1, timing});
+      const result = NetworkAnalyzer.estimateServerResponseTimeByOrigin([record]);
+      const expected = {min: 50, max: 50, avg: 50, median: 50};
+      assert.deepStrictEqual(result.get('https://example.com'), expected);
+    });
+
+    it('should work on a real devtoolsLog', () => {
+      return computedArtifacts.requestNetworkRecords(devtoolsLog).then(records => {
+        const result = NetworkAnalyzer.estimateServerResponseTimeByOrigin(records);
+        assertCloseEnough(result.get('https://pwa.rocks').avg, 162);
+        assertCloseEnough(result.get('https://www.googletagmanager.com').avg, 153);
+        assertCloseEnough(result.get('https://www.google-analytics.com').avg, 161);
+      });
+    });
+
+    it('should approximate well with either method', () => {
+      return computedArtifacts.requestNetworkRecords(devtoolsLog).then(records => {
+        const result = NetworkAnalyzer.estimateServerResponseTimeByOrigin(records).get(NetworkAnalyzer.SUMMARY);
+        const resultApprox = NetworkAnalyzer.estimateServerResponseTimeByOrigin(records, {forceCoarseEstimates: true}).get(NetworkAnalyzer.SUMMARY);
+        assertCloseEnough(result.min, resultApprox.min, 20);
+        assertCloseEnough(result.avg, resultApprox.avg, 30);
+        assertCloseEnough(result.median, resultApprox.median, 30);
+      });
+    });
+  });
+});

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -11,8 +11,6 @@ const assert = require('assert');
 const NetworkAnalyzer = require('../../../../lib/dependency-graph/simulator/network-analyzer');
 const Runner = require('../../../../runner');
 const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtools.log.json');
-// const devtoolsLog = require('../../../../../plots/out-tmp/out-0-300/weather.com-./2017-12-06T17.38.32.470Z/assets-0.devtoolslog.json');
-// const devtoolsLog = require('../../../../../plots/out-tmp/from-lightrider/www.weather.com.cn/devtoolslog-defaultPass.json');
 
 /* eslint-env mocha */
 describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -13,19 +13,18 @@ const assert = require('assert');
 let nextRequestId = 1;
 let nextTid = 1;
 
-function request({requestId, connectionId, transferSize, scheme, timing}) {
-  requestId = requestId || nextRequestId++;
-  connectionId = connectionId || 1;
-  transferSize = transferSize || 1000;
-  scheme = scheme || 'http';
+function request(opts) {
+  const scheme = opts.scheme || 'http';
+  const url = `${scheme}://example.com`;
 
-  return {
-    requestId,
-    connectionId,
-    transferSize,
+  return Object.assign({
+    requestId: opts.requestId || nextRequestId++,
+    url,
+    origin: url,
+    transferSize: opts.transferSize || 1000,
     parsedURL: {scheme},
-    _timing: timing,
-  };
+    _timing: opts.timing,
+  }, opts);
 }
 
 function cpuTask({tid, ts, duration}) {
@@ -38,6 +37,8 @@ function cpuTask({tid, ts, duration}) {
 /* eslint-env mocha */
 describe('DependencyGraph/Simulator', () => {
   describe('.simulate', () => {
+    const serverResponseTimeByOrigin = new Map([['http://example.com', 500]]);
+
     function assertNodeTiming(result, node, assertions) {
       const timing = result.nodeTiming.get(node);
       assert.ok(timing, 'missing node timing information');
@@ -48,7 +49,7 @@ describe('DependencyGraph/Simulator', () => {
 
     it('should simulate basic network graphs', () => {
       const rootNode = new NetworkNode(request({}));
-      const simulator = new Simulator(rootNode, {fallbackTTFB: 500});
+      const simulator = new Simulator(rootNode, {serverResponseTimeByOrigin});
       const result = simulator.simulate();
       // should be 2 RTTs and 500ms for the server response time
       assert.equal(result.timeInMs, 300 + 500);
@@ -60,7 +61,7 @@ describe('DependencyGraph/Simulator', () => {
       const cpuNode = new CpuNode(cpuTask({duration: 200}));
       cpuNode.addDependency(rootNode);
 
-      const simulator = new Simulator(rootNode, {fallbackTTFB: 500, cpuTaskMultiplier: 5});
+      const simulator = new Simulator(rootNode, {serverResponseTimeByOrigin, cpuTaskMultiplier: 5});
       const result = simulator.simulate();
       // should be 2 RTTs and 500ms for the server response time + 200 CPU
       assert.equal(result.timeInMs, 300 + 500 + 200);
@@ -69,16 +70,16 @@ describe('DependencyGraph/Simulator', () => {
     });
 
     it('should simulate basic network waterfall graphs', () => {
-      const nodeA = new NetworkNode(request({connectionId: 1}));
-      const nodeB = new NetworkNode(request({connectionId: 2}));
-      const nodeC = new NetworkNode(request({connectionId: 3}));
-      const nodeD = new NetworkNode(request({connectionId: 4}));
+      const nodeA = new NetworkNode(request({startTime: 0, endTime: 1}));
+      const nodeB = new NetworkNode(request({startTime: 0, endTime: 3}));
+      const nodeC = new NetworkNode(request({startTime: 0, endTime: 5}));
+      const nodeD = new NetworkNode(request({startTime: 0, endTime: 7}));
 
       nodeA.addDependent(nodeB);
       nodeB.addDependent(nodeC);
       nodeC.addDependent(nodeD);
 
-      const simulator = new Simulator(nodeA, {fallbackTTFB: 500});
+      const simulator = new Simulator(nodeA, {serverResponseTimeByOrigin});
       const result = simulator.simulate();
       // should be 800ms each for A, B, C, D
       assert.equal(result.timeInMs, 3200);
@@ -89,7 +90,7 @@ describe('DependencyGraph/Simulator', () => {
     });
 
     it('should simulate basic CPU queue graphs', () => {
-      const nodeA = new NetworkNode(request({connectionId: 1}));
+      const nodeA = new NetworkNode(request({}));
       const nodeB = new CpuNode(cpuTask({duration: 100}));
       const nodeC = new CpuNode(cpuTask({duration: 600}));
       const nodeD = new CpuNode(cpuTask({duration: 300}));
@@ -98,7 +99,7 @@ describe('DependencyGraph/Simulator', () => {
       nodeA.addDependent(nodeC);
       nodeA.addDependent(nodeD);
 
-      const simulator = new Simulator(nodeA, {fallbackTTFB: 500, cpuTaskMultiplier: 5});
+      const simulator = new Simulator(nodeA, {serverResponseTimeByOrigin, cpuTaskMultiplier: 5});
       const result = simulator.simulate();
       // should be 800ms A, then 1000 ms total for B, C, D in serial
       assert.equal(result.timeInMs, 1800);
@@ -109,10 +110,10 @@ describe('DependencyGraph/Simulator', () => {
     });
 
     it('should simulate basic network waterfall graphs with CPU', () => {
-      const nodeA = new NetworkNode(request({connectionId: 1}));
-      const nodeB = new NetworkNode(request({connectionId: 2}));
-      const nodeC = new NetworkNode(request({connectionId: 3}));
-      const nodeD = new NetworkNode(request({connectionId: 4}));
+      const nodeA = new NetworkNode(request({}));
+      const nodeB = new NetworkNode(request({}));
+      const nodeC = new NetworkNode(request({}));
+      const nodeD = new NetworkNode(request({}));
       const nodeE = new CpuNode(cpuTask({duration: 1000}));
       const nodeF = new CpuNode(cpuTask({duration: 1000}));
 
@@ -122,55 +123,55 @@ describe('DependencyGraph/Simulator', () => {
       nodeC.addDependent(nodeD);
       nodeC.addDependent(nodeF); // finishes 400 ms after D
 
-      const simulator = new Simulator(nodeA, {fallbackTTFB: 500, cpuTaskMultiplier: 5});
+      const simulator = new Simulator(nodeA, {serverResponseTimeByOrigin, cpuTaskMultiplier: 5});
       const result = simulator.simulate();
       // should be 800ms each for A, B, C, D, with F finishing 400 ms after D
       assert.equal(result.timeInMs, 3600);
     });
 
     it('should simulate basic parallel requests', () => {
-      const nodeA = new NetworkNode(request({connectionId: 1}));
-      const nodeB = new NetworkNode(request({connectionId: 2}));
-      const nodeC = new NetworkNode(request({connectionId: 3, transferSize: 15000}));
-      const nodeD = new NetworkNode(request({connectionId: 4}));
+      const nodeA = new NetworkNode(request({}));
+      const nodeB = new NetworkNode(request({}));
+      const nodeC = new NetworkNode(request({transferSize: 15000}));
+      const nodeD = new NetworkNode(request({}));
 
       nodeA.addDependent(nodeB);
       nodeA.addDependent(nodeC);
       nodeA.addDependent(nodeD);
 
-      const simulator = new Simulator(nodeA, {fallbackTTFB: 500});
+      const simulator = new Simulator(nodeA, {serverResponseTimeByOrigin});
       const result = simulator.simulate();
       // should be 800ms for A and 950ms for C (2 round trips of downloading)
       assert.equal(result.timeInMs, 800 + 950);
     });
 
     it('should not reuse connections', () => {
-      const nodeA = new NetworkNode(request({connectionId: 1}));
-      const nodeB = new NetworkNode(request({connectionId: 1}));
-      const nodeC = new NetworkNode(request({connectionId: 1}));
-      const nodeD = new NetworkNode(request({connectionId: 1}));
+      const nodeA = new NetworkNode(request({startTime: 0, endTime: 1}));
+      const nodeB = new NetworkNode(request({startTime: 2, endTime: 3}));
+      const nodeC = new NetworkNode(request({startTime: 2, endTime: 5}));
+      const nodeD = new NetworkNode(request({startTime: 2, endTime: 7}));
 
       nodeA.addDependent(nodeB);
       nodeA.addDependent(nodeC);
       nodeA.addDependent(nodeD);
 
-      const simulator = new Simulator(nodeA, {fallbackTTFB: 500});
+      const simulator = new Simulator(nodeA, {serverResponseTimeByOrigin});
       const result = simulator.simulate();
       // should be 800ms for A and 650ms for the next 3
       assert.equal(result.timeInMs, 800 + 650 * 3);
     });
 
     it('should adjust throughput based on number of requests', () => {
-      const nodeA = new NetworkNode(request({connectionId: 1}));
-      const nodeB = new NetworkNode(request({connectionId: 2}));
-      const nodeC = new NetworkNode(request({connectionId: 3, transferSize: 15000}));
-      const nodeD = new NetworkNode(request({connectionId: 4}));
+      const nodeA = new NetworkNode(request({}));
+      const nodeB = new NetworkNode(request({}));
+      const nodeC = new NetworkNode(request({transferSize: 15000}));
+      const nodeD = new NetworkNode(request({}));
 
       nodeA.addDependent(nodeB);
       nodeA.addDependent(nodeC);
       nodeA.addDependent(nodeD);
 
-      const simulator = new Simulator(nodeA, {fallbackTTFB: 500});
+      const simulator = new Simulator(nodeA, {serverResponseTimeByOrigin});
       const result = simulator.simulate();
       // should be 800ms for A and 950ms for C (2 round trips of downloading)
       assert.equal(result.timeInMs, 800 + 950);


### PR DESCRIPTION
### changes
* estimates the observed RTT of each origin and takes this into account when simulating
* estimates the server response time of each origin using *all* available records, instead of just the records involved in the graph (prior behavior responsible for 1st bug in list below)
* ignores observed connectionId from Chrome when simulating and creates its own set of connections instead

### consequences
* fixes a bug where the pessimistic estimate could be smaller than the optimistic estimate due to different connections being used
* should substantially improve accuracy observed in LR when the connectionIds are all `0`
* reduces absolute estimate error by ~4% across the board (25% error -> 21% error, not 25% -> 24% 😉)
* marginally increases rank correlation on FCP, marginally decreases rank correlation on FMP, no impact to rank correlation of TTI