### PR TITLE
report: tweak tooltips

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -22,6 +22,7 @@
   --section-indent: 16px;
   --audit-group-indent: 16px;
   --audit-indent: 16px;
+  --text-indent: 8px;
   --expandable-indent: 20px;
   --secondary-text-color: #565656;
   /*--accent-color: #3879d9;*/
@@ -352,12 +353,14 @@ summary {
 }
 
 .lh-perf-metric {
-  position: relative;
+  border-top: 1px solid var(--report-secondary-border-color);
+}
+
+.lh-perf-metric__innerwrap {
   display: flex;
   justify-content: space-between;
-
-  padding: calc(2 * var(--lh-audit-vpadding)) 0;
-  border-top: 1px solid var(--report-secondary-border-color);
+  margin: var(--lh-audit-vpadding) 0;
+  padding: var(--lh-audit-vpadding) var(--text-indent);
 }
 
 .lh-perf-metric__header {
@@ -941,11 +944,15 @@ summary.lh-passed-audits-summary {
   opacity: 0;
 }
 
+.tooltip-boundary:hover {
+  background-color: #F8F9FA;
+}
+
 .tooltip-boundary:hover .tooltip {
   display: block;
   animation: fadeInTooltip 150ms;
   animation-fill-mode: forwards;
-  animation-delay: 500ms;
+  animation-delay: 900ms;
   min-width: 15em;
   background: #ffffff;
   padding: 15px;
@@ -962,6 +969,7 @@ summary.lh-passed-audits-summary {
   border-width: 10px;
   position: absolute;
   bottom: -20px;
+  right: 6px;
   transform: rotate(180deg);
   pointer-events: none;
 }

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -43,10 +43,12 @@
 <!-- Lighthouse perf metric -->
 <template id="tmpl-lh-perf-metric">
 
-  <div class="lh-perf-metric tooltip-boundary">
-    <span class="lh-perf-metric__title"></span>
-    <div class="lh-perf-metric__value"><span></span></div>
-    <div class="lh-perf-metric__description tooltip"></div>
+  <div class="lh-perf-metric">
+    <div class="lh-perf-metric__innerwrap tooltip-boundary">
+      <span class="lh-perf-metric__title"></span>
+      <div class="lh-perf-metric__value"><span></span></div>
+      <div class="lh-perf-metric__description tooltip"></div>
+    </div>
   </div>
 
 </template>


### PR DESCRIPTION
@hwikyounglee asked for two changes. 1) tooltip arrow points to the number. 2) hover background color.

Also made a few changes:

* tooltip doesnt start showing up for 900ms now (instead of 500ms) 
* tooltip trigger boundary is smaller. It matches the gray background (and doesn't extend to the line)
* left/right padding on these boxes so their container extends a little farther than the text. I'll be applying this padding to other elements in the report, as the mocks suggest. see "padding illustration" below.

before and after gif:
![kapture 2018-04-30 at 15 46 02](https://user-images.githubusercontent.com/39191/39454003-a9f3d47e-4c8d-11e8-9fd0-a1ba8a6ed824.gif)

<details>
<summary>
padding illustration:
</summary>
<img src="https://user-images.githubusercontent.com/39191/39454125-4ee2d3f4-4c8e-11e8-96ba-e75c3a2a3555.png">
</details>
