### PR TITLE
core(tsc): add type checking to dbw audits

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -100,7 +100,7 @@ class Audit {
 
   /**
    * @param {Array<LH.Audit.Heading>} headings
-   * @param {Array<Object<string, string|number|LH.Audit.DetailsRendererNodeDetailsJSON>>} results
+   * @param {Array<Object<string, LH.Audit.DetailsItem>>} results
    * @param {LH.Audit.DetailsRendererDetailsSummary=} summary
    * @return {LH.Audit.DetailsRendererDetailsJSON}
    */

--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -14,7 +14,7 @@ const Audit = require('../audit');
 
 class AppCacheManifestAttr extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -28,8 +28,8 @@ class AppCacheManifestAttr extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const usingAppcache = artifacts.AppCacheManifest !== null;

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -25,7 +25,7 @@ class DOMSize extends Audit {
   }
 
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -58,9 +58,9 @@ class DOMSize extends Audit {
 
 
   /**
-   * @param {!Artifacts} artifacts
+   * @param {LH.Artifacts} artifacts
    * @param {LH.Audit.Context} context
-   * @return {!AuditResult}
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts, context) {
     const stats = artifacts.DOMStats;

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -10,7 +10,7 @@ const Audit = require('../audit');
 
 class ExternalAnchorsUseRelNoopenerAudit extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -25,8 +25,8 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     let debugString;

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -15,7 +15,7 @@ const ViolationAudit = require('../violation-audit');
 
 class GeolocationOnStart extends ViolationAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -30,8 +30,8 @@ class GeolocationOnStart extends ViolationAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     // 'Only request geolocation information in response to a user gesture.'
@@ -41,6 +41,8 @@ class GeolocationOnStart extends ViolationAudit {
       {key: 'url', itemType: 'url', text: 'URL'},
       {key: 'label', itemType: 'text', text: 'Location'},
     ];
+    // TODO(bckenny): there should actually be a ts error here. results[0].stackTrace
+    // should violate the results type. Shouldn't be removed from details items regardless.
     const details = ViolationAudit.makeTableDetails(headings, results);
 
     return {

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -14,7 +14,7 @@ const ViolationAudit = require('../violation-audit');
 
 class NoDocWriteAudit extends ViolationAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -29,8 +29,8 @@ class NoDocWriteAudit extends ViolationAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const results = ViolationAudit.getViolationResults(artifacts, /document\.write/);
@@ -39,6 +39,7 @@ class NoDocWriteAudit extends ViolationAudit {
       {key: 'url', itemType: 'url', text: 'URL'},
       {key: 'label', itemType: 'text', text: 'Location'},
     ];
+    // TODO(bckenny): see TODO in geolocation-on-start
     const details = ViolationAudit.makeTableDetails(headings, results);
 
     return {

--- a/lighthouse-core/audits/dobetterweb/no-mutation-events.js
+++ b/lighthouse-core/audits/dobetterweb/no-mutation-events.js
@@ -31,7 +31,7 @@ class NoMutationEventsAudit extends Audit {
   }
 
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -45,8 +45,8 @@ class NoMutationEventsAudit extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     let debugString;

--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -15,13 +15,17 @@
 const Audit = require('../audit');
 const Sentry = require('../../lib/sentry');
 const semver = require('semver');
+// @ts-ignore - json require
 const snykDatabase = require('../../../third-party/snyk/snapshot.json');
 
 const SEMVER_REGEX = /^(\d+\.\d+\.\d+)[^-0-9]+/;
 
+/** @typedef {{npm: Object<string, Array<{id: string, severity: string, semver: {vulnerable: Array<string>}}>>}} SnykDB */
+/** @typedef {{severity: string, numericSeverity: number, library: string, url: string}} Vulnerability */
+
 class NoVulnerableLibrariesAudit extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -37,14 +41,14 @@ class NoVulnerableLibrariesAudit extends Audit {
   }
 
   /**
-   * @return {{npm: !Object<string, !Array<{id: string, severity: string, semver: {vulnerable: !Array<string>}}>>}}
+   * @return {SnykDB}
    */
   static get snykDB() {
     return snykDatabase;
   }
 
   /**
-   * @return {!Object<string, number>}
+   * @return {Object<string, number>}
    */
   static get severityMap() {
     return {
@@ -66,86 +70,103 @@ class NoVulnerableLibrariesAudit extends Audit {
     // converts 1.5 -> 1.5.0
     if (/^\d+\.\d+$/.test(version)) return `${version}.0`;
     // converts 1.0.0a-bunch-of-crap -> 1.0.0
-    if (SEMVER_REGEX.test(version)) return version.match(SEMVER_REGEX)[1];
+    const versionMatch = version.match(SEMVER_REGEX);
+    if (versionMatch) return versionMatch[1];
     // leave everything else untouched
     return version;
   }
 
   /**
+   * @param {string} normalizedVersion
    * @param {{name: string, version: string, npmPkgName: string|undefined}} lib
-   * @param {{npm: !Object<string, !Array<{id: string, severity: string, semver: {vulnerable: !Array<string>}}>>}} snykDB
-   * @return {!Array<{severity: string, numericSeverity: number, library: string, url: string}>}
+   * @return {Array<Vulnerability>}
    */
-  static getVulns(lib, snykDB) {
-    const vulns = [];
-    if (!snykDB.npm[lib.npmPkgName]) {
-      return vulns;
+  static getVulnerabilities(normalizedVersion, lib) {
+    const snykDB = NoVulnerableLibrariesAudit.snykDB;
+    if (!lib.npmPkgName || !snykDB.npm[lib.npmPkgName]) {
+      return [];
     }
 
     try {
-      semver.satisfies(lib.version, '*');
+      semver.satisfies(normalizedVersion, '*');
     } catch (err) {
       err.pkgName = lib.npmPkgName;
       // Report the failure and skip this library if the version was ill-specified
+      // @ts-ignore TODO(bckenny): Sentry type checking
       Sentry.captureException(err, {level: 'warning'});
-      return vulns;
+      return [];
     }
 
-    lib.pkgLink = `https://snyk.io/vuln/npm:${lib.npmPkgName}?lh@${lib.version}`;
     const snykInfo = snykDB.npm[lib.npmPkgName];
-    snykInfo.forEach(vuln => {
-      if (semver.satisfies(lib.version, vuln.semver.vulnerable[0])) {
-        // valid vulnerability
-        vulns.push({
+    const vulns = snykInfo
+      .filter(vuln => semver.satisfies(normalizedVersion, vuln.semver.vulnerable[0]))
+      // valid vulnerability
+      .map(vuln => {
+        return {
           severity: vuln.severity,
           numericSeverity: this.severityMap[vuln.severity],
-          library: `${lib.name}@${lib.version}`,
+          library: `${lib.name}@${normalizedVersion}`,
           url: 'https://snyk.io/vuln/' + vuln.id,
-        });
-      }
-    });
+        };
+      });
+
     return vulns;
   }
 
   /**
-   * @param {{severity: string, numericSeverity: number, library: string, url:string }} vulns
+   * @param {Array<Vulnerability>} vulnerabilities
    * @return {string}
    */
-  static highestSeverity(vulns) {
-    const sortedVulns = vulns
+  static highestSeverity(vulnerabilities) {
+    const sortedVulns = vulnerabilities
       .sort((a, b) => b.numericSeverity - a.numericSeverity);
     return sortedVulns[0].severity;
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
-    const libraries = artifacts.JSLibraries;
-    if (!libraries.length) {
+    const foundLibraries = artifacts.JSLibraries;
+    if (!foundLibraries.length) {
       return {
         rawValue: true,
       };
     }
 
     let totalVulns = 0;
-    const finalVulns = libraries.map(lib => {
-      lib.version = this.normalizeVersion(lib.version);
-      lib.vulns = this.getVulns(lib, this.snykDB);
-      if (lib.vulns.length > 0) {
-        lib.vulnCount = lib.vulns.length;
-        lib.highestSeverity = this.highestSeverity(lib.vulns).replace(/^\w/, l => l.toUpperCase());
-        totalVulns += lib.vulnCount;
-        lib.detectedLib = {};
-        lib.detectedLib.text = lib.name + '@' + lib.version;
-        lib.detectedLib.url = lib.pkgLink;
-        lib.detectedLib.type = 'link';
+    /** @type {Array<{highestSeverity: string, vulnCount: number, detectedLib: LH.Audit.DetailsRendererLinkDetailsJSON}>} */
+    const vulnerableResults = [];
+
+    const libraryVulns = foundLibraries.map(lib => {
+      const version = this.normalizeVersion(lib.version) || '';
+      const vulns = this.getVulnerabilities(version, lib);
+      const vulnCount = vulns.length;
+      totalVulns += vulnCount;
+
+      let highestSeverity;
+      if (vulns.length > 0) {
+        highestSeverity = this.highestSeverity(vulns).replace(/^\w/, l => l.toUpperCase());
+
+        vulnerableResults.push({
+          highestSeverity,
+          vulnCount,
+          detectedLib: {
+            text: lib.name + '@' + version,
+            url: `https://snyk.io/vuln/npm:${lib.npmPkgName}?lh@${version}`,
+            type: 'link',
+          },
+        });
       }
-      return lib;
-    })
-    .filter(obj => {
-      return obj.vulns.length > 0;
+
+      return {
+        name: lib.name,
+        npmPkgName: lib.npmPkgName,
+        version,
+        vulns,
+        highestSeverity,
+      };
     });
 
     let displayValue = '';
@@ -160,14 +181,14 @@ class NoVulnerableLibrariesAudit extends Audit {
       {key: 'vulnCount', itemType: 'text', text: 'Vulnerability Count'},
       {key: 'highestSeverity', itemType: 'text', text: 'Highest Severity'},
     ];
-    const details = Audit.makeTableDetails(headings, finalVulns, {});
+    const details = Audit.makeTableDetails(headings, vulnerableResults, {});
 
     return {
       rawValue: totalVulns === 0,
       displayValue,
       extendedInfo: {
-        jsLibs: libraries,
-        vulnerabilities: finalVulns,
+        jsLibs: libraryVulns,
+        vulnerabilities: vulnerableResults,
       },
       details,
     };

--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -137,7 +137,7 @@ class NoVulnerableLibrariesAudit extends Audit {
 
     let totalVulns = 0;
     /** @type {Array<{highestSeverity: string, vulnCount: number, detectedLib: LH.Audit.DetailsRendererLinkDetailsJSON}>} */
-    const vulnerableResults = [];
+    const vulnerabilityResults = [];
 
     const libraryVulns = foundLibraries.map(lib => {
       const version = this.normalizeVersion(lib.version) || '';
@@ -149,7 +149,7 @@ class NoVulnerableLibrariesAudit extends Audit {
       if (vulns.length > 0) {
         highestSeverity = this.highestSeverity(vulns).replace(/^\w/, l => l.toUpperCase());
 
-        vulnerableResults.push({
+        vulnerabilityResults.push({
           highestSeverity,
           vulnCount,
           detectedLib: {
@@ -181,14 +181,14 @@ class NoVulnerableLibrariesAudit extends Audit {
       {key: 'vulnCount', itemType: 'text', text: 'Vulnerability Count'},
       {key: 'highestSeverity', itemType: 'text', text: 'Highest Severity'},
     ];
-    const details = Audit.makeTableDetails(headings, vulnerableResults, {});
+    const details = Audit.makeTableDetails(headings, vulnerabilityResults, {});
 
     return {
       rawValue: totalVulns === 0,
       displayValue,
       extendedInfo: {
         jsLibs: libraryVulns,
-        vulnerabilities: vulnerableResults,
+        vulnerabilities: vulnerabilityResults,
       },
       details,
     };

--- a/lighthouse-core/audits/dobetterweb/no-websql.js
+++ b/lighthouse-core/audits/dobetterweb/no-websql.js
@@ -15,7 +15,7 @@ const Audit = require('../audit');
 
 class NoWebSQLAudit extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -29,8 +29,8 @@ class NoWebSQLAudit extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const db = artifacts.WebSQL;

--- a/lighthouse-core/audits/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/notification-on-start.js
@@ -15,7 +15,7 @@ const ViolationAudit = require('../violation-audit');
 
 class NotificationOnStart extends ViolationAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -30,8 +30,8 @@ class NotificationOnStart extends ViolationAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const results = ViolationAudit.getViolationResults(artifacts, /notification permission/);
@@ -40,6 +40,7 @@ class NotificationOnStart extends ViolationAudit {
       {key: 'url', itemType: 'url', text: 'URL'},
       {key: 'label', itemType: 'text', text: 'Location'},
     ];
+    // TODO(bckenny): see TODO in geolocation-on-start
     const details = ViolationAudit.makeTableDetails(headings, results);
 
     return {

--- a/lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
+++ b/lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
@@ -9,7 +9,7 @@ const Audit = require('../audit');
 
 class PasswordInputsCanBePastedIntoAudit extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -23,15 +23,19 @@ class PasswordInputsCanBePastedIntoAudit extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const passwordInputsWithPreventedPaste = artifacts.PasswordInputsWithPreventedPaste;
 
-    const items = passwordInputsWithPreventedPaste.map(input => ({
-      node: {type: 'node', snippet: input.snippet},
-    }));
+    /** @type {Array<{node: LH.Audit.DetailsRendererNodeDetailsJSON}>} */
+    const items = [];
+    passwordInputsWithPreventedPaste.forEach(input => {
+      items.push({
+        node: {type: 'node', snippet: input.snippet},
+      });
+    });
 
     const headings = [
       {key: 'node', itemType: 'node', text: 'Failing Elements'},

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -17,7 +17,7 @@ const Util = require('../../report/html/renderer/util.js');
 
 class UsesHTTP2Audit extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -31,8 +31,8 @@ class UsesHTTP2Audit extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {Promise<LH.Audit.Product>}
    */
   static audit(artifacts) {
     const devtoolsLogs = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -15,7 +15,7 @@ const ViolationAudit = require('../violation-audit');
 
 class PassiveEventsAudit extends ViolationAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -30,8 +30,8 @@ class PassiveEventsAudit extends ViolationAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const results = ViolationAudit.getViolationResults(artifacts, /passive event listener/);
@@ -40,6 +40,7 @@ class PassiveEventsAudit extends ViolationAudit {
       {key: 'url', itemType: 'url', text: 'URL'},
       {key: 'label', itemType: 'text', text: 'Location'},
     ];
+    // TODO(bckenny): see TODO in geolocation-on-start
     const details = ViolationAudit.makeTableDetails(headings, results);
 
     return {

--- a/lighthouse-core/audits/violation-audit.js
+++ b/lighthouse-core/audits/violation-audit.js
@@ -9,9 +9,9 @@ const Audit = require('./audit');
 
 class ViolationAudit extends Audit {
   /**
-   * @param {!Artifacts} artifacts
-   * @param {!RegExp} pattern
-   * @return {!Array}
+   * @param {LH.Artifacts} artifacts
+   * @param {RegExp} pattern
+   * @return {Array<LH.Crdp.Log.LogEntry & {label: string}>}
    */
   static getViolationResults(artifacts, pattern) {
     return artifacts.ChromeConsoleMessages

--- a/lighthouse-core/test/lib/event-helpers-test.js
+++ b/lighthouse-core/test/lib/event-helpers-test.js
@@ -14,13 +14,10 @@ const eventListeners = require('../fixtures/page-level-event-listeners.json');
 
 describe('event helpers', () => {
   describe('addFormattedCodeSnippet()', function() {
-    it('adds label and code snippet and returns new object', () => {
+    it('adds code snippet and returns new object', () => {
       eventListeners.forEach(listener => {
         const obj = EventHelpers.addFormattedCodeSnippet(listener);
-        assert.ok('label' in obj, 'helper adds a label property');
         assert.ok('pre' in obj, 'helper adds a pre property');
-        assert.ok(obj.label.match(/line: (?:\d+), col: (?:\d+)/),
-                  'label is not formatted correctly');
         const regEx = new RegExp(`.addEventListener\\('${listener.type}', `);
         assert.ok(obj.pre.match(regEx), 'code snippet is not formatted correctly');
       });
@@ -46,8 +43,9 @@ describe('event helpers', () => {
 
       const set = new Set();
       groupedListeners.forEach(l => {
-        assert.ok(!set.has(l.label), 'all line/col are unique');
-        set.add(l.label);
+        const lineColkey = `line: ${l.line}, col: ${l.col}`;
+        assert.ok(!set.has(lineColkey), 'all line/col are unique');
+        set.add(lineColkey);
       });
     });
   });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3721,48 +3721,42 @@
               "col": 50,
               "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
               "type": "DOMNodeInserted",
-              "pre": "section#touchmove-section.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted on element');\n  })\n\n",
-              "label": "line: 206, col: 50"
+              "pre": "section#touchmove-section.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted on element');\n  })\n\n"
             },
             {
               "line": 200,
               "col": 61,
               "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
               "type": "DOMNodeInserted",
-              "pre": "body.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-              "label": "line: 200, col: 61"
+              "pre": "body.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n"
             },
             {
               "line": 20,
               "col": 56,
               "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
               "type": "DOMNodeInserted",
-              "pre": "document.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-              "label": "line: 20, col: 56"
+              "pre": "document.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n"
             },
             {
               "line": 190,
               "col": 56,
               "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
               "type": "DOMNodeInserted",
-              "pre": "document.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-              "label": "line: 190, col: 56"
+              "pre": "document.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n"
             },
             {
               "line": 195,
               "col": 55,
               "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
               "type": "DOMNodeRemoved",
-              "pre": "document.addEventListener('DOMNodeRemoved', function(e) {\n    console.log('DOMNodeRemoved');\n  })\n\n",
-              "label": "line: 195, col: 55"
+              "pre": "document.addEventListener('DOMNodeRemoved', function(e) {\n    console.log('DOMNodeRemoved');\n  })\n\n"
             },
             {
               "line": 211,
               "col": 54,
               "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
               "type": "DOMNodeInserted",
-              "pre": "window.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-              "label": "line: 211, col: 54"
+              "pre": "window.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n"
             }
           ]
         }
@@ -3806,48 +3800,42 @@
             "col": 50,
             "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "type": "DOMNodeInserted",
-            "pre": "section#touchmove-section.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted on element');\n  })\n\n",
-            "label": "line: 206, col: 50"
+            "pre": "section#touchmove-section.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted on element');\n  })\n\n"
           },
           {
             "line": 200,
             "col": 61,
             "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "type": "DOMNodeInserted",
-            "pre": "body.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-            "label": "line: 200, col: 61"
+            "pre": "body.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n"
           },
           {
             "line": 20,
             "col": 56,
             "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
             "type": "DOMNodeInserted",
-            "pre": "document.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-            "label": "line: 20, col: 56"
+            "pre": "document.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n"
           },
           {
             "line": 190,
             "col": 56,
             "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "type": "DOMNodeInserted",
-            "pre": "document.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-            "label": "line: 190, col: 56"
+            "pre": "document.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n"
           },
           {
             "line": 195,
             "col": 55,
             "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "type": "DOMNodeRemoved",
-            "pre": "document.addEventListener('DOMNodeRemoved', function(e) {\n    console.log('DOMNodeRemoved');\n  })\n\n",
-            "label": "line: 195, col: 55"
+            "pre": "document.addEventListener('DOMNodeRemoved', function(e) {\n    console.log('DOMNodeRemoved');\n  })\n\n"
           },
           {
             "line": 211,
             "col": 54,
             "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
             "type": "DOMNodeInserted",
-            "pre": "window.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n",
-            "label": "line: 211, col: 54"
+            "pre": "window.addEventListener('DOMNodeInserted', function(e) {\n    console.log('DOMNodeInserted');\n  })\n\n"
           }
         ]
       }
@@ -3860,9 +3848,8 @@
         "jsLibs": [
           {
             "name": "jQuery",
-            "version": "2.1.1",
             "npmPkgName": "jquery",
-            "pkgLink": "https://snyk.io/vuln/npm:jquery?lh@2.1.1",
+            "version": "2.1.1",
             "vulns": [
               {
                 "severity": "medium",
@@ -3877,37 +3864,13 @@
                 "url": "https://snyk.io/vuln/npm:jquery:20160529"
               }
             ],
-            "vulnCount": 2,
-            "highestSeverity": "Medium",
-            "detectedLib": {
-              "text": "jQuery@2.1.1",
-              "url": "https://snyk.io/vuln/npm:jquery?lh@2.1.1",
-              "type": "link"
-            }
+            "highestSeverity": "Medium"
           }
         ],
         "vulnerabilities": [
           {
-            "name": "jQuery",
-            "version": "2.1.1",
-            "npmPkgName": "jquery",
-            "pkgLink": "https://snyk.io/vuln/npm:jquery?lh@2.1.1",
-            "vulns": [
-              {
-                "severity": "medium",
-                "numericSeverity": 2,
-                "library": "jQuery@2.1.1",
-                "url": "https://snyk.io/vuln/npm:jquery:20150627"
-              },
-              {
-                "severity": "low",
-                "numericSeverity": 1,
-                "library": "jQuery@2.1.1",
-                "url": "https://snyk.io/vuln/npm:jquery:20160529"
-              }
-            ],
-            "vulnCount": 2,
             "highestSeverity": "Medium",
+            "vulnCount": 2,
             "detectedLib": {
               "text": "jQuery@2.1.1",
               "url": "https://snyk.io/vuln/npm:jquery?lh@2.1.1",
@@ -3941,26 +3904,8 @@
         ],
         "items": [
           {
-            "name": "jQuery",
-            "version": "2.1.1",
-            "npmPkgName": "jquery",
-            "pkgLink": "https://snyk.io/vuln/npm:jquery?lh@2.1.1",
-            "vulns": [
-              {
-                "severity": "medium",
-                "numericSeverity": 2,
-                "library": "jQuery@2.1.1",
-                "url": "https://snyk.io/vuln/npm:jquery:20150627"
-              },
-              {
-                "severity": "low",
-                "numericSeverity": 1,
-                "library": "jQuery@2.1.1",
-                "url": "https://snyk.io/vuln/npm:jquery:20160529"
-              }
-            ],
-            "vulnCount": 2,
             "highestSeverity": "Medium",
+            "vulnCount": 2,
             "detectedLib": {
               "text": "jQuery@2.1.1",
               "url": "https://snyk.io/vuln/npm:jquery?lh@2.1.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/lodash.isequal": "^4.5.2",
     "@types/node": "*",
     "@types/opn": "^3.0.28",
+    "@types/semver": "^5.5.0",
     "@types/update-notifier": "^1.0.2",
     "@types/ws": "^4.0.1",
     "@types/yargs": "^8.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "lighthouse-cli/**/*.js",
     "lighthouse-core/audits/audit.js",
     "lighthouse-core/audits/accessibility/**/*.js",
+    "lighthouse-core/audits/dobetterweb/**/*.js",
     "lighthouse-core/audits/manual/**/*.js",
     "lighthouse-core/audits/seo/manual/*.js",
     "lighthouse-core/audits/seo/robots-txt.js",

--- a/typings/audit.d.ts
+++ b/typings/audit.d.ts
@@ -47,7 +47,7 @@ declare global {
       debugString?: string;
     }
 
-    // TODO: placeholders typedefs until Details are typed
+    // TODO: placeholder typedefs until Details are typed
     export interface DetailsRendererDetailsSummary {
       wastedMs?: number;
       wastedBytes?: number;

--- a/typings/audit.d.ts
+++ b/typings/audit.d.ts
@@ -7,7 +7,7 @@
 declare global {
   module LH.Audit {
     export interface Context {
-      options: Object; // audit options
+      options: Record<string, any>; // audit options
       settings: Config.Settings;
     }
 
@@ -47,7 +47,7 @@ declare global {
       debugString?: string;
     }
 
-    // TODO: placeholder typedefs until Details are typed
+    // TODO: placeholders typedefs until Details are typed
     export interface DetailsRendererDetailsSummary {
       wastedMs?: number;
       wastedBytes?: number;
@@ -57,9 +57,12 @@ declare global {
     export interface DetailsRendererDetailsJSON {
       type: 'table';
       headings: Array<Audit.Heading>;
-      items: Array<{[x: string]: string|number|DetailsRendererNodeDetailsJSON}>;
+      items: Array<{[x: string]: DetailsItem}>;
       summary?: DetailsRendererDetailsSummary;
     }
+
+    export type DetailsItem = string | number | DetailsRendererNodeDetailsJSON |
+      DetailsRendererLinkDetailsJSON;
 
     export interface DetailsRendererNodeDetailsJSON {
       type: 'node';
@@ -68,16 +71,22 @@ declare global {
       snippet?: string;
     }
 
+    export interface DetailsRendererLinkDetailsJSON {
+      type: 'link';
+      text: string;
+      url: string;
+    }
+
     // Type returned by Audit.audit(). Only rawValue is required.
     export interface Product {
       rawValue: boolean | number | null;
       displayValue?: string;
       debugString?: string;
       score?: number;
-      extendedInfo?: {value: any};
+      extendedInfo?: {[p: string]: any};
       notApplicable?: boolean;
       error?: boolean;
-      // TODO: define details
+      // TODO(bckenny): define details
       details?: object;
     }
 
@@ -89,14 +98,14 @@ declare global {
       score: number;
       scoreDisplayMode: ScoringModeValue;
       description: string;
-      extendedInfo?: {value: any};
+      extendedInfo?: {[p: string]: any};
       notApplicable?: boolean;
       error?: boolean;
       name: string;
       helpText?: string;
       informative?: boolean;
       manual?: boolean;
-      // TODO: define details
+      // TODO(bckenny): define details
       details?: object;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,10 @@
     "@types/rx-lite-time" "*"
     "@types/rx-lite-virtualtime" "*"
 
+"@types/semver@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
+
 "@types/source-map@^0.1.27":
   version "0.1.29"
   resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.1.29.tgz#d7048a60180b09f8aa6d53bda311c6b51cbd7018"


### PR DESCRIPTION
the only major cleanups are in the `no-vulnerable-libraries.js.js` (lots of mutations) and `event-helpers.js` (simplified so that the type checker could follow along).

The golden lhr changes are eliminating the duplicate vulnerability listings (because the original library objects are no longer mutated) and taking out the `label` entry on the event listeners since it appears to only be set, not read, and it's just a duplicate of the line/col info anyways.