### PR TITLE
core(start_url): fix start_url audit while offline

### DIFF
--- a/lighthouse-cli/test/fixtures/manifest.json
+++ b/lighthouse-cli/test/fixtures/manifest.json
@@ -1,0 +1,38 @@
+{
+  "name": "App Install",
+  "short_name": "App Install",
+  "icons": [
+    {
+      "src": "launcher-icon-0-75x.png",
+      "sizes": "36x36",
+      "type": "image/png"
+    },
+    {
+      "src": "launcher-icon-1x.png",
+      "sizes": "48x48",
+      "type": "image/png"
+    },
+    {
+      "src": "launcher-icon-1-5x.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    },
+    {
+      "src": "launcher-icon-2x.png",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "launcher-icon-3x.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    },
+    {
+      "src": "launcher-icon-4x.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "http://localhost:10503/offline-ready.html",
+  "display": "standalone"
+}

--- a/lighthouse-cli/test/fixtures/offline-ready.html
+++ b/lighthouse-cli/test/fixtures/offline-ready.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 <title>So offline-ready. The most.</title>
-<!--<link rel="manifest" href="/manifest.json">-->
+<link rel="manifest" href="/manifest.json">
 
 <h1>
   Whenever you call me, I'll be there.

--- a/lighthouse-cli/test/smokehouse/offline-config.js
+++ b/lighthouse-cli/test/smokehouse/offline-config.js
@@ -30,7 +30,6 @@ module.exports = {
       'label',
       'tabindex',
       'content-width',
-      'cache-start-url',
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/offline-config.js
+++ b/lighthouse-cli/test/smokehouse/offline-config.js
@@ -30,6 +30,7 @@ module.exports = {
       'label',
       'tabindex',
       'content-width',
+      'cache-start-url',
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
@@ -105,7 +105,7 @@ module.exports = [
         displayValue: '',
       },
       'webapp-install-banner': {
-        score: 0,
+        score: 1,
       },
       'splash-screen': {
         score: 0,

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -141,7 +141,7 @@ module.exports = [
         // Ignore speed test; just verify that it ran.
       },
       'webapp-install-banner': {
-        score: 0,
+        score: 1,
         extendedInfo: {
           value: {
             manifestValues: {

--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -55,7 +55,16 @@ class StartUrl extends Gatherer {
             if (response.url === startUrl) {
               options.driver.off('Network.responseReceived', responseReceived);
 
-              resolve({
+              if (!response.fromServiceWorker) {
+                return resolve({
+                  statusCode: -1,
+                  debugString: msgWithExtraDebugString(
+                    'Unable to fetch start URL via service worker'
+                  ),
+                });
+              }
+
+              return resolve({
                 statusCode: response.status,
                 debugString: '',
               });

--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const Gatherer = require('./gatherer');
-const URL = require('../../lib/url-shim');
 const manifestParser = require('../../lib/manifest-parser');
 
 class StartUrl extends Gatherer {
@@ -24,7 +23,6 @@ class StartUrl extends Gatherer {
       .then(manifest => {
         if (!manifest || !manifest.value) {
           const detailedMsg = manifest && manifest.debugString;
-          console.log(manifest);
 
           if (detailedMsg) {
             const message = `Error fetching web app manifest: ${detailedMsg}`;
@@ -54,7 +52,6 @@ class StartUrl extends Gatherer {
 
         return (new Promise(resolve => {
           options.driver.on('Network.responseReceived', function responseReceived({response}) {
-            console.log(response);
             if (response.url === startUrl) {
               options.driver.off('Network.responseReceived', responseReceived);
 
@@ -68,11 +65,12 @@ class StartUrl extends Gatherer {
           options.driver.goOffline(options)
             .then(() => this.executeFetchRequest(options.driver, startUrl))
             .then(() => options.driver.goOnline(options))
-            .catch((err) => {
-              console.log(err);
+            .catch(() => {
               resolve({
                 statusCode: -1,
-                debugString: msgWithExtraDebugString('Unable to fetch start URL via service worker'),
+                debugString: msgWithExtraDebugString(
+                  'Unable to fetch start URL via service worker'
+                ),
               });
             });
         }));

--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -16,7 +16,6 @@ class StartUrl extends Gatherer {
   }
 
   afterPass(options) {
-    const msgWithExtraDebugString = msg => this.debugString ? `${msg}: ${this.debugString}` : msg;
     return options.driver.goOnline(options)
       .then(() => options.driver.getAppManifest())
       .then(response => response && manifestParser(response.data, response.url, options.url))
@@ -25,16 +24,16 @@ class StartUrl extends Gatherer {
           const detailedMsg = manifest && manifest.debugString;
 
           if (detailedMsg) {
-            const message = `Error fetching web app manifest: ${detailedMsg}`;
+            const debugString = `Error fetching web app manifest: ${detailedMsg}`;
             return {
               statusCode: -1,
-              debugString: msgWithExtraDebugString(message),
+              debugString,
             };
           } else {
-            const message = `No usable web app manifest found on page ${options.url}`;
+            const debugString = `No usable web app manifest found on page ${options.url}`;
             return {
               statusCode: -1,
-              debugString: msgWithExtraDebugString(message),
+              debugString,
             };
           }
         }
@@ -44,7 +43,7 @@ class StartUrl extends Gatherer {
           // Therefore, we only set the debugString here and continue with the fetch.
           return {
             statusCode: -1,
-            debugString: msgWithExtraDebugString(manifest.value.start_url.debugString),
+            debugString: manifest.value.start_url.debugString,
           };
         }
 
@@ -58,9 +57,7 @@ class StartUrl extends Gatherer {
               if (!response.fromServiceWorker) {
                 return resolve({
                   statusCode: -1,
-                  debugString: msgWithExtraDebugString(
-                    'Unable to fetch start URL via service worker'
-                  ),
+                  debugString: 'Unable to fetch start URL via service worker',
                 });
               }
 
@@ -77,9 +74,7 @@ class StartUrl extends Gatherer {
             .catch(() => {
               resolve({
                 statusCode: -1,
-                debugString: msgWithExtraDebugString(
-                  'Unable to fetch start URL via service worker'
-                ),
+                debugString: 'Unable to fetch start URL via service worker',
               });
             });
         }));

--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -9,76 +9,92 @@ const Gatherer = require('./gatherer');
 const manifestParser = require('../../lib/manifest-parser');
 
 class StartUrl extends Gatherer {
-  executeFetchRequest(driver, url) {
-    return driver.evaluateAsync(
-      `fetch('${url}')`
-    );
-  }
-
+  /**
+   * Grab the manifest, extract it's start_url, attempt to `fetch()` it while offline
+   * @param {*} options
+   * @return {{statusCode: number, debugString?: string}}
+   */
   afterPass(options) {
-    return options.driver.goOnline(options)
-      .then(() => options.driver.getAppManifest())
+    const driver = options.driver;
+    return driver.goOnline(options)
+      .then(() => driver.getAppManifest())
+      .then(response => driver.goOffline(options).then(() => response))
       .then(response => response && manifestParser(response.data, response.url, options.url))
       .then(manifest => {
-        if (!manifest || !manifest.value) {
-          const detailedMsg = manifest && manifest.debugString;
-
-          if (detailedMsg) {
-            const debugString = `Error fetching web app manifest: ${detailedMsg}`;
-            return {
-              statusCode: -1,
-              debugString,
-            };
-          } else {
-            const debugString = `No usable web app manifest found on page ${options.url}`;
-            return {
-              statusCode: -1,
-              debugString,
-            };
-          }
+        const {isReadFailure, reason, startUrl} = this._readManifestStartUrl(manifest);
+        if (isReadFailure) {
+          return {statusCode: -1, debugString: reason};
         }
 
-        if (manifest.value.start_url.debugString) {
-          // Even if the start URL had an error, the browser will still supply a fallback URL.
-          // Therefore, we only set the debugString here and continue with the fetch.
-          return {
-            statusCode: -1,
-            debugString: manifest.value.start_url.debugString,
-          };
-        }
-
-        const startUrl = manifest.value.start_url.value;
-
-        return (new Promise(resolve => {
-          options.driver.on('Network.responseReceived', function responseReceived({response}) {
-            if (response.url === startUrl) {
-              options.driver.off('Network.responseReceived', responseReceived);
-
-              if (!response.fromServiceWorker) {
-                return resolve({
-                  statusCode: -1,
-                  debugString: 'Unable to fetch start URL via service worker',
-                });
-              }
-
-              return resolve({
-                statusCode: response.status,
-                debugString: '',
-              });
-            }
-          });
-
-          options.driver.goOffline(options)
-            .then(() => this.executeFetchRequest(options.driver, startUrl))
-            .then(() => options.driver.goOnline(options))
-            .catch(() => {
-              resolve({
-                statusCode: -1,
-                debugString: 'Unable to fetch start URL via service worker',
-              });
-            });
-        }));
+        return this._attemptManifestFetch(options.driver, startUrl);
+      }).catch(() => {
+        return {statusCode: -1, debugString: 'Unable to fetch start URL via service worker'};
       });
+  }
+
+  /**
+   * Read the parsed manifest and return failure reasons or the startUrl
+   * @param {Manifest} manifest
+   * @return {{isReadFailure: true, reason: string}|{isReadFailure: false, startUrl: string}}
+   */
+  _readManifestStartUrl(manifest) {
+    if (!manifest || !manifest.value) {
+      const detailedMsg = manifest && manifest.debugString;
+
+      if (detailedMsg) {
+        return {isReadFailure: true, reason: `Error fetching web app manifest: ${detailedMsg}`};
+      } else {
+        return {isReadFailure: true, reason: `No usable web app manifest found on page`};
+      }
+    }
+
+    // Even if the start URL had an error, the browser will still supply a fallback URL.
+    // Therefore, we only set the debugString here and continue with the fetch.
+    if (manifest.value.start_url.debugString) {
+      return {isReadFailure: true, reason: manifest.value.start_url.debugString};
+    }
+
+    return {isReadFailure: false, startUrl: manifest.value.start_url.value};
+  }
+
+  /**
+   * Try to `fetch(start_url)`, return true if fetched by SW
+   * Resolves when we have a matched network request
+   * @param {!Driver} driver
+   * @param {!string} startUrl
+   * @return {Promise<{statusCode: ?number, debugString: ?string}>}
+   */
+  _attemptManifestFetch(driver, startUrl) {
+    // Wait up to 3s to get a matched network request from the fetch() to work
+    const timeoutPromise = new Promise(resolve =>
+      setTimeout(
+        () => resolve({statusCode: -1, debugString: 'Timed out waiting for fetched start_url'}),
+        3000
+      )
+    );
+
+    const fetchPromise = new Promise(resolve => {
+      driver.on('Network.responseReceived', onResponseReceived);
+
+      function onResponseReceived({response}) {
+        // ignore mismatched URLs
+        if (response.url !== startUrl) return;
+        driver.off('Network.responseReceived', onResponseReceived);
+
+        if (!response.fromServiceWorker) {
+          return resolve({
+            statusCode: -1,
+            debugString: 'Unable to fetch start URL via service worker',
+          });
+        }
+        // Successful SW-served fetch of the start_URL
+        return resolve({statusCode: response.status});
+      }
+    });
+
+    return driver
+      .evaluateAsync(`fetch('${startUrl}')`)
+      .then(() => Promise.race([fetchPromise, timeoutPromise]));
   }
 }
 

--- a/lighthouse-core/test/gather/gatherers/start-url-test.js
+++ b/lighthouse-core/test/gather/gatherers/start-url-test.js
@@ -21,11 +21,11 @@ const mockDriver = {
   off() {},
 };
 
-const wrapSendCommand = (mockDriver, url, status = 200) => {
+const wrapSendCommand = (mockDriver, url, status = 200, fromServiceWorker = false) => {
   mockDriver = Object.assign({}, mockDriver);
   mockDriver.evaluateAsync = () => Promise.resolve();
   mockDriver.on = (name, cb) => {
-    cb({response: {status, url}});
+    cb({response: {status, url, fromServiceWorker}});
   };
 
   mockDriver.getAppManifest = () => {
@@ -82,11 +82,11 @@ describe('Start-url gatherer', () => {
     const startUrlGathererWithFragment = new StartUrlGatherer();
     const options = {
       url: 'https://ifixit-pwa.appspot.com/',
-      driver: wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/'),
+      driver: wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/', 200, true),
     };
     const optionsWithQueryString = {
       url: 'https://ifixit-pwa.appspot.com/#/history',
-      driver: wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/#/history'),
+      driver: wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/#/history', 200, true),
     };
 
     return Promise.all([

--- a/lighthouse-core/test/gather/gatherers/start-url-test.js
+++ b/lighthouse-core/test/gather/gatherers/start-url-test.js
@@ -43,13 +43,27 @@ describe('Start-url gatherer', () => {
   it('returns an artifact set to -1 when offline loading fails', () => {
     const startUrlGatherer = new StartUrlGatherer();
     const startUrlGathererWithQueryString = new StartUrlGatherer();
+    const throwOnEvaluate = (mockDriver) => {
+      mockDriver.on = () => {};
+      mockDriver.evaluateAsync = () => {
+        throw new Error({
+          TypeError: 'Failed to fetch',
+          __failedInBrowser: true,
+          name: 'TypeError',
+          message: 'Failed to fetch',
+        });
+      };
+
+      return mockDriver;
+    };
+
     const options = {
       url: 'https://do-not-match.com/',
-      driver: wrapSendCommand(mockDriver, 'https://do-not-match.com/', -1),
+      driver: throwOnEvaluate(wrapSendCommand(mockDriver, 'https://do-not-match.com/', -1)),
     };
     const optionsWithQueryString = {
       url: 'https://ifixit-pwa.appspot.com/?history',
-      driver: wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/?history', -1),
+      driver: throwOnEvaluate(wrapSendCommand(mockDriver, 'https://ifixit-pwa.appspot.com/?history', -1)),
     };
 
     return Promise.all([

--- a/lighthouse-core/test/gather/gatherers/start-url-test.js
+++ b/lighthouse-core/test/gather/gatherers/start-url-test.js
@@ -120,7 +120,7 @@ describe('Start-url gatherer', () => {
     return startUrlGatherer.afterPass(options, tracingData)
       .then(artifact => {
         assert.equal(artifact.debugString,
-          `No usable web app manifest found on page ${options.url}`);
+          `No usable web app manifest found on page`);
       });
   });
 

--- a/lighthouse-core/test/gather/gatherers/start-url-test.js
+++ b/lighthouse-core/test/gather/gatherers/start-url-test.js
@@ -81,7 +81,8 @@ describe('Start-url gatherer', () => {
       assert.equal(artifactWithQueryString.statusCode, -1);
       assert.ok(artifactWithQueryString.debugString, 'did not set debug string');
       assert.equal(artifactWithResponseNotFromSW.statusCode, -1);
-      assert.equal(artifactWithResponseNotFromSW.debugString, 'Unable to fetch start URL via service worker');
+      assert.equal(artifactWithResponseNotFromSW.debugString,
+          'Unable to fetch start URL via service worker');
     });
   });
 
@@ -139,7 +140,8 @@ describe('Start-url gatherer', () => {
     return startUrlGatherer.afterPass(options, tracingData)
       .then(artifact => {
         assert.equal(artifact.debugString,
-          `Error fetching web app manifest: ERROR: file isn't valid JSON: SyntaxError: Unexpected token h in JSON at position 1`);
+          `Error fetching web app manifest: ERROR: file isn't valid JSON: ` +
+          `SyntaxError: Unexpected token h in JSON at position 1`);
       });
   });
 


### PR DESCRIPTION
Tests are broken but I want some feedback on this one.

is this a good approach? It seems to work on some urls I've tested but should test more of them

It fixes #2576