### PR TITLE
core(tsc): fix OptimizedImages type; type check dep audits

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -46,17 +46,16 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
   static audit_(artifacts) {
     const images = artifacts.OptimizedImages;
 
-    /** @type {Array<LH.Artifacts.OptimizedImageError>} */
-    const failedImages = [];
     /** @type {Array<{url: string, fromProtocol: boolean, isCrossOrigin: boolean, totalBytes: number, wastedBytes: number}>} */
     const results = [];
-    images.forEach(image => {
+    const failedImages = [];
+    for (const image of images) {
       if (image.failed) {
         failedImages.push(image);
-        return;
+        continue;
       } else if (/(jpeg|bmp)/.test(image.mimeType) === false ||
                  image.originalSize < image.jpegSize + IGNORE_THRESHOLD_IN_BYTES) {
-        return;
+        continue;
       }
 
       const url = URL.elideDataURI(image.url);
@@ -69,7 +68,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
         totalBytes: image.originalSize,
         wastedBytes: jpegSavings.bytes,
       });
-    });
+    }
 
     let debugString;
     if (failedImages.length) {

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -7,7 +7,6 @@
  * @fileoverview This audit determines if the images used are sufficiently larger
  * than JPEG compressed images without metadata at quality 85.
  */
-// @ts-nocheck - TODO(bckenny)
 'use strict';
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
@@ -47,7 +46,9 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
   static audit_(artifacts) {
     const images = artifacts.OptimizedImages;
 
+    /** @type {Array<LH.Artifacts.OptimizedImageError>} */
     const failedImages = [];
+    /** @type {Array<{url: string, fromProtocol: boolean, isCrossOrigin: boolean, totalBytes: number, wastedBytes: number}>} */
     const results = [];
     images.forEach(image => {
       if (image.failed) {

--- a/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
@@ -6,7 +6,6 @@
 /*
  * @fileoverview This audit determines if the images could be smaller when compressed with WebP.
  */
-// @ts-nocheck - TODO(bckenny)
 'use strict';
 
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
@@ -47,7 +46,9 @@ class UsesWebPImages extends ByteEfficiencyAudit {
   static audit_(artifacts) {
     const images = artifacts.OptimizedImages;
 
+    /** @type {Array<LH.Artifacts.OptimizedImageError>} */
     const failedImages = [];
+    /** @type {Array<{url: string, fromProtocol: boolean, isCrossOrigin: boolean, totalBytes: number, wastedBytes: number}>} */
     const results = [];
     images.forEach(image => {
       if (image.failed) {

--- a/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
@@ -46,16 +46,15 @@ class UsesWebPImages extends ByteEfficiencyAudit {
   static audit_(artifacts) {
     const images = artifacts.OptimizedImages;
 
-    /** @type {Array<LH.Artifacts.OptimizedImageError>} */
-    const failedImages = [];
     /** @type {Array<{url: string, fromProtocol: boolean, isCrossOrigin: boolean, totalBytes: number, wastedBytes: number}>} */
     const results = [];
-    images.forEach(image => {
+    const failedImages = [];
+    for (const image of images) {
       if (image.failed) {
         failedImages.push(image);
-        return;
+        continue;
       } else if (image.originalSize < image.webpSize + IGNORE_THRESHOLD_IN_BYTES) {
-        return;
+        continue;
       }
 
       const url = URL.elideDataURI(image.url);
@@ -68,7 +67,7 @@ class UsesWebPImages extends ByteEfficiencyAudit {
         totalBytes: image.originalSize,
         wastedBytes: webpSavings.bytes,
       });
-    });
+    }
 
     let debugString;
     if (failedImages.length) {

--- a/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
@@ -184,11 +184,10 @@ class OptimizedImages extends Gatherer {
           continue;
         }
 
-        results.push({
-          failed: false,
-          ...stats,
-          ...record,
-        });
+        /** @type {LH.Artifacts.OptimizedImage} */
+        // @ts-ignore TODO(bckenny): fix browserify/Object.spread. See https://github.com/GoogleChrome/lighthouse/issues/5152
+        const image = Object.assign({failed: false}, stats, record);
+        results.push(image);
       } catch (err) {
         // Track this with Sentry since these errors aren't surfaced anywhere else, but we don't
         // want to tank the entire run due to a single image.
@@ -199,11 +198,10 @@ class OptimizedImages extends Gatherer {
           level: 'warning',
         });
 
-        results.push({
-          failed: true,
-          errMsg: err.message,
-          ...record,
-        });
+        /** @type {LH.Artifacts.OptimizedImageError} */
+        // @ts-ignore TODO(bckenny): see above browserify/Object.spread TODO.
+        const imageError = Object.assign({failed: true, errMsg: err.message}, record);
+        results.push(imageError);
       }
     }
 

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/optimized-images-test.js
@@ -157,7 +157,7 @@ describe('Optimized images', () => {
 
       assert.equal(artifact.length, 4);
       assert.ok(failed, 'passed along failure');
-      assert.ok(/whoops/.test(failed.err.message), 'passed along error message');
+      assert.ok(/whoops/.test(failed.errMsg), 'passed along error message');
     });
   });
 

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -71,7 +71,7 @@ declare global {
       /** The status code of the attempted load of the page while network access is disabled. */
       Offline: number;
       /** Size and compression opportunity information for all the images in the page. */
-      OptimizedImages: Artifacts.OptimizedImage[];
+      OptimizedImages: Array<Artifacts.OptimizedImage | Artifacts.OptimizedImageError>;
       /** HTML snippets from any password inputs that prevent pasting. */
       PasswordInputsWithPreventedPaste: {snippet: string}[];
       /** Size info of all network records sent without compression and their size after gzipping. */
@@ -234,18 +234,30 @@ declare global {
       }
 
       export interface OptimizedImage {
+        failed: false;
+        fromProtocol: boolean;
+        originalSize: number;
+        jpegSize: number;
+        webpSize: number;
+
         isSameOrigin: boolean;
         isBase64DataUri: boolean;
         requestId: string;
         url: string;
         mimeType: string;
         resourceSize: number;
-        fromProtocol?: boolean;
-        originalSize?: number;
-        jpegSize?: number;
-        webpSize?: number;
-        failed?: boolean;
-        err?: Error;
+      }
+
+      export interface OptimizedImageError {
+        failed: true;
+        errMsg: string;
+
+        isSameOrigin: boolean;
+        isBase64DataUri: boolean;
+        requestId: string;
+        url: string;
+        mimeType: string;
+        resourceSize: number;
       }
 
       export interface TagBlockingFirstPaint {


### PR DESCRIPTION
make `OptimizedImages` a discriminated union on `failed` or not. Keeps the artifact type simpler and the use of it really simple in these two audits.

The only remaining `// @ts-nocheck` audit is `mixed-content.js`, which should make refactors a little more easier.