### PR TITLE
core(config): switch to throttling settings object

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -137,7 +137,7 @@ class UnusedBytes extends Audit {
   static createAuditResult(result, graph) {
     const simulatorOptions = PredictivePerf.computeRTTAndServerResponseTime(graph);
     // TODO: calibrate multipliers, see https://github.com/GoogleChrome/lighthouse/issues/820
-    Object.assign(simulatorOptions, {cpuTaskMultiplier: 1, layoutTaskMultiplier: 1});
+    Object.assign(simulatorOptions, {cpuSlowdownMultiplier: 1, layoutTaskMultiplier: 1});
     const simulator = new LoadSimulator(graph, simulatorOptions);
 
     const debugString = result.debugString;

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -80,7 +80,7 @@ class LoadFastEnough4Pwa extends Audit {
       });
 
       let firstRequestLatencies = Array.from(firstRequestLatenciesByOrigin.values());
-      const latency3gMin = Emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.targetLatency - 10;
+      const latency3gMin = Emulation.settings.MOBILE_3G_THROTTLING.targetLatencyMs - 10;
       const areLatenciesAll3G = firstRequestLatencies.every(val => val.latency > latency3gMin);
       firstRequestLatencies = firstRequestLatencies.map(item => ({
         url: item.url,

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -6,12 +6,20 @@
 'use strict';
 
 const Driver = require('../gather/driver');
+const emulation = require('../lib/emulation');
 
 /* eslint-disable max-len */
 
 module.exports = {
   settings: {
     maxWaitForLoad: Driver.MAX_WAIT_FOR_FULLY_LOADED,
+    throttlingMethod: 'devtools',
+    throttling: {
+      requestLatency: emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.latency,
+      downloadThroughput: emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.downloadThroughput,
+      uploadThroughput: emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.uploadThroughput,
+      cpuSlowdownMultiplier: emulation.settings.CPU_THROTTLE_METRICS.rate,
+    },
   },
   passes: [{
     passName: 'defaultPass',

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const Driver = require('../gather/driver');
-const emulation = require('../lib/emulation');
+const emulation = require('../lib/emulation').settings;
 
 /* eslint-disable max-len */
 
@@ -15,10 +15,10 @@ module.exports = {
     maxWaitForLoad: Driver.MAX_WAIT_FOR_FULLY_LOADED,
     throttlingMethod: 'devtools',
     throttling: {
-      requestLatency: emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.latency,
-      downloadThroughput: emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.downloadThroughput,
-      uploadThroughput: emulation.settings.TYPICAL_MOBILE_THROTTLING_METRICS.uploadThroughput,
-      cpuSlowdownMultiplier: emulation.settings.CPU_THROTTLE_METRICS.rate,
+      requestLatency: emulation.TYPICAL_MOBILE_THROTTLING_METRICS.latency,
+      downloadThroughput: emulation.TYPICAL_MOBILE_THROTTLING_METRICS.downloadThroughput * 8,
+      uploadThroughput: emulation.TYPICAL_MOBILE_THROTTLING_METRICS.uploadThroughput * 8,
+      cpuSlowdownMultiplier: emulation.CPU_THROTTLE_METRICS.rate,
     },
   },
   passes: [{

--- a/lighthouse-core/config/default.js
+++ b/lighthouse-core/config/default.js
@@ -15,9 +15,9 @@ module.exports = {
     maxWaitForLoad: Driver.MAX_WAIT_FOR_FULLY_LOADED,
     throttlingMethod: 'devtools',
     throttling: {
-      requestLatency: emulation.TYPICAL_MOBILE_THROTTLING_METRICS.latency,
-      downloadThroughput: emulation.TYPICAL_MOBILE_THROTTLING_METRICS.downloadThroughput * 8,
-      uploadThroughput: emulation.TYPICAL_MOBILE_THROTTLING_METRICS.uploadThroughput * 8,
+      requestLatencyMs: emulation.MOBILE_3G_THROTTLING.adjustedLatencyMs,
+      downloadThroughputKbps: emulation.MOBILE_3G_THROTTLING.adjustedDownloadThroughputKbps,
+      uploadThroughputKbps: emulation.MOBILE_3G_THROTTLING.adjustedUploadThroughputKbps,
       cpuSlowdownMultiplier: emulation.CPU_THROTTLE_METRICS.rate,
     },
   },

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1033,13 +1033,15 @@ class Driver {
    * @return {Promise<void>}
    */
   async setThrottling(settings, passConfig) {
-    const throttleCpu = passConfig.useThrottling && !settings.disableCpuThrottling;
-    const throttleNetwork = passConfig.useThrottling && !settings.disableNetworkThrottling;
-    const cpuPromise = throttleCpu ?
-        emulation.enableCPUThrottling(this) :
+    if (settings.throttlingMethod !== 'devtools') {
+      return;
+    }
+
+    const cpuPromise = passConfig.useThrottling ?
+        emulation.enableCPUThrottling(this, settings.throttling) :
         emulation.disableCPUThrottling(this);
-    const networkPromise = throttleNetwork ?
-        emulation.enableNetworkThrottling(this) :
+    const networkPromise = passConfig.useThrottling ?
+        emulation.enableNetworkThrottling(this, settings.throttling) :
         emulation.disableNetworkThrottling(this);
 
     await Promise.all([cpuPromise, networkPromise]);
@@ -1056,8 +1058,7 @@ class Driver {
   }
 
   /**
-   * Enable internet connection, using emulated mobile settings if
-   * `options.settings.disableNetworkThrottling` is false.
+   * Enable internet connection, using emulated mobile settings if applicable.
    * @param {{settings: LH.ConfigSettings, passConfig: LH.ConfigPass}} options
    * @return {Promise<void>}
    */

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1034,7 +1034,7 @@ class Driver {
    */
   async setThrottling(settings, passConfig) {
     if (settings.throttlingMethod !== 'devtools') {
-      return;
+      return emulation.clearAllNetworkEmulation(this);
     }
 
     const cpuPromise = passConfig.useThrottling ?
@@ -1042,7 +1042,7 @@ class Driver {
         emulation.disableCPUThrottling(this);
     const networkPromise = passConfig.useThrottling ?
         emulation.enableNetworkThrottling(this, settings.throttling) :
-        emulation.disableNetworkThrottling(this);
+        emulation.clearAllNetworkEmulation(this);
 
     await Promise.all([cpuPromise, networkPromise]);
   }

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -22,7 +22,7 @@ const DEFAULT_THROUGHPUT = emulation.TYPICAL_MOBILE_THROTTLING_METRICS.targetDow
 // same multiplier as Lighthouse uses for CPU emulation
 const DEFAULT_CPU_TASK_MULTIPLIER = emulation.CPU_THROTTLE_METRICS.rate;
 // layout tasks tend to be less CPU-bound and do not experience the same increase in duration
-const DEFAULT_LAYOUT_TASK_MULTIPLIER = DEFAULT_CPU_TASK_MULTIPLIER / 2;
+const DEFAULT_LAYOUT_TASK_MULTIPLIER = .5;
 // if a task takes more than 10 seconds it's usually a sign it isn't actually CPU bound and we're overestimating
 const DEFAULT_MAXIMUM_CPU_TASK_DURATION = 10000;
 
@@ -45,7 +45,7 @@ class Simulator {
         rtt: DEFAULT_RTT,
         throughput: DEFAULT_THROUGHPUT,
         maximumConcurrentRequests: DEFAULT_MAXIMUM_CONCURRENT_REQUESTS,
-        cpuTaskMultiplier: DEFAULT_CPU_TASK_MULTIPLIER,
+        cpuSlowdownMultiplier: DEFAULT_CPU_TASK_MULTIPLIER,
         layoutTaskMultiplier: DEFAULT_LAYOUT_TASK_MULTIPLIER,
       },
       options
@@ -57,8 +57,8 @@ class Simulator {
       TcpConnection.maximumSaturatedConnections(this._rtt, this._throughput),
       this._options.maximumConcurrentRequests
     );
-    this._cpuTaskMultiplier = this._options.cpuTaskMultiplier;
-    this._layoutTaskMultiplier = this._options.layoutTaskMultiplier;
+    this._cpuSlowdownMultiplier = this._options.cpuSlowdownMultiplier;
+    this._layoutTaskMultiplier = this._cpuSlowdownMultiplier * this._options.layoutTaskMultiplier;
 
     this._nodeTiming = new Map();
     this._numberInProgressByType = new Map();
@@ -206,7 +206,7 @@ class Simulator {
       const timingData = this._nodeTiming.get(node);
       const multiplier = (/** @type {CpuNode} */ (node)).didPerformLayout()
         ? this._layoutTaskMultiplier
-        : this._cpuTaskMultiplier;
+        : this._cpuSlowdownMultiplier;
       const totalDuration = Math.min(
         Math.round((/** @type {CpuNode} */ (node)).event.dur / 1000 * multiplier),
         DEFAULT_MAXIMUM_CPU_TASK_DURATION
@@ -360,7 +360,7 @@ module.exports = Simulator;
  * @property {number} [throughput]
  * @property {number} [fallbackTTFB]
  * @property {number} [maximumConcurrentRequests]
- * @property {number} [cpuTaskMultiplier]
+ * @property {number} [cpuSlowdownMultiplier]
  * @property {number} [layoutTaskMultiplier]
  */
 

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -22,7 +22,7 @@ const DEFAULT_THROUGHPUT = emulation.MOBILE_3G_THROTTLING.targetDownloadThroughp
 // same multiplier as Lighthouse uses for CPU emulation
 const DEFAULT_CPU_TASK_MULTIPLIER = emulation.CPU_THROTTLE_METRICS.rate;
 // layout tasks tend to be less CPU-bound and do not experience the same increase in duration
-const DEFAULT_LAYOUT_TASK_MULTIPLIER = .5;
+const DEFAULT_LAYOUT_TASK_MULTIPLIER = 0.5;
 // if a task takes more than 10 seconds it's usually a sign it isn't actually CPU bound and we're overestimating
 const DEFAULT_MAXIMUM_CPU_TASK_DURATION = 10000;
 

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -16,8 +16,8 @@ const emulation = require('../../emulation').settings;
 const DEFAULT_MAXIMUM_CONCURRENT_REQUESTS = 10;
 
 // Fast 3G emulation target from DevTools, WPT 3G - Fast setting
-const DEFAULT_RTT = emulation.TYPICAL_MOBILE_THROTTLING_METRICS.targetLatency;
-const DEFAULT_THROUGHPUT = emulation.TYPICAL_MOBILE_THROTTLING_METRICS.targetDownloadThroughput * 8; // 1.6 Mbps
+const DEFAULT_RTT = emulation.MOBILE_3G_THROTTLING.targetLatencyMs;
+const DEFAULT_THROUGHPUT = emulation.MOBILE_3G_THROTTLING.targetDownloadThroughputKbps * 1024; // 1.6 Mbps
 
 // same multiplier as Lighthouse uses for CPU emulation
 const DEFAULT_CPU_TASK_MULTIPLIER = emulation.CPU_THROTTLE_METRICS.rate;

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -167,8 +167,6 @@ function getEmulationDesc(settings) {
   let cpuThrottling;
   let networkThrottling;
 
-  /** @type {function(number|undefined):string} */
-  const byteToKbit = (bytes = 0) => (bytes / 1024 * 8).toFixed();
   /** @type {LH.ThrottlingSettings} */
   const throttling = settings.throttling || {};
 
@@ -179,20 +177,17 @@ function getEmulationDesc(settings) {
       break;
     case 'devtools': {
       const {cpuSlowdownMultiplier, requestLatencyMs} = throttling;
-      const down = byteToKbit(throttling.downloadThroughputKbps);
-      const up = byteToKbit(throttling.uploadThroughputKbps);
-
       cpuThrottling = `${cpuSlowdownMultiplier}x slowdown (DevTools)`;
       networkThrottling = `${requestLatencyMs}${NBSP}ms HTTP RTT, ` +
-        `${down}${NBSP}Kbps down, ${up}${NBSP}Kbps up (DevTools)`;
+        `${throttling.downloadThroughputKbps}${NBSP}Kbps down, ` +
+        `${throttling.uploadThroughputKbps}${NBSP}Kbps up (DevTools)`;
       break;
     }
     case 'simulate': {
-      const {cpuSlowdownMultiplier, rttMs} = throttling;
-      const throughput = byteToKbit(throttling.throughputKbps);
+      const {cpuSlowdownMultiplier, rttMs, throughputKbps} = throttling;
       cpuThrottling = `${cpuSlowdownMultiplier}x slowdown (Simulated)`;
       networkThrottling = `${rttMs}${NBSP}ms TCP RTT, ` +
-        `${throughput}${NBSP}Kbps throughput (Simulated)`;
+        `${throughputKbps}${NBSP}Kbps throughput (Simulated)`;
       break;
     }
     default:

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -118,8 +118,8 @@ function enableNetworkThrottling(driver, throttlingSettings) {
   }
 
   // DevTools expects throughput in bytes per second rather than kbps
-  conditions.downloadThroughput = conditions.downloadThroughput * 1024 / 8;
-  conditions.uploadThroughput = conditions.uploadThroughput * 1024 / 8;
+  conditions.downloadThroughput = Math.floor(conditions.downloadThroughput * 1024 / 8);
+  conditions.uploadThroughput = Math.floor(conditions.uploadThroughput * 1024 / 8);
   return driver.sendCommand('Network.emulateNetworkConditions', conditions);
 }
 

--- a/lighthouse-core/lib/sentry.js
+++ b/lighthouse-core/lib/sentry.js
@@ -82,12 +82,11 @@ sentryDelegate.init = function init(opts) {
     );
   }
 
-  const context = {
+  const context = Object.assign({
     url: opts.url,
     deviceEmulation: !opts.flags.disableDeviceEmulation,
-    networkThrottling: !opts.flags.disableNetworkThrottling,
-    cpuThrottling: !opts.flags.disableCpuThrottling,
-  };
+    throttlingMethod: opts.flags.throttlingMethod,
+  }, opts.flags.throttling);
 
   sentryDelegate.mergeContext({extra: Object.assign({}, environmentData.extra, context)});
   return context;

--- a/lighthouse-core/report/v2/renderer/report-renderer.js
+++ b/lighthouse-core/report/v2/renderer/report-renderer.js
@@ -69,8 +69,6 @@ class ReportRenderer {
       const item = this._dom.cloneTemplate('#tmpl-lh-env__items', env);
       this._dom.find('.lh-env__name', item).textContent = runtime.name;
       this._dom.find('.lh-env__description', item).textContent = runtime.description;
-      this._dom.find('.lh-env__enabled', item).textContent =
-          runtime.enabled ? 'Enabled' : 'Disabled';
       env.appendChild(item);
     });
 

--- a/lighthouse-core/report/v2/templates.html
+++ b/lighthouse-core/report/v2/templates.html
@@ -338,9 +338,8 @@
               </li>
               <template id="tmpl-lh-env__items">
                 <li class="lh-env__item">
-                  <span class="lh-env__name"><!-- fill me --></span>
-                  <span class="lh-env__description"><!-- fill me --></span>:
-                  <b class="lh-env__enabled"><!-- fill me --></b>
+                  <span class="lh-env__name"><!-- fill me --></span>:
+                  <span class="lh-env__description"><!-- fill me --></span>
                 </li>
               </template>
             </ul>

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -389,21 +389,18 @@ class Runner {
    * @return {!Object} runtime config
    */
   static getRuntimeConfig(settings) {
-    const emulationDesc = emulation.getEmulationDesc();
+    const emulationDesc = emulation.getEmulationDesc(settings);
     const environment = [
       {
         name: 'Device Emulation',
-        enabled: !settings.disableDeviceEmulation,
         description: emulationDesc['deviceEmulation'],
       },
       {
         name: 'Network Throttling',
-        enabled: !settings.disableNetworkThrottling,
         description: emulationDesc['networkThrottling'],
       },
       {
         name: 'CPU Throttling',
-        enabled: !settings.disableCpuThrottling,
         description: emulationDesc['cpuThrottling'],
       },
     ];

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -134,8 +134,8 @@ describe('GatherRunner', function() {
       calledNetworkEmulation: false,
       calledCpuEmulation: false,
     };
-    const createEmulationCheck = variable => () => {
-      tests[variable] = true;
+    const createEmulationCheck = variable => (arg) => {
+      tests[variable] = arg;
 
       return true;
     };
@@ -149,7 +149,9 @@ describe('GatherRunner', function() {
       settings: {},
     }).then(_ => {
       assert.ok(tests.calledDeviceEmulation, 'did not call device emulation');
-      assert.ok(!tests.calledNetworkEmulation, 'called network emulation');
+      assert.deepEqual(tests.calledNetworkEmulation, {
+        latency: 0, downloadThroughput: 0, uploadThroughput: 0, offline: false,
+      });
       assert.ok(!tests.calledCpuEmulation, 'called cpu emulation');
     });
   });
@@ -205,7 +207,9 @@ describe('GatherRunner', function() {
       },
     }).then(_ => {
       assert.ok(tests.calledDeviceEmulation, 'did not call device emulation');
-      assert.ok(!tests.calledNetworkEmulation, 'called network emulation');
+      assert.deepEqual(tests.calledNetworkEmulation, [{
+        latency: 0, downloadThroughput: 0, uploadThroughput: 0, offline: false,
+      }]);
       assert.ok(!tests.calledCpuEmulation, 'called CPU emulation');
     });
   });
@@ -230,16 +234,16 @@ describe('GatherRunner', function() {
       settings: {
         throttlingMethod: 'devtools',
         throttling: {
-          requestLatency: 100,
-          downloadThroughput: 800,
-          uploadThroughput: 800,
+          requestLatencyMs: 100,
+          downloadThroughputKbps: 8,
+          uploadThroughputKbps: 8,
           cpuSlowdownMultiplier: 1,
         },
       },
     }).then(_ => {
       assert.ok(tests.calledDeviceEmulation, 'did not call device emulation');
       assert.deepEqual(tests.calledNetworkEmulation, [{
-        latency: 100, downloadThroughput: 100, uploadThroughput: 100, offline: false,
+        latency: 100, downloadThroughput: 1024, uploadThroughput: 1024, offline: false,
       }]);
       assert.deepEqual(tests.calledCpuEmulation, [{rate: 1}]);
     });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -61,7 +61,10 @@ describe('DependencyGraph/Simulator', () => {
       const cpuNode = new CpuNode(cpuTask({duration: 200}));
       cpuNode.addDependency(rootNode);
 
-      const simulator = new Simulator(rootNode, {serverResponseTimeByOrigin, cpuTaskMultiplier: 5});
+      const simulator = new Simulator(rootNode, {
+        serverResponseTimeByOrigin,
+        cpuSlowdownMultiplier: 5,
+      });
       const result = simulator.simulate();
       // should be 2 RTTs and 500ms for the server response time + 200 CPU
       assert.equal(result.timeInMs, 300 + 500 + 200);
@@ -99,7 +102,10 @@ describe('DependencyGraph/Simulator', () => {
       nodeA.addDependent(nodeC);
       nodeA.addDependent(nodeD);
 
-      const simulator = new Simulator(nodeA, {serverResponseTimeByOrigin, cpuTaskMultiplier: 5});
+      const simulator = new Simulator(nodeA, {
+        serverResponseTimeByOrigin,
+        cpuSlowdownMultiplier: 5,
+      });
       const result = simulator.simulate();
       // should be 800ms A, then 1000 ms total for B, C, D in serial
       assert.equal(result.timeInMs, 1800);
@@ -123,7 +129,10 @@ describe('DependencyGraph/Simulator', () => {
       nodeC.addDependent(nodeD);
       nodeC.addDependent(nodeF); // finishes 400 ms after D
 
-      const simulator = new Simulator(nodeA, {serverResponseTimeByOrigin, cpuTaskMultiplier: 5});
+      const simulator = new Simulator(nodeA, {
+        serverResponseTimeByOrigin,
+        cpuSlowdownMultiplier: 5,
+      });
       const result = simulator.simulate();
       // should be 800ms each for A, B, C, D, with F finishing 400 ms after D
       assert.equal(result.timeInMs, 3600);

--- a/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/v2/renderer/report-renderer-test.js
@@ -105,11 +105,9 @@ describe('ReportRenderer V2', () => {
       assert.equal(userAgent.textContent, sampleResults.userAgent, 'user agent populated');
 
       // Check runtime settings were populated.
-      const enables = header.querySelectorAll('.lh-env__enabled');
       const names = Array.from(header.querySelectorAll('.lh-env__name')).slice(1);
       const descriptions = header.querySelectorAll('.lh-env__description');
       sampleResults.runtimeConfig.environment.forEach((env, i) => {
-        assert.equal(enables[i].textContent, env.enabled ? 'Enabled' : 'Disabled');
         assert.equal(names[i].textContent, env.name);
         assert.equal(descriptions[i].textContent, env.description);
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "lighthouse-cli/**/*.js",
     "lighthouse-core/audits/audit.js",
     "lighthouse-core/lib/dependency-graph/**/*.js",
+    "lighthouse-core/lib/emulation.js",
     "lighthouse-core/gather/connections/**/*.js",
     "lighthouse-core/gather/gatherers/gatherer.js",
     "lighthouse-core/scripts/*.js",

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -10,6 +10,18 @@ declare global {
   module LH {
     export import Crdp = _Crdp;
 
+    interface ThrottlingSettings {
+      // simulation settings
+      rtt?: number;
+      throughput?: number;
+      // devtools settings
+      requestLatency?: number;
+      downloadThroughput?: number;
+      uploadThroughput?: number;
+      // used by both
+      cpuSlowdownMultiplier?: number
+    }
+
     interface SharedFlagsSettings {
       maxWaitForLoad?: number;
       blockedUrlPatterns?: string[];
@@ -18,8 +30,8 @@ declare global {
       gatherMode?: boolean | string;
       disableStorageReset?: boolean;
       disableDeviceEmulation?: boolean;
-      disableCpuThrottling?: boolean;
-      disableNetworkThrottling?: boolean;
+      throttlingMethod?: 'devtools'|'simulate'|'provided';
+      throttling?: ThrottlingSettings;
       onlyAudits?: string[];
       onlyCategories?: string[];
       skipAudits?: string[];

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -12,12 +12,12 @@ declare global {
 
     interface ThrottlingSettings {
       // simulation settings
-      rtt?: number;
-      throughput?: number;
+      rttMs?: number;
+      throughputKbps?: number;
       // devtools settings
-      requestLatency?: number;
-      downloadThroughput?: number;
-      uploadThroughput?: number;
+      requestLatencyMs?: number;
+      downloadThroughputKbps?: number;
+      uploadThroughputKbps?: number;
       // used by both
       cpuSlowdownMultiplier?: number
     }


### PR DESCRIPTION
ok followup to ongoing work for config settings, I had to draw the line somewhere to keep this reasonable size, so in this PR it simply removes the two flags and changes our existing logic to use the throttling object instead.

upcoming PRs will have the 'simulate' throttlingMethod to actually return simulated metrics, but already at this stage you can do awesome stuff like `lighthouse --throttling.requestLatency 2000` 😃 

I started to do the other constants cleanup here, but it started to balloon the PR

closes #4871 