### PR TITLE
docs(contributing): fix link for closure annotations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We'd love your help! This doc covers how to become a contributor and submit code
 
 ## Follow the coding style
 
-The `.eslintrc` file defines all. We use [JSDoc](http://usejsdoc.org/) along with [closure annotations](https://developers.google.com/closure/compiler/docs/js-for-compiler). Annotations are encouraged for all contributions.
+The `.eslintrc` file defines all. We use [JSDoc](http://usejsdoc.org/) along with [closure annotations](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler). Annotations are encouraged for all contributions.
 
 ## Pull request titles
 


### PR DESCRIPTION
The old page was deprecated and gave an automated redirect.