### PR TITLE
core(noopener-audit): noreferrer implies noopener

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -126,8 +126,14 @@
   <a href="https://www.google.com/" target="_blank" rel="nofollow">external link</a>
   <!-- PASS - external link correctly uses rel="noopener" and an additional rel value -->
   <a href="https://www.google.com/" target="_blank" rel="noopener nofollow">external link that uses rel noopener and another unrelated rel attribute</a>
+  <!-- PASS - external link correctly uses rel="noreferrer" and an additional rel value -->
+  <a href="https://www.google.com/" target="_blank" rel="noreferrer nofollow">external link that uses rel noreferrer and another unrelated rel attribute</a>
   <!-- PASS - external link correctly uses rel="noopener" -->
   <a href="https://www.google.com/" target="_blank" rel="noopener">external link that uses rel noopener</a>
+  <!-- PASS - external link correctly uses rel="noreferrer" -->
+  <a href="https://www.google.com/" target="_blank" rel="noreferrer">external link that uses rel noreferrer</a>
+  <!-- PASS - external link correctly uses rel="noopener" and rel="noreferrer" -->
+  <a href="https://www.google.com/" target="_blank" rel="noopener noreferrer">external link that uses rel noopener and noreferrer</a>
   <!-- PASS - internal link without rel="noopener" -->
   <a href="./doesnotexist" target="_blank">internal link is ok</a>
   <!-- PASS - href uses javascript: -->

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -15,10 +15,9 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
   static get meta() {
     return {
       name: 'external-anchors-use-rel-noopener',
-      description: 'Opens external anchors using `rel="noopener"`',
-      failureDescription: 'Does not open external anchors using `rel="noopener"` or ' +
-          '`rel="noreferrer"`',
-      helpText: 'Open new tabs using `rel="noopener"` or `rel="noreferrer"` to improve ' +
+      description: 'Links to cross-origin destinations are safe',
+      failureDescription: 'Links to cross-origin destinations are unsafe',
+      helpText: 'Add `rel="noopener"` or `rel="noreferrer"` to any external links to improve ' +
           'performance and prevent security vulnerabilities. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).',
       requiredArtifacts: ['URL', 'AnchorsWithNoRelNoopener'],

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -16,9 +16,10 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     return {
       name: 'external-anchors-use-rel-noopener',
       description: 'Opens external anchors using `rel="noopener"`',
-      failureDescription: 'Does not open external anchors using `rel="noopener"`',
-      helpText: 'Open new tabs using `rel="noopener"` to improve performance and ' +
-          'prevent security vulnerabilities. ' +
+      failureDescription: 'Does not open external anchors using `rel="noopener"` or ' +
+          '`rel="noreferrer"`',
+      helpText: 'Open new tabs using `rel="noopener"` or `rel="noreferrer"` to improve ' +
+          'performance and prevent security vulnerabilities. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).',
       requiredArtifacts: ['URL', 'AnchorsWithNoRelNoopener'],
     };

--- a/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/anchors-with-no-rel-noopener.js
@@ -16,7 +16,7 @@ class AnchorsWithNoRelNoopener extends Gatherer {
   afterPass(options) {
     const expression = `(function() {
       ${DOMHelpers.getElementsInDocumentFnString}; // define function on page
-      const selector = 'a[target="_blank"]:not([rel~="noopener"])';
+      const selector = 'a[target="_blank"]:not([rel~="noopener"]):not([rel~="noreferrer"])';
       const elements = getElementsInDocument(selector);
       return elements.map(node => ({
         href: node.href,


### PR DESCRIPTION
This fixes #2482 and updates #2485 fixing conflicts.

The added tests were checked with ./lighthouse-cli/test/smokehouse/dobetterweb/run-tests.sh

Not sure why the byte-efficiency test is failing in appveyor, it happened to me too locally, but I haven't made any changes that would affect it from what I can tell.