### PR TITLE
core(webapp-install): simplify start_url warning when no SW is found

### DIFF
--- a/lighthouse-core/test/audits/webapp-install-banner-test.js
+++ b/lighthouse-core/test/audits/webapp-install-banner-test.js
@@ -134,8 +134,7 @@ describe('PWA: webapp install banner audit', () => {
       assert.strictEqual(result.rawValue, false);
       assert.ok(result.debugString.includes('service worker'), result.debugString);
       const failures = result.extendedInfo.value.failures;
-      // start url will be -1 as well so failures will be 2
-      assert.strictEqual(failures.length, 2, failures);
+      assert.strictEqual(failures.length, 1, failures);
     });
   });
 

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -651,17 +651,13 @@
       "score": 0,
       "displayValue": "",
       "rawValue": false,
-      "debugString": "Failures: No manifest was fetched, Site does not register a service worker, Service worker does not successfully serve the manifest's start_url, No start URL to fetch: No usable web app manifest found on page http://localhost:10200/dobetterweb/dbw_tester.html.",
+      "debugString": "Failures: No manifest was fetched, Site does not register a service worker.",
       "extendedInfo": {
         "value": {
-          "warnings": [
-            "No start URL to fetch: No usable web app manifest found on page http://localhost:10200/dobetterweb/dbw_tester.html"
-          ],
+          "warnings": [],
           "failures": [
             "No manifest was fetched",
-            "Site does not register a service worker",
-            "Service worker does not successfully serve the manifest's start_url",
-            "No start URL to fetch: No usable web app manifest found on page http://localhost:10200/dobetterweb/dbw_tester.html"
+            "Site does not register a service worker"
           ],
           "manifestValues": {
             "isParseFailure": true,


### PR DESCRIPTION
it's a response on #4898 to give a better error message when no Service Worker has loaded.
This makes it a bit more clear on what the issues are. Not sure if it's the correct approach though. wdyt @brendankenny 

before:
![image](https://user-images.githubusercontent.com/1120926/39411059-cb28b9ec-4c02-11e8-99e8-b164c656c53f.png)

after:
![image](https://user-images.githubusercontent.com/1120926/39411033-47315c34-4c02-11e8-9f8e-28735f7febd4.png)
