### PR TITLE
docs(readme): add lighthouse-lambda to related projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,7 +275,7 @@ This section details projects that have integrated Lighthouse. If you're working
 * **[lighthouse-batch](https://www.npmjs.com/package/lighthouse-batch)** - run Lighthouse over a number of sites and generate a summary of their metrics/scores.
 * **[lighthouse-cron](https://github.com/thearegee/lighthouse-cron)** - Cron multiple batch Lighthouse audits and emit results for sending to remote server.
 * **[lightcrawler](https://github.com/github/lightcrawler)** - Crawl a website and run each page found through Lighthouse.
-
+* **[lighthouse-lambda](https://github.com/joytocode/lighthouse-lambda)** - Run Lighthouse on AWS Lambda with prebuilt stable desktop Headless Chrome.
 
 ## FAQ
 


### PR DESCRIPTION
Hi, we made this library to run Lighthouse on AWS Lambda easily. Headless Chrome (stable desktop releases) is built by https://github.com/joytocode/headless-chrome-builder and tested to ensure working with Lighthouse on Lambda. It would be nice if you could add it to related projects.