### PR TITLE
report: error'd audits get 'Error!' treatment

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -55,15 +55,15 @@ class CategoryRenderer {
       auditEl.classList.add('lh-audit--manual');
     }
 
-    this._populateScore(auditEl, audit.result.score, scoreDisplayMode);
+    this._populateScore(auditEl, audit.result.score, scoreDisplayMode, audit.result.error);
 
     if (audit.result.error) {
       auditEl.classList.add(`lh-audit--error`);
       const valueEl = this.dom.find('.lh-score__value', auditEl);
       valueEl.textContent = 'Error';
       valueEl.classList.add('tooltip-boundary');
-      const content = this.dom.createChildOf(valueEl, 'div', 'lh-error-tooltip-content tooltip');
-      content.textContent = audit.result.debugString || 'Report error: no audit information';
+      const tooltip = this.dom.createChildOf(valueEl, 'div', 'lh-error-tooltip-content tooltip');
+      tooltip.textContent = audit.result.debugString || 'Report error: no audit information';
     } else if (audit.result.debugString) {
       const debugStrEl = auditEl.appendChild(this.dom.createElement('div', 'lh-debug'));
       debugStrEl.textContent = audit.result.debugString;
@@ -75,14 +75,16 @@ class CategoryRenderer {
    * @param {!DocumentFragment|!Element} element DOM node to populate with values.
    * @param {number} score
    * @param {string} scoreDisplayMode
+   * @param {?boolean} isError
    * @return {!Element}
    */
-  _populateScore(element, score, scoreDisplayMode) {
+  _populateScore(element, score, scoreDisplayMode, isError) {
     const scoreOutOf100 = Math.round(score * 100);
     const valueEl = this.dom.find('.lh-score__value', element);
     valueEl.textContent = Util.formatNumber(scoreOutOf100);
-    valueEl.classList.add(`lh-score__value--${Util.calculateRating(score)}`,
-        `lh-score__value--${scoreDisplayMode}`);
+    // FIXME(paulirish): this'll have to deal with null scores and scoreDisplayMode stuff..
+    const rating = isError ? 'error' : Util.calculateRating(score);
+    valueEl.classList.add(`lh-score__value--${rating}`, `lh-score__value--${scoreDisplayMode}`);
 
     return /** @type {!Element} **/ (element);
   }

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -60,10 +60,10 @@ class CategoryRenderer {
     if (audit.result.error) {
       auditEl.classList.add(`lh-audit--error`);
       const valueEl = this.dom.find('.lh-score__value', auditEl);
-      valueEl.textContent = 'Error!';
+      valueEl.textContent = 'Error';
       valueEl.classList.add('tooltip-boundary');
       const content = this.dom.createChildOf(valueEl, 'div', 'lh-error-tooltip-content tooltip');
-      content.textContent = audit.result.debugString || 'Report error: no metric information';
+      content.textContent = audit.result.debugString || 'Report error: no audit information';
     } else if (audit.result.debugString) {
       const debugStrEl = auditEl.appendChild(this.dom.createElement('div', 'lh-debug'));
       debugStrEl.textContent = audit.result.debugString;

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -42,11 +42,6 @@ class CategoryRenderer {
     this.dom.find('.lh-audit__description', auditEl)
       .appendChild(this.dom.convertMarkdownLinkSnippets(audit.result.helpText));
 
-    if (audit.result.debugString) {
-      const debugStrEl = auditEl.appendChild(this.dom.createElement('div', 'lh-debug'));
-      debugStrEl.textContent = audit.result.debugString;
-    }
-
     // Append audit details to header section so the entire audit is within a <details>.
     const header = /** @type {!HTMLDetailsElement} */ (this.dom.find('.lh-audit__header', auditEl));
     if (audit.result.details && audit.result.details.type) {
@@ -60,7 +55,20 @@ class CategoryRenderer {
       auditEl.classList.add('lh-audit--manual');
     }
 
-    return this._populateScore(auditEl, audit.result.score, scoreDisplayMode);
+    this._populateScore(auditEl, audit.result.score, scoreDisplayMode);
+
+    if (audit.result.error) {
+      auditEl.classList.add(`lh-audit--error`);
+      const valueEl = this.dom.find('.lh-score__value', auditEl);
+      valueEl.textContent = 'Error!';
+      valueEl.classList.add('tooltip-boundary');
+      const content = this.dom.createChildOf(valueEl, 'div', 'lh-error-tooltip-content tooltip');
+      content.textContent = audit.result.debugString || 'Report error: no metric information';
+    } else if (audit.result.debugString) {
+      const debugStrEl = auditEl.appendChild(this.dom.createElement('div', 'lh-debug'));
+      debugStrEl.textContent = audit.result.debugString;
+    }
+    return auditEl;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -75,7 +75,7 @@ class CategoryRenderer {
    * @param {!DocumentFragment|!Element} element DOM node to populate with values.
    * @param {number} score
    * @param {string} scoreDisplayMode
-   * @param {?boolean} isError
+   * @param {boolean} isError
    * @return {!Element}
    */
   _populateScore(element, score, scoreDisplayMode, isError) {
@@ -105,7 +105,7 @@ class CategoryRenderer {
     this.dom.find('.lh-category-header__description', tmpl)
       .appendChild(this.dom.convertMarkdownLinkSnippets(category.description));
 
-    return this._populateScore(tmpl, category.score, 'numeric');
+    return this._populateScore(tmpl, category.score, 'numeric', false);
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -31,14 +31,16 @@ class CategoryRenderer {
     const tmpl = this.dom.cloneTemplate('#tmpl-lh-audit', this.templateContext);
     const auditEl = this.dom.find('.lh-audit', tmpl);
     auditEl.id = audit.result.name;
-
     const scoreDisplayMode = audit.result.scoreDisplayMode;
-    const description = audit.result.helpText;
     let title = audit.result.description;
-
     if (audit.result.displayValue) {
       title += `:  ${audit.result.displayValue}`;
     }
+
+    this.dom.find('.lh-audit__title', auditEl).appendChild(
+      this.dom.convertMarkdownCodeSnippets(title));
+    this.dom.find('.lh-audit__description', auditEl)
+      .appendChild(this.dom.convertMarkdownLinkSnippets(audit.result.helpText));
 
     if (audit.result.debugString) {
       const debugStrEl = auditEl.appendChild(this.dom.createElement('div', 'lh-debug'));
@@ -58,29 +60,21 @@ class CategoryRenderer {
       auditEl.classList.add('lh-audit--manual');
     }
 
-    return this._populateScore(auditEl, audit.result.score, scoreDisplayMode, title, description);
+    return this._populateScore(auditEl, audit.result.score, scoreDisplayMode);
   }
 
   /**
    * @param {!DocumentFragment|!Element} element DOM node to populate with values.
    * @param {number} score
    * @param {string} scoreDisplayMode
-   * @param {string} title
-   * @param {string} description
    * @return {!Element}
    */
-  _populateScore(element, score, scoreDisplayMode, title, description) {
-    // Fill in the blanks.
+  _populateScore(element, score, scoreDisplayMode) {
     const scoreOutOf100 = Math.round(score * 100);
     const valueEl = this.dom.find('.lh-score__value', element);
     valueEl.textContent = Util.formatNumber(scoreOutOf100);
     valueEl.classList.add(`lh-score__value--${Util.calculateRating(score)}`,
         `lh-score__value--${scoreDisplayMode}`);
-
-    this.dom.find('.lh-audit__title, .lh-category-header__title', element).appendChild(
-        this.dom.convertMarkdownCodeSnippets(title));
-    this.dom.find('.lh-audit__description, .lh-category-header__description', element)
-        .appendChild(this.dom.convertMarkdownLinkSnippets(description));
 
     return /** @type {!Element} **/ (element);
   }
@@ -96,8 +90,12 @@ class CategoryRenderer {
     const gaugeEl = this.renderScoreGauge(category);
     gaugeContainerEl.appendChild(gaugeEl);
 
-    const {score, name, description} = category;
-    return this._populateScore(tmpl, score, 'numeric', name, description);
+    this.dom.find('.lh-category-header__title', tmpl).appendChild(
+      this.dom.convertMarkdownCodeSnippets(category.name));
+    this.dom.find('.lh-category-header__description', tmpl)
+      .appendChild(this.dom.convertMarkdownLinkSnippets(category.description));
+
+    return this._populateScore(tmpl, category.score, 'numeric');
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -16,7 +16,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     const tmpl = this.dom.cloneTemplate('#tmpl-lh-perf-metric', this.templateContext);
     const element = this.dom.find('.lh-perf-metric', tmpl);
     element.id = audit.result.name;
-    // FIXME(paulirish): currently this sets a 'lh-perf-metric--undefined' class on error'd audits
+    // FIXME(paulirish): currently this sets a 'lh-perf-metric--fail' class on error'd audits
     element.classList.add(`lh-perf-metric--${Util.calculateRating(audit.result.score)}`);
 
     const titleEl = this.dom.find('.lh-perf-metric__title', tmpl);
@@ -29,11 +29,12 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     descriptionEl.appendChild(this.dom.convertMarkdownLinkSnippets(audit.result.helpText));
 
     if (audit.result.error) {
+      element.classList.remove(`lh-perf-metric--fail`);
       element.classList.add(`lh-perf-metric--error`);
       descriptionEl.textContent = '';
-      valueEl.textContent = 'Error';
-      const content = this.dom.createChildOf(descriptionEl, 'span', 'lh-error-tooltip-content');
-      content.textContent = audit.result.debugString || 'Report error: no metric information';
+      valueEl.textContent = 'Error!';
+      const tooltip = this.dom.createChildOf(descriptionEl, 'span', 'lh-error-tooltip-content');
+      tooltip.textContent = audit.result.debugString || 'Report error: no metric information';
     }
 
     return element;

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -21,16 +21,18 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     const titleEl = this.dom.find('.lh-perf-metric__title', tmpl);
     titleEl.textContent = audit.result.description;
 
-    const valueEl = this.dom.find('.lh-perf-metric__value span', tmpl);
+    const valueEl = this.dom.find('.lh-perf-metric__value', tmpl);
     valueEl.textContent = audit.result.displayValue;
 
     const descriptionEl = this.dom.find('.lh-perf-metric__description', tmpl);
     descriptionEl.appendChild(this.dom.convertMarkdownLinkSnippets(audit.result.helpText));
 
-    if (typeof audit.result.rawValue !== 'number') {
-      const debugStrEl = this.dom.createChildOf(element, 'div', 'lh-debug');
-      debugStrEl.textContent = audit.result.debugString || 'Report error: no metric information';
-      return element;
+    if (audit.result.error) {
+      element.classList.add(`lh-perf-metric--error`);
+      descriptionEl.innerHTML = '';
+      valueEl.textContent = 'Error';
+      const content = this.dom.createChildOf(descriptionEl, 'span', 'lh-error-tooltip-content');
+      content.textContent = audit.result.debugString || 'Report error: no metric information';
     }
 
     return element;

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -16,6 +16,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     const tmpl = this.dom.cloneTemplate('#tmpl-lh-perf-metric', this.templateContext);
     const element = this.dom.find('.lh-perf-metric', tmpl);
     element.id = audit.result.name;
+    // FIXME(paulirish): currently this sets a 'lh-perf-metric--undefined' class on error'd audits
     element.classList.add(`lh-perf-metric--${Util.calculateRating(audit.result.score)}`);
 
     const titleEl = this.dom.find('.lh-perf-metric__title', tmpl);
@@ -30,7 +31,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     if (audit.result.error) {
       element.classList.add(`lh-perf-metric--error`);
       descriptionEl.innerHTML = '';
-      valueEl.textContent = 'Error';
+      valueEl.textContent = 'Error!';
       const content = this.dom.createChildOf(descriptionEl, 'span', 'lh-error-tooltip-content');
       content.textContent = audit.result.debugString || 'Report error: no metric information';
     }

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -30,8 +30,8 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
 
     if (audit.result.error) {
       element.classList.add(`lh-perf-metric--error`);
-      descriptionEl.innerHTML = '';
-      valueEl.textContent = 'Error!';
+      descriptionEl.textContent = '';
+      valueEl.textContent = 'Error';
       const content = this.dom.createChildOf(descriptionEl, 'span', 'lh-error-tooltip-content');
       content.textContent = audit.result.debugString || 'Report error: no metric information';
     }

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -15,6 +15,7 @@ const RATINGS = {
   PASS: {label: 'pass', minScore: PASS_THRESHOLD},
   AVERAGE: {label: 'average', minScore: 0.45},
   FAIL: {label: 'fail'},
+  ERROR: {label: 'error'},
 };
 
 /**
@@ -37,6 +38,9 @@ class Util {
       rating = RATINGS.PASS.label;
     } else if (score >= RATINGS.AVERAGE.minScore) {
       rating = RATINGS.AVERAGE.label;
+    }
+    if (score === null) {
+      rating = RATINGS.AVERAGE.ERROR;
     }
     return rating;
   }

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -39,9 +39,6 @@ class Util {
     } else if (score >= RATINGS.AVERAGE.minScore) {
       rating = RATINGS.AVERAGE.label;
     }
-    if (score === null) {
-      rating = RATINGS.AVERAGE.ERROR;
-    }
     return rating;
   }
 

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -15,7 +15,6 @@ const RATINGS = {
   PASS: {label: 'pass', minScore: PASS_THRESHOLD},
   AVERAGE: {label: 'average', minScore: 0.45},
   FAIL: {label: 'fail'},
-  ERROR: {label: 'error'},
 };
 
 /**

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -390,7 +390,7 @@ summary {
   color: var(--pass-color);
 }
 
-.lh-perf-metric .lh-perf-metric__value span::after {
+.lh-perf-metric .lh-perf-metric__value::after {
   content: '';
   width: var(--body-font-size);
   height: var(--body-font-size);
@@ -400,7 +400,7 @@ summary {
   margin-left: calc(var(--body-font-size) / 2);
 }
 
-.lh-perf-metric--pass .lh-perf-metric__value span::after {
+.lh-perf-metric--pass .lh-perf-metric__value::after {
   background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>check</title><path fill="hsl(139, 70%, 30%)" d="M24 4C12.95 4 4 12.95 4 24c0 11.04 8.95 20 20 20 11.04 0 20-8.96 20-20 0-11.05-8.96-20-20-20zm-4 30L10 24l2.83-2.83L20 28.34l15.17-15.17L38 16 20 34z"/></svg>') no-repeat 50% 50%;
 }
 
@@ -408,7 +408,7 @@ summary {
 .lh-perf-metric--average .lh-perf-metric__value {
   color: var(--average-color);
 }
-.lh-perf-metric--average .lh-perf-metric__value span::after {
+.lh-perf-metric--average .lh-perf-metric__value::after {
   background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>info</title><path fill="hsl(31, 100%, 45%)" d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm2 30h-4V22h4v12zm0-16h-4v-4h4v4z"/></svg>') no-repeat 50% 50%;
 }
 
@@ -416,12 +416,13 @@ summary {
 .lh-perf-metric--fail .lh-perf-metric__value {
   color: var(--fail-color);
 }
-.lh-perf-metric--fail .lh-perf-metric__value span::after {
+.lh-perf-metric--fail .lh-perf-metric__value::after {
   background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>warn</title><path fill="hsl(1, 73%, 45%)" d="M2 42h44L24 4 2 42zm24-6h-4v-4h4v4zm0-8h-4v-8h4v8z"/></svg>') no-repeat 50% 50%;
 }
 
-.lh-perf-metric .lh-debug {
-  margin-left: var(--expandable-indent);
+.lh-perf-metric--error .lh-perf-metric__value,
+.lh-perf-metric--error .lh-perf-metric__description {
+  color: var(--fail-color);
 }
 
 /* Perf Hint */

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -56,8 +56,8 @@
   --lh-audit-hgap: 12px;
   --lh-audit-group-vpadding: 12px;
   --lh-section-vpadding: 12px;
-  --pass-icon-url: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path stroke="%23007F04" stroke-width="1.5" d="M1 5.75l3.5 3.5 6.5-6.5" fill="none" fill-rule="evenodd"/></svg>');
-  --fail-icon-url: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><g stroke="%23EE1D0A" stroke-width="1.5" fill="none" fill-rule="evenodd"><path d="M2 10l8-8M10 10L2 2"/></g></svg>');
+  --pass-icon-url: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path stroke="hsl(139, 70%, 30%)" stroke-width="1.5" d="M1 5.75l3.5 3.5 6.5-6.5" fill="none" fill-rule="evenodd"/></svg>');
+  --fail-icon-url: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><g stroke="hsl(1, 73%, 45%)" stroke-width="1.5" fill="none" fill-rule="evenodd"><path d="M2 10l8-8M10 10L2 2"/></g></svg>');
   --collapsed-icon-url: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path fill="none" d="M0 0h12v12H0z"/><path fill="hsl(0, 0%, 60%)" d="M3 2l6 4-6 4z"/></g></svg>');
   --expanded-icon-url: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path fill="none" d="M0 0h12v12H0z"/><path fill="hsl(0, 0%, 60%)" d="M10 3L6 9 2 3z"/></g></svg>');
 }

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -425,6 +425,11 @@ summary {
   color: var(--fail-color);
 }
 
+/* Hide icon if there was an error */
+.lh-perf-metric--error .lh-perf-metric__value::after {
+  display: none;
+}
+
 /* Perf Hint */
 
 .lh-perf-hint {

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -243,6 +243,11 @@ summary {
   background: var(--fail-icon-url) no-repeat center center / 12px 12px;
 }
 
+/* This must override the above styles */
+.lh-audit .lh-score__value--binary {
+  color: transparent;
+}
+
 .lh-audit__description, .lh-category-header__description  {
   font-size: var(--body-font-size);
   color: var(--secondary-text-color);
@@ -585,6 +590,11 @@ summary {
 .lh-audit .lh-debug {
   margin-left: var(--expandable-indent);
   margin-right: var(--lh-audit-score-width);
+}
+
+.lh-audit--error .lh-score__value {
+  color: var(--fail-color);
+  font-weight: normal;
 }
 
 /* Audit Group */
@@ -939,13 +949,14 @@ summary.lh-passed-audits-summary {
   animation: fadeInTooltip 150ms;
   animation-fill-mode: forwards;
   animation-delay: 900ms;
-  min-width: 15em;
+  min-width: 23em;
   background: #ffffff;
   padding: 15px;
   border-radius: 5px;
   bottom: 100%;
   z-index: 1;
   will-change: opacity;
+  right: 0;
 }
 
 .tooltip::before {

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -202,29 +202,9 @@ summary {
   width: 16px;
 }
 
-.lh-audit--informative .lh-score__value {
-  color: var(--informative-color);
-  border-radius: 50%;
-  top: 3px;
-}
-
-.lh-audit--informative .lh-score__value::after {
+.lh-audit--informative .lh-score__value,
+.lh-audit--manual .lh-score__value {
   display: none;
-  background: url('data:image/svg+xml;utf8,<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>info</title><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" fill="hsl(218, 89%, 41%)"/></svg>') no-repeat 50% 50%;
-  background-size: var(--lh-score-icon-background-size);
-}
-
-.lh-audit--manual .lh-score__value::after {
-  background: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><title>manual</title><path d="M2 5h8v2H2z" fill="hsl(0, 0%, 100%)" fill-rule="evenodd"/></svg>') no-repeat 50% 50%;
-  background-size: 18px;
-  background-color: var(--medium-75-gray);
-  width: 20px;
-  height:  20px;
-  position: relative;
-}
-
-.lh-score__value--binary {
-  color: transparent !important;
 }
 
 /* No icon for audits with number scores. */

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -46,7 +46,7 @@
   <div class="lh-perf-metric">
     <div class="lh-perf-metric__innerwrap tooltip-boundary">
       <span class="lh-perf-metric__title"></span>
-      <div class="lh-perf-metric__value"><span></span></div>
+      <div class="lh-perf-metric__value"></div>
       <div class="lh-perf-metric__description tooltip"></div>
     </div>
   </div>


### PR DESCRIPTION
### changes

* what the title said
* the report's ❌  and ✅ use standard fail/pass colors
* populateScore no longer sets title/description. Just handles the score gauge.
* removed right column score/icon for informative/manual audits (no more blue '100's)


### screenshots

![image](https://user-images.githubusercontent.com/39191/39457008-8036042e-4c9f-11e8-9261-9cdd521b611a.png)

![image](https://user-images.githubusercontent.com/39191/39457009-85eb65bc-4c9f-11e8-84f5-92641313a58c.png)
