### PR TITLE
misc(viewer): switch to 2x viewer within the same tab

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -353,25 +353,19 @@ class ReportUIFeatures {
    * @protected
    */
   static openTabAndSendJsonReport(reportJson, viewerPath) {
-    let resolve;
-    const p = new Promise(res => resolve = res);
     // Chrome doesn't allow us to immediately postMessage to a popup right
     // after it's created. Normally, we could also listen for the popup window's
     // load event, however it is cross-domain and won't fire. Instead, listen
     // for a message from the target app saying "I'm open".
     const json = reportJson;
     window.addEventListener('message', function msgHandler(/** @type {!Event} */ e) {
-      const messageEvent = /** @type {!MessageEvent<{opened: boolean, rendered: boolean}>} */ (e);
+      const messageEvent = /** @type {!MessageEvent<{opened: boolean}>} */ (e);
       if (messageEvent.origin !== VIEWER_ORIGIN) {
         return;
       }
-      // Most recent deployment
       if (messageEvent.data.opened) {
         popup.postMessage({lhresults: json}, VIEWER_ORIGIN);
-      }
-      if (messageEvent.data.rendered) {
         window.removeEventListener('message', msgHandler);
-        resolve(popup);
       }
     });
 
@@ -379,8 +373,6 @@ class ReportUIFeatures {
     const fetchTime = json.fetchTime || json.generatedTime;
     const windowName = `${json.lighthouseVersion}-${json.requestedUrl}-${fetchTime}`;
     const popup = /** @type {!Window} */ (window.open(`${VIEWER_ORIGIN}${viewerPath}`, windowName));
-
-    return p;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -10,8 +10,6 @@
  * the report.
  */
 
-const VIEWER_ORIGIN = 'https://googlechrome.github.io';
-
 /* globals self URL Blob CustomEvent getFilenamePrefix window */
 
 class ReportUIFeatures {
@@ -353,6 +351,7 @@ class ReportUIFeatures {
    * @protected
    */
   static openTabAndSendJsonReport(reportJson, viewerPath) {
+    const VIEWER_ORIGIN = 'https://googlechrome.github.io';
     // Chrome doesn't allow us to immediately postMessage to a popup right
     // after it's created. Normally, we could also listen for the popup window's
     // load event, however it is cross-domain and won't fire. Instead, listen

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -175,7 +175,7 @@ class LighthouseReportViewer {
   }
 
   /**
-   * Opens legacy viewer in current tab, then renders report
+   * Stores v2.x report in IDB, then navigates to legacy viewer in current tab
    * @param {!ReportRenderer.ReportJSON} reportJson
    * @private
    */

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -175,7 +175,7 @@ class LighthouseReportViewer {
   }
 
   /**
-   * Opens new tab with compatible report viewer version
+   * Opens legacy viewer in current tab, then renders report
    * @param {!ReportRenderer.ReportJSON} reportJson
    * @private
    */
@@ -183,6 +183,7 @@ class LighthouseReportViewer {
     const warnMsg = `Version mismatch between viewer and JSON. Opening compatible viewer...`;
     logger.log(warnMsg, false);
 
+    // Place report in IDB, then navigate current tab to the legacy viewer
     const viewerPath = new URL('../viewer2x/', location.href);
     idbKeyval.set('2xreport', json).then(_ => {
       window.location.href = viewerPath;

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-/* global DOM, ViewerUIFeatures, ReportRenderer, DragAndDrop, GithubApi, logger */
+/* global DOM, ViewerUIFeatures, ReportRenderer, DragAndDrop, GithubApi, logger, idbKeyval */
 
 /**
  * Class that manages viewing Lighthouse reports.
@@ -180,14 +180,12 @@ class LighthouseReportViewer {
    * @private
    */
   _loadInLegacyViewerVersion(json) {
-    const warnMsg = `Version mismatch between viewer and JSON.
-    Opening new tab with compatible viewer.`;
-    const viewerPath = '/lighthouse/viewer2x/';
-
+    const warnMsg = `Version mismatch between viewer and JSON. Opening compatible viewer...`;
     logger.log(warnMsg, false);
-    ViewerUIFeatures.openTabAndSendJsonReport(json, viewerPath).then(_ => {
-      window.close();
-      logger.log(`${warnMsg} You can close this tab.`, false);
+
+    const viewerPath = new URL('../viewer2x/', location.href);
+    idbKeyval.set('2xreport', json).then(_ => {
+      window.location.href = viewerPath;
     });
   }
 

--- a/lighthouse-viewer/app/src/viewer-ui-features.js
+++ b/lighthouse-viewer/app/src/viewer-ui-features.js
@@ -49,7 +49,7 @@ class ViewerUIFeatures extends ReportUIFeatures {
   /**
    * @override
    */
-  sendJsonReport() {
+  openTabAndSendJsonReport() {
     throw new Error('Cannot send JSON to Viewer from Viewer.');
   }
 

--- a/lighthouse-viewer/app/src/viewer-ui-features.js
+++ b/lighthouse-viewer/app/src/viewer-ui-features.js
@@ -49,6 +49,13 @@ class ViewerUIFeatures extends ReportUIFeatures {
   /**
    * @override
    */
+  sendJsonReport() {
+    throw new Error('Cannot send JSON to Viewer from Viewer.');
+  }
+
+  /**
+   * @override
+   */
   saveAsGist() {
     if (this._saveGistCallback) {
       this._saveGistCallback(this.json);


### PR DESCRIPTION
#5204 used postMessage to open the 2x viewer, but this faces problems with popup blockers.

This PR reverts most of that one, and uses IDB and `location.href = ...` to store and open the 2x report.

The complementary 2.x branch PR to this one is: #5232


![2xview](https://user-images.githubusercontent.com/39191/40142630-06e89e44-590e-11e8-93c3-ca3875830be9.gif)
