### PR TITLE
core(runner): support multiple output modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ last-run-results.html
 *.report.html
 *.report.dom.html
 *.report.json
+*.report.csv
 *.report.pretty
 *.artifacts.log
 

--- a/lighthouse-cli/bin.js
+++ b/lighthouse-cli/bin.js
@@ -70,7 +70,11 @@ if (cliFlags.verbose) {
 }
 log.setLevel(cliFlags.logLevel);
 
-if (cliFlags.output === printer.OutputMode.json && !cliFlags.outputPath) {
+if (
+  cliFlags.output.length === 1 &&
+  cliFlags.output[0] === printer.OutputMode.json &&
+  !cliFlags.outputPath
+) {
   cliFlags.outputPath = 'stdout';
 }
 

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -127,11 +127,12 @@ function getFlags(manualArgv) {
       .array('onlyAudits')
       .array('onlyCategories')
       .array('skipAudits')
+      .array('output')
       .string('extraHeaders')
 
       // default values
       .default('chrome-flags', '')
-      .default('output', 'html')
+      .default('output', ['html'])
       .default('port', 0)
       .default('hostname', 'localhost')
       .check(/** @param {!LH.Flags} argv */ (argv) => {

--- a/lighthouse-cli/printer.js
+++ b/lighthouse-cli/printer.js
@@ -69,26 +69,17 @@ function writeFile(filePath, output, outputMode) {
 }
 
 /**
- * Writes the results.
- * @param {LH.RunnerResult} results
+ * Writes the output.
+ * @param {string} output
  * @param {string} mode
  * @param {string} path
- * @return {Promise<LH.RunnerResult>}
+ * @return {Promise<void>}
  */
-function write(results, mode, path) {
-  return new Promise((resolve, reject) => {
-    const outputPath = checkOutputPath(path);
-    const output = results.report;
-
-    if (outputPath === 'stdout') {
-      return writeToStdout(output).then(_ => resolve(results));
-    }
-    return writeFile(outputPath, output, mode)
-      .then(_ => {
-        resolve(results);
-      })
-      .catch(err => reject(err));
-  });
+async function write(output, mode, path) {
+  const outputPath = checkOutputPath(path);
+  return outputPath === 'stdout' ?
+    writeToStdout(output) :
+    writeFile(outputPath, output, mode);
 }
 
 /**

--- a/lighthouse-cli/test/cli/printer-test.js
+++ b/lighthouse-cli/test/cli/printer-test.js
@@ -25,7 +25,7 @@ describe('Printer', () => {
   it('writes file for results', () => {
     const path = './.test-file.json';
     const report = JSON.stringify(sampleResults);
-    return Printer.write({report}, 'json', path).then(_ => {
+    return Printer.write(report, 'json', path).then(_ => {
       const fileContents = fs.readFileSync(path, 'utf8');
       assert.ok(/lighthouseVersion/gim.test(fileContents));
       fs.unlinkSync(path);
@@ -35,7 +35,7 @@ describe('Printer', () => {
   it('throws for invalid paths', () => {
     const path = '!/#@.json';
     const report = JSON.stringify(sampleResults);
-    return Printer.write({report}, 'html', path).catch(err => {
+    return Printer.write(report, 'html', path).catch(err => {
       assert.ok(err.code === 'ENOENT');
     });
   });

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -88,24 +88,31 @@ class ReportGenerator {
   /**
    * Creates the results output in a format based on the `mode`.
    * @param {LH.Result} lhr
-   * @param {'json'|'html'|'csv'} outputMode
-   * @return {string}
+   * @param {LH.Config.Settings['output']} outputModes
+   * @return {string|string[]}
    */
-  static generateReport(lhr, outputMode) {
-    // HTML report.
-    if (outputMode === 'html') {
-      return ReportGenerator.generateReportHtml(lhr);
-    }
-    // CSV report.
-    if (outputMode === 'csv') {
-      return ReportGenerator.generateReportCSV(lhr);
-    }
-    // JSON report.
-    if (outputMode === 'json') {
-      return JSON.stringify(lhr, null, 2);
-    }
+  static generateReport(lhr, outputModes) {
+    const outputAsArray = Array.isArray(outputModes);
+    if (typeof outputModes === 'string') outputModes = [outputModes];
 
-    throw new Error('Invalid output mode: ' + outputMode);
+    const output = outputModes.map(outputMode => {
+      // HTML report.
+      if (outputMode === 'html') {
+        return ReportGenerator.generateReportHtml(lhr);
+      }
+      // CSV report.
+      if (outputMode === 'csv') {
+        return ReportGenerator.generateReportCSV(lhr);
+      }
+      // JSON report.
+      if (outputMode === 'json') {
+        return JSON.stringify(lhr, null, 2);
+      }
+
+      throw new Error('Invalid output mode: ' + outputMode);
+    });
+
+    return outputAsArray ? output : output[0];
   }
 }
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -436,6 +436,11 @@ describe('Config', () => {
     assert.ok(config.settings.nonsense === undefined, 'did not cleanup settings');
   });
 
+  it('allows overriding of array-typed settings', () => {
+    const config = new Config({extends: true}, {output: ['html']});
+    assert.deepStrictEqual(config.settings.output, ['html']);
+  });
+
   it('extends the full config', () => {
     class CustomAudit extends Audit {
       static get meta() {

--- a/lighthouse-core/test/report/report-generator-test.js
+++ b/lighthouse-core/test/report/report-generator-test.js
@@ -114,4 +114,11 @@ describe('ReportGenerator', () => {
       assert.ok(outputCheck.test(htmlOutput));
     });
   });
+
+  it('handles array of outputs', () => {
+    const [json, html] = ReportGenerator.generateReport(sampleResults, ['json', 'html']);
+    assert.doesNotThrow(_ => JSON.parse(json));
+    assert.ok(/<!doctype/gim.test(html));
+    assert.ok(/<html lang="en"/gim.test(html));
+  });
 });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -4448,7 +4448,9 @@
     }
   },
   "configSettings": {
-    "output": "json",
+    "output": [
+      "json"
+    ],
     "maxWaitForLoad": 45000,
     "throttlingMethod": "devtools",
     "throttling": {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -543,4 +543,21 @@ describe('Runner', () => {
       ]);
     });
   });
+
+  it('can handle array of outputs', async () => {
+    const url = 'https://example.com';
+    const config = new Config({
+      extends: 'lighthouse:default',
+      settings: {
+        onlyCategories: ['performance'],
+        output: ['json', 'html'],
+      },
+    });
+
+    const results = await Runner.run(null, {url, config, driverMock});
+    assert.ok(Array.isArray(results.report) && results.report.length === 2,
+      'did not return multiple reports');
+    assert.ok(JSON.parse(results.report[0]), 'did not return json output');
+    assert.ok(/<!doctype/.test(results.report[1]), 'did not return html output');
+  });
 });

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -47,8 +47,10 @@ declare global {
       cpuSlowdownMultiplier?: number
     }
 
+    export type OutputMode = 'json' | 'html' | 'csv';
+
     interface SharedFlagsSettings {
-      output?: 'json' | 'html' | 'csv';
+      output?: OutputMode|OutputMode[];
       maxWaitForLoad?: number;
       blockedUrlPatterns?: string[] | null;
       additionalTraceCategories?: string | null;
@@ -88,7 +90,7 @@ declare global {
 
     export interface RunnerResult {
       lhr: Result;
-      report: string;
+      report: string|string[];
       artifacts: Artifacts;
     }
 


### PR DESCRIPTION
returns support for multiple outputs

I know there's some ugliness in config to get this to work with unified config/CLI settings, but that'll need some good cleanup for type checking soon anyhow

biggest question for 3.0: **do we want to have report/output types be `string|string[]` or `string[]`** 

I did the `|` because it's easier impl wise and won't break common `output: 'html'` case, but it's new functionality anyhow so now's our chance