### PR TITLE
core(scoring): tweak performance weights

### DIFF
--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -265,12 +265,13 @@ module.exports = {
       name: 'Performance',
       description: 'These encapsulate your web app\'s current performance and opportunities to improve it.',
       audits: [
-        {id: 'first-contentful-paint', weight: 5, group: 'perf-metric'},
-        {id: 'first-meaningful-paint', weight: 3, group: 'perf-metric'},
-        {id: 'first-cpu-idle', weight: 5, group: 'perf-metric'},
+        {id: 'first-contentful-paint', weight: 3, group: 'perf-metric'},
+        {id: 'first-meaningful-paint', weight: 1, group: 'perf-metric'},
+        {id: 'speed-index', weight: 4, group: 'perf-metric'},
         {id: 'interactive', weight: 5, group: 'perf-metric'},
-        {id: 'speed-index', weight: 1, group: 'perf-metric'},
-        {id: 'estimated-input-latency', weight: 1, group: 'perf-metric'},
+        {id: 'first-cpu-idle', weight: 2, group: 'perf-metric'},
+        {id: 'estimated-input-latency', weight: 0, group: 'perf-metric'},
+
         {id: 'render-blocking-resources', weight: 0, group: 'perf-hint'},
         {id: 'uses-responsive-images', weight: 0, group: 'perf-hint'},
         {id: 'offscreen-images', weight: 0, group: 'perf-hint'},

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -4571,17 +4571,17 @@
       "audits": [
         {
           "id": "first-contentful-paint",
-          "weight": 5,
-          "group": "perf-metric"
-        },
-        {
-          "id": "first-meaningful-paint",
           "weight": 3,
           "group": "perf-metric"
         },
         {
-          "id": "first-cpu-idle",
-          "weight": 5,
+          "id": "first-meaningful-paint",
+          "weight": 1,
+          "group": "perf-metric"
+        },
+        {
+          "id": "speed-index",
+          "weight": 4,
           "group": "perf-metric"
         },
         {
@@ -4590,13 +4590,13 @@
           "group": "perf-metric"
         },
         {
-          "id": "speed-index",
-          "weight": 1,
+          "id": "first-cpu-idle",
+          "weight": 2,
           "group": "perf-metric"
         },
         {
           "id": "estimated-input-latency",
-          "weight": 1,
+          "weight": 0,
           "group": "perf-metric"
         },
         {
@@ -4723,7 +4723,7 @@
         }
       ],
       "id": "performance",
-      "score": 0.62
+      "score": 0.63
     },
     {
       "name": "Progressive Web App",
@@ -5240,8 +5240,5 @@
       "title": "Additional items to manually check",
       "description": "Run these additional validators on your site to check additional SEO best practices."
     }
-  },
-  "timing": {
-    "total": 667
   }
 }


### PR DESCRIPTION
closes #4629 

tweaks the performance score weights according to https://docs.google.com/document/d/1XiKdkLgWul0l40slhkCmQufNdjUiTlq3H_EAjrBH5Cw/edit#

I ran the weights and new thresholds for what we have in HTTPArchive and got the distribution, it's pretty aggressive.

Median: 27
75th Percentile: 43
90th Percentile: 69
95th Percentile: 83
99th Percentile: 98

Roughly 3% of sites get a 90+
Roughly 0.08% of sites get a 100


I'm disappointed new rolling window EIL won't get any credit, but that'll give us time to take a look at the distribution of the new definition and adjust score thresholds without impacting the overall perf score, and this is aggressive enough as it is :)