### PR TITLE
core(opportunities): take max of savings on TTI, load

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -164,6 +164,8 @@ module.exports = [
         },
       },
       'efficient-animated-content': {
+        score: '<1',
+        rawValue: '>2000',
         extendedInfo: {
           value: {
             wastedKb: 666,

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -135,8 +135,8 @@ class OffscreenImages extends ByteEfficiencyAudit {
     const settings = context.settings;
     return artifacts.requestFirstCPUIdle({trace, devtoolsLog, settings}).then(firstInteractive => {
       // The filter below is just to be extra safe that we exclude images that were loaded post-TTI.
-      // If we're in the Lantern case though, we just have to rely on the graph simulation doing the
-      // right thing.
+      // If we're in the Lantern case and `timestamp` isn't available, we just have to rely on the
+      // graph simulation doing the right thing.
       const ttiTimestamp = firstInteractive.timestamp ? firstInteractive.timestamp / 1e6 : Infinity;
 
       const results = Array.from(resultsMap.values()).filter(item => {

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -26,12 +26,12 @@ class OffscreenImages extends ByteEfficiencyAudit {
   static get meta() {
     return {
       name: 'offscreen-images',
-      description: 'Offscreen images',
+      description: 'Defer offscreen images',
       informative: true,
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
       helpText:
-        'Consider lazy-loading offscreen and hidden images to improve page load speed ' +
-        'and time to interactive. ' +
+        'Consider lazy-loading offscreen and hidden images after all critical resources have ' +
+        'finished loading to lower time to interactive. ' +
         '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images).',
       requiredArtifacts: ['ImageUsage', 'ViewportDimensions', 'traces', 'devtoolsLogs'],
     };
@@ -82,6 +82,21 @@ class OffscreenImages extends ByteEfficiencyAudit {
   }
 
   /**
+   * The default byte efficiency audit will report max(TTI, load), since lazy-loading offscreen
+   * images won't reduce the overall time and the wasted bytes are really only "wasted" for TTI,
+   * override the function to just look at TTI savings.
+   *
+   * @param {Array<LH.Audit.ByteEfficiencyResult>} results
+   * @param {LH.Gatherer.Simulation.GraphNode} graph
+   * @param {LH.Gatherer.Simulation.Simulator} simulator
+   * @return {number}
+   */
+  static computeWasteWithTTIGraph(results, graph, simulator) {
+    return ByteEfficiencyAudit.computeWasteWithTTIGraph(results, graph, simulator,
+      {includeLoad: false});
+  }
+
+  /**
    * @param {LH.Artifacts} artifacts
    * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
    * @param {LH.Audit.Context} context
@@ -117,11 +132,13 @@ class OffscreenImages extends ByteEfficiencyAudit {
       return results;
     }, new Map());
 
-    // TODO(phulce): move this to always use lantern
     const settings = context.settings;
     return artifacts.requestFirstCPUIdle({trace, devtoolsLog, settings}).then(firstInteractive => {
-      // @ts-ignore - see above TODO.
-      const ttiTimestamp = firstInteractive.timestamp / 1000000;
+      // The filter below is just to be extra safe that we exclude images that were loaded post-TTI.
+      // If we're in the Lantern case though, we just have to rely on the graph simulation doing the
+      // right thing.
+      const ttiTimestamp = firstInteractive.timestamp ? firstInteractive.timestamp / 1e6 : Infinity;
+
       const results = Array.from(resultsMap.values()).filter(item => {
         const isWasteful =
           item.wastedBytes > IGNORE_THRESHOLD_IN_BYTES &&

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -22,7 +22,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
   static get meta() {
     return {
       name: 'uses-optimized-images',
-      description: 'Optimize images',
+      description: 'Efficiently encode images',
       informative: true,
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
       helpText: 'Optimized images load faster and consume less cellular data. ' +

--- a/lighthouse-core/audits/font-display.js
+++ b/lighthouse-core/audits/font-display.js
@@ -17,7 +17,7 @@ class FontDisplay extends Audit {
     return {
       name: 'font-display',
       description: 'All text remains visible during webfont loads',
-      failureDescription: 'Avoid invisible text while webfonts are loading',
+      failureDescription: 'Text is invisible while webfonts are loading',
       helpText: 'Leverage the font-display CSS feature to ensure text is user-visible while ' +
         'webfonts are loading. ' +
         '[Learn more](https://developers.google.com/web/updates/2016/02/font-display).',

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -16,8 +16,7 @@ class Redirects extends Audit {
   static get meta() {
     return {
       name: 'redirects',
-      description: 'Avoids page redirects',
-      failureDescription: 'Has multiple page redirects',
+      description: 'Avoid multiple page redirects',
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       helpText: 'Redirects introduce additional delays before the page can be loaded. [Learn more](https://developers.google.com/speed/docs/insights/AvoidRedirects).',
       requiredArtifacts: ['URL', 'devtoolsLogs', 'traces'],

--- a/lighthouse-core/lib/dependency-graph/node.js
+++ b/lighthouse-core/lib/dependency-graph/node.js
@@ -122,7 +122,7 @@ class Node {
    * Clones the entire graph connected to this node filtered by the optional predicate. If a node is
    * included by the predicate, all nodes along the paths between the two will be included. If the
    * node that was called clone is not included in the resulting filtered graph, the method will throw.
-   * @param {function(Node):boolean=} predicate
+   * @param {function(Node):boolean} [predicate]
    * @return {Node}
    */
   cloneWithRelationships(predicate) {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -636,7 +636,7 @@
       },
       "scoreDisplayMode": "numeric",
       "name": "redirects",
-      "description": "Avoids page redirects",
+      "description": "Avoid multiple page redirects",
       "helpText": "Redirects introduce additional delays before the page can be loaded. [Learn more](https://developers.google.com/speed/docs/insights/AvoidRedirects).",
       "details": {
         "type": "table",
@@ -2843,8 +2843,8 @@
       "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "offscreen-images",
-      "description": "Offscreen images",
-      "helpText": "Consider lazy-loading offscreen and hidden images to improve page load speed and time to interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images).",
+      "description": "Defer offscreen images",
+      "helpText": "Consider lazy-loading offscreen and hidden images after all critical resources have finished loading to lower time to interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images).",
       "details": {
         "type": "table",
         "headings": [],
@@ -3111,7 +3111,7 @@
       "scoreDisplayMode": "numeric",
       "informative": true,
       "name": "uses-optimized-images",
-      "description": "Optimize images",
+      "description": "Efficiently encode images",
       "helpText": "Optimized images load faster and consume less cellular data. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/optimize-images).",
       "details": {
         "type": "table",
@@ -5240,8 +5240,5 @@
       "title": "Additional items to manually check",
       "description": "Run these additional validators on your site to check additional SEO best practices."
     }
-  },
-  "timing": {
-    "total": 667
   }
 }

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -314,6 +314,7 @@ declare global {
 
       export interface LanternMetric {
         timing: number;
+        timestamp?: never;
         optimisticEstimate: Gatherer.Simulation.Result
         pessimisticEstimate: Gatherer.Simulation.Result;
         optimisticGraph: Gatherer.Simulation.GraphNode;

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -7,6 +7,7 @@
 import * as _Node from '../lighthouse-core/lib/dependency-graph/node';
 import * as _NetworkNode from '../lighthouse-core/lib/dependency-graph/network-node';
 import * as _CPUNode from '../lighthouse-core/lib/dependency-graph/cpu-node';
+import * as _Simulator from '../lighthouse-core/lib/dependency-graph/simulator/simulator';
 import * as Driver from '../lighthouse-core/gather/driver';
 
 declare global {
@@ -31,6 +32,7 @@ declare global {
       export type GraphNode = InstanceType<typeof _Node>;
       export type GraphNetworkNode = InstanceType<typeof _NetworkNode>;
       export type GraphCPUNode = InstanceType<typeof _CPUNode>;
+      export type Simulator = InstanceType<typeof _Simulator>;
 
       export interface MetricCoefficients {
         intercept: number;


### PR DESCRIPTION
closes #5017 

byte efficiency audits will now take max savings on TTI/load
I had to address offscreen images at the same time otherwise they'd start way over-reporting

also contains some drive-by consistency text changes I noticed while testing, opportunity audits are actions for the user to take