### PR TITLE
report(table): handle null cells

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/unminified-css.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-css.js
@@ -137,7 +137,8 @@ class UnminifiedCSS extends ByteEfficiencyAudit {
       // If the ratio is minimal, the file is likely already minified, so ignore it.
       // If the total number of bytes to be saved is quite small, it's also safe to ignore.
       if (result.wastedPercent < IGNORE_THRESHOLD_IN_PERCENT ||
-          result.wastedBytes < IGNORE_THRESHOLD_IN_BYTES) continue;
+          result.wastedBytes < IGNORE_THRESHOLD_IN_BYTES ||
+          !Number.isFinite(result.wastedBytes)) continue;
       results.push(result);
     }
 

--- a/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
@@ -84,7 +84,8 @@ class UnminifiedJavaScript extends ByteEfficiencyAudit {
         // If the ratio is minimal, the file is likely already minified, so ignore it.
         // If the total number of bytes to be saved is quite small, it's also safe to ignore.
         if (result.wastedPercent < IGNORE_THRESHOLD_IN_PERCENT ||
-          result.wastedBytes < IGNORE_THRESHOLD_IN_BYTES) continue;
+          result.wastedBytes < IGNORE_THRESHOLD_IN_BYTES ||
+          !Number.isFinite(result.wastedBytes)) continue;
         results.push(result);
       } catch (err) {
         debugString = `Unable to process ${networkRecord._url}: ${err.message}`;

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -203,7 +203,7 @@ class DetailsRenderer {
       for (const heading of details.headings) {
         const value = /** @type {number|string|!DetailsRenderer.DetailsJSON} */ (row[heading.key]);
 
-        if (typeof value === 'undefined') {
+        if (typeof value === 'undefined' || value === null) {
           this._dom.createChildOf(rowElem, 'td', 'lh-table-column--empty');
           continue;
         }


### PR DESCRIPTION
just bumped into a case where the report failed to render entirely because a value was `null` in the JSON (presumably because the value was `NaN` on the node side and was stringified into `null` by the time it was injected into the renderer)