### PR TITLE
core(preconnect): use lantern to compute savings

### DIFF
--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -15,6 +15,8 @@ const UnusedBytes = require('./byte-efficiency/byte-efficiency-audit');
 // @see https://github.com/GoogleChrome/lighthouse/issues/3106#issuecomment-333653747
 const PRECONNECT_SOCKET_MAX_IDLE = 15;
 
+const IGNORE_THRESHOLD_IN_MS = 50;
+
 class UsesRelPreconnectAudit extends Audit {
   /**
    * @return {LH.Audit.Meta}
@@ -134,6 +136,8 @@ class UsesRelPreconnectAudit extends Audit {
         firstRecordOfOrigin._timing.dnsStart;
 
       const wastedMs = Math.min(connectionTime, timeBetweenMainResourceAndDnsStart);
+      if (wastedMs < IGNORE_THRESHOLD_IN_MS) return;
+
       maxWasted = Math.max(wastedMs, maxWasted);
       results.push({
         url: securityOrigin,

--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -65,17 +65,22 @@ class UsesRelPreconnectAudit extends Audit {
 
   /**
    * @param {LH.Artifacts} artifacts
+   * @param {LH.Audit.Context} context
    * @return {Promise<LH.Audit.Product>}
    */
-  static async audit(artifacts) {
+  static async audit(artifacts, context) {
     const devtoolsLog = artifacts.devtoolsLogs[UsesRelPreconnectAudit.DEFAULT_PASS];
     const URL = artifacts.URL;
+    const settings = context.settings;
     let maxWasted = 0;
 
-    const [networkRecords, mainResource] = await Promise.all([
+    const [networkRecords, mainResource, loadSimulator] = await Promise.all([
       artifacts.requestNetworkRecords(devtoolsLog),
       artifacts.requestMainResource({devtoolsLog, URL}),
+      artifacts.requestLoadSimulator({devtoolsLog, settings}),
     ]);
+
+    const {rtt, additionalRttByOrigin} = loadSimulator.getOptions();
 
     /** @type {Map<string, LH.WebInspector.NetworkRequest[]>}  */
     const origins = new Map();
@@ -113,17 +118,25 @@ class UsesRelPreconnectAudit extends Audit {
         return (record.startTime < firstRecord.startTime) ? record: firstRecord;
       });
 
-      const connectionTime =
-        firstRecordOfOrigin._timing.connectEnd - firstRecordOfOrigin._timing.dnsStart;
+      const securityOrigin = firstRecordOfOrigin.parsedURL.securityOrigin();
+
+      // Approximate the connection time with the duration of TCP (+potentially SSL) handshake
+      // DNS time can be large but can also be 0 if a commonly used origin that's cached, so make
+      // no assumption about DNS.
+      const additionalRtt = additionalRttByOrigin.get(securityOrigin) || 0;
+      let connectionTime = rtt + additionalRtt;
+      // TCP Handshake will be at least 2 RTTs for TLS connections
+      if (firstRecordOfOrigin.parsedURL.scheme === 'https') connectionTime = connectionTime * 2;
+
       const timeBetweenMainResourceAndDnsStart =
         firstRecordOfOrigin.startTime * 1000 -
         mainResource.endTime * 1000 +
         firstRecordOfOrigin._timing.dnsStart;
+
       const wastedMs = Math.min(connectionTime, timeBetweenMainResourceAndDnsStart);
       maxWasted = Math.max(wastedMs, maxWasted);
       results.push({
-        url: firstRecordOfOrigin.parsedURL.securityOrigin(),
-        type: 'ms',
+        url: securityOrigin,
         wastedMs: wastedMs,
       });
     });

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -31,6 +31,7 @@ class Simulator {
    * @param {LH.Gatherer.Simulation.Options} [options]
    */
   constructor(options) {
+    /** @type {Required<LH.Gatherer.Simulation.Options>} */
     this._options = Object.assign(
       {
         rtt: mobile3G.rttMs,
@@ -38,6 +39,8 @@ class Simulator {
         maximumConcurrentRequests: DEFAULT_MAXIMUM_CONCURRENT_REQUESTS,
         cpuSlowdownMultiplier: mobile3G.cpuSlowdownMultiplier,
         layoutTaskMultiplier: DEFAULT_LAYOUT_TASK_MULTIPLIER,
+        additionalRttByOrigin: new Map(),
+        serverResponseTimeByOrigin: new Map(),
       },
       options
     );
@@ -276,6 +279,13 @@ class Simulator {
       timingData.timeElapsedOvershoot += calculation.timeElapsed - timePeriodLength;
       timingData.bytesDownloaded += calculation.bytesDownloaded;
     }
+  }
+
+  /**
+   * @return {Required<LH.Gatherer.Simulation.Options>}
+   */
+  getOptions() {
+    return this._options;
   }
 
   /**

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -41,7 +41,6 @@ declare global {
       export interface Options {
         rtt?: number;
         throughput?: number;
-        fallbackTTFB?: number;
         maximumConcurrentRequests?: number;
         cpuSlowdownMultiplier?: number;
         layoutTaskMultiplier?: number;

--- a/typings/web-inspector.d.ts
+++ b/typings/web-inspector.d.ts
@@ -18,6 +18,8 @@ declare global {
       _url: string;
       protocol: string;
       parsedURL: ParsedURL;
+      // Use parsedURL.securityOrigin() instead
+      origin: never;
 
       startTime: number;
       endTime: number;


### PR DESCRIPTION
~~blocked on #5071~~

Relatively simple change, approximates the savings using just the TCP handshake time from lantern. The simulator itself doesn't have a notion of preconnect, so we won't estimate savings on a particular metric and bringing in the whole graph isn't necessary.