### PR TITLE
misc(none): removed extra comma to keep the json valid

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
     "lighthouse-core/test/**/*.js",
     "lighthouse-core/closure/**/*.js",
     "lighthouse-core/third_party/src/**/*.js",
-    "lighthouse-core/report/html/renderer/**/*.js",
+    "lighthouse-core/report/html/renderer/**/*.js"
   ]
 }


### PR DESCRIPTION
I executed a validator on the project and found this extra comma in the json file.
It shouldn't be here.