### PR TITLE
core(fast-config): bring back a11y and SEO categories

### DIFF
--- a/lighthouse-core/config/fast-config.js
+++ b/lighthouse-core/config/fast-config.js
@@ -22,8 +22,6 @@ module.exports = {
       'offscreen-images',
       'load-fast-enough-for-pwa',
     ],
-    // skip a11y for now because it's too slow and not in PSI-parity set
-    onlyCategories: ['performance', 'pwa', 'best-practices'],
   },
   passes: [
     {


### PR DESCRIPTION
We want a11y and SEO for fast-mode LR on 2.x now that we're not prioritizing PSI-parity speed.