### PR TITLE
tests(smokehouse): increase timeout

### DIFF
--- a/lighthouse-cli/test/smokehouse/run-smoke.js
+++ b/lighthouse-cli/test/smokehouse/run-smoke.js
@@ -108,7 +108,7 @@ async function runSmokehouse(smokes) {
     ].join(' ');
 
     // The promise ensures we output immediately, even if the process errors
-    const p = execAsync(cmd, {timeout: 3 * 60 * 1000, encoding: 'utf8'})
+    const p = execAsync(cmd, {timeout: 6 * 60 * 1000, encoding: 'utf8'})
       .then(cp => ({id: id, process: cp}))
       .catch(err => ({id: id, error: err}))
       .then(result => displaySmokehouseOutput(result));


### PR DESCRIPTION
so #4988 didn't fully fix the issue (https://travis-ci.org/GoogleChrome/lighthouse/jobs/368349837), we're still seeing timeouts for the 2 site batches, a single test seems to take up to 173s, so seems like we need double the time on travis
![image](https://user-images.githubusercontent.com/2301202/38959265-d22c8508-4314-11e8-8b2b-6dd46504302e.png)
