### PR TITLE
core(tsc): add type checking for seo audits

### DIFF
--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -43,10 +43,10 @@ function getUniqueFailingRules(fontSizeArtifact) {
 }
 
 /**
- * @param {Array<string>} attributes
+ * @param {Array<string>=} attributes
  * @returns {Map<string, string>}
  */
-function getAttributeMap(attributes) {
+function getAttributeMap(attributes = []) {
   const map = new Map();
 
   for (let i = 0; i < attributes.length; i += 2) {
@@ -86,7 +86,8 @@ function getSelector(node) {
  * @return {{type: 'node', selector: string, snippet: string}}
  */
 function nodeToTableNode(node) {
-  const attributesString = node.attributes.map((value, idx) =>
+  const attributes = node.attributes || [];
+  const attributesString = attributes.map((value, idx) =>
     (idx % 2 === 0) ? ` ${value}` : `="${value}"`
   ).join('');
 

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -5,17 +5,22 @@
  */
 'use strict';
 
+/** @typedef {LH.Artifacts.FontSize['analyzedFailingNodesData'][0]} FailingNodeData */
+/** @typedef {{Type: {Regular: 'Regular', Inline: 'Inline', Attributes: 'Attributes'}}} WebInspectorCSSStyle */
+
 const URL = require('../../lib/url-shim');
 const Audit = require('../audit');
 const ViewportAudit = require('../viewport');
-const CSSStyleDeclaration = require('../../lib/web-inspector').CSSStyleDeclaration;
+const WebInspector = require('../../lib/web-inspector');
+const CSSStyleDeclaration = /** @type {WebInspectorCSSStyle} */ (WebInspector.CSSStyleDeclaration);
 const MINIMAL_PERCENTAGE_OF_LEGIBLE_TEXT = 60;
 
 /**
- * @param {Array<{cssRule: SimplifiedStyleDeclaration, fontSize: number, textLength: number, node: Node}>} fontSizeArtifact
- * @returns {Array<{cssRule: SimplifiedStyleDeclaration, fontSize: number, textLength: number, node: Node}>}
+ * @param {Array<FailingNodeData>} fontSizeArtifact
+ * @returns {Array<FailingNodeData>}
  */
 function getUniqueFailingRules(fontSizeArtifact) {
+  /** @type {Map<string, FailingNodeData>} */
   const failingRules = new Map();
 
   fontSizeArtifact.forEach(({cssRule, fontSize, textLength, node}) => {
@@ -34,7 +39,7 @@ function getUniqueFailingRules(fontSizeArtifact) {
     }
   });
 
-  return failingRules.valuesArray();
+  return [...failingRules.values()];
 }
 
 /**
@@ -44,7 +49,7 @@ function getUniqueFailingRules(fontSizeArtifact) {
 function getAttributeMap(attributes) {
   const map = new Map();
 
-  for (let i=0; i<attributes.length; i+=2) {
+  for (let i = 0; i < attributes.length; i += 2) {
     const name = attributes[i].toLowerCase();
     const value = attributes[i + 1].trim();
 
@@ -58,7 +63,7 @@ function getAttributeMap(attributes) {
 
 /**
  * TODO: return unique selector, like axe-core does, instead of just id/class/name of a single node
- * @param {Node} node
+ * @param {FailingNodeData['node']} node
  * @returns {string}
  */
 function getSelector(node) {
@@ -66,16 +71,19 @@ function getSelector(node) {
 
   if (attributeMap.has('id')) {
     return '#' + attributeMap.get('id');
-  } else if (attributeMap.has('class')) {
-    return '.' + attributeMap.get('class').split(/\s+/).join('.');
+  } else {
+    const attrClass = attributeMap.get('class');
+    if (attrClass) {
+      return '.' + attrClass.split(/\s+/).join('.');
+    }
   }
 
   return node.localName.toLowerCase();
 }
 
 /**
- * @param {Node} node
- * @return {{type:string, selector: string, snippet:string}}
+ * @param {FailingNodeData['node']} node
+ * @return {{type: 'node', selector: string, snippet: string}}
  */
 function nodeToTableNode(node) {
   const attributesString = node.attributes.map((value, idx) =>
@@ -91,9 +99,9 @@ function nodeToTableNode(node) {
 
 /**
  * @param {string} baseURL
- * @param {SimplifiedStyleDeclaration} styleDeclaration
- * @param {Node} node
- * @returns {{source:!string, selector:string|object}}
+ * @param {FailingNodeData['cssRule']} styleDeclaration
+ * @param {FailingNodeData['node']} node
+ * @returns {{source: string, selector: string | {type: 'node', selector: string, snippet: string}}}
  */
 function findStyleRuleSource(baseURL, styleDeclaration, node) {
   if (
@@ -102,13 +110,13 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
     styleDeclaration.type === CSSStyleDeclaration.Type.Inline
   ) {
     return {
-      source: baseURL,
       selector: nodeToTableNode(node),
+      source: baseURL,
     };
   }
 
   if (styleDeclaration.parentRule &&
-    styleDeclaration.parentRule.origin === global.CSSAgent.StyleSheetOrigin.USER_AGENT) {
+    styleDeclaration.parentRule.origin === 'user-agent') {
     return {
       selector: styleDeclaration.parentRule.selectors.map(item => item.text).join(', '),
       source: 'User Agent Stylesheet',
@@ -149,14 +157,15 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
   }
 
   return {
+    selector: '',
     source: 'Unknown',
   };
 }
 
 /**
- * @param {SimplifiedStyleDeclaration} styleDeclaration
- * @param {Node} node
- * @return string
+ * @param {FailingNodeData['cssRule']} styleDeclaration
+ * @param {FailingNodeData['node']} node
+ * @return {string}
  */
 function getFontArtifactId(styleDeclaration, node) {
   if (styleDeclaration && styleDeclaration.type === CSSStyleDeclaration.Type.Regular) {
@@ -170,7 +179,7 @@ function getFontArtifactId(styleDeclaration, node) {
 
 class FontSize extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -185,8 +194,8 @@ class FontSize extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const hasViewportSet = ViewportAudit.audit(artifacts).rawValue;

--- a/lighthouse-core/audits/seo/http-status-code.js
+++ b/lighthouse-core/audits/seo/http-status-code.js
@@ -11,7 +11,7 @@ const HTTP_UNSUCCESSFUL_CODE_HIGH = 599;
 
 class HTTPStatusCode extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -26,8 +26,8 @@ class HTTPStatusCode extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {Promise<LH.Audit.Product>}
    */
   static audit(artifacts) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];

--- a/lighthouse-core/audits/seo/is-crawlable.js
+++ b/lighthouse-core/audits/seo/is-crawlable.js
@@ -58,7 +58,7 @@ function hasUserAgent(directives) {
 
 class IsCrawlable extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -73,14 +73,15 @@ class IsCrawlable extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {Promise<LH.Audit.Product>}
    */
   static audit(artifacts) {
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
 
     return artifacts.requestMainResource({devtoolsLog, URL: artifacts.URL})
       .then(mainResource => {
+        /** @type {Array<Object<string, LH.Audit.DetailsItem>>} */
         const blockingDirectives = [];
 
         if (artifacts.MetaRobots) {
@@ -89,14 +90,14 @@ class IsCrawlable extends Audit {
           if (isBlocking) {
             blockingDirectives.push({
               source: {
-                type: 'node',
+                type: /** @type {'node'} */ ('node'),
                 snippet: `<meta name="robots" content="${artifacts.MetaRobots}" />`,
               },
             });
           }
         }
 
-        mainResource.responseHeaders
+        mainResource._responseHeaders && mainResource._responseHeaders
           .filter(h => h.name.toLowerCase() === ROBOTS_HEADER && !hasUserAgent(h.value) &&
             hasBlockingDirective(h.value))
           .forEach(h => blockingDirectives.push({source: `${h.name}: ${h.value}`}));
@@ -108,7 +109,7 @@ class IsCrawlable extends Audit {
           if (!robotsTxt.isAllowed(mainResource.url)) {
             blockingDirectives.push({
               source: {
-                type: 'url',
+                type: /** @type {'url'} */ ('url'),
                 value: robotsFileUrl.href,
               },
             });

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -21,11 +21,10 @@ const BLOCKLIST = new Set([
 
 class LinkText extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
-      category: 'Content Best Practices',
       name: 'link-text',
       description: 'Links have descriptive text',
       failureDescription: 'Links do not have descriptive text',
@@ -36,8 +35,8 @@ class LinkText extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const failingLinks = artifacts.CrawlableLinks

--- a/lighthouse-core/audits/seo/meta-description.js
+++ b/lighthouse-core/audits/seo/meta-description.js
@@ -9,7 +9,7 @@ const Audit = require('../audit');
 
 class Description extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -24,8 +24,8 @@ class Description extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     if (artifacts.MetaDescription === null) {

--- a/lighthouse-core/audits/seo/plugins.js
+++ b/lighthouse-core/audits/seo/plugins.js
@@ -35,6 +35,7 @@ const SOURCE_PARAMS = new Set([
 /**
  * Verifies if given MIME type matches any known plugin MIME type
  * @param {string} type
+ * @return {boolean}
  */
 function isPluginType(type) {
   type = type.trim().toLowerCase();
@@ -47,6 +48,7 @@ function isPluginType(type) {
 /**
  * Verifies if given url points to a file that has a known plugin extension
  * @param {string} url
+ * @return {boolean}
  */
 function isPluginURL(url) {
   try {
@@ -54,7 +56,11 @@ function isPluginURL(url) {
     const filePath = new URL(url, 'http://example.com').pathname;
     const parts = filePath.split('.');
 
-    return parts.length > 1 && FILE_EXTENSION_BLOCKLIST.has(parts.pop().trim().toLowerCase());
+    if (parts.length < 2) {
+      return false;
+    }
+    const part = /** @type {string} */(parts.pop());
+    return FILE_EXTENSION_BLOCKLIST.has(part.trim().toLowerCase());
   } catch (e) {
     return false;
   }
@@ -62,7 +68,7 @@ function isPluginURL(url) {
 
 class Plugins extends Audit {
   /**
-   * @return {!AuditMeta}
+   * @return {LH.Audit.Meta}
    */
   static get meta() {
     return {
@@ -77,8 +83,8 @@ class Plugins extends Audit {
   }
 
   /**
-   * @param {!Artifacts} artifacts
-   * @return {!AuditResult}
+   * @param {LH.Artifacts} artifacts
+   * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
     const plugins = artifacts.EmbeddedContent
@@ -112,7 +118,9 @@ class Plugins extends Audit {
       })
       .map(plugin => {
         const tagName = plugin.tagName.toLowerCase();
-        const attributes = ['src', 'data', 'code', 'type']
+        /** @type {Array<keyof LH.Artifacts.EmbeddedContentInfo>} */
+        const attributeKeys = ['src', 'data', 'code', 'type'];
+        const attributes = attributeKeys
           .reduce((result, attr) => {
             if (plugin[attr] !== null) {
               result += ` ${attr}="${plugin[attr]}"`;
@@ -126,7 +134,7 @@ class Plugins extends Audit {
 
         return {
           source: {
-            type: 'node',
+            type: /** @type {'node'} */ ('node'),
             snippet: `<${tagName}${attributes}>${params}</${tagName}>`,
           },
         };

--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -152,7 +152,7 @@ function isNonEmptyTextNode(node) {
 class FontSize extends Gatherer {
   /**
    * @param {LH.Gatherer.PassContext} passContext
-   * @return {!Promise<{totalTextLength: number, failingTextLength: number, visitedTextLength: number, analyzedFailingTextLength: number, analyzedFailingNodesData: Array<{fontSize: number, textLength: number, node: Node, cssRule: SimplifiedStyleDeclaration}>}>} font-size analysis
+   * @return {Promise<LH.Artifacts.FontSize>} font-size analysis
    */
   afterPass(passContext) {
     /** @type {Map<string, LH.Crdp.CSS.CSSStyleSheetHeader>} */

--- a/lighthouse-core/test/audits/seo/canonical-test.js
+++ b/lighthouse-core/test/audits/seo/canonical-test.js
@@ -14,7 +14,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('succeeds when there are no canonical links', () => {
     const mainResource = {
       url: 'https://example.com/',
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
@@ -31,7 +31,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('fails when there are multiple canonical links', () => {
     const mainResource = {
       url: 'http://www.example.com/',
-      responseHeaders: [{
+      _responseHeaders: [{
         name: 'Link',
         value: '<https://example.com>; rel="canonical"',
       }],
@@ -52,7 +52,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('fails when canonical url is invalid', () => {
     const mainResource = {
       url: 'http://www.example.com',
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
@@ -70,7 +70,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('fails when canonical url is relative', () => {
     const mainResource = {
       url: 'https://example.com/de/',
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
@@ -88,7 +88,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('fails when canonical points to a different hreflang', () => {
     const mainResource = {
       url: 'https://example.com',
-      responseHeaders: [{
+      _responseHeaders: [{
         name: 'Link',
         value: '<https://example.com/>; rel="alternate"; hreflang="xx"',
       }],
@@ -109,7 +109,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('fails when canonical points to a different domain', () => {
     const mainResource = {
       url: 'http://localhost.test',
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
@@ -127,7 +127,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('fails when canonical points to the root while current URL is not the root', () => {
     const mainResource = {
       url: 'https://example.com/articles/cats-and-you',
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
@@ -145,7 +145,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('succeeds when there are multiple identical canonical links', () => {
     const mainResource = {
       url: 'http://www.example.com/',
-      responseHeaders: [{
+      _responseHeaders: [{
         name: 'Link',
         value: '<https://www.example.com>; rel="canonical"',
       }],
@@ -165,7 +165,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('succeeds when valid canonical is provided via meta tag', () => {
     const mainResource = {
       url: 'http://example.com/articles/cats-and-you?utm_source=twitter',
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
@@ -182,7 +182,7 @@ describe('SEO: Document has valid canonical link', () => {
   it('succeeds when valid canonical is provided via header', () => {
     const mainResource = {
       url: 'http://example.com/articles/cats-and-you?utm_source=twitter',
-      responseHeaders: [{
+      _responseHeaders: [{
         name: 'Link',
         value: '<http://example.com/articles/cats-and-you>; rel="canonical"',
       }],

--- a/lighthouse-core/test/audits/seo/hreflang-test.js
+++ b/lighthouse-core/test/audits/seo/hreflang-test.js
@@ -22,7 +22,7 @@ describe('SEO: Document has valid hreflang code', () => {
 
     const allRuns = hreflangValues.map(hreflangValue => {
       const mainResource = {
-        responseHeaders: [],
+        _responseHeaders: [],
       };
       const artifacts = {
         devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
@@ -44,7 +44,7 @@ describe('SEO: Document has valid hreflang code', () => {
 
   it('succeeds when language code provided via link element is valid', () => {
     const mainResource = {
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
@@ -65,7 +65,7 @@ describe('SEO: Document has valid hreflang code', () => {
 
   it('succeeds when there are no rel=alternate link elements nor headers', () => {
     const mainResource = {
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
@@ -100,7 +100,7 @@ describe('SEO: Document has valid hreflang code', () => {
 
     const allRuns = linkHeaders.map(headers => {
       const mainResource = {
-        responseHeaders: headers,
+        _responseHeaders: headers,
       };
       const artifacts = {
         devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
@@ -119,7 +119,7 @@ describe('SEO: Document has valid hreflang code', () => {
 
   it('succeeds when language codes provided via Link header are valid', () => {
     const mainResource = {
-      responseHeaders: [
+      _responseHeaders: [
         {name: 'link', value: ''},
         {name: 'link', value: 'garbage'},
         {name: 'link', value: '<http://es.example.com/>; rel="example"; hreflang="xx"'},
@@ -141,7 +141,7 @@ describe('SEO: Document has valid hreflang code', () => {
 
   it('returns all failing items', () => {
     const mainResource = {
-      responseHeaders: [
+      _responseHeaders: [
         {name: 'link', value: '<http://xx1.example.com/>; rel="alternate"; hreflang="xx1"'},
         {name: 'Link', value: '<http://xx2.example.com/>; rel="alternate"; hreflang="xx2"'},
       ],

--- a/lighthouse-core/test/audits/seo/is-crawlable-test.js
+++ b/lighthouse-core/test/audits/seo/is-crawlable-test.js
@@ -24,7 +24,7 @@ describe('SEO: Is page crawlable audit', () => {
 
     const allRuns = robotsValues.map(robotsValue => {
       const mainResource = {
-        responseHeaders: [],
+        _responseHeaders: [],
       };
       const artifacts = {
         devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
@@ -44,7 +44,7 @@ describe('SEO: Is page crawlable audit', () => {
 
   it('succeeds when there are no blocking directives in the metatag', () => {
     const mainResource = {
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
@@ -60,7 +60,7 @@ describe('SEO: Is page crawlable audit', () => {
 
   it('succeeds when there is no robots metatag', () => {
     const mainResource = {
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
@@ -99,7 +99,7 @@ describe('SEO: Is page crawlable audit', () => {
 
     const allRuns = robotsHeaders.map(headers => {
       const mainResource = {
-        responseHeaders: headers,
+        _responseHeaders: headers,
       };
       const artifacts = {
         devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
@@ -119,7 +119,7 @@ describe('SEO: Is page crawlable audit', () => {
 
   it('succeeds when there are no blocking directives in the robots header', () => {
     const mainResource = {
-      responseHeaders: [
+      _responseHeaders: [
         {name: 'X-Robots-Tag', value: 'all, nofollow'},
         {name: 'X-Robots-Tag', value: 'unavailable_after: 25 Jun 2045 15:00:00 PST'},
       ],
@@ -138,7 +138,7 @@ describe('SEO: Is page crawlable audit', () => {
 
   it('succeeds when there is no robots header and robots.txt is unavailable', () => {
     const mainResource = {
-      responseHeaders: [],
+      _responseHeaders: [],
     };
     const artifacts = {
       devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
@@ -154,7 +154,7 @@ describe('SEO: Is page crawlable audit', () => {
 
   it('ignores UA specific directives', () => {
     const mainResource = {
-      responseHeaders: [
+      _responseHeaders: [
         {name: 'x-robots-tag', value: 'googlebot: unavailable_after: 25 Jun 2007 15:00:00 PST'},
         {name: 'x-robots-tag', value: 'unavailable_after: 25 Jun 2045 15:00:00 PST'},
       ],
@@ -202,7 +202,7 @@ describe('SEO: Is page crawlable audit', () => {
     const allRuns = robotsTxts.map(robotsTxt => {
       const mainResource = {
         url: 'http://example.com/test/page.html',
-        responseHeaders: [],
+        _responseHeaders: [],
       };
       const artifacts = {
         devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
@@ -238,7 +238,7 @@ describe('SEO: Is page crawlable audit', () => {
     const allRuns = robotsTxts.map(robotsTxt => {
       const mainResource = {
         url: 'http://example.com/test/page.html',
-        responseHeaders: [],
+        _responseHeaders: [],
       };
       const artifacts = {
         devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
@@ -258,7 +258,7 @@ describe('SEO: Is page crawlable audit', () => {
   it('returns all failing items', () => {
     const mainResource = {
       url: 'http://example.com/test/page.html',
-      responseHeaders: [
+      _responseHeaders: [
         {name: 'x-robots-tag', value: 'none'},
         {name: 'x-robots-tag', value: 'noindex'},
       ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,20 +16,14 @@
   },
   "include": [
     "lighthouse-cli/**/*.js",
-    "lighthouse-core/audits/*.js",
-    "lighthouse-core/audits/accessibility/**/*.js",
-    "lighthouse-core/audits/dobetterweb/**/*.js",
-    "lighthouse-core/audits/byte-efficiency/**/*.js",
-    "lighthouse-core/audits/manual/**/*.js",
-    "lighthouse-core/audits/seo/manual/*.js",
-    "lighthouse-core/audits/seo/robots-txt.js",
-    "lighthouse-core/lib/dependency-graph/**/*.js",
-    "lighthouse-core/lib/emulation.js",
-    "lighthouse-core/gather/**/*.js",
-    "lighthouse-core/scripts/*.js",
+    "lighthouse-core/**/*.js",
     "./typings/*.d.ts"
   ],
   "exclude": [
-    "lighthouse-cli/test/**/*.js"
+    "lighthouse-cli/test/**/*.js",
+    "lighthouse-core/test/**/*.js",
+    "lighthouse-core/closure/**/*.js",
+    "lighthouse-core/third_party/src/**/*.js",
+    "lighthouse-core/report/html/renderer/**/*.js",
   ]
 }

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -182,24 +182,25 @@ declare global {
         failingTextLength: number;
         visitedTextLength: number;
         analyzedFailingTextLength: number;
-        analyzedFailingNodesData: {
+        analyzedFailingNodesData: Array<{
           fontSize: number;
           textLength: number;
           node: FontSize.DomNodeWithParent;
           cssRule: {
-            type: string;
+            type: 'Regular' | 'Inline' | 'Attributes';
             range: {startLine: number, startColumn: number};
-            parentRule: {origin: string, selectors: {text: string}[]};
+            parentRule: {origin: Crdp.CSS.StyleSheetOrigin, selectors: {text: string}[]};
             styleSheetId: string;
             stylesheet: Crdp.CSS.CSSStyleSheetHeader;
           }
-        }
+        }>
       }
 
       export module FontSize {
         export interface DomNodeWithParent extends Crdp.DOM.Node {
           parentId: number;
           parentNode: DomNodeWithParent;
+          attributes: Array<string>;
         }
       }
 

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -200,7 +200,6 @@ declare global {
         export interface DomNodeWithParent extends Crdp.DOM.Node {
           parentId: number;
           parentNode: DomNodeWithParent;
-          attributes: Array<string>;
         }
       }
 

--- a/typings/audit.d.ts
+++ b/typings/audit.d.ts
@@ -77,7 +77,7 @@ declare global {
 
     export type DetailsItem = string | number | DetailsRendererNodeDetailsJSON |
       DetailsRendererLinkDetailsJSON | DetailsRendererCodeDetailJSON | undefined |
-      boolean;
+      boolean | DetailsRendererUrlDetailsJSON;
 
     export interface DetailsRendererNodeDetailsJSON {
       type: 'node';
@@ -90,6 +90,11 @@ declare global {
       type: 'link';
       text: string;
       url: string;
+    }
+
+    export interface DetailsRendererUrlDetailsJSON {
+      type: 'url';
+      value: string;
     }
 
     // Type returned by Audit.audit(). Only rawValue is required.

--- a/typings/http-link-header/index.d.ts
+++ b/typings/http-link-header/index.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+declare module 'http-link-header' {
+  export interface Reference {
+    uri: string;
+    rel: string;
+    [index: string]: string;
+  }
+  export interface Link {
+      refs: Reference[];
+      has(attribute: string, value: string): boolean;
+      get(attribute: string, value: string): Array<Reference>;
+      rel(value: string): Reference;
+      set(ref: Reference): Reference;
+  }
+  export function parse(header: string): Link;
+}

--- a/typings/robots-parser/index.d.ts
+++ b/typings/robots-parser/index.d.ts
@@ -1,0 +1,20 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+declare module 'robots-parser' {
+  interface Robots {
+    isAllowed(url: string, ua?: string): boolean | undefined;
+    isDisallowed(url: string, ua?: string): boolean | undefined;
+    getMatchingLineNumber(url: string, ua?: string): number | undefined;
+    getCrawlDelay(ua?: string): number | undefined;
+    getSitemaps(): Array<string>;
+    getPreferredHost(): string | null;
+  }
+
+  function RobotsParser(url: string, robotsTxt: string): Robots;
+
+  export = RobotsParser;
+}


### PR DESCRIPTION
with this, all of `lighthouse-core/**/*.js` is type checked :) (with carve outs for tests and the html renderer, for now).

The only remaining files this adds are these seo audits and the all-important `empty-stub.js` (which turns out was already type safe! Good job `empty-stub`).