### PR TITLE
core(network-recorder): fix typo in once() call on super

### DIFF
--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -47,7 +47,7 @@ class NetworkRecorder extends EventEmitter {
    * @param {*} listener
    */
   once(event, listener) {
-    return super.on(event, listener);
+    return super.once(event, listener);
   }
 
   get EventTypes() {


### PR DESCRIPTION
Introduced in #4918, `networkRecorder.once()` calls are being rerouted to `networkRecorder.on()`, which isn't great :)