### PR TITLE
core(seo): support japanese in link-text audit

### DIFF
--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -24,7 +24,7 @@ const BLOCKLIST = new Set([
   'リンク',
   '続きを読む',
   '続く',
-  '全文表示'
+  '全文表示',
 ]);
 
 class LinkText extends Audit {

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -8,6 +8,7 @@
 const Audit = require('../audit');
 const URL = require('../../lib/url-shim');
 const BLOCKLIST = new Set([
+  // English
   'click here',
   'click this',
   'go',
@@ -17,6 +18,13 @@ const BLOCKLIST = new Set([
   'right here',
   'more',
   'learn more',
+  // Japanese
+  'ここをクリック',
+  'こちらをクリック',
+  'リンク',
+  '続きを読む',
+  '続く',
+  '全文表示'
 ]);
 
 class LinkText extends Audit {


### PR DESCRIPTION
**Summary**
lint link-text is great!! I think that it will more wonderful if it supports multiple languages.

I added Japanese easily. But I think this should be separate file, and that various people should be involved in editing.
Please let the opinion. 

thanks.
