### PR TITLE
core(runner): add custom folder support to -G/-A

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -111,7 +111,7 @@ function getFlags(manualArgv) {
         'disable-storage-reset', 'disable-device-emulation', 'disable-cpu-throttling',
         'disable-network-throttling', 'save-assets', 'list-all-audits',
         'list-trace-categories', 'perf', 'view', 'verbose', 'quiet', 'help',
-        'gather-mode', 'audit-mode', 'mixed-content',
+        'mixed-content',
       ])
       .choices('output', printer.getValidOutputOptions())
       // force as an array

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -73,8 +73,8 @@ function getFlags(manualArgv) {
         'disable-cpu-throttling': 'Disable CPU throttling',
         'disable-network-throttling': 'Disable network throttling',
         'gather-mode':
-            'Collect artifacts from a connected browser and save to disk. If audit-mode is not also enabled, the run will quit early.',
-        'audit-mode': 'Process saved artifacts from disk',
+            'Collect artifacts from a connected browser and save to disk. (Artifacts folder path may optionally be provided). If audit-mode is not also enabled, the run will quit early.',
+        'audit-mode': 'Process saved artifacts from disk. (Artifacts folder path may be provided, otherwise defaults to ./latest-run/)',
         'save-assets': 'Save the trace contents & screenshots to disk',
         'list-all-audits': 'Prints a list of all available audits and exits',
         'list-trace-categories': 'Prints a list of all required trace categories and exits',

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -134,19 +134,20 @@ class Runner {
    * @param {*} connection
    * @return {!Promise<!Artifacts>}
    */
-  static _gatherArtifactsFromBrowser(opts, connection) {
+  static async _gatherArtifactsFromBrowser(opts, connection) {
     if (!opts.config.passes) {
       return Promise.reject(new Error('No browser artifacts are either provided or requested.'));
     }
 
     opts.driver = opts.driverMock || new Driver(connection);
-    return GatherRunner.run(opts.config.passes, opts).then(artifacts => {
-      const flags = opts.flags;
-      const shouldSave = flags.gatherMode;
+    const artifacts = await GatherRunner.run(opts.config.passes, opts);
+
+    const flags = opts.flags;
+    if (flags.gatherMode) {
       const path = Runner._getArtifactsPath(flags);
-      const p = shouldSave ? Runner._saveArtifacts(artifacts, path): Promise.resolve();
-      return p.then(_ => artifacts);
-    });
+      await Runner._saveArtifacts(artifacts, path);
+    }
+    return artifacts;
   }
 
   /**

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -66,7 +66,8 @@ class Runner {
     // Gather phase
     // Either load saved artifacts off disk, from config, or get from the browser
     if (opts.flags.auditMode && !opts.flags.gatherMode) {
-      run = run.then(_ => Runner._loadArtifactsFromDisk(Runner._getArtifactsPath(opts.flags)));
+      const path = Runner._getArtifactsPath(opts.flags);
+      run = run.then(_ => Runner._loadArtifactsFromDisk(path));
     } else if (opts.config.artifacts) {
       run = run.then(_ => opts.config.artifacts);
     } else {
@@ -415,7 +416,7 @@ class Runner {
 
   /**
    * Get path to use for -G and -A modes. Defaults to $CWD/latest-run
-   * @param {*} flags
+   * @param {Flags} flags
    * @return {string}
    */
   static _getArtifactsPath(flags) {
@@ -427,5 +428,3 @@ class Runner {
 }
 
 module.exports = Runner;
-
-

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -72,6 +72,14 @@ class Runner {
       run = run.then(_ => opts.config.artifacts);
     } else {
       run = run.then(_ => Runner._gatherArtifactsFromBrowser(opts, connection));
+      // -G means save these to ./latest-run, etc.
+      if (opts.flags.gatherMode) {
+        run = run.then(async artifacts => {
+          const path = Runner._getArtifactsPath(opts.flags);
+          await Runner._saveArtifacts(artifacts, path);
+          return artifacts;
+        });
+      }
     }
 
     // Potentially quit early
@@ -141,14 +149,7 @@ class Runner {
     }
 
     opts.driver = opts.driverMock || new Driver(connection);
-    const artifacts = await GatherRunner.run(opts.config.passes, opts);
-
-    const flags = opts.flags;
-    if (flags.gatherMode) {
-      const path = Runner._getArtifactsPath(flags);
-      await Runner._saveArtifacts(artifacts, path);
-    }
-    return artifacts;
+    return GatherRunner.run(opts.config.passes, opts);
   }
 
   /**
@@ -421,8 +422,8 @@ class Runner {
    */
   static _getArtifactsPath(flags) {
     // This enables usage like: -GA=./custom-folder
-    if (typeof flags.auditMode === 'string') return path.join(process.cwd(), flags.auditMode);
-    if (typeof flags.gatherMode === 'string') return path.join(process.cwd(), flags.gatherMode);
+    if (typeof flags.auditMode === 'string') return path.resolve(process.cwd(), flags.auditMode);
+    if (typeof flags.gatherMode === 'string') return path.resolve(process.cwd(), flags.gatherMode);
     return path.join(process.cwd(), 'latest-run');
   }
 }

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -38,7 +38,7 @@ describe('Runner', () => {
     resetSpies();
   });
 
-  describe.only('Gather Mode & Audit Mode', () => {
+  describe('Gather Mode & Audit Mode', () => {
     const url = 'https://example.com';
     const generateConfig = _ => new Config({
       passes: [{
@@ -47,7 +47,7 @@ describe('Runner', () => {
       audits: ['content-width'],
     });
     const artifactsPath = '.tmp/test_artifacts';
-    const resolvedPath = Runner._getArtifactsPath({auditMode: artifactsPath});
+    const resolvedPath = path.resolve(process.cwd(), artifactsPath);
 
     after(() => {
       rimraf.sync(resolvedPath);

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -11,6 +11,7 @@ const driverMock = require('./gather/fake-driver');
 const Config = require('../config/config');
 const Audit = require('../audits/audit');
 const assetSaver = require('../lib/asset-saver');
+const fs = require('fs');
 const assert = require('assert');
 const path = require('path');
 const sinon = require('sinon');
@@ -37,7 +38,7 @@ describe('Runner', () => {
     resetSpies();
   });
 
-  describe('Gather Mode & Audit Mode', () => {
+  describe.only('Gather Mode & Audit Mode', () => {
     const url = 'https://example.com';
     const generateConfig = _ => new Config({
       passes: [{
@@ -46,10 +47,10 @@ describe('Runner', () => {
       audits: ['content-width'],
     });
     const artifactsPath = '.tmp/test_artifacts';
+    const resolvedPath = Runner._getArtifactsPath({auditMode: artifactsPath});
 
     after(() => {
-      const path = Runner._getArtifactsPath({auditMode: artifactsPath});
-      rimraf.sync(path);
+      rimraf.sync(resolvedPath);
     });
 
     it('-G gathers, quits, and doesn\'t run audits', () => {
@@ -64,6 +65,9 @@ describe('Runner', () => {
 
         assert.equal(gatherRunnerRunSpy.called, true, 'GatherRunner.run was not called');
         assert.equal(runAuditSpy.called, false, '_runAudit was called');
+
+        assert.ok(fs.existsSync(resolvedPath));
+        assert.ok(fs.existsSync(`${resolvedPath}/artifacts.json`));
       });
     });
 

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,10 @@ lighthouse -A http://example.com
 
 lighthouse -GA http://example.com
 # Normal gather + audit run, but also saves collected artifacts to disk for subsequent -A runs.
+
+
+# You can optionally provide a custom folder destination to -G/-A/-GA. Without a value, the default will be `$PWD/latest-run`.
+lighthouse -GA=./gmailartifacts https://gmail.com
 ```
 
 

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -22,8 +22,8 @@ declare namespace LH {
     enableErrorReporting: boolean;
     listAllAudits: boolean;
     listTraceCategories: boolean;
-    auditMode: boolean;
-    gatherMode: boolean;
+    auditMode: boolean|string;
+    gatherMode: boolean|string;
     configPath?: string;
     perf: boolean;
     mixedContent: boolean;


### PR DESCRIPTION
Enable this:

```
lighthouse -G=./cnn_artifacts http://cnn.com
...
lighthouse -A=./cnn_artifacts http://cnn.com
```

Path is resolved via pwd, but absolute paths are allowable, too.