### PR TITLE
core(lantern): handle disk cache simulation

### DIFF
--- a/lighthouse-core/gather/computed/metrics/lantern-metric.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-metric.js
@@ -97,8 +97,11 @@ class LanternMetricArtifact extends ComputedArtifact {
       Object.assign({}, extras, {optimistic: false})
     );
 
+    // Estimates under 1s don't really follow the normal curve fit, minimize the impact of the intercept
+    const interceptMultiplier = this.COEFFICIENTS.intercept > 0 ?
+      Math.min(1, optimisticEstimate.timeInMs / 1000) : 1;
     const timing =
-      this.COEFFICIENTS.intercept +
+      this.COEFFICIENTS.intercept * interceptMultiplier +
       this.COEFFICIENTS.optimistic * optimisticEstimate.timeInMs +
       this.COEFFICIENTS.pessimistic * pessimisticEstimate.timeInMs;
 

--- a/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
@@ -50,7 +50,7 @@ class SpeedIndex extends MetricArtifact {
    * @return {LH.Gatherer.Simulation.Result}
    */
   getEstimateFromSimulation(simulationResult, extras) {
-    const fcpTimeInMs = extras.fcpResult.timing;
+    const fcpTimeInMs = extras.fcpResult.pessimisticEstimate.timeInMs;
     const estimate = extras.optimistic
       ? extras.speedline.speedIndex
       : SpeedIndex.computeLayoutBasedSpeedIndex(simulationResult.nodeTimings, fcpTimeInMs);

--- a/lighthouse-core/lib/dependency-graph/network-node.js
+++ b/lighthouse-core/lib/dependency-graph/network-node.js
@@ -55,6 +55,13 @@ class NetworkNode extends Node {
   /**
    * @return {boolean}
    */
+  get fromDiskCache() {
+    return this._record._fromDiskCache;
+  }
+
+  /**
+   * @return {boolean}
+   */
   hasRenderBlockingPriority() {
     const priority = this._record.priority();
     const isScript = this._record._resourceType === WebInspector.resourceTypes.Script;

--- a/lighthouse-core/lib/dependency-graph/network-node.js
+++ b/lighthouse-core/lib/dependency-graph/network-node.js
@@ -56,7 +56,7 @@ class NetworkNode extends Node {
    * @return {boolean}
    */
   get fromDiskCache() {
-    return this._record._fromDiskCache;
+    return !!this._record._fromDiskCache;
   }
 
   /**

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -377,7 +377,11 @@ class Simulator {
       }
 
       if (!nodesInProgress.size) {
-        throw new Error('Failed to start a node, potential mismatch in original execution');
+        // interplay between fromDiskCache and connectionReused can be incorrect
+        // proceed with flexibleOrdering if we can, otherwise give up
+        if (this._flexibleOrdering) throw new Error('Failed to start a node');
+        this._flexibleOrdering = true;
+        continue;
       }
 
       // set the available throughput for all connections based on # inflight

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -39,8 +39,8 @@ describe('Performance: first-meaningful-paint audit', () => {
     const context = {options, settings: {throttlingMethod: 'simulate'}};
     const fmpResult = await FMPAudit.audit(artifacts, context);
 
-    assert.equal(fmpResult.score, 0.95);
-    assert.equal(Util.formatDisplayValue(fmpResult.displayValue), '2,030\xa0ms');
-    assert.equal(Math.round(fmpResult.rawValue), 2029);
+    assert.equal(fmpResult.score, 0.96);
+    assert.equal(Util.formatDisplayValue(fmpResult.displayValue), '1,950\xa0ms');
+    assert.equal(Math.round(fmpResult.rawValue), 1949);
   });
 });

--- a/lighthouse-core/test/audits/metrics-test.js
+++ b/lighthouse-core/test/audits/metrics-test.js
@@ -29,9 +29,9 @@ describe('Performance: metrics', () => {
     const result = await Audit.audit(artifacts, {settings});
 
     assert.deepStrictEqual(result.details.items[0], {
-      firstContentfulPaint: 1272,
+      firstContentfulPaint: 1038,
       firstContentfulPaintTs: undefined,
-      firstMeaningfulPaint: 2029,
+      firstMeaningfulPaint: 1949,
       firstMeaningfulPaintTs: undefined,
       firstCPUIdle: 4309,
       firstCPUIdleTs: undefined,

--- a/lighthouse-core/test/audits/metrics-test.js
+++ b/lighthouse-core/test/audits/metrics-test.js
@@ -37,7 +37,7 @@ describe('Performance: metrics', () => {
       firstCPUIdleTs: undefined,
       interactive: 4309,
       interactiveTs: undefined,
-      speedIndex: 1501,
+      speedIndex: 1461,
       speedIndexTs: undefined,
       estimatedInputLatency: 104,
       estimatedInputLatencyTs: undefined,

--- a/lighthouse-core/test/audits/predictive-perf-test.js
+++ b/lighthouse-core/test/audits/predictive-perf-test.js
@@ -30,10 +30,10 @@ describe('Performance: predictive performance audit', () => {
       assert.equal(output.displayValue, '4,310\xa0ms');
 
       const valueOf = name => Math.round(output.extendedInfo.value[name]);
-      assert.equal(valueOf('roughEstimateOfFCP'), 1272);
+      assert.equal(valueOf('roughEstimateOfFCP'), 1038);
       assert.equal(valueOf('optimisticFCP'), 611);
       assert.equal(valueOf('pessimisticFCP'), 611);
-      assert.equal(valueOf('roughEstimateOfFMP'), 2029);
+      assert.equal(valueOf('roughEstimateOfFMP'), 1949);
       assert.equal(valueOf('optimisticFMP'), 911);
       assert.equal(valueOf('pessimisticFMP'), 1198);
       assert.equal(valueOf('roughEstimateOfTTI'), 4309);

--- a/lighthouse-core/test/gather/computed/metrics/first-contentful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/first-contentful-paint-test.js
@@ -19,7 +19,7 @@ describe('Metrics: FCP', () => {
     const settings = {throttlingMethod: 'simulate'};
     const result = await artifacts.requestFirstContentfulPaint({trace, devtoolsLog, settings});
 
-    assert.equal(Math.round(result.timing), 1272);
+    assert.equal(Math.round(result.timing), 1038);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 611);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 611);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 2);

--- a/lighthouse-core/test/gather/computed/metrics/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/first-meaningful-paint-test.js
@@ -39,7 +39,7 @@ describe('Metrics: FMP', () => {
 
     const result = await artifacts.requestFirstMeaningfulPaint({trace, devtoolsLog, settings});
 
-    assert.equal(Math.round(result.timing), 2029);
+    assert.equal(Math.round(result.timing), 1949);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 911);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1198);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 4);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-contentful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-contentful-paint-test.js
@@ -18,7 +18,7 @@ describe('Metrics: Lantern FCP', () => {
     const result = await artifacts.requestLanternFirstContentfulPaint({trace, devtoolsLog,
       settings: {}});
 
-    assert.equal(Math.round(result.timing), 1272);
+    assert.equal(Math.round(result.timing), 1038);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 611);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 611);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 2);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-first-meaningful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-first-meaningful-paint-test.js
@@ -18,7 +18,7 @@ describe('Metrics: Lantern FMP', () => {
     const result = await artifacts.requestLanternFirstMeaningfulPaint({trace, devtoolsLog,
       settings: {}});
 
-    assert.equal(Math.round(result.timing), 2029);
+    assert.equal(Math.round(result.timing), 1949);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 911);
     assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1198);
     assert.equal(result.optimisticEstimate.nodeTimings.size, 4);

--- a/lighthouse-core/test/gather/computed/metrics/lantern-speed-index-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/lantern-speed-index-test.js
@@ -17,8 +17,8 @@ describe('Metrics: Lantern Speed Index', () => {
     const artifacts = Runner.instantiateComputedArtifacts();
     const result = await artifacts.requestLanternSpeedIndex({trace, devtoolsLog, settings: {}});
 
-    assert.equal(Math.round(result.timing), 1501);
+    assert.equal(Math.round(result.timing), 1461);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 605);
-    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1392);
+    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1330);
   });
 });

--- a/lighthouse-core/test/gather/computed/metrics/speed-index-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/speed-index-test.js
@@ -19,9 +19,9 @@ describe('Metrics: Speed Index', () => {
     const settings = {throttlingMethod: 'simulate'};
     const result = await artifacts.requestSpeedIndex({trace, devtoolsLog, settings});
 
-    assert.equal(Math.round(result.timing), 1501);
+    assert.equal(Math.round(result.timing), 1461);
     assert.equal(Math.round(result.optimisticEstimate.timeInMs), 605);
-    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1392);
+    assert.equal(Math.round(result.pessimisticEstimate.timeInMs), 1330);
   });
 
   it('should compute an observed value', async () => {

--- a/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/simulator-test.js
@@ -91,6 +91,19 @@ describe('DependencyGraph/Simulator', () => {
       assertNodeTiming(result, nodeD, {startTime: 2400, endTime: 3200});
     });
 
+    it('should simulate cached network graphs', () => {
+      const nodeA = new NetworkNode(request({startTime: 0, endTime: 1, _fromDiskCache: true}));
+      const nodeB = new NetworkNode(request({startTime: 0, endTime: 3, _fromDiskCache: true}));
+      nodeA.addDependent(nodeB);
+
+      const simulator = new Simulator({serverResponseTimeByOrigin});
+      const result = simulator.simulate(nodeA);
+      // should be ~8ms each for A, B
+      assert.equal(result.timeInMs, 16);
+      assertNodeTiming(result, nodeA, {startTime: 0, endTime: 8});
+      assertNodeTiming(result, nodeB, {startTime: 8, endTime: 16});
+    });
+
     it('should simulate basic CPU queue graphs', () => {
       const nodeA = new NetworkNode(request({}));
       const nodeB = new CpuNode(cpuTask({duration: 100}));

--- a/typings/web-inspector.d.ts
+++ b/typings/web-inspector.d.ts
@@ -30,6 +30,7 @@ declare global {
       _transferSize?: number;
       /** Should use a default of 0 if not defined */
       _resourceSize?: number;
+      _fromDiskCache?: boolean;
 
       finished: boolean;
       requestMethod: string;


### PR DESCRIPTION
adds support to lantern for handling network files that were loaded from disk cache instead of network (necessary for working with `--disable-storage-reset` and in DevTools)

this also makes an adjustment to all lantern metrics predicted to be <1s that scales the intercept linearly until 1s. It only affects sites that were predicted to be very fast.

for example a site predicted to have FCP at 500ms
Before: 600 + 500 = 1100
After: 500/1000 * 600 + 500 = 800

for example a site predicted to have FCP at 10ms (for example cached example.com)
Before: 600 + 10 = 610
After: 10/1000 * 600 + 10 = 16

lastly, it adjusts speed index pessimistic estimate to use the pessimistic FCP as the floor rather than the coefficient predicted one. It was similarly unfair to very fast sites to double apply the coefficient in this case.

closes #5193 