### PR TITLE
core(lhr): move runtime config to report, configSettings

### DIFF
--- a/lighthouse-core/closure/closure-type-checking.js
+++ b/lighthouse-core/closure/closure-type-checking.js
@@ -22,6 +22,7 @@ gulp.task('compile-report', () => {
     // externs
     'closure/third_party/commonjs.js',
     'closure/typedefs/viewer-externs.js',
+    'closure/typedefs/devtools-externs.js',
 
     'lib/file-namer.js',
     'report/html/renderer/*.js',

--- a/lighthouse-core/closure/typedefs/devtools-externs.js
+++ b/lighthouse-core/closure/typedefs/devtools-externs.js
@@ -1,0 +1,53 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * Typing externs file needed for DevTools compilation.
+ * @externs
+ */
+
+/**
+ * @struct
+ * @record
+ */
+function ThrottlingSettings() {}
+
+/** @type {number} */
+ThrottlingSettings.prototype.rttMs;
+
+/** @type {number} */
+ThrottlingSettings.prototype.throughputKbps;
+
+/** @type {number} */
+ThrottlingSettings.prototype.requestLatencyMs;
+
+/** @type {number} */
+ThrottlingSettings.prototype.downloadThroughputKbps;
+
+/** @type {number} */
+ThrottlingSettings.prototype.uploadThroughputKbps;
+
+/** @type {number} */
+ThrottlingSettings.prototype.cpuSlowdownMultiplier;
+
+var LH = {};
+LH.Config = {};
+
+/**
+ * @struct
+ * @record
+ */
+LH.Config.Settings = function() {};
+
+/** @type {boolean} */
+LH.Config.Settings.prototype.disableDeviceEmulation;
+
+/** @type {string} */
+LH.Config.Settings.prototype.throttlingMethod;
+
+/** @type {ThrottlingSettings} */
+LH.Config.Settings.prototype.throttling;

--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -8,8 +8,6 @@
 const Driver = require('../gather/driver'); // eslint-disable-line no-unused-vars
 const mobile3G = require('../config/constants').throttling.mobile3G;
 
-const NBSP = '\xa0';
-
 /**
  * Nexus 5X metrics adapted from emulated_devices/module.json
  * @type {LH.Crdp.Emulation.SetDeviceMetricsOverrideRequest}
@@ -130,49 +128,6 @@ function disableCPUThrottling(driver) {
   return driver.sendCommand('Emulation.setCPUThrottlingRate', NO_CPU_THROTTLE_METRICS);
 }
 
-/**
- * @param {LH.Config.Settings} settings
- * @return {{deviceEmulation: string, cpuThrottling: string, networkThrottling: string}}
- */
-function getEmulationDesc(settings) {
-  let cpuThrottling;
-  let networkThrottling;
-
-  /** @type {LH.ThrottlingSettings} */
-  const throttling = settings.throttling || {};
-
-  switch (settings.throttlingMethod) {
-    case 'provided':
-      cpuThrottling = 'Provided by environment';
-      networkThrottling = 'Provided by environment';
-      break;
-    case 'devtools': {
-      const {cpuSlowdownMultiplier, requestLatencyMs} = throttling;
-      cpuThrottling = `${cpuSlowdownMultiplier}x slowdown (DevTools)`;
-      networkThrottling = `${requestLatencyMs}${NBSP}ms HTTP RTT, ` +
-        `${throttling.downloadThroughputKbps}${NBSP}Kbps down, ` +
-        `${throttling.uploadThroughputKbps}${NBSP}Kbps up (DevTools)`;
-      break;
-    }
-    case 'simulate': {
-      const {cpuSlowdownMultiplier, rttMs, throughputKbps} = throttling;
-      cpuThrottling = `${cpuSlowdownMultiplier}x slowdown (Simulated)`;
-      networkThrottling = `${rttMs}${NBSP}ms TCP RTT, ` +
-        `${throughputKbps}${NBSP}Kbps throughput (Simulated)`;
-      break;
-    }
-    default:
-      cpuThrottling = 'Unknown';
-      networkThrottling = 'Unknown';
-  }
-
-  return {
-    deviceEmulation: settings.disableDeviceEmulation ? 'Disabled' : 'Nexus 5X',
-    cpuThrottling,
-    networkThrottling,
-  };
-}
-
 module.exports = {
   enableNexus5X,
   enableNetworkThrottling,
@@ -180,5 +135,4 @@ module.exports = {
   enableCPUThrottling,
   disableCPUThrottling,
   goOffline,
-  getEmulationDesc,
 };

--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -268,7 +268,7 @@ ReportRenderer.GroupJSON; // eslint-disable-line no-unused-expressions
  *     audits: !Object<string, !ReportRenderer.AuditResultJSON>,
  *     reportCategories: !Array<!ReportRenderer.CategoryJSON>,
  *     reportGroups: !Object<string, !ReportRenderer.GroupJSON>,
- *     runtimeSettings: !Object<string, *>,
+ *     runtimeSettings: !LH.Config.Settings,
  * }}
  */
 ReportRenderer.ReportJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -65,7 +65,8 @@ class ReportRenderer {
     this._dom.find('.lh-env__item__ua', header).textContent = report.userAgent;
 
     const env = this._dom.find('.lh-env__items', header);
-    report.runtimeConfig.environment.forEach(runtime => {
+    const environment = Util.getEnvironmentDisplayValues(report.runtimeSettings || {});
+    environment.forEach(runtime => {
       const item = this._dom.cloneTemplate('#tmpl-lh-env__items', env);
       this._dom.find('.lh-env__name', item).textContent = runtime.name;
       this._dom.find('.lh-env__description', item).textContent = runtime.description;
@@ -267,11 +268,7 @@ ReportRenderer.GroupJSON; // eslint-disable-line no-unused-expressions
  *     audits: !Object<string, !ReportRenderer.AuditResultJSON>,
  *     reportCategories: !Array<!ReportRenderer.CategoryJSON>,
  *     reportGroups: !Object<string, !ReportRenderer.GroupJSON>,
- *     runtimeConfig: {
- *       blockedUrlPatterns: !Array<string>,
- *       extraHeaders: !Object<string, string>,
- *       environment: !Array<{description: string, enabled: boolean, name: string}>
- *     }
+ *     runtimeSettings: !Object<string, *>,
  * }}
  */
 ReportRenderer.ReportJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -65,7 +65,7 @@ class ReportRenderer {
     this._dom.find('.lh-env__item__ua', header).textContent = report.userAgent;
 
     const env = this._dom.find('.lh-env__items', header);
-    const environment = Util.getEnvironmentDisplayValues(report.runtimeSettings || {});
+    const environment = Util.getEnvironmentDisplayValues(report.configSettings || {});
     environment.forEach(runtime => {
       const item = this._dom.cloneTemplate('#tmpl-lh-env__items', env);
       this._dom.find('.lh-env__name', item).textContent = runtime.name;
@@ -268,7 +268,7 @@ ReportRenderer.GroupJSON; // eslint-disable-line no-unused-expressions
  *     audits: !Object<string, !ReportRenderer.AuditResultJSON>,
  *     reportCategories: !Array<!ReportRenderer.CategoryJSON>,
  *     reportGroups: !Object<string, !ReportRenderer.GroupJSON>,
- *     runtimeSettings: !LH.Config.Settings,
+ *     configSettings: !LH.Config.Settings,
  * }}
  */
 ReportRenderer.ReportJSON; // eslint-disable-line no-unused-expressions

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -217,6 +217,71 @@ class Util {
   static chainDuration(startTime, endTime) {
     return Util.formatNumber((endTime - startTime) * 1000);
   }
+
+  /**
+   * @param {LH.Config.Settings} settings
+   * @return {Array<{name: string, description: string}>}
+   */
+  static getEnvironmentDisplayValues(settings) {
+    const emulationDesc = Util.getEmulationDescriptions(settings);
+
+    return [
+      {
+        name: 'Device Emulation',
+        description: emulationDesc.deviceEmulation,
+      },
+      {
+        name: 'Network Throttling',
+        description: emulationDesc.networkThrottling,
+      },
+      {
+        name: 'CPU Throttling',
+        description: emulationDesc.cpuThrottling,
+      },
+    ];
+  }
+
+  /**
+   * @param {LH.Config.Settings} settings
+   * @return {{deviceEmulation: string, networkThrottling: string, cpuThrottling: string}}
+   */
+  static getEmulationDescriptions(settings) {
+    let cpuThrottling;
+    let networkThrottling;
+
+    const throttling = settings.throttling;
+
+    switch (settings.throttlingMethod) {
+      case 'provided':
+        cpuThrottling = 'Provided by environment';
+        networkThrottling = 'Provided by environment';
+        break;
+      case 'devtools': {
+        const {cpuSlowdownMultiplier, requestLatencyMs} = throttling;
+        cpuThrottling = `${Util.formatNumber(cpuSlowdownMultiplier)}x slowdown (DevTools)`;
+        networkThrottling = `${Util.formatNumber(requestLatencyMs)}${NBSP}ms HTTP RTT, ` +
+          `${Util.formatNumber(throttling.downloadThroughputKbps)}${NBSP}Kbps down, ` +
+          `${Util.formatNumber(throttling.uploadThroughputKbps)}${NBSP}Kbps up (DevTools)`;
+        break;
+      }
+      case 'simulate': {
+        const {cpuSlowdownMultiplier, rttMs, throughputKbps} = throttling;
+        cpuThrottling = `${Util.formatNumber(cpuSlowdownMultiplier)}x slowdown (Simulated)`;
+        networkThrottling = `${Util.formatNumber(rttMs)}${NBSP}ms TCP RTT, ` +
+          `${Util.formatNumber(throughputKbps)}${NBSP}Kbps throughput (Simulated)`;
+        break;
+      }
+      default:
+        cpuThrottling = 'Unknown';
+        networkThrottling = 'Unknown';
+    }
+
+    return {
+      deviceEmulation: settings.disableDeviceEmulation ? 'Disabled' : 'Nexus 5X',
+      cpuThrottling,
+      networkThrottling,
+    };
+  }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -10,7 +10,6 @@ const Driver = require('./gather/driver.js');
 const GatherRunner = require('./gather/gather-runner');
 const ReportScoring = require('./scoring');
 const Audit = require('./audits/audit');
-const emulation = require('./lib/emulation');
 const log = require('lighthouse-logger');
 const assetSaver = require('./lib/asset-saver');
 const fs = require('fs');
@@ -128,7 +127,7 @@ class Runner {
         url: opts.url,
         runWarnings: lighthouseRunWarnings,
         audits: resultsById,
-        runtimeConfig: Runner.getRuntimeConfig(settings),
+        runtimeSettings: settings,
         reportCategories,
         reportGroups: opts.config.groups,
         timing: {total: Date.now() - startTime},
@@ -405,34 +404,6 @@ class Runner {
     } catch (requireError) {}
 
     throw new Error(errorString + ` and '${relativePath}')`);
-  }
-
-  /**
-   * Get runtime configuration specified by the flags
-   * @param {LH.Config.Settings} settings
-   * @return {LH.Result.RuntimeConfig}
-   */
-  static getRuntimeConfig(settings) {
-    const emulationDesc = emulation.getEmulationDesc(settings);
-
-    return {
-      environment: [
-        {
-          name: 'Device Emulation',
-          description: emulationDesc['deviceEmulation'],
-        },
-        {
-          name: 'Network Throttling',
-          description: emulationDesc['networkThrottling'],
-        },
-        {
-          name: 'CPU Throttling',
-          description: emulationDesc['cpuThrottling'],
-        },
-      ],
-      blockedUrlPatterns: settings.blockedUrlPatterns || [],
-      extraHeaders: settings.extraHeaders || {},
-    };
   }
 
   /**

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -127,7 +127,7 @@ class Runner {
         url: opts.url,
         runWarnings: lighthouseRunWarnings,
         audits: resultsById,
-        runtimeSettings: settings,
+        configSettings: settings,
         reportCategories,
         reportGroups: opts.config.groups,
         timing: {total: Date.now() - startTime},

--- a/lighthouse-core/scripts/cleanup-LHR-for-diff.js
+++ b/lighthouse-core/scripts/cleanup-LHR-for-diff.js
@@ -24,7 +24,7 @@ writeFileSync(filename, cleanAndFormatLHR(data), 'utf8');
  */
 function cleanAndFormatLHR(lhrString) {
   const lhr = JSON.parse(lhrString);
-  delete lhr.runtimeSettings.auditMode;
+  delete lhr.configSettings.auditMode;
   delete lhr.timing;
   if (extraFlag !== '--only-remove-timing') {
     for (const auditResult of Object.values(lhr.audits)) {

--- a/lighthouse-core/scripts/cleanup-LHR-for-diff.js
+++ b/lighthouse-core/scripts/cleanup-LHR-for-diff.js
@@ -24,6 +24,7 @@ writeFileSync(filename, cleanAndFormatLHR(data), 'utf8');
  */
 function cleanAndFormatLHR(lhrString) {
   const lhr = JSON.parse(lhrString);
+  delete lhr.runtimeSettings.auditMode;
   delete lhr.timing;
   if (extraFlag !== '--only-remove-timing') {
     for (const auditResult of Object.values(lhr.audits)) {

--- a/lighthouse-core/test/report/html/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-renderer-test.js
@@ -107,11 +107,13 @@ describe('ReportRenderer', () => {
 
       // Check runtime settings were populated.
       const names = Array.from(header.querySelectorAll('.lh-env__name')).slice(1);
-      const descriptions = header.querySelectorAll('.lh-env__description');
-      sampleResults.runtimeConfig.environment.forEach((env, i) => {
-        assert.equal(names[i].textContent, env.name);
-        assert.equal(descriptions[i].textContent, env.description);
-      });
+      const descriptions = Array.from(header.querySelectorAll('.lh-env__description'));
+      assert.equal(names.length, 3);
+      assert.equal(descriptions.length, 3);
+      const descriptionsTxt = descriptions.map(el => el.textContent).join('\n');
+      assert.ok(/Nexus/.test(descriptionsTxt), 'should have added device emulation');
+      assert.ok(/RTT/.test(descriptionsTxt), 'should have added network');
+      assert.ok(/\dx/.test(descriptionsTxt), 'should have added CPU');
     });
 
     it('should not mutate a report object', () => {

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -53,4 +53,47 @@ describe('util helpers', () => {
     assert.equal(Util.calculateRating(0.80), 'pass');
     assert.equal(Util.calculateRating(1.00), 'pass');
   });
+
+  it('builds device emulation string', () => {
+    const get = opts => Util.getEmulationDescriptions(opts).deviceEmulation;
+    assert.equal(get({disableDeviceEmulation: true}), 'Disabled');
+    assert.equal(get({disableDeviceEmulation: false}), 'Nexus 5X');
+  });
+
+  it('builds throttling strings when provided', () => {
+    const descriptions = Util.getEmulationDescriptions({throttlingMethod: 'provided'});
+    assert.equal(descriptions.cpuThrottling, 'Provided by environment');
+    assert.equal(descriptions.networkThrottling, 'Provided by environment');
+  });
+
+  it('builds throttling strings when devtools', () => {
+    const descriptions = Util.getEmulationDescriptions({
+      throttlingMethod: 'devtools',
+      throttling: {
+        cpuSlowdownMultiplier: 4.5,
+        requestLatencyMs: 565,
+        downloadThroughputKbps: 1400.00000000001,
+        uploadThroughputKbps: 600,
+      },
+    });
+
+    // eslint-disable-next-line max-len
+    assert.equal(descriptions.networkThrottling, '565\xa0ms HTTP RTT, 1,400\xa0Kbps down, 600\xa0Kbps up (DevTools)');
+    assert.equal(descriptions.cpuThrottling, '4.5x slowdown (DevTools)');
+  });
+
+  it('builds throttling strings when simulate', () => {
+    const descriptions = Util.getEmulationDescriptions({
+      throttlingMethod: 'simulate',
+      throttling: {
+        cpuSlowdownMultiplier: 2,
+        rttMs: 150,
+        throughputKbps: 1600,
+      },
+    });
+
+    // eslint-disable-next-line max-len
+    assert.equal(descriptions.networkThrottling, '150\xa0ms TCP RTT, 1,600\xa0Kbps throughput (Simulated)');
+    assert.equal(descriptions.cpuThrottling, '2x slowdown (Simulated)');
+  });
 });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -4546,7 +4546,7 @@
       "helpText": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more](https://developers.google.com/search/docs/guides/mark-up-content)."
     }
   },
-  "runtimeSettings": {
+  "configSettings": {
     "output": "json",
     "maxWaitForLoad": 45000,
     "throttlingMethod": "devtools",
@@ -4558,7 +4558,6 @@
       "uploadThroughputKbps": 675,
       "cpuSlowdownMultiplier": 4
     },
-    "auditMode": "./lighthouse-core/test/results/artifacts",
     "gatherMode": false,
     "disableStorageReset": false,
     "disableDeviceEmulation": false,

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -4546,23 +4546,28 @@
       "helpText": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more](https://developers.google.com/search/docs/guides/mark-up-content)."
     }
   },
-  "runtimeConfig": {
-    "environment": [
-      {
-        "name": "Device Emulation",
-        "description": "Nexus 5X"
-      },
-      {
-        "name": "Network Throttling",
-        "description": "562.5 ms HTTP RTT, 1474.5600000000002 Kbps down, 675 Kbps up (DevTools)"
-      },
-      {
-        "name": "CPU Throttling",
-        "description": "4x slowdown (DevTools)"
-      }
-    ],
-    "blockedUrlPatterns": [],
-    "extraHeaders": {}
+  "runtimeSettings": {
+    "output": "json",
+    "maxWaitForLoad": 45000,
+    "throttlingMethod": "devtools",
+    "throttling": {
+      "rttMs": 150,
+      "throughputKbps": 1638.4,
+      "requestLatencyMs": 562.5,
+      "downloadThroughputKbps": 1474.5600000000002,
+      "uploadThroughputKbps": 675,
+      "cpuSlowdownMultiplier": 4
+    },
+    "auditMode": "./lighthouse-core/test/results/artifacts",
+    "gatherMode": false,
+    "disableStorageReset": false,
+    "disableDeviceEmulation": false,
+    "blockedUrlPatterns": null,
+    "additionalTraceCategories": null,
+    "extraHeaders": null,
+    "onlyAudits": null,
+    "onlyCategories": null,
+    "skipAudits": null
   },
   "reportCategories": [
     {

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -27,8 +27,8 @@ declare global {
 
 
       // Additional non-LHR-lite information.
-      /** Description of the runtime settings used for these results. */
-      runtimeSettings: Config.Settings;
+      /** The config settings used for these results. */
+      configSettings: Config.Settings;
       /** List of top-level warnings for this Lighthouse run. */
       runWarnings: string[];
       /** The User-Agent string of the browser used run Lighthouse for these results. */

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -27,8 +27,8 @@ declare global {
 
 
       // Additional non-LHR-lite information.
-      /** Description of the runtime configuration used for gathering these results. */
-      runtimeConfig: Result.RuntimeConfig;
+      /** Description of the runtime settings used for these results. */
+      runtimeSettings: Config.Settings;
       /** List of top-level warnings for this Lighthouse run. */
       runWarnings: string[];
       /** The User-Agent string of the browser used run Lighthouse for these results. */


### PR DESCRIPTION
- removes `runtimeConfig` from LHR
- adds `runtimeSettings` to LHR (I'd prefer just `.settings` but doing the rename of that back to something else would have been more challenging, so lmk if other folks feel the same I'd I'll happily change :D)
- moves the emulation description logic to the report renderer

I know that this whole thing is ripe for some refactoring, but we've got a long list to get through and this keeps same functional parity, sooooo

![image](https://user-images.githubusercontent.com/2301202/39650590-99cfe7b4-4f9d-11e8-938b-8d0479d4d812.png)


NOTE: closure fixes pending
