### PR TITLE
report: restore missing non-applicable icon

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -325,10 +325,6 @@
   padding: 11px var(--text-indent);
 }
 
-.lh-metric__header {
-  display: flex;
-}
-
 .lh-metric__details {
   order: -1;
 }
@@ -558,7 +554,7 @@
 .lh-audit-group--metrics .lh-audit-group__header::before {
   background-image: var(--av-timer-icon-url);
 }
-.lh-audit-group--notapplicable .lh-audit-group__header::before {
+.lh-audit-group--not-applicable .lh-audit-group__header::before {
   background-image: var(--remove-circle-icon-url);
 }
 


### PR DESCRIPTION
This icon was missing because of all the rebasing:

![image](https://user-images.githubusercontent.com/39191/40249343-90aa81b8-5a87-11e8-90f7-702c435a472c.png)
