### PR TITLE
extension: Pass flags from options in runLighthouseForConnection

### DIFF
--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -22,10 +22,10 @@ const log = require('lighthouse-logger');
 window.runLighthouseForConnection = function(
     connection, url, options, categoryIDs,
     updateBadgeFn = function() { }) {
-  const config = options && options.fastMode ? new Config(fastConfig) : new Config({
+  const config = options && options.fastMode ? new Config(fastConfig, options.flags) : new Config({
     extends: 'lighthouse:default',
     settings: {onlyCategories: categoryIDs},
-  });
+  }, options.flags);
 
   // Add url and config to fresh options object.
   const runOptions = Object.assign({}, options, {url, config});


### PR DESCRIPTION
@patrickhulce 
We pass flags like disableDeviceEmulation from lightrider in options.flags, which used to work. It is broken now due to "unify config and CLI settings".

PTAL.

Thanks!