### PR TITLE
tests: drop port number from dbw_tester for golden lhr

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -30,8 +30,7 @@
 <!-- Note: these will only fail when using the static-server.js, which supports the ?delay=true param.
      If you're using your own server, the resource will load instantly and the
      stylesheets will be ignored for being below the threshold. -->
-<!-- we use a relative protocol url to test that `new URL(resource)` in the critical-request-chains.js audit can handle it -->
-<link rel="stylesheet" href="//localhost:10200/dobetterweb/dbw_tester.css?delay=100"> <!-- FAIL, when run under smokehouse -->
+<link rel="stylesheet" href="./dobetterweb/dbw_tester.css?delay=100"> <!-- FAIL, when run under smokehouse -->
 <link rel="stylesheet" href="./unknown404.css?delay=200"> <!-- FAIL -->
 <link rel="stylesheet" href="./dbw_tester.css?delay=2200"> <!-- FAIL -->
 <link rel="stylesheet" href="./dbw_disabled.css?delay=200&isdisabled" disabled> <!-- PASS -->


### PR DESCRIPTION
this causes an issue with the golden lhr diff test if the artifacts are regenerated. Since `update:sample-artifacts` is run with a random port, this request generates an extra error, a resource is missing, etc vs when run with the original 10200 port.

Rather than use port 10200 for `update:sample-artifacts`, this just makes the href fully relative as we now trust the `URL` constructor much more than we used to, and there hasn't been a `new URL()` in `critical-request-chains.js ` for quite some time anyways :) 