### PR TITLE
core(tsc): add type checking to remote protocol commands

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -162,25 +162,6 @@ class Driver {
   }
 
   /**
-   * Call protocol methods
-   * @param {string} method
-   * @param {object=} params
-   * @param {{silent: boolean}=} cmdOpts
-   * @return {Promise<any>}
-   */
-  sendCommand(method, params, cmdOpts) {
-    const domainCommand = /^(\w+)\.(enable|disable)$/.exec(method);
-    if (domainCommand) {
-      const enable = domainCommand[2] === 'enable';
-      if (!this._shouldToggleDomain(domainCommand[1], enable)) {
-        return Promise.resolve();
-      }
-    }
-
-    return this._connection.sendCommand(method, params, cmdOpts);
-  }
-
-  /**
    * Returns whether a domain is currently enabled.
    * @param {string} domain
    * @return {boolean}
@@ -276,7 +257,7 @@ class Driver {
   }
 
   /**
-   * @return {Promise<LH.Crdp.Page.GetAppManifestResponse>}
+   * @return {Promise<?LH.Crdp.Page.GetAppManifestResponse>}
    */
   getAppManifest() {
     return this.sendCommand('Page.getAppManifest')
@@ -656,11 +637,9 @@ class Driver {
       return this._isolatedExecutionContextId;
     }
 
-    /** @type {LH.Crdp.Page.GetResourceTreeResponse} */
     const resourceTreeResponse = await this.sendCommand('Page.getResourceTree');
     const mainFrameId = resourceTreeResponse.frameTree.frame.id;
 
-    /** @type {LH.Crdp.Page.CreateIsolatedWorldResponse} */
     const isolatedWorldResponse = await this.sendCommand('Page.createIsolatedWorld', {
       frameId: mainFrameId,
       worldName: 'lighthouse_isolated_context',
@@ -725,7 +704,6 @@ class Driver {
    * @return {Promise<string|null>} The property value, or null, if property not found
   */
   async getObjectProperty(objectId, propName) {
-    /** @type {LH.Crdp.Runtime.GetPropertiesResponse} */
     const propertiesResponse = await this.sendCommand('Runtime.getProperties', {
       objectId,
       accessorPropertiesOnly: true,
@@ -760,7 +738,7 @@ class Driver {
       this.sendCommand('Network.getResponseBody', {requestId}).then(result => {
         clearTimeout(asyncTimeout);
         // Ignoring result.base64Encoded, which indicates if body is already encoded
-        resolve(/** @type {LH.Crdp.Network.GetResponseBodyResponse} */(result).body);
+        resolve(result.body);
       }).catch(e => {
         clearTimeout(asyncTimeout);
         reject(e);
@@ -788,11 +766,9 @@ class Driver {
    * @return {Promise<Element|null>} The found element, or null, resolved in a promise
    */
   async querySelector(selector) {
-    /** @type {LH.Crdp.DOM.GetDocumentResponse} */
-    const documentResponse = await this.sendCommand('DOM.getDocument');
+    const documentResponse = await this.sendCommand('DOM.getDocument', {});
     const rootNodeId = documentResponse.root.nodeId;
 
-    /** @type {LH.Crdp.DOM.QuerySelectorResponse} */
     const targetNode = await this.sendCommand('DOM.querySelector', {
       nodeId: rootNodeId,
       selector,
@@ -809,11 +785,9 @@ class Driver {
    * @return {Promise<Array<Element>>} The found elements, or [], resolved in a promise
    */
   async querySelectorAll(selector) {
-    /** @type {LH.Crdp.DOM.GetDocumentResponse} */
-    const documentResponse = await this.sendCommand('DOM.getDocument');
+    const documentResponse = await this.sendCommand('DOM.getDocument', {});
     const rootNodeId = documentResponse.root.nodeId;
 
-    /** @type {LH.Crdp.DOM.QuerySelectorAllResponse} */
     const targetNodeList = await this.sendCommand('DOM.querySelectorAll', {
       nodeId: rootNodeId,
       selector,
@@ -850,7 +824,6 @@ class Driver {
    * @return {Promise<Array<LH.Crdp.DOM.Node>>} The found nodes, or [], resolved in a promise
    */
   async getNodesInDocument(pierce = true) {
-    /** @type {LH.Crdp.DOM.GetFlattenedDocumentResponse} */
     const flattenedDocument = await this.sendCommand('DOM.getFlattenedDocument',
         {depth: -1, pierce});
 
@@ -866,11 +839,6 @@ class Driver {
         settings.additionalTraceCategories.split(',')) || [];
     const traceCategories = this._traceCategories.concat(additionalCategories);
     const uniqueCategories = Array.from(new Set(traceCategories));
-    const tracingOpts = {
-      categories: uniqueCategories.join(','),
-      transferMode: 'ReturnAsStream',
-      options: 'sampling-frequency=10000', // 1000 is default and too slow.
-    };
 
     // Check any domains that could interfere with or add overhead to the trace.
     if (this.isDomainEnabled('Debugger')) {
@@ -888,7 +856,11 @@ class Driver {
       // ensure tracing is stopped before we can start
       // see https://github.com/GoogleChrome/lighthouse/issues/1091
       .then(_ => this.endTraceIfStarted())
-      .then(_ => this.sendCommand('Tracing.start', tracingOpts));
+      .then(_ => this.sendCommand('Tracing.start', {
+        categories: uniqueCategories.join(','),
+        transferMode: 'ReturnAsStream',
+        options: 'sampling-frequency=10000', // 1000 is default and too slow.
+      }));
   }
 
   /**
@@ -928,6 +900,10 @@ class Driver {
     return new Promise((resolve, reject) => {
       let isEOF = false;
       const parser = new TraceParser();
+
+      if (!traceCompleteEvent.stream) {
+        return reject('No streamHandle returned by traceCompleteEvent');
+      }
 
       const readArguments = {
         handle: traceCompleteEvent.stream,
@@ -1210,5 +1186,37 @@ Driver.prototype.off = function off(eventName, cb) {
 
   this._eventEmitter.removeListener(eventName, cb);
 };
+
+/** @typedef {LH.CrdpCommands[keyof LH.CrdpCommands]['returnType']} CommandReturnTypes */
+
+/**
+ * Loosely-typed internal implementation of `Driver.sendCommand` which is
+ * strictly typed externally on exposed Driver interface. Type tightening occurs
+ * when assigned to `Driver.prototype` below and typed with
+ * `LH.Protocol.SendCommand`.
+ * Necessitated by `params` only being optional for some values of `method`.
+ * See https://github.com/Microsoft/TypeScript/issues/5453 for needed variadic
+ * primitive.
+ * @type {(this: Driver, method: any, params?: any, cmdOpts?: {silent?: boolean}) => Promise<CommandReturnTypes>}
+ */
+function _sendCommand(method, params = {}, cmdOpts = {}) {
+  const domainCommand = /^(\w+)\.(enable|disable)$/.exec(method);
+  if (domainCommand) {
+    const enable = domainCommand[2] === 'enable';
+    // eslint-disable-next-line no-invalid-this
+    if (!this._shouldToggleDomain(domainCommand[1], enable)) {
+      return Promise.resolve();
+    }
+  }
+
+  // eslint-disable-next-line no-invalid-this
+  return this._connection.sendCommand(method, params, cmdOpts);
+}
+
+/**
+ * Call protocol methods.
+ * @type {LH.Protocol.SendCommand}
+ */
+Driver.prototype.sendCommand = _sendCommand;
 
 module.exports = Driver;

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -766,7 +766,7 @@ class Driver {
    * @return {Promise<Element|null>} The found element, or null, resolved in a promise
    */
   async querySelector(selector) {
-    const documentResponse = await this.sendCommand('DOM.getDocument', {});
+    const documentResponse = await this.sendCommand('DOM.getDocument');
     const rootNodeId = documentResponse.root.nodeId;
 
     const targetNode = await this.sendCommand('DOM.querySelector', {
@@ -785,7 +785,7 @@ class Driver {
    * @return {Promise<Array<Element>>} The found elements, or [], resolved in a promise
    */
   async querySelectorAll(selector) {
-    const documentResponse = await this.sendCommand('DOM.getDocument', {});
+    const documentResponse = await this.sendCommand('DOM.getDocument');
     const rootNodeId = documentResponse.root.nodeId;
 
     const targetNodeList = await this.sendCommand('DOM.querySelectorAll', {

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -11,6 +11,7 @@ const NBSP = '\xa0';
 
 /**
  * Nexus 5X metrics adapted from emulated_devices/module.json
+ * @type {LH.Crdp.Emulation.SetDeviceMetricsOverrideRequest}
  */
 const NEXUS5X_EMULATION_METRICS = {
   mobile: true,
@@ -22,7 +23,6 @@ const NEXUS5X_EMULATION_METRICS = {
   positionY: 0,
   scale: 1,
   deviceScaleFactor: 2.625,
-  fitWindow: false,
   screenOrientation: {
     angle: 0,
     type: 'portraitPrimary',
@@ -86,7 +86,7 @@ function enableNexus5X(driver) {
     // Network.enable must be called for UA overriding to work
     driver.sendCommand('Network.enable'),
     driver.sendCommand('Network.setUserAgentOverride', NEXUS5X_USERAGENT),
-    driver.sendCommand('Emulation.setTouchEmulationEnabled', {
+    driver.sendCommand('Page.setTouchEmulationEnabled', {
       enabled: true,
       configuration: 'mobile',
     }),
@@ -145,7 +145,8 @@ function goOffline(driver) {
  * @return {Promise<void>}
  */
 function enableCPUThrottling(driver, throttlingSettings) {
-  const rate = throttlingSettings
+  // TODO: cpuSlowdownMultiplier should be a required property by this point
+  const rate = throttlingSettings && throttlingSettings.cpuSlowdownMultiplier !== undefined
     ? throttlingSettings.cpuSlowdownMultiplier
     : CPU_THROTTLE_METRICS.rate;
   return driver.sendCommand('Emulation.setCPUThrottlingRate', {rate});

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -86,7 +86,7 @@ function enableNexus5X(driver) {
     // Network.enable must be called for UA overriding to work
     driver.sendCommand('Network.enable'),
     driver.sendCommand('Network.setUserAgentOverride', NEXUS5X_USERAGENT),
-    driver.sendCommand('Page.setTouchEmulationEnabled', {
+    driver.sendCommand('Emulation.setEmitTouchEventsForMouse', {
       enabled: true,
       configuration: 'mobile',
     }),

--- a/lighthouse-core/lib/errors.js
+++ b/lighthouse-core/lib/errors.js
@@ -39,7 +39,7 @@ class LighthouseError extends Error {
 
   /**
    * @param {string} method
-   * @param {{message: string, data: string|undefined}} protocolError
+   * @param {{message: string, data?: string|undefined}} protocolError
    * @return {!Error|LighthouseError}
    */
   static fromProtocolMessage(method, protocolError) {

--- a/typings/crdp-mapping.d.ts
+++ b/typings/crdp-mapping.d.ts
@@ -126,6 +126,1493 @@ declare global {
       'Tracing.dataCollected': Crdp.Tracing.DataCollectedEvent;
       'Tracing.tracingComplete': Crdp.Tracing.TracingCompleteEvent;
     }
+
+    export interface CrdpCommands {
+      'Console.clearMessages': {
+        paramsType: void,
+        returnType: void
+      };
+      'Console.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Console.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Debugger.continueToLocation': {
+        paramsType: Crdp.Debugger.ContinueToLocationRequest,
+        returnType: void
+      };
+      'Debugger.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Debugger.enable': {
+        paramsType: void,
+        returnType: Crdp.Debugger.EnableResponse
+      };
+      'Debugger.evaluateOnCallFrame': {
+        paramsType: Crdp.Debugger.EvaluateOnCallFrameRequest,
+        returnType: Crdp.Debugger.EvaluateOnCallFrameResponse
+      };
+      'Debugger.getPossibleBreakpoints': {
+        paramsType: Crdp.Debugger.GetPossibleBreakpointsRequest,
+        returnType: Crdp.Debugger.GetPossibleBreakpointsResponse
+      };
+      'Debugger.getScriptSource': {
+        paramsType: Crdp.Debugger.GetScriptSourceRequest,
+        returnType: Crdp.Debugger.GetScriptSourceResponse
+      };
+      'Debugger.getStackTrace': {
+        paramsType: Crdp.Debugger.GetStackTraceRequest,
+        returnType: Crdp.Debugger.GetStackTraceResponse
+      };
+      'Debugger.pause': {
+        paramsType: void,
+        returnType: void
+      };
+      'Debugger.pauseOnAsyncCall': {
+        paramsType: Crdp.Debugger.PauseOnAsyncCallRequest,
+        returnType: void
+      };
+      'Debugger.removeBreakpoint': {
+        paramsType: Crdp.Debugger.RemoveBreakpointRequest,
+        returnType: void
+      };
+      'Debugger.restartFrame': {
+        paramsType: Crdp.Debugger.RestartFrameRequest,
+        returnType: Crdp.Debugger.RestartFrameResponse
+      };
+      'Debugger.resume': {
+        paramsType: void,
+        returnType: void
+      };
+      'Debugger.scheduleStepIntoAsync': {
+        paramsType: void,
+        returnType: void
+      };
+      'Debugger.searchInContent': {
+        paramsType: Crdp.Debugger.SearchInContentRequest,
+        returnType: Crdp.Debugger.SearchInContentResponse
+      };
+      'Debugger.setAsyncCallStackDepth': {
+        paramsType: Crdp.Debugger.SetAsyncCallStackDepthRequest,
+        returnType: void
+      };
+      'Debugger.setBlackboxPatterns': {
+        paramsType: Crdp.Debugger.SetBlackboxPatternsRequest,
+        returnType: void
+      };
+      'Debugger.setBlackboxedRanges': {
+        paramsType: Crdp.Debugger.SetBlackboxedRangesRequest,
+        returnType: void
+      };
+      'Debugger.setBreakpoint': {
+        paramsType: Crdp.Debugger.SetBreakpointRequest,
+        returnType: Crdp.Debugger.SetBreakpointResponse
+      };
+      'Debugger.setBreakpointByUrl': {
+        paramsType: Crdp.Debugger.SetBreakpointByUrlRequest,
+        returnType: Crdp.Debugger.SetBreakpointByUrlResponse
+      };
+      'Debugger.setBreakpointsActive': {
+        paramsType: Crdp.Debugger.SetBreakpointsActiveRequest,
+        returnType: void
+      };
+      'Debugger.setPauseOnExceptions': {
+        paramsType: Crdp.Debugger.SetPauseOnExceptionsRequest,
+        returnType: void
+      };
+      'Debugger.setReturnValue': {
+        paramsType: Crdp.Debugger.SetReturnValueRequest,
+        returnType: void
+      };
+      'Debugger.setScriptSource': {
+        paramsType: Crdp.Debugger.SetScriptSourceRequest,
+        returnType: Crdp.Debugger.SetScriptSourceResponse
+      };
+      'Debugger.setSkipAllPauses': {
+        paramsType: Crdp.Debugger.SetSkipAllPausesRequest,
+        returnType: void
+      };
+      'Debugger.setVariableValue': {
+        paramsType: Crdp.Debugger.SetVariableValueRequest,
+        returnType: void
+      };
+      'Debugger.stepInto': {
+        paramsType: void | Crdp.Debugger.StepIntoRequest,
+        returnType: void
+      };
+      'Debugger.stepOut': {
+        paramsType: void,
+        returnType: void
+      };
+      'Debugger.stepOver': {
+        paramsType: void,
+        returnType: void
+      };
+      'HeapProfiler.addInspectedHeapObject': {
+        paramsType: Crdp.HeapProfiler.AddInspectedHeapObjectRequest,
+        returnType: void
+      };
+      'HeapProfiler.collectGarbage': {
+        paramsType: void,
+        returnType: void
+      };
+      'HeapProfiler.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'HeapProfiler.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'HeapProfiler.getHeapObjectId': {
+        paramsType: Crdp.HeapProfiler.GetHeapObjectIdRequest,
+        returnType: Crdp.HeapProfiler.GetHeapObjectIdResponse
+      };
+      'HeapProfiler.getObjectByHeapObjectId': {
+        paramsType: Crdp.HeapProfiler.GetObjectByHeapObjectIdRequest,
+        returnType: Crdp.HeapProfiler.GetObjectByHeapObjectIdResponse
+      };
+      'HeapProfiler.getSamplingProfile': {
+        paramsType: void,
+        returnType: Crdp.HeapProfiler.GetSamplingProfileResponse
+      };
+      'HeapProfiler.startSampling': {
+        paramsType: void | Crdp.HeapProfiler.StartSamplingRequest,
+        returnType: void
+      };
+      'HeapProfiler.startTrackingHeapObjects': {
+        paramsType: void | Crdp.HeapProfiler.StartTrackingHeapObjectsRequest,
+        returnType: void
+      };
+      'HeapProfiler.stopSampling': {
+        paramsType: void,
+        returnType: Crdp.HeapProfiler.StopSamplingResponse
+      };
+      'HeapProfiler.stopTrackingHeapObjects': {
+        paramsType: void | Crdp.HeapProfiler.StopTrackingHeapObjectsRequest,
+        returnType: void
+      };
+      'HeapProfiler.takeHeapSnapshot': {
+        paramsType: void | Crdp.HeapProfiler.TakeHeapSnapshotRequest,
+        returnType: void
+      };
+      'Profiler.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Profiler.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Profiler.getBestEffortCoverage': {
+        paramsType: void,
+        returnType: Crdp.Profiler.GetBestEffortCoverageResponse
+      };
+      'Profiler.setSamplingInterval': {
+        paramsType: Crdp.Profiler.SetSamplingIntervalRequest,
+        returnType: void
+      };
+      'Profiler.start': {
+        paramsType: void,
+        returnType: void
+      };
+      'Profiler.startPreciseCoverage': {
+        paramsType: void | Crdp.Profiler.StartPreciseCoverageRequest,
+        returnType: void
+      };
+      'Profiler.startTypeProfile': {
+        paramsType: void,
+        returnType: void
+      };
+      'Profiler.stop': {
+        paramsType: void,
+        returnType: Crdp.Profiler.StopResponse
+      };
+      'Profiler.stopPreciseCoverage': {
+        paramsType: void,
+        returnType: void
+      };
+      'Profiler.stopTypeProfile': {
+        paramsType: void,
+        returnType: void
+      };
+      'Profiler.takePreciseCoverage': {
+        paramsType: void,
+        returnType: Crdp.Profiler.TakePreciseCoverageResponse
+      };
+      'Profiler.takeTypeProfile': {
+        paramsType: void,
+        returnType: Crdp.Profiler.TakeTypeProfileResponse
+      };
+      'Runtime.awaitPromise': {
+        paramsType: Crdp.Runtime.AwaitPromiseRequest,
+        returnType: Crdp.Runtime.AwaitPromiseResponse
+      };
+      'Runtime.callFunctionOn': {
+        paramsType: Crdp.Runtime.CallFunctionOnRequest,
+        returnType: Crdp.Runtime.CallFunctionOnResponse
+      };
+      'Runtime.compileScript': {
+        paramsType: Crdp.Runtime.CompileScriptRequest,
+        returnType: Crdp.Runtime.CompileScriptResponse
+      };
+      'Runtime.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Runtime.discardConsoleEntries': {
+        paramsType: void,
+        returnType: void
+      };
+      'Runtime.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Runtime.evaluate': {
+        paramsType: Crdp.Runtime.EvaluateRequest,
+        returnType: Crdp.Runtime.EvaluateResponse
+      };
+      'Runtime.getProperties': {
+        paramsType: Crdp.Runtime.GetPropertiesRequest,
+        returnType: Crdp.Runtime.GetPropertiesResponse
+      };
+      'Runtime.globalLexicalScopeNames': {
+        paramsType: void | Crdp.Runtime.GlobalLexicalScopeNamesRequest,
+        returnType: Crdp.Runtime.GlobalLexicalScopeNamesResponse
+      };
+      'Runtime.queryObjects': {
+        paramsType: Crdp.Runtime.QueryObjectsRequest,
+        returnType: Crdp.Runtime.QueryObjectsResponse
+      };
+      'Runtime.releaseObject': {
+        paramsType: Crdp.Runtime.ReleaseObjectRequest,
+        returnType: void
+      };
+      'Runtime.releaseObjectGroup': {
+        paramsType: Crdp.Runtime.ReleaseObjectGroupRequest,
+        returnType: void
+      };
+      'Runtime.runIfWaitingForDebugger': {
+        paramsType: void,
+        returnType: void
+      };
+      'Runtime.runScript': {
+        paramsType: Crdp.Runtime.RunScriptRequest,
+        returnType: Crdp.Runtime.RunScriptResponse
+      };
+      'Runtime.setCustomObjectFormatterEnabled': {
+        paramsType: Crdp.Runtime.SetCustomObjectFormatterEnabledRequest,
+        returnType: void
+      };
+      'Schema.getDomains': {
+        paramsType: void,
+        returnType: Crdp.Schema.GetDomainsResponse
+      };
+      'Accessibility.getPartialAXTree': {
+        paramsType: Crdp.Accessibility.GetPartialAXTreeRequest,
+        returnType: Crdp.Accessibility.GetPartialAXTreeResponse
+      };
+      'Animation.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Animation.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Animation.getCurrentTime': {
+        paramsType: Crdp.Animation.GetCurrentTimeRequest,
+        returnType: Crdp.Animation.GetCurrentTimeResponse
+      };
+      'Animation.getPlaybackRate': {
+        paramsType: void,
+        returnType: Crdp.Animation.GetPlaybackRateResponse
+      };
+      'Animation.releaseAnimations': {
+        paramsType: Crdp.Animation.ReleaseAnimationsRequest,
+        returnType: void
+      };
+      'Animation.resolveAnimation': {
+        paramsType: Crdp.Animation.ResolveAnimationRequest,
+        returnType: Crdp.Animation.ResolveAnimationResponse
+      };
+      'Animation.seekAnimations': {
+        paramsType: Crdp.Animation.SeekAnimationsRequest,
+        returnType: void
+      };
+      'Animation.setPaused': {
+        paramsType: Crdp.Animation.SetPausedRequest,
+        returnType: void
+      };
+      'Animation.setPlaybackRate': {
+        paramsType: Crdp.Animation.SetPlaybackRateRequest,
+        returnType: void
+      };
+      'Animation.setTiming': {
+        paramsType: Crdp.Animation.SetTimingRequest,
+        returnType: void
+      };
+      'ApplicationCache.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'ApplicationCache.getApplicationCacheForFrame': {
+        paramsType: Crdp.ApplicationCache.GetApplicationCacheForFrameRequest,
+        returnType: Crdp.ApplicationCache.GetApplicationCacheForFrameResponse
+      };
+      'ApplicationCache.getFramesWithManifests': {
+        paramsType: void,
+        returnType: Crdp.ApplicationCache.GetFramesWithManifestsResponse
+      };
+      'ApplicationCache.getManifestForFrame': {
+        paramsType: Crdp.ApplicationCache.GetManifestForFrameRequest,
+        returnType: Crdp.ApplicationCache.GetManifestForFrameResponse
+      };
+      'Audits.getEncodedResponse': {
+        paramsType: Crdp.Audits.GetEncodedResponseRequest,
+        returnType: Crdp.Audits.GetEncodedResponseResponse
+      };
+      'Browser.close': {
+        paramsType: void,
+        returnType: void
+      };
+      'Browser.getVersion': {
+        paramsType: void,
+        returnType: Crdp.Browser.GetVersionResponse
+      };
+      'Browser.getHistograms': {
+        paramsType: void | Crdp.Browser.GetHistogramsRequest,
+        returnType: Crdp.Browser.GetHistogramsResponse
+      };
+      'Browser.getHistogram': {
+        paramsType: Crdp.Browser.GetHistogramRequest,
+        returnType: Crdp.Browser.GetHistogramResponse
+      };
+      'Browser.getWindowBounds': {
+        paramsType: Crdp.Browser.GetWindowBoundsRequest,
+        returnType: Crdp.Browser.GetWindowBoundsResponse
+      };
+      'Browser.getWindowForTarget': {
+        paramsType: Crdp.Browser.GetWindowForTargetRequest,
+        returnType: Crdp.Browser.GetWindowForTargetResponse
+      };
+      'Browser.setWindowBounds': {
+        paramsType: Crdp.Browser.SetWindowBoundsRequest,
+        returnType: void
+      };
+      'CSS.addRule': {
+        paramsType: Crdp.CSS.AddRuleRequest,
+        returnType: Crdp.CSS.AddRuleResponse
+      };
+      'CSS.collectClassNames': {
+        paramsType: Crdp.CSS.CollectClassNamesRequest,
+        returnType: Crdp.CSS.CollectClassNamesResponse
+      };
+      'CSS.createStyleSheet': {
+        paramsType: Crdp.CSS.CreateStyleSheetRequest,
+        returnType: Crdp.CSS.CreateStyleSheetResponse
+      };
+      'CSS.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'CSS.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'CSS.forcePseudoState': {
+        paramsType: Crdp.CSS.ForcePseudoStateRequest,
+        returnType: void
+      };
+      'CSS.getBackgroundColors': {
+        paramsType: Crdp.CSS.GetBackgroundColorsRequest,
+        returnType: Crdp.CSS.GetBackgroundColorsResponse
+      };
+      'CSS.getComputedStyleForNode': {
+        paramsType: Crdp.CSS.GetComputedStyleForNodeRequest,
+        returnType: Crdp.CSS.GetComputedStyleForNodeResponse
+      };
+      'CSS.getInlineStylesForNode': {
+        paramsType: Crdp.CSS.GetInlineStylesForNodeRequest,
+        returnType: Crdp.CSS.GetInlineStylesForNodeResponse
+      };
+      'CSS.getMatchedStylesForNode': {
+        paramsType: Crdp.CSS.GetMatchedStylesForNodeRequest,
+        returnType: Crdp.CSS.GetMatchedStylesForNodeResponse
+      };
+      'CSS.getMediaQueries': {
+        paramsType: void,
+        returnType: Crdp.CSS.GetMediaQueriesResponse
+      };
+      'CSS.getPlatformFontsForNode': {
+        paramsType: Crdp.CSS.GetPlatformFontsForNodeRequest,
+        returnType: Crdp.CSS.GetPlatformFontsForNodeResponse
+      };
+      'CSS.getStyleSheetText': {
+        paramsType: Crdp.CSS.GetStyleSheetTextRequest,
+        returnType: Crdp.CSS.GetStyleSheetTextResponse
+      };
+      'CSS.setEffectivePropertyValueForNode': {
+        paramsType: Crdp.CSS.SetEffectivePropertyValueForNodeRequest,
+        returnType: void
+      };
+      'CSS.setKeyframeKey': {
+        paramsType: Crdp.CSS.SetKeyframeKeyRequest,
+        returnType: Crdp.CSS.SetKeyframeKeyResponse
+      };
+      'CSS.setMediaText': {
+        paramsType: Crdp.CSS.SetMediaTextRequest,
+        returnType: Crdp.CSS.SetMediaTextResponse
+      };
+      'CSS.setRuleSelector': {
+        paramsType: Crdp.CSS.SetRuleSelectorRequest,
+        returnType: Crdp.CSS.SetRuleSelectorResponse
+      };
+      'CSS.setStyleSheetText': {
+        paramsType: Crdp.CSS.SetStyleSheetTextRequest,
+        returnType: Crdp.CSS.SetStyleSheetTextResponse
+      };
+      'CSS.setStyleTexts': {
+        paramsType: Crdp.CSS.SetStyleTextsRequest,
+        returnType: Crdp.CSS.SetStyleTextsResponse
+      };
+      'CSS.startRuleUsageTracking': {
+        paramsType: void,
+        returnType: void
+      };
+      'CSS.stopRuleUsageTracking': {
+        paramsType: void,
+        returnType: Crdp.CSS.StopRuleUsageTrackingResponse
+      };
+      'CSS.takeCoverageDelta': {
+        paramsType: void,
+        returnType: Crdp.CSS.TakeCoverageDeltaResponse
+      };
+      'CacheStorage.deleteCache': {
+        paramsType: Crdp.CacheStorage.DeleteCacheRequest,
+        returnType: void
+      };
+      'CacheStorage.deleteEntry': {
+        paramsType: Crdp.CacheStorage.DeleteEntryRequest,
+        returnType: void
+      };
+      'CacheStorage.requestCacheNames': {
+        paramsType: Crdp.CacheStorage.RequestCacheNamesRequest,
+        returnType: Crdp.CacheStorage.RequestCacheNamesResponse
+      };
+      'CacheStorage.requestCachedResponse': {
+        paramsType: Crdp.CacheStorage.RequestCachedResponseRequest,
+        returnType: Crdp.CacheStorage.RequestCachedResponseResponse
+      };
+      'CacheStorage.requestEntries': {
+        paramsType: Crdp.CacheStorage.RequestEntriesRequest,
+        returnType: Crdp.CacheStorage.RequestEntriesResponse
+      };
+      'DOM.collectClassNamesFromSubtree': {
+        paramsType: Crdp.DOM.CollectClassNamesFromSubtreeRequest,
+        returnType: Crdp.DOM.CollectClassNamesFromSubtreeResponse
+      };
+      'DOM.copyTo': {
+        paramsType: Crdp.DOM.CopyToRequest,
+        returnType: Crdp.DOM.CopyToResponse
+      };
+      'DOM.describeNode': {
+        paramsType: void | Crdp.DOM.DescribeNodeRequest,
+        returnType: Crdp.DOM.DescribeNodeResponse
+      };
+      'DOM.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOM.discardSearchResults': {
+        paramsType: Crdp.DOM.DiscardSearchResultsRequest,
+        returnType: void
+      };
+      'DOM.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOM.focus': {
+        paramsType: void | Crdp.DOM.FocusRequest,
+        returnType: void
+      };
+      'DOM.getAttributes': {
+        paramsType: Crdp.DOM.GetAttributesRequest,
+        returnType: Crdp.DOM.GetAttributesResponse
+      };
+      'DOM.getBoxModel': {
+        paramsType: void | Crdp.DOM.GetBoxModelRequest,
+        returnType: Crdp.DOM.GetBoxModelResponse
+      };
+      'DOM.getDocument': {
+        paramsType: void | Crdp.DOM.GetDocumentRequest,
+        returnType: Crdp.DOM.GetDocumentResponse
+      };
+      'DOM.getFlattenedDocument': {
+        paramsType: void | Crdp.DOM.GetFlattenedDocumentRequest,
+        returnType: Crdp.DOM.GetFlattenedDocumentResponse
+      };
+      'DOM.getNodeForLocation': {
+        paramsType: Crdp.DOM.GetNodeForLocationRequest,
+        returnType: Crdp.DOM.GetNodeForLocationResponse
+      };
+      'DOM.getOuterHTML': {
+        paramsType: void | Crdp.DOM.GetOuterHTMLRequest,
+        returnType: Crdp.DOM.GetOuterHTMLResponse
+      };
+      'DOM.getRelayoutBoundary': {
+        paramsType: Crdp.DOM.GetRelayoutBoundaryRequest,
+        returnType: Crdp.DOM.GetRelayoutBoundaryResponse
+      };
+      'DOM.getSearchResults': {
+        paramsType: Crdp.DOM.GetSearchResultsRequest,
+        returnType: Crdp.DOM.GetSearchResultsResponse
+      };
+      'DOM.hideHighlight': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOM.highlightNode': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOM.highlightRect': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOM.markUndoableState': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOM.moveTo': {
+        paramsType: Crdp.DOM.MoveToRequest,
+        returnType: Crdp.DOM.MoveToResponse
+      };
+      'DOM.performSearch': {
+        paramsType: Crdp.DOM.PerformSearchRequest,
+        returnType: Crdp.DOM.PerformSearchResponse
+      };
+      'DOM.pushNodeByPathToFrontend': {
+        paramsType: Crdp.DOM.PushNodeByPathToFrontendRequest,
+        returnType: Crdp.DOM.PushNodeByPathToFrontendResponse
+      };
+      'DOM.pushNodesByBackendIdsToFrontend': {
+        paramsType: Crdp.DOM.PushNodesByBackendIdsToFrontendRequest,
+        returnType: Crdp.DOM.PushNodesByBackendIdsToFrontendResponse
+      };
+      'DOM.querySelector': {
+        paramsType: Crdp.DOM.QuerySelectorRequest,
+        returnType: Crdp.DOM.QuerySelectorResponse
+      };
+      'DOM.querySelectorAll': {
+        paramsType: Crdp.DOM.QuerySelectorAllRequest,
+        returnType: Crdp.DOM.QuerySelectorAllResponse
+      };
+      'DOM.redo': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOM.removeAttribute': {
+        paramsType: Crdp.DOM.RemoveAttributeRequest,
+        returnType: void
+      };
+      'DOM.removeNode': {
+        paramsType: Crdp.DOM.RemoveNodeRequest,
+        returnType: void
+      };
+      'DOM.requestChildNodes': {
+        paramsType: Crdp.DOM.RequestChildNodesRequest,
+        returnType: void
+      };
+      'DOM.requestNode': {
+        paramsType: Crdp.DOM.RequestNodeRequest,
+        returnType: Crdp.DOM.RequestNodeResponse
+      };
+      'DOM.resolveNode': {
+        paramsType: void | Crdp.DOM.ResolveNodeRequest,
+        returnType: Crdp.DOM.ResolveNodeResponse
+      };
+      'DOM.setAttributeValue': {
+        paramsType: Crdp.DOM.SetAttributeValueRequest,
+        returnType: void
+      };
+      'DOM.setAttributesAsText': {
+        paramsType: Crdp.DOM.SetAttributesAsTextRequest,
+        returnType: void
+      };
+      'DOM.setFileInputFiles': {
+        paramsType: Crdp.DOM.SetFileInputFilesRequest,
+        returnType: void
+      };
+      'DOM.setInspectedNode': {
+        paramsType: Crdp.DOM.SetInspectedNodeRequest,
+        returnType: void
+      };
+      'DOM.setNodeName': {
+        paramsType: Crdp.DOM.SetNodeNameRequest,
+        returnType: Crdp.DOM.SetNodeNameResponse
+      };
+      'DOM.setNodeValue': {
+        paramsType: Crdp.DOM.SetNodeValueRequest,
+        returnType: void
+      };
+      'DOM.setOuterHTML': {
+        paramsType: Crdp.DOM.SetOuterHTMLRequest,
+        returnType: void
+      };
+      'DOM.undo': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOMDebugger.getEventListeners': {
+        paramsType: Crdp.DOMDebugger.GetEventListenersRequest,
+        returnType: Crdp.DOMDebugger.GetEventListenersResponse
+      };
+      'DOMDebugger.removeDOMBreakpoint': {
+        paramsType: Crdp.DOMDebugger.RemoveDOMBreakpointRequest,
+        returnType: void
+      };
+      'DOMDebugger.removeEventListenerBreakpoint': {
+        paramsType: Crdp.DOMDebugger.RemoveEventListenerBreakpointRequest,
+        returnType: void
+      };
+      'DOMDebugger.removeInstrumentationBreakpoint': {
+        paramsType: Crdp.DOMDebugger.RemoveInstrumentationBreakpointRequest,
+        returnType: void
+      };
+      'DOMDebugger.removeXHRBreakpoint': {
+        paramsType: Crdp.DOMDebugger.RemoveXHRBreakpointRequest,
+        returnType: void
+      };
+      'DOMDebugger.setDOMBreakpoint': {
+        paramsType: Crdp.DOMDebugger.SetDOMBreakpointRequest,
+        returnType: void
+      };
+      'DOMDebugger.setEventListenerBreakpoint': {
+        paramsType: Crdp.DOMDebugger.SetEventListenerBreakpointRequest,
+        returnType: void
+      };
+      'DOMDebugger.setInstrumentationBreakpoint': {
+        paramsType: Crdp.DOMDebugger.SetInstrumentationBreakpointRequest,
+        returnType: void
+      };
+      'DOMDebugger.setXHRBreakpoint': {
+        paramsType: Crdp.DOMDebugger.SetXHRBreakpointRequest,
+        returnType: void
+      };
+      'DOMSnapshot.getSnapshot': {
+        paramsType: Crdp.DOMSnapshot.GetSnapshotRequest,
+        returnType: Crdp.DOMSnapshot.GetSnapshotResponse
+      };
+      'DOMStorage.clear': {
+        paramsType: Crdp.DOMStorage.ClearRequest,
+        returnType: void
+      };
+      'DOMStorage.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOMStorage.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'DOMStorage.getDOMStorageItems': {
+        paramsType: Crdp.DOMStorage.GetDOMStorageItemsRequest,
+        returnType: Crdp.DOMStorage.GetDOMStorageItemsResponse
+      };
+      'DOMStorage.removeDOMStorageItem': {
+        paramsType: Crdp.DOMStorage.RemoveDOMStorageItemRequest,
+        returnType: void
+      };
+      'DOMStorage.setDOMStorageItem': {
+        paramsType: Crdp.DOMStorage.SetDOMStorageItemRequest,
+        returnType: void
+      };
+      'Database.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Database.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Database.executeSQL': {
+        paramsType: Crdp.Database.ExecuteSQLRequest,
+        returnType: Crdp.Database.ExecuteSQLResponse
+      };
+      'Database.getDatabaseTableNames': {
+        paramsType: Crdp.Database.GetDatabaseTableNamesRequest,
+        returnType: Crdp.Database.GetDatabaseTableNamesResponse
+      };
+      'DeviceOrientation.clearDeviceOrientationOverride': {
+        paramsType: void,
+        returnType: void
+      };
+      'DeviceOrientation.setDeviceOrientationOverride': {
+        paramsType: Crdp.DeviceOrientation.SetDeviceOrientationOverrideRequest,
+        returnType: void
+      };
+      'Emulation.canEmulate': {
+        paramsType: void,
+        returnType: Crdp.Emulation.CanEmulateResponse
+      };
+      'Emulation.clearDeviceMetricsOverride': {
+        paramsType: void,
+        returnType: void
+      };
+      'Emulation.clearGeolocationOverride': {
+        paramsType: void,
+        returnType: void
+      };
+      'Emulation.resetPageScaleFactor': {
+        paramsType: void,
+        returnType: void
+      };
+      'Emulation.setCPUThrottlingRate': {
+        paramsType: Crdp.Emulation.SetCPUThrottlingRateRequest,
+        returnType: void
+      };
+      'Emulation.setDefaultBackgroundColorOverride': {
+        paramsType: void | Crdp.Emulation.SetDefaultBackgroundColorOverrideRequest,
+        returnType: void
+      };
+      'Emulation.setDeviceMetricsOverride': {
+        paramsType: Crdp.Emulation.SetDeviceMetricsOverrideRequest,
+        returnType: void
+      };
+      'Emulation.setEmitTouchEventsForMouse': {
+        paramsType: Crdp.Emulation.SetEmitTouchEventsForMouseRequest,
+        returnType: void
+      };
+      'Emulation.setEmulatedMedia': {
+        paramsType: Crdp.Emulation.SetEmulatedMediaRequest,
+        returnType: void
+      };
+      'Emulation.setGeolocationOverride': {
+        paramsType: void | Crdp.Emulation.SetGeolocationOverrideRequest,
+        returnType: void
+      };
+      'Emulation.setNavigatorOverrides': {
+        paramsType: Crdp.Emulation.SetNavigatorOverridesRequest,
+        returnType: void
+      };
+      'Emulation.setPageScaleFactor': {
+        paramsType: Crdp.Emulation.SetPageScaleFactorRequest,
+        returnType: void
+      };
+      'Emulation.setScriptExecutionDisabled': {
+        paramsType: Crdp.Emulation.SetScriptExecutionDisabledRequest,
+        returnType: void
+      };
+      'Emulation.setTouchEmulationEnabled': {
+        paramsType: Crdp.Emulation.SetTouchEmulationEnabledRequest,
+        returnType: void
+      };
+      'Emulation.setVirtualTimePolicy': {
+        paramsType: Crdp.Emulation.SetVirtualTimePolicyRequest,
+        returnType: Crdp.Emulation.SetVirtualTimePolicyResponse
+      };
+      'Emulation.setVisibleSize': {
+        paramsType: Crdp.Emulation.SetVisibleSizeRequest,
+        returnType: void
+      };
+      'HeadlessExperimental.beginFrame': {
+        paramsType: void | Crdp.HeadlessExperimental.BeginFrameRequest,
+        returnType: Crdp.HeadlessExperimental.BeginFrameResponse
+      };
+      'HeadlessExperimental.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'HeadlessExperimental.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'IO.close': {
+        paramsType: Crdp.IO.CloseRequest,
+        returnType: void
+      };
+      'IO.read': {
+        paramsType: Crdp.IO.ReadRequest,
+        returnType: Crdp.IO.ReadResponse
+      };
+      'IO.resolveBlob': {
+        paramsType: Crdp.IO.ResolveBlobRequest,
+        returnType: Crdp.IO.ResolveBlobResponse
+      };
+      'IndexedDB.clearObjectStore': {
+        paramsType: Crdp.IndexedDB.ClearObjectStoreRequest,
+        returnType: void
+      };
+      'IndexedDB.deleteDatabase': {
+        paramsType: Crdp.IndexedDB.DeleteDatabaseRequest,
+        returnType: void
+      };
+      'IndexedDB.deleteObjectStoreEntries': {
+        paramsType: Crdp.IndexedDB.DeleteObjectStoreEntriesRequest,
+        returnType: void
+      };
+      'IndexedDB.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'IndexedDB.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'IndexedDB.requestData': {
+        paramsType: Crdp.IndexedDB.RequestDataRequest,
+        returnType: Crdp.IndexedDB.RequestDataResponse
+      };
+      'IndexedDB.requestDatabase': {
+        paramsType: Crdp.IndexedDB.RequestDatabaseRequest,
+        returnType: Crdp.IndexedDB.RequestDatabaseResponse
+      };
+      'IndexedDB.requestDatabaseNames': {
+        paramsType: Crdp.IndexedDB.RequestDatabaseNamesRequest,
+        returnType: Crdp.IndexedDB.RequestDatabaseNamesResponse
+      };
+      'Input.dispatchKeyEvent': {
+        paramsType: Crdp.Input.DispatchKeyEventRequest,
+        returnType: void
+      };
+      'Input.dispatchMouseEvent': {
+        paramsType: Crdp.Input.DispatchMouseEventRequest,
+        returnType: void
+      };
+      'Input.dispatchTouchEvent': {
+        paramsType: Crdp.Input.DispatchTouchEventRequest,
+        returnType: void
+      };
+      'Input.emulateTouchFromMouseEvent': {
+        paramsType: Crdp.Input.EmulateTouchFromMouseEventRequest,
+        returnType: void
+      };
+      'Input.setIgnoreInputEvents': {
+        paramsType: Crdp.Input.SetIgnoreInputEventsRequest,
+        returnType: void
+      };
+      'Input.synthesizePinchGesture': {
+        paramsType: Crdp.Input.SynthesizePinchGestureRequest,
+        returnType: void
+      };
+      'Input.synthesizeScrollGesture': {
+        paramsType: Crdp.Input.SynthesizeScrollGestureRequest,
+        returnType: void
+      };
+      'Input.synthesizeTapGesture': {
+        paramsType: Crdp.Input.SynthesizeTapGestureRequest,
+        returnType: void
+      };
+      'Inspector.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Inspector.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'LayerTree.compositingReasons': {
+        paramsType: Crdp.LayerTree.CompositingReasonsRequest,
+        returnType: Crdp.LayerTree.CompositingReasonsResponse
+      };
+      'LayerTree.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'LayerTree.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'LayerTree.loadSnapshot': {
+        paramsType: Crdp.LayerTree.LoadSnapshotRequest,
+        returnType: Crdp.LayerTree.LoadSnapshotResponse
+      };
+      'LayerTree.makeSnapshot': {
+        paramsType: Crdp.LayerTree.MakeSnapshotRequest,
+        returnType: Crdp.LayerTree.MakeSnapshotResponse
+      };
+      'LayerTree.profileSnapshot': {
+        paramsType: Crdp.LayerTree.ProfileSnapshotRequest,
+        returnType: Crdp.LayerTree.ProfileSnapshotResponse
+      };
+      'LayerTree.releaseSnapshot': {
+        paramsType: Crdp.LayerTree.ReleaseSnapshotRequest,
+        returnType: void
+      };
+      'LayerTree.replaySnapshot': {
+        paramsType: Crdp.LayerTree.ReplaySnapshotRequest,
+        returnType: Crdp.LayerTree.ReplaySnapshotResponse
+      };
+      'LayerTree.snapshotCommandLog': {
+        paramsType: Crdp.LayerTree.SnapshotCommandLogRequest,
+        returnType: Crdp.LayerTree.SnapshotCommandLogResponse
+      };
+      'Log.clear': {
+        paramsType: void,
+        returnType: void
+      };
+      'Log.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Log.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Log.startViolationsReport': {
+        paramsType: Crdp.Log.StartViolationsReportRequest,
+        returnType: void
+      };
+      'Log.stopViolationsReport': {
+        paramsType: void,
+        returnType: void
+      };
+      'Memory.getDOMCounters': {
+        paramsType: void,
+        returnType: Crdp.Memory.GetDOMCountersResponse
+      };
+      'Memory.prepareForLeakDetection': {
+        paramsType: void,
+        returnType: void
+      };
+      'Memory.setPressureNotificationsSuppressed': {
+        paramsType: Crdp.Memory.SetPressureNotificationsSuppressedRequest,
+        returnType: void
+      };
+      'Memory.simulatePressureNotification': {
+        paramsType: Crdp.Memory.SimulatePressureNotificationRequest,
+        returnType: void
+      };
+      'Network.canClearBrowserCache': {
+        paramsType: void,
+        returnType: Crdp.Network.CanClearBrowserCacheResponse
+      };
+      'Network.canClearBrowserCookies': {
+        paramsType: void,
+        returnType: Crdp.Network.CanClearBrowserCookiesResponse
+      };
+      'Network.canEmulateNetworkConditions': {
+        paramsType: void,
+        returnType: Crdp.Network.CanEmulateNetworkConditionsResponse
+      };
+      'Network.clearBrowserCache': {
+        paramsType: void,
+        returnType: void
+      };
+      'Network.clearBrowserCookies': {
+        paramsType: void,
+        returnType: void
+      };
+      'Network.continueInterceptedRequest': {
+        paramsType: Crdp.Network.ContinueInterceptedRequestRequest,
+        returnType: void
+      };
+      'Network.deleteCookies': {
+        paramsType: Crdp.Network.DeleteCookiesRequest,
+        returnType: void
+      };
+      'Network.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Network.emulateNetworkConditions': {
+        paramsType: Crdp.Network.EmulateNetworkConditionsRequest,
+        returnType: void
+      };
+      'Network.enable': {
+        paramsType: void | Crdp.Network.EnableRequest,
+        returnType: void
+      };
+      'Network.getAllCookies': {
+        paramsType: void,
+        returnType: Crdp.Network.GetAllCookiesResponse
+      };
+      'Network.getCertificate': {
+        paramsType: Crdp.Network.GetCertificateRequest,
+        returnType: Crdp.Network.GetCertificateResponse
+      };
+      'Network.getCookies': {
+        paramsType: void | Crdp.Network.GetCookiesRequest,
+        returnType: Crdp.Network.GetCookiesResponse
+      };
+      'Network.getResponseBody': {
+        paramsType: Crdp.Network.GetResponseBodyRequest,
+        returnType: Crdp.Network.GetResponseBodyResponse
+      };
+      'Network.getRequestPostData': {
+        paramsType: Crdp.Network.GetRequestPostDataRequest,
+        returnType: Crdp.Network.GetRequestPostDataResponse
+      };
+      'Network.getResponseBodyForInterception': {
+        paramsType: Crdp.Network.GetResponseBodyForInterceptionRequest,
+        returnType: Crdp.Network.GetResponseBodyForInterceptionResponse
+      };
+      'Network.replayXHR': {
+        paramsType: Crdp.Network.ReplayXHRRequest,
+        returnType: void
+      };
+      'Network.searchInResponseBody': {
+        paramsType: Crdp.Network.SearchInResponseBodyRequest,
+        returnType: Crdp.Network.SearchInResponseBodyResponse
+      };
+      'Network.setBlockedURLs': {
+        paramsType: Crdp.Network.SetBlockedURLsRequest,
+        returnType: void
+      };
+      'Network.setBypassServiceWorker': {
+        paramsType: Crdp.Network.SetBypassServiceWorkerRequest,
+        returnType: void
+      };
+      'Network.setCacheDisabled': {
+        paramsType: Crdp.Network.SetCacheDisabledRequest,
+        returnType: void
+      };
+      'Network.setCookie': {
+        paramsType: Crdp.Network.SetCookieRequest,
+        returnType: Crdp.Network.SetCookieResponse
+      };
+      'Network.setCookies': {
+        paramsType: Crdp.Network.SetCookiesRequest,
+        returnType: void
+      };
+      'Network.setDataSizeLimitsForTest': {
+        paramsType: Crdp.Network.SetDataSizeLimitsForTestRequest,
+        returnType: void
+      };
+      'Network.setExtraHTTPHeaders': {
+        paramsType: Crdp.Network.SetExtraHTTPHeadersRequest,
+        returnType: void
+      };
+      'Network.setRequestInterception': {
+        paramsType: Crdp.Network.SetRequestInterceptionRequest,
+        returnType: void
+      };
+      'Network.setUserAgentOverride': {
+        paramsType: Crdp.Network.SetUserAgentOverrideRequest,
+        returnType: void
+      };
+      'Overlay.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Overlay.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Overlay.getHighlightObjectForTest': {
+        paramsType: Crdp.Overlay.GetHighlightObjectForTestRequest,
+        returnType: Crdp.Overlay.GetHighlightObjectForTestResponse
+      };
+      'Overlay.hideHighlight': {
+        paramsType: void,
+        returnType: void
+      };
+      'Overlay.highlightFrame': {
+        paramsType: Crdp.Overlay.HighlightFrameRequest,
+        returnType: void
+      };
+      'Overlay.highlightNode': {
+        paramsType: Crdp.Overlay.HighlightNodeRequest,
+        returnType: void
+      };
+      'Overlay.highlightQuad': {
+        paramsType: Crdp.Overlay.HighlightQuadRequest,
+        returnType: void
+      };
+      'Overlay.highlightRect': {
+        paramsType: Crdp.Overlay.HighlightRectRequest,
+        returnType: void
+      };
+      'Overlay.setInspectMode': {
+        paramsType: Crdp.Overlay.SetInspectModeRequest,
+        returnType: void
+      };
+      'Overlay.setPausedInDebuggerMessage': {
+        paramsType: void | Crdp.Overlay.SetPausedInDebuggerMessageRequest,
+        returnType: void
+      };
+      'Overlay.setShowDebugBorders': {
+        paramsType: Crdp.Overlay.SetShowDebugBordersRequest,
+        returnType: void
+      };
+      'Overlay.setShowFPSCounter': {
+        paramsType: Crdp.Overlay.SetShowFPSCounterRequest,
+        returnType: void
+      };
+      'Overlay.setShowPaintRects': {
+        paramsType: Crdp.Overlay.SetShowPaintRectsRequest,
+        returnType: void
+      };
+      'Overlay.setShowScrollBottleneckRects': {
+        paramsType: Crdp.Overlay.SetShowScrollBottleneckRectsRequest,
+        returnType: void
+      };
+      'Overlay.setShowViewportSizeOnResize': {
+        paramsType: Crdp.Overlay.SetShowViewportSizeOnResizeRequest,
+        returnType: void
+      };
+      'Overlay.setSuspended': {
+        paramsType: Crdp.Overlay.SetSuspendedRequest,
+        returnType: void
+      };
+      'Page.addScriptToEvaluateOnLoad': {
+        paramsType: Crdp.Page.AddScriptToEvaluateOnLoadRequest,
+        returnType: Crdp.Page.AddScriptToEvaluateOnLoadResponse
+      };
+      'Page.addScriptToEvaluateOnNewDocument': {
+        paramsType: Crdp.Page.AddScriptToEvaluateOnNewDocumentRequest,
+        returnType: Crdp.Page.AddScriptToEvaluateOnNewDocumentResponse
+      };
+      'Page.bringToFront': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.captureScreenshot': {
+        paramsType: void | Crdp.Page.CaptureScreenshotRequest,
+        returnType: Crdp.Page.CaptureScreenshotResponse
+      };
+      'Page.clearDeviceMetricsOverride': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.clearDeviceOrientationOverride': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.clearGeolocationOverride': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.createIsolatedWorld': {
+        paramsType: Crdp.Page.CreateIsolatedWorldRequest,
+        returnType: Crdp.Page.CreateIsolatedWorldResponse
+      };
+      'Page.deleteCookie': {
+        paramsType: Crdp.Page.DeleteCookieRequest,
+        returnType: void
+      };
+      'Page.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.getAppManifest': {
+        paramsType: void,
+        returnType: Crdp.Page.GetAppManifestResponse
+      };
+      'Page.getCookies': {
+        paramsType: void,
+        returnType: Crdp.Page.GetCookiesResponse
+      };
+      'Page.getFrameTree': {
+        paramsType: void,
+        returnType: Crdp.Page.GetFrameTreeResponse
+      };
+      'Page.getLayoutMetrics': {
+        paramsType: void,
+        returnType: Crdp.Page.GetLayoutMetricsResponse
+      };
+      'Page.getNavigationHistory': {
+        paramsType: void,
+        returnType: Crdp.Page.GetNavigationHistoryResponse
+      };
+      'Page.getResourceContent': {
+        paramsType: Crdp.Page.GetResourceContentRequest,
+        returnType: Crdp.Page.GetResourceContentResponse
+      };
+      'Page.getResourceTree': {
+        paramsType: void,
+        returnType: Crdp.Page.GetResourceTreeResponse
+      };
+      'Page.handleJavaScriptDialog': {
+        paramsType: Crdp.Page.HandleJavaScriptDialogRequest,
+        returnType: void
+      };
+      'Page.navigate': {
+        paramsType: Crdp.Page.NavigateRequest,
+        returnType: Crdp.Page.NavigateResponse
+      };
+      'Page.navigateToHistoryEntry': {
+        paramsType: Crdp.Page.NavigateToHistoryEntryRequest,
+        returnType: void
+      };
+      'Page.printToPDF': {
+        paramsType: void | Crdp.Page.PrintToPDFRequest,
+        returnType: Crdp.Page.PrintToPDFResponse
+      };
+      'Page.reload': {
+        paramsType: void | Crdp.Page.ReloadRequest,
+        returnType: void
+      };
+      'Page.removeScriptToEvaluateOnLoad': {
+        paramsType: Crdp.Page.RemoveScriptToEvaluateOnLoadRequest,
+        returnType: void
+      };
+      'Page.removeScriptToEvaluateOnNewDocument': {
+        paramsType: Crdp.Page.RemoveScriptToEvaluateOnNewDocumentRequest,
+        returnType: void
+      };
+      'Page.requestAppBanner': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.screencastFrameAck': {
+        paramsType: Crdp.Page.ScreencastFrameAckRequest,
+        returnType: void
+      };
+      'Page.searchInResource': {
+        paramsType: Crdp.Page.SearchInResourceRequest,
+        returnType: Crdp.Page.SearchInResourceResponse
+      };
+      'Page.setAdBlockingEnabled': {
+        paramsType: Crdp.Page.SetAdBlockingEnabledRequest,
+        returnType: void
+      };
+      'Page.setDeviceMetricsOverride': {
+        paramsType: Crdp.Page.SetDeviceMetricsOverrideRequest,
+        returnType: void
+      };
+      'Page.setDeviceOrientationOverride': {
+        paramsType: Crdp.Page.SetDeviceOrientationOverrideRequest,
+        returnType: void
+      };
+      'Page.setDocumentContent': {
+        paramsType: Crdp.Page.SetDocumentContentRequest,
+        returnType: void
+      };
+      'Page.setDownloadBehavior': {
+        paramsType: Crdp.Page.SetDownloadBehaviorRequest,
+        returnType: void
+      };
+      'Page.setGeolocationOverride': {
+        paramsType: void | Crdp.Page.SetGeolocationOverrideRequest,
+        returnType: void
+      };
+      'Page.setLifecycleEventsEnabled': {
+        paramsType: Crdp.Page.SetLifecycleEventsEnabledRequest,
+        returnType: void
+      };
+      'Page.setTouchEmulationEnabled': {
+        paramsType: Crdp.Page.SetTouchEmulationEnabledRequest,
+        returnType: void
+      };
+      'Page.startScreencast': {
+        paramsType: void | Crdp.Page.StartScreencastRequest,
+        returnType: void
+      };
+      'Page.stopLoading': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.crash': {
+        paramsType: void,
+        returnType: void
+      };
+      'Page.stopScreencast': {
+        paramsType: void,
+        returnType: void
+      };
+      'Performance.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Performance.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Performance.getMetrics': {
+        paramsType: void,
+        returnType: Crdp.Performance.GetMetricsResponse
+      };
+      'Security.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Security.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'Security.setIgnoreCertificateErrors': {
+        paramsType: Crdp.Security.SetIgnoreCertificateErrorsRequest,
+        returnType: void
+      };
+      'Security.handleCertificateError': {
+        paramsType: Crdp.Security.HandleCertificateErrorRequest,
+        returnType: void
+      };
+      'Security.setOverrideCertificateErrors': {
+        paramsType: Crdp.Security.SetOverrideCertificateErrorsRequest,
+        returnType: void
+      };
+      'ServiceWorker.deliverPushMessage': {
+        paramsType: Crdp.ServiceWorker.DeliverPushMessageRequest,
+        returnType: void
+      };
+      'ServiceWorker.disable': {
+        paramsType: void,
+        returnType: void
+      };
+      'ServiceWorker.dispatchSyncEvent': {
+        paramsType: Crdp.ServiceWorker.DispatchSyncEventRequest,
+        returnType: void
+      };
+      'ServiceWorker.enable': {
+        paramsType: void,
+        returnType: void
+      };
+      'ServiceWorker.inspectWorker': {
+        paramsType: Crdp.ServiceWorker.InspectWorkerRequest,
+        returnType: void
+      };
+      'ServiceWorker.setForceUpdateOnPageLoad': {
+        paramsType: Crdp.ServiceWorker.SetForceUpdateOnPageLoadRequest,
+        returnType: void
+      };
+      'ServiceWorker.skipWaiting': {
+        paramsType: Crdp.ServiceWorker.SkipWaitingRequest,
+        returnType: void
+      };
+      'ServiceWorker.startWorker': {
+        paramsType: Crdp.ServiceWorker.StartWorkerRequest,
+        returnType: void
+      };
+      'ServiceWorker.stopAllWorkers': {
+        paramsType: void,
+        returnType: void
+      };
+      'ServiceWorker.stopWorker': {
+        paramsType: Crdp.ServiceWorker.StopWorkerRequest,
+        returnType: void
+      };
+      'ServiceWorker.unregister': {
+        paramsType: Crdp.ServiceWorker.UnregisterRequest,
+        returnType: void
+      };
+      'ServiceWorker.updateRegistration': {
+        paramsType: Crdp.ServiceWorker.UpdateRegistrationRequest,
+        returnType: void
+      };
+      'Storage.clearDataForOrigin': {
+        paramsType: Crdp.Storage.ClearDataForOriginRequest,
+        returnType: void
+      };
+      'Storage.getUsageAndQuota': {
+        paramsType: Crdp.Storage.GetUsageAndQuotaRequest,
+        returnType: Crdp.Storage.GetUsageAndQuotaResponse
+      };
+      'Storage.trackCacheStorageForOrigin': {
+        paramsType: Crdp.Storage.TrackCacheStorageForOriginRequest,
+        returnType: void
+      };
+      'Storage.trackIndexedDBForOrigin': {
+        paramsType: Crdp.Storage.TrackIndexedDBForOriginRequest,
+        returnType: void
+      };
+      'Storage.untrackCacheStorageForOrigin': {
+        paramsType: Crdp.Storage.UntrackCacheStorageForOriginRequest,
+        returnType: void
+      };
+      'Storage.untrackIndexedDBForOrigin': {
+        paramsType: Crdp.Storage.UntrackIndexedDBForOriginRequest,
+        returnType: void
+      };
+      'SystemInfo.getInfo': {
+        paramsType: void,
+        returnType: Crdp.SystemInfo.GetInfoResponse
+      };
+      'Target.activateTarget': {
+        paramsType: Crdp.Target.ActivateTargetRequest,
+        returnType: void
+      };
+      'Target.attachToTarget': {
+        paramsType: Crdp.Target.AttachToTargetRequest,
+        returnType: Crdp.Target.AttachToTargetResponse
+      };
+      'Target.closeTarget': {
+        paramsType: Crdp.Target.CloseTargetRequest,
+        returnType: Crdp.Target.CloseTargetResponse
+      };
+      'Target.createBrowserContext': {
+        paramsType: void,
+        returnType: Crdp.Target.CreateBrowserContextResponse
+      };
+      'Target.createTarget': {
+        paramsType: Crdp.Target.CreateTargetRequest,
+        returnType: Crdp.Target.CreateTargetResponse
+      };
+      'Target.detachFromTarget': {
+        paramsType: void | Crdp.Target.DetachFromTargetRequest,
+        returnType: void
+      };
+      'Target.disposeBrowserContext': {
+        paramsType: Crdp.Target.DisposeBrowserContextRequest,
+        returnType: Crdp.Target.DisposeBrowserContextResponse
+      };
+      'Target.getTargetInfo': {
+        paramsType: Crdp.Target.GetTargetInfoRequest,
+        returnType: Crdp.Target.GetTargetInfoResponse
+      };
+      'Target.getTargets': {
+        paramsType: void,
+        returnType: Crdp.Target.GetTargetsResponse
+      };
+      'Target.sendMessageToTarget': {
+        paramsType: Crdp.Target.SendMessageToTargetRequest,
+        returnType: void
+      };
+      'Target.setAttachToFrames': {
+        paramsType: Crdp.Target.SetAttachToFramesRequest,
+        returnType: void
+      };
+      'Target.setAutoAttach': {
+        paramsType: Crdp.Target.SetAutoAttachRequest,
+        returnType: void
+      };
+      'Target.setDiscoverTargets': {
+        paramsType: Crdp.Target.SetDiscoverTargetsRequest,
+        returnType: void
+      };
+      'Target.setRemoteLocations': {
+        paramsType: Crdp.Target.SetRemoteLocationsRequest,
+        returnType: void
+      };
+      'Tethering.bind': {
+        paramsType: Crdp.Tethering.BindRequest,
+        returnType: void
+      };
+      'Tethering.unbind': {
+        paramsType: Crdp.Tethering.UnbindRequest,
+        returnType: void
+      };
+      'Tracing.end': {
+        paramsType: void,
+        returnType: void
+      };
+      'Tracing.getCategories': {
+        paramsType: void,
+        returnType: Crdp.Tracing.GetCategoriesResponse
+      };
+      'Tracing.recordClockSyncMarker': {
+        paramsType: Crdp.Tracing.RecordClockSyncMarkerRequest,
+        returnType: void
+      };
+      'Tracing.requestMemoryDump': {
+        paramsType: void,
+        returnType: Crdp.Tracing.RequestMemoryDumpResponse
+      };
+      'Tracing.start': {
+        paramsType: void | Crdp.Tracing.StartRequest,
+        returnType: void
+      };
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds type checking/inference for `Driver.sendCommand` (to go along with typing events in #4886).

![command-completion-gif](https://user-images.githubusercontent.com/316891/38230352-4f352d02-36c2-11e8-9844-adf798d72013.gif)

Like #4886, this PR has changes to `scripts/extract-crdp-mapping.js` to extract all the protocol commands which are then written to `typings/crdp-mapping.d.ts`. Again, hopefully most of this can be upstreamed into `devtools-protocol`. This time the types need both the options `params` object (if any) associated with the command but also the command's return type (if any).

The other set of changes are in `Driver`, `Connection`, and `ExtensionConnection` (everything else is just minor fixes for any type errors that popped up after all the above changes). This time `sendCommand` is pulled out of the class bodies for stricter typing. Getting the typing correct is a little harder than it was for the events because this time we aren't tying together an event name and payload type, but two function parameters and a return type.

Typescript types (in typescript or jsdoc) can express that one property of an object is defined only for certain values of a different property (or similarly, for an event payload in a callback and an event name), but typescript can't yet express that a function parameter is not to be provided depending on the value of another parameter (there's a [proposal to enable this](https://github.com/Microsoft/TypeScript/issues/5453), which is now on the typescript roadmap, but under the "Future" heading with no planned implementation schedule).

As a result, the solution is a little more awkward, but not too bad. The function is defined with somewhat loose argument types, but when added to the class prototype it's cast to a much stricter type as the external interface. This allows casting with an overloaded type signature, which can create a one argument version (for commands like `DOM.enable`) or a two argument version so options can be passed (for e.g. `DOM.querySelector`), depending on the first argument (the command string).

One last wrinkle: for commands that have all optional options that we don't use, we have often just dropped the second argument when calling (e.g. for `Network.enable`). I've added `void` as one option for the `params` object for those commands, so they actually show up in both the one and two argument versions of `sendCommand`