### PR TITLE
core(driver): add timeout to getRequestContent

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -715,7 +715,7 @@ class Driver {
   /**
    * Return the body of the response with the given ID.
    * @param {string} requestId
-   * @param {?number} timeout
+   * @param {number|undefined} timeout
    * @return {string}
    */
   getRequestContent(requestId, timeout = 1000) {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -9,6 +9,7 @@
 const NetworkRecorder = require('../lib/network-recorder');
 const emulation = require('../lib/emulation');
 const Element = require('../lib/element');
+const LHError = require('../lib/errors');
 const EventEmitter = require('events').EventEmitter;
 const URL = require('../lib/url-shim');
 const TraceParser = require('../lib/traces/trace-parser');
@@ -718,9 +719,9 @@ class Driver {
    */
   getRequestContent(requestId) {
     return new Promise((resolve, reject) => {
-      // If this takes more than 2s, reject the Promise.
-      const err = new Error('Fetching resource content has exceeded the allotted time of 2s');
-      const asyncTimeout = setTimeout((_ => reject(err)), 2000);
+      // If this takes more than 1s, reject the Promise.
+      const err = new LHError(LHError.errors.REQUEST_CONTENT_TIMEOUT);
+      const asyncTimeout = setTimeout((_ => reject(err)), 1000);
 
       this.sendCommand('Network.getResponseBody', {requestId}).then(result => {
         clearTimeout(asyncTimeout);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -715,14 +715,15 @@ class Driver {
   /**
    * Return the body of the response with the given ID.
    * @param {string} requestId
+   * @param {?number} timeout
    * @return {string}
    */
-  getRequestContent(requestId) {
+  getRequestContent(requestId, timeout = 1000) {
     return new Promise((resolve, reject) => {
       // If this takes more than 1s, reject the Promise.
       // Why? Encoding issues can lead to hanging getResponseBody calls: https://github.com/GoogleChrome/lighthouse/pull/4718
       const err = new LHError(LHError.errors.REQUEST_CONTENT_TIMEOUT);
-      const asyncTimeout = setTimeout((_ => reject(err)), 1000);
+      const asyncTimeout = setTimeout((_ => reject(err)), timeout);
 
       this.sendCommand('Network.getResponseBody', {requestId}).then(result => {
         clearTimeout(asyncTimeout);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -720,6 +720,7 @@ class Driver {
   getRequestContent(requestId) {
     return new Promise((resolve, reject) => {
       // If this takes more than 1s, reject the Promise.
+      // Why? Encoding issues can lead to hanging getResponseBody calls: https://github.com/GoogleChrome/lighthouse/pull/4718
       const err = new LHError(LHError.errors.REQUEST_CONTENT_TIMEOUT);
       const asyncTimeout = setTimeout((_ => reject(err)), 1000);
 

--- a/lighthouse-core/lib/errors.js
+++ b/lighthouse-core/lib/errors.js
@@ -88,6 +88,9 @@ const ERRORS = {
   TRACING_ALREADY_STARTED: {message: strings.internalChromeError, pattern: /Tracing.*started/},
   PARSING_PROBLEM: {message: strings.internalChromeError, pattern: /Parsing problem/},
   READ_FAILED: {message: strings.internalChromeError, pattern: /Read failed/},
+
+  // Protocol timeout failures
+  REQUEST_CONTENT_TIMEOUT: {message: strings.requestContentTimeout},
 };
 
 Object.keys(ERRORS).forEach(code => ERRORS[code].code = code);

--- a/lighthouse-core/lib/strings.js
+++ b/lighthouse-core/lib/strings.js
@@ -12,4 +12,5 @@ module.exports = {
   pageLoadTookTooLong: `Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse.`,
   pageLoadFailed: `Your page failed to load. Verify that the URL is valid and re-run Lighthouse.`,
   internalChromeError: `An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse.`,
+  requestContentTimeout: 'Fetching resource content has exceeded the allotted time',
 };

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -141,11 +141,11 @@ describe('Browser Driver', () => {
   });
 
   it('throws if getRequestContent takes too long', () => {
-    return driverStub.getRequestContent(0).then(value => {
+    return driverStub.getRequestContent(0).then(_ => {
       assert.ok(false, 'long-running getRequestContent supposed to reject');
     }).catch(e => {
       assert.equal(e.code, 'REQUEST_CONTENT_TIMEOUT');
-    })
+    });
   });
 
   it('evaluates an expression', () => {

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -75,6 +75,8 @@ connection.sendCommand = function(command, params) {
       return Promise.resolve({frameTree: {frame: {id: 1}}});
     case 'Page.createIsolatedWorld':
       return Promise.resolve({executionContextId: 1});
+    case 'Network.getResponseBody':
+      return new Promise(res => setTimeout(res, 1100));
     case 'Page.enable':
     case 'Tracing.start':
     case 'ServiceWorker.enable':
@@ -136,6 +138,14 @@ describe('Browser Driver', () => {
     return driverStub.getObjectProperty('test', 'novalue').then(value => {
       assert.deepEqual(value, null);
     });
+  });
+
+  it('throws if getRequestContent takes too long', () => {
+    return driverStub.getRequestContent(0).then(value => {
+      assert.ok(false, 'long-running getRequestContent supposed to reject');
+    }).catch(e => {
+      assert.equal(e.code, 'REQUEST_CONTENT_TIMEOUT');
+    })
   });
 
   it('evaluates an expression', () => {

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -17,6 +17,7 @@ const connection = new Connection();
 const driverStub = new Driver(connection);
 
 const redirectDevtoolsLog = require('../fixtures/wikipedia-redirect.devtoolslog.json');
+const MAX_WAIT_FOR_PROTOCOL = 20;
 
 function createOnceStub(events) {
   return (eventName, cb) => {
@@ -76,7 +77,7 @@ connection.sendCommand = function(command, params) {
     case 'Page.createIsolatedWorld':
       return Promise.resolve({executionContextId: 1});
     case 'Network.getResponseBody':
-      return new Promise(res => setTimeout(res, 1100));
+      return new Promise(res => setTimeout(res, MAX_WAIT_FOR_PROTOCOL + 20));
     case 'Page.enable':
     case 'Tracing.start':
     case 'ServiceWorker.enable':
@@ -141,7 +142,7 @@ describe('Browser Driver', () => {
   });
 
   it('throws if getRequestContent takes too long', () => {
-    return driverStub.getRequestContent(0).then(_ => {
+    return driverStub.getRequestContent(0, MAX_WAIT_FOR_PROTOCOL).then(_ => {
       assert.ok(false, 'long-running getRequestContent supposed to reject');
     }).catch(e => {
       assert.equal(e.code, 'REQUEST_CONTENT_TIMEOUT');

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -144,7 +144,7 @@ describe('Browser Driver', () => {
   it('throws if getRequestContent takes too long', () => {
     return driverStub.getRequestContent(0, MAX_WAIT_FOR_PROTOCOL).then(_ => {
       assert.ok(false, 'long-running getRequestContent supposed to reject');
-    }).catch(e => {
+    }, e => {
       assert.equal(e.code, 'REQUEST_CONTENT_TIMEOUT');
     });
   });


### PR DESCRIPTION
fixes #4258


I was able to repro on all the URLs mentioned in the ticket: 

* https://openvegemap.netlib.re/#zoom=16&lat=48.85659&lon=2.35149
* https://dreamteamtrips.com/
* https://itsroo.com/
* https://anketa.alfabank.ru/land/pil-refin/

`Network.getResponseBody` is taking >5s to respond when provided particular requestIds. But it's quite odd. If i have devtools open at the same time, the devtools frontend can issue the exact same protocol method with the same requestId and it has no problem. (and apparently devtools and CLI also have no problem)

![image](https://user-images.githubusercontent.com/39191/37195652-9a5bbf10-2328-11e8-84f7-8be2ffa5a394.png)


So this is particular to the extension.. sort of.

**Update:** the root bug appears to be an encoding issue in how the extension handles `chrome.debugger` payloads. Below is a bunch of details that supports that argument:

<details>

here's the 4 scripts that will reliably cause a problem: 

* https://openvegemap.netlib.re/dist/bundle.js 
* https://smartsupp-widget-161959.c.cdn77.org/build/smartchat-2.1.16.min.js
* https://itsroo.com/bower_components/firebase/firebase-firestore.js
* https://anketa.alfabank.ru/land/pil-refin/assets/index.592fac88f8cec24d8b0e.js

I believe these files all have some characters in common that are mishandled somewhere in encoding.

I ran this across these 4 files: 

```js
var codepoints = []; 
for (const char of filesource){ 
	var code = char.codePointAt(0); 
	if (code > 30000) codepoints.push(code) 
}
```

And they all have in common some fairly high codepoints:

```
bundle.js 
[ 127828, 127860, 127860, 127861, 127864, 127866, 128722, 129366, 65306, 65306, 65374, 65374, 65534 ]

smartchat
[ 65311, 65311, 65311, 65311, 65520, 65521, 65522, 65523, 65524, 65525, 65526, 65527, 65528, 65529, 65530, 65531, 65532, 65533, 65534, 65535 ]

firebase firestore
[ 65535 ]

alfabank
[ 65533, 65533, 65533, 65533, 65534 ]
```

They all have in common 65534 or 65535. 


**And...** check this out. Run this in any DevTools console:

```js
String.fromCodePoint(65535)
```

Now take that resulting string, copy/paste it back and try to evaluate it. DevTools won't. :)
</details>

----

So, since this appears to be rather an involved bug. My easy workaround is to add a 2s timeout. 

I did observe a 300ms successful response time for this method on a fairly big file so 2000ms seems an OK maximum.

