### PR TITLE
core: add node 6 support to (patched) robots-parser

### DIFF
--- a/patches/robots-parser+1.0.2.patch
+++ b/patches/robots-parser+1.0.2.patch
@@ -1,36 +1,54 @@
 patch-package
 --- a/node_modules/robots-parser/Robots.js
 +++ b/node_modules/robots-parser/Robots.js
-@@ -1,4 +1,4 @@
+@@ -1,4 +1,22 @@
 -var libUrl   = require('url');
-+var URL   = (typeof self !== 'undefined' && self.URL) || require('url').URL;
++
++var getUrlPath;
++var parse;
++if (typeof self !== 'undefined' && self.URL) {
++	// Extra safety for invalid URLs
++	parse = url => {
++		try {
++			return new URL(url);
++		} catch(e) {
++			return null;
++		}
++	};
++  	getUrlPath = parsedUrl => parsedUrl.pathname + parsedUrl.search;
++} else {
++	// Add Fallback for Node 6, which doesn't have require('url').URL
++	parse = require('url').parse;
++	getUrlPath = parsedUrl => parsedUrl.path;
++}
++
  var punycode = require('punycode');
- 
+
  /**
-@@ -176,7 +176,7 @@ function isPathAllowed(path, rules) {
- 
- 
+@@ -176,7 +194,7 @@ function isPathAllowed(path, rules) {
+
+
  function Robots(url, contents) {
 -	this._url = libUrl.parse(url);
-+	this._url = new URL(url);
++	this._url = parse(url)|| {};
  	this._url.port = this._url.port || 80;
  	this._url.hostname = punycode.toUnicode(this._url.hostname);
- 
-@@ -262,7 +262,7 @@ Robots.prototype.setPreferredHost = function (url) {
+
+@@ -262,7 +280,7 @@ Robots.prototype.setPreferredHost = function (url) {
   * @return {boolean?}
   */
  Robots.prototype.isAllowed = function (url, ua) {
 -	var parsedUrl = libUrl.parse(url);
-+	var parsedUrl = new URL(url);
++	var parsedUrl = parse(url) || {};
  	var userAgent = formatUserAgent(ua || '*');
- 
+
  	parsedUrl.port = parsedUrl.port || 80;
-@@ -277,7 +277,7 @@ Robots.prototype.isAllowed = function (url, ua) {
- 
+@@ -277,7 +295,7 @@ Robots.prototype.isAllowed = function (url, ua) {
+
  	var rules = this._rules[userAgent] || this._rules['*'] || [];
- 
+
 -	return isPathAllowed(parsedUrl.path, rules);
-+	return isPathAllowed(parsedUrl.pathname + parsedUrl.search, rules);
++	return isPathAllowed(getUrlPath(parsedUrl), rules);
  };
- 
+
  /**


### PR DESCRIPTION
Our new patch leaves out node 6 out in cold:
https://travis-ci.org/GoogleChrome/lighthouse/jobs/357025749#L634


node 6.13 has `require('url').URL` but its a month old and no other node 6 has it. 
so we'll add this backwards-compat support for the rest of node 6's out there.

This PR is for branch2.x only.

Konrad has an upcoming PR to roll latest `robots-parser` (which will now be node 7+ only).


Audience-wise: this patch only matters for our Node 6 (>6.0.0 and [<6.13.0](https://github.com/nodejs/Release/issues/208#issuecomment-364697107)) CLI users
