### PR TITLE
core(scoring): tweak scoring thresholds based on HTTPArchive data

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -37,9 +37,11 @@ class CacheHeaders extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/zokzso8umm
+      // 50th and 75th percentiles HTTPArchive -> 50 and 75
+      // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
+      // see https://www.desmos.com/calculator/8meohdnjbl
       scorePODR: 4 * 1024,
-      scoreMedian: 768 * 1024,
+      scoreMedian: 128 * 1024,
     };
   }
 

--- a/lighthouse-core/audits/consistently-interactive.js
+++ b/lighthouse-core/audits/consistently-interactive.js
@@ -35,9 +35,11 @@ class ConsistentlyInteractiveMetric extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/uti67afozh
-      scorePODR: 1700,
-      scoreMedian: 10000,
+      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
+      // see https://www.desmos.com/calculator/dohd3b0sbr
+      scorePODR: 1200,
+      scoreMedian: 7300,
     };
   }
 

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -48,9 +48,11 @@ class DOMSize extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/9cyxpm5qgp
-      scorePODR: 2400,
-      scoreMedian: 3000,
+      // 25th and 50th percentiles HTTPArchive -> 50 and 75
+      // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
+      // see https://www.desmos.com/calculator/vqot3wci4g
+      scorePODR: 700,
+      scoreMedian: 1400,
     };
   }
 

--- a/lighthouse-core/audits/first-contentful-paint.js
+++ b/lighthouse-core/audits/first-contentful-paint.js
@@ -28,8 +28,10 @@ class FirstContentfulPaint extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/joz3pqttdq
-      scorePODR: 1600,
+      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
+      // see https://www.desmos.com/calculator/trv2goqvsd
+      scorePODR: 1400,
       scoreMedian: 4000,
     };
   }

--- a/lighthouse-core/audits/first-cpu-idle.js
+++ b/lighthouse-core/audits/first-cpu-idle.js
@@ -29,9 +29,11 @@ class FirstCPUIdle extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/uti67afozh
-      scorePODR: 1700,
-      scoreMedian: 10000,
+      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
+      // see https://www.desmos.com/calculator/cwuavnclzj
+      scorePODR: 1400,
+      scoreMedian: 6500,
     };
   }
 

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -28,8 +28,10 @@ class FirstMeaningfulPaint extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/joz3pqttdq
-      scorePODR: 1600,
+      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
+      // see https://www.desmos.com/calculator/trv2goqvsd
+      scorePODR: 1400,
       scoreMedian: 4000,
     };
   }

--- a/lighthouse-core/audits/speed-index.js
+++ b/lighthouse-core/audits/speed-index.js
@@ -28,9 +28,11 @@ class SpeedIndex extends Audit {
    */
   static get defaultOptions() {
     return {
-      // see https://www.desmos.com/calculator/mdgjzchijg
-      scorePODR: 1250,
-      scoreMedian: 5500,
+      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
+      // see https://www.desmos.com/calculator/y1bg8ij7ti
+      scorePODR: 1700,
+      scoreMedian: 5800,
     };
   }
 


### PR DESCRIPTION
tweaks all the metric scoring points according to our agreed upon scheme, 90th percentile becomes a 75, 75th percentile becomes a 50. Pretty much everything got much harsher except for speedIndex.

I also updated 2 non-metric numeric audits, long-cache-ttl and dom-size which were insanely out of whack with the distributions, for them I picked the quantiles which still seemed reasonable (i.e. the real 75th percentile for dom-size was like 30 nodes, or something ridiculously low)

I didn't update bootup-time/mainthread since something seemed fishy with the data, like ~30% of values are 0, which seems impossible that that many sites have 0ms of javascript on mobile.

ref #4629 #4333 #5008 