### PR TITLE
Runtime error encountered: Cannot change settings between gathering and auditing

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -19,7 +19,7 @@ const printer = require('./printer');
 function getFlags(manualArgv) {
   // @ts-ignore yargs() is incorrectly typed as not returning itself
   const y = manualArgv ? yargs(manualArgv) : yargs;
-  return y.help('help')
+  const argv = y.help('help')
       .version(() => pkg.version)
       .showHelpOnFail(false, 'Specify --help for available options')
 
@@ -143,6 +143,17 @@ function getFlags(manualArgv) {
           'For more information on Lighthouse, see https://developers.google.com/web/tools/lighthouse/.')
       .wrap(yargs.terminalWidth())
       .argv;
+
+  // Map all undefined values to null so our asset-saver does not discard them.
+  // Asset saver uses JSON.stringify to save our settings to disk. JSON.stringify removes undefined values
+  // as it's not valid json.
+  for (const key in argv) {
+    if (typeof argv[key] === 'undefined') {
+      argv[key] = null;
+    }
+  }
+
+  return argv;
 }
 
 module.exports = {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -180,7 +180,7 @@ class Runner {
 
     if (artifacts.settings) {
       const overrides = {'gatherMode': undefined, 'G': undefined, 'gather-mode': undefined,
-        'auditMode': undefined, 'A': undefined, 'audit-mode': undefined};
+        'auditMode': undefined, 'A': undefined, 'audit-mode': undefined, 'port': 0};
       const normalizedGatherSettings = Object.assign({}, artifacts.settings, overrides);
       const normalizedAuditSettings = Object.assign({}, opts.settings, overrides);
 

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -179,7 +179,8 @@ class Runner {
         artifacts || opts.config.artifacts);
 
     if (artifacts.settings) {
-      const overrides = {gatherMode: undefined, auditMode: undefined};
+      const overrides = {'gatherMode': undefined, 'G': undefined, 'gather-mode': undefined,
+        'auditMode': undefined, 'A': undefined, 'audit-mode': undefined};
       const normalizedGatherSettings = Object.assign({}, artifacts.settings, overrides);
       const normalizedAuditSettings = Object.assign({}, opts.settings, overrides);
 


### PR DESCRIPTION
I couldn't run lighthouse-cli with -A anymore. I would always get the following error:
```
Runtime error encountered: Cannot change settings between gathering and auditing
Error: Cannot change settings between gathering and auditing
```
It seems that lodash isEqual checks the length of our objects which are not the same. The saved artifact removes all undefined values as it uses JSON.stringify. I convert all undefined values to null so it keeps the keys intact. 