### PR TITLE
misc: remove checkboxes from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -6,24 +6,20 @@ about: Report something working incorrectly
 
 <!-- Before creating an issue please make sure you are using the latest version and have checked for duplicate issues. -->
 
-# Bug report
+## Bug report
 
-**Provide the steps to reproduce.**
+#### Provide the steps to reproduce
 1. Run LH on <affected url>
 
-**What is the current behavior?**
+#### What is the current behavior?
 
-**What is the expected behavior?**
+#### What is the expected behavior?
 
 
-**Environment Information**:
-
-Affected Channels: <!-- CLI, Node, Extension, DevTools -->
-
-Lighthouse version:
-
-Node.js version:
-
-Operating System:
+#### Environment Information
+* Affected Channels: <!-- CLI, Node, Extension, DevTools -->
+* Lighthouse version:
+* Node.js version:
+* Operating System:
 
 **Related issues**

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: File an issue ticket to help us improve
+about: Report something working incorrectly
 
 ---
 
@@ -17,14 +17,13 @@ about: File an issue ticket to help us improve
 
 
 **Environment Information**:
-Affected Channels:
-- [ ] CLI
-- [ ] Node Module
-- [ ] Extension
-- [ ] DevTools
+
+Affected Channels: CLI, Node, Extension, DevTools
 
 Lighthouse version:
+
 Node.js version:
+
 Operating System:
 
 **Related issues**

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -18,7 +18,7 @@ about: Report something working incorrectly
 
 **Environment Information**:
 
-Affected Channels: CLI, Node, Extension, DevTools
+Affected Channels: <!-- CLI, Node, Extension, DevTools -->
 
 Lighthouse version:
 


### PR DESCRIPTION
Just created a bug report from the template and it doesn't make sense to use checkboxes for the environment since then it shows up in the issues UI as "progress" toward completion.