### PR TITLE
core(lantern): use securityOrigin on record

### DIFF
--- a/lighthouse-core/lib/dependency-graph/network-node.js
+++ b/lighthouse-core/lib/dependency-graph/network-node.js
@@ -42,13 +42,6 @@ class NetworkNode extends Node {
    * @return {LH.WebInspector.NetworkRequest}
    */
   get record() {
-    // Ensure that the record has an origin value
-    if (this._record.origin === undefined) {
-      this._record.origin = this._record.parsedURL
-        ? `${this._record.parsedURL.scheme}://${this._record.parsedURL.host}`
-        : null;
-    }
-
     return this._record;
   }
 

--- a/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
@@ -96,7 +96,7 @@ module.exports = class ConnectionPool {
       return this._connectionsByRecord.get(record);
     }
 
-    const origin = String(record.origin);
+    const origin = String(record.parsedURL.securityOrigin());
     /** @type {TcpConnection[]} */
     const connections = this._connectionsByOrigin.get(origin) || [];
     const wasConnectionWarm = !!this._connectionReusedByRequestId.get(record.requestId);

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -22,7 +22,7 @@ class NetworkAnalyzer {
   static groupByOrigin(records) {
     const grouped = new Map();
     records.forEach(item => {
-      const key = item.origin;
+      const key = item.parsedURL.securityOrigin();
       const group = grouped.get(key) || [];
       group.push(item);
       grouped.set(key, group);
@@ -179,7 +179,7 @@ class NetworkAnalyzer {
       if (!Number.isFinite(timing.sendEnd) || timing.sendEnd < 0) return;
 
       const ttfb = timing.receiveHeadersEnd - timing.sendEnd;
-      const origin = record.origin;
+      const origin = record.parsedURL.securityOrigin();
       const rtt = rttByOrigin.get(origin) || rttByOrigin.get(NetworkAnalyzer.SUMMARY) || 0;
       return Math.max(ttfb - rtt, 0);
     });

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -25,7 +25,7 @@ describe('Byte efficiency base audit', () => {
     const networkRecord = {
       requestId: 1,
       url: 'http://example.com/',
-      parsedURL: {scheme: 'http'},
+      parsedURL: {scheme: 'http', securityOrigin: () => 'http://example.com'},
       _transferSize: 400000,
       _timing: {receiveHeadersEnd: 0},
     };

--- a/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
@@ -51,7 +51,8 @@ describe('Render blocking resources audit', () => {
     beforeEach(() => {
       requestId = 1;
       record = props => {
-        const ret = Object.assign({parsedURL: {}, requestId: requestId++}, props);
+        const parsedURL = {securityOrigin: () => 'http://example.com'};
+        const ret = Object.assign({parsedURL, requestId: requestId++}, props);
         Object.defineProperty(ret, 'transferSize', {
           get() {
             return ret._transferSize;
@@ -62,7 +63,7 @@ describe('Render blocking resources audit', () => {
     });
 
     it('computes savings from deferring', () => {
-      const serverResponseTimeByOrigin = new Map([['undefined://undefined', 100]]);
+      const serverResponseTimeByOrigin = new Map([['http://example.com', 100]]);
       const simulator = new Simulator({rtt: 1000, serverResponseTimeByOrigin});
       const documentNode = new NetworkNode(record({_transferSize: 4000}));
       const styleNode = new NetworkNode(record({_transferSize: 3000}));
@@ -81,7 +82,7 @@ describe('Render blocking resources audit', () => {
     });
 
     it('computes savings from inlining', () => {
-      const serverResponseTimeByOrigin = new Map([['undefined://undefined', 100]]);
+      const serverResponseTimeByOrigin = new Map([['http://example.com', 100]]);
       const simulator = new Simulator({rtt: 1000, serverResponseTimeByOrigin});
       const documentNode = new NetworkNode(record({_transferSize: 10 * 1000}));
       const styleNode = new NetworkNode(

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -19,7 +19,8 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
 
   function addOriginToRecord(record) {
     const parsed = record.parsedURL || {};
-    record.origin = `${parsed.scheme}://${parsed.host}`;
+    parsed.securityOrigin = () => `${parsed.scheme}://${parsed.host}`;
+    if (!record.parsedURL) record.parsedURL = parsed;
   }
 
   function createRecord(opts) {
@@ -27,7 +28,6 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
     return Object.assign(
       {
         url,
-        origin: url.match(/.*\.com/)[0],
         requestId: recordId++,
         connectionId: 0,
         connectionReused: false,
@@ -35,7 +35,7 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
         endTime: 0.01,
         transferSize: 0,
         protocol: 'http/1.1',
-        parsedURL: {scheme: url.match(/https?/)[0]},
+        parsedURL: {scheme: url.match(/https?/)[0], securityOrigin: () => url.match(/.*\.com/)[0]},
         _timing: opts.timing || null,
       },
       opts

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -20,9 +20,8 @@ function request(opts) {
   return Object.assign({
     requestId: opts.requestId || nextRequestId++,
     url,
-    origin: url,
     transferSize: opts.transferSize || 1000,
-    parsedURL: {scheme},
+    parsedURL: {scheme, securityOrigin: () => url},
     _timing: opts.timing,
   }, opts);
 }

--- a/typings/web-inspector.d.ts
+++ b/typings/web-inspector.d.ts
@@ -17,7 +17,6 @@ declare global {
       url: string;
       _url: string;
       protocol: string;
-      origin: string | null;
       parsedURL: ParsedURL;
 
       startTime: number;
@@ -54,6 +53,7 @@ declare global {
     export interface ParsedURL {
       scheme: string;
       host: string;
+      securityOrigin(): string;
     }
 
     export interface ResourceType {


### PR DESCRIPTION
found a good bug while working on #5070 that's relatively independent

basically if you try to call network analysis before you create a network node from the network record, all the origins will be undefined and so the `additionalRttByOrigin` and `serverResponseTimeByOrigin` are totally useless for the future cached runs that *do* properly create a network node from the network record. We originally did this because calling `new URL()` to get the origin was super expensive and these are somewhat hot paths, while the function call + getter is a bit more expensive, it's still not nearly as bad as `new URL`. Seems OK until it crops up as a bottleneck

this PR reverts the `.origin` dance we do on network records and just uses `.securityOrigin()` on the record, if it becomes a big bottleneck again we can further optimize