### PR TITLE
core(tsc): add type checking to most byte efficiency audits

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/efficient-animated-content.js
+++ b/lighthouse-core/audits/byte-efficiency/efficient-animated-content.js
@@ -42,26 +42,25 @@ class EfficientAnimatedContent extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!LH.Artifacts} artifacts
-   * @return {Promise<LH.Audit.Product>}
+   * @param {LH.Artifacts} artifacts
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
+   * @return {LH.Audit.ByteEfficiencyProduct}
    */
-  static async audit_(artifacts) {
-    const devtoolsLogs = artifacts.devtoolsLogs[EfficientAnimatedContent.DEFAULT_PASS];
-
-    const networkRecords = await artifacts.requestNetworkRecords(devtoolsLogs);
+  static audit_(artifacts, networkRecords) {
     const unoptimizedContent = networkRecords.filter(
-      record => record.mimeType === 'image/gif' &&
+      record => record._mimeType === 'image/gif' &&
         record._resourceType === WebInspector.resourceTypes.Image &&
-        record.resourceSize > GIF_BYTE_THRESHOLD
+        (record._resourceSize || 0) > GIF_BYTE_THRESHOLD
     );
 
     /** @type {Array<{url: string, totalBytes: number, wastedBytes: number}>}*/
     const results = unoptimizedContent.map(record => {
+      const resourceSize = record._resourceSize || 0;
       return {
         url: record.url,
-        totalBytes: record.resourceSize,
-        wastedBytes: Math.round(record.resourceSize *
-          EfficientAnimatedContent.getPercentSavings(record.resourceSize)),
+        totalBytes: resourceSize,
+        wastedBytes: Math.round(resourceSize *
+          EfficientAnimatedContent.getPercentSavings(resourceSize)),
       };
     });
 

--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -10,7 +10,7 @@ const Util = require('../../report/html/renderer/util');
 
 class TotalByteWeight extends ByteEfficiencyAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -39,9 +39,9 @@ class TotalByteWeight extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
+   * @param {LH.Artifacts} artifacts
    * @param {LH.Audit.Context} context
-   * @return {!Promise<!AuditResult>}
+   * @return {Promise<LH.Audit.Product>}
    */
   static audit(artifacts, context) {
     const devtoolsLogs = artifacts.devtoolsLogs[ByteEfficiencyAudit.DEFAULT_PASS];
@@ -50,11 +50,12 @@ class TotalByteWeight extends ByteEfficiencyAudit {
       artifacts.requestNetworkThroughput(devtoolsLogs),
     ]).then(([networkRecords, networkThroughput]) => {
       let totalBytes = 0;
+      /** @type {Array<{url: string, totalBytes: number, totalMs: number}>} */
       let results = [];
       networkRecords.forEach(record => {
         // exclude data URIs since their size is reflected in other resources
         // exclude unfinished requests since they won't have transfer size information
-        if (record.scheme === 'data' || !record.finished) return;
+        if (record.parsedURL.scheme === 'data' || !record.finished) return;
 
         const result = {
           url: record.url,

--- a/lighthouse-core/audits/byte-efficiency/unminified-css.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-css.js
@@ -16,7 +16,7 @@ const IGNORE_THRESHOLD_IN_BYTES = 2048;
  */
 class UnminifiedCSS extends ByteEfficiencyAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -92,15 +92,16 @@ class UnminifiedCSS extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {{content: string, header: {sourceURL: string}}} stylesheet
-   * @param {?LH.WebInspector.NetworkRequest} networkRecord
+   * @param {LH.Artifacts.CSSStyleSheetInfo} stylesheet
+   * @param {LH.WebInspector.NetworkRequest=} networkRecord
    * @param {string} pageUrl
-   * @return {{minifiedLength: number, contentLength: number}}
+   * @return {{url: string|LH.Audit.DetailsRendererCodeDetailJSON, totalBytes: number, wastedBytes: number, wastedPercent: number}}
    */
   static computeWaste(stylesheet, networkRecord, pageUrl) {
     const content = stylesheet.content;
     const totalTokenLength = UnminifiedCSS.computeTokenLength(content);
 
+    /** @type {LH.Audit.ByteEfficiencyResult['url']} */
     let url = stylesheet.header.sourceURL;
     if (!url || url === pageUrl) {
       const contentPreview = UnusedCSSRules.determineContentPreview(stylesheet.content);
@@ -121,8 +122,9 @@ class UnminifiedCSS extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!Audit.HeadingsResult}
+   * @param {LH.Artifacts} artifacts
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
+   * @return {LH.Audit.ByteEfficiencyProduct}
    */
   static audit_(artifacts, networkRecords) {
     const pageUrl = artifacts.URL.finalUrl;

--- a/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
+// @ts-ignore - TODO: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25410
 const esprima = require('esprima');
 
 const IGNORE_THRESHOLD_IN_PERCENT = 10;
@@ -23,7 +24,7 @@ const IGNORE_THRESHOLD_IN_BYTES = 2048;
  */
 class UnminifiedJavaScript extends ByteEfficiencyAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -39,7 +40,8 @@ class UnminifiedJavaScript extends ByteEfficiencyAudit {
 
   /**
    * @param {string} scriptContent
-   * @return {{minifiedLength: number, contentLength: number}}
+   * @param {LH.WebInspector.NetworkRequest} networkRecord
+   * @return {{url: string, totalBytes: number, wastedBytes: number, wastedPercent: number}}
    */
   static computeWaste(scriptContent, networkRecord) {
     const contentLength = scriptContent.length;
@@ -68,10 +70,12 @@ class UnminifiedJavaScript extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!Audit.HeadingsResult}
+   * @param {LH.Artifacts} artifacts
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
+   * @return {LH.Audit.ByteEfficiencyProduct}
    */
   static audit_(artifacts, networkRecords) {
+    /** @type {Array<LH.Audit.ByteEfficiencyResult>} */
     const results = [];
     let debugString;
     for (const requestId of Object.keys(artifacts.Scripts)) {

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -10,9 +10,11 @@ const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const IGNORE_THRESHOLD_IN_BYTES = 2048;
 const PREVIEW_LENGTH = 100;
 
+/** @typedef {LH.Artifacts.CSSStyleSheetInfo & {networkRecord: LH.WebInspector.NetworkRequest, usedRules: Array<LH.Crdp.CSS.RuleUsage>}} StyleSheetInfo */
+
 class UnusedCSSRules extends ByteEfficiencyAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -28,16 +30,16 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Array.<{header: {styleSheetId: string}}>} styles The output of the Styles gatherer.
+   * @param {Array<LH.Artifacts.CSSStyleSheetInfo>} styles The output of the Styles gatherer.
    * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
-   * @return {!Object} A map of styleSheetId to stylesheet information.
+   * @return {Object<string, StyleSheetInfo>} A map of styleSheetId to stylesheet information.
    */
   static indexStylesheetsById(styles, networkRecords) {
     const indexedNetworkRecords = networkRecords
         .reduce((indexed, record) => {
           indexed[record.url] = record;
           return indexed;
-        }, {});
+        }, /** @type {Object<string, LH.WebInspector.NetworkRequest>} */ ({}));
 
     return styles.reduce((indexed, stylesheet) => {
       indexed[stylesheet.header.styleSheetId] = Object.assign({
@@ -45,13 +47,13 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
         networkRecord: indexedNetworkRecords[stylesheet.header.sourceURL],
       }, stylesheet);
       return indexed;
-    }, {});
+    }, /** @type {Object<string, StyleSheetInfo>} */ ({}));
   }
 
   /**
    * Adds used rules to their corresponding stylesheet.
-   * @param {!Array.<{styleSheetId: string, used: boolean}>} rules The output of the CSSUsage gatherer.
-   * @param {!Object} indexedStylesheets Stylesheet information indexed by id.
+   * @param {Array<LH.Crdp.CSS.RuleUsage>} rules The output of the CSSUsage gatherer.
+   * @param {Object<string, StyleSheetInfo>} indexedStylesheets Stylesheet information indexed by id.
    */
   static indexUsedRules(rules, indexedStylesheets) {
     rules.forEach(rule => {
@@ -68,7 +70,7 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Object} stylesheetInfo
+   * @param {StyleSheetInfo} stylesheetInfo
    * @return {{wastedBytes: number, totalBytes: number, wastedPercent: number}}
    */
   static computeUsage(stylesheetInfo) {
@@ -93,7 +95,7 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
 
   /**
    * Trims stylesheet content down to the first rule-set definition.
-   * @param {?string} content
+   * @param {string=} content
    * @return {string}
    */
   static determineContentPreview(content) {
@@ -128,15 +130,12 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Object} stylesheetInfo The stylesheetInfo object.
+   * @param {StyleSheetInfo} stylesheetInfo The stylesheetInfo object.
    * @param {string} pageUrl The URL of the page, used to identify inline styles.
-   * @return {?{url: string, wastedBytes: number, totalBytes: number}}
+   * @return {LH.Audit.ByteEfficiencyResult}
    */
   static mapSheetToResult(stylesheetInfo, pageUrl) {
-    if (stylesheetInfo.isDuplicate) {
-      return null;
-    }
-
+    /** @type {LH.Audit.ByteEfficiencyResult['url']} */
     let url = stylesheetInfo.header.sourceURL;
     if (!url || url === pageUrl) {
       const contentPreview = UnusedCSSRules.determineContentPreview(stylesheetInfo.content);
@@ -148,8 +147,8 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!Audit.HeadingsResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {Promise<LH.Audit.ByteEfficiencyProduct>}
    */
   static audit_(artifacts) {
     const styles = artifacts.CSSUsage.stylesheets;

--- a/lighthouse-core/audits/byte-efficiency/unused-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-javascript.js
@@ -11,7 +11,7 @@ const IGNORE_THRESHOLD_IN_BYTES = 2048;
 
 class UnusedJavaScript extends ByteEfficiencyAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -25,7 +25,7 @@ class UnusedJavaScript extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!JsUsageArtifact} script
+   * @param {LH.Crdp.Profiler.ScriptCoverage} script
    * @return {{unusedLength: number, contentLength: number}}
    */
   static computeWaste(script) {
@@ -61,9 +61,9 @@ class UnusedJavaScript extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Array<{unusedLength: number, contentLength: number}>} wasteData
+   * @param {Array<{unusedLength: number, contentLength: number}>} wasteData
    * @param {LH.WebInspector.NetworkRequest} networkRecord
-   * @return {{url: string, totalBytes: number, wastedBytes: number, wastedPercent: number}}
+   * @return {LH.Audit.ByteEfficiencyResult}
    */
   static mergeWaste(wasteData, networkRecord) {
     let unusedLength = 0;
@@ -87,10 +87,12 @@ class UnusedJavaScript extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!Audit.HeadingsResult}
+   * @param {LH.Artifacts} artifacts
+   * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
+   * @return {LH.Audit.ByteEfficiencyProduct}
    */
   static audit_(artifacts, networkRecords) {
+    /** @type {Map<string, Array<LH.Crdp.Profiler.ScriptCoverage>>} */
     const scriptsByUrl = new Map();
     for (const script of artifacts.JsUsage) {
       const scripts = scriptsByUrl.get(script.url) || [];
@@ -98,6 +100,7 @@ class UnusedJavaScript extends ByteEfficiencyAudit {
       scriptsByUrl.set(script.url, scripts);
     }
 
+    /** @type {Array<LH.Audit.ByteEfficiencyResult>} */
     const results = [];
     for (const [url, scripts] of scriptsByUrl.entries()) {
       const networkRecord = networkRecords.find(record => record.url === url);

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -7,6 +7,7 @@
  * @fileoverview This audit determines if the images used are sufficiently larger
  * than JPEG compressed images without metadata at quality 85.
  */
+// @ts-nocheck - TODO(bckenny)
 'use strict';
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
@@ -16,7 +17,7 @@ const IGNORE_THRESHOLD_IN_BYTES = 4096;
 
 class UsesOptimizedImages extends ByteEfficiencyAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -31,19 +32,18 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {{originalSize: number, webpSize: number, jpegSize: number}} image
-   * @param {string} type
+   * @param {{originalSize: number, jpegSize: number}} image
    * @return {{bytes: number, percent: number}}
    */
-  static computeSavings(image, type) {
-    const bytes = image.originalSize - image[type + 'Size'];
+  static computeSavings(image) {
+    const bytes = image.originalSize - image.jpegSize;
     const percent = 100 * bytes / image.originalSize;
     return {bytes, percent};
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!Audit.HeadingsResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.ByteEfficiencyProduct}
    */
   static audit_(artifacts) {
     const images = artifacts.OptimizedImages;
@@ -60,7 +60,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
       }
 
       const url = URL.elideDataURI(image.url);
-      const jpegSavings = UsesOptimizedImages.computeSavings(image, 'jpeg');
+      const jpegSavings = UsesOptimizedImages.computeSavings(image);
 
       results.push({
         url,

--- a/lighthouse-core/audits/byte-efficiency/uses-text-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-text-compression.js
@@ -17,7 +17,7 @@ const IGNORE_THRESHOLD_IN_PERCENT = 0.1;
 
 class ResponsesAreCompressed extends ByteEfficiencyAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -33,13 +33,13 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @param {number} networkThroughput
-   * @return {!Audit.HeadingsResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.ByteEfficiencyProduct}
    */
   static audit_(artifacts) {
     const uncompressedResponses = artifacts.ResponseCompression;
 
+    /** @type {Array<LH.Audit.ByteEfficiencyResult>} */
     const results = [];
     uncompressedResponses.forEach(record => {
       const originalSize = record.resourceSize;

--- a/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
@@ -6,17 +6,17 @@
 /*
  * @fileoverview This audit determines if the images could be smaller when compressed with WebP.
  */
+// @ts-nocheck - TODO(bckenny)
 'use strict';
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
-const OptimizedImages = require('./uses-optimized-images');
 const URL = require('../../lib/url-shim');
 
 const IGNORE_THRESHOLD_IN_BYTES = 8192;
 
 class UsesWebPImages extends ByteEfficiencyAudit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -32,8 +32,18 @@ class UsesWebPImages extends ByteEfficiencyAudit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!Audit.HeadingsResult}
+   * @param {{originalSize: number, webpSize: number}} image
+   * @return {{bytes: number, percent: number}}
+   */
+  static computeSavings(image) {
+    const bytes = image.originalSize - image.webpSize;
+    const percent = 100 * bytes / image.originalSize;
+    return {bytes, percent};
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.ByteEfficiencyProduct}
    */
   static audit_(artifacts) {
     const images = artifacts.OptimizedImages;
@@ -49,7 +59,7 @@ class UsesWebPImages extends ByteEfficiencyAudit {
       }
 
       const url = URL.elideDataURI(image.url);
-      const webpSavings = OptimizedImages.computeSavings(image, 'webp');
+      const webpSavings = UsesWebPImages.computeSavings(image);
 
       results.push({
         url,

--- a/lighthouse-core/lib/dependency-graph/node.js
+++ b/lighthouse-core/lib/dependency-graph/node.js
@@ -19,7 +19,7 @@
  */
 class Node {
   /**
-   * @param {string|number} id
+   * @param {string} id
    */
   constructor(id) {
     this._id = id;
@@ -30,7 +30,7 @@ class Node {
   }
 
   /**
-   * @return {string|number}
+   * @return {string}
    */
   get id() {
     return this._id;

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -76,7 +76,7 @@ describe('Byte efficiency base audit', () => {
   });
 
   it('should format details', () => {
-    const result = ByteEfficiencyAudit.createAuditResult({
+    const result = ByteEfficiencyAudit.createAuditProduct({
       headings: baseHeadings,
       results: [],
     }, graph, simulator);
@@ -85,7 +85,7 @@ describe('Byte efficiency base audit', () => {
   });
 
   it('should set the rawValue', () => {
-    const result = ByteEfficiencyAudit.createAuditResult(
+    const result = ByteEfficiencyAudit.createAuditProduct(
       {
         headings: baseHeadings,
         results: [
@@ -101,22 +101,22 @@ describe('Byte efficiency base audit', () => {
   });
 
   it('should score the wastedMs', () => {
-    const perfectResult = ByteEfficiencyAudit.createAuditResult({
+    const perfectResult = ByteEfficiencyAudit.createAuditProduct({
       headings: baseHeadings,
       results: [{url: 'http://example.com/', wastedBytes: 1 * 1000}],
     }, graph, simulator);
 
-    const goodResult = ByteEfficiencyAudit.createAuditResult({
+    const goodResult = ByteEfficiencyAudit.createAuditProduct({
       headings: baseHeadings,
       results: [{url: 'http://example.com/', wastedBytes: 20 * 1000}],
     }, graph, simulator);
 
-    const averageResult = ByteEfficiencyAudit.createAuditResult({
+    const averageResult = ByteEfficiencyAudit.createAuditProduct({
       headings: baseHeadings,
       results: [{url: 'http://example.com/', wastedBytes: 100 * 1000}],
     }, graph, simulator);
 
-    const failingResult = ByteEfficiencyAudit.createAuditResult({
+    const failingResult = ByteEfficiencyAudit.createAuditProduct({
       headings: baseHeadings,
       results: [{url: 'http://example.com/', wastedBytes: 400 * 1000}],
     }, graph, simulator);
@@ -129,7 +129,7 @@ describe('Byte efficiency base audit', () => {
 
   it('should throw on invalid graph', () => {
     assert.throws(() => {
-      ByteEfficiencyAudit.createAuditResult({
+      ByteEfficiencyAudit.createAuditProduct({
         headings: baseHeadings,
         results: [{wastedBytes: 350, totalBytes: 700, wastedPercent: 50}],
       }, null);
@@ -137,7 +137,7 @@ describe('Byte efficiency base audit', () => {
   });
 
   it('should populate KB', () => {
-    const result = ByteEfficiencyAudit.createAuditResult({
+    const result = ByteEfficiencyAudit.createAuditProduct({
       headings: baseHeadings,
       results: [
         {wastedBytes: 2048, totalBytes: 4096, wastedPercent: 50},
@@ -152,7 +152,7 @@ describe('Byte efficiency base audit', () => {
   });
 
   it('should sort on wastedBytes', () => {
-    const result = ByteEfficiencyAudit.createAuditResult({
+    const result = ByteEfficiencyAudit.createAuditProduct({
       headings: baseHeadings,
       results: [
         {wastedBytes: 350, totalBytes: 700, wastedPercent: 50},
@@ -167,7 +167,7 @@ describe('Byte efficiency base audit', () => {
   });
 
   it('should create a display value', () => {
-    const result = ByteEfficiencyAudit.createAuditResult({
+    const result = ByteEfficiencyAudit.createAuditProduct({
       headings: baseHeadings,
       results: [
         {wastedBytes: 512, totalBytes: 700, wastedPercent: 50},
@@ -185,7 +185,7 @@ describe('Byte efficiency base audit', () => {
     const artifacts = Runner.instantiateComputedArtifacts();
     const graph = await artifacts.requestPageDependencyGraph({trace, devtoolsLog});
     const simulator = await artifacts.requestLoadSimulator({devtoolsLog, settings});
-    const result = ByteEfficiencyAudit.createAuditResult(
+    const result = ByteEfficiencyAudit.createAuditProduct(
       {
         headings: [{key: 'value', text: 'Label'}],
         results: [

--- a/lighthouse-core/test/audits/byte-efficiency/efficient-animated-content-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/efficient-animated-content-test.js
@@ -16,23 +16,22 @@ describe('Page uses videos for animated GIFs', () => {
     const networkRecords = [
       {
         _resourceType: WebInspector.resourceTypes.Image,
-        mimeType: 'image/gif',
-        resourceSize: 100240,
+        _mimeType: 'image/gif',
+        _resourceSize: 100240,
         url: 'https://example.com/example.gif',
       },
       {
         _resourceType: WebInspector.resourceTypes.Image,
-        mimeType: 'image/gif',
-        resourceSize: 110000,
+        _mimeType: 'image/gif',
+        _resourceSize: 110000,
         url: 'https://example.com/example2.gif',
       },
     ];
     const artifacts = {
       devtoolsLogs: {[EfficientAnimatedContent.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
     };
 
-    const {results} = await EfficientAnimatedContent.audit_(artifacts);
+    const {results} = await EfficientAnimatedContent.audit_(artifacts, networkRecords);
     assert.equal(results.length, 1);
     assert.equal(results[0].url, 'https://example.com/example2.gif');
     assert.equal(results[0].totalBytes, 110000);
@@ -49,10 +48,9 @@ describe('Page uses videos for animated GIFs', () => {
     ];
     const artifacts = {
       devtoolsLogs: {[EfficientAnimatedContent.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
     };
 
-    const {results} = await EfficientAnimatedContent.audit_(artifacts);
+    const {results} = await EfficientAnimatedContent.audit_(artifacts, networkRecords);
     assert.equal(results.length, 0);
   });
 
@@ -71,10 +69,9 @@ describe('Page uses videos for animated GIFs', () => {
     ];
     const artifacts = {
       devtoolsLogs: {[EfficientAnimatedContent.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
     };
 
-    const {results} = await EfficientAnimatedContent.audit_(artifacts);
+    const {results} = await EfficientAnimatedContent.audit_(artifacts, networkRecords);
     assert.equal(results.length, 0);
   });
 });

--- a/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
@@ -7,17 +7,23 @@
 
 const TotalByteWeight = require('../../../audits/byte-efficiency/total-byte-weight.js');
 const assert = require('assert');
+const URL = require('url').URL;
 const options = TotalByteWeight.defaultOptions;
 
 /* eslint-env mocha */
 
 function generateRequest(url, size, baseUrl = 'http://google.com/') {
+  const parsedUrl = new URL(url, baseUrl);
+  const scheme = parsedUrl.protocol.slice(0, -1);
   return {
-    url: `${baseUrl}${url}`,
+    url: parsedUrl.href,
     finished: true,
     transferSize: size * 1024,
     responseReceivedTime: 1000,
     endTime: 2000,
+    parsedURL: {
+      scheme,
+    },
   };
 }
 
@@ -25,6 +31,7 @@ function generateArtifacts(records) {
   if (records[0] && records[0].length > 1) {
     records = records.map(args => generateRequest(...args));
   }
+
   return {
     devtoolsLogs: {defaultPass: []},
     requestNetworkRecords: () => Promise.resolve(records),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "lighthouse-core/audits/audit.js",
     "lighthouse-core/audits/accessibility/**/*.js",
     "lighthouse-core/audits/dobetterweb/**/*.js",
+    "lighthouse-core/audits/byte-efficiency/**/*.js",
     "lighthouse-core/audits/manual/**/*.js",
     "lighthouse-core/audits/seo/manual/*.js",
     "lighthouse-core/audits/seo/robots-txt.js",

--- a/typings/audit.d.ts
+++ b/typings/audit.d.ts
@@ -38,13 +38,22 @@ declare global {
       key: string;
       itemType: string;
       text: string;
+      displayUnit?: string;
+      granularity?: number;
     }
 
-    export interface HeadingsResult {
-      results: number;
+    export interface ByteEfficiencyProduct {
+      results: Array<ByteEfficiencyResult>;
       headings: Array<Audit.Heading>;
-      passes: boolean;
+      displayValue?: string;
       debugString?: string;
+    }
+
+    export interface ByteEfficiencyResult {
+      url: string | DetailsRendererCodeDetailJSON;
+      wastedBytes: number;
+      totalBytes: number;
+      wastedPercent?: number;
     }
 
     // TODO: placeholder typedefs until Details are typed
@@ -61,8 +70,13 @@ declare global {
       summary?: DetailsRendererDetailsSummary;
     }
 
+    export interface DetailsRendererCodeDetailJSON {
+      type: 'code',
+      value: string;
+    }
+
     export type DetailsItem = string | number | DetailsRendererNodeDetailsJSON |
-      DetailsRendererLinkDetailsJSON;
+      DetailsRendererLinkDetailsJSON | DetailsRendererCodeDetailJSON;
 
     export interface DetailsRendererNodeDetailsJSON {
       type: 'node';

--- a/typings/web-inspector.d.ts
+++ b/typings/web-inspector.d.ts
@@ -25,7 +25,9 @@ declare global {
       _responseReceivedTime: number;
 
       transferSize: number;
+      /** Should use a default of 0 if not defined */
       _transferSize?: number;
+      /** Should use a default of 0 if not defined */
       _resourceSize?: number;
 
       finished: boolean;


### PR DESCRIPTION
`uses-optimized-images.js` and `uses-webp-images.js` only get the surface treatment for now as I noticed I was lazy typing the `OptimizedImages` in the error case. Fixing that will make their changes really easy.

The only annoying change here is having to explicitly cast `Node` to `NetworkNode` when wanting to access its network record. The cast is somewhat reasonable, but since they already have a readonly `type` property to differentiate, we could make them a discriminated union in the future. That way the compiler knows a node could only be a CPU or network node (+ whatever the future brings), and checking `node.type === 'network'` would establish to it that the following code was dealing with a `NetworkNode`.