### PR TITLE
core(tsc): add types for DevtoolsLog and NetworkRecorder

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -45,7 +45,7 @@ class UnusedBytes extends Audit {
    * Estimates the number of bytes this network record would have consumed on the network based on the
    * uncompressed size (totalBytes), uses the actual transfer size from the network record if applicable.
    *
-   * @param {?WebInspector.NetworkRequest} networkRecord
+   * @param {?LH.WebInspector.NetworkRequest} networkRecord
    * @param {number} totalBytes Uncompressed size of the resource
    * @param {string=} resourceType
    * @param {number=} compressionRatio

--- a/lighthouse-core/audits/byte-efficiency/unminified-css.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-css.js
@@ -93,7 +93,7 @@ class UnminifiedCSS extends ByteEfficiencyAudit {
 
   /**
    * @param {{content: string, header: {sourceURL: string}}} stylesheet
-   * @param {?WebInspector.NetworkRequest} networkRecord
+   * @param {?LH.WebInspector.NetworkRequest} networkRecord
    * @param {string} pageUrl
    * @return {{minifiedLength: number, contentLength: number}}
    */

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -29,7 +29,7 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
 
   /**
    * @param {!Array.<{header: {styleSheetId: string}}>} styles The output of the Styles gatherer.
-   * @param {!Array<WebInspector.NetworkRequest>} networkRecords
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @return {!Object} A map of styleSheetId to stylesheet information.
    */
   static indexStylesheetsById(styles, networkRecords) {

--- a/lighthouse-core/audits/byte-efficiency/unused-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-javascript.js
@@ -62,7 +62,7 @@ class UnusedJavaScript extends ByteEfficiencyAudit {
 
   /**
    * @param {!Array<{unusedLength: number, contentLength: number}>} wasteData
-   * @param {!WebInspector.NetworkRequest} networkRecord
+   * @param {LH.WebInspector.NetworkRequest} networkRecord
    * @return {{url: string, totalBytes: number, wastedBytes: number, wastedPercent: number}}
    */
   static mergeWaste(wasteData, networkRecord) {

--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -130,7 +130,7 @@ class CacheHeaders extends Audit {
    *
    * TODO: Investigate impact in HTTPArchive, experiment with this policy to see what changes.
    *
-   * @param {!WebInspector.NetworkRequest} record
+   * @param {LH.WebInspector.NetworkRequest} record
    * @return {boolean}
    */
   static isCacheableAsset(record) {

--- a/lighthouse-core/audits/consistently-interactive.js
+++ b/lighthouse-core/audits/consistently-interactive.js
@@ -44,7 +44,7 @@ class ConsistentlyInteractiveMetric extends Audit {
   /**
    * Finds all time periods where the number of inflight requests is less than or equal to the
    * number of allowed concurrent requests (2).
-   * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @param {{timestamps: {traceEnd: number}}} traceOfTab
    * @return {!Array<!TimePeriod>}
    */
@@ -95,7 +95,7 @@ class ConsistentlyInteractiveMetric extends Audit {
   /**
    * Finds the first time period where a network quiet period and a CPU quiet period overlap.
    * @param {!Array<!TimePeriod>} longTasks
-   * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @param {{timestamps: {navigationStart: number, firstMeaningfulPaint: number,
    *    traceEnd: number}}} traceOfTab
    * @return {{cpuQuietPeriod: !TimePeriod, networkQuietPeriod: !TimePeriod,

--- a/lighthouse-core/gather/computed/critical-request-chains.js
+++ b/lighthouse-core/gather/computed/critical-request-chains.js
@@ -19,7 +19,7 @@ class CriticalRequestChains extends ComputedArtifact {
    * It's imperfect, but there is not a higher-fidelity signal available yet.
    * @see https://docs.google.com/document/d/1bCDuq9H1ih9iNjgzyAL0gpwNFiEP4TZS-YLRp_RuMlc
    * @param {any} request
-   * @param {!WebInspector.NetworkRequest} mainResource
+   * @param {LH.WebInspector.NetworkRequest} mainResource
    */
   static isCritical(request, mainResource) {
     assert.ok(mainResource, 'mainResource not provided');

--- a/lighthouse-core/gather/computed/main-resource.js
+++ b/lighthouse-core/gather/computed/main-resource.js
@@ -19,7 +19,7 @@ class MainResource extends ComputedArtifact {
   /**
    * @param {!DevtoolsLog} devtoolsLog
    * @param {!ComputedArtifacts} artifacts
-   * @return {!WebInspector.NetworkRequest}
+   * @return {LH.WebInspector.NetworkRequest}
    */
   compute_(devtoolsLog, artifacts) {
     return artifacts.requestNetworkRecords(devtoolsLog)

--- a/lighthouse-core/gather/computed/network-records.js
+++ b/lighthouse-core/gather/computed/network-records.js
@@ -15,7 +15,7 @@ class NetworkRecords extends ComputedArtifact {
 
   /**
    * @param {!DevtoolsLog} devtoolsLog
-   * @return {!Array<!WebInspector.NetworkRequest>} networkRecords
+   * @return {Array<LH.WebInspector.NetworkRequest>} networkRecords
    */
   compute_(devtoolsLog) {
     return NetworkRecorder.recordsFromLogs(devtoolsLog);

--- a/lighthouse-core/gather/computed/network-throughput.js
+++ b/lighthouse-core/gather/computed/network-throughput.js
@@ -17,7 +17,7 @@ class NetworkThroughput extends ComputedArtifact {
    * Excludes data URI, failed or otherwise incomplete, and cached requests.
    * Returns Infinity if there were no analyzable network records.
    *
-   * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @return {number}
    */
   static getThroughput(networkRecords) {

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -23,7 +23,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {!WebInspector.NetworkRequest} record
+   * @param {LH.WebInspector.NetworkRequest} record
    * @return {!Array<string>}
    */
   static getNetworkInitiators(record) {
@@ -38,7 +38,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @return {!NetworkNodeOutput}
    */
   static getNetworkNodeOutput(networkRecords) {
@@ -230,7 +230,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
 
   /**
    * @param {!TraceOfTabArtifact} traceOfTab
-   * @param {!Array<!WebInspector.NetworkRequest>} networkRecords
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @return {!Node}
    */
   static createGraph(traceOfTab, networkRecords) {

--- a/lighthouse-core/gather/computed/pushed-requests.js
+++ b/lighthouse-core/gather/computed/pushed-requests.js
@@ -16,7 +16,7 @@ class PushedRequests extends ComputedArtifact {
    * Return list of network requests that were pushed.
    * @param {!DevtoolsLog} devtoolsLog
    * @param {!ComputedArtifacts} artifacts
-   * @return {!Promise<!Array<!WebInspector.NetworkRequest>>}
+   * @return {Promise<Array<LH.WebInspector.NetworkRequest>>}
    */
   compute_(devtoolsLog, artifacts) {
     return artifacts.requestNetworkRecords(devtoolsLog).then(records => {

--- a/lighthouse-core/gather/devtools-log.js
+++ b/lighthouse-core/gather/devtools-log.js
@@ -17,13 +17,13 @@ class DevtoolsLog {
   constructor(regexFilter) {
     this._filter = regexFilter;
 
-    /** @type {!Array<{method: string, params: !Object}>} */
+    /** @type {Array<LH.Protocol.RawEventMessage>} */
     this._messages = [];
     this._isRecording = false;
   }
 
   /**
-   * @return {!Array<{method: string, params: !Object}>}
+   * @return {Array<LH.Protocol.RawEventMessage>}
    */
   get messages() {
     return this._messages;
@@ -43,7 +43,7 @@ class DevtoolsLog {
 
   /**
    * Records a message if method matches filter and recording has been started.
-   * @param {{method: string, params: !Object}} message
+   * @param {LH.Protocol.RawEventMessage} message
    */
   record(message) {
     if (this._isRecording && (!this._filter || this._filter.test(message.method))) {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -603,7 +603,7 @@ class Driver {
       if (earlierRequest.url === this._monitoredUrl) {
         this._monitoredUrl = redirectRequest.url;
       }
-    }
+    };
     this._networkStatusMonitor.on('requestloaded', requestLoadedListener);
 
     return this.sendCommand('Network.enable');

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -74,7 +74,7 @@ class Driver {
     connection.on('protocolevent', event => {
       this._devtoolsLog.record(event);
       if (this._networkStatusMonitor) {
-        this._networkStatusMonitor.dispatch(event.method, event.params);
+        this._networkStatusMonitor.dispatch(event);
       }
       this._eventEmitter.emit(event.method, event.params);
     });
@@ -593,8 +593,8 @@ class Driver {
 
     // Update startingUrl if it's ever redirected.
     this._monitoredUrl = startingUrl;
-    // TODO(bckenny): WebInspector.NetworkRequest
-    this._networkStatusMonitor.on('requestloaded', redirectRequest => {
+    /** @param {LH.WebInspector.NetworkRequest} redirectRequest */
+    const requestLoadedListener = redirectRequest => {
       // Ignore if this is not a redirected request.
       if (!redirectRequest.redirectSource) {
         return;
@@ -603,7 +603,8 @@ class Driver {
       if (earlierRequest.url === this._monitoredUrl) {
         this._monitoredUrl = redirectRequest.url;
       }
-    });
+    }
+    this._networkStatusMonitor.on('requestloaded', requestLoadedListener);
 
     return this.sendCommand('Network.enable');
   }
@@ -942,7 +943,7 @@ class Driver {
 
   /**
    * Stop recording to devtoolsLog and return log contents.
-   * @return {Array<{method: string, params: (Object<string, *>|undefined)}>}
+   * @return {Array<LH.Protocol.RawEventMessage>}
    */
   endDevtoolsLog() {
     this._devtoolsLog.endRecording();

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -140,7 +140,7 @@ class GatherRunner {
   /**
    * Returns an error if the original network request failed or wasn't found.
    * @param {string} url The URL of the original requested page.
-   * @param {!Array<WebInspector.NetworkRequest>} networkRecords
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @return {?Error}
    */
   static getPageLoadError(url, networkRecords) {

--- a/lighthouse-core/gather/gatherers/scripts.js
+++ b/lighthouse-core/gather/gatherers/scripts.js
@@ -14,7 +14,7 @@ const WebInspector = require('../../lib/web-inspector');
 class Scripts extends Gatherer {
   /**
    * @param {{driver: !Driver}} options
-   * @param {{networkRecords: !Array<WebInspector.NetworkRequest}} traceData
+   * @param {{networkRecords: Array<LH.WebInspector.NetworkRequest}} traceData
    * @return {!Promise<!Map<string, string>>}
    */
   afterPass(options, traceData) {

--- a/lighthouse-core/lib/dependency-graph/cpu-node.js
+++ b/lighthouse-core/lib/dependency-graph/cpu-node.js
@@ -71,7 +71,7 @@ class CPUNode extends Node {
   isEvaluateScriptFor(urls) {
     return this._childEvents.some(evt => {
       return evt.name === 'EvaluateScript' &&
-        evt.args.data &&
+        !!evt.args.data &&
         urls.has(evt.args.data.url);
     });
   }

--- a/lighthouse-core/lib/dependency-graph/cpu-node.js
+++ b/lighthouse-core/lib/dependency-graph/cpu-node.js
@@ -71,7 +71,7 @@ class CPUNode extends Node {
   isEvaluateScriptFor(urls) {
     return this._childEvents.some(evt => {
       return evt.name === 'EvaluateScript' &&
-        !!evt.args.data &&
+        !!evt.args.data && !!evt.args.data.url &&
         urls.has(evt.args.data.url);
     });
   }

--- a/lighthouse-core/lib/dependency-graph/network-node.js
+++ b/lighthouse-core/lib/dependency-graph/network-node.js
@@ -10,7 +10,7 @@ const WebInspector = require('../web-inspector');
 
 class NetworkNode extends Node {
   /**
-   * @param {LH.NetworkRequest} networkRecord
+   * @param {LH.WebInspector.NetworkRequest} networkRecord
    */
   constructor(networkRecord) {
     super(networkRecord.requestId);
@@ -39,7 +39,7 @@ class NetworkNode extends Node {
   }
 
   /**
-   * @return {LH.NetworkRequest}
+   * @return {LH.WebInspector.NetworkRequest}
    */
   get record() {
     // Ensure that the record has an origin value

--- a/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
@@ -13,7 +13,7 @@ const TLS_SCHEMES = ['https', 'wss'];
 
 module.exports = class ConnectionPool {
   /**
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @param {Object=} options
    */
   constructor(records, options) {
@@ -34,7 +34,7 @@ module.exports = class ConnectionPool {
     this._records = records;
     /** @type {Map<string, TcpConnection[]>} */
     this._connectionsByOrigin = new Map();
-    /** @type {Map<LH.NetworkRequest, TcpConnection>} */
+    /** @type {Map<LH.WebInspector.NetworkRequest, TcpConnection>} */
     this._connectionsByRecord = new Map();
     this._connectionsInUse = new Set();
     this._connectionReusedByRequestId = NetworkAnalyzer.estimateIfConnectionWasReused(records, {
@@ -87,7 +87,7 @@ module.exports = class ConnectionPool {
   }
 
   /**
-   * @param {LH.NetworkRequest} record
+   * @param {LH.WebInspector.NetworkRequest} record
    * @return {?TcpConnection}
    */
   acquire(record) {
@@ -112,7 +112,7 @@ module.exports = class ConnectionPool {
   }
 
   /**
-   * @param {LH.NetworkRequest} record
+   * @param {LH.WebInspector.NetworkRequest} record
    */
   release(record) {
     const connection = this._connectionsByRecord.get(record);

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -16,8 +16,8 @@ class NetworkAnalyzer {
   }
 
   /**
-   * @param {LH.NetworkRequest[]} records
-   * @return {Map<string, LH.NetworkRequest[]>}
+   * @param {LH.WebInspector.NetworkRequest[]} records
+   * @return {Map<string, LH.WebInspector.NetworkRequest[]>}
    */
   static groupByOrigin(records) {
     const grouped = new Map();
@@ -62,7 +62,7 @@ class NetworkAnalyzer {
   }
 
   /**
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @param {function(any):any} iteratee
    * @return {Map<string, number[]>}
    */
@@ -100,7 +100,7 @@ class NetworkAnalyzer {
    * Estimates the observed RTT to each origin based on how long the TCP handshake took.
    * This is the most accurate and preferred method of measurement when the data is available.
    *
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @return {Map<string, number[]>}
    */
   static _estimateRTTByOriginViaTCPTiming(records) {
@@ -122,7 +122,7 @@ class NetworkAnalyzer {
    * NOTE: this will tend to overestimate the actual RTT quite significantly as the download can be
    * slow for other reasons as well such as bandwidth constraints.
    *
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @return {Map<string, number[]>}
    */
   static _estimateRTTByOriginViaDownloadTiming(records) {
@@ -150,7 +150,7 @@ class NetworkAnalyzer {
    * NOTE: this will tend to overestimate the actual RTT as the request can be delayed for other
    * reasons as well such as DNS lookup.
    *
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @return {Map<string, number[]>}
    */
   static _estimateRTTByOriginViaSendStartTiming(records) {
@@ -169,7 +169,7 @@ class NetworkAnalyzer {
   /**
    * Given the RTT to each origin, estimates the observed server response times.
    *
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @param {Map<string, number>} rttByOrigin
    * @return {Map<string, number[]>}
    */
@@ -186,7 +186,7 @@ class NetworkAnalyzer {
   }
 
   /**
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @return {boolean}
    */
   static canTrustConnectionInformation(records) {
@@ -206,7 +206,7 @@ class NetworkAnalyzer {
    * Returns a map of requestId -> connectionReused, estimating the information if the information
    * available in the records themselves appears untrustworthy.
    *
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @param {object} [options]
    * @return {Map<string, boolean>}
    */
@@ -251,7 +251,7 @@ class NetworkAnalyzer {
    * Attempts to use the most accurate information first and falls back to coarser estimates when it
    * is unavailable.
    *
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @param {object} [options]
    * @return {Map<string, !NetworkAnalyzer.Summary>}
    */
@@ -296,7 +296,7 @@ class NetworkAnalyzer {
    * Estimates the server response time of each origin. RTT times can be passed in or will be
    * estimated automatically if not provided.
    *
-   * @param {LH.NetworkRequest[]} records
+   * @param {LH.WebInspector.NetworkRequest[]} records
    * @param {Object=} options
    * @return {Map<string, !NetworkAnalyzer.Summary>}
    */

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -71,7 +71,7 @@ class Simulator {
    *
    */
   _initializeConnectionPool() {
-    /** @type {LH.NetworkRequest[]} */
+    /** @type {LH.WebInspector.NetworkRequest[]} */
     const records = [];
     this._graph.getRootNode().traverse(node => {
       if (node.type === Node.TYPES.NETWORK) {

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -113,46 +113,6 @@ declare global {
       dur: number;
     }
 
-    export interface NetworkRequest {
-      requestId: string;
-      connectionId: string;
-      connectionReused: boolean;
-
-      url: string;
-      protocol: string;
-      origin: string | null;
-      parsedURL: DevToolsParsedURL;
-
-      startTime: number;
-      endTime: number;
-
-      transferSize: number;
-
-      _initiator: NetworkRequestInitiator;
-      _timing: NetworkRequestTiming;
-      _resourceType: any;
-      priority(): 'VeryHigh' | 'High' | 'Medium' | 'Low';
-    }
-
-    export interface NetworkRequestInitiator {
-      type: 'script' | 'parser';
-    }
-
-    export interface NetworkRequestTiming {
-      connectStart: number;
-      connectEnd: number;
-      sslStart: number;
-      sslEnd: number;
-      sendStart: number;
-      sendEnd: number;
-      receiveHeadersEnd: number;
-    }
-
-    export interface DevToolsParsedURL {
-      scheme: string;
-      host: string;
-    }
-
     export interface DevToolsJsonTarget {
       description: string;
       devtoolsFrontendUrl: string;

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -103,7 +103,11 @@ declare global {
 
     export interface TraceEvent {
       name: string;
-      args: any;
+      args: {
+        data?: {
+          url: string
+        };
+      };
       tid: number;
       ts: number;
       dur: number;

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -105,7 +105,7 @@ declare global {
       name: string;
       args: {
         data?: {
-          url: string
+          url?: string
         };
       };
       tid: number;

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -18,8 +18,8 @@ declare global {
     }
 
     export interface LoadData {
-      networkRecords: Array<void>;
-      devtoolsLog: Array<void>;
+      networkRecords: Array<WebInspector.NetworkRequest>;
+      devtoolsLog: Array<Protocol.RawEventMessage>;
       trace: {traceEvents: Array<TraceEvent>};
     }
 

--- a/typings/web-inspector.d.ts
+++ b/typings/web-inspector.d.ts
@@ -1,0 +1,58 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+declare global {
+  module LH.WebInspector {
+    // externs for chrome-devtools-frontend/front_end/sdk/NetworkRequest.js
+    export interface NetworkRequest {
+      requestId: string;
+      connectionId: string;
+      connectionReused: boolean;
+
+      url: string;
+      protocol: string;
+      origin: string | null;
+      parsedURL: ParsedURL;
+
+      startTime: number;
+      endTime: number;
+
+      transferSize: number;
+
+      finished: boolean;
+      redirectSource?: {
+        url: string;
+      }
+
+      _initiator: NetworkRequestInitiator;
+      _timing: NetworkRequestTiming;
+      _resourceType: any;
+      priority(): 'VeryHigh' | 'High' | 'Medium' | 'Low';
+    }
+
+    export interface ParsedURL {
+      scheme: string;
+      host: string;
+    }
+
+    export interface NetworkRequestInitiator {
+      type: 'script' | 'parser';
+    }
+
+    export interface NetworkRequestTiming {
+      connectStart: number;
+      connectEnd: number;
+      sslStart: number;
+      sslEnd: number;
+      sendStart: number;
+      sendEnd: number;
+      receiveHeadersEnd: number;
+    }
+  }
+}
+
+// empty export to keep file a module
+export {}


### PR DESCRIPTION
easy change to add types to `DevtoolsLog` and `NetworkRecorder` since we already have all the crdp event types.

Moved @patrickhulce's existing work on `NetworkRequest` to a `LH.WebInspector` namespace (since that's how we've nested it in our not-actually-type-checking past) and added the additional properties we needed to the interface. 

We can probably continue to add properties as we go (seems ok?), though we do need to be careful about optional properties on the interface because the state we deal with these requests (after passing through NetworkRecorder which requires the full request lifecycle) is quite different than the [initial constructed object](https://github.com/ChromeDevTools/devtools-frontend/blob/cfbe097a93de280bc99ca1cab1689335d5999115/front_end/sdk/NetworkRequest.js#L43-L110) which has many uninitialized properties (and even more added later but not initialized in the constructor :S)

Also did a quick `s/WebInspector.NetworkRequest/LH.WebInspector.NetworkRequest` params replacement elsewhere so that they'll be correct when we turn on type checking for all those files.