### PR TITLE
misc(viewer): fix saving as gist

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -291,7 +291,7 @@ class ReportUIFeatures {
 
     const el = /** @type {?Element} */ (e.target);
 
-    if (!el || el.hasAttribute('data-action')) {
+    if (!el || !el.hasAttribute('data-action')) {
       return;
     }
 

--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -18,7 +18,7 @@ chromium_dir="$HOME/chromium/src"
 if [[ -n "$1" ]]; then
   frontend_dir="$1"
 else
-  frontend_dir="$chromium_dir/third_party/WebKit/Source/devtools/front_end"
+  frontend_dir="$chromium_dir/third_party/blink/renderer/devtools/front_end"
 fi
 
 if [[ ! -d "$frontend_dir" || ! -a "$frontend_dir/Runtime.js" ]]; then

--- a/lighthouse-viewer/app/src/github-api.js
+++ b/lighthouse-viewer/app/src/github-api.js
@@ -36,7 +36,7 @@ class GithubApi {
     return this._auth.getAccessToken()
       .then(accessToken => {
         const filename = getFilenamePrefix({
-          url: jsonFile.url,
+          finalUrl: jsonFile.finalUrl,
           fetchTime: jsonFile.fetchTime,
         });
         const body = {


### PR DESCRIPTION
1. some `.url` that weren't yet `.finalUrl`
1. a regression from brendan's tsc that nuked a `!`
1. driveby fix for a path in `roll-to-devtools.sh`


fixes #5250