### PR TITLE
core(tsc): add type checking to computed artifacts

### DIFF
--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -22,7 +22,7 @@ class CriticalRequestChains extends Audit {
           'the length of chains, reducing the download size of resources, or ' +
           'deferring the download of unnecessary resources to improve page load. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains).',
-      requiredArtifacts: ['devtoolsLogs'],
+      requiredArtifacts: ['devtoolsLogs', 'URL'],
     };
   }
 
@@ -120,8 +120,9 @@ class CriticalRequestChains extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const devtoolsLogs = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    return artifacts.requestCriticalRequestChains(devtoolsLogs).then(chains => {
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const URL = artifacts.URL;
+    return artifacts.requestCriticalRequestChains({devtoolsLog, URL}).then(chains => {
       let chainCount = 0;
       function walk(node, depth) {
         const children = Object.keys(node);

--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -30,18 +30,20 @@ class PredictivePerf extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
+   * @param {LH.Artifacts} artifacts
    * @return {!AuditResult}
    */
   static async audit(artifacts) {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    const fcp = await artifacts.requestLanternFirstContentfulPaint({trace, devtoolsLog});
-    const fmp = await artifacts.requestLanternFirstMeaningfulPaint({trace, devtoolsLog});
-    const ttci = await artifacts.requestLanternConsistentlyInteractive({trace, devtoolsLog});
-    const ttfcpui = await artifacts.requestLanternFirstCPUIdle({trace, devtoolsLog});
-    const si = await artifacts.requestLanternSpeedIndex({trace, devtoolsLog});
-    const eil = await artifacts.requestLanternEstimatedInputLatency({trace, devtoolsLog});
+    const settings = {}; // Use default settings.
+    const fcp = await artifacts.requestLanternFirstContentfulPaint({trace, devtoolsLog, settings});
+    const fmp = await artifacts.requestLanternFirstMeaningfulPaint({trace, devtoolsLog, settings});
+    const ttci = await artifacts.requestLanternConsistentlyInteractive({trace, devtoolsLog,
+      settings});
+    const ttfcpui = await artifacts.requestLanternFirstCPUIdle({trace, devtoolsLog, settings});
+    const si = await artifacts.requestLanternSpeedIndex({trace, devtoolsLog, settings});
+    const eil = await artifacts.requestLanternEstimatedInputLatency({trace, devtoolsLog, settings});
 
     const values = {
       roughEstimateOfFCP: fcp.timing,

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -29,7 +29,8 @@ class Redirects extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    return artifacts.requestMainResource(artifacts.devtoolsLogs[Audit.DEFAULT_PASS])
+    const data = {URL: artifacts.URL, devtoolsLog: artifacts.devtoolsLogs[Audit.DEFAULT_PASS]};
+    return artifacts.requestMainResource(data)
       .then(mainResource => {
         // redirects is only available when redirects happens
         const redirectRequests = Array.from(mainResource.redirects || []);

--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -65,7 +65,7 @@ class Canonical extends Audit {
       failureDescription: 'Document does not have a valid `rel=canonical`',
       helpText: 'Canonical links suggest which URL to show in search results. ' +
         '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/canonical).',
-      requiredArtifacts: ['Canonical', 'Hreflang'],
+      requiredArtifacts: ['Canonical', 'Hreflang', 'URL'],
     };
   }
 
@@ -74,9 +74,9 @@ class Canonical extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const devtoolsLogs = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
 
-    return artifacts.requestMainResource(devtoolsLogs)
+    return artifacts.requestMainResource({devtoolsLog, URL: artifacts.URL})
       .then(mainResource => {
         const baseURL = new URL(mainResource.url);
         let canonicals = [];

--- a/lighthouse-core/audits/seo/hreflang.js
+++ b/lighthouse-core/audits/seo/hreflang.js
@@ -63,7 +63,7 @@ class Hreflang extends Audit {
       helpText: 'hreflang links tell search engines what version of a page they should ' +
         'list in search results for a given language or region. [Learn more]' +
         '(https://developers.google.com/web/tools/lighthouse/audits/hreflang).',
-      requiredArtifacts: ['Hreflang'],
+      requiredArtifacts: ['Hreflang', 'URL'],
     };
   }
 
@@ -72,9 +72,10 @@ class Hreflang extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const devtoolsLogs = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const URL = artifacts.URL;
 
-    return artifacts.requestMainResource(devtoolsLogs)
+    return artifacts.requestMainResource({devtoolsLog, URL})
       .then(mainResource => {
         /** @type {Array<{source: string|{type: string, snippet: string}}>} */
         const invalidHreflangs = [];

--- a/lighthouse-core/audits/seo/http-status-code.js
+++ b/lighthouse-core/audits/seo/http-status-code.js
@@ -21,7 +21,7 @@ class HTTPStatusCode extends Audit {
       helpText: 'Pages with unsuccessful HTTP status codes may not be indexed properly. ' +
       '[Learn more]' +
       '(https://developers.google.com/web/tools/lighthouse/audits/successful-http-code).',
-      requiredArtifacts: ['devtoolsLogs'],
+      requiredArtifacts: ['devtoolsLogs', 'URL'],
     };
   }
 
@@ -30,9 +30,10 @@ class HTTPStatusCode extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const devtoolsLogs = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const URL = artifacts.URL;
 
-    return artifacts.requestMainResource(devtoolsLogs)
+    return artifacts.requestMainResource({devtoolsLog, URL})
       .then(mainResource => {
         const statusCode = mainResource.statusCode;
 

--- a/lighthouse-core/audits/seo/is-crawlable.js
+++ b/lighthouse-core/audits/seo/is-crawlable.js
@@ -68,7 +68,7 @@ class IsCrawlable extends Audit {
       helpText: 'Search engines are unable to include your pages in search results ' +
           'if they don\'t have permission to crawl them. [Learn ' +
           'more](https://developers.google.com/web/tools/lighthouse/audits/indexing).',
-      requiredArtifacts: ['MetaRobots', 'RobotsTxt'],
+      requiredArtifacts: ['MetaRobots', 'RobotsTxt', 'URL'],
     };
   }
 
@@ -77,7 +77,9 @@ class IsCrawlable extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    return artifacts.requestMainResource(artifacts.devtoolsLogs[Audit.DEFAULT_PASS])
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+
+    return artifacts.requestMainResource({devtoolsLog, URL: artifacts.URL})
       .then(mainResource => {
         const blockingDirectives = [];
 

--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -27,7 +27,7 @@ class UsesRelPreconnectAudit extends Audit {
       helpText:
         'Consider adding preconnect or dns-prefetch resource hints to establish early ' +
         `connections to important third-party origins. [Learn more](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect).`,
-      requiredArtifacts: ['devtoolsLogs'],
+      requiredArtifacts: ['devtoolsLogs', 'URL'],
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
     };
   }
@@ -68,12 +68,13 @@ class UsesRelPreconnectAudit extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit(artifacts) {
-    const devtoolsLogs = artifacts.devtoolsLogs[UsesRelPreconnectAudit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.devtoolsLogs[UsesRelPreconnectAudit.DEFAULT_PASS];
+    const URL = artifacts.URL;
     let maxWasted = 0;
 
     const [networkRecords, mainResource] = await Promise.all([
-      artifacts.requestNetworkRecords(devtoolsLogs),
-      artifacts.requestMainResource(devtoolsLogs),
+      artifacts.requestNetworkRecords(devtoolsLog),
+      artifacts.requestMainResource({devtoolsLog, URL}),
     ]);
 
     /** @type {Map<string, LH.WebInspector.NetworkRequest[]>}  */

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -23,7 +23,7 @@ class UsesRelPreloadAudit extends Audit {
       informative: true,
       helpText: 'Consider using <link rel=preload> to prioritize fetching late-discovered ' +
         'resources sooner. [Learn more](https://developers.google.com/web/updates/2016/03/link-rel-preload).',
-      requiredArtifacts: ['devtoolsLogs', 'traces'],
+      requiredArtifacts: ['devtoolsLogs', 'traces', 'URL'],
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
     };
   }
@@ -55,11 +55,12 @@ class UsesRelPreloadAudit extends Audit {
    * @return {!AuditResult}
    */
   static audit(artifacts) {
-    const devtoolsLogs = artifacts.devtoolsLogs[UsesRelPreloadAudit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.devtoolsLogs[UsesRelPreloadAudit.DEFAULT_PASS];
+    const URL = artifacts.URL;
 
     return Promise.all([
-      artifacts.requestCriticalRequestChains(devtoolsLogs),
-      artifacts.requestMainResource(devtoolsLogs),
+      artifacts.requestCriticalRequestChains({devtoolsLog, URL}),
+      artifacts.requestMainResource({devtoolsLog, URL}),
     ]).then(([critChains, mainResource]) => {
       const results = [];
       let maxWasted = 0;

--- a/lighthouse-core/gather/computed/dtm-model.js
+++ b/lighthouse-core/gather/computed/dtm-model.js
@@ -14,11 +14,11 @@ class DevtoolsTimelineModel extends ComputedArtifact {
   }
 
   /**
-   * @param {Object} trace
-   * @return {Object}
+   * @param {LH.Trace} trace
+   * @return {Promise<DTM>}
    */
-  compute_(trace) {
-    return Promise.resolve(new DTM(trace));
+  async compute_(trace) {
+    return new DTM(trace);
   }
 }
 

--- a/lighthouse-core/gather/computed/load-simulator.js
+++ b/lighthouse-core/gather/computed/load-simulator.js
@@ -15,12 +15,12 @@ class LoadSimulatorArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {{devtoolsLog: Array, settings: LH.ConfigSettings|undefined}} data
-   * @param {!Artifacts} artifacts
-   * @return {!Promise}
+   * @param {{devtoolsLog: LH.DevtoolsLog, settings: LH.Config.Settings}} data
+   * @param {LH.Artifacts} artifacts
+   * @return {Promise<Simulator>}
    */
   async compute_(data, artifacts) {
-    const {throttlingMethod, throttling} = data.settings || {};
+    const {throttlingMethod, throttling} = data.settings;
     const networkAnalysis = await artifacts.requestNetworkAnalysis(data.devtoolsLog);
 
     const options = {

--- a/lighthouse-core/gather/computed/main-resource.js
+++ b/lighthouse-core/gather/computed/main-resource.js
@@ -17,14 +17,15 @@ class MainResource extends ComputedArtifact {
   }
 
   /**
-   * @param {!DevtoolsLog} devtoolsLog
-   * @param {!ComputedArtifacts} artifacts
-   * @return {LH.WebInspector.NetworkRequest}
+   * @param {{URL: LH.Artifacts['URL'], devtoolsLog: LH.DevtoolsLog}} data
+   * @param {LH.ComputedArtifacts} artifacts
+   * @return {Promise<LH.WebInspector.NetworkRequest>}
    */
-  compute_(devtoolsLog, artifacts) {
+  compute_(data, artifacts) {
+    const {URL, devtoolsLog} = data;
     return artifacts.requestNetworkRecords(devtoolsLog)
       .then(requests => {
-        const mainResource = requests.find(request => request.url === artifacts.URL.finalUrl);
+        const mainResource = requests.find(request => request.url === URL.finalUrl);
 
         if (!mainResource) {
           throw new Error('Unable to identify the main resource');

--- a/lighthouse-core/gather/computed/manifest-values.js
+++ b/lighthouse-core/gather/computed/manifest-values.js
@@ -8,8 +8,6 @@
 const ComputedArtifact = require('./computed-artifact');
 const icons = require('../../lib/icons');
 
-const ManifestParser = require('../../lib/manifest-parser.js'); // eslint-disable-line no-unused-vars
-
 const PWA_DISPLAY_VALUES = ['minimal-ui', 'fullscreen', 'standalone'];
 
 // Historically, Chrome recommended 12 chars as the maximum short_name length to prevent truncation.
@@ -25,10 +23,10 @@ class ManifestValues extends ComputedArtifact {
     return ['hasManifest', 'hasParseableManifest'];
   }
 
-  /** @typedef {(val: NonNullable<LH.Artifacts.Manifest['value']>) => boolean} validator */
+  /** @typedef {(val: NonNullable<LH.Artifacts.Manifest['value']>) => boolean} Validator */
 
   /**
-   * @return {Array<{id: string, failureText: string, validate: validator}>}
+   * @return {Array<{id: string, failureText: string, validate: Validator}>}
    */
   static get manifestChecks() {
     return [

--- a/lighthouse-core/gather/computed/manifest-values.js
+++ b/lighthouse-core/gather/computed/manifest-values.js
@@ -8,6 +8,8 @@
 const ComputedArtifact = require('./computed-artifact');
 const icons = require('../../lib/icons');
 
+const ManifestParser = require('../../lib/manifest-parser.js'); // eslint-disable-line no-unused-vars
+
 const PWA_DISPLAY_VALUES = ['minimal-ui', 'fullscreen', 'standalone'];
 
 // Historically, Chrome recommended 12 chars as the maximum short_name length to prevent truncation.
@@ -23,86 +25,96 @@ class ManifestValues extends ComputedArtifact {
     return ['hasManifest', 'hasParseableManifest'];
   }
 
+  /** @typedef {(val: NonNullable<LH.Artifacts.Manifest['value']>) => boolean} validator */
+
+  /**
+   * @return {Array<{id: string, failureText: string, validate: validator}>}
+   */
   static get manifestChecks() {
     return [
       {
         id: 'hasStartUrl',
         failureText: 'Manifest does not contain a `start_url`',
-        validate: manifest => !!manifest.value.start_url.value,
+        validate: manifestValue => !!manifestValue.start_url.value,
       },
       {
         id: 'hasIconsAtLeast192px',
         failureText: 'Manifest does not have icons at least 192px',
-        validate: manifest => icons.doExist(manifest.value) &&
-            icons.sizeAtLeast(192, /** @type {!Manifest} */ (manifest.value)).length > 0,
+        validate: manifestValue => icons.doExist(manifestValue) &&
+            icons.sizeAtLeast(192, manifestValue).length > 0,
       },
       {
         id: 'hasIconsAtLeast512px',
         failureText: 'Manifest does not have icons at least 512px',
-        validate: manifest => icons.doExist(manifest.value) &&
-            icons.sizeAtLeast(512, /** @type {!Manifest} */ (manifest.value)).length > 0,
+        validate: manifestValue => icons.doExist(manifestValue) &&
+            icons.sizeAtLeast(512, manifestValue).length > 0,
       },
       {
         id: 'hasPWADisplayValue',
         failureText: 'Manifest\'s `display` value is not one of: ' + PWA_DISPLAY_VALUES.join(' | '),
-        validate: manifest => PWA_DISPLAY_VALUES.includes(manifest.value.display.value),
+        validate: manifestValue => PWA_DISPLAY_VALUES.includes(manifestValue.display.value),
       },
       {
         id: 'hasBackgroundColor',
         failureText: 'Manifest does not have `background_color`',
-        validate: manifest => !!manifest.value.background_color.value,
+        validate: manifestValue => !!manifestValue.background_color.value,
       },
       {
         id: 'hasThemeColor',
         failureText: 'Manifest does not have `theme_color`',
-        validate: manifest => !!manifest.value.theme_color.value,
+        validate: manifestValue => !!manifestValue.theme_color.value,
       },
       {
         id: 'hasShortName',
         failureText: 'Manifest does not have `short_name`',
-        validate: manifest => !!manifest.value.short_name.value,
+        validate: manifestValue => !!manifestValue.short_name.value,
       },
       {
         id: 'shortNameLength',
         failureText: 'Manifest `short_name` will be truncated when displayed on the homescreen',
-        validate: manifest => !!manifest.value.short_name.value &&
-            manifest.value.short_name.value.length <= SUGGESTED_SHORTNAME_LENGTH,
+        validate: manifestValue => !!manifestValue.short_name.value &&
+            manifestValue.short_name.value.length <= SUGGESTED_SHORTNAME_LENGTH,
       },
       {
         id: 'hasName',
         failureText: 'Manifest does not have `name`',
-        validate: manifest => !!manifest.value.name.value,
+        validate: manifestValue => !!manifestValue.name.value,
       },
     ];
   }
 
   /**
    * Returns results of all manifest checks
-   * @param {Manifest} manifest
-   * @return {{isParseFailure: !boolean, parseFailureReason: ?string, allChecks: !Array}}
+   * @param {LH.Artifacts['Manifest']} manifest
+   * @return {Promise<LH.Artifacts.ManifestValues>}
    */
-  compute_(manifest) {
+  async compute_(manifest) {
     // if the manifest isn't there or is invalid json, we report that and bail
     let parseFailureReason;
 
     if (manifest === null) {
-      parseFailureReason = 'No manifest was fetched';
-    }
-    if (manifest && manifest.value === undefined) {
-      parseFailureReason = 'Manifest failed to parse as valid JSON';
-    }
-    if (parseFailureReason) {
       return {
         isParseFailure: true,
-        parseFailureReason,
+        parseFailureReason: 'No manifest was fetched',
+        allChecks: [],
+      };
+    }
+    const manifestValue = manifest.value;
+    if (manifestValue === undefined) {
+      return {
+        isParseFailure: true,
+        parseFailureReason: 'Manifest failed to parse as valid JSON',
         allChecks: [],
       };
     }
 
     // manifest is valid, so do the rest of the checks
     const remainingChecks = ManifestValues.manifestChecks.map(item => {
-      item.passing = item.validate(manifest);
-      return item;
+      return {
+        id: item.id,
+        failureText: item.failureText,
+        passing: item.validate(manifestValue),
+      };
     });
 
     return {

--- a/lighthouse-core/gather/computed/metrics/lantern-consistently-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-consistently-interactive.js
@@ -83,11 +83,11 @@ class ConsistentlyInteractive extends MetricArtifact {
 
   /**
    * @param {LH.Artifacts.MetricComputationData} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} artifacts
    * @return {Promise<LH.Artifacts.LanternMetric>}
    */
   async compute_(data, artifacts) {
-    const fmpResult = await artifacts.requestLanternFirstMeaningfulPaint(data, artifacts);
+    const fmpResult = await artifacts.requestLanternFirstMeaningfulPaint(data);
     const metricResult = await this.computeMetricWithGraphs(data, artifacts, {fmpResult});
     metricResult.timing = Math.max(metricResult.timing, fmpResult.timing);
     return metricResult;

--- a/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
@@ -66,11 +66,11 @@ class LanternEstimatedInputLatency extends LanternMetricArtifact {
 
   /**
    * @param {LH.Artifacts.MetricComputationData} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} artifacts
    * @return {Promise<LH.Artifacts.LanternMetric>}
    */
   async compute_(data, artifacts) {
-    const fmpResult = await artifacts.requestLanternFirstMeaningfulPaint(data, artifacts);
+    const fmpResult = await artifacts.requestLanternFirstMeaningfulPaint(data);
     return this.computeMetricWithGraphs(data, artifacts, {fmpResult});
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
@@ -27,9 +27,9 @@ class FirstContentfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {!Node} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {!Node}
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) {
     const fcp = traceOfTab.timestamps.firstContentfulPaint;
@@ -53,9 +53,9 @@ class FirstContentfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {!Node} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {!Node}
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) {
     const fcp = traceOfTab.timestamps.firstContentfulPaint;

--- a/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
@@ -27,9 +27,9 @@ class FirstMeaningfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {!Node} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {!Node}
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) {
     const fmp = traceOfTab.timestamps.firstMeaningfulPaint;
@@ -53,9 +53,9 @@ class FirstMeaningfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {!Node} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {!Node}
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) {
     const fmp = traceOfTab.timestamps.firstMeaningfulPaint;
@@ -79,11 +79,11 @@ class FirstMeaningfulPaint extends MetricArtifact {
 
   /**
    * @param {LH.Artifacts.MetricComputationData} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} artifacts
    * @return {Promise<LH.Artifacts.LanternMetric>}
    */
   async compute_(data, artifacts) {
-    const fcpResult = await artifacts.requestLanternFirstContentfulPaint(data, artifacts);
+    const fcpResult = await artifacts.requestLanternFirstContentfulPaint(data);
     const metricResult = await this.computeMetricWithGraphs(data, artifacts);
     metricResult.timing = Math.max(metricResult.timing, fcpResult.timing);
     return metricResult;

--- a/lighthouse-core/gather/computed/metrics/lantern-metric.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-metric.js
@@ -13,9 +13,9 @@ const WebInspector = require('../../../lib/web-inspector');
 
 class LanternMetricArtifact extends ComputedArtifact {
   /**
-   * @param {!Node} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {function(NetworkNode):boolean=} condition
-   * @return {!Set<string>}
+   * @return {Set<string>}
    */
   static getScriptUrls(dependencyGraph, condition) {
     const scriptUrls = new Set();
@@ -39,18 +39,18 @@ class LanternMetricArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {!Node} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {!Node}
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) { // eslint-disable-line no-unused-vars
     throw new Error('Optimistic graph unimplemented!');
   }
 
   /**
-   * @param {!Node} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {!Node}
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) { // eslint-disable-line no-unused-vars
     throw new Error('Pessmistic graph unimplemented!');
@@ -66,8 +66,8 @@ class LanternMetricArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {{trace: Object, devtoolsLog: Object, settings: LH.Config.Settings, simulator?: Simulator}} data
-   * @param {Object} artifacts
+   * @param {LH.Artifacts.MetricComputationData} data
+   * @param {LH.ComputedArtifacts} artifacts
    * @param {any=} extras
    * @return {Promise<LH.Artifacts.LanternMetric>}
    */
@@ -111,11 +111,11 @@ class LanternMetricArtifact extends ComputedArtifact {
 
   /**
    * @param {LH.Artifacts.MetricComputationData} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} computedArtifacts
    * @return {Promise<LH.Artifacts.LanternMetric>}
    */
-  compute_(data, artifacts) {
-    return this.computeMetricWithGraphs(data, artifacts);
+  compute_(data, computedArtifacts) {
+    return this.computeMetricWithGraphs(data, computedArtifacts);
   }
 }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
@@ -59,12 +59,12 @@ class SpeedIndex extends MetricArtifact {
 
   /**
    * @param {LH.Artifacts.MetricComputationData} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} artifacts
    * @return {Promise<LH.Artifacts.LanternMetric>}
    */
   async compute_(data, artifacts) {
     const speedline = await artifacts.requestSpeedline(data.trace);
-    const fcpResult = await artifacts.requestLanternFirstContentfulPaint(data, artifacts);
+    const fcpResult = await artifacts.requestLanternFirstContentfulPaint(data);
     const metricResult = await this.computeMetricWithGraphs(data, artifacts, {
       speedline,
       fcpResult,

--- a/lighthouse-core/gather/computed/metrics/metric.js
+++ b/lighthouse-core/gather/computed/metrics/metric.js
@@ -25,16 +25,17 @@ class ComputedMetric extends ComputedArtifact {
 
   /**
    * @param {LH.Artifacts.MetricComputationData} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} artifacts
    * @return {Promise<LH.Artifacts.LanternMetric>}
    */
   computeSimulatedMetric(data, artifacts) {
+    // @ts-ignore TODO(bckenny): allow string constuction access to lantern metric.
     return artifacts[`requestLantern${this.name}`](data);
   }
 
   /**
    * @param {LH.Artifacts.MetricComputationData} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} artifacts
    * @return {Promise<LH.Artifacts.Metric>}
    */
   computeObservedMetric(data, artifacts) { // eslint-disable-line no-unused-vars
@@ -43,26 +44,26 @@ class ComputedMetric extends ComputedArtifact {
 
   /**
    * @param {LH.Artifacts.MetricComputationDataInput} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} computedArtifacts
    * @return {Promise<LH.Artifacts.LanternMetric|LH.Artifacts.Metric>}
    */
-  async compute_(data, artifacts) {
+  async compute_(data, computedArtifacts) {
     const {trace, devtoolsLog, settings} = data;
     if (!trace || !devtoolsLog || !settings) {
       throw new Error('Did not provide necessary metric computation data');
     }
 
     const augmentedData = Object.assign({
-      networkRecords: await artifacts.requestNetworkRecords(devtoolsLog),
-      traceOfTab: await artifacts.requestTraceOfTab(trace),
+      networkRecords: await computedArtifacts.requestNetworkRecords(devtoolsLog),
+      traceOfTab: await computedArtifacts.requestTraceOfTab(trace),
     }, data);
 
     switch (settings.throttlingMethod) {
       case 'simulate':
-        return this.computeSimulatedMetric(augmentedData, artifacts);
+        return this.computeSimulatedMetric(augmentedData, computedArtifacts);
       case 'provided':
       case 'devtools':
-        return this.computeObservedMetric(augmentedData, artifacts);
+        return this.computeObservedMetric(augmentedData, computedArtifacts);
       default:
         throw new TypeError(`Unrecognized throttling method: ${settings.throttlingMethod}`);
     }

--- a/lighthouse-core/gather/computed/metrics/speed-index.js
+++ b/lighthouse-core/gather/computed/metrics/speed-index.js
@@ -14,7 +14,7 @@ class SpeedIndex extends MetricArtifact {
 
   /**
    * @param {LH.Artifacts.MetricComputationData} data
-   * @param {Object} artifacts
+   * @param {LH.ComputedArtifacts} artifacts
    * @return {Promise<LH.Artifacts.Metric>}
    */
   async computeObservedMetric(data, artifacts) {

--- a/lighthouse-core/gather/computed/network-records.js
+++ b/lighthouse-core/gather/computed/network-records.js
@@ -14,10 +14,10 @@ class NetworkRecords extends ComputedArtifact {
   }
 
   /**
-   * @param {!DevtoolsLog} devtoolsLog
-   * @return {Array<LH.WebInspector.NetworkRequest>} networkRecords
+   * @param {LH.DevtoolsLog} devtoolsLog
+   * @return {Promise<Array<LH.WebInspector.NetworkRequest>>} networkRecords
    */
-  compute_(devtoolsLog) {
+  async compute_(devtoolsLog) {
     return NetworkRecorder.recordsFromLogs(devtoolsLog);
   }
 }

--- a/lighthouse-core/gather/computed/network-throughput.js
+++ b/lighthouse-core/gather/computed/network-throughput.js
@@ -30,10 +30,10 @@ class NetworkThroughput extends ComputedArtifact {
       }
 
       totalBytes += record.transferSize;
-      boundaries.push({time: record.responseReceivedTime, isStart: true});
+      boundaries.push({time: record._responseReceivedTime, isStart: true});
       boundaries.push({time: record.endTime, isStart: false});
       return boundaries;
-    }, []).sort((a, b) => a.time - b.time);
+    }, /** @type {Array<{time: number, isStart: boolean}>} */([])).sort((a, b) => a.time - b.time);
 
     if (!timeBoundaries.length) {
       return Infinity;
@@ -60,13 +60,13 @@ class NetworkThroughput extends ComputedArtifact {
   }
 
   /**
-   * @param {!DevtoolsLog} devtoolsLog
-   * @param {!ComputedArtifacts} artifacts
-   * @return {!Promise<!Object>}
+   * @param {LH.DevtoolsLog} devtoolsLog
+   * @param {LH.ComputedArtifacts} computedArtifacts
+   * @return {Promise<number>}
    */
-  compute_(devtoolsLog, artifacts) {
+  compute_(devtoolsLog, computedArtifacts) {
     // TODO(phulce): migrate this to network-analysis computed artifact
-    return artifacts.requestNetworkRecords(devtoolsLog)
+    return computedArtifacts.requestNetworkRecords(devtoolsLog)
       .then(NetworkThroughput.getThroughput);
   }
 }

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -194,7 +194,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       for (const evt of node.childEvents) {
         if (!evt.args.data) continue;
 
-        const dataUrl = evt.args.data.url;
+        const argsUrl = evt.args.data.url;
         const stackTraceUrls = (evt.args.data.stackTrace || []).map(l => l.url).filter(Boolean);
 
         switch (evt.name) {
@@ -217,8 +217,8 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
             break;
 
           case 'EvaluateScript':
-            // @ts-ignore - 'EvaluateScript' event means dataUrl is defined.
-            addDependencyOnUrl(node, dataUrl);
+            // @ts-ignore - 'EvaluateScript' event means argsUrl is defined.
+            addDependencyOnUrl(node, argsUrl);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
 
@@ -227,15 +227,15 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
             // @ts-ignore - 'XHRReadyStateChange' event means readyState is defined.
             if (evt.args.data.readyState !== 4) break;
 
-            // @ts-ignore - 'XHRReadyStateChange' event means dataUrl is defined.
-            addDependencyOnUrl(node, dataUrl);
+            // @ts-ignore - 'XHRReadyStateChange' event means argsUrl is defined.
+            addDependencyOnUrl(node, argsUrl);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
 
           case 'FunctionCall':
           case 'v8.compile':
-            // @ts-ignore - events mean dataUrl is defined.
-            addDependencyOnUrl(node, dataUrl);
+            // @ts-ignore - events mean argsUrl is defined.
+            addDependencyOnUrl(node, argsUrl);
             break;
 
           case 'ParseAuthorStyleSheet':

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -11,6 +11,8 @@ const CPUNode = require('../../lib/dependency-graph/cpu-node');
 const TracingProcessor = require('../../lib/traces/tracing-processor');
 const WebInspector = require('../../lib/web-inspector');
 
+const Node = require('../../lib/dependency-graph/node.js'); // eslint-disable-line no-unused-vars
+
 // Tasks smaller than 10 ms have minimal impact on simulation
 const MINIMUM_TASK_DURATION_OF_INTEREST = 10;
 // TODO: video files tend to be enormous and throw off all graph traversals, move this ignore
@@ -24,12 +26,12 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
 
   /**
    * @param {LH.WebInspector.NetworkRequest} record
-   * @return {!Array<string>}
+   * @return {Array<string>}
    */
   static getNetworkInitiators(record) {
     if (!record._initiator) return [];
     if (record._initiator.url) return [record._initiator.url];
-    if (record._initiator.type === 'script') {
+    if (record._initiator.type === 'script' && record._initiator.stack) {
       const frames = record._initiator.stack.callFrames;
       return Array.from(new Set(frames.map(frame => frame.url))).filter(Boolean);
     }
@@ -39,15 +41,16 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
 
   /**
    * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
-   * @return {!NetworkNodeOutput}
+   * @return {NetworkNodeOutput}
    */
   static getNetworkNodeOutput(networkRecords) {
+    /** @type {Array<NetworkNode>} */
     const nodes = [];
     const idToNodeMap = new Map();
     const urlToNodeMap = new Map();
 
     networkRecords.forEach(record => {
-      if (IGNORED_MIME_TYPES_REGEX.test(record.mimeType)) return;
+      if (IGNORED_MIME_TYPES_REGEX.test(record._mimeType)) return;
 
       // Network record requestIds can be duplicated for an unknown reason
       // Suffix all subsequent records with `:duplicate` until it's unique
@@ -70,9 +73,10 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
 
   /**
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {!Array<!CPUNode>}
+   * @return {Array<CPUNode>}
    */
   static getCPUNodes(traceOfTab) {
+    /** @type {Array<CPUNode>} */
     const nodes = [];
     let i = 0;
 
@@ -91,6 +95,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       }
 
       // Capture all events that occurred within the task
+      /** @type {Array<LH.TraceEvent>} */
       const children = [];
       i++; // Start examining events after this one
       for (
@@ -108,8 +113,8 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {!Node} rootNode
-   * @param {!NetworkNodeOutput} networkNodeOutput
+   * @param {Node} rootNode
+   * @param {NetworkNodeOutput} networkNodeOutput
    */
   static linkNetworkNodes(rootNode, networkNodeOutput) {
     networkNodeOutput.nodes.forEach(node => {
@@ -131,17 +136,20 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       for (let i = 1; i < redirects.length; i++) {
         const redirectNode = networkNodeOutput.idToNodeMap.get(redirects[i - 1].requestId);
         const actualNode = networkNodeOutput.idToNodeMap.get(redirects[i].requestId);
-        actualNode.addDependency(redirectNode);
+        if (actualNode && redirectNode) {
+          actualNode.addDependency(redirectNode);
+        }
       }
     });
   }
 
   /**
-   * @param {!Node} rootNode
-   * @param {!NetworkNodeOutput} networkNodeOutput
-   * @param {!Array<!CPUNode>} cpuNodes
+   * @param {Node} rootNode
+   * @param {NetworkNodeOutput} networkNodeOutput
+   * @param {Array<CPUNode>} cpuNodes
    */
   static linkCPUNodes(rootNode, networkNodeOutput, cpuNodes) {
+    /** @param {CPUNode} cpuNode @param {string} reqId */
     function addDependentNetworkRequest(cpuNode, reqId) {
       const networkNode = networkNodeOutput.idToNodeMap.get(reqId);
       if (!networkNode ||
@@ -153,6 +161,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       cpuNode.addDependent(networkNode);
     }
 
+    /** @param {CPUNode} cpuNode @param {string} url */
     function addDependencyOnUrl(cpuNode, url) {
       if (!url) return;
       // Allow network requests that end up to 100ms before the task started
@@ -163,7 +172,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       let minCandidate = null;
       let minDistance = Infinity;
       // Find the closest request that finished before this CPU task started
-      candidates.forEach(candidate => {
+      for (const candidate of candidates) {
         // Explicitly ignore all requests that started after this CPU node
         // A network request that started after this task started cannot possibly be a dependency
         if (cpuNode.startTime <= candidate.startTime) return;
@@ -173,26 +182,29 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
           minCandidate = candidate;
           minDistance = distance;
         }
-      });
+      }
 
       if (!minCandidate) return;
       cpuNode.addDependency(minCandidate);
     }
 
+    /** @type {Map<string, CPUNode>} */
     const timers = new Map();
     for (const node of cpuNodes) {
       for (const evt of node.childEvents) {
         if (!evt.args.data) continue;
 
-        const url = evt.args.data.url;
+        const dataUrl = evt.args.data.url;
         const stackTraceUrls = (evt.args.data.stackTrace || []).map(l => l.url).filter(Boolean);
 
         switch (evt.name) {
           case 'TimerInstall':
+            // @ts-ignore - 'TimerInstall' event means timerId exists.
             timers.set(evt.args.data.timerId, node);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
           case 'TimerFire': {
+            // @ts-ignore - 'TimerFire' event means timerId exists.
             const installer = timers.get(evt.args.data.timerId);
             if (!installer) break;
             installer.addDependent(node);
@@ -205,29 +217,35 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
             break;
 
           case 'EvaluateScript':
-            addDependencyOnUrl(node, url);
+            // @ts-ignore - 'EvaluateScript' event means dataUrl is defined.
+            addDependencyOnUrl(node, dataUrl);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
 
           case 'XHRReadyStateChange':
             // Only create the dependency if the request was completed
+            // @ts-ignore - 'XHRReadyStateChange' event means readyState is defined.
             if (evt.args.data.readyState !== 4) break;
 
-            addDependencyOnUrl(node, url);
+            // @ts-ignore - 'XHRReadyStateChange' event means dataUrl is defined.
+            addDependencyOnUrl(node, dataUrl);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
 
           case 'FunctionCall':
           case 'v8.compile':
-            addDependencyOnUrl(node, url);
+            // @ts-ignore - events mean dataUrl is defined.
+            addDependencyOnUrl(node, dataUrl);
             break;
 
           case 'ParseAuthorStyleSheet':
+            // @ts-ignore - 'ParseAuthorStyleSheet' event means styleSheetUrl is defined.
             addDependencyOnUrl(node, evt.args.data.styleSheetUrl);
             break;
 
           case 'ResourceSendRequest':
-            addDependentNetworkRequest(node, evt.args.data.requestId, evt);
+            // @ts-ignore - 'ResourceSendRequest' event means requestId is defined.
+            addDependentNetworkRequest(node, evt.args.data.requestId);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
         }
@@ -242,7 +260,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   /**
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
    * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
-   * @return {!Node}
+   * @return {Node}
    */
   static createGraph(traceOfTab, networkRecords) {
     const networkNodeOutput = PageDependencyGraphArtifact.getNetworkNodeOutput(networkRecords);
@@ -251,7 +269,12 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
     const rootRequest = networkRecords.reduce((min, r) => (min.startTime < r.startTime ? min : r));
     const rootNode = networkNodeOutput.idToNodeMap.get(rootRequest.requestId);
 
-    PageDependencyGraphArtifact.linkNetworkNodes(rootNode, networkNodeOutput, networkRecords);
+    if (!rootNode) {
+      // Should always be found.
+      throw new Error('rootNode not found.');
+    }
+
+    PageDependencyGraphArtifact.linkNetworkNodes(rootNode, networkNodeOutput);
     PageDependencyGraphArtifact.linkCPUNodes(rootNode, networkNodeOutput, cpuNodes);
 
     if (NetworkNode.hasCycle(rootNode)) {
@@ -263,13 +286,15 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
 
   /**
    *
-   * @param {!Node} rootNode
+   * @param {Node} rootNode
    */
   static printGraph(rootNode, widthInCharacters = 100) {
+    /** @param {string} str @param {number} target */
     function padRight(str, target, padChar = ' ') {
       return str + padChar.repeat(Math.max(target - str.length, 0));
     }
 
+    /** @type {Array<Node>} */
     const nodes = [];
     rootNode.traverse(node => nodes.push(node));
     nodes.sort((a, b) => a.startTime - b.startTime);
@@ -284,6 +309,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       const length = Math.ceil((node.endTime - node.startTime) / timePerCharacter);
       const bar = padRight('', offset) + padRight('', length, '=');
 
+      // @ts-ignore -- disambiguate displayName from across possible Node types.
       const displayName = node.record ? node.record._url : node.type;
       // eslint-disable-next-line
       console.log(padRight(bar, widthInCharacters), `| ${displayName.slice(0, 30)}`);
@@ -291,31 +317,27 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {{trace: !Trace, devtoolsLog: !DevToolsLog}} data
-   * @param {!ComputedArtifacts} artifacts
-   * @return {!Promise<!Node>}
+   * @param {{trace: LH.Trace, devtoolsLog: LH.DevtoolsLog}} data
+   * @param {LH.ComputedArtifacts} artifacts
+   * @return {Promise<Node>}
    */
-  compute_(data, artifacts) {
+  async compute_(data, artifacts) {
     const trace = data.trace;
     const devtoolsLog = data.devtoolsLog;
-    const promises = [
+    const [traceOfTab, networkRecords] = await Promise.all([
       artifacts.requestTraceOfTab(trace),
       artifacts.requestNetworkRecords(devtoolsLog),
-    ];
+    ]);
 
-    return Promise.all(promises).then(([traceOfTab, networkRecords]) => {
-      return PageDependencyGraphArtifact.createGraph(traceOfTab, networkRecords);
-    });
+    return PageDependencyGraphArtifact.createGraph(traceOfTab, networkRecords);
   }
 }
 
 module.exports = PageDependencyGraphArtifact;
 
 /**
- * @typedef {{
- *    nodes: !Array<!NetworkNode>,
- *    idToNodeMap: !Map<string, !NetworkNode>,
- *    urlToNodeMap: !Map<string, !Array<!NetworkNode>
- * }}
+ * @typedef {Object} NetworkNodeOutput
+ * @property {Array<NetworkNode>} nodes
+ * @property {Map<string, NetworkNode>} idToNodeMap
+ * @property {Map<string, Array<NetworkNode>>} urlToNodeMap
  */
-PageDependencyGraphArtifact.NetworkNodeOutput; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/gather/computed/pushed-requests.js
+++ b/lighthouse-core/gather/computed/pushed-requests.js
@@ -14,8 +14,8 @@ class PushedRequests extends ComputedArtifact {
 
   /**
    * Return list of network requests that were pushed.
-   * @param {!DevtoolsLog} devtoolsLog
-   * @param {!ComputedArtifacts} artifacts
+   * @param {LH.DevtoolsLog} devtoolsLog
+   * @param {LH.ComputedArtifacts} artifacts
    * @return {Promise<Array<LH.WebInspector.NetworkRequest>>}
    */
   compute_(devtoolsLog, artifacts) {

--- a/lighthouse-core/gather/computed/screenshots.js
+++ b/lighthouse-core/gather/computed/screenshots.js
@@ -12,6 +12,10 @@ class ScreenshotFilmstrip extends ComputedArtifact {
     return 'Screenshots';
   }
 
+  /**
+   * @param {{imageDataPromise: function(): Promise<string>}} frame
+   * @return {Promise<string>}
+   */
   fetchScreenshot(frame) {
     return frame
       .imageDataPromise()
@@ -19,12 +23,12 @@ class ScreenshotFilmstrip extends ComputedArtifact {
   }
 
   /**
-   * @param {{traceEvents: !Array}} trace
-   * @param {!Artifacts} trace
-   * @return {!Promise}
+   * @param {LH.Trace} trace
+   * @param {LH.ComputedArtifacts} computedArtifacts
+   * @return {Promise<Array<{timestamp: number, datauri: string}>>}
   */
-  compute_(trace, artifacts) {
-    return artifacts.requestDevtoolsTimelineModel(trace).then(model => {
+  compute_(trace, computedArtifacts) {
+    return computedArtifacts.requestDevtoolsTimelineModel(trace).then(model => {
       const filmStripFrames = model.filmStripModel().frames();
       const frameFetches = filmStripFrames.map(frame => this.fetchScreenshot(frame));
 

--- a/lighthouse-core/gather/computed/speedline.js
+++ b/lighthouse-core/gather/computed/speedline.js
@@ -15,7 +15,9 @@ class Speedline extends ComputedArtifact {
   }
 
   /**
-   * @return {!Promise}
+   * @param {LH.Trace} trace
+   * @param {LH.ComputedArtifacts} computedArtifacts
+   * @return {Promise<LH.Artifacts.Speedline>}
    */
   compute_(trace, computedArtifacts) {
     // speedline() may throw without a promise, so we resolve immediately

--- a/lighthouse-core/lib/console-quieter.js
+++ b/lighthouse-core/lib/console-quieter.js
@@ -9,18 +9,25 @@
 
 const log = require('lighthouse-logger');
 
-class ConsoleQuieter {
-  static mute(opts) {
-    ConsoleQuieter._logs = ConsoleQuieter._logs || [];
+/** @type {Array<{type: 'log'|'warn'|'error', args: any[], prefix: string}>} */
+let _logs = [];
 
+class ConsoleQuieter {
+  /** @param {{prefix: string}} opts */
+  static mute(opts) {
+    _logs = _logs || [];
+
+    /** @param {any[]} args */
     console.log = function(...args) {
-      ConsoleQuieter._logs.push({type: 'log', args, prefix: opts.prefix});
+      _logs.push({type: 'log', args, prefix: opts.prefix});
     };
+    /** @param {any[]} args */
     console.warn = function(...args) {
-      ConsoleQuieter._logs.push({type: 'warn', args, prefix: opts.prefix});
+      _logs.push({type: 'warn', args, prefix: opts.prefix});
     };
+    /** @param {any[]} args */
     console.error = function(...args) {
-      ConsoleQuieter._logs.push({type: 'error', args, prefix: opts.prefix});
+      _logs.push({type: 'error', args, prefix: opts.prefix});
     };
   }
 
@@ -29,10 +36,10 @@ class ConsoleQuieter {
     console.warn = ConsoleQuieter._consolewarn;
     console.error = ConsoleQuieter._consoleerror;
 
-    ConsoleQuieter._logs.forEach(entry => {
+    _logs.forEach(entry => {
       log.verbose(`${entry.prefix}-${entry.type}`, ...entry.args);
     });
-    ConsoleQuieter._logs = [];
+    _logs = [];
   }
 }
 

--- a/lighthouse-core/lib/icons.js
+++ b/lighthouse-core/lib/icons.js
@@ -6,7 +6,7 @@
 'use strict';
 
 /**
- * @param {!Manifest=} manifest
+ * @param {NonNullable<LH.Artifacts.Manifest['value']>} manifest
  * @return {boolean} Does the manifest have any icons?
  */
 function doExist(manifest) {
@@ -21,19 +21,22 @@ function doExist(manifest) {
 
 /**
  * @param {number} sizeRequirement
- * @param {!Manifest} manifest
- * @return {!Array<string>} Value of satisfactory sizes (eg. ['192x192', '256x256'])
+ * @param {NonNullable<LH.Artifacts.Manifest['value']>} manifest
+ * @return {Array<string>} Value of satisfactory sizes (eg. ['192x192', '256x256'])
  */
 function sizeAtLeast(sizeRequirement, manifest) {
   // An icon can be provided for a single size, or for multiple sizes.
   // To handle both, we flatten all found sizes into a single array.
   const iconValues = manifest.icons.value;
-  const nestedSizes = iconValues.map(icon => icon.value.sizes.value);
-  const flattenedSizes = [].concat(...nestedSizes);
+  /** @type {Array<string>} */
+  const flattenedSizes = [];
+  iconValues.forEach(icon => {
+    if (icon.value.sizes.value) {
+      flattenedSizes.push(...icon.value.sizes.value);
+    }
+  });
 
   return flattenedSizes
-      // First, filter out any undefined values, in case an icon was defined without a size
-      .filter(size => typeof size === 'string')
       // discard sizes that are not AAxBB (eg. "any")
       .filter(size => /\d+x\d+/.test(size))
       .filter(size => {

--- a/lighthouse-core/lib/manifest-parser.js
+++ b/lighthouse-core/lib/manifest-parser.js
@@ -158,21 +158,32 @@ function parseStartUrl(jsonInput, manifestUrl, documentUrl) {
  * @param {*} jsonInput
  */
 function parseDisplay(jsonInput) {
-  const display = parseString(jsonInput.display, true);
+  const parsedString = parseString(jsonInput.display, true);
+  const stringValue = parsedString.value;
 
-  if (!display.value) {
-    display.value = DEFAULT_DISPLAY_MODE;
-    return display;
+  if (!stringValue) {
+    return {
+      raw: jsonInput,
+      value: DEFAULT_DISPLAY_MODE,
+      debugString: parsedString.debugString,
+    };
   }
 
-  display.value = display.value.toLowerCase();
-  if (!ALLOWED_DISPLAY_VALUES.includes(display.value)) {
-    display.debugString = 'ERROR: \'display\' has invalid value ' + display.value +
-        ` will fall back to ${DEFAULT_DISPLAY_MODE}.`;
-    display.value = DEFAULT_DISPLAY_MODE;
+  const displayValue = stringValue.toLowerCase();
+  if (!ALLOWED_DISPLAY_VALUES.includes(displayValue)) {
+    return {
+      raw: jsonInput,
+      value: DEFAULT_DISPLAY_MODE,
+      debugString: 'ERROR: \'display\' has invalid value ' + displayValue +
+        `. will fall back to ${DEFAULT_DISPLAY_MODE}.`,
+    };
   }
 
-  return display;
+  return {
+    raw: jsonInput,
+    value: displayValue,
+    debugString: undefined,
+  };
 }
 
 /**
@@ -234,7 +245,7 @@ function parseIcon(raw, manifestUrl) {
       debugString: undefined,
     };
   } else {
-    sizes = {...parsedSizes};
+    sizes = {...parsedSizes, value: undefined};
   }
 
   return {
@@ -259,6 +270,7 @@ function parseIcons(jsonInput, manifestUrl) {
   if (raw === undefined) {
     return {
       raw,
+      /** @type {Array<ReturnType<typeof parseIcon>>} */
       value: [],
       debugString: undefined,
     };
@@ -267,6 +279,7 @@ function parseIcons(jsonInput, manifestUrl) {
   if (!Array.isArray(raw)) {
     return {
       raw,
+      /** @type {Array<ReturnType<typeof parseIcon>>} */
       value: [],
       debugString: 'ERROR: \'icons\' expected to be an array but is not.',
     };

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -176,7 +176,7 @@ class Runner {
    */
   static async _runAudits(settings, audits, artifacts) {
     log.log('status', 'Analyzing and running audits...');
-    artifacts = Object.assign(Runner.instantiateComputedArtifacts(), artifacts);
+    artifacts = Object.assign({}, Runner.instantiateComputedArtifacts(), artifacts);
 
     if (artifacts.settings) {
       const overrides = {gatherMode: undefined, auditMode: undefined, output: undefined};
@@ -344,7 +344,8 @@ class Runner {
   }
 
   /**
-   * TODO(bckenny): computed artifact types
+   * TODO(bckenny): refactor artifact types
+   * @return {LH.ComputedArtifacts}
    */
   static instantiateComputedArtifacts() {
     const computedArtifacts = {};
@@ -357,7 +358,7 @@ class Runner {
       computedArtifacts['request' + artifact.name] = artifact.request.bind(artifact);
     });
 
-    return computedArtifacts;
+    return /** @type {LH.ComputedArtifacts} */ (computedArtifacts);
   }
 
   /**

--- a/lighthouse-core/test/gather/computed/computed-artifact-test.js
+++ b/lighthouse-core/test/gather/computed/computed-artifact-test.js
@@ -23,7 +23,7 @@ class TestComputedArtifact extends ComputedArtifact {
     return 'TestComputedArtifact';
   }
 
-  compute_(...args) {
+  async compute_(...args) {
     this.lastArguments = args;
     return this.computeCounter++;
   }

--- a/lighthouse-core/test/gather/computed/main-resource-test.js
+++ b/lighthouse-core/test/gather/computed/main-resource-test.js
@@ -26,9 +26,9 @@ describe('MainResource computed artifact', () => {
       record,
     ];
     computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
-    computedArtifacts.URL = {finalUrl: 'https://example.com'};
+    const URL = {finalUrl: 'https://example.com'};
 
-    return computedArtifacts.requestMainResource({}).then(output => {
+    return computedArtifacts.requestMainResource({URL}).then(output => {
       assert.equal(output, record);
     });
   });
@@ -38,9 +38,9 @@ describe('MainResource computed artifact', () => {
       {url: 'https://example.com'},
     ];
     computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
-    computedArtifacts.URL = {finalUrl: 'https://m.example.com'};
+    const URL = {finalUrl: 'https://m.example.com'};
 
-    return computedArtifacts.requestMainResource({}).then(() => {
+    return computedArtifacts.requestMainResource({URL}).then(() => {
       assert.ok(false, 'should have thrown');
     }).catch(err => {
       assert.equal(err.message, 'Unable to identify the main resource');
@@ -49,9 +49,10 @@ describe('MainResource computed artifact', () => {
 
   it('should identify correct main resource in the wikipedia fixture', () => {
     const wikiDevtoolsLog = require('../../fixtures/wikipedia-redirect.devtoolslog.json');
-    computedArtifacts.URL = {finalUrl: 'https://en.m.wikipedia.org/wiki/Main_Page'};
+    const URL = {finalUrl: 'https://en.m.wikipedia.org/wiki/Main_Page'};
+    const artifacts = {devtoolsLog: wikiDevtoolsLog, URL};
 
-    return computedArtifacts.requestMainResource(wikiDevtoolsLog).then(output => {
+    return computedArtifacts.requestMainResource(artifacts).then(output => {
       assert.equal(output.url, 'https://en.m.wikipedia.org/wiki/Main_Page');
     });
   });

--- a/lighthouse-core/test/gather/computed/manifest-values-test.js
+++ b/lighthouse-core/test/gather/computed/manifest-values-test.js
@@ -30,32 +30,32 @@ function noUrlManifestParser(manifestSrc) {
 
 /* eslint-env mocha */
 describe('ManifestValues computed artifact', () => {
-  it('reports a parse failure if page had no manifest', () => {
+  it('reports a parse failure if page had no manifest', async () => {
     const manifestArtifact = null;
-    const results = manifestValues.compute_(manifestArtifact);
+    const results = await manifestValues.compute_(manifestArtifact);
     assert.equal(results.isParseFailure, true);
     assert.ok(results.parseFailureReason, 'No manifest was fetched');
     assert.equal(results.allChecks.length, 0);
   });
 
-  it('reports a parse failure if page had an unparseable manifest', () => {
+  it('reports a parse failure if page had an unparseable manifest', async () => {
     const manifestArtifact = noUrlManifestParser('{:,}');
-    const results = manifestValues.compute_(manifestArtifact);
+    const results = await manifestValues.compute_(manifestArtifact);
     assert.equal(results.isParseFailure, true);
     assert.ok(results.parseFailureReason.includes('failed to parse as valid JSON'));
     assert.equal(results.allChecks.length, 0);
   });
 
-  it('passes the parsing checks on an empty manifest', () => {
+  it('passes the parsing checks on an empty manifest', async () => {
     const manifestArtifact = noUrlManifestParser('{}');
-    const results = manifestValues.compute_(manifestArtifact);
+    const results = await manifestValues.compute_(manifestArtifact);
     assert.equal(results.isParseFailure, false);
     assert.equal(results.parseFailureReason, undefined);
   });
 
-  it('passes the all checks with fixture manifest', () => {
+  it('passes the all checks with fixture manifest', async () => {
     const manifestArtifact = noUrlManifestParser(manifestSrc);
-    const results = manifestValues.compute_(manifestArtifact);
+    const results = await manifestValues.compute_(manifestArtifact);
     assert.equal(results.isParseFailure, false);
     assert.equal(results.parseFailureReason, undefined);
 
@@ -63,34 +63,34 @@ describe('ManifestValues computed artifact', () => {
     assert.equal(results.allChecks.every(i => i.passing), true, 'not all checks passed');
   });
 
-  describe('color checks', () => {
-    it('fails when a minimal manifest contains no background_color', () => {
+  describe('color checks', async () => {
+    it('fails when a minimal manifest contains no background_color', async () => {
       const Manifest = noUrlManifestParser(JSON.stringify({
         start_url: '/',
       }));
-      const results = manifestValues.compute_(Manifest);
+      const results = await manifestValues.compute_(Manifest);
       const colorResults = results.allChecks.filter(i => i.id.includes('Color'));
       assert.equal(colorResults.every(i => i.passing === false), true);
     });
 
-    it('fails when a minimal manifest contains an invalid background_color', () => {
+    it('fails when a minimal manifest contains an invalid background_color', async () => {
       const Manifest = noUrlManifestParser(JSON.stringify({
         background_color: 'no',
         theme_color: 'no',
       }));
 
-      const results = manifestValues.compute_(Manifest);
+      const results = await manifestValues.compute_(Manifest);
       const colorResults = results.allChecks.filter(i => i.id.includes('Color'));
       assert.equal(colorResults.every(i => i.passing === false), true);
     });
 
-    it('succeeds when a minimal manifest contains a valid background_color', () => {
+    it('succeeds when a minimal manifest contains a valid background_color', async () => {
       const Manifest = noUrlManifestParser(JSON.stringify({
         background_color: '#FAFAFA',
         theme_color: '#FAFAFA',
       }));
 
-      const results = manifestValues.compute_(Manifest);
+      const results = await manifestValues.compute_(Manifest);
       const colorResults = results.allChecks.filter(i => i.id.includes('Color'));
       assert.equal(colorResults.every(i => i.passing === true), true);
     });
@@ -102,59 +102,59 @@ describe('ManifestValues computed artifact', () => {
     it('passes accepted values', () => {
       let Manifest;
       Manifest = noUrlManifestParser(JSON.stringify({display: 'minimal-ui'}));
-      assert.equal(check.validate(Manifest), true, 'doesnt pass minimal-ui');
+      assert.equal(check.validate(Manifest.value), true, 'doesnt pass minimal-ui');
       Manifest = noUrlManifestParser(JSON.stringify({display: 'standalone'}));
-      assert.equal(check.validate(Manifest), true, 'doesnt pass standalone');
+      assert.equal(check.validate(Manifest.value), true, 'doesnt pass standalone');
       Manifest = noUrlManifestParser(JSON.stringify({display: 'fullscreen'}));
-      assert.equal(check.validate(Manifest), true, 'doesnt pass fullscreen');
+      assert.equal(check.validate(Manifest.value), true, 'doesnt pass fullscreen');
     });
     it('fails invalid values', () => {
       let Manifest;
       Manifest = noUrlManifestParser(JSON.stringify({display: 'display'}));
-      assert.equal(check.validate(Manifest), false, 'doesnt fail display');
+      assert.equal(check.validate(Manifest.value), false, 'doesnt fail display');
       Manifest = noUrlManifestParser(JSON.stringify({display: ''}));
-      assert.equal(check.validate(Manifest), false, 'doesnt fail empty string');
+      assert.equal(check.validate(Manifest.value), false, 'doesnt fail empty string');
     });
   });
 
-  describe('icons checks', () => {
+  describe('icons checks', async () => {
     describe('icons exist check', () => {
-      it('fails when a manifest contains no icons array', () => {
+      it('fails when a manifest contains no icons array', async () => {
         const manifestSrc = JSON.stringify({
           name: 'NoIconsHere',
         });
         const Manifest = noUrlManifestParser(manifestSrc);
-        const results = manifestValues.compute_(Manifest);
+        const results = await manifestValues.compute_(Manifest);
         const iconResults = results.allChecks.filter(i => i.id.includes('Icons'));
         assert.equal(iconResults.every(i => i.passing === false), true);
       });
 
-      it('fails when a manifest contains no icons', () => {
+      it('fails when a manifest contains no icons', async () => {
         const manifestSrc = JSON.stringify({
           icons: [],
         });
         const Manifest = noUrlManifestParser(manifestSrc);
-        const results = manifestValues.compute_(Manifest);
+        const results = await manifestValues.compute_(Manifest);
         const iconResults = results.allChecks.filter(i => i.id.includes('Icons'));
         assert.equal(iconResults.every(i => i.passing === false), true);
       });
     });
 
     describe('icons at least X size check', () => {
-      it('fails when a manifest contains an icon with no size', () => {
+      it('fails when a manifest contains an icon with no size', async () => {
         const manifestSrc = JSON.stringify({
           icons: [{
             src: 'icon.png',
           }],
         });
         const Manifest = noUrlManifestParser(manifestSrc);
-        const results = manifestValues.compute_(Manifest);
+        const results = await manifestValues.compute_(Manifest);
         const iconResults = results.allChecks.filter(i => i.id.includes('Icons'));
 
         assert.equal(iconResults.every(i => i.passing === false), true);
       });
 
-      it('succeeds when there\'s one icon with multiple sizes, and one is valid', () => {
+      it('succeeds when there\'s one icon with multiple sizes, and one is valid', async () => {
         const manifestSrc = JSON.stringify({
           icons: [{
             src: 'icon.png',
@@ -162,13 +162,13 @@ describe('ManifestValues computed artifact', () => {
           }],
         });
         const Manifest = noUrlManifestParser(manifestSrc);
-        const results = manifestValues.compute_(Manifest);
+        const results = await manifestValues.compute_(Manifest);
         const iconResults = results.allChecks.filter(i => i.id.includes('Icons'));
 
         assert.equal(iconResults.every(i => i.passing === true), true);
       });
 
-      it('succeeds when there\'s two icons, one without sizes; the other with a valid size', () => {
+      it('succeeds when there\'s two icons, one with and one without valid size', async () => {
         const manifestSrc = JSON.stringify({
           icons: [{
             src: 'icon.png',
@@ -178,13 +178,13 @@ describe('ManifestValues computed artifact', () => {
           }],
         });
         const Manifest = noUrlManifestParser(manifestSrc);
-        const results = manifestValues.compute_(Manifest);
+        const results = await manifestValues.compute_(Manifest);
         const iconResults = results.allChecks.filter(i => i.id.includes('Icons'));
 
         assert.equal(iconResults.every(i => i.passing === true), true);
       });
 
-      it('fails when an icon has a valid size, though it\'s non-square.', () => {
+      it('fails when an icon has a valid size, though it\'s non-square.', async () => {
         // See also: https://code.google.com/p/chromium/codesearch#chromium/src/chrome/browser/banners/app_banner_data_fetcher_unittest.cc&sq=package:chromium&type=cs&q=%22Non-square%20is%20okay%22%20file:%5Esrc/chrome/browser/banners/
         const manifestSrc = JSON.stringify({
           icons: [{
@@ -193,7 +193,7 @@ describe('ManifestValues computed artifact', () => {
           }],
         });
         const Manifest = noUrlManifestParser(manifestSrc);
-        const results = manifestValues.compute_(Manifest);
+        const results = await manifestValues.compute_(Manifest);
         const iconResults = results.allChecks.filter(i => i.id.includes('Icons'));
 
         assert.equal(iconResults.every(i => i.passing === false), true);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-consistently-interactive-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-consistently-interactive-test.js
@@ -15,7 +15,8 @@ const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtoo
 describe('Metrics: Lantern TTCI', () => {
   it('should compute predicted value', async () => {
     const artifacts = Runner.instantiateComputedArtifacts();
-    const result = await artifacts.requestLanternConsistentlyInteractive({trace, devtoolsLog});
+    const result = await artifacts.requestLanternConsistentlyInteractive({trace, devtoolsLog,
+      settings: {}});
 
     assert.equal(Math.round(result.timing), 5308);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 2451);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-contentful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-contentful-paint-test.js
@@ -15,7 +15,8 @@ const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtoo
 describe('Metrics: Lantern FCP', () => {
   it('should compute predicted value', async () => {
     const artifacts = Runner.instantiateComputedArtifacts();
-    const result = await artifacts.requestLanternFirstContentfulPaint({trace, devtoolsLog});
+    const result = await artifacts.requestLanternFirstContentfulPaint({trace, devtoolsLog,
+      settings: {}});
 
     assert.equal(Math.round(result.timing), 2038);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 611);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-cpu-idle-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-cpu-idle-test.js
@@ -15,7 +15,7 @@ const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtoo
 describe('Metrics: Lantern TTFCPUI', () => {
   it('should compute predicted value', async () => {
     const artifacts = Runner.instantiateComputedArtifacts();
-    const result = await artifacts.requestLanternFirstCPUIdle({trace, devtoolsLog});
+    const result = await artifacts.requestLanternFirstCPUIdle({trace, devtoolsLog, settings: {}});
 
     assert.equal(Math.round(result.timing), 5308);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 2451);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-meaningful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-meaningful-paint-test.js
@@ -15,7 +15,8 @@ const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtoo
 describe('Metrics: Lantern FMP', () => {
   it('should compute predicted value', async () => {
     const artifacts = Runner.instantiateComputedArtifacts();
-    const result = await artifacts.requestLanternFirstMeaningfulPaint({trace, devtoolsLog});
+    const result = await artifacts.requestLanternFirstMeaningfulPaint({trace, devtoolsLog,
+      settings: {}});
 
     assert.equal(Math.round(result.timing), 2851);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 911);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-speed-index-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-speed-index-test.js
@@ -15,7 +15,7 @@ const devtoolsLog = require('../../../fixtures/traces/progressive-app-m60.devtoo
 describe('Metrics: Lantern Speed Index', () => {
   it('should compute predicted value', async () => {
     const artifacts = Runner.instantiateComputedArtifacts();
-    const result = await artifacts.requestLanternSpeedIndex({trace, devtoolsLog});
+    const result = await artifacts.requestLanternSpeedIndex({trace, devtoolsLog, settings: {}});
 
     assert.equal(Math.round(result.timing), 2063);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 605);

--- a/lighthouse-core/test/gather/computed/network-throughput-test.js
+++ b/lighthouse-core/test/gather/computed/network-throughput-test.js
@@ -12,9 +12,9 @@ const assert = require('assert');
 
 describe('NetworkThroughput', () => {
   const compute = NetworkThroughput.getThroughput;
-  function createRecord(responseReceivedTime, endTime, extras) {
+  function createRecord(_responseReceivedTime, endTime, extras) {
     return Object.assign({
-      responseReceivedTime,
+      _responseReceivedTime,
       endTime,
       transferSize: 1000,
       finished: true,

--- a/lighthouse-core/test/gather/computed/trace-of-tab-test.js
+++ b/lighthouse-core/test/gather/computed/trace-of-tab-test.js
@@ -19,8 +19,8 @@ const backgroundTabTrace = require('../../fixtures/traces/backgrounded-tab-missi
 
 /* eslint-env mocha */
 describe('Trace of Tab computed artifact:', () => {
-  it('gathers the events from the tab\'s process', () => {
-    const trace = traceOfTab.compute_(lateTracingStartedTrace);
+  it('gathers the events from the tab\'s process', async () => {
+    const trace = await traceOfTab.compute_(lateTracingStartedTrace);
 
     const firstEvt = trace.processEvents[0];
     trace.processEvents.forEach(evt => {
@@ -33,8 +33,8 @@ describe('Trace of Tab computed artifact:', () => {
     assert.ok(firstEvt.pid === trace.firstMeaningfulPaintEvt.pid);
   });
 
-  it('computes timings of each event', () => {
-    const trace = traceOfTab.compute_(lateTracingStartedTrace);
+  it('computes timings of each event', async () => {
+    const trace = await traceOfTab.compute_(lateTracingStartedTrace);
     assert.equal(Math.round(trace.timings.navigationStart), 0);
     assert.equal(Math.round(trace.timings.firstPaint), 80);
     assert.equal(Math.round(trace.timings.firstContentfulPaint), 80);
@@ -42,8 +42,8 @@ describe('Trace of Tab computed artifact:', () => {
     assert.equal(Math.round(trace.timings.traceEnd), 649);
   });
 
-  it('computes timestamps of each event', () => {
-    const trace = traceOfTab.compute_(lateTracingStartedTrace);
+  it('computes timestamps of each event', async () => {
+    const trace = await traceOfTab.compute_(lateTracingStartedTrace);
     assert.equal(Math.round(trace.timestamps.navigationStart), 29343540951);
     assert.equal(Math.round(trace.timestamps.firstPaint), 29343620997);
     assert.equal(Math.round(trace.timestamps.firstContentfulPaint), 29343621005);
@@ -52,8 +52,8 @@ describe('Trace of Tab computed artifact:', () => {
   });
 
   describe('finds correct FMP', () => {
-    it('if there was a tracingStartedInPage after the frame\'s navStart', () => {
-      const trace = traceOfTab.compute_(lateTracingStartedTrace);
+    it('if there was a tracingStartedInPage after the frame\'s navStart', async () => {
+      const trace = await traceOfTab.compute_(lateTracingStartedTrace);
       assert.equal(trace.startedInPageEvt.ts, 29343544280);
       assert.equal(trace.navigationStartEvt.ts, 29343540951);
       assert.equal(trace.firstContentfulPaintEvt.ts, 29343621005);
@@ -61,8 +61,8 @@ describe('Trace of Tab computed artifact:', () => {
       assert.ok(!trace.fmpFellBack);
     });
 
-    it('if there was a tracingStartedInPage after the frame\'s navStart #2', () => {
-      const trace = traceOfTab.compute_(badNavStartTrace);
+    it('if there was a tracingStartedInPage after the frame\'s navStart #2', async () => {
+      const trace = await traceOfTab.compute_(badNavStartTrace);
       assert.equal(trace.startedInPageEvt.ts, 8885435611);
       assert.equal(trace.navigationStartEvt.ts, 8885424467);
       assert.equal(trace.firstContentfulPaintEvt.ts, 8886056886);
@@ -70,8 +70,8 @@ describe('Trace of Tab computed artifact:', () => {
       assert.ok(!trace.fmpFellBack);
     });
 
-    it('if it appears slightly before the fCP', () => {
-      const trace = traceOfTab.compute_(preactTrace);
+    it('if it appears slightly before the fCP', async () => {
+      const trace = await traceOfTab.compute_(preactTrace);
       assert.equal(trace.startedInPageEvt.ts, 1805796376829);
       assert.equal(trace.navigationStartEvt.ts, 1805796384607);
       assert.equal(trace.firstContentfulPaintEvt.ts, 1805797263653);
@@ -79,8 +79,8 @@ describe('Trace of Tab computed artifact:', () => {
       assert.ok(!trace.fmpFellBack);
     });
 
-    it('from candidates if no defined FMP exists', () => {
-      const trace = traceOfTab.compute_(noFMPtrace);
+    it('from candidates if no defined FMP exists', async () => {
+      const trace = await traceOfTab.compute_(noFMPtrace);
       assert.equal(trace.startedInPageEvt.ts, 2146735802456);
       assert.equal(trace.navigationStartEvt.ts, 2146735807738);
       assert.equal(trace.firstContentfulPaintEvt.ts, 2146737302468);
@@ -89,8 +89,8 @@ describe('Trace of Tab computed artifact:', () => {
     });
   });
 
-  it('handles traces missing an FCP', () => {
-    const trace = traceOfTab.compute_(noFCPtrace);
+  it('handles traces missing an FCP', async () => {
+    const trace = await traceOfTab.compute_(noFCPtrace);
     assert.equal(trace.startedInPageEvt.ts, 2149509117532, 'bad tracingstartedInPage');
     assert.equal(trace.navigationStartEvt.ts, 2149509122585, 'bad navStart');
     assert.equal(trace.firstContentfulPaintEvt, undefined, 'bad fcp');
@@ -98,8 +98,8 @@ describe('Trace of Tab computed artifact:', () => {
     assert.ok(trace.fmpFellBack);
   });
 
-  it('handles traces missing a paints (captured in background tab)', () => {
-    const trace = traceOfTab.compute_(backgroundTabTrace);
+  it('handles traces missing a paints (captured in background tab)', async () => {
+    const trace = await traceOfTab.compute_(backgroundTabTrace);
     assert.equal(trace.startedInPageEvt.ts, 1966813248134);
     assert.notEqual(trace.navigationStartEvt.ts, 1966813346529, 'picked wrong frame');
     assert.notEqual(trace.navigationStartEvt.ts, 1966813520313, 'picked wrong frame');
@@ -112,10 +112,10 @@ describe('Trace of Tab computed artifact:', () => {
     assert.equal(trace.firstMeaningfulPaintEvt, undefined, 'bad fmp');
   });
 
-  it('stably sorts events', () => {
+  it('stably sorts events', async () => {
     const traceJson = fs.readFileSync(__dirname +
         '/../../fixtures/traces/tracingstarted-after-navstart.json', 'utf8');
-    const trace = traceOfTab.compute_(JSON.parse(traceJson));
+    const trace = await traceOfTab.compute_(JSON.parse(traceJson));
     const mainPid = trace.mainThreadEvents[0].pid;
 
     const freshProcessEvents = JSON.parse(traceJson).traceEvents

--- a/lighthouse-core/test/lib/traces/tracing-processor-test.js
+++ b/lighthouse-core/test/lib/traces/tracing-processor-test.js
@@ -147,9 +147,9 @@ describe('TracingProcessor lib', () => {
   });
 
   describe('getMainThreadTopLevelEvents', () => {
-    it('gets durations of top-level tasks', () => {
+    it('gets durations of top-level tasks', async () => {
       const trace = {traceEvents: pwaTrace};
-      const tabTrace = new TraceOfTab().compute_(trace);
+      const tabTrace = await new TraceOfTab().compute_(trace);
       const ret = TracingProcessor.getMainThreadTopLevelEvents(tabTrace);
 
       assert.equal(ret.length, 645);
@@ -188,9 +188,9 @@ describe('TracingProcessor lib', () => {
   });
 
   describe('getMainThreadTopLevelEventDurations', () => {
-    it('gets durations of top-level tasks', () => {
+    it('gets durations of top-level tasks', async () => {
       const trace = {traceEvents: pwaTrace};
-      const tabTrace = new TraceOfTab().compute_(trace);
+      const tabTrace = await new TraceOfTab().compute_(trace);
       const events = TracingProcessor.getMainThreadTopLevelEvents(tabTrace);
       const ret = TracingProcessor.getMainThreadTopLevelEventDurations(events);
       const durations = ret.durations;
@@ -223,9 +223,9 @@ describe('TracingProcessor lib', () => {
       };
     });
 
-    it('compute correct defaults', () => {
+    it('compute correct defaults', async () => {
       const trace = {traceEvents: pwaTrace};
-      const tabTrace = new TraceOfTab().compute_(trace);
+      const tabTrace = await new TraceOfTab().compute_(trace);
       const events = TracingProcessor.getMainThreadTopLevelEvents(tabTrace);
       const ret = TracingProcessor.getRiskToResponsiveness(events, 0, tabTrace.timings.traceEnd);
       assert.equal(ret.durations.length, 645);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,7 @@
     "lighthouse-core/audits/seo/robots-txt.js",
     "lighthouse-core/lib/dependency-graph/**/*.js",
     "lighthouse-core/lib/emulation.js",
-    "lighthouse-core/gather/computed/metrics/*.js",
-    "lighthouse-core/gather/connections/**/*.js",
-    "lighthouse-core/gather/gatherers/**/*.js",
+    "lighthouse-core/gather/**/*.js",
     "lighthouse-core/scripts/*.js",
     "./typings/*.d.ts"
   ],

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -113,6 +113,7 @@ declare global {
 
       // Metrics.
       requestConsistentlyInteractive(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
+      requestEstimatedInputLatency(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
       requestFirstContentfulPaint(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
       requestFirstCPUIdle(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
       requestFirstMeaningfulPaint(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
@@ -120,6 +121,7 @@ declare global {
 
       // Lantern metrics.
       requestLanternConsistentlyInteractive(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
+      requestLanternEstimatedInputLatency(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
       requestLanternFirstContentfulPaint(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
       requestLanternFirstCPUIdle(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
       requestLanternFirstMeaningfulPaint(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -6,6 +6,7 @@
 
 import * as parseManifest from '../lighthouse-core/lib/manifest-parser.js';
 import * as _LanternSimulator from '../lighthouse-core/lib/dependency-graph/simulator/simulator.js';
+import speedline = require('speedline');
 
 type LanternSimulator = InstanceType<typeof _LanternSimulator>;
 
@@ -319,19 +320,7 @@ declare global {
         pessimisticGraph: Gatherer.Simulation.GraphNode;
       }
 
-      export interface Speedline {
-        beginning: number;
-        complete: number;
-        duration: number;
-        end: number;
-        first: number;
-        speedIndex: number;
-        frames: {
-          getProgress(): number;
-          getTimeStamp(): number;
-          isProgressInterpolated(): number;
-        }[]
-      }
+      export type Speedline = ReturnType<typeof speedline>;
 
       // TODO(bckenny): all but navigationStart could actually be undefined.
       export interface TraceTimes {

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -5,10 +5,13 @@
  */
 
 import * as parseManifest from '../lighthouse-core/lib/manifest-parser.js';
+import * as _LanternSimulator from '../lighthouse-core/lib/dependency-graph/simulator/simulator.js';
+
+type LanternSimulator = InstanceType<typeof _LanternSimulator>;
 
 declare global {
   module LH {
-    export interface Artifacts {
+    export interface Artifacts extends ComputedArtifacts {
       // Created by by gather-runner
       fetchedAt: string;
       LighthouseRunWarnings: string[];
@@ -57,7 +60,7 @@ declare global {
       /** JS coverage information for code used during page load. */
       JsUsage: Crdp.Profiler.ScriptCoverage[];
       /** Parsed version of the page's Web App Manifest, or null if none found. */
-      Manifest: ReturnType<typeof parseManifest> | null;
+      Manifest: Artifacts.Manifest | null;
       /** The value of the <meta name="description">'s content attribute, or null. */
       MetaDescription: string|null;
       /** The value of the <meta name="robots">'s content attribute, or null. */
@@ -92,11 +95,35 @@ declare global {
       ViewportDimensions: Artifacts.ViewportDimensions;
       /** WebSQL database information for the page or null if none was found. */
       WebSQL: Crdp.Database.Database | null;
+    }
 
-      // TODO(bckenny): remove this for real computed artifacts approach
-      requestTraceOfTab(trace: Trace): Promise<Artifacts.TraceOfTab>
-      requestNetworkRecords(devtoolsLogs: DevtoolsLog): Promise<WebInspector.NetworkRequest[]>
-      requestMainResource(devtoolsLogs: DevtoolsLog): Promise<WebInspector.NetworkRequest>
+    export interface ComputedArtifacts {
+      requestDevtoolsTimelineModel(trace: Trace): Promise<{filmStripModel(): Artifacts.DevtoolsTimelineFilmStripModel}>;
+      requestLoadSimulator(data: {devtoolsLog: DevtoolsLog, settings: Config.Settings}): Promise<LanternSimulator>;
+      requestMainResource(data: {devtoolsLog: DevtoolsLog, URL: Artifacts['URL']}): Promise<WebInspector.NetworkRequest>;
+      requestManifestValues(manifest: LH.Artifacts['Manifest']): Promise<LH.Artifacts.ManifestValues>;
+      requestNetworkAnalysis(devtoolsLog: DevtoolsLog): Promise<LH.Artifacts.NetworkAnalysis>;
+      requestNetworkThroughput(devtoolsLog: DevtoolsLog): Promise<number>;
+      requestNetworkRecords(devtoolsLog: DevtoolsLog): Promise<WebInspector.NetworkRequest[]>;
+      requestPageDependencyGraph(data: {trace: Trace, devtoolsLog: DevtoolsLog}): Promise<Gatherer.Simulation.GraphNode>;
+      requestPushedRequests(devtoolsLogs: DevtoolsLog): Promise<WebInspector.NetworkRequest[]>;
+      requestTraceOfTab(trace: Trace): Promise<Artifacts.TraceOfTab>;
+      requestScreenshots(trace: Trace): Promise<{timestamp: number, datauri: string}[]>;
+      requestSpeedline(trace: Trace): Promise<LH.Artifacts.Speedline>;
+
+      // Metrics.
+      requestConsistentlyInteractive(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
+      requestFirstContentfulPaint(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
+      requestFirstCPUIdle(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
+      requestFirstMeaningfulPaint(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
+      requestSpeedIndex(data: LH.Artifacts.MetricComputationDataInput): Promise<Artifacts.LanternMetric|Artifacts.Metric>;
+
+      // Lantern metrics.
+      requestLanternConsistentlyInteractive(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
+      requestLanternFirstContentfulPaint(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
+      requestLanternFirstCPUIdle(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
+      requestLanternFirstMeaningfulPaint(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
+      requestLanternSpeedIndex(data: LH.Artifacts.MetricComputationData): Promise<Artifacts.LanternMetric>;
     }
 
     module Artifacts {
@@ -172,6 +199,9 @@ declare global {
         }
       }
 
+      // TODO(bckenny): real type for parsed manifest.
+      export type Manifest = ReturnType<typeof parseManifest>;
+
       export interface SingleImageUsage {
         src: string;
         clientWidth: number;
@@ -230,6 +260,31 @@ declare global {
         devicePixelRatio: number;
       }
 
+      // Computed artifact types below.
+      export type CriticalRequestNode = {
+        [id: string]: {
+          request: WebInspector.NetworkRequest;
+          children: CriticalRequestNode;
+        }
+      }
+
+      export interface DevtoolsTimelineFilmStripModel {
+        frames(): Array<{
+          imageDataPromise(): Promise<string>;
+          timestamp: number;
+        }>;
+      }
+
+      export interface ManifestValues {
+        isParseFailure: boolean;
+        parseFailureReason: string | undefined;
+        allChecks: {
+          id: string;
+          failureText: string;
+          passing: boolean;
+        }[];
+      }
+
       export interface MetricComputationDataInput {
         devtoolsLog: DevtoolsLog;
         trace: Trace;
@@ -239,11 +294,19 @@ declare global {
       export interface MetricComputationData extends MetricComputationDataInput {
         networkRecords: Array<WebInspector.NetworkRequest>;
         traceOfTab: TraceOfTab;
+        simulator?: LanternSimulator;
       }
 
       export interface Metric {
         timing: number;
         timestamp?: number;
+      }
+
+      export interface NetworkAnalysis {
+        rtt: number;
+        additionalRttByOrigin: Map<string, number>;
+        serverResponseTimeByOrigin: Map<string, number>;
+        throughput: number;
       }
 
       export interface LanternMetric {
@@ -254,16 +317,32 @@ declare global {
         pessimisticGraph: Gatherer.Simulation.GraphNode;
       }
 
+      export interface Speedline {
+        beginning: number;
+        complete: number;
+        duration: number;
+        end: number;
+        first: number;
+        speedIndex: number;
+        frames: {
+          getProgress(): number;
+          getTimeStamp(): number;
+          isProgressInterpolated(): number;
+        }[]
+      }
+
+      // TODO(bckenny): all but navigationStart could actually be undefined.
       export interface TraceTimes {
         navigationStart: number;
         firstPaint: number;
         firstContentfulPaint: number;
         firstMeaningfulPaint: number;
         traceEnd: number;
-        onLoad: number;
+        load: number;
         domContentLoaded: number;
       }
 
+      // TODO(bckenny): events other than started and navStart could be undefined.
       export interface TraceOfTab {
         timings: TraceTimes;
         timestamps: TraceTimes;
@@ -274,7 +353,8 @@ declare global {
         firstPaintEvt: TraceEvent;
         firstContentfulPaintEvt: TraceEvent;
         firstMeaningfulPaintEvt: TraceEvent;
-        onLoadEvt: TraceEvent;
+        loadEvt: TraceEvent;
+        domContentLoadedEvt: TraceEvent;
         fmpFellBack: boolean;
       }
     }

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -81,7 +81,9 @@ declare global {
       }
 
       // TODO(bckenny): we likely don't want to require all these
-      export type Settings = Required<SettingsJson>;
+      export interface Settings extends Required<SettingsJson> {
+        throttling: Required<ThrottlingSettings>;
+      }
 
       export interface Pass extends Required<PassJson> {
         gatherers: GathererDefn[];

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -22,6 +22,10 @@ declare global {
     [P in K]+?: T[P]
   }
 
+  /** Obtain the type of the first parameter of a function. */
+  type FirstParamType<T extends (arg1: any, ...args: any[]) => any> =
+    T extends (arg1: infer P, ...args: any[]) => any ? P : any;
+
   module LH {
     // re-export useful type modules under global LH module.
     export import Crdp = _Crdp;
@@ -121,11 +125,22 @@ declare global {
 
     export interface TraceEvent {
       name: string;
+      cat: string;
       args: {
         data?: {
-          url?: string
+          page?: string;
+          readyState?: number;
+          requestId?: string;
+          stackTrace?: {
+            url: string
+          }[];
+          styleSheetUrl?: string;
+          timerId?: string;
+          url?: string;
         };
+        frame?: string;
       };
+      pid: number;
       tid: number;
       ts: number;
       dur: number;

--- a/typings/speedline/index.d.ts
+++ b/typings/speedline/index.d.ts
@@ -1,0 +1,31 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+interface SpeedlineOutput {
+  beginning: number;
+  end: number;
+  speedIndex: number;
+  first: number;
+  complete: number;
+  duration: number;
+  frames: {
+    getProgress(): number;
+    getTimeStamp(): number;
+    isProgressInterpolated(): number;
+  }[]
+}
+
+interface SpeedlineOptions {
+  timeOrigin?: number;
+  fastMode?: boolean;
+  include?: 'all' | 'speedIndex' | 'perceptualSpeedIndex';
+}
+
+declare module 'speedline' {
+  function Speedline(trace: LH.TraceEvent[], opts: SpeedlineOptions): SpeedlineOutput;
+
+  export = Speedline;
+}

--- a/typings/speedline/index.d.ts
+++ b/typings/speedline/index.d.ts
@@ -4,28 +4,38 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-interface SpeedlineOutput {
-  beginning: number;
-  end: number;
-  speedIndex: number;
-  first: number;
-  complete: number;
-  duration: number;
-  frames: {
-    getProgress(): number;
-    getTimeStamp(): number;
-    isProgressInterpolated(): number;
-  }[]
-}
-
-interface SpeedlineOptions {
-  timeOrigin?: number;
-  fastMode?: boolean;
-  include?: 'all' | 'speedIndex' | 'perceptualSpeedIndex';
-}
-
 declare module 'speedline' {
-  function Speedline(trace: LH.TraceEvent[], opts: SpeedlineOptions): SpeedlineOutput;
+	interface SpeedlineOutput {
+		beginning: number;
+		end: number;
+		frames: Array<{
+			getHistogram(): number[][];
+			getTimeStamp(): number;
+			getImage(): Buffer;
+			setProgress(progress: number, isInterpolated: boolean): void;
+			setPerceptualProgress(progress: number, isInterpolated: boolean): void;
+			getProgress(): number;
+			getPerceptualProgress(): number;
+			isProgressInterpolated(): boolean;
+			isPerceptualProgressInterpolated(): boolean;
+		}>;
+		first: number;
+		complete: number;
+		duration: number;
+	
+		// TODO: speedIndex may actually be optional based on input options.
+		// Use a more clever way to declare these exist based on SpeedlineOptions['include']
+		speedIndex: number;
+		perceptualSpeedIndex?: number;
+	}
+	
+	interface SpeedlineOptions {
+		timeOrigin?: number;
+		fastMode?: boolean;
+		include?: 'all' | 'speedIndex' | 'perceptualSpeedIndex';
+	}
 
-  export = Speedline;
+  function speedline(trace: LH.TraceEvent[], opts: SpeedlineOptions): SpeedlineOutput;
+
+  export = speedline;
 }

--- a/typings/web-inspector.d.ts
+++ b/typings/web-inspector.d.ts
@@ -37,15 +37,18 @@ declare global {
       failed?: boolean;
       localizedFailDescription?: string;
 
-      _initiator: NetworkRequestInitiator;
-      initiatorRequest(): NetworkRequest,
-      _timing: NetworkRequestTiming;
+      _initiator: Crdp.Network.Initiator;
+      _timing: Crdp.Network.ResourceTiming;
       _resourceType: ResourceType;
       _mimeType: string;
       priority(): 'VeryHigh' | 'High' | 'Medium' | 'Low';
       _responseHeaders?: {name: string, value: string}[];
 
       _fetchedViaServiceWorker?: boolean;
+      _frameId: Crdp.Page.FrameId;
+      _isLinkPreload?: boolean;
+      initiatorRequest(): NetworkRequest | null;
+      redirects?: NetworkRequest[];
     }
 
     export interface ParsedURL {
@@ -53,27 +56,16 @@ declare global {
       host: string;
     }
 
-    export interface NetworkRequestInitiator {
-      type: 'script' | 'parser';
-    }
-
-    export interface NetworkRequestTiming {
-      dnsStart: number;
-      dnsEnd: number;
-      connectStart: number;
-      connectEnd: number;
-      sslStart: number;
-      sslEnd: number;
-      sendStart: number;
-      sendEnd: number;
-      receiveHeadersEnd: number;
-    }
-
     export interface ResourceType {
+      _category: ResourceCategory;
       name(): string;
       _name: string;
       title(): string;
       isTextType(): boolean;
+    }
+
+    export interface ResourceCategory {
+      title: string;
     }
   }
 }


### PR DESCRIPTION
Important first step to refactoring computed artifacts to be just regular requires. Big PR, but almost all type stuff.

Introduces the lie that the computed artifact `request*()` methods are part of the `Artifacts` type, which isn't usually true except when calling `myaudit.audit(artifacts, auditContext)`. Follow ups will untangle that.

Only real code changes:
- The only time that the `computedArtifacts` object realized it also had all the artifacts on it was in `MainResource`, where `artifacts.URL` was accessed. Instead, `URL` is now passed in as an artifact dependency (as it should be), but that requires `CriticalRequestChains` also needing `URL` passed in. This needed a lot of small test tweaks.
- The lantern simulator needs a settings object passed in, even if it's empty, to keep tsc happy about destructuring. This required some scattered `settings: {}` around.
- the `ComputedArtifact.compute_` method now *has* to be async. It was too annoying dealing with it either being sync (`URL`, `TraceOfTab`, maybe one more?) or async, so just easier this way. Required a good number of additional async/await scattered around, especially in tests.

Pretty much everything else is just adding type annotations or making code a little more explicit for the compiler.