### PR TITLE
core(start-url): use window.location over fetch

### DIFF
--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -97,7 +97,7 @@ class StartUrl extends Gatherer {
     });
 
     return driver
-      .evaluateAsync(`fetch('${startUrl}')`)
+      .evaluateAsync(`window.location = '${startUrl}'`)
       .then(() => Promise.race([fetchPromise, timeoutPromise]));
   }
 }


### PR DESCRIPTION
ref #4541

simple fix for sites like https://pwa-starter-kit.appspot.com/ that don't respond to `fetch` requests

not clear what other the other consequences are but it passes all smoke tests and a few of the sites mentioned in #4541 that originally failed