### PR TITLE
tests: fix run-smoke handoff of testResults

### DIFF
--- a/lighthouse-cli/test/smokehouse/run-smoke.js
+++ b/lighthouse-cli/test/smokehouse/run-smoke.js
@@ -84,6 +84,7 @@ function displaySmokehouseOutput(result) {
   }
   console.timeEnd(`smoketest-${result.id}`);
   console.log(`${purpleify(result.id)} smoketest complete. \n`);
+  return result;
 }
 
 /**
@@ -183,4 +184,7 @@ async function cli() {
   process.exit(0);
 }
 
-cli();
+cli().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
brendan was running into this:

![image](https://user-images.githubusercontent.com/39191/38707433-31141e04-3e66-11e8-9dd0-a03a4b62c9f9.png)

It was a fairly stupid error, but wasn't being caught. 

Lesson learned is that the top-level async invocation always needs a catch. ;)