### PR TITLE
core: make url-shim extend native URL module; add type checking

### DIFF
--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -3,7 +3,6 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-// @ts-nocheck
 'use strict';
 
 /**
@@ -14,97 +13,17 @@
 
 const Util = require('../report/v2/renderer/util.js');
 
-// TODO: Add back node require('url').URL parsing when bug is resolved:
-// https://github.com/GoogleChrome/lighthouse/issues/1186
-const URL = (typeof self !== 'undefined' && self.URL) || require('whatwg-url').URL;
-
-URL.URLSearchParams = (typeof self !== 'undefined' && self.URLSearchParams) ||
-    require('whatwg-url').URLSearchParams;
-
-URL.INVALID_URL_DEBUG_STRING =
-    'Lighthouse was unable to determine the URL of some script executions. ' +
-    'It\'s possible a Chrome extension or other eval\'d code is the source.';
+// Type cast so tsc sees window.URL and require('url').URL as sufficiently equivalent.
+const URL = /** @type {!Window["URL"]} */ (typeof self !== 'undefined' && self.URL) ||
+    require('url').URL;
 
 /**
- * @param {string} url
- * @return {boolean}
- */
-URL.isValid = function isValid(url) {
-  try {
-    new URL(url);
-    return true;
-  } catch (e) {
-    return false;
-  }
-};
-
-/**
- * @param {string} urlA
- * @param {string} urlB
- * @return {boolean}
- */
-URL.hostsMatch = function hostsMatch(urlA, urlB) {
-  try {
-    return new URL(urlA).host === new URL(urlB).host;
-  } catch (e) {
-    return false;
-  }
-};
-
-/**
- * @param {string} urlA
- * @param {string} urlB
- * @return {boolean}
- */
-URL.originsMatch = function originsMatch(urlA, urlB) {
-  try {
-    return new URL(urlA).origin === new URL(urlB).origin;
-  } catch (e) {
-    return false;
-  }
-};
-
-/**
- * @param {string} url
- * @return {?string}
- */
-URL.getOrigin = function getOrigin(url) {
-  try {
-    const urlInfo = new URL(url);
-    // check for both host and origin since some URLs schemes like data and file set origin to the
-    // string "null" instead of the object
-    return (urlInfo.host && urlInfo.origin) || null;
-  } catch (e) {
-    return null;
-  }
-};
-
-/**
- * @param {string} url
- * @param {{numPathParts: number, preserveQuery: boolean, preserveHost: boolean}=} options
- * @return {string}
- */
-URL.getURLDisplayName = function getURLDisplayName(url, options) {
-  return Util.getURLDisplayName(new URL(url), options);
-};
-
-/**
- * Limits data URIs to 100 characters, returns all other strings untouched.
+ * There is fancy URL rewriting logic for the chrome://settings page that we need to work around.
+ * Why? Special handling was added by Chrome team to allow a pushState transition between chrome:// pages.
+ * As a result, the network URL (chrome://chrome/settings/) doesn't match the final document URL (chrome://settings/).
  * @param {string} url
  * @return {string}
  */
-URL.elideDataURI = function elideDataURI(url) {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === 'data:' ? url.slice(0, 100) : url;
-  } catch (e) {
-    return url;
-  }
-};
-
-// There is fancy URL rewriting logic for the chrome://settings page that we need to work around.
-// Why? Special handling was added by Chrome team to allow a pushState transition between chrome:// pages.
-// As a result, the network URL (chrome://chrome/settings/) doesn't match the final document URL (chrome://settings/).
 function rewriteChromeInternalUrl(url) {
   if (!url || !url.startsWith('chrome://')) return url;
   // Chrome adds a trailing slash to `chrome://` URLs, but the spec does not.
@@ -113,25 +32,111 @@ function rewriteChromeInternalUrl(url) {
   return url.replace(/^chrome:\/\/chrome\//, 'chrome://');
 }
 
-/**
- * Determine if url1 equals url2, ignoring URL fragments.
- * @param {string} url1
- * @param {string} url2
- * @return {boolean}
- */
-URL.equalWithExcludedFragments = function(url1, url2) {
-  [url1, url2] = [url1, url2].map(rewriteChromeInternalUrl);
-  try {
-    url1 = new URL(url1);
-    url1.hash = '';
-
-    url2 = new URL(url2);
-    url2.hash = '';
-
-    return url1.href === url2.href;
-  } catch (e) {
-    return false;
+class URLShim extends URL {
+  /**
+   * @param {string} url
+   * @return {boolean}
+   */
+  static isValid(url) {
+    try {
+      new URL(url);
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
-};
 
-module.exports = URL;
+  /**
+   * @param {string} urlA
+   * @param {string} urlB
+   * @return {boolean}
+   */
+  static hostsMatch(urlA, urlB) {
+    try {
+      return new URL(urlA).host === new URL(urlB).host;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * @param {string} urlA
+   * @param {string} urlB
+   * @return {boolean}
+   */
+  static originsMatch(urlA, urlB) {
+    try {
+      return new URL(urlA).origin === new URL(urlB).origin;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * @param {string} url
+   * @return {?string}
+   */
+  static getOrigin(url) {
+    try {
+      const urlInfo = new URL(url);
+      // check for both host and origin since some URLs schemes like data and file set origin to the
+      // string "null" instead of the object
+      return (urlInfo.host && urlInfo.origin) || null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /**
+   * @param {string} url
+   * @param {{numPathParts: number, preserveQuery: boolean, preserveHost: boolean}=} options
+   * @return {string}
+   */
+  static getURLDisplayName(url, options) {
+    return Util.getURLDisplayName(new URL(url), options);
+  }
+
+  /**
+   * Limits data URIs to 100 characters, returns all other strings untouched.
+   * @param {string} url
+   * @return {string}
+   */
+  static elideDataURI(url) {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'data:' ? url.slice(0, 100) : url;
+    } catch (e) {
+      return url;
+    }
+  }
+
+  /**
+   * Determine if url1 equals url2, ignoring URL fragments.
+   * @param {string} url1
+   * @param {string} url2
+   * @return {boolean}
+   */
+  static equalWithExcludedFragments(url1, url2) {
+    [url1, url2] = [url1, url2].map(rewriteChromeInternalUrl);
+    try {
+      const urla = new URL(url1);
+      urla.hash = '';
+
+      const urlb = new URL(url2);
+      urlb.hash = '';
+
+      return urla.href === urlb.href;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+URLShim.URLSearchParams = (typeof self !== 'undefined' && self.URLSearchParams) ||
+    require('url').URLSearchParams;
+
+URLShim.INVALID_URL_DEBUG_STRING =
+    'Lighthouse was unable to determine the URL of some script executions. ' +
+    'It\'s possible a Chrome extension or other eval\'d code is the source.';
+
+module.exports = URLShim;

--- a/lighthouse-extension/gulpfile.js
+++ b/lighthouse-extension/gulpfile.js
@@ -121,7 +121,6 @@ gulp.task('browserify-lighthouse', () => {
       // to the modified version internal to Lighthouse.
       bundle.transform('./dtm-transform.js', {global: true})
       .ignore('source-map')
-      .ignore('whatwg-url')
       .ignore('url')
       .ignore('debug/node')
       .ignore('raven')

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "semver": "^5.3.0",
     "speedline": "1.3.0",
     "update-notifier": "^2.1.0",
-    "whatwg-url": "^6.3.0",
     "ws": "3.3.2",
     "yargs": "3.32.0",
     "yargs-parser": "7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,10 +2705,6 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-
 lodash.template@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f"
@@ -3297,10 +3293,6 @@ pseudomap@^1.0.2:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-punycode@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 q@^1.4.1:
   version "1.5.1"
@@ -4040,12 +4032,6 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-tr46@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
-  dependencies:
-    punycode "^2.1.0"
-
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -4239,10 +4225,6 @@ webidl-conversions@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
 
-webidl-conversions@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-
 whatwg-encoding@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
@@ -4255,14 +4237,6 @@ whatwg-url@^4.3.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
-
-whatwg-url@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.3.0.tgz#597ee5488371abe7922c843397ddec1ae94c048d"
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.0"
-    webidl-conversions "^4.0.1"
 
 which@^1.1.1, which@^1.2.10, which@^1.2.8, which@^1.2.9:
   version "1.2.11"


### PR DESCRIPTION
adds type checking to URLShim. removes `whatwg-url` now that Node 8 is required (fixes #1186)

This moves us back to extending `URL`, which was removed in #1407. If anyone can remember *why* we did that  at the timeplease let me know, but for now CLI and extension seem to work fine with this change.