### PR TITLE
tests: fix cli handling empty runnerResult during gatherMode

### DIFF
--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -100,12 +100,12 @@ function handleError(err) {
  * @return {Promise<void>}
  */
 function saveResults(runnerResult, flags) {
-  const {lhr, artifacts} = runnerResult;
   const cwd = process.cwd();
   let promise = Promise.resolve();
 
   const shouldSaveResults = flags.auditMode || (flags.gatherMode === flags.auditMode);
   if (!shouldSaveResults) return promise;
+  const {lhr, artifacts} = runnerResult;
 
   // Use the output path as the prefix for all generated files.
   // If no output path is set, generate a file prefix using the URL and date.

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -53,6 +53,14 @@ describe('flag coercing', () => {
   });
 });
 
+
+describe('saveResults', () => {
+  it('will quit early if we\'re in gather mode', async () => {
+    const result = await run.saveResults(undefined, {gatherMode: true});
+    assert.equal(result, undefined);
+  });
+});
+
 describe('Parsing --chrome-flags', () => {
   it('returns boolean flags that are true as a bare flag', () => {
     assert.deepStrictEqual(parseChromeFlags('--debug'), ['--debug']);

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -179,7 +179,7 @@ class Runner {
     artifacts = Object.assign(Runner.instantiateComputedArtifacts(), artifacts);
 
     if (artifacts.settings) {
-      const overrides = {gatherMode: undefined, auditMode: undefined};
+      const overrides = {gatherMode: undefined, auditMode: undefined, output: undefined};
       const normalizedGatherSettings = Object.assign({}, artifacts.settings, overrides);
       const normalizedAuditSettings = Object.assign({}, settings, overrides);
 


### PR DESCRIPTION
the destructure in `saveResults` broke cases where gatherMode existed runner early with an `undefined` runnerResult


plenty of others ways to solve this. happy to do them, though this seemed like the most non-invasive.

-----

driveby fix: avoid comparing `output` much like gather/auditMode as the `output` is irrelevant to a gather run.