### PR TITLE
misc: drop support of Node 6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,11 +9,11 @@ branches:
 environment:
   fast_finish: true
   matrix:
-    - nodejs_version: "6"
+    - nodejs_version: "8"
       platform: x86
-    # node 7 is skipped, as appveyor only allows 1 concurrent job
+    # other Node versions are skipped, as appveyor only allows 1 concurrent job
     # and we want appveyor finishing ASAP. see #2382
-    # - nodejs_version: "7"
+    # - nodejs_version: "9"
     #   platform: x86
 
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ branches:
   - master
 matrix:
   include:
-    - node_js: "6.9.1"
     - node_js: "8"
-      if: head_branch IS blank AND branch = master
     - node_js: "9"
       if: head_branch IS blank AND branch = master
 dist: trusty

--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -2,7 +2,7 @@
   "name": "lighthouse-extension",
   "private": true,
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "scripts": {
     "watch": "gulp watch",

--- a/lighthouse-viewer/package.json
+++ b/lighthouse-viewer/package.json
@@ -2,7 +2,7 @@
   "name": "lighthouse-viewer",
   "private": true,
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "scripts": {
     "watch": "gulp watch",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "chrome-debug": "./chrome-launcher/manual-chrome-launcher.js"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "scripts": {
     "install-all": "npm-run-posix-or-windows install-all:task",


### PR DESCRIPTION
Moving to Node 8 as lowest supported version.
This is a breaking change, and we've already branched the `2.x` branch, as master is now our 3.0. ref #4333 

(Breaking  ecc3d06 out of #4640 for clarity)

fixes #3742 


