### PR TITLE
docs(headless-chrome): switch to prioritize headless

### DIFF
--- a/docs/headless-chrome.md
+++ b/docs/headless-chrome.md
@@ -2,9 +2,6 @@
 
 ## CLI (headless)
 
-> **Note**: Headless Chrome still has a few bugs to work out. For example, [network emulation](https://bugs.chromium.org/p/chromium/issues/detail?id=728451) is not supported yet.
-This can affect the accuracy of performance scores returned by Lighthouse.
-
 Setup:
 
 ```sh
@@ -27,7 +24,7 @@ lighthouse --chrome-flags="--headless" https://github.com
 
 ## CLI (xvfb)
 
-Alternativeluy, you can run full Chrome + xvfb instead of headless mode. These steps worked on Debian Jessie:
+Alternatively, you can run full Chrome + xvfb instead of headless mode. These steps worked on Debian Jessie:
 
 ```sh
 # get node 6

--- a/docs/headless-chrome.md
+++ b/docs/headless-chrome.md
@@ -1,10 +1,33 @@
 # Running Lighthouse using headless Chrome
 
-For now, we recommend running Chrome with xvfb. See below.
+## CLI (headless)
+
+> **Note**: Headless Chrome still has a few bugs to work out. For example, [network emulation](https://bugs.chromium.org/p/chromium/issues/detail?id=728451) is not supported yet.
+This can affect the accuracy of performance scores returned by Lighthouse.
+
+Setup:
+
+```sh
+# get node 6
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - &&\
+sudo apt-get install -y nodejs
+
+# get chromium (stable)
+apt-get install chromium-browser
+
+# install lighthouse
+npm i -g lighthouse
+```
+
+Kick off run of Lighthouse using headless Chrome:
+
+```sh
+lighthouse --chrome-flags="--headless" https://github.com
+```
 
 ## CLI (xvfb)
 
-Chrome + xvfb is the stable solution we recommend. These steps worked on Debian Jessie:
+Alternativeluy, you can run full Chrome + xvfb instead of headless mode. These steps worked on Debian Jessie:
 
 ```sh
 # get node 6
@@ -35,32 +58,7 @@ xvfb-run --server-args='-screen 0, 1024x768x16' \
 lighthouse --port=9222 https://github.com
 ```
 
-## CLI (headless)
-
-> **Note**: Headless Chrome still has a few bugs to work out. For example, [network emulation](https://bugs.chromium.org/p/chromium/issues/detail?id=728451) is not supported yet.
-This can affect the accuracy of performance scores returned by Lighthouse.
-
-Setup:
-
-```sh
-# get node 6
-curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - &&\
-sudo apt-get install -y nodejs
-
-# get chromium (stable)
-apt-get install chromium-browser
-
-# install lighthouse
-npm i -g lighthouse
-```
-
-Kick off run of Lighthouse using headless Chrome:
-
-```sh
-lighthouse --chrome-flags="--headless" https://github.com
-```
-
-## Node
+## Node module
 
 Install:
 


### PR DESCRIPTION
Prioritizing headless now that it supports emulation.