### PR TITLE
core(font-size, link-text): update docs links

### DIFF
--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -179,7 +179,7 @@ class FontSize extends Audit {
       failureDescription: 'Document doesn\'t use legible font sizes',
       helpText: 'Font sizes less than 12px are too small to be legible and require mobile ' +
       'visitors to “pinch to zoom” in order to read. Strive to have >60% of page text ≥12px. ' +
-      '[Learn more](https://developers.google.com/web/fundamentals/design-and-ux/responsive/#optimize_text_for_reading).',
+      '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/font-sizes).',
       requiredArtifacts: ['FontSize', 'URL', 'Viewport'],
     };
   }

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -30,7 +30,7 @@ class LinkText extends Audit {
       description: 'Links have descriptive text',
       failureDescription: 'Links do not have descriptive text',
       helpText: 'Descriptive link text helps search engines understand your content. ' +
-      '[Learn more](https://webmasters.googleblog.com/2008/10/importance-of-link-architecture.html).',
+      '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text).',
       requiredArtifacts: ['URL', 'CrawlableLinks'],
     };
   }


### PR DESCRIPTION
developers.google.com docs for [font-size](https://developers.google.com/web/tools/lighthouse/audits/font-sizes) and [link-text](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text) are up, time to update the links!

cc @kaycebasques @rviscomi 

Part of #4355