### PR TITLE
report: improved text-wrapping....

### DIFF
--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -85,8 +85,14 @@ class DOMSize extends Audit {
       },
       {
         totalNodes: '',
-        depth: stats.depth.snippet,
-        width: stats.width.snippet,
+        depth: {
+          type: 'code',
+          value: stats.depth.snippet,
+        },
+        width: {
+          type: 'code',
+          value: stats.width.snippet,
+        },
       },
     ];
 

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -657,14 +657,11 @@
   font-size: large;
 }
 
-.lh-text {
-  white-space: nowrap;
-}
-
 .lh-code {
   white-space: normal;
   margin-top: 0;
   font-size: 85%;
+  word-break: break-word;
 }
 
 .lh-run-warnings {
@@ -895,7 +892,7 @@ summary.lh-passed-audits-summary {
 }
 
 .lh-text__url > .lh-text, .lh-text__url-host {
-  display: inline;
+  display: inline-block;
 }
 
 .lh-text__url-host {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3156,7 +3156,13 @@
             "width": "22"
           },
           {
-            "totalNodes": ""
+            "totalNodes": "",
+            "depth": {
+              "type": "code"
+            },
+            "width": {
+              "type": "code"
+            }
           }
         ]
       },
@@ -3190,7 +3196,13 @@
             "width": "22"
           },
           {
-            "totalNodes": ""
+            "totalNodes": "",
+            "depth": {
+              "type": "code"
+            },
+            "width": {
+              "type": "code"
+            }
           }
         ]
       }


### PR DESCRIPTION
`break-word` makes a surprising amount of difference. It's excellent.

And fixing dom-size audit, as it can get pretty funky.

Before and after: 
![image](https://user-images.githubusercontent.com/39191/39669912-95f28b18-50ad-11e8-96a8-4f577b91dc33.png)
![image](https://user-images.githubusercontent.com/39191/39669914-9958a27e-50ad-11e8-95e2-1546325abe24.png)



This PR isn't dependent on any others yay.