### PR TITLE
core(tsc): add type checking to asset-saver

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,11 +69,10 @@ module.exports = {
     'arrow-parens': 0,
   },
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     ecmaFeatures: {
       globalReturn: true,
       jsx: false,
-      experimentalObjectRestSpread: false,
     },
     sourceType: 'script',
   },

--- a/lighthouse-core/gather/devtools-log.js
+++ b/lighthouse-core/gather/devtools-log.js
@@ -17,13 +17,13 @@ class DevtoolsLog {
   constructor(regexFilter) {
     this._filter = regexFilter;
 
-    /** @type {Array<LH.Protocol.RawEventMessage>} */
+    /** @type {LH.DevtoolsLog} */
     this._messages = [];
     this._isRecording = false;
   }
 
   /**
-   * @return {Array<LH.Protocol.RawEventMessage>}
+   * @return {LH.DevtoolsLog}
    */
   get messages() {
     return this._messages;

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -729,7 +729,6 @@ class Driver {
     return new Promise((resolve, reject) => {
       // If this takes more than 1s, reject the Promise.
       // Why? Encoding issues can lead to hanging getResponseBody calls: https://github.com/GoogleChrome/lighthouse/pull/4718
-      // @ts-ignore TODO(bckenny): fix LHError constructor/errors mismatch
       const err = new LHError(LHError.errors.REQUEST_CONTENT_TIMEOUT);
       const asyncTimeout = setTimeout((_ => reject(err)), timeout);
 
@@ -941,7 +940,7 @@ class Driver {
 
   /**
    * Stop recording to devtoolsLog and return log contents.
-   * @return {Array<LH.Protocol.RawEventMessage>}
+   * @return {LH.DevtoolsLog}
    */
   endDevtoolsLog() {
     this._devtoolsLog.endRecording();

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -19,7 +19,7 @@ const Driver = require('../gather/driver.js'); // eslint-disable-line no-unused-
  * `collectArtifacts`.
  * @typedef {{LighthouseRunWarnings: Array<string>, [artifactName: string]: Array<*>}} GathererResults
  */
-/** @typedef {{traces: Object<string, LH.Trace>, devtoolsLogs: Object<string, Array<LH.Protocol.RawEventMessage>>}} TracingData */
+/** @typedef {{traces: Object<string, LH.Trace>, devtoolsLogs: Object<string, LH.DevtoolsLog>}} TracingData */
 
 /**
  * Class that drives browser to load the page and runs gatherer lifecycle hooks.
@@ -173,7 +173,6 @@ class GatherRunner {
     }
 
     if (errorCode) {
-      // @ts-ignore TODO(bckenny): fix LHError constructor/errors mismatch
       const error = new LHError(errorCode, {reason: errorReason});
       log.error('GatherRunner', error.message, url);
       return error;

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -129,7 +129,13 @@ async function saveArtifacts(artifacts, basePath) {
   rimraf.sync(`${basePath}/*${traceSuffix}`);
   rimraf.sync(`${basePath}/${artifactsFilename}`);
 
-  const {traces, devtoolsLogs, ...restArtifacts} = artifacts;
+  // TODO: when https://github.com/GoogleChrome/lighthouse/issues/4952 is fixed
+  // const {traces, devtoolsLogs, ...restArtifacts} = artifacts;
+  const traces = artifacts.traces;
+  const devtoolsLogs = artifacts.devtoolsLogs;
+  const restArtifacts = Object.assign({}, artifacts);
+  delete restArtifacts.traces;
+  delete restArtifacts.devtoolsLogs;
 
   // save traces
   for (const [passName, trace] of Object.entries(traces)) {

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -3,7 +3,6 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-// @ts-nocheck
 'use strict';
 
 const fs = require('fs');
@@ -15,10 +14,24 @@ const TraceParser = require('./traces/trace-parser');
 const rimraf = require('rimraf');
 const mkdirp = require('mkdirp');
 
+const artifactsFilename = 'artifacts.json';
+const traceSuffix = '.trace.json';
+const devtoolsLogSuffix = '.devtoolslog.json';
+
+/** @typedef {{timestamp: number, datauri: string}} Screenshot */
+/**
+ * @typedef {object} PreparedAssets
+ * @property {string} passName
+ * @property {LH.Trace} traceData
+ * @property {LH.DevtoolsLog} devtoolsLog
+ * @property {string} screenshotsHTML
+ * @property {Array<Screenshot>} screenshots
+ */
+
 /**
  * Generate basic HTML page of screenshot filmstrip
- * @param {!Array<{timestamp: number, datauri: string}>} screenshots
- * @return {!string}
+ * @param {Array<Screenshot>} screenshots
+ * @return {string}
  */
 function screenshotDump(screenshots) {
   return `
@@ -58,25 +71,20 @@ img {
   `;
 }
 
-const artifactsFilename = 'artifacts.json';
-const traceSuffix = '.trace.json';
-const devtoolsLogSuffix = '.devtoolslog.json';
-
 /**
  * Load artifacts object from files located within basePath
  * Also save the traces to their own files
  * @param {string} basePath
- * @return {!Promise<!Artifacts>}
+ * @return {Promise<LH.Artifacts>}
  */
-// Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
-/* istanbul ignore next */
-function loadArtifacts(basePath) {
+async function loadArtifacts(basePath) {
   log.log('Reading artifacts from disk:', basePath);
 
   if (!fs.existsSync(basePath)) return Promise.reject(new Error('No saved artifacts found'));
 
   // load artifacts.json
   const filenames = fs.readdirSync(basePath);
+  /** @type {LH.Artifacts} */
   const artifacts = JSON.parse(fs.readFileSync(path.join(basePath, artifactsFilename), 'utf8'));
 
   // load devtoolsLogs
@@ -104,91 +112,85 @@ function loadArtifacts(basePath) {
       });
     });
   });
-  return Promise.all(promises).then(_ => artifacts);
+  await Promise.all(promises);
+
+  return artifacts;
 }
 
 /**
  * Save artifacts object mostly to single file located at basePath/artifacts.log.
  * Also save the traces & devtoolsLogs to their own files
- * @param {!Artifacts} artifacts
+ * @param {LH.Artifacts} artifacts
  * @param {string} basePath
+ * @return {Promise<void>}
  */
-// Set to ignore because testing it would imply testing fs, which isn't strictly necessary.
-/* istanbul ignore next */
-function saveArtifacts(artifacts, basePath) {
+async function saveArtifacts(artifacts, basePath) {
   mkdirp.sync(basePath);
   rimraf.sync(`${basePath}/*${traceSuffix}`);
   rimraf.sync(`${basePath}/${artifactsFilename}`);
 
-  // We don't want to mutate the artifacts as provided
-  artifacts = Object.assign({}, artifacts);
+  const {traces, devtoolsLogs, ...restArtifacts} = artifacts;
 
   // save traces
-  const traces = artifacts.traces;
-  let promise = Promise.all(Object.keys(traces).map(passName => {
-    return saveTrace(traces[passName], `${basePath}/${passName}${traceSuffix}`);
-  }));
+  for (const [passName, trace] of Object.entries(traces)) {
+    await saveTrace(trace, `${basePath}/${passName}${traceSuffix}`);
+  }
 
   // save devtools log
-  const devtoolsLogs = artifacts.devtoolsLogs;
-  promise = promise.then(_ => {
-    Object.keys(devtoolsLogs).map(passName => {
-      const log = JSON.stringify(devtoolsLogs[passName]);
-      fs.writeFileSync(`${basePath}/${passName}${devtoolsLogSuffix}`, log, 'utf8');
-    });
-    delete artifacts.traces;
-    delete artifacts.devtoolsLogs;
-  });
+  for (const [passName, devtoolsLog] of Object.entries(devtoolsLogs)) {
+    const log = JSON.stringify(devtoolsLog);
+    fs.writeFileSync(`${basePath}/${passName}${devtoolsLogSuffix}`, log, 'utf8');
+  }
 
   // save everything else
-  promise = promise.then(_ => {
-    fs.writeFileSync(`${basePath}/${artifactsFilename}`, JSON.stringify(artifacts, 0, 2), 'utf8');
-    log.log('Artifacts saved to disk in folder:', basePath);
-  });
-  return promise;
+  const restArtifactsString = JSON.stringify(restArtifacts, null, 2);
+  fs.writeFileSync(`${basePath}/${artifactsFilename}`, restArtifactsString, 'utf8');
+  log.log('Artifacts saved to disk in folder:', basePath);
 }
 
 /**
  * Filter traces and extract screenshots to prepare for saving.
- * @param {!Artifacts} artifacts
- * @param {!Audits} audits
- * @return {!Promise<!Array<{traceData: !Object, html: string}>>}
+ * @param {LH.Artifacts} artifacts
+ * @param {LH.Audit.Results} [audits]
+ * @return {Promise<Array<PreparedAssets>>}
  */
-function prepareAssets(artifacts, audits) {
+async function prepareAssets(artifacts, audits) {
   const passNames = Object.keys(artifacts.traces);
+  /** @type {Array<PreparedAssets>} */
   const assets = [];
 
-  return passNames.reduce((chain, passName) => {
+  for (const passName of passNames) {
     const trace = artifacts.traces[passName];
     const devtoolsLog = artifacts.devtoolsLogs[passName];
+    /** @type {Array<Screenshot>} */
+    // @ts-ignore TODO(bckenny): need typed computed artifacts
+    const screenshots = await artifacts.requestScreenshots(trace);
 
-    return chain.then(_ => artifacts.requestScreenshots(trace))
-      .then(screenshots => {
-        const traceData = Object.assign({}, trace);
-        const screenshotsHTML = screenshotDump(screenshots);
+    const traceData = Object.assign({}, trace);
+    const screenshotsHTML = screenshotDump(screenshots);
 
-        if (audits) {
-          const evts = new Metrics(traceData.traceEvents, audits).generateFakeEvents();
-          traceData.traceEvents = traceData.traceEvents.concat(evts);
-        }
+    if (audits) {
+      const evts = new Metrics(traceData.traceEvents, audits).generateFakeEvents();
+      traceData.traceEvents = traceData.traceEvents.concat(evts);
+    }
 
-        assets.push({
-          passName,
-          traceData,
-          devtoolsLog,
-          screenshotsHTML,
-          screenshots,
-        });
-      });
-  }, Promise.resolve())
-    .then(_ => assets);
+    assets.push({
+      passName,
+      traceData,
+      devtoolsLog,
+      screenshotsHTML,
+      screenshots,
+    });
+  }
+
+  return assets;
 }
 
 /**
  * Generates a JSON representation of traceData line-by-line to avoid OOM due to
  * very large traces.
- * @param {{traceEvents: !Array}} traceData
- * @return {!Iterator<string>}
+ * @param {LH.Trace} traceData
+ * @return {IterableIterator<string>}
  */
 function* traceJsonGenerator(traceData) {
   const keys = Object.keys(traceData);
@@ -222,9 +224,9 @@ function* traceJsonGenerator(traceData) {
 
 /**
  * Save a trace as JSON by streaming to disk at traceFilename.
- * @param {{traceEvents: !Array}} traceData
+ * @param {LH.Trace} traceData
  * @param {string} traceFilename
- * @return {!Promise<undefined>}
+ * @return {Promise<void>}
  */
 function saveTrace(traceData, traceFilename) {
   return new Promise((resolve, reject) => {
@@ -247,53 +249,52 @@ function saveTrace(traceData, traceFilename) {
 }
 
 /**
- * Writes trace(s) and associated screenshot(s) to disk.
- * @param {!Artifacts} artifacts
- * @param {!Audits} audits
+ * Writes trace(s) and associated asset(s) to disk.
+ * @param {LH.Artifacts} artifacts
+ * @param {LH.Audit.Results} audits
  * @param {string} pathWithBasename
- * @return {!Promise}
+ * @return {Promise<void>}
  */
-function saveAssets(artifacts, audits, pathWithBasename) {
-  return prepareAssets(artifacts, audits).then(assets => {
-    return Promise.all(assets.map((data, index) => {
-      const devtoolsLogFilename = `${pathWithBasename}-${index}${devtoolsLogSuffix}`;
-      fs.writeFileSync(devtoolsLogFilename, JSON.stringify(data.devtoolsLog, null, 2));
-      log.log('saveAssets', 'devtools log saved to disk: ' + devtoolsLogFilename);
+async function saveAssets(artifacts, audits, pathWithBasename) {
+  const allAssets = await prepareAssets(artifacts, audits);
+  const saveAll = allAssets.map(async (passAssets, index) => {
+    const devtoolsLogFilename = `${pathWithBasename}-${index}${devtoolsLogSuffix}`;
+    fs.writeFileSync(devtoolsLogFilename, JSON.stringify(passAssets.devtoolsLog, null, 2));
+    log.log('saveAssets', 'devtools log saved to disk: ' + devtoolsLogFilename);
 
-      const screenshotsHTMLFilename = `${pathWithBasename}-${index}.screenshots.html`;
-      fs.writeFileSync(screenshotsHTMLFilename, data.screenshotsHTML);
-      log.log('saveAssets', 'screenshots saved to disk: ' + screenshotsHTMLFilename);
+    const screenshotsHTMLFilename = `${pathWithBasename}-${index}.screenshots.html`;
+    fs.writeFileSync(screenshotsHTMLFilename, passAssets.screenshotsHTML);
+    log.log('saveAssets', 'screenshots saved to disk: ' + screenshotsHTMLFilename);
 
-      const screenshotsJSONFilename = `${pathWithBasename}-${index}.screenshots.json`;
-      fs.writeFileSync(screenshotsJSONFilename, JSON.stringify(data.screenshots, null, 2));
-      log.log('saveAssets', 'screenshots saved to disk: ' + screenshotsJSONFilename);
+    const screenshotsJSONFilename = `${pathWithBasename}-${index}.screenshots.json`;
+    fs.writeFileSync(screenshotsJSONFilename, JSON.stringify(passAssets.screenshots, null, 2));
+    log.log('saveAssets', 'screenshots saved to disk: ' + screenshotsJSONFilename);
 
-      const streamTraceFilename = `${pathWithBasename}-${index}${traceSuffix}`;
-      log.log('saveAssets', 'streaming trace file to disk: ' + streamTraceFilename);
-      return saveTrace(data.traceData, streamTraceFilename).then(_ => {
-        log.log('saveAssets', 'trace file streamed to disk: ' + streamTraceFilename);
-      });
-    }));
+    const streamTraceFilename = `${pathWithBasename}-${index}${traceSuffix}`;
+    log.log('saveAssets', 'streaming trace file to disk: ' + streamTraceFilename);
+    await saveTrace(passAssets.traceData, streamTraceFilename);
+    log.log('saveAssets', 'trace file streamed to disk: ' + streamTraceFilename);
   });
+
+  await Promise.all(saveAll);
 }
 
 /**
- * Log trace(s) and associated screenshot(s) to console.
- * @param {!Artifacts} artifacts
- * @param {!Audits} audits
- * @return {!Promise}
+ * Log trace(s) and associated devtoolsLog(s) to console.
+ * @param {LH.Artifacts} artifacts
+ * @param {LH.Audit.Results} audits
+ * @return {Promise<void>}
  */
-function logAssets(artifacts, audits) {
-  return prepareAssets(artifacts, audits).then(assets => {
-    assets.map(data => {
-      log.log(`devtoolslog-${data.passName}.json`, JSON.stringify(data.devtoolsLog));
-      const traceIter = traceJsonGenerator(data.traceData);
-      let traceJson = '';
-      for (const trace of traceIter) {
-        traceJson += trace;
-      }
-      log.log(`trace-${data.passName}.json`, traceJson);
-    });
+async function logAssets(artifacts, audits) {
+  const allAssets = await prepareAssets(artifacts, audits);
+  allAssets.map(passAssets => {
+    log.log(`devtoolslog-${passAssets.passName}.json`, JSON.stringify(passAssets.devtoolsLog));
+    const traceIter = traceJsonGenerator(passAssets.traceData);
+    let traceJson = '';
+    for (const trace of traceIter) {
+      traceJson += trace;
+    }
+    log.log(`trace-${passAssets.passName}.json`, traceJson);
   });
 }
 

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -259,7 +259,7 @@ class NetworkRecorder extends EventEmitter {
 
   /**
    * Construct network records from a log of devtools protocol messages.
-   * @param {Array<LH.Protocol.RawEventMessage>} devtoolsLog
+   * @param {LH.DevtoolsLog} devtoolsLog
    * @return {Array<LH.WebInspector.NetworkRequest>}
    */
   static recordsFromLogs(devtoolsLog) {

--- a/lighthouse-core/lib/traces/pwmetrics-events.js
+++ b/lighthouse-core/lib/traces/pwmetrics-events.js
@@ -235,7 +235,7 @@ class Metrics {
   }
 
   /**
-   * @returns {!Array} User timing raw trace event pairs
+   * @returns {Array<LH.TraceEvent>} User timing raw trace event pairs
    */
   generateFakeEvents() {
     const fakeEvents = [];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "chrome-debug": "./lighthouse-core/scripts/manual-chrome-launcher.js"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "install-all": "npm-run-posix-or-windows install-all:task",
@@ -75,7 +75,7 @@
     "coveralls": "^2.11.9",
     "csv-validator": "^0.0.3",
     "cz-customizable": "^5.2.0",
-    "eslint": "^4.8.0",
+    "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
     "google-closure-compiler": "^20170521.0.0",
     "gulp": "^3.9.1",

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -11,12 +11,12 @@ declare global {
       LighthouseRunWarnings: string[];
       UserAgent: string;
       traces: {[passName: string]: Trace};
-      devtoolsLogs: {[passName: string]: Protocol.RawEventMessage};
+      devtoolsLogs: {[passName: string]: DevtoolsLog};
     }
 
     module Artifacts {
       export interface MetricComputationDataInput {
-        devtoolsLog: Array<Protocol.RawEventMessage>;
+        devtoolsLog: DevtoolsLog;
         trace: Trace;
         settings: Config.Settings;
       }

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -102,8 +102,17 @@ declare global {
       friendlyMessage?: string;
     }
 
+    /**
+     * A record of DevTools Debugging Protocol events.
+     */
+    export type DevtoolsLog = Array<Protocol.RawEventMessage>;
+
     export interface Trace {
       traceEvents: TraceEvent[];
+      metadata?: {
+        'cpu-family'?: number;
+      };
+      [futureProps: string]: any;
     }
 
     export interface TraceEvent {

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -22,7 +22,7 @@ declare global {
 
     export interface LoadData {
       networkRecords: Array<WebInspector.NetworkRequest>;
-      devtoolsLog: Array<Protocol.RawEventMessage>;
+      devtoolsLog: DevtoolsLog;
       trace?: Trace;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,8 +42,8 @@
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
 
 "@types/node@*", "@types/node@^9.3.0":
-  version "8.0.49"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.49.tgz#417f86ab4829c629fe561779ee48751e0fe2a11b"
+  version "8.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.9.5.tgz#162b864bc70be077e6db212b322754917929e976"
 
 "@types/opn@^3.0.28":
   version "3.0.28"
@@ -199,9 +199,9 @@ acorn@^4.0.4:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
-acorn@^5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
+acorn@^5.5.0:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -217,7 +217,7 @@ ajv-keywords@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.0.tgz#a296e17f7bfae7c1ce4f7e0de53d29cb32162df0"
 
-ajv@^5.2.0, ajv@^5.2.3:
+ajv@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
   dependencies:
@@ -225,6 +225,15 @@ ajv@^5.2.0, ajv@^5.2.3:
     fast-deep-equal "^1.0.0"
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1362,7 +1371,7 @@ debug@^2.1.1, debug@^2.2.0, debug@^2.4.5, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0:
+debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -1474,12 +1483,11 @@ diff@^3.1.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
-doctrine@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
-    isarray "^1.0.0"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -1565,32 +1573,36 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.8.0.tgz#229ef0e354e0e61d837c7a80fdfba825e199815e"
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
   dependencies:
-    ajv "^5.2.0"
+    ajv "^5.3.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
-    debug "^3.0.1"
-    doctrine "^2.0.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
     eslint-scope "^3.7.1"
-    espree "^3.5.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
     esquery "^1.0.0"
-    estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
-    globals "^9.17.0"
+    globals "^11.0.1"
     ignore "^3.3.3"
     imurmurhash "^0.1.4"
     inquirer "^3.0.6"
     is-resolvable "^1.0.0"
     js-yaml "^3.9.1"
-    json-stable-stringify "^1.0.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.4"
     minimatch "^3.0.2"
@@ -1600,18 +1612,19 @@ eslint@^4.8.0:
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
+    regexpp "^1.0.1"
     require-uncached "^1.0.3"
     semver "^5.3.0"
     strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
-    table "^4.0.1"
+    table "4.0.2"
     text-table "~0.2.0"
 
-espree@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
-    acorn "^5.1.1"
+    acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
 esprima@^2.6.0, esprima@^2.7.1:
@@ -1639,7 +1652,7 @@ estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -1787,6 +1800,10 @@ fancy-log@^1.1.0:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.5"
@@ -2192,11 +2209,15 @@ global-prefix@^0.1.4:
     osenv "^0.1.3"
     which "^1.2.10"
 
+globals@^11.0.1:
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.4.0.tgz#b85c793349561c16076a3c13549238a27945f1bc"
+
 globals@^8.3.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-8.18.0.tgz#93d4a62bdcac38cfafafc47d6b034768cb0ffcb4"
 
-globals@^9.17.0, globals@^9.18.0:
+globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -2806,7 +2827,7 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
-isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -2969,6 +2990,10 @@ json-schema-traverse@^0.3.0:
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -4180,6 +4205,10 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
 registry-auth-token@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.1.0.tgz#997c08256e0c7999837b90e944db39d8a790276b"
@@ -4796,7 +4825,7 @@ symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@^4.0.1:
+table@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:


### PR DESCRIPTION
another step on the way to typing the LHR pipeline, but was self contained enough that I split it out for easier review. Adds types to `asset-saver.js` and a few places changes due to that touch, like e.g. making a type alias for `LH.DevtoolsLog` (instead of (`Array<LH.Protocol.RawEventMessage>` :).

`asset-saver.js` is mostly the same except for indenting, so probably easier to review with [?w=1](https://github.com/GoogleChrome/lighthouse/pull/4949/files?w=1).

With the use of object spread, I moved our minimum node engine to 8.9 (the [first Node 8 LTS release](https://nodejs.org/en/blog/release/v8.9.0/)) and bumped our eslint to support what it calls `ecmaVersion` 2018.