### PR TITLE
core(preload): use lantern to compute savings

### DIFF
--- a/lighthouse-core/lib/dependency-graph/node.js
+++ b/lighthouse-core/lib/dependency-graph/node.js
@@ -111,6 +111,31 @@ class Node {
   }
 
   /**
+   * @param {Node} node
+   */
+  removeDependent(node) {
+    node.removeDependency(this);
+  }
+
+  /**
+   * @param {Node} node
+   */
+  removeDependency(node) {
+    if (!this._dependencies.includes(node)) {
+      return;
+    }
+
+    node._dependents.splice(node._dependents.indexOf(this), 1);
+    this._dependencies.splice(this._dependencies.indexOf(node), 1);
+  }
+
+  removeAllDependencies() {
+    for (const node of this._dependencies.slice()) {
+      this.removeDependency(node);
+    }
+  }
+
+  /**
    * Clones the node's information without adding any dependencies/dependents.
    * @return {Node}
    */

--- a/lighthouse-core/lib/dependency-graph/simulator/tcp-connection.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/tcp-connection.js
@@ -79,6 +79,20 @@ class TcpConnection {
   }
 
   /**
+   * @return {boolean}
+   */
+  isH2() {
+    return this._h2;
+  }
+
+  /**
+   * @return {number}
+   */
+  get congestionWindow() {
+    return this._congestionWindow;
+  }
+
+  /**
    * Sets the number of excess bytes that are available to this connection on future downloads, only
    * applies to H2 connections.
    * @param {number} bytes
@@ -86,6 +100,14 @@ class TcpConnection {
   setH2OverflowBytesDownloaded(bytes) {
     if (!this._h2) return;
     this._h2OverflowBytesDownloaded = bytes;
+  }
+
+  /**
+   * @return {TcpConnection}
+   */
+  clone() {
+    // @ts-ignore
+    return Object.assign(new TcpConnection(), this);
   }
 
   /**

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -9,56 +9,105 @@
 /* eslint-env mocha */
 
 const UsesRelPreload = require('../../audits/uses-rel-preload.js');
+const NetworkNode = require('../../lib/dependency-graph/network-node');
 const assert = require('assert');
 const defaultMainResource = {
   _endTime: 1,
 };
 
-const mockArtifacts = (networkRecords, mockChain, mainResource = defaultMainResource) => {
-  return {
-    devtoolsLogs: {
-      [UsesRelPreload.DEFAULT_PASS]: [],
-    },
-    requestCriticalRequestChains: () => {
-      return Promise.resolve(mockChain);
-    },
-    requestNetworkRecords: () => networkRecords,
-    requestMainResource: () => {
-      return Promise.resolve(mainResource);
-    },
-  };
-};
-
 describe('Performance: uses-rel-preload audit', () => {
-  it(`should suggest preload resource`, () => {
+  let mockGraph;
+  let mockSimulator;
+
+  const mockArtifacts = (networkRecords, mockChain, mainResource = defaultMainResource) => {
+    return {
+      traces: {[UsesRelPreload.DEFAULT_PASS]: {traceEvents: []}},
+      devtoolsLogs: {[UsesRelPreload.DEFAULT_PASS]: []},
+      requestCriticalRequestChains: () => {
+        return Promise.resolve(mockChain);
+      },
+      requestLoadSimulator: () => mockSimulator,
+      requestPageDependencyGraph: () => mockGraph,
+      requestNetworkRecords: () => networkRecords,
+      requestMainResource: () => {
+        return Promise.resolve(mainResource);
+      },
+    };
+  };
+
+  function buildNode(requestId, url) {
+    return new NetworkNode({url, requestId});
+  }
+
+  it('should suggest preload resource', () => {
+    const rootNode = buildNode(1, 'http://example.com');
+    const mainDocumentNode = buildNode(2, 'http://www.example.com');
+    const scriptNode = buildNode(3, 'http://www.example.com/script.js');
+    const scriptAddedNode = buildNode(4, 'http://www.example.com/script-added.js');
+
+    mainDocumentNode.addDependency(rootNode);
+    scriptNode.addDependency(mainDocumentNode);
+    scriptAddedNode.addDependency(scriptNode);
+
+    mockGraph = rootNode;
+    mockSimulator = {
+      simulate(graph) {
+        const nodesByUrl = new Map();
+        graph.traverse(node => nodesByUrl.set(node.record.url, node));
+
+        const rootNodeLocal = nodesByUrl.get(rootNode.record.url);
+        const mainDocumentNodeLocal = nodesByUrl.get(mainDocumentNode.record.url);
+        const scriptNodeLocal = nodesByUrl.get(scriptNode.record.url);
+        const scriptAddedNodeLocal = nodesByUrl.get(scriptAddedNode.record.url);
+
+        const nodeTimings = new Map([
+          [rootNodeLocal, {starTime: 0, endTime: 500}],
+          [mainDocumentNodeLocal, {startTime: 500, endTime: 1000}],
+          [scriptNodeLocal, {startTime: 1000, endTime: 2000}],
+          [scriptAddedNodeLocal, {startTime: 2000, endTime: 3250}],
+        ]);
+
+        if (scriptAddedNodeLocal.getDependencies()[0] === mainDocumentNodeLocal) {
+          nodeTimings.set(scriptAddedNodeLocal, {startTime: 1000, endTime: 2000});
+        }
+
+        return {nodeTimings};
+      },
+    };
+
     const mainResource = Object.assign({}, defaultMainResource, {
+      url: 'http://www.example.com',
       redirects: [''],
     });
     const networkRecords = [
       {
         requestId: '2',
-        _endTime: 1,
         _isLinkPreload: false,
         _url: 'http://www.example.com',
       },
       {
         requestId: '3',
-        _startTime: 10,
-        _endTime: 19,
         _isLinkPreload: false,
         _url: 'http://www.example.com/script.js',
       },
+      {
+        requestId: '4',
+        _isLinkPreload: false,
+        _url: 'http://www.example.com/script-added.js',
+      },
     ];
+
     const chains = {
       '1': {
         children: {
           '2': {
+            request: networkRecords[0],
             children: {
               '3': {
-                request: networkRecords[0],
+                request: networkRecords[1],
                 children: {
                   '4': {
-                    request: networkRecords[1],
+                    request: networkRecords[2],
                     children: {},
                   },
                 },
@@ -69,11 +118,12 @@ describe('Performance: uses-rel-preload audit', () => {
       },
     };
 
-    return UsesRelPreload.audit(mockArtifacts(networkRecords, chains, mainResource))
-      .then(output => {
-        assert.equal(output.rawValue, 9000);
+    return UsesRelPreload.audit(mockArtifacts(networkRecords, chains, mainResource), {}).then(
+      output => {
+        assert.equal(output.rawValue, 1250);
         assert.equal(output.details.items.length, 1);
-      });
+      }
+    );
   });
 
   it(`shouldn't suggest preload for already preloaded records`, () => {
@@ -100,7 +150,7 @@ describe('Performance: uses-rel-preload audit', () => {
       },
     };
 
-    return UsesRelPreload.audit(mockArtifacts(networkRecords, chains)).then(output => {
+    return UsesRelPreload.audit(mockArtifacts(networkRecords, chains), {}).then(output => {
       assert.equal(output.rawValue, 0);
       assert.equal(output.details.items.length, 0);
     });
@@ -130,7 +180,7 @@ describe('Performance: uses-rel-preload audit', () => {
       },
     };
 
-    return UsesRelPreload.audit(mockArtifacts(networkRecords, chains)).then(output => {
+    return UsesRelPreload.audit(mockArtifacts(networkRecords, chains), {}).then(output => {
       assert.equal(output.rawValue, 0);
       assert.equal(output.details.items.length, 0);
     });

--- a/lighthouse-core/test/lib/dependency-graph/simulator/connection-pool-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/connection-pool-test.js
@@ -1,0 +1,187 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const ConnectionPool = require('../../../../lib/dependency-graph/simulator/connection-pool');
+
+const assert = require('assert');
+const URL = require('url').URL;
+
+/* eslint-env mocha */
+describe('DependencyGraph/Simulator/ConnectionPool', () => {
+  const rtt = 100;
+  const throughput = 10000 * 1024;
+  let requestId;
+
+  function record(data = {}) {
+    const url = data.url || 'http://example.com';
+    const origin = new URL(url).origin;
+    const scheme = url.split(':')[0];
+
+    return Object.assign({
+      requestId: requestId++,
+      url,
+      origin,
+      protocol: 'http/1.1',
+      parsedURL: {scheme},
+    }, data);
+  }
+
+  beforeEach(() => {
+    requestId = 1;
+  });
+
+  describe('#constructor', () => {
+    it('should create the pool', () => {
+      const pool = new ConnectionPool([record()], {rtt, throughput});
+      // Make sure 6 connections are created for each origin
+      assert.equal(pool._connectionsByOrigin.get('http://example.com').length, 6);
+      // Make sure it populates connectionWasReused
+      assert.equal(pool._connectionReusedByRequestId.get(1), false);
+
+      const connection = pool._connectionsByOrigin.get('http://example.com')[0];
+      assert.equal(connection._rtt, rtt);
+      assert.equal(connection._throughput, throughput);
+      assert.equal(connection._serverLatency, 30); // sets to default value
+    });
+
+    it('should set TLS properly', () => {
+      const recordA = record({url: 'https://example.com'});
+      const pool = new ConnectionPool([recordA], {rtt, throughput});
+      const connection = pool._connectionsByOrigin.get('https://example.com')[0];
+      assert.ok(connection._ssl, 'should have set connection TLS');
+    });
+
+    it('should set H2 properly', () => {
+      const recordA = record({protocol: 'h2'});
+      const pool = new ConnectionPool([recordA], {rtt, throughput});
+      const connection = pool._connectionsByOrigin.get('http://example.com')[0];
+      assert.ok(connection.isH2(), 'should have set HTTP/2');
+    });
+
+    it('should set origin-specific RTT properly', () => {
+      const additionalRttByOrigin = new Map([['http://example.com', 63]]);
+      const pool = new ConnectionPool([record()], {rtt, throughput, additionalRttByOrigin});
+      const connection = pool._connectionsByOrigin.get('http://example.com')[0];
+      assert.ok(connection._rtt, rtt + 63);
+    });
+
+    it('should set origin-specific server latency properly', () => {
+      const serverResponseTimeByOrigin = new Map([['http://example.com', 63]]);
+      const pool = new ConnectionPool([record()], {rtt, throughput, serverResponseTimeByOrigin});
+      const connection = pool._connectionsByOrigin.get('http://example.com')[0];
+      assert.ok(connection._serverLatency, 63);
+    });
+  });
+
+  describe('.acquire', () => {
+    it('should remember the connection associated with each record', () => {
+      const recordA = record();
+      const recordB = record();
+      const pool = new ConnectionPool([recordA, recordB], {rtt, throughput});
+
+      const connectionForA = pool.acquire(recordA);
+      const connectionForB = pool.acquire(recordB);
+      for (let i = 0; i < 10; i++) {
+        assert.equal(pool.acquire(recordA), connectionForA);
+        assert.equal(pool.acquire(recordB), connectionForB);
+      }
+
+      assert.deepStrictEqual(pool.connectionsInUse(), [connectionForA, connectionForB]);
+    });
+
+    it('should return null when available connections are exhausted', () => {
+      const records = new Array(7).fill(undefined, 0, 7).map(() => record());
+      const pool = new ConnectionPool(records, {rtt, throughput});
+      const connections = records.map(record => pool.acquire(record));
+      assert.ok(connections[0], 'did not find connection for 1st record');
+      assert.ok(connections[5], 'did not find connection for 6th record');
+      assert.equal(connections[6], null);
+    });
+
+    it('should respect observed connection reuse', () => {
+      const coldRecord = record();
+      const warmRecord = record();
+      const pool = new ConnectionPool([coldRecord, warmRecord], {rtt, throughput});
+      pool._connectionReusedByRequestId.set(warmRecord.requestId, true);
+      assert.ok(pool.acquire(coldRecord), 'should have acquired cold connection');
+      assert.ok(!pool.acquire(warmRecord), 'should not have acquired connection');
+      pool.release(coldRecord);
+
+      for (const connection of pool._connectionsByOrigin.get('http://example.com')) {
+        connection.setWarmed(true);
+      }
+
+      assert.ok(!pool.acquire(coldRecord), 'should not have acquired connection');
+      assert.ok(pool.acquire(warmRecord), 'should have acquired warm connection');
+    });
+
+    it('should ignore observed connection reuse when flag is present', () => {
+      const coldRecord = record();
+      const warmRecord = record();
+      const pool = new ConnectionPool([coldRecord, warmRecord], {rtt, throughput});
+      pool._connectionReusedByRequestId.set(warmRecord.requestId, true);
+
+      const opts = {ignoreObserved: true};
+      assert.ok(pool.acquire(coldRecord, opts), 'should have acquired connection');
+      assert.ok(pool.acquire(warmRecord, opts), 'should have acquired connection');
+      pool.release(coldRecord);
+
+      for (const connection of pool._connectionsByOrigin.get('http://example.com')) {
+        connection.setWarmed(true);
+      }
+
+      assert.ok(pool.acquire(coldRecord, opts), 'should have acquired connection');
+      assert.ok(pool.acquire(warmRecord, opts), 'should have acquired connection');
+    });
+
+    it('should acquire in order of warmness', () => {
+      const recordA = record();
+      const recordB = record();
+      const recordC = record();
+      const pool = new ConnectionPool([recordA, recordB, recordC], {rtt, throughput});
+      pool._connectionReusedByRequestId.set(recordA.requestId, true);
+      pool._connectionReusedByRequestId.set(recordB.requestId, true);
+      pool._connectionReusedByRequestId.set(recordC.requestId, true);
+
+      const [connectionWarm, connectionWarmer, connectionWarmest] =
+        pool._connectionsByOrigin.get('http://example.com');
+      connectionWarm.setWarmed(true);
+      connectionWarm.setCongestionWindow(10);
+      connectionWarmer.setWarmed(true);
+      connectionWarmer.setCongestionWindow(100);
+      connectionWarmest.setWarmed(true);
+      connectionWarmest.setCongestionWindow(1000);
+
+      assert.equal(pool.acquire(recordA), connectionWarmest);
+      assert.equal(pool.acquire(recordB), connectionWarmer);
+      assert.equal(pool.acquire(recordC), connectionWarm);
+    });
+  });
+
+  describe('.release', () => {
+    it('noop for record without connection', () => {
+      const recordA = record();
+      const pool = new ConnectionPool([recordA], {rtt, throughput});
+      assert.equal(pool.release(recordA), undefined);
+    });
+
+    it('frees the connection for reissue', () => {
+      const records = new Array(7).fill(undefined, 0, 7).map(() => record());
+      const pool = new ConnectionPool(records, {rtt, throughput});
+      records.forEach(record => pool.acquire(record));
+
+      assert.equal(pool.connectionsInUse().length, 6);
+      assert.ok(!pool.acquire(records[6]), 'had connection that is in use');
+
+      pool.release(records[0]);
+      assert.equal(pool.connectionsInUse().length, 5);
+
+      assert.ok(pool.acquire(records[6]), 'could not reissue released connection');
+      assert.ok(!pool.acquire(records[0]), 'had connection that is in use');
+    });
+  });
+});


### PR DESCRIPTION
this ended up turning into quite the behemoth, I was tempted to break up the lantern/connection-pool test changes, but it's kinda hard to grok without the motivating example.

most of the lines are tests, so that's the good news :)