### PR TITLE
misc(viewer): support 3.x and legacy (2.x) reports in viewer

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -349,6 +349,7 @@ class ReportUIFeatures {
    * to the online viewer using postMessage.
    * @param {!ReportRenderer.ReportJSON} reportJson
    * @param {string} viewerPath
+   * @suppress {reportUnknownTypes}
    * @protected
    */
   static openTabAndSendJsonReport(reportJson, viewerPath) {
@@ -375,8 +376,8 @@ class ReportUIFeatures {
     });
 
     // The popup's window.name is keyed by version+url+fetchTime, so we reuse/select tabs correctly
-    const fetchTime = /** @type {!string} */ (json.fetchTime || json.generatedTime);
-    const windowName = `${json.lighthouseVersion}-${json.initialUrl}-${fetchTime}`;
+    const fetchTime = json.fetchTime || json.generatedTime;
+    const windowName = `${json.lighthouseVersion}-${json.requestedUrl}-${fetchTime}`;
     const popup = /** @type {!Window} */ (window.open(`${VIEWER_ORIGIN}${viewerPath}`, windowName));
 
     return p;

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -368,7 +368,10 @@ class ReportUIFeatures {
       onMessageCallback(messageEvent.data);
     });
 
-    const popup = /** @type {!Window} */ (window.open(`${VIEWER_ORIGIN}${viewerPath}`, 'zblank'));
+    // The popup's window.name is keyed by version+url+fetchTime, so we reuse/select tabs correctly
+    const fetchTime = json.fetchTime || json.generatedTime;
+    const windowName = `${json.lighthouseVersion}-${json.initialUrl}-${fetchTime}`;
+    const popup = /** @type {!Window} */ (window.open(`${VIEWER_ORIGIN}${viewerPath}`, windowName));
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -364,10 +364,12 @@ class ReportUIFeatures {
       if (messageEvent.origin !== VIEWER_ORIGIN) {
         return;
       }
+      // Most recent deployment
       if (messageEvent.data.opened) {
         popup.postMessage({lhresults: json}, VIEWER_ORIGIN);
       }
       if (messageEvent.data.rendered) {
+        window.removeEventListener('message', msgHandler);
         resolve(popup);
       }
     });

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -179,15 +179,16 @@ class LighthouseReportViewer {
    * @param {!ReportRenderer.ReportJSON} reportJson
    * @private
    */
-  async _loadInLegacyViewerVersion(json) {
+  _loadInLegacyViewerVersion(json) {
     const warnMsg = `Version mismatch between viewer and JSON.
     Opening new tab with compatible viewer.`;
     const viewerPath = '/lighthouse/viewer2x/';
 
     logger.log(warnMsg, false);
-    await ViewerUIFeatures.openTabAndSendJsonReport(json, viewerPath);
-    window.close();
-    logger.log(`${warnMsg} You can close this tab.`, false);
+    ViewerUIFeatures.openTabAndSendJsonReport(json, viewerPath).then(_ => {
+      window.close();
+      logger.log(`${warnMsg} You can close this tab.`, false);
+    });
   }
 
   /**

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -179,18 +179,15 @@ class LighthouseReportViewer {
    * @param {!ReportRenderer.ReportJSON} reportJson
    * @private
    */
-  _loadInLegacyViewerVersion(json) {
+  async _loadInLegacyViewerVersion(json) {
     const warnMsg = `Version mismatch between viewer and JSON.
     Opening new tab with compatible viewer.`;
-    const features = new ViewerUIFeatures(new DOM(document));
     const viewerPath = '/lighthouse/viewer2x/';
 
     logger.log(warnMsg, false);
-    features.sendJsonReport(json, viewerPath, onMessage);
-    function onMessage(data) {
-      if (data.rendered) window.close();
-      logger.log(`${warnMsg} You can close this tab.`, false);
-    }
+    await ViewerUIFeatures.openTabAndSendJsonReport(json, viewerPath);
+    window.close();
+    logger.log(`${warnMsg} You can close this tab.`, false);
   }
 
   /**

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -180,12 +180,17 @@ class LighthouseReportViewer {
    * @private
    */
   _loadInLegacyViewerVersion(json) {
+    const warnMsg = `Version mismatch between viewer and JSON.
+    Opening new tab with compatible viewer.`;
     const features = new ViewerUIFeatures(new DOM(document));
     const viewerPath = '/lighthouse/viewer2x/';
+
+    logger.log(warnMsg, false);
+    features.sendJsonReport(json, viewerPath, onMessage);
     function onMessage(data) {
       if (data.rendered) window.close();
+      logger.log(`${warnMsg} You can close this tab.`, false);
     }
-    features.sendJsonReport(json, viewerPath, onMessage);
   }
 
   /**

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -113,6 +113,11 @@ class LighthouseReportViewer {
   _replaceReportHtml(json) {
     this._validateReportJson(json);
 
+    if (!json.lighthouseVersion.startsWith('3')) {
+      this._loadInLegacyViewerVersion(json);
+      return;
+    }
+
     const dom = new DOM(document);
     const renderer = new ReportRenderer(dom);
 
@@ -165,12 +170,7 @@ class LighthouseReportViewer {
         throw new Error('Could not parse JSON file.');
       }
       this._reportIsFromGist = false;
-
-      if (!json.lighthouseVersion.startsWith('3')) {
-        this._loadInLegacyViewerVersion(json);
-      } else {
-        this._replaceReportHtml(json);
-      }
+      this._replaceReportHtml(json);
     }).catch(err => logger.error(err.message));
   }
 

--- a/lighthouse-viewer/app/src/viewer-ui-features.js
+++ b/lighthouse-viewer/app/src/viewer-ui-features.js
@@ -49,13 +49,6 @@ class ViewerUIFeatures extends ReportUIFeatures {
   /**
    * @override
    */
-  sendJsonReport() {
-    throw new Error('Cannot send JSON to Viewer from Viewer.');
-  }
-
-  /**
-   * @override
-   */
   saveAsGist() {
     if (this._saveGistCallback) {
       this._saveGistCallback(this.json);


### PR DESCRIPTION
#### Basic setup:

1. The 2.x viewer is published to https://googlechrome.github.io/lighthouse/viewer2x/
2. The 3.x viewer will live at https://googlechrome.github.io/lighthouse/viewer/ (but doesn't yet)
3. User opens report in 3.x viewer app (via however: drag, paste, click menu item)
4. The 3.x viewer app notices report isn't v3 and opens another tab with `viewer2x/` and has it render the report.
4. The 3.x viewer attempts to close it's own tab (but this doesn't always work (because user gestures?))
1. The 3.x viewer tells the user what's happening with some toaster notifications.


#### Screencast:
![2xviewr](https://user-images.githubusercontent.com/39191/40015371-fe3b1f94-5767-11e8-8960-48b7f4958bb9.gif)

This also relies on a few commits added to 2.x branch: https://github.com/GoogleChrome/lighthouse/compare/branch2.x...viewer2x-deploy

fixes #5170