### PR TITLE
core(scoring): loosen metric thresholds

### DIFF
--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,10 +1,10 @@
 # Goal
 The goal of this document is to explain how scoring works in Lighthouse and what to do to improve your Lighthouse scores across the four sections of the report.
 
-Note 1: if you want a **nice spreadsheet** version of this doc to understand weighting and scoring, check out the [scoring spreadsheet](https://docs.google.com/spreadsheets/d/1dXH-bXX3gxqqpD1f7rp6ImSOhobsT1gn_GQ2fGZp8UU/edit?ts=59fb61d2#gid=0)
+Note 1: if you want a **nice spreadsheet** version of this doc to understand weighting and scoring, check out the [scoring spreadsheet](https://docs.google.com/spreadsheets/d/1Cxzhy5ecqJCucdf1M0iOzM8mIxNc7mmx107o5nj38Eo/edit#gid=0)
 
 ![alt text](https://user-images.githubusercontent.com/39191/32397461-2d20c87a-c0a7-11e7-99d8-61576113a710.png)
-*Screenshot of the [scoring spreadsheet](https://docs.google.com/spreadsheets/d/1dXH-bXX3gxqqpD1f7rp6ImSOhobsT1gn_GQ2fGZp8UU/edit?ts=59fb61d2#gid=0)*
+*Screenshot of the [scoring spreadsheet](https://docs.google.com/spreadsheets/d/1Cxzhy5ecqJCucdf1M0iOzM8mIxNc7mmx107o5nj38Eo/edit#gid=0)*
 
 Note 2: if you receive a **score of 0** in any Lighthouse category, that usually indicates an error on our part. Please file an [issue](https://github.com/GoogleChrome/lighthouse/issues) so our team can look into it.
 
@@ -58,7 +58,7 @@ The PWA score is calculated based on the [Baseline PWA checklist](https://develo
 
 # Accessibility
 ### How is the accessibility score calculated?
-The accessibility score is a weighted average of all the different audits (the weights for each audit can be found in [the scoring spreadsheet](https://docs.google.com/spreadsheets/d/1dXH-bXX3gxqqpD1f7rp6ImSOhobsT1gn_GQ2fGZp8UU/edit?ts=59fb61d2#gid=0)). Each audit is a pass/fail (meaning there is no room for partial points for getting an audit half-right). For example, that means if half your buttons have screenreader friendly names, and half don't, you don't get "half" of the weighted average-you get a 0 because it needs to be implemented *throughout* the page.
+The accessibility score is a weighted average of all the different audits (the weights for each audit can be found in [the scoring spreadsheet](https://docs.google.com/spreadsheets/d/1Cxzhy5ecqJCucdf1M0iOzM8mIxNc7mmx107o5nj38Eo/edit#gid=0)). Each audit is a pass/fail (meaning there is no room for partial points for getting an audit half-right). For example, that means if half your buttons have screenreader friendly names, and half don't, you don't get "half" of the weighted average-you get a 0 because it needs to be implemented *throughout* the page.
 
 # Best Practices
 ### How is the Best Practices score calculated?

--- a/lighthouse-core/audits/first-contentful-paint.js
+++ b/lighthouse-core/audits/first-contentful-paint.js
@@ -28,10 +28,10 @@ class FirstContentfulPaint extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // 75th and 95th percentiles HTTPArchive -> median and PODR
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-      // see https://www.desmos.com/calculator/trv2goqvsd
-      scorePODR: 1400,
+      // see https://www.desmos.com/calculator/2t1ugwykrl
+      scorePODR: 2900,
       scoreMedian: 4000,
     };
   }

--- a/lighthouse-core/audits/first-cpu-idle.js
+++ b/lighthouse-core/audits/first-cpu-idle.js
@@ -29,10 +29,10 @@ class FirstCPUIdle extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // 75th and 95th percentiles HTTPArchive -> median and PODR
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-      // see https://www.desmos.com/calculator/cwuavnclzj
-      scorePODR: 1400,
+      // see https://www.desmos.com/calculator/yv89gz2nwf
+      scorePODR: 2900,
       scoreMedian: 6500,
     };
   }

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -28,10 +28,10 @@ class FirstMeaningfulPaint extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // 75th and 95th percentiles HTTPArchive -> median and PODR
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-      // see https://www.desmos.com/calculator/trv2goqvsd
-      scorePODR: 1400,
+      // see https://www.desmos.com/calculator/2t1ugwykrl
+      scorePODR: 2000,
       scoreMedian: 4000,
     };
   }

--- a/lighthouse-core/audits/interactive.js
+++ b/lighthouse-core/audits/interactive.js
@@ -34,10 +34,10 @@ class InteractiveMetric extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // 75th and 95th percentiles HTTPArchive -> median and PODR
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-      // see https://www.desmos.com/calculator/dohd3b0sbr
-      scorePODR: 1200,
+      // see https://www.desmos.com/calculator/5xgy0pyrbp
+      scorePODR: 2900,
       scoreMedian: 7300,
     };
   }

--- a/lighthouse-core/audits/speed-index.js
+++ b/lighthouse-core/audits/speed-index.js
@@ -28,10 +28,10 @@ class SpeedIndex extends Audit {
    */
   static get defaultOptions() {
     return {
-      // 75th and 90th percentiles HTTPArchive -> 50 and 75
+      // 75th and 95th percentiles HTTPArchive -> median and PODR
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
-      // see https://www.desmos.com/calculator/y1bg8ij7ti
-      scorePODR: 1700,
+      // see https://www.desmos.com/calculator/orvoyu9ygq
+      scorePODR: 2900,
       scoreMedian: 5800,
     };
   }

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -38,7 +38,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     const context = {options, settings: {throttlingMethod: 'simulate'}};
     const fmpResult = await FMPAudit.audit(artifacts, context);
 
-    assert.equal(fmpResult.score, 0.73);
+    assert.equal(fmpResult.score, 0.79);
     assert.equal(fmpResult.displayValue, '2,850\xa0ms');
     assert.equal(Math.round(fmpResult.rawValue), 2851);
   });

--- a/lighthouse-core/test/audits/interactive-test.js
+++ b/lighthouse-core/test/audits/interactive-test.js
@@ -31,7 +31,7 @@ describe('Performance: interactive audit', () => {
 
     const settings = {throttlingMethod: 'provided'};
     return Interactive.audit(artifacts, {options, settings}).then(output => {
-      assert.equal(output.score, 0.97);
+      assert.equal(output.score, 1);
       assert.equal(Math.round(output.rawValue), 1582);
       assert.equal(output.displayValue, '1,580\xa0ms');
     });
@@ -49,7 +49,7 @@ describe('Performance: interactive audit', () => {
 
     const settings = {throttlingMethod: 'provided'};
     return Interactive.audit(artifacts, {options, settings}).then(output => {
-      assert.equal(output.score, 0.89);
+      assert.equal(output.score, 0.97);
       assert.equal(Math.round(output.rawValue), 2712);
       assert.equal(output.displayValue, '2,710\xa0ms');
     });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -112,7 +112,7 @@
       "helpText": "A fast page load over a 3G network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g)."
     },
     "speed-index": {
-      "score": 0.67,
+      "score": 0.74,
       "displayValue": "4,420 ms",
       "rawValue": 4417,
       "scoreDisplayMode": "numeric",
@@ -267,7 +267,7 @@
       }
     },
     "first-cpu-idle": {
-      "score": 0.65,
+      "score": 0.72,
       "displayValue": "4,930 ms",
       "rawValue": 4927.278,
       "scoreDisplayMode": "numeric",
@@ -276,7 +276,7 @@
       "helpText": "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-interactive)."
     },
     "interactive": {
-      "score": 0.69,
+      "score": 0.78,
       "displayValue": "4,930 ms",
       "rawValue": 4927.278,
       "extendedInfo": {
@@ -4723,7 +4723,7 @@
         }
       ],
       "id": "performance",
-      "score": 0.63
+      "score": 0.69
     },
     {
       "name": "Progressive Web App",


### PR DESCRIPTION
As we just discussed, the new scoring thresholds based on 50/75 were making the requirements for 99/100 too unachievable. The root issue was that our PODR was not considered with our policy. The new policy instead...

Median === 75th percentile
PODR = 95th percentile

This makes a 100 roughly equal to the 98th percentile and keeps the green/orange boundary of 75 to the ~87th percentile which is pretty close to our old policy. Checkout the new scoring calculator sheet https://docs.google.com/spreadsheets/d/1Cxzhy5ecqJCucdf1M0iOzM8mIxNc7mmx107o5nj38Eo/edit#gid=0 to play around with the values.
