### PR TITLE
report: minimum time scale, text tweaks

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -19,7 +19,7 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
   static get meta() {
     return {
       name: 'unused-css-rules',
-      description: 'Unused CSS rules',
+      description: 'Remove unused CSS',
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
       helpText: 'Remove unused rules from stylesheets to reduce unnecessary ' +
           'bytes consumed by network activity. ' +

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -19,7 +19,7 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
   static get meta() {
     return {
       name: 'unused-css-rules',
-      description: 'Remove unused CSS',
+      description: 'Defer unused CSS',
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
       helpText: 'Remove unused rules from stylesheets to reduce unnecessary ' +
           'bytes consumed by network activity. ' +

--- a/lighthouse-core/audits/screenshot-thumbnails.js
+++ b/lighthouse-core/audits/screenshot-thumbnails.js
@@ -76,17 +76,16 @@ class ScreenshotThumbnails extends Audit {
 
     const speedline = await artifacts.requestSpeedline(trace);
 
-    let minimumTimelineDuration = 0;
+    // Make the minimum time range 3s so sites that load super quickly don't get a single screenshot
+    let minimumTimelineDuration = 3000;
     // Ensure thumbnails cover the full range of the trace (TTI can be later than visually complete)
     if (context.settings.throttlingMethod !== 'simulate') {
       const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
       const metricComputationData = {trace, devtoolsLog, settings: context.settings};
       const tti = artifacts.requestInteractive(metricComputationData);
       try {
-        minimumTimelineDuration = (await tti).timing;
-      } catch (_) {
-        minimumTimelineDuration = 0;
-      }
+        minimumTimelineDuration = Math.max((await tti).timing, minimumTimelineDuration);
+      } catch (_) {}
     }
 
     const thumbnails = [];

--- a/lighthouse-core/audits/screenshot-thumbnails.js
+++ b/lighthouse-core/audits/screenshot-thumbnails.js
@@ -77,7 +77,7 @@ class ScreenshotThumbnails extends Audit {
     const speedline = await artifacts.requestSpeedline(trace);
 
     // Make the minimum time range 3s so sites that load super quickly don't get a single screenshot
-    let minimumTimelineDuration = 3000;
+    let minimumTimelineDuration = context.options.minimumTimelineDuration || 3000;
     // Ensure thumbnails cover the full range of the trace (TTI can be later than visually complete)
     if (context.settings.throttlingMethod !== 'simulate') {
       const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -157,9 +157,11 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
         .sort((auditA, auditB) => this._getWastedMs(auditB) - this._getWastedMs(auditA));
 
     if (opportunityAudits.length) {
+      // Scale the sparklines relative to savings, minimum 2s to not overstate small savings
+      const minimumScale = 2000;
       const wastedMsValues = opportunityAudits.map(audit => this._getWastedMs(audit));
       const maxWaste = Math.max(...wastedMsValues);
-      const scale = Math.ceil(maxWaste / 1000) * 1000;
+      const scale = Math.max(Math.ceil(maxWaste / 1000) * 1000, minimumScale);
       const groupEl = this.renderAuditGroup(groups['load-opportunities'], {expandable: false});
       const tmpl = this.dom.cloneTemplate('#tmpl-lh-opportunity-header', this.templateContext);
       const headerEl = this.dom.find('.lh-load-opportunity__header', tmpl);

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -120,7 +120,7 @@
     }
     .lh-metadata {
       flex: 1 1 0;
-      margin-right: calc(var(--default-padding) * 8);
+      padding-right: calc(var(--default-padding) / 2);
       line-height: 20px;
       color: var(--report-header-color);
       z-index: 1;
@@ -269,9 +269,9 @@
     .lh-env {
       padding: var(--default-padding) 0 var(--default-padding) calc(var(--default-padding) * 2);
       left: 0;
-      right: calc(var(--default-padding) * -8);
       top: 100%;
       position: absolute;
+      width: 100%;
       background-color: var(--header-bg-color);
       border-top: 1px solid var(--report-secondary-border-color);
       border-bottom: 1px solid var(--report-secondary-border-color);

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -120,7 +120,7 @@
     }
     .lh-metadata {
       flex: 1 1 0;
-      padding-right: calc(var(--default-padding) / 2);
+      margin-right: calc(var(--default-padding) * 8);
       line-height: 20px;
       color: var(--report-header-color);
       z-index: 1;
@@ -269,9 +269,9 @@
     .lh-env {
       padding: var(--default-padding) 0 var(--default-padding) calc(var(--default-padding) * 2);
       left: 0;
+      right: calc(var(--default-padding) * -8);
       top: 100%;
       position: absolute;
-      width: 100%;
       background-color: var(--header-bg-color);
       border-top: 1px solid var(--report-secondary-border-color);
       border-bottom: 1px solid var(--report-secondary-border-color);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2007,7 +2007,7 @@
       "displayValue": "",
       "scoreDisplayMode": "numeric",
       "name": "unused-css-rules",
-      "description": "Remove unused CSS",
+      "description": "Defer unused CSS",
       "helpText": "Remove unused rules from stylesheets to reduce unnecessary bytes consumed by network activity. [Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery).",
       "details": {
         "type": "table",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2007,7 +2007,7 @@
       "displayValue": "",
       "scoreDisplayMode": "numeric",
       "name": "unused-css-rules",
-      "description": "Unused CSS rules",
+      "description": "Remove unused CSS",
       "helpText": "Remove unused rules from stylesheets to reduce unnecessary bytes consumed by network activity. [Learn more](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery).",
       "details": {
         "type": "table",


### PR DESCRIPTION
drive-by I/O polish I noticed while doing demos

* Unused CSS Rules inconsistent name
* minimum filmstrip scale 3s
* minimum opportunity scale of 2s

EDIT: removed the share dropdown fix since ward already put up a PR :D #5185 