### PR TITLE
tests(viewer): upgrade pptr to handle new CSSOM use in the report

### DIFF
--- a/lighthouse-core/report/html/renderer/logger.js
+++ b/lighthouse-core/report/html/renderer/logger.js
@@ -49,6 +49,11 @@ class Logger {
    */
   error(msg) {
     this.log(msg);
+
+    // Rethrow to make sure it's auditable as an error.
+    setTimeout(_ => {
+      throw new Error(msg);
+    }, 0);
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/logger.js
+++ b/lighthouse-core/report/html/renderer/logger.js
@@ -50,7 +50,8 @@ class Logger {
   error(msg) {
     this.log(msg);
 
-    // Rethrow to make sure it's auditable as an error.
+    // Rethrow to make sure it's auditable as an error, but in a setTimeout so page
+    // recovers gracefully and user can try loading a report again.
     setTimeout(_ => {
       throw new Error(msg);
     }, 0);

--- a/lighthouse-viewer/test/viewer-test-pptr.js
+++ b/lighthouse-viewer/test/viewer-test-pptr.js
@@ -66,6 +66,10 @@ describe('Lighthouse Viewer', function() {
   });
 
   after(async function() {
+    // Log any page load errors encountered in case before() failed.
+    // eslint-disable-next-line no-console
+    console.log(pageErrors);
+
     await Promise.all([
       new Promise(resolve => server.close(resolve)),
       browser && browser.close(),

--- a/lighthouse-viewer/test/viewer-test-pptr.js
+++ b/lighthouse-viewer/test/viewer-test-pptr.js
@@ -68,7 +68,7 @@ describe('Lighthouse Viewer', function() {
   after(async function() {
     // Log any page load errors encountered in case before() failed.
     // eslint-disable-next-line no-console
-    console.log(pageErrors);
+    console.error(pageErrors);
 
     await Promise.all([
       new Promise(resolve => server.close(resolve)),

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "npm-run-posix-or-windows": "^2.0.2",
     "nyc": "^11.6.0",
     "postinstall-prepare": "^1.0.1",
-    "puppeteer": "^1.1.1",
+    "puppeteer": "1.4.0",
     "sinon": "^2.3.5",
     "typescript": "2.9.0-dev.20180323",
     "vscode-chrome-debug-core": "^3.23.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,9 +3481,9 @@ mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.24.0"
 
-mime@^1.3.4:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+mime@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -4043,14 +4043,14 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-puppeteer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.1.1.tgz#adbf25e49f5ef03443c10ab8e09a954ca0c7bfee"
+puppeteer@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.4.0.tgz#437f0f3450d76e437185c0bf06f446e80f184692"
   dependencies:
-    debug "^2.6.8"
+    debug "^3.1.0"
     extract-zip "^1.6.5"
     https-proxy-agent "^2.1.0"
-    mime "^1.3.4"
+    mime "^2.0.3"
     progress "^2.0.0"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"


### PR DESCRIPTION
`computedStyleMap` in the report fails in the Chromium version that our current version of puppeteer ships with. This revs the version so that we get a more recent Chromium.

Drive by change to viewer and the viewer pptr test so that when there's an in-page error like this, the test can pick it up and print it to console instead of just timing out in `before()` waiting for the report to load.