### PR TITLE
tests: node 10 compat

### DIFF
--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -235,7 +235,7 @@ describe('Config', () => {
           ],
         },
       },
-    }), 'missing an audit id at pwa[0]');
+    }), /missing an audit id at pwa\[0\]/);
   });
 
   it('throws when an accessibility audit does not have a group', () => {


### PR DESCRIPTION
avoids this terribly useless error message:
![image](https://user-images.githubusercontent.com/39191/39606612-1d4680c0-4eeb-11e8-9ebe-3d98864e4353.png)
