### PR TITLE
core(lantern): never exclude main document from graphs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,13 @@ before_script:
   - sh -e /etc/init.d/xvfb start
   - yarn build-all
 script:
-  - yarn bundlesize
-  - yarn lint
-  - yarn unit:silentcoverage
-  - yarn type-check
-  - yarn closure
-  - yarn diff:sample-json
-  - yarn smoke:silentcoverage
+  # - yarn bundlesize
+  # - yarn lint
+  # - yarn unit:silentcoverage
+  # - yarn type-check
+  # - yarn closure
+  # - yarn diff:sample-json
+  # - yarn smoke:silentcoverage
   - yarn test-extension
   - yarn test-viewer
   # _JAVA_OPTIONS is breaking parsing of compiler output. See #3338.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,13 @@ before_script:
   - sh -e /etc/init.d/xvfb start
   - yarn build-all
 script:
-  # - yarn bundlesize
-  # - yarn lint
-  # - yarn unit:silentcoverage
-  # - yarn type-check
-  # - yarn closure
-  # - yarn diff:sample-json
-  # - yarn smoke:silentcoverage
+  - yarn bundlesize
+  - yarn lint
+  - yarn unit:silentcoverage
+  - yarn type-check
+  - yarn closure
+  - yarn diff:sample-json
+  - yarn smoke:silentcoverage
   - yarn test-extension
   - yarn test-viewer
   # _JAVA_OPTIONS is breaking parsing of compiler output. See #3338.

--- a/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
@@ -40,7 +40,7 @@ class FirstContentfulPaint extends MetricArtifact {
     });
 
     return dependencyGraph.cloneWithRelationships(node => {
-      if (node.endTime > fcp) return false;
+      if (node.endTime > fcp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
       if (node.type === Node.TYPES.CPU) {
         return /** @type {CPUNode} */ (node).isEvaluateScriptFor(blockingScriptUrls);
@@ -64,7 +64,7 @@ class FirstContentfulPaint extends MetricArtifact {
     });
 
     return dependencyGraph.cloneWithRelationships(node => {
-      if (node.endTime > fcp) return false;
+      if (node.endTime > fcp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
       if (node.type === Node.TYPES.CPU) {
         return /** @type {CPUNode} */ (node).isEvaluateScriptFor(blockingScriptUrls);

--- a/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
@@ -40,7 +40,7 @@ class FirstMeaningfulPaint extends MetricArtifact {
     });
 
     return dependencyGraph.cloneWithRelationships(node => {
-      if (node.endTime > fmp) return false;
+      if (node.endTime > fmp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
       if (node.type === Node.TYPES.CPU) {
         return /** @type {CPUNode} */ (node).isEvaluateScriptFor(blockingScriptUrls);
@@ -64,7 +64,7 @@ class FirstMeaningfulPaint extends MetricArtifact {
     });
 
     return dependencyGraph.cloneWithRelationships(node => {
-      if (node.endTime > fmp) return false;
+      if (node.endTime > fmp && !node.isMainDocument()) return false;
 
       // Include CPU tasks that performed a layout or were evaluations of required scripts
       if (node.type === Node.TYPES.CPU) {

--- a/lighthouse-core/lib/dependency-graph/node.js
+++ b/lighthouse-core/lib/dependency-graph/node.js
@@ -23,6 +23,7 @@ class Node {
    */
   constructor(id) {
     this._id = id;
+    this._isMainDocument = false;
     /** @type {Node[]} */
     this._dependents = [];
     /** @type {Node[]} */
@@ -55,6 +56,20 @@ class Node {
    */
   get endTime() {
     throw new Error('Unimplemented');
+  }
+
+  /**
+   * @param {boolean} value
+   */
+  setIsMainDocument(value) {
+    this._isMainDocument = value;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isMainDocument() {
+    return this._isMainDocument;
   }
 
   /**

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const INITIAL_CWD = 14 * 1024;
+const WebInspector = require('../../web-inspector');
 
 class NetworkAnalyzer {
   /**
@@ -318,6 +319,17 @@ class NetworkAnalyzer {
 
     const estimatesByOrigin = NetworkAnalyzer._estimateResponseTimeByOrigin(records, rttByOrigin);
     return NetworkAnalyzer.summarize(estimatesByOrigin);
+  }
+
+  /**
+   * @param {Array<LH.WebInspector.NetworkRequest>} records
+   * @return {LH.WebInspector.NetworkRequest}
+   */
+  static findMainDocument(records) {
+    // TODO(phulce): handle more edge cases like client redirects, or plumb through finalUrl
+    const documentRequests = records.filter(record => record._resourceType ===
+        WebInspector.resourceTypes.Document);
+    return documentRequests.sort((a, b) => a.startTime - b.startTime)[0];
   }
 }
 

--- a/lighthouse-core/test/gather/computed/page-dependency-graph-test.js
+++ b/lighthouse-core/test/gather/computed/page-dependency-graph-test.js
@@ -15,7 +15,8 @@ const sampleDevtoolsLog = require('../../fixtures/traces/progressive-app-m60.dev
 
 const assert = require('assert');
 
-function createRequest(requestId, url, startTime = 0, _initiator = null, _resourceType = null) {
+function createRequest(requestId, url, startTime = 0, _initiator = null,
+    _resourceType = WebInspector.resourceTypes.Document) {
   startTime = startTime / 1000;
   const endTime = startTime + 0.05;
   return {requestId, url, startTime, endTime, _initiator, _resourceType};
@@ -248,6 +249,20 @@ describe('PageDependencyGraph computed artifact:', () => {
       assert.deepEqual(getDependencyIds(nodes[4]), [1]);
       assert.deepEqual(getDependencyIds(nodes[5]), [1]);
       assert.deepEqual(getDependencyIds(nodes[6]), [4]);
+    });
+
+    it('should set isMainDocument on first document request', () => {
+      const request1 = createRequest(1, '1', 0, null, WebInspector.resourceTypes.Image);
+      const request2 = createRequest(2, '2', 5);
+      const networkRecords = [request1, request2];
+
+      const graph = PageDependencyGraph.createGraph(traceOfTab, networkRecords);
+      const nodes = [];
+      graph.traverse(node => nodes.push(node));
+
+      assert.equal(nodes.length, 2);
+      assert.equal(nodes[0].isMainDocument(), false);
+      assert.equal(nodes[1].isMainDocument(), true);
     });
   });
 });

--- a/lighthouse-core/test/gather/computed/page-dependency-graph-test.js
+++ b/lighthouse-core/test/gather/computed/page-dependency-graph-test.js
@@ -15,8 +15,13 @@ const sampleDevtoolsLog = require('../../fixtures/traces/progressive-app-m60.dev
 
 const assert = require('assert');
 
-function createRequest(requestId, url, startTime = 0, _initiator = null,
-    _resourceType = WebInspector.resourceTypes.Document) {
+function createRequest(
+  requestId,
+  url,
+  startTime = 0,
+  _initiator = null,
+  _resourceType = WebInspector.resourceTypes.Document
+) {
   startTime = startTime / 1000;
   const endTime = startTime + 0.05;
   return {requestId, url, startTime, endTime, _initiator, _resourceType};

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -262,4 +262,12 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
       });
     });
   });
+
+  describe('#findMainDocument', () => {
+    it('should find the main document', async () => {
+      const records = await computedArtifacts.requestNetworkRecords(devtoolsLog);
+      const mainDocument = NetworkAnalyzer.findMainDocument(records);
+      assert.equal(mainDocument.url, 'https://pwa.rocks/');
+    });
+  });
 });


### PR DESCRIPTION
should fix the travis flake we've been seeing on extension tests `cannot find node ID 02u309rjfja0fsdjflajsfd`