### PR TITLE
tests(smoke): add smoke test code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - yarn type-check
   - yarn closure
   - yarn diff:sample-json
-  - yarn smoke
+  - yarn smoke:silentcoverage
   - yarn test-extension
   # _JAVA_OPTIONS is breaking parsing of compiler output. See #3338.
   - unset _JAVA_OPTIONS
@@ -49,5 +49,6 @@ before_cache:
   - rm -rf ./node_modules/temp-devtoolsprotocol/
 after_success:
   - yarn coveralls
+  - yarn codecov
 addons:
   chrome: stable

--- a/lighthouse-core/gather/gatherers/dobetterweb/js-libraries.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/js-libraries.js
@@ -22,8 +22,8 @@ const libDetectorSource = fs.readFileSync(
  * Obtains a list of detected JS libraries and their versions.
  * @return {!Array<!{name: string, version: string, npmPkgName: string}>}
  */
-/* istanbul ignore next */
 /* eslint-disable camelcase */
+/* istanbul ignore next */
 function detectLibraries() {
   const libraries = [];
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
@@ -23,6 +23,7 @@ const Gatherer = require('../gatherer');
 
 /* global document,window,HTMLLinkElement */
 
+/* istanbul ignore next */
 function installMediaListener() {
   window.___linkMediaChanges = [];
   Object.defineProperty(HTMLLinkElement.prototype, 'media', {

--- a/lighthouse-core/gather/gatherers/seo/robots-txt.js
+++ b/lighthouse-core/gather/gatherers/seo/robots-txt.js
@@ -9,6 +9,7 @@ const Gatherer = require('../gatherer');
 
 /* global fetch, URL, location */
 
+/* istanbul ignore next */
 function getRobotsTxtContent() {
   return fetch(new URL('/robots.txt', location.href))
     .then(response => {

--- a/lighthouse-core/lib/dom-helpers.js
+++ b/lighthouse-core/lib/dom-helpers.js
@@ -19,6 +19,7 @@
  *     Combinators are not supported.
  * @param {!Array<!Element>}
  */
+/* istanbul ignore next */
 function getElementsInDocument(selector) {
   const results = [];
 

--- a/package.json
+++ b/package.json
@@ -40,9 +40,12 @@
     "viewer-unit": "yarn unit-viewer",
     "watch": "yarn unit-core --watch",
 
-    "unit:silentcoverage": "nyc --silent yarn unit",
+    "unit:silentcoverage": "nyc --silent yarn unit && nyc report --reporter text-lcov > unit-coverage.lcov",
     "coverage": "nyc yarn unit && nyc report --reporter html",
-    "coveralls": "nyc report --reporter lcovonly && cat ./coverage/lcov.info | coveralls && codecov",
+    "smoke:silentcoverage": "nyc --silent yarn smoke && nyc report --reporter text-lcov > smoke-coverage.lcov",
+    "coverage:smoke": "nyc yarn smoke && nyc report --reporter html",
+    "coveralls": "cat unit-coverage.lcov | coveralls",
+    "codecov": "codecov -f unit-coverage.lcov -F unit && codecov -f smoke-coverage.lcov -F smoke",
 
     "closure": "cd lighthouse-core && node closure/closure-type-checking.js",
     "devtools": "bash lighthouse-core/scripts/roll-to-devtools.sh",


### PR DESCRIPTION
Since:
- #4748 moved the smoke test runner to pure js
- `nyc` supports merging code coverage from any tests run in child processes
- `codecov` [supports uploading multiple coverage reports](https://docs.codecov.io/v4.3.6/docs/flags)

it's now easy to add smoke test coverage :)

Run locally with `yarn coverage:smoke` and on codcov you get little `unit`/`smoke` tabs at the top of file views (e.g. [`report-generator.js`](https://codecov.io/gh/GoogleChrome/lighthouse/src/2a9a772fa8bb57ff6b308251789cd0ad58c79355/lighthouse-core/report/v2/report-generator.js)). In codecov you seem to only get those tabs in individual files, both tabs are selected at first by default, and the coverage numbers on the left may be the sum of the two? So the view is a little shaky if you're interested in comparing unit vs smoke coverage, but it's nice that if you want the union of the two you can see that as well without uploading yet another coverage file.