### PR TITLE
core(tsc): fix ImageUsage artifact type and gather bug

### DIFF
--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -110,12 +110,18 @@ module.exports = [
         },
       },
       'uses-responsive-images': {
+        displayValue: [
+          'Potential savings of %d\xa0KB',
+          75,
+        ],
         extendedInfo: {
           value: {
             wastedKb: '>50',
-            results: {
-              length: 3,
-            },
+            results: [
+              {wastedPercent: '<60'},
+              {wastedPercent: '<60'},
+              {wastedPercent: '<60'},
+            ]
           },
         },
       },

--- a/lighthouse-core/audits/image-aspect-ratio.js
+++ b/lighthouse-core/audits/image-aspect-ratio.js
@@ -9,13 +9,14 @@
  *   audit will list all images that don't match with their display size
  *   aspect ratio.
  */
-// @ts-nocheck - TODO(bckenny): fix optional width/height in ImageUsage artifact
 'use strict';
 
 const Audit = require('./audit');
 
 const URL = require('../lib/url-shim');
 const THRESHOLD = 0.05;
+
+/** @typedef {Required<LH.Artifacts.SingleImageUsage>} WellDefinedImage */
 
 class ImageAspectRatio extends Audit {
   /**
@@ -32,7 +33,7 @@ class ImageAspectRatio extends Audit {
   }
 
   /**
-   * @param {Required<LH.Artifacts.SingleImageUsage>} image
+   * @param {WellDefinedImage} image
    * @return {Error|{url: string, displayedAspectRatio: string, actualAspectRatio: string, doRatiosMatch: boolean}}
    */
   static computeAspectRatios(image) {
@@ -76,7 +77,7 @@ class ImageAspectRatio extends Audit {
         image.height &&
         !image.usesObjectFit;
     }).forEach(image => {
-      const wellDefinedImage = /** @type {Required<LH.Artifacts.SingleImageUsage>} */ (image);
+      const wellDefinedImage = /** @type {WellDefinedImage} */ (image);
       const processed = ImageAspectRatio.computeAspectRatios(wellDefinedImage);
       if (processed instanceof Error) {
         debugString = processed.message;

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -228,7 +228,9 @@ declare global {
           endTime: number;
           responseReceivedTime: number;
           mimeType: string;
-        }
+        };
+        width?: number;
+        height?: number;
       }
 
       export interface OptimizedImage {

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -22,6 +22,9 @@ declare global {
     [P in K]+?: T[P]
   }
 
+  /** Remove properties K from T. */
+  type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
   /** Obtain the type of the first parameter of a function. */
   type FirstParamType<T extends (arg1: any, ...args: any[]) => any> =
     T extends (arg1: infer P, ...args: any[]) => any ? P : any;


### PR DESCRIPTION
The type for the `ImageUsage` artifact accidentally left off the optional image `width` and `height`, which made using it in the `image-aspect-ratio` audit impossible before. Fixed the artifact and removed the `@ts-nocheck` from the audit.

In the process, uncovered a bug in the gatherer. At some point shifting types made the extra fetch of size information never run for css or `<picture>` images. As a result, the `naturalWidth` and `naturalHeight` was being left at `Number.MAX_VALUE` for those and so the `wastedPercent` for those images was 100% in the `uses-responsive-images` audit :)

There was a [clue in the smoke code coverage](https://codecov.io/gh/GoogleChrome/lighthouse/src/aad3aa6/lighthouse-core/gather/gatherers/image-usage.js#L131), but we hadn't noticed yet :)

Fixed the bug and added more specific expectations for that audit.