### PR TITLE
extension: another speculative fix for getCurrentTabURL; more logging

### DIFF
--- a/lighthouse-core/gather/connections/extension.js
+++ b/lighthouse-core/gather/connections/extension.js
@@ -122,14 +122,23 @@ class ExtensionConnection extends Connection {
         if (chrome.runtime.lastError) {
           return reject(chrome.runtime.lastError);
         }
+
+        const errMessage = 'Couldn\'t resolve current tab. Check your URL, reload, and try again.';
         if (tabs.length === 0) {
-          const message = 'Couldn\'t resolve current tab. Check your URL, reload, and try again.';
-          return reject(new Error(message));
+          return reject(new Error(errMessage));
         }
         if (tabs.length > 1) {
           log.warn('ExtensionConnection', '_queryCurrentTab returned multiple tabs');
         }
-        resolve(tabs[0]);
+
+        const firstUrledTab = tabs.find(tab => !!tab.url);
+        if (!firstUrledTab) {
+          const tabIds = tabs.map(tab => tab.id).join(', ');
+          const message = errMessage + ` Found ${tabs.length} tab(s) with id(s) [${tabIds}].`;
+          return reject(new Error(message));
+        }
+
+        resolve(firstUrledTab);
       }));
     });
   }

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -40,7 +40,7 @@ class Runner {
       // save the requestedUrl provided by the user
       const rawRequestedUrl = opts.url;
       if (typeof rawRequestedUrl !== 'string' || rawRequestedUrl.length === 0) {
-        throw new Error('You must provide a url to the runner');
+        throw new Error(`You must provide a url to the runner. '${rawRequestedUrl}' provided.`);
       }
 
       let parsedURL;


### PR DESCRIPTION
Speculative fix for "getCurrentTabURL returned empty string".

Uses Patrick's idea to pick the first tab with a URL. Unclear if there will actually be a tab with a url (maybe there are no other tabs provided since we ask only for the active tabs in the current window) but it won't hurt the current correct cases where the first tab has a URL.

In addition, added more detailed error messages that may give us some hints for what's going on
- log what URL is provided to `runner` that fails the first URL exists check (#1834)
- log the number of tabs found and their IDs if no tab with a URL is found (the ID *might* help if it's [`chrome.tabs.TAB_ID_NONE`](https://developer.chrome.com/extensions/tabs#type-Tab), which is set for "for apps and devtools windows)). I don't see anything else in that property list that leaps out as helping to debug, but happy to add others.