### PR TITLE
deps(axe-core): update axe-core to latest (beta) release

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "zone.js": "^0.7.3"
   },
   "dependencies": {
-    "axe-core": "3.0.0-beta.1",
+    "axe-core": "3.0.0-beta.2",
     "chrome-devtools-frontend": "1.0.422034",
     "chrome-launcher": "^0.10.2",
     "configstore": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "zone.js": "^0.7.3"
   },
   "dependencies": {
-    "axe-core": "2.6.1",
+    "axe-core": "3.0.0-beta.1",
     "chrome-devtools-frontend": "1.0.422034",
     "chrome-launcher": "^0.10.2",
     "configstore": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,9 +335,9 @@ aws4@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
 
-axe-core@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.6.1.tgz#28772c4f76966d373acda35b9a409299dc00d1b5"
+axe-core@3.0.0-beta.1:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.0.0-beta.1.tgz#304a775cbf1f9159aa89171fef3db7203c2f6c8e"
 
 axios@0.15.3:
   version "0.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,9 +335,9 @@ aws4@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
 
-axe-core@3.0.0-beta.1:
-  version "3.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.0.0-beta.1.tgz#304a775cbf1f9159aa89171fef3db7203c2f6c8e"
+axe-core@3.0.0-beta.2:
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.0.0-beta.2.tgz#82a13d371268034352bba2bcb263c5625b3e4a09"
 
 axios@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
There's a number of important performance fixes in the latest axe-core release that will significantly improve the speed of LH (and in many cases allow the accessibility audits to complete successfully for sites with big dom).

Ref: dequelabs/axe-core/issues/696
Ref: dequelabs/axe-core/issues/701
Ref: dequelabs/axe-core/issues/702

Top work, @paulirish 💓 