### PR TITLE
report(helptext): fix typos

### DIFF
--- a/lighthouse-core/audits/accessibility/image-alt.js
+++ b/lighthouse-core/audits/accessibility/image-alt.js
@@ -22,7 +22,7 @@ class ImageAlt extends AxeAudit {
       description: 'Image elements have `[alt]` attributes',
       failureDescription: 'Image elements do not have `[alt]` attributes',
       helpText: 'Informative elements should aim for short, descriptive alternate text. ' +
-          'Decorative elements can be ignored with an empty alt attribute.' +
+          'Decorative elements can be ignored with an empty alt attribute. ' +
           '[Learn more](https://dequeuniversity.com/rules/axe/2.2/image-alt?application=lighthouse).',
       requiredArtifacts: ['Accessibility'],
     };

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -22,7 +22,7 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
       helpText: 'Remove unused rules from stylesheets to reduce unnecessary ' +
           'bytes consumed by network activity. ' +
-          '[Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery)',
+          '[Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery).',
       requiredArtifacts: ['CSSUsage', 'URL', 'devtoolsLogs'],
     };
   }

--- a/lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
+++ b/lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
@@ -17,7 +17,7 @@ class PasswordInputsCanBePastedIntoAudit extends Audit {
       description: 'Allows users to paste into password fields',
       failureDescription: 'Prevents users to paste into password fields',
       helpText: 'Preventing password pasting undermines good security policy. ' +
-          '[Learn more](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords)',
+          '[Learn more](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords).',
       requiredArtifacts: ['PasswordInputsWithPreventedPaste'],
     };
   }

--- a/lighthouse-core/audits/mainthread-work-breakdown.js
+++ b/lighthouse-core/audits/mainthread-work-breakdown.js
@@ -31,7 +31,7 @@ class MainThreadWorkBreakdown extends Audit {
       description: 'Minimizes main thread work',
       failureDescription: 'Has significant main thread work',
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
-      helpText: 'Consider reducing the time spent parsing, compiling and executing JS.' +
+      helpText: 'Consider reducing the time spent parsing, compiling and executing JS. ' +
         'You may find delivering smaller JS payloads helps with this.',
       requiredArtifacts: ['traces'],
     };

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -22,7 +22,7 @@ class UsesRelPreloadAudit extends Audit {
       description: 'Preload key requests',
       informative: true,
       helpText: 'Consider using <link rel=preload> to prioritize fetching late-discovered ' +
-        'resources sooner [Learn more](https://developers.google.com/web/updates/2016/03/link-rel-preload).',
+        'resources sooner. [Learn more](https://developers.google.com/web/updates/2016/03/link-rel-preload).',
       requiredArtifacts: ['devtoolsLogs', 'traces'],
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
     };

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -4081,7 +4081,7 @@
       "scoreDisplayMode": "binary",
       "name": "password-inputs-can-be-pasted-into",
       "description": "Prevents users to paste into password fields",
-      "helpText": "Preventing password pasting undermines good security policy. [Learn more](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords)",
+      "helpText": "Preventing password pasting undermines good security policy. [Learn more](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords).",
       "details": {
         "type": "table",
         "headings": [

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1007,7 +1007,7 @@
       "scoreDisplayMode": "numeric",
       "name": "mainthread-work-breakdown",
       "description": "Minimizes main thread work",
-      "helpText": "Consider reducing the time spent parsing, compiling and executing JS.You may find delivering smaller JS payloads helps with this.",
+      "helpText": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this.",
       "details": {
         "type": "table",
         "headings": [
@@ -1187,7 +1187,7 @@
       "informative": true,
       "name": "uses-rel-preload",
       "description": "Preload key requests",
-      "helpText": "Consider using <link rel=preload> to prioritize fetching late-discovered resources sooner [Learn more](https://developers.google.com/web/updates/2016/03/link-rel-preload).",
+      "helpText": "Consider using <link rel=preload> to prioritize fetching late-discovered resources sooner. [Learn more](https://developers.google.com/web/updates/2016/03/link-rel-preload).",
       "details": {
         "type": "table",
         "headings": [],
@@ -2010,7 +2010,7 @@
       "scoreDisplayMode": "binary",
       "name": "image-alt",
       "description": "Image elements do not have `[alt]` attributes",
-      "helpText": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute.[Learn more](https://dequeuniversity.com/rules/axe/2.2/image-alt?application=lighthouse).",
+      "helpText": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://dequeuniversity.com/rules/axe/2.2/image-alt?application=lighthouse).",
       "details": {
         "type": "table",
         "headings": [
@@ -2963,7 +2963,7 @@
       "informative": true,
       "name": "unused-css-rules",
       "description": "Unused CSS rules",
-      "helpText": "Remove unused rules from stylesheets to reduce unnecessary bytes consumed by network activity. [Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery)",
+      "helpText": "Remove unused rules from stylesheets to reduce unnecessary bytes consumed by network activity. [Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery).",
       "details": {
         "type": "table",
         "headings": [],


### PR DESCRIPTION
This PR fixes typos in `helpText`s:
* missing spaces between some sentences
* missing periods at the end of some sentences