### PR TITLE
misc(scripts): add trace/devtoolslog minification scripts

### DIFF
--- a/lighthouse-core/scripts/lantern/minify-devtoolslog.js
+++ b/lighthouse-core/scripts/lantern/minify-devtoolslog.js
@@ -8,6 +8,10 @@
 
 /* eslint-disable no-console */
 
+/**
+ * @fileoverview Minifies a devtools log by removing noisy header values, eliminating data URIs, etc.
+ */
+
 const fs = require('fs');
 const path = require('path');
 
@@ -40,7 +44,7 @@ const headersToKeep = new Set([
   'x-robots-tag',
 ]);
 
-/** @param {any} headers */
+/** @param {Partial<LH.Crdp.Network.Headers>} [headers] */
 function cleanHeaders(headers) {
   if (!headers) return;
 
@@ -54,7 +58,7 @@ function cleanDataURI(obj) {
   obj.url = obj.url.replace(/^(data:.*?base64,).*/, '$1FILLER');
 }
 
-/** @param {LH.Crdp.Network.ResponseReceivedEvent['response']} [response] */
+/** @param {LH.Crdp.Network.Response} [response] */
 function cleanResponse(response) {
   if (!response) return;
   cleanDataURI(response);

--- a/lighthouse-core/scripts/lantern/minify-devtoolslog.js
+++ b/lighthouse-core/scripts/lantern/minify-devtoolslog.js
@@ -14,7 +14,7 @@ const inputDevtoolsLogRaw = fs.readFileSync(inputDevtoolsLogPath, 'utf8');
 /** @type {LH.DevtoolsLog} */
 const inputDevtoolsLog = JSON.parse(inputDevtoolsLogRaw);
 
-const includedHeaders = new Set([
+const headersToKeep = new Set([
   // Request headers
   'accept',
   'accept-encoding',
@@ -37,7 +37,7 @@ function cleanHeaders(headers) {
   if (!headers) return;
 
   for (const [k, v] of Object.entries(headers)) {
-    if (!includedHeaders.has(k.toLowerCase())) headers[k] = undefined;
+    if (!headersToKeep.has(k.toLowerCase())) headers[k] = undefined;
   }
 }
 

--- a/lighthouse-core/scripts/lantern/minify-devtoolslog.js
+++ b/lighthouse-core/scripts/lantern/minify-devtoolslog.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+if (process.argv.length !== 4) {
+  console.error('Usage $0: <input file> <output file>');
+  process.exit(1);
+}
+
+const inputDevtoolsLogPath = path.resolve(process.cwd(), process.argv[2]);
+const outputDevtoolsLogPath = path.resolve(process.cwd(), process.argv[3]);
+const inputDevtoolsLogRaw = fs.readFileSync(inputDevtoolsLogPath, 'utf8');
+/** @type {LH.DevtoolsLog} */
+const inputDevtoolsLog = JSON.parse(inputDevtoolsLogRaw);
+
+const includedHeaders = new Set([
+  // Request headers
+  'accept',
+  'accept-encoding',
+  'accept-ranges',
+  // Response headers
+  'status',
+  'content-length',
+  'content-type',
+  'content-encoding',
+  'content-range',
+  'etag',
+  'cache-control',
+  'last-modified',
+  'link',
+  'x-robots-tag',
+]);
+
+/** @param {any} headers */
+function cleanHeaders(headers) {
+  if (!headers) return;
+
+  for (const [k, v] of Object.entries(headers)) {
+    if (!includedHeaders.has(k.toLowerCase())) headers[k] = undefined;
+  }
+}
+
+/** @param {{url: string}} obj */
+function cleanDataURI(obj) {
+  obj.url = obj.url.replace(/^(data:.*?base64,).*/, '$1FILLER');
+}
+
+/** @param {LH.Crdp.Network.ResponseReceivedEvent['response']} [response] */
+function cleanResponse(response) {
+  if (!response) return;
+  cleanDataURI(response);
+  cleanHeaders(response.requestHeaders);
+  cleanHeaders(response.headers);
+  response.securityDetails = undefined;
+  response.headersText = undefined;
+  response.requestHeadersText = undefined;
+
+  /** @type {any} */
+  const timing = response.timing || {}
+  for (const [k, v] of Object.entries(timing)) {
+    if (v === -1) timing[k] = undefined;
+  }
+}
+
+/** @param {LH.DevtoolsLog} log */
+function filterDevtoolsLogEvents(log) {
+  return log.map(original => {
+    /** @type {LH.Protocol.RawEventMessage} */
+    const entry = JSON.parse(JSON.stringify(original));
+
+    switch (entry.method) {
+      case 'Network.requestWillBeSent':
+        cleanDataURI(entry.params.request);
+        cleanHeaders(entry.params.request.headers);
+        cleanResponse(entry.params.redirectResponse);
+        break;
+      case 'Network.responseReceived':
+        cleanResponse(entry.params.response);
+        break;
+    }
+
+    return entry;
+  });
+}
+
+const filteredLog = filterDevtoolsLogEvents(inputDevtoolsLog);
+const output = `[
+${filteredLog.map(e => '  ' + JSON.stringify(e)).join(',\n')}
+]`;
+
+/** @param {string} s */
+const size = s => Math.round(s.length / 1024) + 'kb';
+console.log(`Reduced DevtoolsLog from ${size(inputDevtoolsLogRaw)} to ${size(output)}`);
+fs.writeFileSync(outputDevtoolsLogPath, output);

--- a/lighthouse-core/scripts/lantern/minify-devtoolslog.js
+++ b/lighthouse-core/scripts/lantern/minify-devtoolslog.js
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-disable no-console */
 
 const fs = require('fs');
 const path = require('path');
@@ -36,8 +44,8 @@ const headersToKeep = new Set([
 function cleanHeaders(headers) {
   if (!headers) return;
 
-  for (const [k, v] of Object.entries(headers)) {
-    if (!headersToKeep.has(k.toLowerCase())) headers[k] = undefined;
+  for (const key of Object.keys(headers)) {
+    if (!headersToKeep.has(key.toLowerCase())) headers[key] = undefined;
   }
 }
 
@@ -57,7 +65,7 @@ function cleanResponse(response) {
   response.requestHeadersText = undefined;
 
   /** @type {any} */
-  const timing = response.timing || {}
+  const timing = response.timing || {};
   for (const [k, v] of Object.entries(timing)) {
     if (v === -1) timing[k] = undefined;
   }

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -51,6 +51,7 @@ function filterTraceEvents(events) {
   if (!startedInPageEvt) throw new Error('Could not find TracingStartedInPage');
 
   return events.filter(evt => {
+    if (evt.name === 'Screenshot') return true;
     if (evt.pid !== startedInPageEvt.pid || !includedTraceEventNames.has(evt.name)) return false;
     return !toplevelTaskNames.includes(evt.name) || evt.dur > 1000;
   });

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-disable no-console */
 
 const fs = require('fs');
 const path = require('path');
@@ -32,7 +40,7 @@ const traceEventsToAlwaysKeep = new Set([
   'ResourceFinish',
   'ResourceReceivedData',
   'EventDispatch',
-])
+]);
 
 const traceEventsToKeepProcess = new Set([
   ...toplevelTaskNames,
@@ -50,7 +58,7 @@ const traceEventsToKeepProcess = new Set([
   'XHRReadyStateChange',
   'FunctionCall',
   'v8.compile',
-])
+]);
 
 /**
  * @param {LH.TraceEvent[]} events

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -76,6 +76,7 @@ const traceEventsToKeepInProcess = new Set([
  * @param {LH.TraceEvent[]} events
  */
 function filterOutUnnecessaryTasksByNameAndDuration(events) {
+  // TODO(phulce): update this once https://github.com/GoogleChrome/lighthouse/pull/5271 lands
   const startedInPageEvt = events.find(evt => evt.name === 'TracingStartedInPage');
   if (!startedInPageEvt) throw new Error('Could not find TracingStartedInPage');
 

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -8,6 +8,14 @@
 
 /* eslint-disable no-console */
 
+/**
+ * @fileoverview Minifies a trace by removing unnecessary events, throttling screenshots, etc.
+ *  See the following files for necessary events:
+ *    - lighthouse-core/gather/computed/trace-of-tab.js
+ *    - lighthouse-core/gather/computed/page-dependency-graph.js
+ *    - lighthouse-core/lib/traces/tracing-processor.js
+ */
+
 const fs = require('fs');
 const path = require('path');
 
@@ -67,42 +75,51 @@ const traceEventsToKeepInProcess = new Set([
 /**
  * @param {LH.TraceEvent[]} events
  */
-function filterTraceEvents(events) {
+function filterOutUnnecessaryTasksByNameAndDuration(events) {
   const startedInPageEvt = events.find(evt => evt.name === 'TracingStartedInPage');
   if (!startedInPageEvt) throw new Error('Could not find TracingStartedInPage');
 
-  // Filter out event names we don't care about and tasks <1ms
-  let filtered = events.filter(evt => {
+  return events.filter(evt => {
     if (toplevelTaskNames.has(evt.name) && evt.dur < 1000) return false;
     if (evt.pid === startedInPageEvt.pid && traceEventsToKeepInProcess.has(evt.name)) return true;
     return traceEventsToAlwaysKeep.has(evt.name);
   });
+}
 
-  // Filter out events not inside a toplevel task
-  const toplevelRanges = filtered
+/**
+ * Filters out tasks that are not within a toplevel task.
+ * @param {LH.TraceEvent[]} events
+ */
+function filterOutOrphanedTasks(events) {
+  const toplevelRanges = events
     .filter(evt => toplevelTaskNames.has(evt.name))
     .map(evt => [evt.ts, evt.ts + evt.dur]);
 
   /** @param {LH.TraceEvent} e */
   const isInToplevelTask = e => toplevelRanges.some(([start, end]) => e.ts >= start && e.ts <= end);
 
-  filtered = filtered.filter((evt, index) => {
+  return events.filter((evt, index) => {
     if (!traceEventsToKeepInToplevelTask.has(evt.name)) return true;
     if (!isInToplevelTask(evt)) return false;
 
     if (evt.ph === 'B') {
-      const endEvent = filtered.slice(index).find(e => e.name === evt.name && e.ph === 'E');
+      const endEvent = events.slice(index).find(e => e.name === evt.name && e.ph === 'E');
       return endEvent && isInToplevelTask(endEvent);
     } else {
       return true;
     }
   });
+}
 
-  // Filter down the screenshots to key moments + 2fps animations
-  const screenshotTimestamps = filtered.filter(evt => evt.name === 'Screenshot').map(evt => evt.ts);
+/**
+ * Throttles screenshot events in the trace to 2fps.
+ * @param {LH.TraceEvent[]} events
+ */
+function filterOutExcessiveScreenshots(events) {
+  const screenshotTimestamps = events.filter(evt => evt.name === 'Screenshot').map(evt => evt.ts);
 
   let lastScreenshotTs = -Infinity;
-  filtered = filtered.filter(evt => {
+  return events.filter(evt => {
     if (evt.name !== 'Screenshot') return true;
     const timeSinceLastScreenshot = evt.ts - lastScreenshotTs;
     const nextScreenshotTs = screenshotTimestamps.find(ts => ts > evt.ts);
@@ -113,8 +130,18 @@ function filterTraceEvents(events) {
     if (shouldKeep) lastScreenshotTs = evt.ts;
     return shouldKeep;
   });
+}
 
-  return filtered;
+/**
+ * @param {LH.TraceEvent[]} events
+ */
+function filterTraceEvents(events) {
+  // Filter out event names we don't care about and tasks <1ms
+  let filtered = filterOutUnnecessaryTasksByNameAndDuration(events);
+  // Filter out events not inside a toplevel task
+  filtered = filterOutOrphanedTasks(filtered);
+  // Filter down the screenshots to key moments + 2fps animations
+  return filterOutExcessiveScreenshots(filtered);
 }
 
 const filteredEvents = filterTraceEvents(inputTrace.traceEvents);

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+if (process.argv.length !== 4) {
+  console.error('Usage $0: <input file> <output file>');
+  process.exit(1);
+}
+
+const inputTracePath = path.resolve(process.cwd(), process.argv[2]);
+const outputTracePath = path.resolve(process.cwd(), process.argv[3]);
+const inputTraceRaw = fs.readFileSync(inputTracePath, 'utf8');
+/** @type {LH.Trace} */
+const inputTrace = JSON.parse(inputTraceRaw);
+
+const toplevelTaskNames = [
+  'TaskQueueManager::ProcessTaskFromWorkQueue',
+  'ThreadControllerImpl::DoWork',
+];
+
+const includedTraceEventNames = new Set([
+  ...toplevelTaskNames,
+  'Screenshot',
+  'TracingStartedInBrowser',
+  'TracingStartedInPage',
+  'navigationStart',
+  'firstPaint',
+  'firstContentfulPaint',
+  'firstMeaningfulPaint',
+  'firstMeaningfulPaintCandidate',
+  'loadEventEnd',
+  'domContentLoadedEventEnd',
+  'TimerInstall',
+  'TimerFire',
+  'InvalidateLayout',
+  'ScheduleStyleRecalculation',
+  'EvaluateScript',
+  'XHRReadyStateChange',
+  'FunctionCall',
+  'v8.compile',
+  'ParseAuthorStyleSheet',
+  'ResourceSendRequest',
+]);
+
+/**
+ * @param {LH.TraceEvent[]} events
+ */
+function filterTraceEvents(events) {
+  const startedInPageEvt = events.find(evt => evt.name === 'TracingStartedInPage');
+  if (!startedInPageEvt) throw new Error('Could not find TracingStartedInPage');
+
+  return events.filter(evt => {
+    if (evt.pid !== startedInPageEvt.pid || !includedTraceEventNames.has(evt.name)) return false;
+    return !toplevelTaskNames.includes(evt.name) || evt.dur > 1000;
+  });
+}
+
+const filteredEvents = filterTraceEvents(inputTrace.traceEvents);
+const output = `{
+  "traceEvents": [
+${filteredEvents.map(e => '    ' + JSON.stringify(e)).join(',\n')}
+  ]
+}`;
+
+/** @param {string} s */
+const size = s => Math.round(s.length / 1024) + 'kb';
+console.log(`Reduced trace from ${size(inputTraceRaw)} to ${size(output)}`);
+console.log(`Filtered out ${inputTrace.traceEvents.length - filteredEvents.length} trace events`);
+fs.writeFileSync(outputTracePath, output);

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "update:sample-json": "node ./lighthouse-cli -A=./lighthouse-core/test/results/artifacts --throttling-method=devtools --output=json --output-path=./lighthouse-core/test/results/sample_v2.json http://localhost/dobetterweb/dbw_tester.html && node lighthouse-core/scripts/cleanup-LHR-for-diff.js ./lighthouse-core/test/results/sample_v2.json --only-remove-timing",
     "diff:sample-json": "bash lighthouse-core/scripts/assert-golden-lhr-unchanged.sh",
     "update:crdp-typings": "node lighthouse-core/scripts/extract-crdp-mapping.js",
-    "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --config-path=./lighthouse-core/config/mixed-content.js"
+    "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --config-path=./lighthouse-core/config/mixed-content.js",
+    "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.json"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.60",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "diff:sample-json": "bash lighthouse-core/scripts/assert-golden-lhr-unchanged.sh",
     "update:crdp-typings": "node lighthouse-core/scripts/extract-crdp-mapping.js",
     "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --config-path=./lighthouse-core/config/mixed-content.js",
-    "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.json"
+    "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.60",


### PR DESCRIPTION
### phase 1 of lantern accuracy checks per commit

does a pretty awesome job of minifying traces from light/medium sites for inclusion, OK job of minifying the devtoolslog

example.com: 526KB -> 28KB, 7KB -> 4KB
paulirish.com: 2.3MB -> 151KB, 147KB -> 47KB

does okish on heavy sites like CNN

cnn.com: 30MB ->3.8MB, 2.9MB -> 1.3MB