### PR TITLE
report: new styling for audit details

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -47,7 +47,8 @@ class CategoryRenderer {
     // Append audit details to header section so the entire audit is within a <details>.
     const header = /** @type {!HTMLDetailsElement} */ (this.dom.find('details', auditEl));
     if (audit.result.details && audit.result.details.type) {
-      header.appendChild(this.detailsRenderer.render(audit.result.details));
+      const elem = header.appendChild(this.detailsRenderer.render(audit.result.details));
+      elem.classList.add('lh-details');
     }
 
     auditEl.classList.add(`lh-audit--${audit.result.scoreDisplayMode}`);

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -47,8 +47,9 @@ class CategoryRenderer {
     // Append audit details to header section so the entire audit is within a <details>.
     const header = /** @type {!HTMLDetailsElement} */ (this.dom.find('details', auditEl));
     if (audit.result.details && audit.result.details.type) {
-      const elem = header.appendChild(this.detailsRenderer.render(audit.result.details));
+      const elem = this.detailsRenderer.render(audit.result.details);
       elem.classList.add('lh-details');
+      header.appendChild(elem);
     }
 
     auditEl.classList.add(`lh-audit--${audit.result.scoreDisplayMode}`);

--- a/lighthouse-core/report/html/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/html/renderer/crc-details-renderer.js
@@ -131,16 +131,16 @@ class CriticalRequestChainRenderer {
    * @param {!DOM} dom
    * @param {!DocumentFragment} tmpl
    * @param {!CriticalRequestChainRenderer.CRCSegment} segment
-   * @param {!Element} detailsEl Parent details element.
+   * @param {!Element} elem Parent element.
    * @param {!CriticalRequestChainRenderer.CRCDetailsJSON} details
    */
-  static buildTree(dom, tmpl, segment, detailsEl, details) {
-    detailsEl.appendChild(CriticalRequestChainRenderer.createChainNode(dom, tmpl, segment));
+  static buildTree(dom, tmpl, segment, elem, details) {
+    elem.appendChild(CriticalRequestChainRenderer.createChainNode(dom, tmpl, segment));
 
     for (const key of Object.keys(segment.node.children)) {
       const childSegment = CriticalRequestChainRenderer.createSegment(segment.node.children, key,
          segment.startTime, segment.transferSize, segment.treeMarkers, segment.isLastChild);
-      CriticalRequestChainRenderer.buildTree(dom, tmpl, childSegment, detailsEl, details);
+      CriticalRequestChainRenderer.buildTree(dom, tmpl, childSegment, elem, details);
     }
   }
 
@@ -152,6 +152,7 @@ class CriticalRequestChainRenderer {
    */
   static render(dom, templateContext, details) {
     const tmpl = dom.cloneTemplate('#tmpl-lh-crc', templateContext);
+    const containerEl = dom.find('.lh-crc', tmpl);
 
     // Fill in top summary.
     dom.find('.lh-crc__longest_duration', tmpl).textContent =
@@ -160,20 +161,15 @@ class CriticalRequestChainRenderer {
     dom.find('.lh-crc__longest_transfersize', tmpl).textContent =
         Util.formatBytesToKB(details.longestChain.transferSize);
 
-    const detailsEl = dom.find('.lh-details', tmpl);
-    detailsEl.open = true;
-
-    dom.find('.lh-details > summary', tmpl).textContent = details.header.text;
-
     // Construct visual tree.
     const root = CriticalRequestChainRenderer.initTree(details.chains);
     for (const key of Object.keys(root.tree)) {
       const segment = CriticalRequestChainRenderer.createSegment(root.tree, key,
           root.startTime, root.transferSize);
-      CriticalRequestChainRenderer.buildTree(dom, tmpl, segment, detailsEl, details);
+      CriticalRequestChainRenderer.buildTree(dom, tmpl, segment, containerEl, details);
     }
 
-    return tmpl;
+    return dom.find('.lh-crc-container', tmpl);
   }
 }
 

--- a/lighthouse-core/report/html/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/html/renderer/crc-details-renderer.js
@@ -148,7 +148,7 @@ class CriticalRequestChainRenderer {
    * @param {!DOM} dom
    * @param {!Node} templateContext
    * @param {!CriticalRequestChainRenderer.CRCDetailsJSON} details
-   * @return {!Node}
+   * @return {!Element}
    */
   static render(dom, templateContext, details) {
     const tmpl = dom.cloneTemplate('#tmpl-lh-crc', templateContext);

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -180,11 +180,7 @@ class DetailsRenderer {
   _renderTable(details) {
     if (!details.items.length) return this._dom.createElement('span');
 
-    const element = this._dom.createElement('details', 'lh-details');
-    element.open = true;
-    element.appendChild(this._dom.createElement('summary')).textContent = 'View Details';
-
-    const tableElem = this._dom.createChildOf(element, 'table', 'lh-table');
+    const tableElem = this._dom.createElement('table', 'lh-table');
     const theadElem = this._dom.createChildOf(tableElem, 'thead');
     const theadTrElem = this._dom.createChildOf(theadElem, 'tr');
 
@@ -226,7 +222,7 @@ class DetailsRenderer {
         this._dom.createChildOf(rowElem, 'td', classes).appendChild(this.render(item));
       }
     }
-    return element;
+    return tableElem;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -27,7 +27,7 @@ class DetailsRenderer {
 
   /**
    * @param {!DetailsRenderer.DetailsJSON} details
-   * @return {!Node}
+   * @return {!Element}
    */
   render(details) {
     switch (details.type) {

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -79,7 +79,9 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
 
     // If there's no `type`, then we only used details for `summary`
     if (details.type) {
-      element.appendChild(this.detailsRenderer.render(details));
+      const detailsElem = this.detailsRenderer.render(details);
+      detailsElem.classList.add('lh-details');
+      element.appendChild(detailsElem);
     }
 
     return element;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -120,8 +120,7 @@
   scroll-behavior: smooth;
 }
 
-.lh-root :focus,
-.lh-root .lh-details > summary:focus {
+.lh-root :focus {
     outline: -webkit-focus-ring-color auto 3px;
 }
 .lh-root summary:focus {
@@ -145,21 +144,18 @@
 .lh-audit__description,
 .lh-load-opportunity__description,
 .lh-details {
-  margin-left: calc(var(--text-indent) + var(--lh-audit-index-width) + 2 * var(--audit-item-gap));
-  margin-right: calc(var(--text-indent) + 2px);
+  --inner-audit-left-padding: calc(var(--text-indent) + var(--lh-audit-index-width) + 2 * var(--audit-item-gap));
+  --inner-audit-right-padding: calc(var(--text-indent) + 2px);
+  margin-left: var(--inner-audit-left-padding);
+  margin-right: var(--inner-audit-right-padding);
 }
 
 .lh-details {
   font-size: var(--body-font-size);
   margin-top: var(--default-padding);
-}
-
-.lh-details[open] summary {
   margin-bottom: var(--default-padding);
-}
-
-.lh-details summary::-webkit-details-marker {
-  color: #9e9e9e;
+  /* whatever the .lh-details side margins are */
+  width: calc(100% - var(--inner-audit-left-padding) - var(--inner-audit-right-padding));
 }
 
 .lh-details.flex .lh-code {
@@ -884,8 +880,6 @@ summary.lh-passed-audits-summary {
 .lh-table {
   --image-preview-size: 24px;
   border-collapse: collapse;
-  width: 100%;
-  margin-bottom: var(--lh-audit-vpadding);
 
   --url-col-max-width: 450px;
 }
@@ -893,11 +887,9 @@ summary.lh-passed-audits-summary {
 .lh-table thead {
   background: var(--lh-table-header-bg);
 }
-.lh-table thead th,
-.lh-details summary {
+.lh-table thead th {
   color: var(--medium-75-gray);
   font-weight: normal;
-  text-align: left;
 }
 
 .lh-table tbody tr:nth-child(even) {

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -522,74 +522,74 @@
 
 <!-- Lighthouse crtiical request chains component -->
 <template id="tmpl-lh-crc">
-<div class="lh-crc-container">
-  <style>
-    .lh-crc .tree-marker {
-      width: 12px;
-      height: 26px;
-      display: block;
-      float: left;
-      background-position: top left;
-    }
-    .lh-crc .horiz-down {
-      background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><g fill="%23D8D8D8" fill-rule="evenodd"><path d="M16 12v2H-2v-2z"/><path d="M9 12v14H7V12z"/></g></svg>');
-    }
-    .lh-crc .right {
-      background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M16 12v2H0v-2z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
-    }
-    .lh-crc .up-right {
-      background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v14H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
-    }
-    .lh-crc .vert-right {
-      background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v27H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
-    }
-    .lh-crc .vert {
-      background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v26H7z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
-    }
-    .lh-crc .crc-tree {
-      font-size: 14px;
-      width: 100%;
-      overflow-x: auto;
-    }
-    .lh-crc .crc-node {
-      height: 26px;
-      line-height: 26px;
-      white-space: nowrap;
-    }
-    .lh-crc .crc-node__tree-value {
-      margin-left: 10px;
-    }
-    .lh-crc .crc-node__chain-duration {
-      font-weight: 700;
-    }
-    .lh-crc .crc-node__tree-hostname {
-      color: #595959;
-    }
-    .lh-crc .crc-initial-nav {
-      color: #595959;
-      font-style: italic;
-    }
-  </style>
-  <div>
-    Longest chain: <b class="lh-crc__longest_duration"><!-- fill me: longestChain.duration --></b>
-    over <b class="lh-crc__longest_length"><!-- fill me: longestChain.length --></b> requests, totalling
-    <b class="lh-crc__longest_transfersize"><!-- fill me: longestChain.length --></b>
-  </div>
-  <div class="lh-crc">
-    <div class="crc-initial-nav">Initial Navigation</div>
-    <!-- stamp for each chain -->
-    <template id="tmpl-lh-crc__chains">
-      <div class="crc-node">
-        <span class="crc-node__tree-marker">
+  <div class="lh-crc-container">
+    <style>
+      .lh-crc .tree-marker {
+        width: 12px;
+        height: 26px;
+        display: block;
+        float: left;
+        background-position: top left;
+      }
+      .lh-crc .horiz-down {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><g fill="%23D8D8D8" fill-rule="evenodd"><path d="M16 12v2H-2v-2z"/><path d="M9 12v14H7V12z"/></g></svg>');
+      }
+      .lh-crc .right {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M16 12v2H0v-2z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+      }
+      .lh-crc .up-right {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v14H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+      }
+      .lh-crc .vert-right {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v27H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+      }
+      .lh-crc .vert {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v26H7z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+      }
+      .lh-crc .crc-tree {
+        font-size: 14px;
+        width: 100%;
+        overflow-x: auto;
+      }
+      .lh-crc .crc-node {
+        height: 26px;
+        line-height: 26px;
+        white-space: nowrap;
+      }
+      .lh-crc .crc-node__tree-value {
+        margin-left: 10px;
+      }
+      .lh-crc .crc-node__chain-duration {
+        font-weight: 700;
+      }
+      .lh-crc .crc-node__tree-hostname {
+        color: #595959;
+      }
+      .lh-crc .crc-initial-nav {
+        color: #595959;
+        font-style: italic;
+      }
+    </style>
+    <div>
+      Longest chain: <b class="lh-crc__longest_duration"><!-- fill me: longestChain.duration --></b>
+      over <b class="lh-crc__longest_length"><!-- fill me: longestChain.length --></b> requests, totalling
+      <b class="lh-crc__longest_transfersize"><!-- fill me: longestChain.length --></b>
+    </div>
+    <div class="lh-crc">
+      <div class="crc-initial-nav">Initial Navigation</div>
+      <!-- stamp for each chain -->
+      <template id="tmpl-lh-crc__chains">
+        <div class="crc-node">
+          <span class="crc-node__tree-marker">
 
-        </span>
-        <span class="crc-node__tree-value">
-          <span class="crc-node__tree-file"><!-- fill me: node.request.url.file --></span>
-          <span class="crc-node__tree-hostname">(<!-- fill me: node.request.url.host -->)</span>
+          </span>
+          <span class="crc-node__tree-value">
+            <span class="crc-node__tree-file"><!-- fill me: node.request.url.file --></span>
+            <span class="crc-node__tree-hostname">(<!-- fill me: node.request.url.host -->)</span>
 
-        </span>
-      </div>
-    </template>
+          </span>
+        </div>
+      </template>
+    </div>
   </div>
-</div>
 </template>

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -522,6 +522,7 @@
 
 <!-- Lighthouse crtiical request chains component -->
 <template id="tmpl-lh-crc">
+<div class="lh-crc-container">
   <style>
     .lh-crc .tree-marker {
       width: 12px;
@@ -575,22 +576,20 @@
     <b class="lh-crc__longest_transfersize"><!-- fill me: longestChain.length --></b>
   </div>
   <div class="lh-crc">
-    <details class="lh-details">
-      <summary></summary>
-      <div class="crc-initial-nav">Initial Navigation</div>
-      <!-- stamp for each chain -->
-      <template id="tmpl-lh-crc__chains">
-        <div class="crc-node">
-          <span class="crc-node__tree-marker">
+    <div class="crc-initial-nav">Initial Navigation</div>
+    <!-- stamp for each chain -->
+    <template id="tmpl-lh-crc__chains">
+      <div class="crc-node">
+        <span class="crc-node__tree-marker">
 
-          </span>
-          <span class="crc-node__tree-value">
-            <span class="crc-node__tree-file"><!-- fill me: node.request.url.file --></span>
-            <span class="crc-node__tree-hostname">(<!-- fill me: node.request.url.host -->)</span>
+        </span>
+        <span class="crc-node__tree-value">
+          <span class="crc-node__tree-file"><!-- fill me: node.request.url.file --></span>
+          <span class="crc-node__tree-hostname">(<!-- fill me: node.request.url.host -->)</span>
 
-          </span>
-        </div>
-      </template>
-    </details>
+        </span>
+      </div>
+    </template>
   </div>
+</div>
 </template>

--- a/lighthouse-core/test/report/html/renderer/crc-details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/crc-details-renderer-test.js
@@ -91,8 +91,7 @@ describe('DetailsRenderer', () => {
 
   it('renders tree structure', () => {
     const el = CriticalRequestChainRenderer.render(dom, dom.document(), DETAILS);
-    const details = el.querySelector('.lh-details');
-    const chains = details.querySelectorAll('.crc-node');
+    const chains = el.querySelectorAll('.crc-node');
 
     // Main request
     assert.equal(chains.length, 4, 'generates correct number of chain nodes');

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -110,8 +110,7 @@ describe('DetailsRenderer', () => {
         ],
       });
 
-      assert.equal(el.localName, 'details');
-      assert.ok(el.querySelector('table'), 'did not render table');
+      assert.equal(el.localName, 'table', 'did not render table');
       assert.ok(el.querySelector('img'), 'did not render recursive items');
       assert.equal(el.querySelectorAll('th').length, 3, 'did not render header items');
       assert.equal(el.querySelectorAll('td').length, 6, 'did not render table cells');


### PR DESCRIPTION
* remove the collapsible details/summary control entirely.
* new colors.
* make sure we're always max 100% width.

![image](https://user-images.githubusercontent.com/39191/39719541-634137f4-51ee-11e8-8f4b-e28eb511a758.png)



### example reports:

https://venomous-horse.surge.sh/cnn.html
https://venomous-horse.surge.sh/dbwtester.html
https://venomous-horse.surge.sh/errors.html
https://venomous-horse.surge.sh/example.html
https://venomous-horse.surge.sh/paulirish.html
https://venomous-horse.surge.sh/tinyhouse.html

https://venomous-horse.surge.sh/z.devtools.cnn.html
https://venomous-horse.surge.sh/z.devtools.dbwtester.html
https://venomous-horse.surge.sh/z.devtools.errors.html
https://venomous-horse.surge.sh/z.devtools.example.html
https://venomous-horse.surge.sh/z.devtools.paulirish.html
https://venomous-horse.surge.sh/z.devtools.tinyhouse.html

