### PR TITLE
core(canonical): pass when there are multiple identical canonical links

### DIFF
--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -138,7 +138,7 @@ module.exports = [
       },
       'canonical': {
         score: 0,
-        debugString: 'Multiple URLs (https://example.com, https://example.com/)',
+        debugString: 'Multiple conflicting URLs (https://example.com, https://example.com/)',
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -23,13 +23,18 @@ const failureHeaders = headersParam([[
   '<https://example.com>; rel="canonical"',
 ]]);
 
+const passHeaders = headersParam([[
+  'link',
+  '<http://localhost:10200/seo/>; rel="canonical"',
+]]);
+
 /**
  * Expected Lighthouse audit values for seo tests
  */
 module.exports = [
   {
-    initialUrl: BASE_URL + 'seo-tester.html',
-    url: BASE_URL + 'seo-tester.html',
+    initialUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+    url: BASE_URL + 'seo-tester.html?' + passHeaders,
     audits: {
       'viewport': {
         score: 1,

--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -110,7 +110,7 @@ class Canonical extends Audit {
         if (canonicals.length > 1) {
           return {
             rawValue: false,
-            debugString: `Multiple URLs (${canonicals.join(', ')})`,
+            debugString: `Multiple conflicting URLs (${canonicals.join(', ')})`,
           };
         }
 

--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -90,6 +90,8 @@ class Canonical extends Audit {
           });
 
         canonicals = canonicals.concat(artifacts.Canonical);
+        // we should only fail if there are multiple conflicting URLs
+        // see: https://github.com/GoogleChrome/lighthouse/issues/3178#issuecomment-381181762
         canonicals = Array.from(new Set(canonicals));
 
         artifacts.Hreflang.forEach(({href}) => hreflangs.push(href));

--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -90,6 +90,7 @@ class Canonical extends Audit {
           });
 
         canonicals = canonicals.concat(artifacts.Canonical);
+        canonicals = Array.from(new Set(canonicals));
 
         artifacts.Hreflang.forEach(({href}) => hreflangs.push(href));
 

--- a/lighthouse-core/test/audits/seo/canonical-test.js
+++ b/lighthouse-core/test/audits/seo/canonical-test.js
@@ -142,6 +142,26 @@ describe('SEO: Document has valid canonical link', () => {
     });
   });
 
+  it('succeeds when there are multiple identical canonical links', () => {
+    const mainResource = {
+      url: 'http://www.example.com/',
+      responseHeaders: [{
+        name: 'Link',
+        value: '<https://www.example.com>; rel="canonical"',
+      }],
+    };
+    const artifacts = {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
+      requestMainResource: () => Promise.resolve(mainResource),
+      Canonical: ['https://www.example.com'],
+      Hreflang: [],
+    };
+
+    return CanonicalAudit.audit(artifacts).then(auditResult => {
+      assert.equal(auditResult.rawValue, true);
+    });
+  });
+
   it('succeeds when valid canonical is provided via meta tag', () => {
     const mainResource = {
       url: 'http://example.com/articles/cats-and-you?utm_source=twitter',


### PR DESCRIPTION
We were failing when multiple canonical links were provided (as suggested by the docs). [John says](https://github.com/GoogleChrome/lighthouse/issues/3178#issuecomment-381181762) that we shound only fail if URLs are different.

<img width="819" alt="oh no" src="https://user-images.githubusercontent.com/985504/38783841-5fd49256-4108-11e8-8e60-7eeefb33aea2.png">

Closes #3178