### PR TITLE
extension: fix issue where gatherers cannot be found

### DIFF
--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -136,7 +136,7 @@ gulp.task('browserify-lighthouse', () => {
         bundle = bundle.require(audit, {expose: audit.replace(corePath, '../')});
       });
       gatherers.forEach(gatherer => {
-        bundle = bundle.require(gatherer, {expose: gatherer.replace(driverPath, './')});
+        bundle = bundle.require(gatherer, {expose: gatherer.replace(driverPath, '../gather/')});
       });
       computedArtifacts.forEach(artifact => {
         bundle = bundle.require(artifact, {expose: artifact.replace(corePath, './')});


### PR DESCRIPTION
broken by #4394 which moved where gatherers are required from, the browserify transform needed to be updated too

thanks to @wardpeet for noticing!