### PR TITLE
core(is-https): use network record's securityState

### DIFF
--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -31,8 +31,10 @@ class HTTPS extends Audit {
 
   /**
    * Checks whether the resource was securely loaded.
-   * We special-case data: URLs, as they inherit the security state of their
-   * referring document url. Localhost is also safelisted.
+   * While `Security.securityStateChanged` is broken on Android, the networkResponse.securityState
+   * property is functional, so we use that instead of checking the URL scheme.
+   * We special-case data: URLs, as they inherit the security state of their referring document url.
+   * Localhost is also safelisted.
    *
    * @param {{scheme: string, domain: string, protocol: string, securityState: function}} record
    * @return {boolean}

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -31,13 +31,18 @@ class HTTPS extends Audit {
   }
 
   /**
-   * @param {{scheme: string, domain: string}} record
+   * Checks whether the resource was securely loaded.
+   * We special-case data: URLs, as they inherit the security state of their
+   * referring document url, and so are trivially "upgradeable" for mixed-content purposes.
+   *
+   * @param {{scheme: string, domain: string, protocol: string, securityState: function}} record
    * @return {boolean}
    */
   static isSecureRecord(record) {
-    return SECURE_SCHEMES.includes(record.scheme) ||
-           SECURE_SCHEMES.includes(record.protocol) ||
-           SECURE_DOMAINS.includes(record.domain);
+    return record.securityState() === 'secure' ||
+      SECURE_SCHEMES.includes(record.scheme) ||
+      SECURE_SCHEMES.includes(record.protocol) ||
+      SECURE_DOMAINS.includes(record.domain);
   }
 
   /**

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -9,7 +9,6 @@ const Audit = require('./audit');
 const URL = require('../lib/url-shim');
 const Util = require('../report/v2/renderer/util');
 
-const SECURE_SCHEMES = ['data', 'https', 'wss', 'blob', 'chrome', 'chrome-extension'];
 const SECURE_DOMAINS = ['localhost', '127.0.0.1'];
 
 class HTTPS extends Audit {
@@ -33,15 +32,13 @@ class HTTPS extends Audit {
   /**
    * Checks whether the resource was securely loaded.
    * We special-case data: URLs, as they inherit the security state of their
-   * referring document url, and so are trivially "upgradeable" for mixed-content purposes.
+   * referring document url. Localhost is also safelisted.
    *
    * @param {{scheme: string, domain: string, protocol: string, securityState: function}} record
    * @return {boolean}
    */
   static isSecureRecord(record) {
-    return record.securityState() === 'secure' ||
-      SECURE_SCHEMES.includes(record.scheme) ||
-      SECURE_SCHEMES.includes(record.protocol) ||
+    return record.securityState() === 'secure' || record.protocol === 'data' ||
       SECURE_DOMAINS.includes(record.domain);
   }
 

--- a/lighthouse-core/test/audits/is-on-https-test.js
+++ b/lighthouse-core/test/audits/is-on-https-test.js
@@ -21,12 +21,24 @@ describe('Security: HTTPS audit', () => {
   const insecure = _ => 'insecure';
 
   it('fails when there is more than one insecure record', () => {
-    return Audit.audit(getArtifacts([
-      {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
-      {url: 'http://insecure.com/image.jpeg', scheme: 'http', domain: 'insecure.com', securityState: insecure},
-      {url: 'http://insecure.com/image2.jpeg', scheme: 'http', domain: 'insecure.com', securityState: insecure},
-      {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
-    ])).then(result => {
+    return Audit.audit(
+      getArtifacts([
+        {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
+        {
+          url: 'http://insecure.com/image.jpeg',
+          scheme: 'http',
+          domain: 'insecure.com',
+          securityState: insecure,
+        },
+        {
+          url: 'http://insecure.com/image2.jpeg',
+          scheme: 'http',
+          domain: 'insecure.com',
+          securityState: insecure,
+        },
+        {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
+      ])
+    ).then(result => {
       assert.strictEqual(result.rawValue, false);
       assert.ok(result.displayValue.includes('requests found'));
       assert.strictEqual(result.extendedInfo.value.length, 2);
@@ -34,11 +46,18 @@ describe('Security: HTTPS audit', () => {
   });
 
   it('fails when there is one insecure record', () => {
-    return Audit.audit(getArtifacts([
-      {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
-      {url: 'http://insecure.com/image.jpeg', scheme: 'http', domain: 'insecure.com', securityState: insecure},
-      {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
-    ])).then(result => {
+    return Audit.audit(
+      getArtifacts([
+        {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
+        {
+          url: 'http://insecure.com/image.jpeg',
+          scheme: 'http',
+          domain: 'insecure.com',
+          securityState: insecure,
+        },
+        {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
+      ])
+    ).then(result => {
       assert.strictEqual(result.rawValue, false);
       assert.ok(result.displayValue.includes('request found'));
       assert.deepEqual(result.extendedInfo.value[0], {url: 'http://insecure.com/image.jpeg'});
@@ -47,48 +66,91 @@ describe('Security: HTTPS audit', () => {
 
   // Upgrade-Insecure-Requests will turn http references to https. If the requests fail, we want to know
   it('fails when there is a failed-to-upgrade request', () => {
-    return Audit.audit(getArtifacts([
-      {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
-      {url: 'https://upgraded.com/image.jpg', scheme: 'https', domain: 'upgraded.com', securityState: insecure},
-    ])).then(result => {
+    return Audit.audit(
+      getArtifacts([
+        {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
+        {
+          url: 'https://upgraded.com/image.jpg',
+          scheme: 'https',
+          domain: 'upgraded.com',
+          securityState: insecure,
+        },
+      ])
+    ).then(result => {
       assert.strictEqual(result.rawValue, false);
       assert.ok(result.displayValue.includes('request found'));
       assert.deepEqual(result.extendedInfo.value[0], {url: 'https://upgraded.com/image.jpg'});
     });
   });
 
-
   it('passes when all records are secure', () => {
-    return Audit.audit(getArtifacts([
-      {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
-      {url: 'http://localhost/image.jpeg', scheme: 'http', domain: 'localhost', securityState: insecure},
-      {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
-    ])).then(result => {
+    return Audit.audit(
+      getArtifacts([
+        {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
+        {
+          url: 'http://localhost/image.jpeg',
+          scheme: 'http',
+          domain: 'localhost',
+          securityState: insecure,
+        },
+        {url: 'https://google.com/', scheme: 'https', domain: 'google.com', securityState},
+      ])
+    ).then(result => {
       assert.strictEqual(result.rawValue, true);
     });
   });
 
   describe('#isSecureRecord', () => {
     it('correctly identifies insecure records', () => {
-      assert.strictEqual(Audit.isSecureRecord({scheme: 'http', domain: 'google.com', securityState: insecure}), false);
-      assert.strictEqual(Audit.isSecureRecord({scheme: 'http', domain: '54.33.21.23', securityState: insecure}), false);
-      assert.strictEqual(Audit.isSecureRecord({scheme: 'ws', domain: 'my-service.com', securityState: insecure}), false);
-      assert.strictEqual(Audit.isSecureRecord({scheme: '', domain: 'google.com', securityState: insecure}), false);
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: 'http', domain: 'google.com', securityState: insecure}),
+        false
+      );
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: 'http', domain: '54.33.21.23', securityState: insecure}),
+        false
+      );
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: 'ws', domain: 'my-service.com', securityState: insecure}),
+        false
+      );
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: '', domain: 'google.com', securityState: insecure}),
+        false
+      );
     });
 
     it('correctly identifies secure records', () => {
-      assert.strictEqual(Audit.isSecureRecord({scheme: 'http', domain: 'localhost', securityState}), true);
-      assert.strictEqual(Audit.isSecureRecord({scheme: 'https', domain: 'google.com', securityState}), true);
-      assert.strictEqual(Audit.isSecureRecord({scheme: 'wss', domain: 'my-service.com', securityState}), true);
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: 'http', domain: 'localhost', securityState}),
+        true
+      );
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: 'https', domain: 'google.com', securityState}),
+        true
+      );
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: 'wss', domain: 'my-service.com', securityState}),
+        true
+      );
       assert.strictEqual(Audit.isSecureRecord({scheme: 'data', domain: '', securityState}), true);
       assert.strictEqual(Audit.isSecureRecord({scheme: 'blob', domain: '', securityState}), true);
-      assert.strictEqual(Audit.isSecureRecord({scheme: '', protocol: 'blob', domain: '', securityState}), true);
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: '', protocol: 'blob', domain: '', securityState}),
+        true
+      );
       assert.strictEqual(Audit.isSecureRecord({scheme: 'chrome', domain: '', securityState}), true);
-      assert.strictEqual(Audit.isSecureRecord({scheme: 'chrome-extension', domain: '', securityState}), true);
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: 'chrome-extension', domain: '', securityState}),
+        true
+      );
     });
 
     it('correctly handles failed-to-upgrade requests', () => {
-      assert.strictEqual(Audit.isSecureRecord({scheme: 'https', domain: 'upgraded.com', securityState: insecure}), false);
-    })
+      assert.strictEqual(
+        Audit.isSecureRecord({scheme: 'https', domain: 'upgraded.com', securityState: insecure}),
+        false
+      );
+    });
   });
 });


### PR DESCRIPTION
The `mixed-content` audit uses it. 

By adopting it in `is-https`, we can correctly include some `http` resources that were upgraded via "Upgrade Insecure Requests" but failed regardless.

repro: `lighthouse --mixed-content https://www.paulirish.com/2006/think-you-can-recycle-the-single-serving-coffee-packets-think-again/`

Before: 
![image](https://user-images.githubusercontent.com/39191/37228562-ea29f904-2395-11e8-9b74-02819fc0a442.png)

After: 
![image](https://user-images.githubusercontent.com/39191/37228552-e26d17f0-2395-11e8-88d0-aaa8de0dc1fe.png)

fixes #4722 i think? 