### PR TITLE
core(tsc): update for new @types/css-font-loading-module

### DIFF
--- a/lighthouse-core/gather/gatherers/fonts.js
+++ b/lighthouse-core/gather/gatherers/fonts.js
@@ -10,9 +10,9 @@
 const Gatherer = require('./gatherer');
 const Sentry = require('../../lib/sentry');
 
-// TODO(bckenny): manually add 'display' for now.
-// PR to add full FontFace props in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25045
-/** @typedef {Exclude<keyof FontFace, 'load'|'loaded'|'status'> | 'display'} FontFaceStringKeys */
+// All the property keys of FontFace where the value is a string and are worth
+// using for finding font matches (see _findSameFontFamily).
+/** @typedef {'family'|'style'|'weight'|'stretch'|'unicodeRange'|'variant'|'featureSettings'|'display'} FontFaceStringKeys */
 /** @typedef {{err: {message: string, stack: string}}} FontGatherError */
 
 /** @type {Array<FontFaceStringKeys>} */
@@ -42,7 +42,6 @@ function getAllLoadedFonts(descriptors) {
       src: [],
     };
     descriptors.forEach(descriptor => {
-      // @ts-ignore TODO(bckenny): see above 'display' TODO
       fontRule[descriptor] = fontFace[descriptor];
     });
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@types/chrome": "^0.0.60",
     "@types/configstore": "^2.1.1",
-    "@types/css-font-loading-module": "^0.0.1",
+    "@types/css-font-loading-module": "^0.0.2",
     "@types/inquirer": "^0.0.35",
     "@types/lodash.isequal": "^4.5.2",
     "@types/node": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
   version "0.9.43"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-0.9.43.tgz#65d646c5e8c0cd1bdee37065799f9d3d48748253"
 
-"@types/css-font-loading-module@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.1.tgz#00f3594bcb15813282b8d5595d9d997db49b2608"
+"@types/css-font-loading-module@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.2.tgz#09f1f1772975777e37851b7b7a4389d97c210add"
 
 "@types/events@*":
   version "1.2.0"


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25045 landed, so can pull out the TODOs adding support for the `FontFace` props added in the last year.