### PR TITLE
core(metrics): add first CPU idle lantern metric

### DIFF
--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -39,6 +39,7 @@ class PredictivePerf extends Audit {
     const fcp = await artifacts.requestLanternFirstContentfulPaint({trace, devtoolsLog});
     const fmp = await artifacts.requestLanternFirstMeaningfulPaint({trace, devtoolsLog});
     const ttci = await artifacts.requestLanternConsistentlyInteractive({trace, devtoolsLog});
+    const ttfcpui = await artifacts.requestLanternFirstCPUIdle({trace, devtoolsLog});
 
     const values = {
       roughEstimateOfFCP: fcp.timing,
@@ -52,6 +53,10 @@ class PredictivePerf extends Audit {
       roughEstimateOfTTCI: ttci.timing,
       optimisticTTCI: ttci.optimisticEstimate.timeInMs,
       pessimisticTTCI: ttci.pessimisticEstimate.timeInMs,
+
+      roughEstimateOfTTFCPUI: ttfcpui.timing,
+      optimisticTTFCPUI: ttfcpui.optimisticEstimate.timeInMs,
+      pessimisticTTFCPUI: ttfcpui.pessimisticEstimate.timeInMs,
     };
 
     const score = Audit.computeLogNormalScore(

--- a/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
@@ -1,0 +1,56 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Node = require('../../../lib/dependency-graph/node');
+const CPUNode = require('../../../lib/dependency-graph/cpu-node'); // eslint-disable-line no-unused-vars
+const NetworkNode = require('../../../lib/dependency-graph/network-node'); // eslint-disable-line no-unused-vars
+
+const FirstInteractive = require('../first-interactive');
+const LanternConsistentlyInteractive = require('./lantern-consistently-interactive');
+
+class FirstCPUIdle extends LanternConsistentlyInteractive {
+  get name() {
+    return 'LanternFirstCPUIdle';
+  }
+
+  /**
+   * @param {LH.Gatherer.Simulation.Result} simulationResult
+   * @param {Object} extras
+   * @return {LH.Gatherer.Simulation.Result}
+   */
+  getEstimateFromSimulation(simulationResult, extras) {
+    const fmpTimeInMs = extras.optimistic
+      ? extras.fmpResult.optimisticEstimate.timeInMs
+      : extras.fmpResult.pessimisticEstimate.timeInMs;
+
+    return {
+      timeInMs: FirstCPUIdle.getFirstCPUIdleWindowStart(simulationResult.nodeTiming, fmpTimeInMs),
+      nodeTiming: simulationResult.nodeTiming,
+    };
+  }
+
+  /**
+   *
+   * @param {Map<Node, LH.Gatherer.Simulation.NodeTiming>} nodeTiming
+   * @param {number} fmpTimeInMs
+   */
+  static getFirstCPUIdleWindowStart(nodeTiming, fmpTimeInMs, longTaskLength = 50) {
+    /** @type {Array<{start: number, end: number}>} */
+    const longTasks = [];
+    for (const [node, timing] of nodeTiming.entries()) {
+      if (node.type !== Node.TYPES.CPU) continue;
+      if (!timing.endTime || !timing.startTime) continue;
+      if (timing.endTime - timing.startTime < longTaskLength) continue;
+      longTasks.push({start: timing.startTime, end: timing.endTime});
+    }
+
+    // @ts-ignore TODO(phulce): typecheck first-interactive on refactor to real metric
+    return FirstInteractive.findQuietWindow(fmpTimeInMs, Infinity, longTasks);
+  }
+}
+
+module.exports = FirstCPUIdle;

--- a/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
@@ -48,7 +48,6 @@ class FirstCPUIdle extends LanternConsistentlyInteractive {
       longTasks.push({start: timing.startTime, end: timing.endTime});
     }
 
-    // @ts-ignore TODO(phulce): typecheck first-interactive on refactor to real metric
     return FirstInteractive.findQuietWindow(fmpTimeInMs, Infinity, longTasks);
   }
 }

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-cpu-idle-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-cpu-idle-test.js
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Runner = require('../../../../runner');
+const assert = require('assert');
+
+const trace = require('../../../fixtures/traces/progressive-app-m60.json');
+const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtools.log.json');
+
+/* eslint-env mocha */
+describe('Metrics: Lantern TTFCPUI', () => {
+  it('should compute predicted value', async () => {
+    const artifacts = Runner.instantiateComputedArtifacts();
+    const result = await artifacts.requestLanternFirstCPUIdle({trace, devtoolsLog});
+
+    assert.equal(Math.round(result.timing), 5308);
+    assert.equal(Math.round(result.optimisticEstimate.timeInMs), 2451);
+    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 2752);
+    assert.equal(result.optimisticEstimate.nodeTiming.size, 19);
+    assert.equal(result.pessimisticEstimate.nodeTiming.size, 79);
+    assert.ok(result.optimisticGraph, 'should have created optimistic graph');
+    assert.ok(result.pessimisticGraph, 'should have created pessimistic graph');
+  });
+});

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -12,6 +12,8 @@ declare global {
       UserAgent: string;
       traces: {[passName: string]: Trace};
       devtoolsLogs: {[passName: string]: DevtoolsLog};
+      // TODO(bckenny): remove this for real computed artifacts approach
+      requestTraceOfTab(trace: Trace): Promise<Artifacts.TraceOfTab>
     }
 
     module Artifacts {


### PR DESCRIPTION
I realized that we can realistically carry over all of our existing metrics in lantern world, and really FCPUI is the only one that I didn't have an impl of yet

this just reuses the graphs and coefficients of TTI combined with the existing algorithm for first interactive that does shortening window size/task clusters/etc

by reusing the graphs and coefficients of TTI we will also always give consistent answers on TTI/TTFCPUI because in the worst case, the start of the quiet window will be the last long task (which is equal to TTI estimate)

accuracy is really quite good, spearman's rho of ~0.82, which is slightly worse than TTI but better than FCP/FMP. MAPE of ~30%, which is nearly identical to TTI absolute error