### PR TITLE
core: refactor scoring to be numeric only. introduce scoreDisplayMode

### DIFF
--- a/docs/understanding-results.md
+++ b/docs/understanding-results.md
@@ -57,7 +57,7 @@ An object containing the results of the audits, keyed by their name.
 | rawValue | <code>boolean&#124;number</code> | The unscored value determined by the audit. Typically this will match the score if there's no additional information to impart. For performance audits, this value is typically a number indicating the metric value. |
 | displayValue | `string` | The string to display in the report alongside audit results. If empty, nothing additional is shown. This is typically used to explain additional information such as the number and nature of failing items. |
 | score | <code>boolean&#124;number</code> | The scored value determined by the audit as either boolean or a number `0-100`. If the audit is a boolean, the implication is `score ? 100 : 0`. |
-| scoringMode | <code>"binary"&#124;"numeric"</code> | A string identifying how granular the score is meant to be indicating, i.e. is the audit pass/fail or are there shades of gray 0-100. *NOTE: This does not necessarily mean `typeof audit.score === audit.scoringMode`, an audit can have a score of 40 with a scoringMode of `"binary"` meant to indicate display should be failure.* |
+| scoreDisplayMode | <code>"binary"&#124;"numeric"</code> | A string identifying how granular the score is meant to be indicating, i.e. is the audit pass/fail or are there shades of gray 0-100. *NOTE: This does not necessarily mean `typeof audit.score === audit.scoreDisplayMode`, an audit can have a score of 40 with a scoreDisplayMode of `"binary"` meant to indicate display should be failure.* |
 | details | `Object` | Extra information found by the audit necessary for display. The structure of this object varies from audit to audit. The structure of this object is somewhat stable between minor version bumps as this object is used to render the HTML report.
 | extendedInfo | `Object` | Extra information found by the audit. The structure of this object varies from audit to audit and is generally for programmatic consumption and debugging, though there is typically overlap with `details`. *WARNING: The structure of this object is not stable and cannot be trusted to follow semver* |
 | manual | `boolean` | Indicator used for display that the audit does not have results and is a placeholder for the user to conduct manual testing. |
@@ -74,10 +74,10 @@ An object containing the results of the audits, keyed by their name.
     "description": "Uses HTTPS",
     "failureDescription": "Does not use HTTPS",
     "helpText": "HTTPS is the best. [Learn more](https://learn-more)",
-    "score": false,
+    "score": 0,
     "rawValue": false,
     "displayValue": "2 insecure requests found",
-    "scoringMode": "binary",
+    "scoreDisplayMode": "binary",
     "details": {
       "type": "list",
       "header": {
@@ -205,7 +205,7 @@ An array containing the different categories, their scores, and the results of t
         "weight": 1,
         "result": {
           "name": "is-on-https",
-          "score": false,
+          "score": 0,
           ...
         }
       }

--- a/lighthouse-cli/test/smokehouse/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/a11y/expectations.js
@@ -14,7 +14,7 @@ module.exports = [
     url: 'http://localhost:10200/a11y/a11y_tester.html',
     audits: {
       'accesskeys': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -22,7 +22,7 @@ module.exports = [
         },
       },
       'aria-allowed-attr': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -30,7 +30,7 @@ module.exports = [
         },
       },
       'aria-required-children': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -38,7 +38,7 @@ module.exports = [
         },
       },
       'aria-required-parent': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -46,7 +46,7 @@ module.exports = [
         },
       },
       'aria-roles': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -54,7 +54,7 @@ module.exports = [
         },
       },
       'aria-valid-attr-value': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -62,7 +62,7 @@ module.exports = [
         },
       },
       'aria-valid-attr': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -70,7 +70,7 @@ module.exports = [
         },
       },
       'button-name': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -78,7 +78,7 @@ module.exports = [
         },
       },
       'bypass': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -86,7 +86,7 @@ module.exports = [
         },
       },
       'color-contrast': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -94,7 +94,7 @@ module.exports = [
         },
       },
       'definition-list': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -102,7 +102,7 @@ module.exports = [
         },
       },
       'dlitem': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -110,7 +110,7 @@ module.exports = [
         },
       },
       'document-title': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -118,7 +118,7 @@ module.exports = [
         },
       },
       'duplicate-id': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -126,7 +126,7 @@ module.exports = [
         },
       },
       'frame-title': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -134,7 +134,7 @@ module.exports = [
         },
       },
       'html-has-lang': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -142,7 +142,7 @@ module.exports = [
         },
       },
       'image-alt': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -150,7 +150,7 @@ module.exports = [
         },
       },
       'input-image-alt': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -158,7 +158,7 @@ module.exports = [
         },
       },
       'label': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -166,7 +166,7 @@ module.exports = [
         },
       },
       'layout-table': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -174,7 +174,7 @@ module.exports = [
         },
       },
       'link-name': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -182,7 +182,7 @@ module.exports = [
         },
       },
       'list': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -190,7 +190,7 @@ module.exports = [
         },
       },
       'listitem': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -198,7 +198,7 @@ module.exports = [
         },
       },
       'meta-viewport': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -206,7 +206,7 @@ module.exports = [
         },
       },
       'object-alt': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -214,7 +214,7 @@ module.exports = [
         },
       },
       'tabindex': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -222,7 +222,7 @@ module.exports = [
         },
       },
       'td-headers-attr': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -230,7 +230,7 @@ module.exports = [
         },
       },
       'valid-lang': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -14,7 +14,7 @@ module.exports = [
     url: 'http://localhost:10200/byte-efficiency/tester.html',
     audits: {
       'unminified-css': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             wastedKb: 17,
@@ -25,7 +25,7 @@ module.exports = [
         },
       },
       'unminified-javascript': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             wastedKb: 14,
@@ -36,7 +36,7 @@ module.exports = [
         },
       },
       'unused-css-rules': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             wastedKb: 39,
@@ -47,7 +47,7 @@ module.exports = [
         },
       },
       'unused-javascript': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             // TODO(phulce): Update this to =32 once block-level coverage tracking hits stable
@@ -59,7 +59,7 @@ module.exports = [
         },
       },
       'offscreen-images': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             results: [
@@ -77,7 +77,7 @@ module.exports = [
         },
       },
       'uses-webp-images': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             results: {
@@ -87,7 +87,7 @@ module.exports = [
         },
       },
       'uses-optimized-images': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             results: {
@@ -97,7 +97,7 @@ module.exports = [
         },
       },
       'uses-responsive-images': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             results: {

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -14,7 +14,7 @@ module.exports = [
     url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
     audits: {
       'errors-in-console': {
-        score: false,
+        score: 0,
         rawValue: '>3',
         details: {
           items: {
@@ -23,7 +23,7 @@ module.exports = [
         },
       },
       'is-on-https': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             length: 1,
@@ -31,7 +31,7 @@ module.exports = [
         },
       },
       'uses-http2': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             results: {
@@ -46,7 +46,7 @@ module.exports = [
         },
       },
       'external-anchors-use-rel-noopener': {
-        score: false,
+        score: 0,
         debugString: 'Lighthouse was unable to determine the destination of some anchor tags. ' +
                      'If they are not used as hyperlinks, consider removing the _blank target.',
         extendedInfo: {
@@ -61,11 +61,11 @@ module.exports = [
         },
       },
       'appcache-manifest': {
-        score: false,
+        score: 0,
         debugString: 'Found <html manifest="clock.appcache">.',
       },
       'geolocation-on-start': {
-        score: false,
+        score: 0,
       },
       'link-blocking-first-paint': {
         score: 0,
@@ -84,7 +84,7 @@ module.exports = [
         },
       },
       'no-document-write': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             length: 3,
@@ -97,7 +97,7 @@ module.exports = [
         },
       },
       'no-mutation-events': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             results: {
@@ -112,7 +112,7 @@ module.exports = [
         },
       },
       'no-vulnerable-libraries': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 1,
@@ -120,14 +120,14 @@ module.exports = [
         },
       },
       'no-websql': {
-        score: false,
+        score: 0,
         debugString: 'Found database "mydb", version: 1.0.',
       },
       'notification-on-start': {
-        score: false,
+        score: 0,
       },
       'script-blocking-first-paint': {
-        score: '<100',
+        score: '<1.00',
         extendedInfo: {
           value: {
             results: {
@@ -142,7 +142,7 @@ module.exports = [
         },
       },
       'uses-passive-event-listeners': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             // Note: Originally this was 7 but M56 defaults document-level
@@ -154,7 +154,7 @@ module.exports = [
         },
       },
       'deprecations': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             length: 3,
@@ -167,7 +167,7 @@ module.exports = [
         },
       },
       'password-inputs-can-be-pasted-into': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             length: 2,
@@ -175,7 +175,7 @@ module.exports = [
         },
       },
       'image-aspect-ratio': {
-        score: false,
+        score: 0,
         details: {
           items: {
             0: {
@@ -191,7 +191,7 @@ module.exports = [
     url: 'http://localhost:10200/dobetterweb/domtester.html?smallDOM',
     audits: {
       'dom-size': {
-        score: 100,
+        score: 1,
         extendedInfo: {
           value: {
             0: {value: '1,324'},
@@ -235,7 +235,7 @@ module.exports = [
     url: 'http://localhost:10200/dobetterweb/domtester.html?withShadowDOM',
     audits: {
       'dom-size': {
-        score: 100,
+        score: 1,
         extendedInfo: {
           value: {
             0: {value: '37'},
@@ -257,7 +257,7 @@ module.exports = [
     url: 'http://localhost:10200/dobetterweb/domtester.html?ShadowRootWithManyChildren',
     audits: {
       'dom-size': {
-        score: 100,
+        score: 1,
         extendedInfo: {
           value: {
             0: {value: '33'},
@@ -279,40 +279,40 @@ module.exports = [
     url: 'http://localhost:10200/online-only.html',
     audits: {
       'is-on-https': {
-        score: true,
+        score: 1,
       },
       'uses-http2': {
-        score: false,
+        score: 0,
       },
       'external-anchors-use-rel-noopener': {
-        score: true,
+        score: 1,
       },
       'appcache-manifest': {
-        score: true,
+        score: 1,
       },
       'geolocation-on-start': {
-        score: true,
+        score: 1,
       },
       'link-blocking-first-paint': {
-        score: 100,
+        score: 1.00,
       },
       'no-document-write': {
-        score: true,
+        score: 1,
       },
       'no-mutation-events': {
-        score: true,
+        score: 1,
       },
       'no-websql': {
-        score: true,
+        score: 1,
       },
       'script-blocking-first-paint': {
-        score: 100,
+        score: 1.00,
       },
       'uses-passive-event-listeners': {
-        score: true,
+        score: 1,
       },
       'password-inputs-can-be-pasted-into': {
-        score: true,
+        score: 1,
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
@@ -16,39 +16,39 @@ module.exports = [
     url: 'http://localhost:10200/online-only.html',
     audits: {
       'is-on-https': {
-        score: true,
+        score: 1,
       },
       'redirects-http': {
-        score: false,
+        score: 0,
       },
       'service-worker': {
-        score: false,
+        score: 0,
       },
       'works-offline': {
-        score: false,
+        score: 0,
       },
       'viewport': {
-        score: true,
+        score: 1,
       },
       'without-javascript': {
-        score: true,
+        score: 1,
       },
       'user-timings': {
-        score: true,
+        score: 1,
         displayValue: '0',
       },
       'critical-request-chains': {
-        score: true,
+        score: 1,
         displayValue: '0',
       },
       'webapp-install-banner': {
-        score: false,
+        score: 0,
       },
       'splash-screen': {
-        score: false,
+        score: 0,
       },
       'themed-omnibox': {
-        score: false,
+        score: 0,
       },
       'aria-valid-attr': {
         notApplicable: true,
@@ -57,7 +57,7 @@ module.exports = [
         notApplicable: true,
       },
       'color-contrast': {
-        score: true,
+        score: 1,
       },
       'image-alt': {
         notApplicable: true,
@@ -69,7 +69,7 @@ module.exports = [
         notApplicable: true,
       },
       'content-width': {
-        score: true,
+        score: 1,
       },
     },
   },
@@ -79,39 +79,39 @@ module.exports = [
     url: 'http://localhost:10503/offline-ready.html',
     audits: {
       'is-on-https': {
-        score: true,
+        score: 1,
       },
       'redirects-http': {
-        score: false,
+        score: 0,
       },
       'service-worker': {
-        score: true,
+        score: 1,
       },
       'works-offline': {
-        score: true,
+        score: 1,
       },
       'viewport': {
-        score: true,
+        score: 1,
       },
       'without-javascript': {
-        score: true,
+        score: 1,
       },
       'user-timings': {
-        score: true,
+        score: 1,
         displayValue: '0',
       },
       'critical-request-chains': {
-        score: true,
+        score: 1,
         displayValue: '0',
       },
       'webapp-install-banner': {
-        score: false,
+        score: 0,
       },
       'splash-screen': {
-        score: false,
+        score: 0,
       },
       'themed-omnibox': {
-        score: false,
+        score: 0,
       },
       'aria-valid-attr': {
         notApplicable: true,
@@ -120,10 +120,10 @@ module.exports = [
         notApplicable: true,
       },
       'color-contrast': {
-        score: true,
+        score: 1,
       },
       'image-alt': {
-        score: false,
+        score: 0,
       },
       'label': {
         notApplicable: true,
@@ -132,7 +132,7 @@ module.exports = [
         notApplicable: true,
       },
       'content-width': {
-        score: true,
+        score: 1,
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -14,7 +14,7 @@ module.exports = [
     url: 'http://localhost:10200/preload.html',
     audits: {
       'speed-index-metric': {
-        score: '>=80',
+        score: '>=.80',
         extendedInfo: {
           value: {
             timings: {},
@@ -24,13 +24,13 @@ module.exports = [
         },
       },
       'first-meaningful-paint': {
-        score: '>=90',
+        score: '>=.90',
       },
       'first-interactive': {
-        score: '>=90',
+        score: '>=.90',
       },
       'consistently-interactive': {
-        score: '>=90',
+        score: '>=.90',
       },
       'time-to-first-byte': {
         // Can be flaky, so test float rawValue instead of boolean score
@@ -44,7 +44,7 @@ module.exports = [
         },
       },
       'uses-rel-preload': {
-        score: '<100',
+        score: '<1.00',
         rawValue: '>500',
         details: {
           items: {
@@ -59,7 +59,7 @@ module.exports = [
     url: 'http://localhost:10200/perf/fonts.html',
     audits: {
       'font-display': {
-        score: false,
+        score: 0,
         rawValue: false,
         details: {
           items: {

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -15,28 +15,28 @@ module.exports = [
     url: 'https://airhorner.com/',
     audits: {
       'is-on-https': {
-        score: true,
+        score: 1,
       },
       'redirects-http': {
-        score: true,
+        score: 1,
       },
       'service-worker': {
-        score: true,
+        score: 1,
       },
       'works-offline': {
-        score: true,
+        score: 1,
       },
       'viewport': {
-        score: true,
+        score: 1,
       },
       'without-javascript': {
-        score: true,
+        score: 1,
       },
       'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
       },
       'webapp-install-banner': {
-        score: true,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -56,7 +56,7 @@ module.exports = [
         },
       },
       'splash-screen': {
-        score: true,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -76,7 +76,7 @@ module.exports = [
         },
       },
       'themed-omnibox': {
-        score: true,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -96,20 +96,20 @@ module.exports = [
         },
       },
       'content-width': {
-        score: true,
+        score: 1,
       },
 
       // "manual" audits. Just verify in the results.
       'pwa-cross-browser': {
-        score: false,
+        score: 0,
         manual: true,
       },
       'pwa-page-transitions': {
-        score: false,
+        score: 0,
         manual: true,
       },
       'pwa-each-page-has-url': {
-        score: false,
+        score: 0,
         manual: true,
       },
     },
@@ -120,28 +120,28 @@ module.exports = [
     url: 'https://www.chromestatus.com/features',
     audits: {
       'is-on-https': {
-        score: true,
+        score: 1,
       },
       'redirects-http': {
-        score: true,
+        score: 1,
       },
       'service-worker': {
-        score: true,
+        score: 1,
       },
       'works-offline': {
-        score: false,
+        score: 0,
       },
       'viewport': {
-        score: true,
+        score: 1,
       },
       'without-javascript': {
-        score: true,
+        score: 1,
       },
       'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
       },
       'webapp-install-banner': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -161,7 +161,7 @@ module.exports = [
         },
       },
       'splash-screen': {
-        score: true,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -181,7 +181,7 @@ module.exports = [
         },
       },
       'themed-omnibox': {
-        score: true,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -201,20 +201,20 @@ module.exports = [
         },
       },
       'content-width': {
-        score: true,
+        score: 1,
       },
 
       // "manual" audits. Just verify in the results.
       'pwa-cross-browser': {
-        score: false,
+        score: 0,
         manual: true,
       },
       'pwa-page-transitions': {
-        score: false,
+        score: 0,
         manual: true,
       },
       'pwa-each-page-has-url': {
-        score: false,
+        score: 0,
         manual: true,
       },
     },
@@ -225,30 +225,30 @@ module.exports = [
     url: 'https://jakearchibald.github.io/svgomg/',
     audits: {
       'is-on-https': {
-        score: true,
+        score: 1,
       },
       'redirects-http': {
         // Note: relies on JS redirect.
         // see https://github.com/GoogleChrome/lighthouse/issues/2383
-        score: false,
+        score: 0,
       },
       'service-worker': {
-        score: true,
+        score: 1,
       },
       'works-offline': {
-        score: true,
+        score: 1,
       },
       'viewport': {
-        score: true,
+        score: 1,
       },
       'without-javascript': {
-        score: true,
+        score: 1,
       },
       'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
       },
       'webapp-install-banner': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -268,7 +268,7 @@ module.exports = [
         },
       },
       'splash-screen': {
-        score: true,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -288,7 +288,7 @@ module.exports = [
         },
       },
       'themed-omnibox': {
-        score: true,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -308,20 +308,20 @@ module.exports = [
         },
       },
       'content-width': {
-        score: true,
+        score: 1,
       },
 
       // "manual" audits. Just verify in the results.
       'pwa-cross-browser': {
-        score: false,
+        score: 0,
         manual: true,
       },
       'pwa-page-transitions': {
-        score: false,
+        score: 0,
         manual: true,
       },
       'pwa-each-page-has-url': {
-        score: false,
+        score: 0,
         manual: true,
       },
     },
@@ -334,28 +334,28 @@ module.exports = [
   //   url: 'https://shop.polymer-project.org/',
   //   audits: {
   //     'is-on-https': {
-  //       score: true
+  //       score: 1
   //     },
   //     'redirects-http': {
-  //       score: true
+  //       score: 1
   //     },
   //     'service-worker': {
-  //       score: true
+  //       score: 1
   //     },
   //     'works-offline': {
-  //       score: true
+  //       score: 1
   //     },
   //     'viewport': {
-  //       score: true
+  //       score: 1
   //     },
   //     'without-javascript': {
-  //       score: true
+  //       score: 1
   //     },
   //     'load-fast-enough-for-pwa': {
   //       // Ignore speed test; just verify that it ran.
   //     },
   //     'webapp-install-banner': {
-  //       score: true,
+  //       score: 1,
   //       extendedInfo: {
   //         value: {
   //           manifestValues: {
@@ -375,7 +375,7 @@ module.exports = [
   //       }
   //     },
   //     'splash-screen': {
-  //       score: true,
+  //       score: 1,
   //       extendedInfo: {
   //         value: {
   //           manifestValues: {
@@ -395,7 +395,7 @@ module.exports = [
   //       }
   //     },
   //     'themed-omnibox': {
-  //       score: true,
+  //       score: 1,
   //       extendedInfo: {
   //         value: {
   //           manifestValues: {
@@ -415,20 +415,20 @@ module.exports = [
   //       }
   //     },
   //     'content-width': {
-  //       score: true
+  //       score: 1
   //     },
 
   //     // "manual" audits. Just verify in the results.
   //     'pwa-cross-browser': {
-  //       score: false,
+  //       score: 0,
   //       manual: true
   //     },
   //     'pwa-page-transitions': {
-  //       score: false,
+  //       score: 0,
   //       manual: true
   //     },
   //     'pwa-each-page-has-url': {
-  //       score: false,
+  //       score: 0,
   //       manual: true
   //     }
   //   }
@@ -439,28 +439,28 @@ module.exports = [
     url: 'https://pwa.rocks/',
     audits: {
       'is-on-https': {
-        score: true,
+        score: 1,
       },
       'redirects-http': {
-        score: true,
+        score: 1,
       },
       'service-worker': {
-        score: true,
+        score: 1,
       },
       'works-offline': {
-        score: true,
+        score: 1,
       },
       'viewport': {
-        score: true,
+        score: 1,
       },
       'without-javascript': {
-        score: true,
+        score: 1,
       },
       'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran .
       },
       'webapp-install-banner': {
-        score: true,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -480,7 +480,7 @@ module.exports = [
         },
       },
       'splash-screen': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -500,7 +500,7 @@ module.exports = [
         },
       },
       'themed-omnibox': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             manifestValues: {
@@ -520,20 +520,20 @@ module.exports = [
         },
       },
       'content-width': {
-        score: true,
+        score: 1,
       },
 
       // "manual" audits. Just verify in the results.
       'pwa-cross-browser': {
-        score: false,
+        score: 0,
         manual: true,
       },
       'pwa-page-transitions': {
-        score: false,
+        score: 0,
         manual: true,
       },
       'pwa-each-page-has-url': {
-        score: false,
+        score: 0,
         manual: true,
       },
     },

--- a/lighthouse-cli/test/smokehouse/redirects/expectations.js
+++ b/lighthouse-cli/test/smokehouse/redirects/expectations.js
@@ -16,7 +16,7 @@ module.exports = [
     url: 'http://localhost:10200/redirects-final.html',
     audits: {
       'redirects': {
-        score: '<100',
+        score: '<1.00',
         rawValue: '>=500',
         details: {
           items: {
@@ -31,7 +31,7 @@ module.exports = [
     url: 'http://localhost:10200/redirects-final.html',
     audits: {
       'redirects': {
-        score: 100,
+        score: 1,
         rawValue: '>=250',
         details: {
           items: {

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -32,16 +32,16 @@ module.exports = [
     url: BASE_URL + 'seo-tester.html',
     audits: {
       'viewport': {
-        score: true,
+        score: 1,
       },
       'document-title': {
-        score: true,
+        score: 1,
       },
       'meta-description': {
-        score: true,
+        score: 1,
       },
       'http-status-code': {
-        score: true,
+        score: 1,
       },
       'font-size': {
         rawValue: true,
@@ -52,19 +52,19 @@ module.exports = [
         },
       },
       'link-text': {
-        score: true,
+        score: 1,
       },
       'is-crawlable': {
-        score: true,
+        score: 1,
       },
       'hreflang': {
-        score: true,
+        score: 1,
       },
       'plugins': {
-        score: true,
+        score: 1,
       },
       'canonical': {
-        score: true,
+        score: 1,
       },
     },
   },
@@ -73,10 +73,10 @@ module.exports = [
     url: BASE_URL + 'seo-failure-cases.html?status_code=403&' + failureHeaders,
     audits: {
       'viewport': {
-        score: false,
+        score: 0,
       },
       'document-title': {
-        score: false,
+        score: 0,
         extendedInfo: {
           value: {
             id: 'document-title',
@@ -84,10 +84,10 @@ module.exports = [
         },
       },
       'meta-description': {
-        score: false,
+        score: 0,
       },
       'http-status-code': {
-        score: false,
+        score: 0,
         displayValue: '403',
       },
       'font-size': {
@@ -95,7 +95,7 @@ module.exports = [
         debugString: 'Text is illegible because of a missing viewport config',
       },
       'link-text': {
-        score: false,
+        score: 0,
         displayValue: '3 links found',
         details: {
           items: {
@@ -104,7 +104,7 @@ module.exports = [
         },
       },
       'is-crawlable': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 2,
@@ -112,7 +112,7 @@ module.exports = [
         },
       },
       'hreflang': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 3,
@@ -120,7 +120,7 @@ module.exports = [
         },
       },
       'plugins': {
-        score: false,
+        score: 0,
         details: {
           items: {
             length: 3,
@@ -128,7 +128,7 @@ module.exports = [
         },
       },
       'canonical': {
-        score: false,
+        score: 0,
         debugString: 'Multiple URLs (https://example.com, https://example.com/)',
       },
     },

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -181,13 +181,6 @@ function collateResults(actual, expected) {
       throw new Error(`Config did not trigger run of expected audit ${auditName}`);
     }
 
-    // TODO: TERRIBLE HACK, remove asap
-    // Smokehouse has been asserting the AuditResult.score, whereas report cares about AuditDfn score (within reportCategories)
-    // A subsequent PR will change scores completely which means rebaselining all our smokehouse expectations
-    if (actualResult.scoringMode === 'binary') {
-      actualResult.score = Boolean(actualResult.score);
-    }
-
     const expectedResult = expected.audits[auditName];
     const diff = findDifference(auditName, actualResult, expectedResult);
 

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -18,7 +18,7 @@ const DEFAULT_EXPECTATIONS_PATH = 'pwa-expectations';
 
 const PROTOCOL_TIMEOUT_EXIT_CODE = 67;
 const RETRIES = 3;
-const NUMERICAL_EXPECTATION_REGEXP = /^(<=?|>=?)(\d+)$/;
+const NUMERICAL_EXPECTATION_REGEXP = /^(<=?|>=?)((\d|\.)+)$/;
 
 
 /**
@@ -97,7 +97,7 @@ function matchesExpectation(actual, expected) {
   if (typeof actual === 'number' && NUMERICAL_EXPECTATION_REGEXP.test(expected)) {
     const parts = expected.match(NUMERICAL_EXPECTATION_REGEXP);
     const operator = parts[1];
-    const number = parseInt(parts[2]);
+    const number = parseFloat(parts[2]);
     switch (operator) {
       case '>':
         return actual > number;

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -51,10 +51,10 @@ class Audit {
       diminishingReturnsValue
     );
 
-    let score = 100 * distribution.computeComplementaryPercentile(measuredValue);
-    score = Math.min(100, score);
+    let score = distribution.computeComplementaryPercentile(measuredValue);
+    score = Math.min(1, score);
     score = Math.max(0, score);
-    return Math.round(score);
+    return Math.round(score * 100) / 100;
   }
 
   /**
@@ -104,7 +104,7 @@ class Audit {
       throw new Error('generateAuditResult requires a rawValue');
     }
 
-    const score = typeof result.score === 'undefined' ? result.rawValue : result.score;
+    let score = typeof result.score === 'undefined' ? result.rawValue : result.score;
     let displayValue = result.displayValue;
     if (typeof displayValue === 'undefined') {
       displayValue = result.rawValue ? result.rawValue : '';
@@ -115,18 +115,15 @@ class Audit {
       displayValue = '';
     }
 
-    // TODO: restore after initial 3.0 branching
-    // if (typeof score === 'boolean' || score === null) {
-    //   score = score ? 100 : 0;
-    // }
+    if (typeof score === 'boolean' || score === null) {
+      score = score ? 1 : 0;
+    }
 
-    // if (!Number.isFinite(score)) {
-    //   throw new Error(`Invalid score: ${score}`);
-    // }
+    if (!Number.isFinite(score)) {
+      throw new Error(`Invalid score: ${score}`);
+    }
 
-    // TODO, don't consider an auditResult's scoringMode (currently applied to all ByteEfficiency)
-    const scoringMode = result.scoringMode || audit.meta.scoringMode || Audit.SCORING_MODES.BINARY;
-    delete result.scoringMode;
+    const scoreDisplayMode = result.scoreDisplayMode || audit.meta.scoreDisplayMode || Audit.SCORING_MODES.BINARY;
 
     let auditDescription = audit.meta.description;
     if (audit.meta.failureDescription) {
@@ -142,7 +139,7 @@ class Audit {
       error: result.error,
       debugString: result.debugString,
       extendedInfo: result.extendedInfo,
-      scoringMode,
+      scoreDisplayMode,
       informative: audit.meta.informative,
       manual: audit.meta.manual,
       notApplicable: result.notApplicable,

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -123,7 +123,8 @@ class Audit {
       throw new Error(`Invalid score: ${score}`);
     }
 
-    const scoreDisplayMode = result.scoreDisplayMode || audit.meta.scoreDisplayMode || Audit.SCORING_MODES.BINARY;
+    const scoreDisplayMode = result.scoreDisplayMode || audit.meta.scoreDisplayMode ||
+        Audit.SCORING_MODES.BINARY;
 
     let auditDescription = audit.meta.description;
     if (audit.meta.failureDescription) {

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -22,9 +22,9 @@ class UnusedBytes extends Audit {
    * @return {number}
    */
   static scoreForWastedMs(wastedMs) {
-    if (wastedMs === 0) return 100;
-    else if (wastedMs < WASTED_MS_FOR_AVERAGE) return 90;
-    else if (wastedMs < WASTED_MS_FOR_POOR) return 65;
+    if (wastedMs === 0) return 1.00;
+    else if (wastedMs < WASTED_MS_FOR_AVERAGE) return .90;
+    else if (wastedMs < WASTED_MS_FOR_POOR) return .65;
     else return 0;
   }
 
@@ -118,7 +118,7 @@ class UnusedBytes extends Audit {
       displayValue,
       rawValue: wastedMs,
       score: UnusedBytes.scoreForWastedMs(wastedMs),
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       extendedInfo: {
         value: {
           wastedMs,

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -26,7 +26,7 @@ class TotalByteWeight extends ByteEfficiencyAudit {
         'Large network payloads cost users real money and are highly correlated with ' +
         'long load times. [Learn ' +
         'more](https://developers.google.com/web/tools/lighthouse/audits/network-payloads).',
-      scoringMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['devtoolsLogs'],
     };
   }

--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -32,7 +32,7 @@ class CacheHeaders extends Audit {
       helpText:
         'A long cache lifetime can speed up repeat visits to your page. ' +
         '[Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#cache-control).',
-      scoringMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['devtoolsLogs'],
     };
   }

--- a/lighthouse-core/audits/consistently-interactive.js
+++ b/lighthouse-core/audits/consistently-interactive.js
@@ -36,7 +36,7 @@ class ConsistentlyInteractiveMetric extends Audit {
       helpText: 'Consistently Interactive marks the time at which the page is ' +
           'fully interactive. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive).',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
   }

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -42,7 +42,7 @@ class DOMSize extends Audit {
         'children/parent element. A large DOM can increase memory usage, cause longer ' +
         '[style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), ' +
         'and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/fundamentals/performance/rendering/).',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['DOMStats'],
     };
   }

--- a/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/link-blocking-first-paint.js
@@ -29,7 +29,7 @@ class LinkBlockingFirstPaintAudit extends Audit {
       name: 'link-blocking-first-paint',
       description: 'Reduce render-blocking stylesheets',
       informative: true,
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       helpText: 'External stylesheets are blocking the first paint of your page. Consider ' +
           'delivering critical CSS via `<style>` tags and deferring non-critical ' +
           'styles. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
+++ b/lighthouse-core/audits/dobetterweb/script-blocking-first-paint.js
@@ -22,7 +22,7 @@ class ScriptBlockingFirstPaint extends Audit {
       name: 'script-blocking-first-paint',
       description: 'Reduce render-blocking scripts',
       informative: true,
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       helpText: 'Script elements are blocking the first paint of your page. Consider inlining ' +
           'critical scripts and deferring non-critical ones. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',

--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -28,7 +28,7 @@ class EstimatedInputLatency extends Audit {
           'of latency, or less. 10% of the time a user can expect additional latency. If your ' +
           'latency is higher than 50 ms, users may perceive your app as laggy. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency).',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces'],
     };
   }

--- a/lighthouse-core/audits/first-interactive.js
+++ b/lighthouse-core/audits/first-interactive.js
@@ -24,7 +24,7 @@ class FirstInteractiveMetric extends Audit {
       helpText: 'First Interactive marks the time at which the page is ' +
           'minimally interactive. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-interactive).',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces'],
     };
   }

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -25,7 +25,7 @@ class FirstMeaningfulPaint extends Audit {
       description: 'First meaningful paint',
       helpText: 'First meaningful paint measures when the primary content of a page is visible. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint).',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces'],
     };
   }

--- a/lighthouse-core/audits/network-requests.js
+++ b/lighthouse-core/audits/network-requests.js
@@ -61,7 +61,7 @@ class NetworkRequests extends Audit {
       const tableDetails = Audit.makeTableDetails(headings, results);
 
       return {
-        score: 100,
+        score: 1.00,
         rawValue: records.length,
         extendedInfo: {value: results},
         details: tableDetails,

--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -49,7 +49,7 @@ class PredictivePerf extends Audit {
       helpText:
         'Predicted performance evaluates how your site will perform under ' +
         'a 3G connection on a mobile device.',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
   }

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -18,7 +18,7 @@ class Redirects extends Audit {
       name: 'redirects',
       description: 'Avoids page redirects',
       failureDescription: 'Has multiple page redirects',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       helpText: 'Redirects introduce additional delays before the page can be loaded. [Learn more](https://developers.google.com/speed/docs/insights/AvoidRedirects).',
       requiredArtifacts: ['URL', 'devtoolsLogs'],
     };
@@ -70,7 +70,7 @@ class Redirects extends Audit {
 
         return {
           // We award a passing grade if you only have 1 redirect
-          score: redirectRequests.length <= 2 ? 100 : UnusedBytes.scoreForWastedMs(totalWastedMs),
+          score: redirectRequests.length <= 2 ? 1 : UnusedBytes.scoreForWastedMs(totalWastedMs),
           rawValue: totalWastedMs,
           displayValue: Util.formatMilliseconds(totalWastedMs, 1),
           extendedInfo: {

--- a/lighthouse-core/audits/screenshot-thumbnails.js
+++ b/lighthouse-core/audits/screenshot-thumbnails.js
@@ -114,7 +114,7 @@ class ScreenshotThumbnails extends Audit {
       }
 
       return {
-        score: 100,
+        score: 1.00,
         rawValue: thumbnails.length > 0,
         details: {
           type: 'filmstrip',

--- a/lighthouse-core/audits/speed-index-metric.js
+++ b/lighthouse-core/audits/speed-index-metric.js
@@ -24,7 +24,7 @@ class SpeedIndexMetric extends Audit {
       description: 'Perceptual Speed Index',
       helpText: 'Speed Index shows how quickly the contents of a page are visibly populated. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index).',
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces'],
     };
   }

--- a/lighthouse-core/audits/time-to-first-byte.js
+++ b/lighthouse-core/audits/time-to-first-byte.js
@@ -53,7 +53,7 @@ class TTFBMetric extends Audit {
 
         return {
           rawValue: ttfb,
-          score: passed,
+          score: passed ? 1 : 0,
           displayValue,
           details: {
             summary: {

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -24,7 +24,7 @@ class UsesRelPreloadAudit extends Audit {
       helpText: 'Consider using <link rel=preload> to prioritize fetching late-discovered ' +
         'resources sooner [Learn more](https://developers.google.com/web/updates/2016/03/link-rel-preload).',
       requiredArtifacts: ['devtoolsLogs', 'traces'],
-      scoringMode: Audit.SCORING_MODES.NUMERIC,
+      scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
     };
   }
 

--- a/lighthouse-core/closure/typedefs/AuditResult.js
+++ b/lighthouse-core/closure/typedefs/AuditResult.js
@@ -52,7 +52,7 @@ function AuditFullResult() {}
 AuditFullResult.prototype.score;
 
 /** @type {string} */
-AuditFullResult.prototype.scoringMode;
+AuditFullResult.prototype.scoreDisplayMode;
 
 /** @type {string} */
 AuditFullResult.prototype.displayValue;

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -187,7 +187,7 @@ function assertValidAudit(auditDefinition, auditPath) {
   // If it'll have a ✔ or ✖ displayed alongside the result, it should have failureDescription
   if (typeof auditDefinition.meta.failureDescription !== 'string' &&
     auditDefinition.meta.informative !== true &&
-    auditDefinition.meta.scoringMode !== Audit.SCORING_MODES.NUMERIC) {
+    auditDefinition.meta.scoreDisplayMode !== Audit.SCORING_MODES.NUMERIC) {
     throw new Error(`${auditName} has no failureDescription and should.`);
   }
 

--- a/lighthouse-core/report/v2/renderer/category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/category-renderer.js
@@ -30,7 +30,7 @@ class CategoryRenderer {
   _renderAuditScore(audit) {
     const tmpl = this.dom.cloneTemplate('#tmpl-lh-audit-score', this.templateContext);
 
-    const scoringMode = audit.result.scoringMode;
+    const scoreDisplayMode = audit.result.scoreDisplayMode;
     const description = audit.result.helpText;
     let title = audit.result.description;
 
@@ -57,23 +57,23 @@ class CategoryRenderer {
       scoreEl.classList.add('lh-score--manual');
     }
 
-    return this._populateScore(tmpl, audit.result.score, scoringMode, title, description);
+    return this._populateScore(tmpl, audit.result.score, scoreDisplayMode, title, description);
   }
 
   /**
    * @param {!DocumentFragment|!Element} element DOM node to populate with values.
    * @param {number} score
-   * @param {string} scoringMode
+   * @param {string} scoreDisplayMode
    * @param {string} title
    * @param {string} description
    * @return {!Element}
    */
-  _populateScore(element, score, scoringMode, title, description) {
+  _populateScore(element, score, scoreDisplayMode, title, description) {
     // Fill in the blanks.
     const valueEl = this.dom.find('.lh-score__value', element);
     valueEl.textContent = Util.formatNumber(score);
     valueEl.classList.add(`lh-score__value--${Util.calculateRating(score)}`,
-        `lh-score__value--${scoringMode}`);
+        `lh-score__value--${scoreDisplayMode}`);
 
     this.dom.find('.lh-score__title', element).appendChild(
         this.dom.convertMarkdownCodeSnippets(title));
@@ -296,7 +296,7 @@ class CategoryRenderer {
 
       if (audit.result.notApplicable) {
         group.notApplicable.push(audit);
-      } else if (audit.result.score === 100 && !audit.result.debugString) {
+      } else if (audit.result.score === 1 && !audit.result.debugString) {
         group.passed.push(audit);
       } else {
         group.failed.push(audit);

--- a/lighthouse-core/report/v2/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/v2/renderer/performance-category-renderer.js
@@ -152,7 +152,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     element.appendChild(metricAuditsEl);
 
     const hintAudits = category.audits
-        .filter(audit => audit.group === 'perf-hint' && audit.result.score < 100)
+        .filter(audit => audit.group === 'perf-hint' && audit.result.score < 1.00)
         .sort((auditA, auditB) => auditB.result.rawValue - auditA.result.rawValue);
     if (hintAudits.length) {
       const maxWaste = Math.max(...hintAudits.map(audit => audit.result.rawValue));
@@ -164,7 +164,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     }
 
     const infoAudits = category.audits
-        .filter(audit => audit.group === 'perf-info' && audit.result.score < 100);
+        .filter(audit => audit.group === 'perf-info' && audit.result.score < 1.00);
     if (infoAudits.length) {
       const infoAuditsEl = this.renderAuditGroup(groups['perf-info'], {expandable: false});
       infoAudits.forEach(item => infoAuditsEl.appendChild(this.renderAudit(item)));
@@ -174,7 +174,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
 
     const passedElements = category.audits
         .filter(audit => (audit.group === 'perf-hint' || audit.group === 'perf-info') &&
-            audit.result.score === 100)
+            audit.result.score === 1)
         .map(audit => this.renderAudit(audit));
 
     if (!passedElements.length) return element;

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -216,7 +216,7 @@ ReportRenderer.AuditJSON; // eslint-disable-line no-unused-expressions
  *     debugString: (string|undefined),
  *     displayValue: string,
  *     helpText: string,
- *     scoringMode: string,
+ *     scoreDisplayMode: string,
  *     extendedInfo: Object,
  *     error: boolean,
  *     score: number,

--- a/lighthouse-core/test/audits/bootup-time-test.js
+++ b/lighthouse-core/test/audits/bootup-time-test.js
@@ -24,7 +24,7 @@ describe('Performance: bootup-time audit', () => {
 
     return BootupTime.audit(artifacts).then(output => {
       assert.equal(output.details.items.length, 4);
-      assert.equal(output.score, true);
+      assert.equal(output.score, 1);
       assert.equal(Math.round(output.rawValue), 176);
 
       const roundedValueOf = name => {
@@ -54,7 +54,7 @@ describe('Performance: bootup-time audit', () => {
     return BootupTime.audit(artifacts)
       .then(output => {
         assert.equal(output.details.items.length, 0);
-        assert.equal(output.score, true);
+        assert.equal(output.score, 1);
         assert.equal(Math.round(output.rawValue), 0);
       });
   });

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -83,10 +83,10 @@ describe('Byte efficiency base audit', () => {
       results: [{wastedBytes: 45000, totalBytes: 45000, wastedPercent: 100}],
     }, 10000);
 
-    assert.equal(perfectResult.score, 100, 'scores perfect wastedMs');
-    assert.ok(goodResult.score > 75 && goodResult.score < 100, 'scores good wastedMs');
-    assert.ok(averageResult.score > 50 && averageResult.score < 75, 'scores average wastedMs');
-    assert.ok(failingResult.score < 50, 'scores failing wastedMs');
+    assert.equal(perfectResult.score, 1.00, 'scores perfect wastedMs');
+    assert.ok(goodResult.score > .75 && goodResult.score < 1.00, 'scores good wastedMs');
+    assert.ok(averageResult.score > .50 && averageResult.score < .75, 'scores average wastedMs');
+    assert.ok(failingResult.score < .50, 'scores failing wastedMs');
   });
 
   it('should throw on invalid network throughput', () => {

--- a/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
@@ -41,7 +41,7 @@ describe('Total byte weight audit', () => {
 
     return TotalByteWeight.audit(artifacts).then(result => {
       assert.strictEqual(result.rawValue, 150 * 1024);
-      assert.strictEqual(result.score, 100);
+      assert.strictEqual(result.score, 1.00);
       const results = result.details.items;
       assert.strictEqual(results.length, 3);
       assert.strictEqual(result.extendedInfo.value.totalCompletedRequests, 3);
@@ -65,7 +65,7 @@ describe('Total byte weight audit', () => {
     ]);
 
     return TotalByteWeight.audit(artifacts).then(result => {
-      assert.ok(40 < result.score && result.score < 60, 'score is around 50');
+      assert.ok(.40 < result.score && result.score < .60, 'score is around .50');
       assert.strictEqual(result.rawValue, 4180 * 1024);
       const results = result.details.items;
       assert.strictEqual(results.length, 10, 'results are clipped at top 10');

--- a/lighthouse-core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js
@@ -157,7 +157,7 @@ describe('Cache headers audit', () => {
 
     return CacheHeadersAudit.audit(artifacts).then(result => {
       const items = result.extendedInfo.value.results;
-      assert.equal(result.score, 100);
+      assert.equal(result.score, 1.00);
       assert.equal(items.length, 0);
     });
   });
@@ -171,7 +171,7 @@ describe('Cache headers audit', () => {
     ];
 
     return CacheHeadersAudit.audit(artifacts).then(result => {
-      assert.equal(result.score, 100);
+      assert.equal(result.score, 1.00);
       const items = result.extendedInfo.value.results;
       assert.equal(items.length, 1);
       assert.equal(result.extendedInfo.value.queryStringCount, 1);

--- a/lighthouse-core/test/audits/consistently-interactive-test.js
+++ b/lighthouse-core/test/audits/consistently-interactive-test.js
@@ -39,7 +39,7 @@ describe('Performance: consistently-interactive audit', () => {
     }, Runner.instantiateComputedArtifacts());
 
     return ConsistentlyInteractive.audit(artifacts).then(output => {
-      assert.equal(output.score, 99);
+      assert.equal(output.score, .99);
       assert.equal(Math.round(output.rawValue), 1582);
       assert.equal(output.displayValue, '1,580\xa0ms');
     });
@@ -56,7 +56,7 @@ describe('Performance: consistently-interactive audit', () => {
     }, Runner.instantiateComputedArtifacts());
 
     return ConsistentlyInteractive.audit(artifacts).then(output => {
-      assert.equal(output.score, 95);
+      assert.equal(output.score, .95);
       assert.equal(Math.round(output.rawValue), 2712);
       assert.equal(output.displayValue, '2,710\xa0ms');
     });

--- a/lighthouse-core/test/audits/dobetterweb/dom-size-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/dom-size-test.js
@@ -27,7 +27,7 @@ describe('Num DOM nodes audit', () => {
 
   it('calculates score hitting top of distribution', () => {
     const auditResult = DOMSize.audit(artifact);
-    assert.equal(auditResult.score, 100);
+    assert.equal(auditResult.score, 1.00);
     assert.equal(auditResult.rawValue, numNodes);
     assert.equal(auditResult.displayValue, `${numNodes.toLocaleString()} nodes`);
     assert.equal(auditResult.details.items[0].title, 'Total DOM Nodes');
@@ -41,7 +41,7 @@ describe('Num DOM nodes audit', () => {
 
   it('calculates score hitting mid distribution', () => {
     artifact.DOMStats.totalDOMNodes = 3100;
-    assert.equal(DOMSize.audit(artifact).score, 43);
+    assert.equal(DOMSize.audit(artifact).score, .43);
   });
 
   it('calculates score hitting bottom of distribution', () => {

--- a/lighthouse-core/test/audits/errors-in-console-test.js
+++ b/lighthouse-core/test/audits/errors-in-console-test.js
@@ -17,7 +17,7 @@ describe('Console error logs audit', () => {
       RuntimeExceptions: [],
     });
     assert.equal(auditResult.rawValue, 0);
-    assert.equal(auditResult.score, true);
+    assert.equal(auditResult.score, 1);
     assert.ok(!auditResult.displayValue, 0);
     assert.equal(auditResult.details.items.length, 0);
   });
@@ -36,7 +36,7 @@ describe('Console error logs audit', () => {
       RuntimeExceptions: [],
     });
     assert.equal(auditResult.rawValue, 0);
-    assert.equal(auditResult.score, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
   });
 
@@ -82,7 +82,7 @@ describe('Console error logs audit', () => {
     });
 
     assert.equal(auditResult.rawValue, 3);
-    assert.equal(auditResult.score, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 3);
     assert.equal(auditResult.details.items[0].url, 'http://www.example.com/favicon.ico');
     assert.equal(auditResult.details.items[0].description,
@@ -108,7 +108,7 @@ describe('Console error logs audit', () => {
       RuntimeExceptions: [],
     });
     assert.equal(auditResult.rawValue, 1);
-    assert.equal(auditResult.score, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 1);
     // url is undefined
     assert.strictEqual(auditResult.details.items[0].url, undefined);
@@ -139,7 +139,7 @@ describe('Console error logs audit', () => {
       }],
     });
     assert.equal(auditResult.rawValue, 1);
-    assert.equal(auditResult.score, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 1);
     assert.strictEqual(auditResult.details.items[0].url, 'http://example.com/fancybox.js');
     assert.strictEqual(auditResult.details.items[0].description,

--- a/lighthouse-core/test/audits/estimated-input-latency-test.js
+++ b/lighthouse-core/test/audits/estimated-input-latency-test.js
@@ -29,7 +29,7 @@ describe('Performance: estimated-input-latency audit', () => {
       assert.equal(output.debugString, undefined);
       assert.equal(output.rawValue, 16.2);
       assert.equal(output.displayValue, '16\xa0ms');
-      assert.equal(output.score, 100);
+      assert.equal(output.score, 1.00);
     });
   });
 });

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -57,7 +57,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     });
 
     it('scores the fMP correctly', () => {
-      assert.equal(fmpResult.score, 99);
+      assert.equal(fmpResult.score, 0.99);
     });
 
     it('did not fall back to an FMP candidate event', () => {

--- a/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
+++ b/lighthouse-core/test/audits/mainthread-work-breakdown-test.js
@@ -71,7 +71,7 @@ describe('Performance: page execution timings audit', () => {
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
 
       assert.equal(output.details.items.length, 12);
-      assert.equal(output.score, true);
+      assert.equal(output.score, 1);
       assert.equal(Math.round(output.rawValue), 611);
 
       for (const category in output.extendedInfo.value) {
@@ -92,7 +92,7 @@ describe('Performance: page execution timings audit', () => {
     return PageExecutionTimings.audit(artifacts).then(output => {
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
       assert.equal(output.details.items.length, 13);
-      assert.equal(output.score, true);
+      assert.equal(output.score, 1);
       assert.equal(Math.round(output.rawValue), 596);
 
       for (const category in output.extendedInfo.value) {
@@ -113,7 +113,7 @@ describe('Performance: page execution timings audit', () => {
     return PageExecutionTimings.audit(artifacts).then(output => {
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
       assert.equal(output.details.items.length, 12);
-      assert.equal(output.score, true);
+      assert.equal(output.score, 1);
       assert.equal(Math.round(output.rawValue), 524);
 
       for (const category in output.extendedInfo.value) {
@@ -133,7 +133,7 @@ describe('Performance: page execution timings audit', () => {
 
     return PageExecutionTimings.audit(artifacts).then(output => {
       assert.equal(output.details.items.length, 0);
-      assert.equal(output.score, true);
+      assert.equal(output.score, 1);
       assert.equal(Math.round(output.rawValue), 0);
     });
   });

--- a/lighthouse-core/test/audits/network-requests-test.js
+++ b/lighthouse-core/test/audits/network-requests-test.js
@@ -21,7 +21,7 @@ describe('Network requests audit', () => {
     }, Runner.instantiateComputedArtifacts());
 
     return NetworkRequests.audit(artifacts).then(output => {
-      assert.equal(output.score, 100);
+      assert.equal(output.score, 1.00);
       assert.equal(output.rawValue, 66);
       assert.equal(output.details.items.length, 66);
       assert.equal(output.extendedInfo.value[0].url, 'https://pwa.rocks/');

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -25,7 +25,7 @@ describe('Performance: predictive performance audit', () => {
     }, Runner.instantiateComputedArtifacts());
 
     return PredictivePerf.audit(artifacts).then(output => {
-      assert.equal(output.score, 79);
+      assert.equal(output.score, .79);
       assert.equal(Math.round(output.rawValue), 5308);
       assert.equal(output.displayValue, '5,310\xa0ms');
 

--- a/lighthouse-core/test/audits/redirects-test.js
+++ b/lighthouse-core/test/audits/redirects-test.js
@@ -82,7 +82,7 @@ describe('Performance: Redirects audit', () => {
   });
   it('fails when 2 redirects detected', () => {
     return Audit.audit(mockArtifacts(FAILING_TWO_REDIRECTS)).then(output => {
-      assert.equal(output.score, 65);
+      assert.equal(output.score, .65);
       assert.equal(output.details.items.length, 3);
       assert.equal(Math.round(output.rawValue), 638);
     });
@@ -91,7 +91,7 @@ describe('Performance: Redirects audit', () => {
   it('passes when one redirect detected', () => {
     return Audit.audit(mockArtifacts(SUCCESS_ONE_REDIRECT)).then(output => {
       // If === 1 redirect, perfect score is expected, regardless of latency
-      assert.equal(output.score, 100);
+      assert.equal(output.score, 1.00);
       // We will still generate a table and show wasted time
       assert.equal(output.details.items.length, 2);
       assert.equal(Math.round(output.rawValue), 510);
@@ -100,7 +100,7 @@ describe('Performance: Redirects audit', () => {
 
   it('passes when no redirect detected', () => {
     return Audit.audit(mockArtifacts(SUCCESS_NOREDIRECT)).then(output => {
-      assert.equal(output.score, 100);
+      assert.equal(output.score, 1.00);
       assert.equal(output.details.items.length, 0);
       assert.equal(output.rawValue, 0);
     });

--- a/lighthouse-core/test/audits/speed-index-metric-test.js
+++ b/lighthouse-core/test/audits/speed-index-metric-test.js
@@ -42,7 +42,7 @@ describe('Performance: speed-index-metric audit', () => {
     });
 
     return Audit.audit(artifacts).then(result => {
-      assert.equal(result.score, 100);
+      assert.equal(result.score, 1.00);
       assert.equal(result.rawValue, 609);
       assert.equal(Math.round(result.extendedInfo.value.timings.firstVisualChange), 475);
       assert.equal(Math.round(result.extendedInfo.value.timings.visuallyReady), 700);

--- a/lighthouse-core/test/audits/time-to-first-byte-test.js
+++ b/lighthouse-core/test/audits/time-to-first-byte-test.js
@@ -24,7 +24,7 @@ describe('Performance: time-to-first-byte audit', () => {
 
     return TimeToFirstByte.audit(artifacts).then(result => {
       assert.strictEqual(result.rawValue, 630);
-      assert.strictEqual(result.score, false);
+      assert.strictEqual(result.score, 0);
     });
   });
 
@@ -42,7 +42,7 @@ describe('Performance: time-to-first-byte audit', () => {
 
     return TimeToFirstByte.audit(artifacts).then(result => {
       assert.strictEqual(result.rawValue, 200);
-      assert.strictEqual(result.score, true);
+      assert.strictEqual(result.score, 1);
     });
   });
 });

--- a/lighthouse-core/test/fixtures/dbw_tester-perf-results.json
+++ b/lighthouse-core/test/fixtures/dbw_tester-perf-results.json
@@ -239,7 +239,7 @@
       "helpText": "Time to Interactive identifies the time at which your app appears to be ready enough to interact with. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/time-to-interactive)."
     },
     "user-timings": {
-      "score": true,
+      "score": 1,
       "displayValue": "0",
       "rawValue": true,
       "extendedInfo": {
@@ -253,7 +253,7 @@
       "helpText": "Consider instrumenting your app with the User Timing API to create custom, real-world measurements of key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing)."
     },
     "critical-request-chains": {
-      "score": false,
+      "score": 0,
       "displayValue": "12",
       "rawValue": false,
       "optimalValue": 0,
@@ -2139,7 +2139,7 @@
           "weight": 0,
           "group": "perf-info",
           "result": {
-            "score": false,
+            "score": 0,
             "displayValue": "12",
             "rawValue": false,
             "optimalValue": 0,
@@ -2299,7 +2299,7 @@
           "weight": 0,
           "group": "perf-info",
           "result": {
-            "score": true,
+            "score": 1,
             "displayValue": "0",
             "rawValue": true,
             "extendedInfo": {

--- a/lighthouse-core/test/index-test.js
+++ b/lighthouse-core/test/index-test.js
@@ -93,7 +93,7 @@ describe('Module Tests', function() {
       output: 'json',
     }, {
       auditResults: [{
-        score: true,
+        score: 0,
         displayValue: '',
         rawValue: true,
         name: 'viewport',

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -60,18 +60,18 @@ describe('CategoryRenderer', () => {
     assert.ok(description.querySelector('a'), 'audit help text contains coverted markdown links');
     assert.equal(score.textContent, '0');
     assert.ok(score.classList.contains('lh-score__value--fail'));
-    assert.ok(score.classList.contains(`lh-score__value--${audit.result.scoringMode}`));
+    assert.ok(score.classList.contains(`lh-score__value--${audit.result.scoreDisplayMode}`));
   });
 
   it('renders an audit debug str when appropriate', () => {
     const audit1 = renderer.renderAudit({
-      scoringMode: 'binary', score: 0,
+      scoreDisplayMode: 'binary', score: 0,
       result: {helpText: 'help text', debugString: 'Debug string', description: 'Audit title'},
     });
     assert.ok(audit1.querySelector('.lh-debug'));
 
     const audit2 = renderer.renderAudit({
-      scoringMode: 'binary', score: 0, result: {helpText: 'help text', description: 'Audit title'},
+      scoreDisplayMode: 'binary', score: 0, result: {helpText: 'help text', description: 'Audit title'},
     });
     assert.ok(!audit2.querySelector('.lh-debug'));
   });
@@ -119,10 +119,10 @@ describe('CategoryRenderer', () => {
       description: 'Audit',
       helpText: 'Learn more',
       debugString: 'It may not have worked!',
-      score: 100,
+      score: 1.00,
     };
-    const audit = {result: auditResult, score: 100};
-    const category = {name: 'Fake', description: '', score: 100, audits: [audit]};
+    const audit = {result: auditResult, score: 1.00};
+    const category = {name: 'Fake', description: '', score: 1.00, audits: [audit]};
     const categoryDOM = renderer.render(category, sampleResults.reportGroups);
     assert.ok(categoryDOM.querySelector(
         '.lh-category > .lh-audit-group:not(.lh-passed-audits) > .lh-audit'),
@@ -182,7 +182,7 @@ describe('CategoryRenderer', () => {
     it.skip('renders the failed audits grouped by group', () => {
       const categoryDOM = renderer.render(category, sampleResults.reportGroups);
       const failedAudits = category.audits.filter(audit => {
-        return audit.result.score !== 100 && !audit.result.notApplicable;
+        return audit.result.score !== 1.00 && !audit.result.notApplicable;
       });
       const failedAuditTags = new Set(failedAudits.map(audit => audit.group));
 
@@ -193,7 +193,7 @@ describe('CategoryRenderer', () => {
     it('renders the passed audits grouped by group', () => {
       const categoryDOM = renderer.render(category, sampleResults.reportGroups);
       const passedAudits = category.audits.filter(audit =>
-          !audit.result.notApplicable && audit.result.score === 100);
+          !audit.result.notApplicable && audit.result.score === 1);
       const passedAuditTags = new Set(passedAudits.map(audit => audit.group));
 
       const passedAuditGroups = categoryDOM.querySelectorAll('.lh-passed-audits .lh-audit-group');

--- a/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/category-renderer-test.js
@@ -71,7 +71,8 @@ describe('CategoryRenderer', () => {
     assert.ok(audit1.querySelector('.lh-debug'));
 
     const audit2 = renderer.renderAudit({
-      scoreDisplayMode: 'binary', score: 0, result: {helpText: 'help text', description: 'Audit title'},
+      scoreDisplayMode: 'binary', score: 0,
+      result: {helpText: 'help text', description: 'Audit title'},
     });
     assert.ok(!audit2.querySelector('.lh-debug'));
   });

--- a/lighthouse-core/test/report/v2/renderer/performance-category-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/performance-category-renderer-test.js
@@ -84,7 +84,7 @@ describe('PerfCategoryRenderer', () => {
     const categoryDOM = renderer.render(category, sampleResults.reportGroups);
 
     const hintAudits = category.audits.filter(audit => audit.group === 'perf-hint' &&
-        audit.result.score !== 100);
+        audit.result.score !== 1.00);
     const hintElements = categoryDOM.querySelectorAll('.lh-perf-hint');
     assert.equal(hintElements.length, hintAudits.length);
 
@@ -102,7 +102,7 @@ describe('PerfCategoryRenderer', () => {
       group: 'perf-hint',
       result: {
         rawValue: 100, debugString: 'Yikes!', description: 'Bug',
-        helpText: '', score: 32,
+        helpText: '', score: .32,
         details: {summary: {wastedMs: 3223}},
       },
     };
@@ -138,7 +138,7 @@ describe('PerfCategoryRenderer', () => {
       group: 'perf-hint',
       result: {
         rawValue: 100, description: 'Bug',
-        helpText: '', score: 32,
+        helpText: '', score: .32,
       },
     };
 
@@ -153,7 +153,7 @@ describe('PerfCategoryRenderer', () => {
     const diagnosticSection = categoryDOM.querySelectorAll('.lh-category > .lh-audit-group')[2];
 
     const diagnosticAudits = category.audits.filter(audit => audit.group === 'perf-info' &&
-        audit.result.score !== 100);
+        audit.result.score !== 1.00);
     const diagnosticElements = diagnosticSection.querySelectorAll('.lh-audit');
     assert.equal(diagnosticElements.length, diagnosticAudits.length);
   });
@@ -164,7 +164,7 @@ describe('PerfCategoryRenderer', () => {
 
     const passedAudits = category.audits.filter(audit =>
         audit.group && audit.group !== 'perf-metric' &&
-        audit.result.score === 100);
+        audit.result.score === 1);
     const passedElements = passedSection.querySelectorAll('.lh-audit');
     assert.equal(passedElements.length, passedAudits.length);
   });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1,7 +1,7 @@
 {
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
   "lighthouseVersion": "2.9.1",
-  "generatedTime": "2018-03-02T22:12:35.706Z",
+  "generatedTime": "2018-03-03T05:21:52.744Z",
   "initialUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "runWarnings": [],
@@ -17,7 +17,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "is-on-https",
       "description": "Does not use HTTPS",
       "helpText": "All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/https).",
@@ -39,7 +39,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "redirects-http",
       "description": "Does not redirect HTTP traffic to HTTPS",
       "helpText": "If you've already set up HTTPS, make sure that you redirect all HTTP traffic to HTTPS. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-redirects-to-https)."
@@ -48,7 +48,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "service-worker",
       "description": "Does not register a service worker",
       "helpText": "The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker)."
@@ -57,32 +57,32 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "works-offline",
       "description": "Does not respond with a 200 when offline",
       "helpText": "If you're building a Progressive Web App, consider using a service worker so that your app can work offline. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline)."
     },
     "viewport": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
       "debugString": "",
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "viewport",
-      "description": "Has a `<meta name=\"viewport\">` tag with `width` or `initial-scale`",
+      "description": "Does not have a `<meta name=\"viewport\">` tag with `width` or `initial-scale`",
       "helpText": "Add a viewport meta tag to optimize your app for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag)."
     },
     "without-javascript": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "without-javascript",
-      "description": "Contains some content when JavaScript is not available",
+      "description": "Does not provide fallback content when JavaScript is not available",
       "helpText": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/no-js)."
     },
     "first-meaningful-paint": {
-      "score": 51,
+      "score": 0.51,
       "displayValue": "3,970 ms",
       "rawValue": 3969.1,
       "extendedInfo": {
@@ -104,13 +104,13 @@
           "fmpFellBack": false
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "name": "first-meaningful-paint",
       "description": "First meaningful paint",
       "helpText": "First meaningful paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint)."
     },
     "load-fast-enough-for-pwa": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
       "extendedInfo": {
@@ -130,13 +130,13 @@
           "timeToFirstInteractive": 4927.278
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "load-fast-enough-for-pwa",
-      "description": "Page load is fast enough on 3G",
+      "description": "Page load is not fast enough on 3G",
       "helpText": "A fast page load over a 3G network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
     },
     "speed-index-metric": {
-      "score": 60,
+      "score": 0.6,
       "displayValue": "4,565",
       "rawValue": 4565,
       "extendedInfo": {
@@ -173,16 +173,16 @@
           ]
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "name": "speed-index-metric",
       "description": "Perceptual Speed Index",
       "helpText": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index)."
     },
     "screenshot-thumbnails": {
-      "score": 100,
+      "score": 1,
       "displayValue": "true",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "name": "screenshot-thumbnails",
       "description": "Screenshot Thumbnails",
@@ -245,7 +245,7 @@
       }
     },
     "estimated-input-latency": {
-      "score": 100,
+      "score": 1,
       "displayValue": "16 ms",
       "rawValue": 16,
       "extendedInfo": {
@@ -272,7 +272,7 @@
           }
         ]
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "name": "estimated-input-latency",
       "description": "Estimated Input Latency",
       "helpText": "The score above is an estimate of how long your app takes to respond to user input, in milliseconds. There is a 90% probability that a user encounters this amount of latency, or less. 10% of the time a user can expect additional latency. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency)."
@@ -281,7 +281,7 @@
       "score": 0,
       "displayValue": "5",
       "rawValue": 5,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "errors-in-console",
       "description": "Browser errors were logged to the console",
       "helpText": "Errors logged to the console indicate unresolved problems. They can come from network request failures and other browser concerns.",
@@ -329,7 +329,7 @@
       }
     },
     "time-to-first-byte": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": 570.5630000000001,
       "extendedInfo": {
@@ -337,7 +337,7 @@
           "wastedMs": -29.436999999999898
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "name": "time-to-first-byte",
       "description": "Keep server response times low (TTFB)",
@@ -349,7 +349,7 @@
       }
     },
     "first-interactive": {
-      "score": 82,
+      "score": 0.82,
       "displayValue": "4,930 ms",
       "rawValue": 4927.278,
       "extendedInfo": {
@@ -358,13 +358,13 @@
           "timestamp": 185608247190
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "name": "first-interactive",
       "description": "First Interactive (beta)",
       "helpText": "First Interactive marks the time at which the page is minimally interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
     },
     "consistently-interactive": {
-      "score": 82,
+      "score": 0.82,
       "displayValue": "4,930 ms",
       "rawValue": 4927.278,
       "extendedInfo": {
@@ -393,19 +393,19 @@
           "timeInMs": 4927.278
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "name": "consistently-interactive",
       "description": "Consistently Interactive (beta)",
       "helpText": "Consistently Interactive marks the time at which the page is fully interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
     },
     "user-timings": {
-      "score": 100,
+      "score": 1,
       "displayValue": "0",
       "rawValue": true,
       "extendedInfo": {
         "value": []
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "name": "user-timings",
       "description": "User Timing marks and measures",
@@ -582,7 +582,7 @@
           }
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "name": "critical-request-chains",
       "description": "Critical Request Chains",
@@ -754,7 +754,7 @@
       }
     },
     "redirects": {
-      "score": 100,
+      "score": 1,
       "displayValue": "0 ms",
       "rawValue": 0,
       "extendedInfo": {
@@ -762,9 +762,9 @@
           "wastedMs": 0
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "numeric",
       "name": "redirects",
-      "description": "Avoids page redirects",
+      "description": "Has multiple page redirects",
       "helpText": "Redirects introduce additional delays before the page can be loaded. [Learn more](https://developers.google.com/speed/docs/insights/AvoidRedirects).",
       "details": {
         "type": "table",
@@ -798,7 +798,7 @@
           }
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "webapp-install-banner",
       "description": "User will not be prompted to Install the Web App",
       "helpText": "Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/install-prompt)."
@@ -820,7 +820,7 @@
           }
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "splash-screen",
       "description": "Is not configured for a custom splash screen",
       "helpText": "A themed splash screen ensures a high-quality experience when users launch your app from their homescreens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/custom-splash-screen)."
@@ -844,7 +844,7 @@
           "themeColor": null
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "themed-omnibox",
       "description": "Address bar does not match brand colors",
       "helpText": "The browser address bar can be themed to match your site. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/address-bar)."
@@ -853,26 +853,26 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "manifest-short-name-length",
       "description": "Manifest's `short_name` will be truncated when displayed on homescreen",
       "helpText": "Make your app's `short_name` fewer than 12 characters to ensure that it's not truncated on homescreens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/manifest-short_name-is-not-truncated)."
     },
     "content-width": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
       "debugString": "",
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "content-width",
-      "description": "Content is sized correctly for the viewport",
+      "description": "Content is not sized correctly for the viewport",
       "helpText": "If the width of your app's content doesn't match the width of the viewport, your app might not be optimized for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport)."
     },
     "image-aspect-ratio": {
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "image-aspect-ratio",
       "description": "Displays images with incorrect aspect ratio",
       "helpText": "Image display dimensions should match natural aspect ratio.",
@@ -935,7 +935,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "deprecations",
       "description": "Uses deprecated API's",
       "helpText": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated).",
@@ -980,7 +980,7 @@
       }
     },
     "mainthread-work-breakdown": {
-      "score": 100,
+      "score": 1,
       "displayValue": "1,360 ms",
       "rawValue": 1359.7759999930859,
       "extendedInfo": {
@@ -1001,7 +1001,7 @@
           "XHR Load": 0.011000007390975952
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "name": "mainthread-work-breakdown",
       "description": "Main thread work breakdown",
@@ -1100,7 +1100,7 @@
       }
     },
     "bootup-time": {
-      "score": 100,
+      "score": 1,
       "displayValue": "1,300 ms",
       "rawValue": 1302.3579999804497,
       "extendedInfo": {
@@ -1126,9 +1126,9 @@
           }
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "bootup-time",
-      "description": "JavaScript boot-up time",
+      "description": "JavaScript boot-up time is too high",
       "helpText": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://developers.google.com/web/lighthouse/audits/bootup).",
       "details": {
         "type": "table",
@@ -1175,13 +1175,13 @@
       }
     },
     "uses-rel-preload": {
-      "score": 100,
+      "score": 1,
       "displayValue": "0 ms",
       "rawValue": 0,
       "extendedInfo": {
         "value": []
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "uses-rel-preload",
       "description": "Preload key requests",
@@ -1196,12 +1196,12 @@
       }
     },
     "font-display": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "font-display",
-      "description": "All text remains visible during webfont loads",
+      "description": "Avoid invisible text while webfonts are loading",
       "helpText": "Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading. [Learn more](https://developers.google.com/web/updates/2016/02/font-display).",
       "details": {
         "type": "table",
@@ -1209,11 +1209,313 @@
         "items": []
       }
     },
+    "network-requests": {
+      "score": 1,
+      "displayValue": "18",
+      "rawValue": 18,
+      "extendedInfo": {
+        "value": [
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+            "startTime": 0,
+            "endTime": 640.1550000009593,
+            "transferSize": 12640,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true",
+            "startTime": 630.2950000099372,
+            "endTime": 2635.035000013886,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
+            "startTime": 635.496000002604,
+            "endTime": 1204.6590000099968,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
+            "startTime": 636.6400000115391,
+            "endTime": 1213.2910000218544,
+            "transferSize": 139,
+            "statusCode": 404
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
+            "startTime": 638.0040000076406,
+            "endTime": 2849.3670000170823,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+            "startTime": 638.7899999972433,
+            "endTime": 1220.04100002232,
+            "transferSize": 1108,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200",
+            "startTime": 640.5979999981355,
+            "endTime": 1228.5180000180844,
+            "transferSize": 736,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+            "startTime": 641.3450000109151,
+            "endTime": 1776.4320000133011,
+            "transferSize": 733,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true",
+            "startTime": 642.8679999953602,
+            "endTime": 4216.161000018474,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+            "startTime": 644.0820000134408,
+            "endTime": 1792.0860000012908,
+            "transferSize": 1703,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500",
+            "startTime": 645.529000001261,
+            "endTime": 1236.1859999946319,
+            "transferSize": 144,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
+            "startTime": 3951.6250000160653,
+            "endTime": 4779.641000000993,
+            "transferSize": 24741,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/zone.js",
+            "startTime": 2849.7340000176337,
+            "endTime": 3961.049000005005,
+            "transferSize": 71654,
+            "statusCode": 200
+          },
+          {
+            "url": "http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js",
+            "startTime": 3874.7540000185836,
+            "endTime": 4796.288000012282,
+            "transferSize": 30174,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+            "startTime": 2924.34100000537,
+            "endTime": 3964.233000006061,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+            "startTime": 3066.252999997232,
+            "endTime": 3772.7560000203084,
+            "transferSize": 12640,
+            "statusCode": 200
+          },
+          {
+            "url": "blob:http://localhost:10200/ae0eac03-ab9b-4a6a-b299-f5212153e277",
+            "startTime": 3829.6360000094865,
+            "endTime": 3968.59800000675,
+            "transferSize": 0,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/favicon.ico",
+            "startTime": 4967.373000021325,
+            "endTime": 5536.498000001302,
+            "transferSize": 221,
+            "statusCode": 404
+          }
+        ]
+      },
+      "scoreDisplayMode": "binary",
+      "informative": true,
+      "name": "network-requests",
+      "description": "Network Requests",
+      "helpText": "Lists the network requests that were made during page load.",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "url",
+            "itemType": "url",
+            "text": "URL"
+          },
+          {
+            "key": "startTime",
+            "itemType": "ms",
+            "granularity": 1,
+            "text": "Start Time"
+          },
+          {
+            "key": "endTime",
+            "itemType": "ms",
+            "granularity": 1,
+            "text": "End Time"
+          },
+          {
+            "key": "transferSize",
+            "itemType": "bytes",
+            "displayUnit": "kb",
+            "granularity": 1,
+            "text": "Transfer Size"
+          },
+          {
+            "key": "statusCode",
+            "itemType": "text",
+            "text": "Status Code"
+          }
+        ],
+        "items": [
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+            "startTime": 0,
+            "endTime": 640.1550000009593,
+            "transferSize": 12640,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true",
+            "startTime": 630.2950000099372,
+            "endTime": 2635.035000013886,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
+            "startTime": 635.496000002604,
+            "endTime": 1204.6590000099968,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
+            "startTime": 636.6400000115391,
+            "endTime": 1213.2910000218544,
+            "transferSize": 139,
+            "statusCode": 404
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
+            "startTime": 638.0040000076406,
+            "endTime": 2849.3670000170823,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+            "startTime": 638.7899999972433,
+            "endTime": 1220.04100002232,
+            "transferSize": 1108,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200",
+            "startTime": 640.5979999981355,
+            "endTime": 1228.5180000180844,
+            "transferSize": 736,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+            "startTime": 641.3450000109151,
+            "endTime": 1776.4320000133011,
+            "transferSize": 733,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true",
+            "startTime": 642.8679999953602,
+            "endTime": 4216.161000018474,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+            "startTime": 644.0820000134408,
+            "endTime": 1792.0860000012908,
+            "transferSize": 1703,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500",
+            "startTime": 645.529000001261,
+            "endTime": 1236.1859999946319,
+            "transferSize": 144,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
+            "startTime": 3951.6250000160653,
+            "endTime": 4779.641000000993,
+            "transferSize": 24741,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/zone.js",
+            "startTime": 2849.7340000176337,
+            "endTime": 3961.049000005005,
+            "transferSize": 71654,
+            "statusCode": 200
+          },
+          {
+            "url": "http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js",
+            "startTime": 3874.7540000185836,
+            "endTime": 4796.288000012282,
+            "transferSize": 30174,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+            "startTime": 2924.34100000537,
+            "endTime": 3964.233000006061,
+            "transferSize": 821,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+            "startTime": 3066.252999997232,
+            "endTime": 3772.7560000203084,
+            "transferSize": 12640,
+            "statusCode": 200
+          },
+          {
+            "url": "blob:http://localhost:10200/ae0eac03-ab9b-4a6a-b299-f5212153e277",
+            "startTime": 3829.6360000094865,
+            "endTime": 3968.59800000675,
+            "transferSize": 0,
+            "statusCode": 200
+          },
+          {
+            "url": "http://localhost:10200/favicon.ico",
+            "startTime": 4967.373000021325,
+            "endTime": 5536.498000001302,
+            "transferSize": 221,
+            "statusCode": 404
+          }
+        ]
+      }
+    },
     "pwa-cross-browser": {
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "pwa-cross-browser",
@@ -1224,7 +1526,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "pwa-page-transitions",
@@ -1235,7 +1537,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "pwa-each-page-has-url",
@@ -1243,10 +1545,10 @@
       "helpText": "Ensure individual pages are deep linkable via the URLs and that URLs are unique for the purpose of shareability on social media. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#each-page-has-a-url)."
     },
     "accesskeys": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "accesskeys",
@@ -1254,10 +1556,10 @@
       "helpText": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/2.2/accesskeys?application=lighthouse)."
     },
     "aria-allowed-attr": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "aria-allowed-attr",
@@ -1265,10 +1567,10 @@
       "helpText": "Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-allowed-attr?application=lighthouse)."
     },
     "aria-required-attr": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "aria-required-attr",
@@ -1276,10 +1578,10 @@
       "helpText": "Some ARIA roles have required attributes that describe the state of the element to screen readers. [Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-required-attr?application=lighthouse)."
     },
     "aria-required-children": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "aria-required-children",
@@ -1287,10 +1589,10 @@
       "helpText": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-required-children?application=lighthouse)."
     },
     "aria-required-parent": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "aria-required-parent",
@@ -1298,10 +1600,10 @@
       "helpText": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-required-parent?application=lighthouse)."
     },
     "aria-roles": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "aria-roles",
@@ -1309,10 +1611,10 @@
       "helpText": "ARIA roles must have valid values in order to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-roles?application=lighthouse)."
     },
     "aria-valid-attr-value": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "aria-valid-attr-value",
@@ -1320,10 +1622,10 @@
       "helpText": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid values. [Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-valid-attr-value?application=lighthouse)."
     },
     "aria-valid-attr": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "aria-valid-attr",
@@ -1331,10 +1633,10 @@
       "helpText": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid names. [Learn more](https://dequeuniversity.com/rules/axe/2.2/aria-valid-attr?application=lighthouse)."
     },
     "audio-caption": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "audio-caption",
@@ -1342,10 +1644,10 @@
       "helpText": "Captions make audio elements usable for deaf or hearing-impaired users, providing critical information such as who is talking, what they're saying, and other non-speech information. [Learn more](https://dequeuniversity.com/rules/axe/2.2/audio-caption?application=lighthouse)."
     },
     "button-name": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "button-name",
@@ -1353,13 +1655,13 @@
       "helpText": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://dequeuniversity.com/rules/axe/2.2/button-name?application=lighthouse)."
     },
     "bypass": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
       "extendedInfo": {},
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "bypass",
-      "description": "The page contains a heading, skip link, or landmark region",
+      "description": "The page does not contain a heading, skip link, or landmark region",
       "helpText": "Adding ways to bypass repetitive content lets keyboard users navigate the page more efficiently. [Learn more](https://dequeuniversity.com/rules/axe/2.2/bypass?application=lighthouse).",
       "details": {
         "type": "list",
@@ -1410,7 +1712,7 @@
           ]
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "color-contrast",
       "description": "Background and foreground colors do not have a sufficient contrast ratio.",
       "helpText": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://dequeuniversity.com/rules/axe/2.2/color-contrast?application=lighthouse).",
@@ -1437,10 +1739,10 @@
       }
     },
     "definition-list": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "definition-list",
@@ -1448,10 +1750,10 @@
       "helpText": "When definition lists are not properly marked up, screen readers may produce confusing or inaccurate output. [Learn more](https://dequeuniversity.com/rules/axe/2.2/definition-list?application=lighthouse)."
     },
     "dlitem": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "dlitem",
@@ -1459,14 +1761,14 @@
       "helpText": "Definition list items (`<dt>` and `<dd>`) must be wrapped in a parent `<dl>` element to ensure that screen readers can properly announce them. [Learn more](https://dequeuniversity.com/rules/axe/2.2/dlitem?application=lighthouse)."
     },
     "document-title": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
       "extendedInfo": {},
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "document-title",
-      "description": "Document has a `<title>` element",
-      "helpText": "Screen reader users use page titles to get an overview of the contents of the page. [Learn more](https://dequeuniversity.com/rules/axe/2.2/document-title?application=lighthouse).",
+      "description": "Document doesn't have a `<title>` element",
+      "helpText": "The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/title).",
       "details": {
         "type": "list",
         "header": {
@@ -1477,13 +1779,13 @@
       }
     },
     "duplicate-id": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
       "extendedInfo": {},
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "duplicate-id",
-      "description": "`[id]` attributes on the page are unique",
+      "description": "`[id]` attributes on the page are not unique",
       "helpText": "The value of an id attribute must be unique to prevent other instances from being overlooked by assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/2.2/duplicate-id?application=lighthouse).",
       "details": {
         "type": "list",
@@ -1495,10 +1797,10 @@
       }
     },
     "frame-title": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "frame-title",
@@ -1535,7 +1837,7 @@
           ]
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "html-has-lang",
       "description": "`<html>` element does not have a `[lang]` attribute",
       "helpText": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://dequeuniversity.com/rules/axe/2.2/html-lang?application=lighthouse).",
@@ -1556,10 +1858,10 @@
       }
     },
     "html-lang-valid": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "html-lang-valid",
@@ -1618,7 +1920,7 @@
           ]
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "image-alt",
       "description": "Image elements do not have `[alt]` attributes",
       "helpText": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute.[Learn more](https://dequeuniversity.com/rules/axe/2.2/image-alt?application=lighthouse).",
@@ -1651,10 +1953,10 @@
       }
     },
     "input-image-alt": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "input-image-alt",
@@ -1714,7 +2016,7 @@
           ]
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "label",
       "description": "Form elements do not have associated labels",
       "helpText": "Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://dequeuniversity.com/rules/axe/2.2/label?application=lighthouse).",
@@ -1747,10 +2049,10 @@
       }
     },
     "layout-table": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "layout-table",
@@ -1801,7 +2103,7 @@
           ]
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "link-name",
       "description": "Links do not have a discernible name",
       "helpText": "Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/2.2/link-name?application=lighthouse).",
@@ -1828,10 +2130,10 @@
       }
     },
     "list": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "list",
@@ -1839,10 +2141,10 @@
       "helpText": "Screen readers have a specific way of announcing lists. Ensuring proper list structure aids screen reader output. [Learn more](https://dequeuniversity.com/rules/axe/2.2/list?application=lighthouse)."
     },
     "listitem": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "listitem",
@@ -1850,10 +2152,10 @@
       "helpText": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/2.2/listitem?application=lighthouse)."
     },
     "meta-refresh": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "meta-refresh",
@@ -1861,13 +2163,13 @@
       "helpText": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://dequeuniversity.com/rules/axe/2.2/meta-refresh?application=lighthouse)."
     },
     "meta-viewport": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
       "extendedInfo": {},
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "meta-viewport",
-      "description": "`[user-scalable=\"no\"]` is not used in the `<meta name=\"viewport\">` element and the `[maximum-scale]` attribute is not less than 5.",
+      "description": "`[user-scalable=\"no\"]` is used in the `<meta name=\"viewport\">` element or the `[maximum-scale]` attribute is less than 5.",
       "helpText": "Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page. [Learn more](https://dequeuniversity.com/rules/axe/2.2/meta-viewport?application=lighthouse).",
       "details": {
         "type": "list",
@@ -1879,10 +2181,10 @@
       }
     },
     "object-alt": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "object-alt",
@@ -1890,10 +2192,10 @@
       "helpText": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://dequeuniversity.com/rules/axe/2.2/object-alt?application=lighthouse)."
     },
     "tabindex": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "tabindex",
@@ -1901,10 +2203,10 @@
       "helpText": "A value greater than 0 implies an explicit navigation ordering. Although technically valid, this often creates frustrating experiences for users who rely on assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/2.2/tabindex?application=lighthouse)."
     },
     "td-headers-attr": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "td-headers-attr",
@@ -1912,10 +2214,10 @@
       "helpText": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/2.2/td-headers-attr?application=lighthouse)."
     },
     "th-has-data-cells": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "th-has-data-cells",
@@ -1923,10 +2225,10 @@
       "helpText": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/2.2/th-has-data-cells?application=lighthouse)."
     },
     "valid-lang": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "valid-lang",
@@ -1934,10 +2236,10 @@
       "helpText": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) on elements helps ensure that text is pronounced correctly by a screen reader. [Learn more](https://dequeuniversity.com/rules/axe/2.2/valid-lang?application=lighthouse)."
     },
     "video-caption": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "video-caption",
@@ -1945,10 +2247,10 @@
       "helpText": "When a video provides a caption it is easier for deaf and hearing impaired users to access its information. [Learn more](https://dequeuniversity.com/rules/axe/2.2/video-caption?application=lighthouse)."
     },
     "video-description": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "video-description",
@@ -1959,7 +2261,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "custom-controls-labels",
@@ -1970,7 +2272,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "custom-controls-roles",
@@ -1981,7 +2283,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "focus-traps",
@@ -1992,7 +2294,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "focusable-controls",
@@ -2003,7 +2305,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "heading-levels",
@@ -2014,7 +2316,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "logical-tab-order",
@@ -2025,7 +2327,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "managed-focus",
@@ -2036,7 +2338,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "offscreen-content-hidden",
@@ -2047,7 +2349,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "use-landmarks",
@@ -2058,7 +2360,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "visual-order-follows-dom",
@@ -2066,7 +2368,7 @@
       "helpText": "DOM order matches the visual order, improving navigation for assistive technology. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader)."
     },
     "uses-long-cache-ttl": {
-      "score": 91,
+      "score": 0.91,
       "displayValue": "11 assets found",
       "rawValue": 103455,
       "extendedInfo": {
@@ -2164,7 +2466,7 @@
           "queryStringCount": 7
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "name": "uses-long-cache-ttl",
       "description": "Uses inefficient cache policy on static assets",
       "helpText": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#cache-control).",
@@ -2286,7 +2588,7 @@
       }
     },
     "total-byte-weight": {
-      "score": 100,
+      "score": 1,
       "displayValue": "Total size was 157 KB",
       "rawValue": 160738,
       "extendedInfo": {
@@ -2346,9 +2648,9 @@
           "totalCompletedRequests": 18
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "name": "total-byte-weight",
-      "description": "Avoids enormous network payloads",
+      "description": "Has enormous network payloads",
       "helpText": "Large network payloads cost users real money and are highly correlated with long load times. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/network-payloads).",
       "details": {
         "type": "table",
@@ -2426,7 +2728,7 @@
       }
     },
     "offscreen-images": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": 0,
       "extendedInfo": {
@@ -2436,7 +2738,7 @@
           "results": []
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "offscreen-images",
       "description": "Offscreen images",
@@ -2452,7 +2754,7 @@
       }
     },
     "unminified-css": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": 0,
       "extendedInfo": {
@@ -2462,7 +2764,7 @@
           "results": []
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "unminified-css",
       "description": "Minify CSS",
@@ -2478,7 +2780,7 @@
       }
     },
     "unminified-javascript": {
-      "score": 90,
+      "score": 0.9,
       "displayValue": "Potential savings of 30470 bytes",
       "rawValue": 170,
       "extendedInfo": {
@@ -2497,7 +2799,7 @@
           ]
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "unminified-javascript",
       "description": "Minify JavaScript",
@@ -2542,7 +2844,7 @@
       }
     },
     "unused-css-rules": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": 0,
       "extendedInfo": {
@@ -2552,7 +2854,7 @@
           "results": []
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "unused-css-rules",
       "description": "Unused CSS rules",
@@ -2568,7 +2870,7 @@
       }
     },
     "uses-webp-images": {
-      "score": 90,
+      "score": 0.9,
       "displayValue": "Potential savings of 8526 bytes",
       "rawValue": 50,
       "extendedInfo": {
@@ -2588,7 +2890,7 @@
           ]
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "uses-webp-images",
       "description": "Serve images in next-gen formats",
@@ -2639,7 +2941,7 @@
       }
     },
     "uses-optimized-images": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": 0,
       "extendedInfo": {
@@ -2649,7 +2951,7 @@
           "results": []
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "uses-optimized-images",
       "description": "Optimize images",
@@ -2665,7 +2967,7 @@
       }
     },
     "uses-request-compression": {
-      "score": 65,
+      "score": 0.65,
       "displayValue": "Potential savings of 64646 bytes",
       "rawValue": 370,
       "extendedInfo": {
@@ -2690,7 +2992,7 @@
           ]
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "uses-request-compression",
       "description": "Enable text compression",
@@ -2741,7 +3043,7 @@
       }
     },
     "uses-responsive-images": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": 0,
       "extendedInfo": {
@@ -2751,7 +3053,7 @@
           "results": []
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "uses-responsive-images",
       "description": "Properly size images",
@@ -2771,13 +3073,13 @@
       "displayValue": "",
       "rawValue": false,
       "debugString": "Found <html manifest=\"clock.appcache\">.",
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "appcache-manifest",
       "description": "Uses Application Cache",
       "helpText": "Application Cache is deprecated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/appcache)."
     },
     "dom-size": {
-      "score": 100,
+      "score": 1,
       "displayValue": "53 nodes",
       "rawValue": 53,
       "extendedInfo": {
@@ -2801,9 +3103,9 @@
           }
         ]
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "name": "dom-size",
-      "description": "Avoids an excessive DOM size",
+      "description": "Uses an excessive DOM size",
       "helpText": "Browser engineers recommend pages contain fewer than ~1,500 DOM nodes. The sweet spot is a tree depth < 32 elements and fewer than 60 children/parent element. A large DOM can increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/fundamentals/performance/rendering/).",
       "details": {
         "type": "cards",
@@ -2859,7 +3161,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "external-anchors-use-rel-noopener",
       "description": "Does not open external anchors using `rel=\"noopener\"`",
       "helpText": "Open new tabs using `rel=\"noopener\"` to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).",
@@ -2966,7 +3268,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "geolocation-on-start",
       "description": "Requests the geolocation permission on page load",
       "helpText": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).",
@@ -3072,7 +3374,7 @@
           ]
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "link-blocking-first-paint",
       "description": "Reduce render-blocking stylesheets",
@@ -3215,7 +3517,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "no-document-write",
       "description": "Uses `document.write()`",
       "helpText": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).",
@@ -3376,7 +3678,7 @@
           ]
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "no-mutation-events",
       "description": "Uses Mutation Events in its own scripts",
       "helpText": "Mutation Events are deprecated and harm performance. Consider using Mutation Observers instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/mutation-events).",
@@ -3525,7 +3827,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "no-vulnerable-libraries",
       "description": "Includes front-end JavaScript libraries with known security vulnerabilities",
       "helpText": "Some third-party scripts may contain known security vulnerabilities  that are easily identified and exploited by attackers.",
@@ -3585,7 +3887,7 @@
       "displayValue": "",
       "rawValue": false,
       "debugString": "Found database \"mydb\", version: 1.0.",
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "no-websql",
       "description": "Uses WebSQL DB",
       "helpText": "Web SQL is deprecated. Consider using IndexedDB instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/web-sql)."
@@ -3625,7 +3927,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "notification-on-start",
       "description": "Requests the notification permission on page load",
       "helpText": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).",
@@ -3688,7 +3990,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "password-inputs-can-be-pasted-into",
       "description": "Prevents users to paste into password fields",
       "helpText": "Preventing password pasting undermines good security policy. [Learn more](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords)",
@@ -3725,7 +4027,7 @@
           ]
         }
       },
-      "scoringMode": "numeric",
+      "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "script-blocking-first-paint",
       "description": "Reduce render-blocking scripts",
@@ -3838,7 +4140,7 @@
           ]
         }
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "uses-http2",
       "description": "Does not use HTTP/2 for all of its resources",
       "helpText": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).",
@@ -4013,7 +4315,7 @@
           }
         ]
       },
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "uses-passive-event-listeners",
       "description": "Does not use passive listeners to improve scrolling performance",
       "helpText": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).",
@@ -4120,27 +4422,27 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "meta-description",
       "description": "Document does not have a meta description",
       "helpText": "Meta descriptions may be included in search results to concisely summarize page content. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/description)."
     },
     "http-status-code": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "http-status-code",
-      "description": "Page has successful HTTP status code",
+      "description": "Page has unsuccessful HTTP status code",
       "helpText": "Pages with unsuccessful HTTP status codes may not be indexed properly. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code)."
     },
     "font-size": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "font-size",
-      "description": "Document uses legible font sizes",
+      "description": "Document doesn't use legible font sizes",
       "helpText": "Font sizes less than 12px are too small to be legible and require mobile visitors to “pinch to zoom” in order to read. Strive to have >60% of page text ≥12px. [Learn more](https://developers.google.com/web/fundamentals/design-and-ux/responsive/#optimize_text_for_reading).",
       "details": {
         "type": "table",
@@ -4177,12 +4479,12 @@
       }
     },
     "link-text": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "link-text",
-      "description": "Links have descriptive text",
+      "description": "Links do not have descriptive text",
       "helpText": "Descriptive link text helps search engines understand your content. [Learn more](https://webmasters.googleblog.com/2008/10/importance-of-link-architecture.html).",
       "details": {
         "type": "table",
@@ -4192,26 +4494,23 @@
       }
     },
     "is-crawlable": {
-      "score": 100,
+      "score": 0,
       "displayValue": "",
-      "rawValue": true,
-      "scoringMode": "binary",
+      "rawValue": null,
+      "error": true,
+      "debugString": "Audit error: Required RobotsTxt gatherer did not run.",
+      "scoreDisplayMode": "binary",
       "name": "is-crawlable",
-      "description": "Page isn’t blocked from indexing",
-      "helpText": "The \"Robots\" directives tell crawlers how your content should be indexed. [Learn more](https://developers.google.com/search/reference/robots_meta_tag).",
-      "details": {
-        "type": "table",
-        "headings": [],
-        "items": []
-      }
+      "description": "Page is blocked from indexing",
+      "helpText": "The \"Robots\" directives tell crawlers how your content should be indexed. [Learn more](https://developers.google.com/search/reference/robots_meta_tag)."
     },
     "hreflang": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "hreflang",
-      "description": "Document has a valid `hreflang`",
+      "description": "Document doesn't have a valid `hreflang`",
       "helpText": "hreflang allows crawlers to discover alternate translations of the page content. [Learn more](https://support.google.com/webmasters/answer/189077).",
       "details": {
         "type": "table",
@@ -4220,12 +4519,12 @@
       }
     },
     "plugins": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "name": "plugins",
-      "description": "Document avoids plugins",
+      "description": "Document uses plugins",
       "helpText": "Most mobile devices do not support plugins, and many desktop browsers restrict them.",
       "details": {
         "type": "table",
@@ -4234,21 +4533,21 @@
       }
     },
     "canonical": {
-      "score": 100,
+      "score": 1,
       "displayValue": "",
       "rawValue": true,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "notApplicable": true,
       "name": "canonical",
-      "description": "Document has a valid `rel=canonical`",
+      "description": "Document does not have a valid `rel=canonical`",
       "helpText": "Canonical links suggest which URL to show in search results. Read more in [Use canonical URLs](https://support.google.com/webmasters/answer/139066)."
     },
     "mobile-friendly": {
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "mobile-friendly",
@@ -4259,7 +4558,7 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "scoringMode": "binary",
+      "scoreDisplayMode": "binary",
       "informative": true,
       "manual": true,
       "name": "structured-data",
@@ -4404,6 +4703,10 @@
           "group": "perf-info"
         },
         {
+          "id": "network-requests",
+          "weight": 0
+        },
+        {
           "id": "user-timings",
           "weight": 0,
           "group": "perf-info"
@@ -4429,7 +4732,7 @@
         }
       ],
       "id": "performance",
-      "score": 72.6470588235294
+      "score": 0.73
     },
     {
       "name": "Progressive Web App",
@@ -4496,7 +4799,7 @@
         }
       ],
       "id": "pwa",
-      "score": 36.36363636363637
+      "score": 0.36
     },
     {
       "name": "Accessibility",
@@ -4729,7 +5032,7 @@
         }
       ],
       "id": "accessibility",
-      "score": 35.08771929824562
+      "score": 0.35
     },
     {
       "name": "Best Practices",
@@ -4869,7 +5172,7 @@
         }
       ],
       "id": "seo",
-      "score": 88.88888888888889
+      "score": 0.78
     }
   ],
   "reportGroups": {
@@ -4943,6 +5246,6 @@
     }
   },
   "timing": {
-    "total": 1085
+    "total": 1081
   }
 }

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -445,8 +445,8 @@ describe('Runner', () => {
       assert.equal(results.initialUrl, url);
       assert.equal(gatherRunnerRunSpy.called, true, 'GatherRunner.run was not called');
       assert.equal(results.audits['content-width'].name, 'content-width');
-      assert.equal(results.audits['content-width'].score, 100);
-      assert.equal(results.reportCategories[0].score, 100);
+      assert.equal(results.audits['content-width'].score, 1.00);
+      assert.equal(results.reportCategories[0].score, 1.00);
       assert.equal(results.reportCategories[0].audits[0].id, 'content-width');
     });
   });

--- a/lighthouse-core/test/scoring-test.js
+++ b/lighthouse-core/test/scoring-test.js
@@ -17,38 +17,38 @@ describe('ReportScoring', () => {
 
     it('should work for equal weights', () => {
       assert.equal(ReportScoring.arithmeticMean([
-        {score: 10, weight: 1},
-        {score: 20, weight: 1},
-        {score: 3, weight: 1},
-      ]), 11);
+        {score: .10, weight: 1},
+        {score: .20, weight: 1},
+        {score: .03, weight: 1},
+      ]), .11);
     });
 
     it('should work for varying weights', () => {
       assert.equal(ReportScoring.arithmeticMean([
-        {score: 10, weight: 2},
-        {score: 0, weight: 7},
-        {score: 20, weight: 1},
-      ]), 4);
+        {score: .10, weight: 2},
+        {score: .00, weight: 7},
+        {score: .20, weight: 1},
+      ]), .04);
     });
 
     it('should work for missing values', () => {
       assert.equal(ReportScoring.arithmeticMean([
         {weight: 1},
-        {score: 30, weight: 1},
+        {score: .30, weight: 1},
         {weight: 1},
-        {score: 100},
-      ]), 10);
+        {score: 1.00},
+      ]), .10);
     });
   });
 
   describe('#scoreAllCategories', () => {
     it('should score the categories', () => {
       const resultsByAuditId = {
-        'my-audit': {rawValue: 'you passed'},
-        'my-boolean-audit': {score: true, extendedInfo: {}},
-        'my-scored-audit': {score: 100},
-        'my-failed-audit': {score: 20},
-        'my-boolean-failed-audit': {score: false},
+        'my-audit': {rawValue: 'you passed', score: 0},
+        'my-boolean-audit': {score: 0, extendedInfo: {}},
+        'my-scored-audit': {score: 1.00},
+        'my-failed-audit': {score: .20},
+        'my-boolean-failed-audit': {score: 0},
       };
 
       const result = {
@@ -68,7 +68,7 @@ describe('ReportScoring', () => {
       ReportScoring.scoreAllCategories(result, resultsByAuditId);
 
       assert.equal(result.categories.categoryA.score, 0);
-      assert.equal(result.categories.categoryB.score, 55);
+      assert.equal(result.categories.categoryB.score, .55);
     });
   });
 });

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -37,7 +37,7 @@ export interface AuditResult {
   rawValue: boolean | number;
   displayValue?: string;
   debugString?: string;
-  score?: boolean | number;
+  score?: number;
   optimalValue: number | string;
   extendedInfo?: {value: string};
 }
@@ -50,8 +50,8 @@ export interface AuditFullResult {
   rawValue: boolean | number;
   displayValue: string;
   debugString?: string;
-  score: boolean | number;
-  scoringMode: string;
+  score: number;
+  scoreDisplayMode: string;
   error?: boolean;
   description: string;
   name: string;


### PR DESCRIPTION
1. Ensure all audits return a numeric `score` (0-1), no boolean nonsense. 
1. `scoreDisplayMode` forces how it's displayed (renamed from `scoringMode`)