### PR TITLE
core(img-usage): handle invalid images within determineNaturalSize

### DIFF
--- a/lighthouse-core/gather/gatherers/image-usage.js
+++ b/lighthouse-core/gather/gatherers/image-usage.js
@@ -96,7 +96,7 @@ function collectImageElementInfo() {
 function determineNaturalSize(url) {
   return new Promise((resolve, reject) => {
     const img = new Image();
-    img.addEventListener('error', reject);
+    img.addEventListener('error', _ => reject(new Error('determineNaturalSize failed img load')));
     img.addEventListener('load', () => {
       resolve({
         naturalWidth: img.naturalWidth,
@@ -118,6 +118,9 @@ class ImageUsage extends Gatherer {
     return this.driver.evaluateAsync(`(${determineNaturalSize.toString()})(${url})`)
       .then(size => {
         return Object.assign(element, size);
+      }).catch(_ => {
+        // determineNaturalSize fails on invalid images, which we treat as non-visible
+        return Object.assign(element, {naturalWidth: 0, naturalHeight: 0});
       });
   }
 


### PR DESCRIPTION
fixes https://sentry.io/google-lighthouse/lighthouse/issues/407848291/.. our 4th most common error!

It's reproducible on https://www.habitatetjardin.com/ with this image (https://i.habitatetjardin.com/images/bandefin_jardin.gif), though there's probably another URL that's a tad more minimal.