### PR TITLE
core(start-url): reorganize start_url gatherer

### DIFF
--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -9,75 +9,93 @@ const Gatherer = require('./gatherer');
 const manifestParser = require('../../lib/manifest-parser');
 
 class StartUrl extends Gatherer {
+  readManifest(manifest) {
+    if (!manifest || !manifest.value) {
+      const detailedMsg = manifest && manifest.debugString;
+
+      if (detailedMsg) {
+        const debugString = `Error fetching web app manifest: ${detailedMsg}`;
+        return {
+          statusCode: -1,
+          debugString,
+        };
+      } else {
+        const debugString = `No usable web app manifest found on page`;
+        return {
+          statusCode: -1,
+          debugString,
+        };
+      }
+    }
+
+    if (manifest.value.start_url.debugString) {
+      // Even if the start URL had an error, the browser will still supply a fallback URL.
+      // Therefore, we only set the debugString here and continue with the fetch.
+      return {
+        statusCode: -1,
+        debugString: manifest.value.start_url.debugString,
+      };
+    }
+
+    return {
+      statusCode: 1,
+      startUrl: manifest.value.start_url.value,
+    };
+  }
+
+  attemptManifestFetch(options, startUrl) {
+    return new Promise(resolve => {
+      const driver = options.driver;
+      driver.on('Network.responseReceived', responseReceived);
+
+      driver.goOffline(options)
+        .then(() => this.executeFetchRequest(driver, startUrl))
+        .then(() => driver.goOnline(options));
+
+      function responseReceived({response}) {
+        // ignore mismatched URLs
+        if (response.url !== startUrl) return;
+
+        driver.off('Network.responseReceived', responseReceived);
+
+        if (!response.fromServiceWorker) {
+          return resolve({
+            statusCode: -1,
+            debugString: 'Unable to fetch start URL via service worker',
+          });
+        }
+
+        return resolve({
+          statusCode: response.status,
+          debugString: '',
+        });
+      }
+    });
+  }
+
   executeFetchRequest(driver, url) {
     return driver.evaluateAsync(
       `fetch('${url}')`
     );
   }
 
+
   afterPass(options) {
     return options.driver.goOnline(options)
       .then(() => options.driver.getAppManifest())
       .then(response => response && manifestParser(response.data, response.url, options.url))
       .then(manifest => {
-        if (!manifest || !manifest.value) {
-          const detailedMsg = manifest && manifest.debugString;
-
-          if (detailedMsg) {
-            const debugString = `Error fetching web app manifest: ${detailedMsg}`;
-            return {
-              statusCode: -1,
-              debugString,
-            };
-          } else {
-            const debugString = `No usable web app manifest found on page ${options.url}`;
-            return {
-              statusCode: -1,
-              debugString,
-            };
-          }
+        const {statusCode, debugString, startUrl} = this.readManifest(manifest);
+        if (statusCode === -1) {
+          return {statusCode, debugString};
         }
 
-        if (manifest.value.start_url.debugString) {
-          // Even if the start URL had an error, the browser will still supply a fallback URL.
-          // Therefore, we only set the debugString here and continue with the fetch.
-          return {
-            statusCode: -1,
-            debugString: manifest.value.start_url.debugString,
-          };
-        }
-
-        const startUrl = manifest.value.start_url.value;
-
-        return (new Promise(resolve => {
-          options.driver.on('Network.responseReceived', function responseReceived({response}) {
-            if (response.url === startUrl) {
-              options.driver.off('Network.responseReceived', responseReceived);
-
-              if (!response.fromServiceWorker) {
-                return resolve({
-                  statusCode: -1,
-                  debugString: 'Unable to fetch start URL via service worker',
-                });
-              }
-
-              return resolve({
-                statusCode: response.status,
-                debugString: '',
-              });
-            }
-          });
-
-          options.driver.goOffline(options)
-            .then(() => this.executeFetchRequest(options.driver, startUrl))
-            .then(() => options.driver.goOnline(options))
-            .catch(() => {
-              resolve({
-                statusCode: -1,
-                debugString: 'Unable to fetch start URL via service worker',
-              });
-            });
-        }));
+        return this.attemptManifestFetch(options, startUrl);
+      }).catch(() => {
+        return {
+          statusCode: -1,
+          debugString: 'Unable to fetch start URL via service worker',
+        };
       });
   }
 }

--- a/lighthouse-core/test/gather/gatherers/start-url-test.js
+++ b/lighthouse-core/test/gather/gatherers/start-url-test.js
@@ -120,7 +120,7 @@ describe('Start-url gatherer', () => {
     return startUrlGatherer.afterPass(options, tracingData)
       .then(artifact => {
         assert.equal(artifact.debugString,
-          `No usable web app manifest found on page ${options.url}`);
+          `No usable web app manifest found on page`);
       });
   });
 


### PR DESCRIPTION
(This is a merge into #4710) 

This is reusing the exact same new logic from 4710, just separated a bit.

Only interesting things:

1. using `isReadFailure` boolean to indicate if we should bail and fail before trying a `fetch`
1. added a timeout to make sure we're not waiting forever for a matching network request
1. more comments & jsdoc