### PR TITLE
 3.0.0-alpha.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,6 +15,9 @@ lighthouse-extension/
 lighthouse-cli/results/
 lighthouse-logger/
 
+# keep the chrome launcher script
+!lighthouse-core/scripts/manual-chrome-launcher.js
+
 # excluding cli/test minus smokehouse
 lighthouse-cli/test
 !lighthouse-cli/test/smokehouse

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -15,7 +15,7 @@ module.exports = {
     passName: 'defaultPass',
     recordTrace: true,
     useThrottling: true,
-    pauseAfterLoadMs: 10000,
+    pauseAfterLoadMs: 1000,
     networkQuietThresholdMs: 1000,
     cpuQuietThresholdMs: 1000,
     gatherers: [

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1,6 +1,6 @@
 {
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
-  "lighthouseVersion": "3.0.0-alpha",
+  "lighthouseVersion": "3.0.0-alpha.1",
   "fetchTime": "2018-03-13T00:55:45.840Z",
   "requestedUrl": "http://localhost/dobetterweb/dbw_tester.html",
   "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "3.0.0-alpha",
+  "version": "3.0.0-alpha.1",
   "description": "Lighthouse",
   "main": "./lighthouse-core/index.js",
   "bin": {


### PR DESCRIPTION
npmignore was busted since the chrome launcher script got moved, guess that issue we saw was real afterall @paulirish ;)

also reverts an accidental change that snuck in from a bad rebase to the config constants

already published since lighthouse was borked anyhow, but this puts master back in a good state