### PR TITLE
tests(closure): fix BSD sed calls within compile-devtools

### DIFF
--- a/lighthouse-core/scripts/compile-against-devtools.sh
+++ b/lighthouse-core/scripts/compile-against-devtools.sh
@@ -49,10 +49,9 @@ yarn devtools "$frontend_path/front_end/"
 #
 audit2_modulejson_path="$frontend_path/front_end/audits2/module.json"
 # remove existing renderer file mentions
-sed -i 's/.*\/renderer\/.*//' $audit2_modulejson_path
-# remove existing renderer file mentions
-sed -i "s/\"Audits2Panel\.js\"/ $files_to_include \"Audits2Panel.js\"/" $audit2_modulejson_path
-
+sed -i='' 's/.*\/renderer\/.*//' $audit2_modulejson_path
+# add in our hardcoded renderer file mentions
+sed -i='' "s/\"Audits2Panel\.js\"/ $files_to_include \"Audits2Panel.js\"/" $audit2_modulejson_path
 
 # compile, finally
 python "$frontend_path/scripts/compile_frontend.py" --protocol-externs-file "$protocol_path/externs/protocol_externs.js"


### PR DESCRIPTION
This at least allows you to reproduce the error from #4735 locally on a mac. (BSD sed vs GNU sed strikes again, ugh).

But it doesn't fix the actual error. I'm stumped on that so far.