### PR TITLE
core: add type checking to connection

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,12 +61,6 @@ module.exports = {
       exports: 'never',
       functions: 'never',
     }],
-    'spaced-comment': [2, 'always', {
-      line: {
-        // allow typescript triple-slash directives
-        markers: ['/'],
-      },
-    }],
 
     // Disabled rules
     'require-jsdoc': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,12 @@ module.exports = {
       exports: 'never',
       functions: 'never',
     }],
+    'spaced-comment': [2, 'always', {
+      line: {
+        // allow typescript triple-slash directives
+        markers: ['/'],
+      },
+    }],
 
     // Disabled rules
     'require-jsdoc': 0,

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -3,7 +3,6 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-// @ts-nocheck
 'use strict';
 
 const EventEmitter = require('events').EventEmitter;
@@ -13,20 +12,20 @@ const LHError = require('../../lib/errors');
 class Connection {
   constructor() {
     this._lastCommandId = 0;
-    /** @type {!Map<number, {resolve: function(*), reject: function(*), method: string}>}*/
+    /** @type {Map<number, {resolve: function(Promise<*>), method: string, options: {silent?: boolean}}>}*/
     this._callbacks = new Map();
     this._eventEmitter = new EventEmitter();
   }
 
   /**
-   * @return {!Promise}
+   * @return {Promise<void>}
    */
   connect() {
     return Promise.reject(new Error('Not implemented'));
   }
 
   /**
-   * @return {!Promise}
+   * @return {Promise<void>}
    */
   disconnect() {
     return Promise.reject(new Error('Not implemented'));
@@ -34,7 +33,7 @@ class Connection {
 
 
   /**
-   * @return {!Promise<string>}
+   * @return {Promise<string>}
    */
   wsEndpoint() {
     return Promise.reject(new Error('Not implemented'));
@@ -43,29 +42,33 @@ class Connection {
 
   /**
    * Call protocol methods
-   * @param {!string} method
-   * @param {!Object} params
-   * @param {{silent: boolean}=} cmdOpts
-   * @return {!Promise}
+   * @param {string} method
+   * @param {object=} params
+   * @param {{silent?: boolean}=} cmdOpts
+   * @return {Promise<*>}
    */
   sendCommand(method, params = {}, cmdOpts = {}) {
     log.formatProtocol('method => browser', {method, params}, 'verbose');
     const id = ++this._lastCommandId;
     const message = JSON.stringify({id, method, params});
     this.sendRawMessage(message);
-    return new Promise((resolve, reject) => {
-      this._callbacks.set(id, {resolve, reject, method, options: cmdOpts});
+    return new Promise(resolve => {
+      this._callbacks.set(id, {resolve, method, options: cmdOpts});
     });
   }
 
   /**
    * Bind listeners for connection events
-   * @param {!string} eventName
-   * @param {function(...args)} cb
+   * @param {'notification'} eventName
+   * @param {(...args: any[]) => void} cb
    */
   on(eventName, cb) {
     if (eventName !== 'notification') {
       throw new Error('Only supports "notification" events');
+    }
+
+    if (!this._eventEmitter) {
+      throw new Error('Attempted to add event listener after connection disposed.');
     }
     this._eventEmitter.on(eventName, cb);
   }
@@ -74,31 +77,37 @@ class Connection {
 
   /**
    * @param {string} message
-   * @return {!Promise}
    * @protected
    */
   sendRawMessage(message) {
-    return Promise.reject(new Error('Not implemented'));
+    throw new Error('Not implemented');
   }
 
   /* eslint-enable no-unused-vars */
 
   /**
    * @param {string} message
-   * @return {!Promise}
+   * @return {void}
    * @protected
    */
   handleRawMessage(message) {
     const object = JSON.parse(message);
     // Remote debugging protocol is JSON RPC 2.0 compiant. In terms of that transport,
     // responses to the commands carry "id" property, while notifications do not.
-    if (this._callbacks.has(object.id)) {
-      const callback = this._callbacks.get(object.id);
+    if (!object.id) {
+      log.formatProtocol('<= event',
+          {method: object.method, params: object.params}, 'verbose');
+      this.emitNotification(object.method, object.params);
+      return;
+    }
+
+    const callback = this._callbacks.get(object.id);
+    if (callback) {
       this._callbacks.delete(object.id);
 
       return callback.resolve(Promise.resolve().then(_ => {
         if (object.error) {
-          const logLevel = callback.options && callback.options.silent ? 'verbose' : 'error';
+          const logLevel = callback.options.silent ? 'verbose' : 'error';
           log.formatProtocol('method <= browser ERR', {method: callback.method}, logLevel);
           throw LHError.fromProtocolMessage(callback.method, object.error);
         }
@@ -107,25 +116,24 @@ class Connection {
           {method: callback.method, params: object.result}, 'verbose');
         return object.result;
       }));
-    } else if (object.id) {
+    } else {
       // In DevTools we receive responses to commands we did not send which we cannot act on, so we
       // just log these occurrences.
       const error = object.error && object.error.message;
       log.formatProtocol(`disowned method <= browser ${error ? 'ERR' : 'OK'}`,
           {method: object.method, params: error || object.result}, 'verbose');
-    } else {
-      log.formatProtocol('<= event',
-          {method: object.method, params: object.params}, 'verbose');
-      this.emitNotification(object.method, object.params);
     }
   }
 
   /**
-   * @param {!string} method
-   * @param {!Object} params
+   * @param {string} method
+   * @param {object=} params
    * @protected
    */
   emitNotification(method, params) {
+    if (!this._eventEmitter) {
+      throw new Error('Attempted to emit event after connection disposed.');
+    }
     this._eventEmitter.emit('notification', {method, params});
   }
 
@@ -133,8 +141,10 @@ class Connection {
    * @protected
    */
   dispose() {
-    this._eventEmitter.removeAllListeners();
-    this._eventEmitter = null;
+    if (this._eventEmitter) {
+      this._eventEmitter.removeAllListeners();
+      this._eventEmitter = null;
+    }
   }
 }
 

--- a/lighthouse-core/gather/connections/cri.js
+++ b/lighthouse-core/gather/connections/cri.js
@@ -3,7 +3,6 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-// @ts-nocheck
 'use strict';
 
 const Connection = require('./connection.js');
@@ -25,34 +24,37 @@ class CriConnection extends Connection {
     super();
     this.port = port;
     this.hostname = hostname;
+    this._ws = null;
+    this._pageId = null;
   }
 
   /**
    * @override
-   * @return {!Promise}
+   * @return {Promise<void>}
    */
   connect() {
     return this._runJsonCommand('new')
-      .then(response => this._connectToSocket(response))
+      .then(response => this._connectToSocket(/** @type {LH.DevToolsJsonTarget} */(response)))
       .catch(_ => {
         // Compat: headless didn't support `/json/new` before m59. (#970, crbug.com/699392)
         // If no support, we fallback and reuse an existing open tab
         log.warn('CriConnection', 'Cannot create new tab; reusing open tab.');
         return this._runJsonCommand('list').then(tabs => {
-          const firstTab = tabs[0];
-          if (!Array.isArray(tabs) || !firstTab) {
+          if (!Array.isArray(tabs) || tabs.length === 0) {
             return Promise.reject(new Error('Cannot create new tab, and no tabs already open.'));
           }
+          const firstTab = tabs[0];
           // first, we activate it to a foreground tab, then we connect
           return this._runJsonCommand(`activate/${firstTab.id}`)
-              .then(_ => this._connectToSocket(firstTab));
+              .then(() => this._connectToSocket(firstTab));
         });
       });
   }
 
   /**
-   * @param {!Object} response
-   * @return {!Promise}
+   * @param {LH.DevToolsJsonTarget} response
+   * @return {Promise<void>}
+   * @private
    */
   _connectToSocket(response) {
     const url = response.webSocketDebuggerUrl;
@@ -66,17 +68,19 @@ class CriConnection extends Connection {
         this._ws = ws;
         resolve();
       });
-      ws.on('message', data => this.handleRawMessage(data));
+      ws.on('message', data => this.handleRawMessage(/** @type {string} */ (data)));
       ws.on('close', this.dispose.bind(this));
       ws.on('error', reject);
     });
   }
 
   /**
-   * @param {!string} command
-   * @return {!Promise<string>}
+   * @param {string} command
+   * @return {Promise<LH.DevToolsJsonTarget | Array<LH.DevToolsJsonTarget> | {message: string}>}
+   * @private
    */
   _runJsonCommand(command) {
+    // TODO(bckenny): can base type on command once conditional types land in TS
     return new Promise((resolve, reject) => {
       const request = http.get({
         hostname: this.hostname,
@@ -87,7 +91,7 @@ class CriConnection extends Connection {
         response.on('data', chunk => {
           data += chunk;
         });
-        response.on('end', _ => {
+        response.on('end', () => {
           if (response.statusCode === 200) {
             try {
               resolve(JSON.parse(data));
@@ -104,11 +108,12 @@ class CriConnection extends Connection {
         });
       });
 
-      request.setTimeout(CONNECT_TIMEOUT, _ => {
+      request.setTimeout(CONNECT_TIMEOUT, () => {
         request.abort();
 
         // After aborting, we expect an ECONNRESET error. Ignore.
         request.on('error', err => {
+          // @ts-ignore `code` property extension to Error by Node.
           if (err.code !== 'ECONNRESET') {
             throw err;
           }
@@ -117,6 +122,7 @@ class CriConnection extends Connection {
         // TODO: Replace this with an LHError on next major version bump
         // Reject on error with code specifically indicating timeout in connection setup.
         const err = new Error('Timeout waiting for initial Debugger Protocol connection.');
+        // @ts-ignore fixed by above TODO
         err.code = 'CRI_TIMEOUT';
         log.error('CriConnection', err.message);
         reject(err);
@@ -126,34 +132,45 @@ class CriConnection extends Connection {
 
   /**
    * @override
+   * @return {Promise<void>}
    */
   disconnect() {
     if (!this._ws) {
       log.warn('CriConnection', 'disconnect() was called without an established connection.');
       return Promise.resolve();
     }
+
     return this._runJsonCommand(`close/${this._pageId}`).then(_ => {
-      this._ws.removeAllListeners();
-      this._ws.close();
-      this._ws = null;
+      if (this._ws) {
+        this._ws.removeAllListeners();
+        this._ws.close();
+        this._ws = null;
+      }
       this._pageId = null;
     });
   }
 
   /**
    * @override
-   * @return {!Promise<string>}
+   * @return {Promise<string>}
    */
   wsEndpoint() {
-    return this._runJsonCommand('version').then(response => response.webSocketDebuggerUrl);
+    return this._runJsonCommand('version').then(response => {
+      return /** @type {LH.DevToolsJsonTarget} */ (response).webSocketDebuggerUrl;
+    });
   }
 
 
   /**
    * @override
    * @param {string} message
+   * @protected
    */
   sendRawMessage(message) {
+    if (!this._ws) {
+      log.error('CriConnection', 'sendRawMessage() was called without an established connection.');
+      throw new Error('sendRawMessage() was called without an established connection.');
+    }
     this._ws.send(message);
   }
 }

--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -3,6 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
+/// <reference types="chrome" />
 'use strict';
 
 const Connection = require('./connection.js');
@@ -19,17 +20,32 @@ class ExtensionConnection extends Connection {
     this._onUnexpectedDetach = this._onUnexpectedDetach.bind(this);
   }
 
+  /**
+   * @param {chrome.debugger.Debuggee} source
+   * @param {string} method
+   * @param {object=} params
+   * @private
+   */
   _onEvent(source, method, params) {
     // log events received
     log.log('<=', method, params);
     this.emitNotification(method, params);
   }
 
-  _onUnexpectedDetach(debuggee, detachReason) {
+  /**
+   * @param {chrome.debugger.Debuggee} source
+   * @param {string} detachReason
+   * @return {never}
+   * @private
+   */
+  _onUnexpectedDetach(source, detachReason) {
     this._detachCleanup();
     throw new Error('Lighthouse detached from browser: ' + detachReason);
   }
 
+  /**
+   * @private
+   */
   _detachCleanup() {
     this._tabId = null;
     chrome.debugger.onEvent.removeListener(this._onEvent);
@@ -39,25 +55,25 @@ class ExtensionConnection extends Connection {
 
   /**
    * @override
-   * @return {!Promise}
+   * @return {Promise<void>}
    */
   connect() {
     if (this._tabId !== null) {
       return Promise.resolve();
     }
 
-    return this._queryCurrentTab()
-      .then(tab => {
-        const tabId = this._tabId = tab.id;
+    return this._getCurrentTabId()
+      .then(tabId => {
+        this._tabId = tabId;
         chrome.debugger.onEvent.addListener(this._onEvent);
         chrome.debugger.onDetach.addListener(this._onUnexpectedDetach);
 
         return new Promise((resolve, reject) => {
-          chrome.debugger.attach({tabId}, '1.1', _ => {
+          chrome.debugger.attach({tabId}, '1.1', () => {
             if (chrome.runtime.lastError) {
               return reject(new Error(chrome.runtime.lastError.message));
             }
-            resolve(tabId);
+            resolve();
           });
         });
       });
@@ -65,7 +81,7 @@ class ExtensionConnection extends Connection {
 
   /**
    * @override
-   * @return {!Promise}
+   * @return {Promise<void>}
    */
   disconnect() {
     if (this._tabId === null) {
@@ -75,7 +91,7 @@ class ExtensionConnection extends Connection {
 
     const tabId = this._tabId;
     return new Promise((resolve, reject) => {
-      chrome.debugger.detach({tabId}, _ => {
+      chrome.debugger.detach({tabId}, () => {
         if (chrome.runtime.lastError) {
           return reject(new Error(chrome.runtime.lastError.message));
         }
@@ -87,39 +103,45 @@ class ExtensionConnection extends Connection {
   }
 
   /**
+   * Call protocol methods.
    * @override
-   * @param {!string} command
-   * @param {!Object} params
-   * @return {!Promise}
+   * @param {string} method
+   * @param {object=} params
+   * @return {Promise<*>}
    */
-  sendCommand(command, params) {
+  sendCommand(method, params) {
     return new Promise((resolve, reject) => {
-      log.formatProtocol('method => browser', {method: command, params: params}, 'verbose');
+      log.formatProtocol('method => browser', {method, params}, 'verbose');
       if (!this._tabId) {
         log.error('ExtensionConnection', 'No tabId set for sendCommand');
+        return reject(new Error('No tabId set for sendCommand'));
       }
 
-      chrome.debugger.sendCommand({tabId: this._tabId}, command, params, result => {
+      chrome.debugger.sendCommand({tabId: this._tabId}, method, params, result => {
         if (chrome.runtime.lastError) {
           // The error from the extension has a `message` property that is the
           // stringified version of the actual protocol error object.
-          const message = chrome.runtime.lastError.message;
+          const message = chrome.runtime.lastError.message || '';
           let errorMessage;
           try {
             errorMessage = JSON.parse(message).message;
           } catch (e) {}
           errorMessage = errorMessage || message || 'Unknown debugger protocol error.';
 
-          log.formatProtocol('method <= browser ERR', {method: command}, 'error');
-          return reject(new Error(`Protocol error (${command}): ${errorMessage}`));
+          log.formatProtocol('method <= browser ERR', {method}, 'error');
+          return reject(new Error(`Protocol error (${method}): ${errorMessage}`));
         }
 
-        log.formatProtocol('method <= browser OK', {method: command, params: result}, 'verbose');
+        log.formatProtocol('method <= browser OK', {method, params: result}, 'verbose');
         resolve(result);
       });
     });
   }
 
+  /**
+   * @return {Promise<chrome.tabs.Tab>}
+   * @private
+   */
   _queryCurrentTab() {
     return new Promise((resolve, reject) => {
       const queryOpts = {
@@ -144,12 +166,28 @@ class ExtensionConnection extends Connection {
   }
 
   /**
+   * @return {Promise<number>}
+   * @private
+   */
+  _getCurrentTabId() {
+    return this._queryCurrentTab().then(tab => {
+      if (tab.id === undefined) {
+        throw new Error('Unable to resolve current tab ID. Check the tab, reload, and try again.');
+      }
+
+      return tab.id;
+    });
+  }
+
+  /**
    * Used by lighthouse-ext-background to kick off the run on the current page
+   * @return {Promise<string>}
    */
   getCurrentTabURL() {
     return this._queryCurrentTab().then(tab => {
       if (!tab.url) {
         log.error('ExtensionConnection', 'getCurrentTabURL returned empty string', tab);
+        throw new Error('getCurrentTabURL returned empty string');
       }
       return tab.url;
     });

--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -3,6 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
+// eslint-disable-next-line spaced-comment
 /// <reference types="chrome" />
 'use strict';
 

--- a/lighthouse-core/gather/connections/raw.js
+++ b/lighthouse-core/gather/connections/raw.js
@@ -14,7 +14,7 @@ const Connection = require('./connection.js');
  */
 class Port {
   /**
-   * @param {!string} eventName, 'message', 'close'
+   * @param {'message' | 'close'} eventName
    * @param {function(string|undefined)} cb
    */
   on(eventName, cb) { }
@@ -30,6 +30,9 @@ class Port {
 /* eslint-enable no-unused-vars */
 
 class RawConnection extends Connection {
+  /**
+   * @param {Port} port 
+   */
   constructor(port) {
     super();
     this._port = port;
@@ -39,14 +42,14 @@ class RawConnection extends Connection {
 
   /**
    * @override
-   * @return {!Promise}
+   * @return {Promise<void>}
    */
   connect() {
     return Promise.resolve();
   }
 
   /**
-   * @override
+   * @return {Promise<void>}
    */
   disconnect() {
     this._port.close();
@@ -56,6 +59,7 @@ class RawConnection extends Connection {
   /**
    * @override
    * @param {string} message
+   * @protected
    */
   sendRawMessage(message) {
     this._port.send(message);

--- a/lighthouse-core/scoring.js
+++ b/lighthouse-core/scoring.js
@@ -28,7 +28,7 @@ class ReportScoring {
   /**
    * Returns the report JSON object with computed scores.
    * @param {{categories: !Object<string, {id: string|undefined, weight: number|undefined, audits: !Array<{id: string, weight: number|undefined}>}>}} config
-   * @param {!Object<{score: ?number|boolean|undefined}>} resultsByAuditId
+   * @param {!Object<string, {score: ?number|boolean|undefined, notApplicable: boolean, informative: boolean}>} resultsByAuditId
    * @return {{score: number, categories: !Array<{audits: !Array<{score: number, result: !Object}>}>}}
    */
   static scoreAllCategories(config, resultsByAuditId) {

--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
     "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --config-path=./lighthouse-core/config/mixed-content.js"
   },
   "devDependencies": {
+    "@types/chrome": "^0.0.60",
     "@types/configstore": "^2.1.1",
     "@types/inquirer": "^0.0.35",
     "@types/node": "*",
     "@types/opn": "^3.0.28",
     "@types/update-notifier": "^1.0.2",
+    "@types/ws": "^4.0.1",
     "@types/yargs": "^8.0.2",
     "babel-core": "^6.16.0",
     "bundlesize": "^0.14.4",
@@ -75,7 +77,7 @@
     "mocha": "^3.2.0",
     "npm-run-posix-or-windows": "^2.0.2",
     "sinon": "^2.3.5",
-    "typescript": "^2.6.1",
+    "typescript": "2.7.2",
     "zone.js": "^0.7.3"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
   "include": [
     "lighthouse-cli/**/*.js",
     "lighthouse-core/lib/dependency-graph/**/*.js",
+    "lighthouse-core/gather/connections/**/*.js",
     "./typings/externs.d.ts"
   ],
   "exclude": [

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -130,3 +130,13 @@ export interface DevToolsParsedURL {
   scheme: string;
   host: string;
 }
+
+export interface DevToolsJsonTarget {
+  description: string;
+  devtoolsFrontendUrl: string;
+  id: string;
+  title: string;
+  type: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@types/chrome@^0.0.60":
+  version "0.0.60"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.60.tgz#058eed1587b7aec3b83d4be905c8758ea145ba84"
+  dependencies:
+    "@types/filesystem" "*"
+
 "@types/configstore@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/configstore/-/configstore-2.1.1.tgz#cd1e8553633ad3185c3f2f239ecff5d2643e92b6"
@@ -9,6 +15,20 @@
 "@types/core-js@^0.9.41":
   version "0.9.43"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.43.tgz#65d646c5e8c0cd1bdee37065799f9d3d48748253"
+
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+
+"@types/filesystem@*":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.28.tgz#3fd7735830f2c7413cb5ac45780bc45904697b0e"
+  dependencies:
+    "@types/filewriter" "*"
+
+"@types/filewriter@*":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
 
 "@types/inquirer@^0.0.35":
   version "0.0.35"
@@ -132,6 +152,13 @@
 "@types/update-notifier@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/update-notifier/-/update-notifier-1.0.2.tgz#7a9269a38545bfd90155aac1350669a19f8ecb4a"
+
+"@types/ws@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-4.0.1.tgz#3309d4d02a1ea9cf617d638b9239a2e1e28ef21e"
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
 
 "@types/yargs@^8.0.2":
   version "8.0.2"
@@ -4070,9 +4097,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uglify-js@^2.6:
   version "2.7.3"


### PR DESCRIPTION
no significant changes, mostly typings (e.g. `runJsonCommand` returns an object, not a string).

The biggest shifts were just e.g. assuring the compiler we wouldn't emit events after the event emitter was disposed.

For the future, there are a lot of opportunities for better typing on these methods that take a string but return a bunch of different things via TS's conditional types (or plain overloading with string literal arguments)