### PR TITLE
deps(browserify): update deep transitive dependency to use recent acorn

### DIFF
--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -25,5 +25,8 @@
     "run-sequence": "^1.1.5",
     "through2": "^2.0.1"
   },
+  "resolutions": {
+    "browserify/insert-module-globals/lexical-scope/astw": "github:goto-bus-stop/astw#new-acorn"
+  },
   "dependencies": {}
 }

--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -26,7 +26,7 @@
     "through2": "^2.0.1"
   },
   "resolutions": {
-    "browserify/insert-module-globals/lexical-scope/astw": "github:goto-bus-stop/astw#new-acorn"
+    "browserify/insert-module-globals/lexical-scope/astw": "github:paulirish/astw#new-acorn"
   },
   "dependencies": {}
 }

--- a/lighthouse-extension/package.json
+++ b/lighthouse-extension/package.json
@@ -26,7 +26,7 @@
     "through2": "^2.0.1"
   },
   "resolutions": {
-    "browserify/insert-module-globals/lexical-scope/astw": "github:paulirish/astw#new-acorn"
+    "browserify/insert-module-globals/lexical-scope/astw": "2.2.0"
   },
   "dependencies": {}
 }

--- a/lighthouse-extension/yarn.lock
+++ b/lighthouse-extension/yarn.lock
@@ -22,10 +22,6 @@ acorn-node@^1.3.0:
     acorn "^5.4.1"
     xtend "^4.0.1"
 
-acorn@^1.0.3:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-1.2.2.tgz#c8ce27de0acc76d896d2b1fad3df588d9e82f014"
-
 acorn@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
@@ -34,7 +30,7 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.0, acorn@^5.4.1:
+acorn@^5.0.0, acorn@^5.2.1, acorn@^5.4.1:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
@@ -185,11 +181,12 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-astw@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astw/-/astw-2.0.0.tgz#08121ac8288d35611c0ceec663f6cd545604897d"
+astw@^2.0.0, "astw@github:goto-bus-stop/astw#new-acorn":
+  version "2.2.0"
+  resolved "https://codeload.github.com/goto-bus-stop/astw/tar.gz/c1131eb355f90e2053f3abec016f1e07972269ae"
   dependencies:
-    acorn "^1.0.3"
+    acorn "^5.2.1"
+    xtend "^4.0.1"
 
 babel-code-frame@^6.22.0:
   version "6.26.0"

--- a/lighthouse-extension/yarn.lock
+++ b/lighthouse-extension/yarn.lock
@@ -30,7 +30,11 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.0, acorn@^5.2.1, acorn@^5.4.1:
+acorn@^4.0.3:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
+
+acorn@^5.0.0, acorn@^5.4.1:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
@@ -181,12 +185,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-astw@^2.0.0, "astw@github:paulirish/astw#new-acorn":
+astw@2.2.0, astw@^2.0.0:
   version "2.2.0"
-  resolved "https://codeload.github.com/paulirish/astw/tar.gz/c1131eb355f90e2053f3abec016f1e07972269ae"
+  resolved "https://registry.yarnpkg.com/astw/-/astw-2.2.0.tgz#7bd41784d32493987aeb239b6b4e1c57a873b917"
   dependencies:
-    acorn "^5.2.1"
-    xtend "^4.0.1"
+    acorn "^4.0.3"
 
 babel-code-frame@^6.22.0:
   version "6.26.0"

--- a/lighthouse-extension/yarn.lock
+++ b/lighthouse-extension/yarn.lock
@@ -181,9 +181,9 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-astw@^2.0.0, "astw@github:goto-bus-stop/astw#new-acorn":
+astw@^2.0.0, "astw@github:paulirish/astw#new-acorn":
   version "2.2.0"
-  resolved "https://codeload.github.com/goto-bus-stop/astw/tar.gz/c1131eb355f90e2053f3abec016f1e07972269ae"
+  resolved "https://codeload.github.com/paulirish/astw/tar.gz/c1131eb355f90e2053f3abec016f1e07972269ae"
   dependencies:
     acorn "^5.2.1"
     xtend "^4.0.1"


### PR DESCRIPTION
without this, #4792 fails in `yarn build-extension`

see https://github.com/substack/astw/pull/14