### PR TITLE
report: avoid paint storms on scrolly header.

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -34,7 +34,7 @@ class ReportUIFeatures {
     /** @type {!Element} */
     this.lighthouseIcon; // eslint-disable-line no-unused-expressions
     /** @type {!Element} */
-    this.scoresShadowWrapper; // eslint-disable-line no-unused-expressions
+    this.scoresWrapperBg; // eslint-disable-line no-unused-expressions
     /** @type {!Element} */
     this.productInfo; // eslint-disable-line no-unused-expressions
     /** @type {!Element} */
@@ -122,7 +122,7 @@ class ReportUIFeatures {
     this.headerSticky = this._dom.find('.lh-header-sticky', this._document);
     this.headerBackground = this._dom.find('.lh-header-bg', this._document);
     this.lighthouseIcon = this._dom.find('.lh-lighthouse', this._document);
-    this.scoresShadowWrapper = this._dom.find('.lh-scores-wrapper__shadow', this._document);
+    this.scoresWrapperBg = this._dom.find('.lh-scores-wrapper__background', this._document);
     this.productInfo = this._dom.find('.lh-product-info', this._document);
     this.toolbar = this._dom.find('.lh-toolbar', this._document);
     this.toolbarMetadata = this._dom.find('.lh-toolbar__metadata', this._document);
@@ -206,45 +206,40 @@ class ReportUIFeatures {
 
   animateHeader() {
     const collapsedHeaderHeight = 50;
-    const animateScrollPercentage = Math.min(1, this.latestKnownScrollY /
-      (this.headerHeight - collapsedHeaderHeight));
-    const headerTransitionHeightDiff = this.headerHeight - collapsedHeaderHeight +
-      this.headerOverlap;
+    const heightDiff = this.headerHeight - collapsedHeaderHeight + this.headerOverlap;
+    const scrollPct = Math.min(1,
+      this.latestKnownScrollY / (this.headerHeight - collapsedHeaderHeight));
 
-    this.headerSticky.style.transform = `translateY(${headerTransitionHeightDiff *
-      animateScrollPercentage *
-      -1}px)`;
-    this.headerBackground.style.transform = `translateY(${animateScrollPercentage *
-      this.headerOverlap}px)`;
+    const scoresContainer = this.scoresWrapperBg.parentElement;
+
+    this.headerSticky.style.transform = `translateY(${heightDiff * scrollPct * -1}px)`;
+    this.headerBackground.style.transform = `translateY(${scrollPct * this.headerOverlap}px)`;
     this.lighthouseIcon.style.transform =
       `translate3d(calc(var(--report-content-width) / 2),` +
-      ` calc(-100% - ${animateScrollPercentage * this.headerOverlap * -1}px), 0) scale(${1 -
-        animateScrollPercentage})`;
-    this.lighthouseIcon.style.opacity = Math.max(0, 1 - animateScrollPercentage);
-    this.scoresShadowWrapper.style.opacity = 1 - animateScrollPercentage;
-    const scoresContainer = this.scoresShadowWrapper.parentElement;
-    scoresContainer.style.borderRadius = (1 - animateScrollPercentage) * 8 + 'px';
-    scoresContainer.style.boxShadow =
-        `0 4px 2px -2px rgba(0, 0, 0, ${animateScrollPercentage * 0.2})`;
-    const scoreScale = scoresContainer.querySelector('.lh-scorescale');
-    scoreScale.style.opacity = `${1 - animateScrollPercentage}`;
-    const scoreHeader = scoresContainer.querySelector('.lh-scores-header');
-    const delta = 32 * animateScrollPercentage;
-    scoreHeader.style.paddingBottom = `${32 - delta}px`;
-    scoresContainer.style.marginBottom = `${delta}px`;
-    this.toolbar.style.transform = `translateY(${headerTransitionHeightDiff *
-      animateScrollPercentage}px)`;
-    this.exportButton.parentElement.style.transform = `translateY(${headerTransitionHeightDiff *
-      animateScrollPercentage}px)`;
-    this.exportButton.style.transform = `scale(${1 - 0.2 * animateScrollPercentage})`;
-    // start showing the productinfo when we are at the 50% mark of our animation
-    this.productInfo.style.opacity = this.toolbarMetadata.style.opacity =
-      animateScrollPercentage < 0.5 ? 0 : (animateScrollPercentage - 0.5) * 2;
-    this.env.style.transform = `translateY(${Math.max(
-      0,
-      headerTransitionHeightDiff * animateScrollPercentage - 6
-    )}px)`;
+      ` calc(-100% - ${scrollPct * this.headerOverlap * -1}px), 0) scale(${1 - scrollPct})`;
+    this.lighthouseIcon.style.opacity = Math.max(0, 1 - scrollPct);
 
+    // Switch up the score background & shadows
+    this.scoresWrapperBg.style.opacity = 1 - scrollPct;
+    this.scoresWrapperBg.style.transform = `scaleY(${1 - scrollPct * 0.2})`;
+    const scoreShadow = scoresContainer.querySelector('.lh-scores-wrapper__shadow');
+    scoreShadow.style.opacity = scrollPct;
+    scoreShadow.style.transform = `scaleY(${1 - scrollPct * 0.2})`;
+
+    // Fade & move the scorescale
+    const scoreScalePositionDelta = 32;
+    const scoreScale = scoresContainer.querySelector('.lh-scorescale');
+    scoreScale.style.opacity = `${1 - scrollPct}`;
+    scoreScale.style.transform = `translateY(${scrollPct * -scoreScalePositionDelta}px)`;
+
+    // Move the toolbar & export
+    this.toolbar.style.transform = `translateY(${heightDiff * scrollPct}px)`;
+    this.exportButton.parentElement.style.transform = `translateY(${heightDiff * scrollPct}px)`;
+    this.exportButton.style.transform = `scale(${1 - 0.2 * scrollPct})`;
+    // Start showing the productinfo when we are at the 50% mark of our animation
+    this.productInfo.style.opacity = this.toolbarMetadata.style.opacity =
+      scrollPct < 0.5 ? 0 : (scrollPct - 0.5) * 2;
+    this.env.style.transform = `translateY(${Math.max(0, heightDiff * scrollPct - 6)}px)`;
 
     this.isAnimatingHeader = false;
   }

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -730,7 +730,7 @@
   justify-content: center;
   overflow-x: hidden;
   position: relative;
-  padding-bottom: calc(var(--section-indent) * 2);
+  padding: var(--section-indent) calc(var(--section-indent) / 2) calc(var(--section-indent) * 2);
 }
 .lh-scores-header__solo {
   padding: 0;
@@ -739,9 +739,10 @@
 
 .lh-scorescale {
   color: var(--medium-75-gray);
-  padding: 0 var(--section-indent) 0 0;
+  padding: 0 calc(var(--section-indent) * 1.5) 0;
   text-align: right;
   transform-origin: bottom right;
+  will-change: opacity; /* opacity is changed on scroll */
 }
 
 .lh-scorescale-range {

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -331,9 +331,72 @@
         margin-left: 0;
       }
     }
+    .lh-lighthouse__clouds {
+      animation: panacross 15s linear infinite;
+      animation-play-state: paused;
+    }
+    .lh-header-sticky:hover .lh-lighthouse__clouds {
+      animation-play-state: running;
+    }
+    @keyframes panacross {
+      0% { transform: translateX(0px); }
+      50% { transform: translateX(195px); }
+      50.0001% { transform: translateX(-180px); }
+      100% { transform: translateX(0px); }
+
+    }
   </style>
   <div class="lh-header-bg"></div>
-  <div class="lh-lighthouse"><svg width="217" height="189" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="a" d="M0 0h284v202H0z"/><linearGradient x1="0%" y1="50%" x2="93.17%" y2="50%" id="c"><stop stop-color="#F1F3F4" offset="0%"/><stop stop-color="#FFF" offset="100%"/></linearGradient></defs><g transform="translate(-56 -13)" fill="none" fill-rule="evenodd"><mask id="b" fill="#fff"><use xlink:href="#a"/></mask><g mask="url(#b)"><g transform="translate(56 70)"><path fill="#EC5548" d="M95 31h24v2H95z"/><path fill="#FBC21B" d="M98 33h18v11H98z"/><path fill="#EC5548" d="M95 43h24v7H95z"/><path fill="#FFF" d="M97.63 50h19.74L120 97H95z"/><path d="M107 22a10 10 0 0 1 10 10v1H97v-1a10 10 0 0 1 10-10zM96.77 66.23l20.97-10.7.63 11.87-22.28 11.87zM95 94.8L119.1 82l.9 14H95z" fill="#EC5548"/><path d="M0 132a177.07 177.07 0 0 1 108.5-37c40.78 0 78.38 13.78 108.5 37H0z" fill="#E8EAED"/><rect fill="#FEF0C8" x="98" y="33" width="10" height="10" rx="5"/><path fill="url(#c)" d="M7 0l91 33.18v10.05L7 77z"/></g></g><g mask="url(#b)" fill="#FFF"><g transform="translate(96 86)"><circle cx="87.5" cy=".5" r="1"/><circle cx="86" cy="20" r="1"/><circle cx="96" cy="40" r="1"/><circle cx="27" cy="68" r="1"/><circle cx="15" cy="44" r="1"/><circle cx="127" cy="64" r="1"/><circle cx="109.5" cy="44.5" r="1"/><circle cx="14.5" cy="54.5" r="1"/><circle cx="8.5" cy="57.5" r="1"/><circle cx=".5" cy="78.5" r="1"/><circle cx="27.5" cy="39.5" r="1"/><circle cx="134.5" cy="41.5" r="1"/><circle cx="97.5" cy="65.5" r="1"/><circle cx="161.5" cy="69.5" r="1"/></g></g><g mask="url(#b)" fill="#FFF"><path d="M101.2 34H70.21A7.42 7.42 0 0 1 69 29.91a7.31 7.31 0 0 1 8.54-7.26v-.11c0-5.27 4.2-9.54 9.39-9.54a9.44 9.44 0 0 1 9.24 7.83 7.24 7.24 0 0 1 7.83 7.35 7.4 7.4 0 0 1-2.8 5.82zM193.53 54h-17.9a4.3 4.3 0 0 1-.63-2.25 4.2 4.2 0 0 1 4.88-4.18v-.07c0-3.04 2.4-5.5 5.36-5.5a5.4 5.4 0 0 1 5.28 4.51l.33-.01a4.2 4.2 0 0 1 4.15 4.25c0 1.3-.57 2.47-1.47 3.25zM219.01 116h-24.16a5.1 5.1 0 0 1-.85-2.81c0-2.94 2.5-5.31 5.6-5.31.33 0 .67.02.99.08v-.08c0-3.8 3.24-6.88 7.24-6.88a7.15 7.15 0 0 1 7.13 5.64l.44-.02c3.1 0 5.6 2.38 5.6 5.32a5.2 5.2 0 0 1-1.99 4.06z"/></g></g></svg></div>
+  <div class="lh-lighthouse">
+    <svg width="217" height="189" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <defs>
+        <path id="a" d="M0 0h284v202H0z" />
+        <linearGradient x1="0%" y1="50%" x2="93.17%" y2="50%" id="c">
+          <stop stop-color="#F1F3F4" offset="0%" />
+          <stop stop-color="#FFF" offset="100%" />
+        </linearGradient>
+      </defs>
+      <g transform="translate(-56 -13)" fill="none" fill-rule="evenodd">
+        <mask id="b" fill="#fff">
+          <use xlink:href="#a" />
+        </mask>
+        <g mask="url(#b)">
+          <g transform="translate(56 70)">
+            <path fill="#EC5548" d="M95 31h24v2H95z" />
+            <path fill="#FBC21B" d="M98 33h18v11H98z" />
+            <path fill="#EC5548" d="M95 43h24v7H95z" />
+            <path fill="#FFF" d="M97.63 50h19.74L120 97H95z" />
+            <path d="M107 22a10 10 0 0 1 10 10v1H97v-1a10 10 0 0 1 10-10zM96.77 66.23l20.97-10.7.63 11.87-22.28 11.87zM95 94.8L119.1 82l.9 14H95z"
+              fill="#EC5548" />
+            <path d="M0 132a177.07 177.07 0 0 1 108.5-37c40.78 0 78.38 13.78 108.5 37H0z" fill="#E8EAED" />
+            <rect fill="#FEF0C8" x="98" y="33" width="10" height="10" rx="5" />
+            <path fill="url(#c)" d="M7 0l91 33.18v10.05L7 77z" />
+          </g>
+        </g>
+        <g mask="url(#b)" fill="#FFF">
+          <g transform="translate(96 86)">
+            <circle cx="87.5" cy=".5" r="1" />
+            <circle cx="86" cy="20" r="1" />
+            <circle cx="96" cy="40" r="1" />
+            <circle cx="27" cy="68" r="1" />
+            <circle cx="15" cy="44" r="1" />
+            <circle cx="127" cy="64" r="1" />
+            <circle cx="109.5" cy="44.5" r="1" />
+            <circle cx="14.5" cy="54.5" r="1" />
+            <circle cx="8.5" cy="57.5" r="1" />
+            <circle cx=".5" cy="78.5" r="1" />
+            <circle cx="27.5" cy="39.5" r="1" />
+            <circle cx="134.5" cy="41.5" r="1" />
+            <circle cx="97.5" cy="65.5" r="1" />
+            <circle cx="161.5" cy="69.5" r="1" />
+          </g>
+        </g>
+        <g mask="url(#b)" fill="#FFF" class="lh-lighthouse__clouds">
+          <path d="M101.2 34H70.21A7.42 7.42 0 0 1 69 29.91a7.31 7.31 0 0 1 8.54-7.26v-.11c0-5.27 4.2-9.54 9.39-9.54a9.44 9.44 0 0 1 9.24 7.83 7.24 7.24 0 0 1 7.83 7.35 7.4 7.4 0 0 1-2.8 5.82zM193.53 54h-17.9a4.3 4.3 0 0 1-.63-2.25 4.2 4.2 0 0 1 4.88-4.18v-.07c0-3.04 2.4-5.5 5.36-5.5a5.4 5.4 0 0 1 5.28 4.51l.33-.01a4.2 4.2 0 0 1 4.15 4.25c0 1.3-.57 2.47-1.47 3.25zM219.01 116h-24.16a5.1 5.1 0 0 1-.85-2.81c0-2.94 2.5-5.31 5.6-5.31.33 0 .67.02.99.08v-.08c0-3.8 3.24-6.88 7.24-6.88a7.15 7.15 0 0 1 7.13 5.64l.44-.02c3.1 0 5.6 2.38 5.6 5.32a5.2 5.2 0 0 1-1.99 4.06z"/>
+        </g>
+      </g>
+    </svg>
+  </div>
 
   <div class="lh-header-container">
     <div class="lh-header">

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -137,22 +137,27 @@
       margin-top: -30px;
       transform: translateZ(1px);
     }
+    .lh-scores-wrapper__background,
     .lh-scores-wrapper__shadow {
       position: absolute;
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
+      background: white;
       box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.1);
       opacity: 1;
       border-radius: 8px;
-      will-change: opacity;
+      will-change: opacity, transform;
+      transform-origin: top;
+    }
+    .lh-scores-wrapper__shadow {
+      opacity: 0;
+      border-radius: 4px;
+      box-shadow: rgba(0, 0, 0, 0.2) 0px 4px 2px -2px;
     }
     .lh-scores-container {
-      background: #fff;
-      border-bottom: 1px solid #ebebeb;
-      border-radius: 8px;
-      padding: var(--section-indent) calc(var(--section-indent) / 2) calc(var(--section-indent) / 2);
+      padding-bottom: calc(var(--section-indent) / 2);
       position: relative;
       width: 100%;
     }
@@ -166,6 +171,7 @@
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
+      will-change: opacity;
     }
     .lh-product-info__icon {
       height: 20px;
@@ -362,6 +368,7 @@
 
     <div class="lh-scores-wrapper">
       <div class="lh-scores-container">
+        <div class="lh-scores-wrapper__background"></div>
         <div class="lh-scores-wrapper__shadow"></div>
       </div>
     </div>

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -332,7 +332,7 @@
       }
     }
     .lh-lighthouse__clouds {
-      animation: panacross 15s linear infinite;
+      animation: panacross 30s linear infinite;
       animation-play-state: paused;
     }
     .lh-header-sticky:hover .lh-lighthouse__clouds {
@@ -340,15 +340,15 @@
     }
     @keyframes panacross {
       0% { transform: translateX(0px); }
-      50% { transform: translateX(195px); }
-      50.0001% { transform: translateX(-180px); }
+      77% { transform: translateX(-680px); }
+      77.0001% { transform: translateX(195px); }
       100% { transform: translateX(0px); }
 
     }
   </style>
   <div class="lh-header-bg"></div>
   <div class="lh-lighthouse">
-    <svg width="217" height="189" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <svg width="717" height="189" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <defs>
         <path id="a" d="M0 0h284v202H0z" />
         <linearGradient x1="0%" y1="50%" x2="93.17%" y2="50%" id="c">
@@ -356,7 +356,7 @@
           <stop stop-color="#FFF" offset="100%" />
         </linearGradient>
       </defs>
-      <g transform="translate(-56 -13)" fill="none" fill-rule="evenodd">
+      <g transform="translate(444 -13)" fill="none" fill-rule="evenodd">
         <mask id="b" fill="#fff">
           <use xlink:href="#a" />
         </mask>


### PR DESCRIPTION
And animate the clouds on hover

Here's the diff on the paint storms. Before and after:

![layerslh](https://user-images.githubusercontent.com/39191/40041131-d28a8636-57d1-11e8-9e21-6d1cbdfe65d7.gif)


Check out the deployment to try the animated clouds.