### PR TITLE
core(tsc): add type defs for Chrome Remote Debugging Protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "npm-run-posix-or-windows": "^2.0.2",
     "sinon": "^2.3.5",
     "typescript": "^2.8.0-rc",
+    "vscode-chrome-debug-core": "^3.23.8",
     "zone.js": "^0.7.3"
   },
   "dependencies": {

--- a/typings/audit.d.ts
+++ b/typings/audit.d.ts
@@ -4,85 +4,90 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-declare namespace LH.Audit {
-  export interface ScoringModes {
-    NUMERIC: 'numeric';
-    BINARY: 'binary';
-  }
+declare global {
+  module LH.Audit {
+    export interface ScoringModes {
+      NUMERIC: 'numeric';
+      BINARY: 'binary';
+    }
 
-  export type ScoringModeValue = Audit.ScoringModes[keyof Audit.ScoringModes];
+    export type ScoringModeValue = Audit.ScoringModes[keyof Audit.ScoringModes];
 
-  export interface Meta {
-    name: string;
-    description: string;
-    helpText: string;
-    requiredArtifacts: Array<string>;
-    failureDescription?: string;
-    informative?: boolean;
-    manual?: boolean;
-    scoreDisplayMode?: Audit.ScoringModeValue;
-  }
+    export interface Meta {
+      name: string;
+      description: string;
+      helpText: string;
+      requiredArtifacts: Array<string>;
+      failureDescription?: string;
+      informative?: boolean;
+      manual?: boolean;
+      scoreDisplayMode?: Audit.ScoringModeValue;
+    }
 
-  export interface Heading {
-    key: string;
-    itemType: string;
-    text: string;
-  }
+    export interface Heading {
+      key: string;
+      itemType: string;
+      text: string;
+    }
 
-  export interface HeadingsResult {
-    results: number;
-    headings: Array<Audit.Heading>;
-    passes: boolean;
-    debugString?: string;
-  }
+    export interface HeadingsResult {
+      results: number;
+      headings: Array<Audit.Heading>;
+      passes: boolean;
+      debugString?: string;
+    }
 
-  // TODO: placeholder typedefs until Details are typed
-  export interface DetailsRendererDetailsSummary {
-    wastedMs?: number;
-    wastedBytes?: number;
-  }
+    // TODO: placeholder typedefs until Details are typed
+    export interface DetailsRendererDetailsSummary {
+      wastedMs?: number;
+      wastedBytes?: number;
+    }
 
-  // TODO: placeholder typedefs until Details are typed
-  export interface DetailsRendererDetailsJSON {
-    type: 'table';
-    headings: Array<Audit.Heading>;
-    items: Array<{[x: string]: string}>;
-    summary: DetailsRendererDetailsSummary;
-  }
+    // TODO: placeholder typedefs until Details are typed
+    export interface DetailsRendererDetailsJSON {
+      type: 'table';
+      headings: Array<Audit.Heading>;
+      items: Array<{[x: string]: string}>;
+      summary: DetailsRendererDetailsSummary;
+    }
 
-  // Type returned by Audit.audit(). Only rawValue is required.
-  export interface Product {
-    rawValue: boolean | number | null;
-    displayValue?: string;
-    debugString?: string;
-    score?: number;
-    extendedInfo?: {value: string};
-    notApplicable?: boolean;
-    error?: boolean;
-    // TODO: define details
-    details?: object;
-  }
+    // Type returned by Audit.audit(). Only rawValue is required.
+    export interface Product {
+      rawValue: boolean | number | null;
+      displayValue?: string;
+      debugString?: string;
+      score?: number;
+      extendedInfo?: {value: string};
+      notApplicable?: boolean;
+      error?: boolean;
+      // TODO: define details
+      details?: object;
+    }
 
-  /* Audit result returned in Lighthouse report. All audits offer a description and score of 0-1 */
-  export interface Result {
-    rawValue: boolean | number | null;
-    displayValue: string;
-    debugString?: string;
-    score: number;
-    scoreDisplayMode: ScoringModeValue;
-    description: string;
-    extendedInfo?: {value: string};
-    notApplicable?: boolean;
-    error?: boolean;
-    name: string;
-    helpText?: string;
-    informative?: boolean;
-    manual?: boolean;
-    // TODO: define details
-    details?: object;
-  }
+    /* Audit result returned in Lighthouse report. All audits offer a description and score of 0-1 */
+    export interface Result {
+      rawValue: boolean | number | null;
+      displayValue: string;
+      debugString?: string;
+      score: number;
+      scoreDisplayMode: ScoringModeValue;
+      description: string;
+      extendedInfo?: {value: string};
+      notApplicable?: boolean;
+      error?: boolean;
+      name: string;
+      helpText?: string;
+      informative?: boolean;
+      manual?: boolean;
+      // TODO: define details
+      details?: object;
+    }
 
-  export interface Results {
-    [metric: string]: Result;
+    export interface Results {
+      [metric: string]: Result;
+    }
   }
 }
+
+// empty export to keep file a module
+export {}

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -4,110 +4,115 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-declare namespace LH {
+import _Crdp from "../node_modules/vscode-chrome-debug-core/lib/crdp/crdp";
 
-  export interface Flags {
-    _: string[];
-    port: number;
-    chromeFlags: string;
-    output: any;
-    outputPath: string;
-    saveAssets: boolean;
-    view: boolean;
-    maxWaitForLoad: number;
-    logLevel: string;
-    hostname: string;
-    blockedUrlPatterns: string[];
-    extraHeaders: string;
-    enableErrorReporting: boolean;
-    listAllAudits: boolean;
-    listTraceCategories: boolean;
-    auditMode: boolean|string;
-    gatherMode: boolean|string;
-    configPath?: string;
-    perf: boolean;
-    mixedContent: boolean;
-    verbose: boolean;
-    quiet: boolean;
-  }
+declare global {
+  module LH {
+    export import Crdp = _Crdp;
 
-  export interface Config {}
+    export interface Flags {
+      _: string[];
+      port: number;
+      chromeFlags: string;
+      output: any;
+      outputPath: string;
+      saveAssets: boolean;
+      view: boolean;
+      maxWaitForLoad: number;
+      logLevel: string;
+      hostname: string;
+      blockedUrlPatterns: string[];
+      extraHeaders: string;
+      enableErrorReporting: boolean;
+      listAllAudits: boolean;
+      listTraceCategories: boolean;
+      auditMode: boolean|string;
+      gatherMode: boolean|string;
+      configPath?: string;
+      perf: boolean;
+      mixedContent: boolean;
+      verbose: boolean;
+      quiet: boolean;
+    }
 
-  export interface Results {
-    url: string;
-    audits: LH.Audit.Results;
-    lighthouseVersion: string;
-    artifacts?: Object;
-    initialUrl: string;
-    generatedTime: string;
-  }
+    export interface Config {}
 
-  export interface LaunchedChrome {
-    pid: number;
-    port: number;
-    kill: () => Promise<{}>;
-  }
+    export interface Results {
+      url: string;
+      audits: Audit.Results;
+      lighthouseVersion: string;
+      artifacts?: Object;
+      initialUrl: string;
+      generatedTime: string;
+    }
 
-  export interface LighthouseError extends Error {
-    code?: string;
-    friendlyMessage?: string;
-  }
+    export interface LaunchedChrome {
+      pid: number;
+      port: number;
+      kill: () => Promise<{}>;
+    }
 
-  export interface TraceEvent {
-    name: string;
-    args: any;
-    tid: number;
-    ts: number;
-    dur: number;
-  }
+    export interface LighthouseError extends Error {
+      code?: string;
+      friendlyMessage?: string;
+    }
 
-  export interface NetworkRequest {
-    requestId: string;
-    connectionId: string;
-    connectionReused: boolean;
+    export interface TraceEvent {
+      name: string;
+      args: any;
+      tid: number;
+      ts: number;
+      dur: number;
+    }
 
-    url: string;
-    protocol: string;
-    origin: string | null;
-    parsedURL: DevToolsParsedURL;
+    export interface NetworkRequest {
+      requestId: string;
+      connectionId: string;
+      connectionReused: boolean;
 
-    startTime: number;
-    endTime: number;
+      url: string;
+      protocol: string;
+      origin: string | null;
+      parsedURL: DevToolsParsedURL;
 
-    transferSize: number;
+      startTime: number;
+      endTime: number;
 
-    _initiator: NetworkRequestInitiator;
-    _timing: NetworkRequestTiming;
-    _resourceType: any;
-    priority(): 'VeryHigh' | 'High' | 'Medium' | 'Low';
-  }
+      transferSize: number;
 
-  export interface NetworkRequestInitiator {
-    type: 'script' | 'parser';
-  }
+      _initiator: NetworkRequestInitiator;
+      _timing: NetworkRequestTiming;
+      _resourceType: any;
+      priority(): 'VeryHigh' | 'High' | 'Medium' | 'Low';
+    }
 
-  export interface NetworkRequestTiming {
-    connectStart: number;
-    connectEnd: number
-    sslStart: number;
-    sslEnd: number;
-    sendStart: number;
-    sendEnd: number;
-    receiveHeadersEnd: number;
-  }
+    export interface NetworkRequestInitiator {
+      type: 'script' | 'parser';
+    }
 
-  export interface DevToolsParsedURL {
-    scheme: string;
-    host: string;
-  }
+    export interface NetworkRequestTiming {
+      connectStart: number;
+      connectEnd: number
+      sslStart: number;
+      sslEnd: number;
+      sendStart: number;
+      sendEnd: number;
+      receiveHeadersEnd: number;
+    }
 
-  export interface DevToolsJsonTarget {
-    description: string;
-    devtoolsFrontendUrl: string;
-    id: string;
-    title: string;
-    type: string;
-    url: string;
-    webSocketDebuggerUrl: string;
+    export interface DevToolsParsedURL {
+      scheme: string;
+      host: string;
+    }
+
+    export interface DevToolsJsonTarget {
+      description: string;
+      devtoolsFrontendUrl: string;
+      id: string;
+      title: string;
+      type: string;
+      url: string;
+      webSocketDebuggerUrl: string;
+    }
   }
 }

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -4,14 +4,19 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-declare namespace LH.Gatherer {
-  export interface PassContext {
-    options: object;
-  }
+declare global {
+  module LH.Gatherer {
+    export interface PassContext {
+      options: object;
+    }
 
-  export interface LoadData {
-    networkRecords: Array<LH.NetworkRequest>;
-    devtoolsLog: Array<void>;
-    trace: {trraceEvents: Array<LH.TraceEvent>}
+    export interface LoadData {
+      networkRecords: Array<Crdp.Network.Response>;
+      devtoolsLog: Array<void>;
+      trace: {traceEvents: Array<TraceEvent>}
+    }
   }
 }
+
+// empty export to keep file a module
+export {}

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -11,7 +11,7 @@ declare global {
     }
 
     export interface LoadData {
-      networkRecords: Array<Crdp.Network.Response>;
+      networkRecords: Array<void>;
       devtoolsLog: Array<void>;
       trace: {traceEvents: Array<TraceEvent>}
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,6 +143,10 @@
     "@types/rx-lite-time" "*"
     "@types/rx-lite-virtualtime" "*"
 
+"@types/source-map@^0.1.27":
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.1.29.tgz#d7048a60180b09f8aa6d53bda311c6b51cbd7018"
+
 "@types/through@*":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.29.tgz#72943aac922e179339c651fa34a4428a4d722f93"
@@ -1811,7 +1815,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2992,6 +2996,10 @@ node-uuid@~1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
 
+noice-json-rpc@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/noice-json-rpc/-/noice-json-rpc-1.0.1.tgz#5e7289a60a1c20880489cb15101552bac392266e"
+
 nopt@3.x:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -3762,6 +3770,10 @@ source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 source-map@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
@@ -4244,6 +4256,38 @@ vinyl@^2.0.1:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
+vscode-chrome-debug-core@^3.23.8:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/vscode-chrome-debug-core/-/vscode-chrome-debug-core-3.23.8.tgz#f0fd1582b6d7653d327171104b9c8e2eebb6bf41"
+  dependencies:
+    "@types/source-map" "^0.1.27"
+    glob "^7.0.6"
+    noice-json-rpc "1.0.1"
+    source-map "^0.6.1"
+    vscode-debugadapter "^1.28.0-pre.2"
+    vscode-debugprotocol "^1.28.0-pre.1"
+    vscode-nls "^3.2.1"
+    ws "^3.3.2"
+
+vscode-debugadapter@^1.28.0-pre.2:
+  version "1.28.0-pre.2"
+  resolved "https://registry.yarnpkg.com/vscode-debugadapter/-/vscode-debugadapter-1.28.0-pre.2.tgz#165ccd179f5a43319c8d6a3dc77832e9392ae254"
+  dependencies:
+    vscode-debugprotocol "1.28.0-pre.1"
+    vscode-uri "1.0.1"
+
+vscode-debugprotocol@1.28.0-pre.1, vscode-debugprotocol@^1.28.0-pre.1:
+  version "1.28.0-pre.1"
+  resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.28.0-pre.1.tgz#2641b753cbb78416e897a2f1653e7bc391d2db0b"
+
+vscode-nls@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-3.2.2.tgz#3817eca5b985c2393de325197cf4e15eb2aa5350"
+
+vscode-uri@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.1.tgz#11a86befeac3c4aa3ec08623651a3c81a6d0bbc8"
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -4348,6 +4392,14 @@ write@^0.2.1:
 ws@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.2.tgz#96c1d08b3fefda1d5c1e33700d3bfaa9be2d5608"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
+ws@^3.3.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"


### PR DESCRIPTION
`vscode-chrome-debug-core` has up-to-date type defs for the protocol. Pull those in until https://github.com/ChromeDevTools/devtools-protocol/issues/55 is fixed

This exposes the types on `LH.Crdp.*` (e.g. `LH.Crdp.Network.Response`). Happy to bikeshed.

Once again github is tricked by indentation. Check out [?w=1](https://github.com/GoogleChrome/lighthouse/pull/4816/files?w=1) for a better diff