### PR TITLE
core(tsc): fancier displayValue type

### DIFF
--- a/typings/audit.d.ts
+++ b/typings/audit.d.ts
@@ -23,7 +23,11 @@ declare global {
 
     export type ScoringModeValue = Audit.ScoringModes[keyof Audit.ScoringModes];
 
-    export type DisplayValue = string | Array<string|number>;
+    interface DisplayValueArray extends Array<string|number> {
+      0: string;
+    }
+
+    export type DisplayValue = string | DisplayValueArray;
 
     export interface Meta {
       name: string;


### PR DESCRIPTION
tsc wasn't inferring the correct type for displayValue in #5099 (widening it to just `Array<string | number>` which doesn't fit our requirement that the first element always be a string). It turns out this was because it was losing track of the more specific array type when passing back up the promise chain.

Flattening execution a bit with async/await and it can track the more specific type again :)

Diff is relatively tiny if you look at [?w=1](https://github.com/GoogleChrome/lighthouse/pull/5111/files?w=1)