### PR TITLE
report(description): update helpText for document.title audit

### DIFF
--- a/lighthouse-core/audits/accessibility/document-title.js
+++ b/lighthouse-core/audits/accessibility/document-title.js
@@ -20,10 +20,10 @@ class DocumentTitle extends AxeAudit {
     return {
       name: 'document-title',
       description: 'Document has a `<title>` element',
-      failureDescription: 'Document does not have a `<title>` element',
-      helpText: 'Screen reader users use page titles to get an overview of the contents of ' +
-          'the page. ' +
-          '[Learn more](https://dequeuniversity.com/rules/axe/2.2/document-title?application=lighthouse).',
+      failureDescription: 'Document doesn\'t have a `<title>` element',
+      helpText: 'The title gives screen reader users an overview of the page, and search ' +
+          'engine users rely on it heavily to determine if a page is relevant to their search. ' +
+          '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/title).',
       requiredArtifacts: ['Accessibility'],
     };
   }


### PR DESCRIPTION
Since the audit occurs in both the a11y and SEO categories, the new helpText now mentions both. The helpText links to a new reference on d.g.c/web that discusses both the a11y and SEO aspects of the audit. The previously-linked-to aXe doc only mentioned the a11y side. But that aXe doc is itself mentioned in the new reference. I also updated the failureDescription while I was here, since we agreed in group chat that contractions are more in-tune with the Lighthouse voice.

#polish