### PR TITLE
core(pwa): adjust score weights

### DIFF
--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -289,16 +289,20 @@ module.exports = {
           '[PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are ' +
           'not automatically checked by Lighthouse. They do not affect your score but it\'s important that you verify them manually.',
       auditRefs: [
+        // Most difficult and critical for good UX
+        {id: 'works-offline', weight: 5},
+        {id: 'load-fast-enough-for-pwa', weight: 5},
+        // Encompasses most of the other checks
+        {id: 'webapp-install-banner', weight: 3},
+        // Important but not too difficult
+        {id: 'is-on-https', weight: 2},
+        {id: 'redirects-http', weight: 2},
+        {id: 'viewport', weight: 2},
+        // Relatively easy checkboxes to tick with minimal value on their own
         {id: 'service-worker', weight: 1},
-        {id: 'works-offline', weight: 1},
         {id: 'without-javascript', weight: 1},
-        {id: 'is-on-https', weight: 1},
-        {id: 'redirects-http', weight: 1},
-        {id: 'load-fast-enough-for-pwa', weight: 1},
-        {id: 'webapp-install-banner', weight: 1},
         {id: 'splash-screen', weight: 1},
         {id: 'themed-omnibox', weight: 1},
-        {id: 'viewport', weight: 1},
         {id: 'content-width', weight: 1},
         // Manual audits
         {id: 'pwa-cross-browser', weight: 0},

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -290,8 +290,8 @@ module.exports = {
           'not automatically checked by Lighthouse. They do not affect your score but it\'s important that you verify them manually.',
       auditRefs: [
         // Most difficult and critical for good UX
+        {id: 'load-fast-enough-for-pwa', weight: 7}, // can't be green in the category without being fast
         {id: 'works-offline', weight: 5},
-        {id: 'load-fast-enough-for-pwa', weight: 5},
         // Encompasses most of the other checks
         {id: 'webapp-install-banner', weight: 3},
         // Important but not too difficult

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3011,31 +3011,35 @@
       "manualDescription": "These checks are required by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are not automatically checked by Lighthouse. They do not affect your score but it's important that you verify them manually.",
       "auditRefs": [
         {
+          "id": "load-fast-enough-for-pwa",
+          "weight": 7
+        },
+        {
+          "id": "works-offline",
+          "weight": 5
+        },
+        {
+          "id": "webapp-install-banner",
+          "weight": 3
+        },
+        {
+          "id": "is-on-https",
+          "weight": 2
+        },
+        {
+          "id": "redirects-http",
+          "weight": 2
+        },
+        {
+          "id": "viewport",
+          "weight": 2
+        },
+        {
           "id": "service-worker",
           "weight": 1
         },
         {
-          "id": "works-offline",
-          "weight": 1
-        },
-        {
           "id": "without-javascript",
-          "weight": 1
-        },
-        {
-          "id": "is-on-https",
-          "weight": 1
-        },
-        {
-          "id": "redirects-http",
-          "weight": 1
-        },
-        {
-          "id": "load-fast-enough-for-pwa",
-          "weight": 1
-        },
-        {
-          "id": "webapp-install-banner",
           "weight": 1
         },
         {
@@ -3044,10 +3048,6 @@
         },
         {
           "id": "themed-omnibox",
-          "weight": 1
-        },
-        {
-          "id": "viewport",
           "weight": 1
         },
         {
@@ -3068,7 +3068,7 @@
         }
       ],
       "id": "pwa",
-      "score": 0.36
+      "score": 0.42
     },
     "accessibility": {
       "title": "Accessibility",


### PR DESCRIPTION
adjust the PWA score weights to give more credit to speed/offline, less to adding a manifest/1-line meta

You can play around with how this affects score at [the calculator](https://docs.google.com/spreadsheets/d/1Cxzhy5ecqJCucdf1M0iOzM8mIxNc7mmx107o5nj38Eo/edit#gid=283330180)

Basically... 

Adding manifest alone used to be worth 18, now worth 8
Adding noop service worker used to be worth 9, now worth 4
Adding service worker to make site work offline used to be worth 18, now worth 23
Performance used to be worth 9, now worth 27
