### PR TITLE
core(lhr): savingsMs, savingsBytes

### DIFF
--- a/typings/lhr-lite.d.ts
+++ b/typings/lhr-lite.d.ts
@@ -84,8 +84,8 @@ declare global {
 
         export interface OpportunityDetails {
           type: 'opportunity';
-          savingsMs: number
-          savingsBytes?: number
+          overallSavingsMs: number
+          overallSavingsBytes?: number
           headings: ColumnHeading[];
           items: (WastedBytesDetailsItem | WastedTimeDetailsItem)[];
         }

--- a/typings/lhr-lite.d.ts
+++ b/typings/lhr-lite.d.ts
@@ -64,7 +64,7 @@ declare global {
          * 'informative': the audit is an FYI only, and can't be interpreted as pass/fail. Score is null and should be ignored.
          * 'notApplicable': the audit turned out to not apply to the page. Score is null and should be ignored.
          * 'manual': The audit exists only to tell you to review something yourself. Score is null and should be ignored.
-         * 'error': There was an error while running the object (check `errorMessage` for details). Score is null and should be ignored.
+         * 'error': There was an error while running the audit (check `errorMessage` for details). Score is null and should be ignored.
          */
         scoreDisplayMode: 'binary' | 'numeric' | 'informative' | 'notApplicable' | 'manual' | 'error';
         /** An explanation of audit-related issues encountered on the test page. */
@@ -84,8 +84,8 @@ declare global {
 
         export interface OpportunityDetails {
           type: 'opportunity';
-          wastedMs: number
-          wastedBytes?: number
+          savingsMs: number
+          savingsBytes?: number
           headings: ColumnHeading[];
           items: (WastedBytesDetailsItem | WastedTimeDetailsItem)[];
         }


### PR DESCRIPTION
proposal to rename.

Helps to differentiate between the item-level `wastedMs`. Got mixed up between the two just a moment ago. :)	 