### PR TITLE
core: convert diagnostics to numeric scores

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const statistics = require('../lib/statistics');
+const Util = require('../report/v2/renderer/util');
 
 const DEFAULT_PASS = 'defaultPass';
 
@@ -149,7 +150,7 @@ class Audit {
 
     let auditDescription = audit.meta.description;
     if (audit.meta.failureDescription) {
-      if (score < 1) {
+      if (score < Util.PASS_THRESHOLD) {
         auditDescription = audit.meta.failureDescription;
       }
     }

--- a/lighthouse-core/report/v2/renderer/util.js
+++ b/lighthouse-core/report/v2/renderer/util.js
@@ -9,14 +9,19 @@
 
 const ELLIPSIS = '\u2026';
 const NBSP = '\xa0';
+const PASS_THRESHOLD = 0.75;
 
 const RATINGS = {
-  PASS: {label: 'pass', minScore: 0.75},
+  PASS: {label: 'pass', minScore: PASS_THRESHOLD},
   AVERAGE: {label: 'average', minScore: 0.45},
   FAIL: {label: 'fail'},
 };
 
 class Util {
+  static get PASS_THRESHOLD() {
+    return PASS_THRESHOLD;
+  }
+
   /**
    * Convert a score to a rating label.
    * @param {number} score

--- a/lighthouse-core/report/v2/renderer/util.js
+++ b/lighthouse-core/report/v2/renderer/util.js
@@ -17,6 +17,10 @@ const RATINGS = {
   FAIL: {label: 'fail'},
 };
 
+/**
+ * @fileoverview
+ * @suppress {reportUnknownTypes} see https://github.com/GoogleChrome/lighthouse/pull/4778#issuecomment-373549391
+ */
 class Util {
   static get PASS_THRESHOLD() {
     return PASS_THRESHOLD;


### PR DESCRIPTION
closes #4521 

I picked the thresholds so that the score turns yellow at whatever the previous threshold was
this also changes the base audit class so that the `failureDescription` is only used if we mark the audit not in green as it was strange to see "JavaScript bootup time is too high: 99"