### PR TITLE
tests: split up parallel smoketests into 2 batches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,12 @@ before_script:
   - sh -e /etc/init.d/xvfb start
   - yarn build-all
 script:
-
+  - yarn bundlesize
+  - yarn lint
+  - yarn unit:silentcoverage
+  - yarn type-check
+  - yarn closure
+  - yarn diff:sample-json
   - yarn smoke:silentcoverage
   - yarn test-extension
   # _JAVA_OPTIONS is breaking parsing of compiler output. See #3338.


### PR DESCRIPTION
Used some data to split these into batches of similar size. (hopefully)


### results from travis

total time for smoketests:

| . | run 1 | run 2 | run 3 | run 4 |
|---|---|---|---|---|
| 2 batches | 213s | 237s | 217s | 219s | 
| 3 batches | 233s | 208s | 234s | 244s |

run 2 was just whack, i guess..