### PR TITLE
core(domstats): useIsolation within domstats

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -138,7 +138,7 @@ class DOMStats extends Gatherer {
       return (${getDOMStats.toString()}(document.documentElement));
     })()`;
     return options.driver.sendCommand('DOM.enable')
-      .then(() => options.driver.evaluateAsync(expression))
+      .then(() => options.driver.evaluateAsync(expression, {useIsolation: true}))
       .then(results => options.driver.getElementsInDocument().then(allNodes => {
         results.totalDOMNodes = allNodes.length;
         return options.driver.sendCommand('DOM.disable').then(() => results);


### PR DESCRIPTION
fixes https://sentry.io/google-lighthouse/lighthouse/issues/408582172/ our 6th most common error.

error is "Set is not a constructor" always coming from `elementPathInDOM`