### PR TITLE
core(metrics): update lantern coefficients

### DIFF
--- a/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
@@ -21,8 +21,8 @@ class FirstContentfulPaint extends MetricArtifact {
   get COEFFICIENTS() {
     return {
       intercept: 600,
-      optimistic: .6,
-      pessimistic: .5,
+      optimistic: 0.6,
+      pessimistic: 0.5,
     };
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
@@ -20,9 +20,9 @@ class FirstContentfulPaint extends MetricArtifact {
    */
   get COEFFICIENTS() {
     return {
-      intercept: 1440,
-      optimistic: -1.75,
-      pessimistic: 2.73,
+      intercept: 600,
+      optimistic: .6,
+      pessimistic: .5,
     };
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
@@ -20,9 +20,9 @@ class FirstMeaningfulPaint extends MetricArtifact {
    */
   get COEFFICIENTS() {
     return {
-      intercept: 1532,
-      optimistic: -0.3,
-      pessimistic: 1.33,
+      intercept: 900,
+      optimistic: .45,
+      pessimistic: .6,
     };
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
@@ -21,8 +21,8 @@ class FirstMeaningfulPaint extends MetricArtifact {
   get COEFFICIENTS() {
     return {
       intercept: 900,
-      optimistic: .45,
-      pessimistic: .6,
+      optimistic: 0.45,
+      pessimistic: 0.6,
     };
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-interactive.js
@@ -25,8 +25,8 @@ class Interactive extends MetricArtifact {
   get COEFFICIENTS() {
     return {
       intercept: 1600,
-      optimistic: .6,
-      pessimistic: .45,
+      optimistic: 0.6,
+      pessimistic: 0.45,
     };
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-interactive.js
@@ -24,9 +24,9 @@ class Interactive extends MetricArtifact {
    */
   get COEFFICIENTS() {
     return {
-      intercept: 1582,
-      optimistic: 0.97,
-      pessimistic: 0.49,
+      intercept: 1600,
+      optimistic: .6,
+      pessimistic: .45,
     };
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-metric.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-metric.js
@@ -82,11 +82,13 @@ class LanternMetricArtifact extends ComputedArtifact {
     const optimisticGraph = this.getOptimisticGraph(graph, traceOfTab);
     const pessimisticGraph = this.getPessimisticGraph(graph, traceOfTab);
 
-    const optimisticSimulation = simulator.simulate(optimisticGraph, {flexibleOrdering: true});
+    const optimisticSimulation = simulator.simulate(optimisticGraph);
+    const optimisticFlexSimulation = simulator.simulate(optimisticGraph, {flexibleOrdering: true});
     const pessimisticSimulation = simulator.simulate(pessimisticGraph);
 
     const optimisticEstimate = this.getEstimateFromSimulation(
-      optimisticSimulation,
+      optimisticSimulation.timeInMs < optimisticFlexSimulation.timeInMs ?
+        optimisticSimulation : optimisticFlexSimulation,
       Object.assign({}, extras, {optimistic: true})
     );
 

--- a/lighthouse-core/gather/computed/metrics/lantern-metric.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-metric.js
@@ -82,7 +82,7 @@ class LanternMetricArtifact extends ComputedArtifact {
     const optimisticGraph = this.getOptimisticGraph(graph, traceOfTab);
     const pessimisticGraph = this.getPessimisticGraph(graph, traceOfTab);
 
-    const optimisticSimulation = simulator.simulate(optimisticGraph);
+    const optimisticSimulation = simulator.simulate(optimisticGraph, {flexibleOrdering: true});
     const pessimisticSimulation = simulator.simulate(pessimisticGraph);
 
     const optimisticEstimate = this.getEstimateFromSimulation(

--- a/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
@@ -19,9 +19,12 @@ class SpeedIndex extends MetricArtifact {
    */
   get COEFFICIENTS() {
     return {
-      intercept: 200,
-      optimistic: 1.16,
-      pessimistic: 0.57,
+      // Negative intercept is OK because estimate is Math.max(FCP, Speed Index) and
+      // the optimistic estimate is based on the real observed speed index rather than a real
+      // lantern graph.
+      intercept: -250,
+      optimistic: 1.4,
+      pessimistic: 0.65,
     };
   }
 

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -39,8 +39,8 @@ describe('Performance: first-meaningful-paint audit', () => {
     const context = {options, settings: {throttlingMethod: 'simulate'}};
     const fmpResult = await FMPAudit.audit(artifacts, context);
 
-    assert.equal(fmpResult.score, 0.92);
-    assert.equal(Util.formatDisplayValue(fmpResult.displayValue), '2,850\xa0ms');
-    assert.equal(Math.round(fmpResult.rawValue), 2851);
+    assert.equal(fmpResult.score, 0.95);
+    assert.equal(Util.formatDisplayValue(fmpResult.displayValue), '2,030\xa0ms');
+    assert.equal(Math.round(fmpResult.rawValue), 2029);
   });
 });

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -39,7 +39,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     const context = {options, settings: {throttlingMethod: 'simulate'}};
     const fmpResult = await FMPAudit.audit(artifacts, context);
 
-    assert.equal(fmpResult.score, 0.79);
+    assert.equal(fmpResult.score, 0.92);
     assert.equal(Util.formatDisplayValue(fmpResult.displayValue), '2,850\xa0ms');
     assert.equal(Math.round(fmpResult.rawValue), 2851);
   });

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -67,6 +67,6 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
 
     const settings = {throttlingMethod: 'provided', throttling: {rttMs: 40, throughput: 100000}};
     const result = await FastPWAAudit.audit(artifacts, {settings});
-    assert.equal(Math.round(result.rawValue), 5308);
+    assert.equal(Math.round(result.rawValue), 4309);
   });
 });

--- a/lighthouse-core/test/audits/metrics-test.js
+++ b/lighthouse-core/test/audits/metrics-test.js
@@ -29,15 +29,15 @@ describe('Performance: metrics', () => {
     const result = await Audit.audit(artifacts, {settings});
 
     assert.deepStrictEqual(result.details.items[0], {
-      firstContentfulPaint: 2038,
+      firstContentfulPaint: 1272,
       firstContentfulPaintTs: undefined,
-      firstMeaningfulPaint: 2851,
+      firstMeaningfulPaint: 2029,
       firstMeaningfulPaintTs: undefined,
-      firstCPUIdle: 5308,
+      firstCPUIdle: 4309,
       firstCPUIdleTs: undefined,
-      interactive: 5308,
+      interactive: 4309,
       interactiveTs: undefined,
-      speedIndex: 2063,
+      speedIndex: 1501,
       speedIndexTs: undefined,
       estimatedInputLatency: 104,
       estimatedInputLatencyTs: undefined,

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -25,18 +25,18 @@ describe('Performance: predictive performance audit', () => {
     }, Runner.instantiateComputedArtifacts());
 
     return PredictivePerf.audit(artifacts).then(output => {
-      assert.equal(output.score, 0.79);
-      assert.equal(Math.round(output.rawValue), 5308);
-      assert.equal(output.displayValue, '5,310\xa0ms');
+      assert.equal(output.score, 0.86);
+      assert.equal(Math.round(output.rawValue), 4309);
+      assert.equal(output.displayValue, '4,310\xa0ms');
 
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
-      assert.equal(valueOf('roughEstimateOfFCP'), 2038);
+      assert.equal(valueOf('roughEstimateOfFCP'), 1272);
       assert.equal(valueOf('optimisticFCP'), 611);
       assert.equal(valueOf('pessimisticFCP'), 611);
-      assert.equal(valueOf('roughEstimateOfFMP'), 2851);
+      assert.equal(valueOf('roughEstimateOfFMP'), 2029);
       assert.equal(valueOf('optimisticFMP'), 911);
       assert.equal(valueOf('pessimisticFMP'), 1198);
-      assert.equal(valueOf('roughEstimateOfTTI'), 5308);
+      assert.equal(valueOf('roughEstimateOfTTI'), 4309);
       assert.equal(valueOf('optimisticTTI'), 2451);
       assert.equal(valueOf('pessimisticTTI'), 2752);
     });

--- a/lighthouse-core/test/gather/computed/metrics/first-contentful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/first-contentful-paint-test.js
@@ -19,7 +19,7 @@ describe('Metrics: FCP', () => {
     const settings = {throttlingMethod: 'simulate'};
     const result = await artifacts.requestFirstContentfulPaint({trace, devtoolsLog, settings});
 
-    assert.equal(Math.round(result.timing), 2038);
+    assert.equal(Math.round(result.timing), 1272);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 611);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 611);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 2);

--- a/lighthouse-core/test/gather/computed/metrics/first-cpu-idle-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/first-cpu-idle-test.js
@@ -63,7 +63,7 @@ describe('FirstInteractive computed artifact:', () => {
     const artifacts = Runner.instantiateComputedArtifacts();
     const result = await artifacts.requestFirstCPUIdle({trace, devtoolsLog, settings});
 
-    assert.equal(Math.round(result.timing), 5308);
+    assert.equal(Math.round(result.timing), 4309);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 2451);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 2752);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 19);

--- a/lighthouse-core/test/gather/computed/metrics/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/first-meaningful-paint-test.js
@@ -39,7 +39,7 @@ describe('Metrics: FMP', () => {
 
     const result = await artifacts.requestFirstMeaningfulPaint({trace, devtoolsLog, settings});
 
-    assert.equal(Math.round(result.timing), 2851);
+    assert.equal(Math.round(result.timing), 2029);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 911);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1198);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 4);

--- a/lighthouse-core/test/gather/computed/metrics/interactive-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/interactive-test.js
@@ -34,7 +34,7 @@ describe('Metrics: TTI', () => {
     const settings = {throttlingMethod: 'simulate'};
     const result = await artifacts.requestInteractive({trace, devtoolsLog, settings});
 
-    assert.equal(Math.round(result.timing), 5308);
+    assert.equal(Math.round(result.timing), 4309);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 2451);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 2752);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 19);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-contentful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-contentful-paint-test.js
@@ -18,7 +18,7 @@ describe('Metrics: Lantern FCP', () => {
     const result = await artifacts.requestLanternFirstContentfulPaint({trace, devtoolsLog,
       settings: {}});
 
-    assert.equal(Math.round(result.timing), 2038);
+    assert.equal(Math.round(result.timing), 1272);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 611);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 611);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 2);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-cpu-idle-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-cpu-idle-test.js
@@ -17,7 +17,7 @@ describe('Metrics: Lantern TTFCPUI', () => {
     const artifacts = Runner.instantiateComputedArtifacts();
     const result = await artifacts.requestLanternFirstCPUIdle({trace, devtoolsLog, settings: {}});
 
-    assert.equal(Math.round(result.timing), 5308);
+    assert.equal(Math.round(result.timing), 4309);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 2451);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 2752);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 19);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-meaningful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-meaningful-paint-test.js
@@ -18,7 +18,7 @@ describe('Metrics: Lantern FMP', () => {
     const result = await artifacts.requestLanternFirstMeaningfulPaint({trace, devtoolsLog,
       settings: {}});
 
-    assert.equal(Math.round(result.timing), 2851);
+    assert.equal(Math.round(result.timing), 2029);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 911);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1198);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 4);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-interactive-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-interactive-test.js
@@ -18,7 +18,7 @@ describe('Metrics: Lantern TTI', () => {
     const result = await artifacts.requestLanternInteractive({trace, devtoolsLog,
       settings: {}});
 
-    assert.equal(Math.round(result.timing), 5308);
+    assert.equal(Math.round(result.timing), 4309);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 2451);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 2752);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 19);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-speed-index-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-speed-index-test.js
@@ -17,8 +17,8 @@ describe('Metrics: Lantern Speed Index', () => {
     const artifacts = Runner.instantiateComputedArtifacts();
     const result = await artifacts.requestLanternSpeedIndex({trace, devtoolsLog, settings: {}});
 
-    assert.equal(Math.round(result.timing), 2063);
+    assert.equal(Math.round(result.timing), 1501);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 605);
-    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 2038);
+    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1392);
   });
 });

--- a/lighthouse-core/test/gather/computed/metrics/speed-index-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/speed-index-test.js
@@ -19,9 +19,9 @@ describe('Metrics: Speed Index', () => {
     const settings = {throttlingMethod: 'simulate'};
     const result = await artifacts.requestSpeedIndex({trace, devtoolsLog, settings});
 
-    assert.equal(Math.round(result.timing), 2063);
+    assert.equal(Math.round(result.timing), 1501);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 605);
-    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 2038);
+    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1392);
   });
 
   it('should compute an observed value', async () => {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2735,7 +2735,7 @@
           {
             "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200",
             "totalBytes": 736,
-            "wastedMs": 723
+            "wastedMs": 873
           },
           {
             "url": "http://localhost:10200/dobetterweb/dbw_tester.js",


### PR DESCRIPTION
This PR updates the lantern coefficients to the values that offer the lowest absolute error of the 9-run accuracy/variance dataset, they haven't ever been updated so the jump is expected. this PR also turns on the `flexibleOrdering` feature for the optimistic estimate which improved accuracy ~5% on FCP/FMP 🎉 

In the ideal case if lantern were perfect, we would expect the optimistic/pessimistic coefficients to both be positive, sum to ~1, and the intercept to be 0. The good news is we've made considerable progress toward this goal for FCP/FMP, intercepts are significantly lower and coefficients are positive and sum to ~1.

Progress is positive on TTI, the coefficients now sum to ~1 instead of ~1.5 and the intercept is roughly the same.

Speed Index is just weird, the optimistic estimate being real speed index throws things off quite a bit. The lowest absolute error is coefficients at ~2x and then a negative intercept. This actually doesn't seem *that* bad since on the low end we'll be using the FCP estimate for speed index anyhow, and if it improves accuracy on the high end of speed index, we'll take it, but still not an ideal situation.

## MAPE State of the World

Aside: once I add the GCP test suite I think we should shift away from measuring based on MAPE and do the search approach, % of results that are Good/OK/Terrible which is much easier to interpret and judge success

| Metric | MAPE | MAPE on middle 50% |
| - | - | - |
| FCP | 24.4% | 9.8% |
| FMP | 27.4% | 11.0% |
| FCPUI | 29.9% | 16.2% |
| TTI | 30.9% | 16.1% |
| SI | 39.6% | 18.7% |