### PR TITLE
core(tti): update ignorable network requests and start point

### DIFF
--- a/lighthouse-core/gather/computed/metrics/consistently-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/consistently-interactive.js
@@ -14,6 +14,11 @@ const LHError = require('../../../lib/errors');
 const REQUIRED_QUIET_WINDOW = 5000;
 const ALLOWED_CONCURRENT_REQUESTS = 2;
 
+/**
+ * @fileoverview Computes "Time To Interactive", the time at which the page has loaded critical
+ * resources and is mostly idle.
+ * @see https://docs.google.com/document/d/1yE4YWsusi5wVXrnwhR61j-QyjK9tzENIzfxrCjA1NAk/edit#heading=h.yozfsuqcgpc4
+ */
 class ConsistentlyInteractive extends MetricArtifact {
   get name() {
     return 'ConsistentlyInteractive';
@@ -28,8 +33,11 @@ class ConsistentlyInteractive extends MetricArtifact {
    */
   static _findNetworkQuietPeriods(networkRecords, traceOfTab) {
     const traceEndTsInMs = traceOfTab.timestamps.traceEnd / 1000;
+    /** @param {LH.WebInspector.NetworkRequest} record */
+    const filter = record => record.finished && record.requestMethod === 'GET' && !record.failed &&
+        Math.floor(record.statusCode / 100) < 4;
     return NetworkRecorder.findNetworkQuietPeriods(networkRecords,
-      ALLOWED_CONCURRENT_REQUESTS, traceEndTsInMs);
+      ALLOWED_CONCURRENT_REQUESTS, traceEndTsInMs, filter);
   }
 
   /**
@@ -79,11 +87,11 @@ class ConsistentlyInteractive extends MetricArtifact {
    * @return {{cpuQuietPeriod: TimePeriod, networkQuietPeriod: TimePeriod, cpuQuietPeriods: Array<TimePeriod>, networkQuietPeriods: Array<TimePeriod>}}
    */
   static findOverlappingQuietPeriods(longTasks, networkRecords, traceOfTab) {
-    const FMPTsInMs = traceOfTab.timestamps.firstMeaningfulPaint / 1000;
+    const FCPTsInMs = traceOfTab.timestamps.firstContentfulPaint / 1000;
 
     /** @type {function(TimePeriod):boolean} */
     const isLongEnoughQuietPeriod = period =>
-        period.end > FMPTsInMs + REQUIRED_QUIET_WINDOW &&
+        period.end > FCPTsInMs + REQUIRED_QUIET_WINDOW &&
         period.end - period.start >= REQUIRED_QUIET_WINDOW;
     const networkQuietPeriods = this._findNetworkQuietPeriods(networkRecords, traceOfTab)
         .filter(isLongEnoughQuietPeriod);
@@ -137,8 +145,8 @@ class ConsistentlyInteractive extends MetricArtifact {
    */
   computeObservedMetric(data) {
     const {traceOfTab, networkRecords} = data;
-    if (!traceOfTab.timestamps.firstMeaningfulPaint) {
-      throw new LHError(LHError.errors.NO_FMP);
+    if (!traceOfTab.timestamps.firstContentfulPaint) {
+      throw new LHError(LHError.errors.NO_FCP);
     }
 
     if (!traceOfTab.timestamps.domContentLoaded) {
@@ -157,7 +165,7 @@ class ConsistentlyInteractive extends MetricArtifact {
 
     const timestamp = Math.max(
       cpuQuietPeriod.start,
-      traceOfTab.timestamps.firstMeaningfulPaint / 1000,
+      traceOfTab.timestamps.firstContentfulPaint / 1000,
       traceOfTab.timestamps.domContentLoaded / 1000
     ) * 1000;
     const timing = (timestamp - traceOfTab.timestamps.navigationStart) / 1000;

--- a/lighthouse-core/gather/computed/metrics/consistently-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/consistently-interactive.js
@@ -37,7 +37,7 @@ class ConsistentlyInteractive extends MetricArtifact {
     const filteredNetworkRecords = networkRecords.filter(record => {
       return record.finished && record.requestMethod === 'GET' && !record.failed &&
           // Consider network records that had 4xx/5xx status code as "failed"
-          Math.floor(record.statusCode / 100) < 4;
+          record.statusCode < 400;
     });
     return NetworkRecorder.findNetworkQuietPeriods(filteredNetworkRecords,
       ALLOWED_CONCURRENT_REQUESTS, traceEndTsInMs);

--- a/lighthouse-core/lib/errors.js
+++ b/lighthouse-core/lib/errors.js
@@ -97,7 +97,7 @@ const ERRORS = {
 
 Object.keys(ERRORS).forEach(code => ERRORS[code].code = code);
 
-/** @type {Object<string, LighthouseErrorDefinition>} */
+/** @type {Object<keyof ERRORS, LighthouseErrorDefinition>} */
 LighthouseError.errors = ERRORS;
 module.exports = LighthouseError;
 

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -95,21 +95,15 @@ class NetworkRecorder extends EventEmitter {
    * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @param {number} allowedConcurrentRequests
    * @param {number=} endTime
-   * @param {(function(LH.WebInspector.NetworkRequest):boolean)=} filter
    * @return {Array<{start: number, end: number}>}
    */
-  static findNetworkQuietPeriods(
-      networkRecords,
-      allowedConcurrentRequests,
-      endTime = Infinity,
-      filter
-  ) {
+  static findNetworkQuietPeriods(networkRecords, allowedConcurrentRequests, endTime = Infinity) {
     // First collect the timestamps of when requests start and end
     /** @type {Array<{time: number, isStart: boolean}>} */
     let timeBoundaries = [];
     networkRecords.forEach(record => {
       const scheme = record.parsedURL && record.parsedURL.scheme;
-      if (IGNORED_NETWORK_SCHEMES.includes(scheme) || (filter && !filter(record))) {
+      if (IGNORED_NETWORK_SCHEMES.includes(scheme)) {
         return;
       }
 

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -95,15 +95,21 @@ class NetworkRecorder extends EventEmitter {
    * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @param {number} allowedConcurrentRequests
    * @param {number=} endTime
+   * @param {(function(LH.WebInspector.NetworkRequest):boolean)=} filter
    * @return {Array<{start: number, end: number}>}
    */
-  static findNetworkQuietPeriods(networkRecords, allowedConcurrentRequests, endTime = Infinity) {
+  static findNetworkQuietPeriods(
+      networkRecords,
+      allowedConcurrentRequests,
+      endTime = Infinity,
+      filter
+  ) {
     // First collect the timestamps of when requests start and end
     /** @type {Array<{time: number, isStart: boolean}>} */
     let timeBoundaries = [];
     networkRecords.forEach(record => {
       const scheme = record.parsedURL && record.parsedURL.scheme;
-      if (IGNORED_NETWORK_SCHEMES.includes(scheme)) {
+      if (IGNORED_NETWORK_SCHEMES.includes(scheme) || (filter && !filter(record))) {
         return;
       }
 

--- a/typings/web-inspector.d.ts
+++ b/typings/web-inspector.d.ts
@@ -28,6 +28,7 @@ declare global {
       _resourceSize?: number;
 
       finished: boolean;
+      requestMethod: string;
       statusCode: number;
       redirectSource?: {
         url: string;


### PR DESCRIPTION
updates TTI definition based on v1.0 in the [doc](https://docs.google.com/document/d/1yE4YWsusi5wVXrnwhR61j-QyjK9tzENIzfxrCjA1NAk/edit#heading=h.yozfsuqcgpc4)
- use FCP instead of FMP
- ignore non-GET network requests
- ignore failed/unfinished network requests

NOTE: this PR does *not* tweak our decision of when to stop tracing, just the computation for observed TTI

ref #4629 #5008 #4333 