### PR TITLE
core(is-crawlable): fix empty row in the details table when showing an URL

### DIFF
--- a/lighthouse-core/audits/seo/is-crawlable.js
+++ b/lighthouse-core/audits/seo/is-crawlable.js
@@ -107,7 +107,7 @@ class IsCrawlable extends Audit {
             blockingDirectives.push({
               source: {
                 type: 'url',
-                text: robotsFileUrl.href,
+                value: robotsFileUrl.href,
               },
             });
           }


### PR DESCRIPTION
Fixes #4818 

<img width="793" alt="screen shot 2018-03-20 at 03 01 56" src="https://user-images.githubusercontent.com/985504/37631674-1e0f5338-2beb-11e8-9f60-31510802c8c4.png">

It looks like #4616 was created before is-crawlable was merged causing this file to be overlooked. I searched for other similar issues, but found none.