### PR TITLE
misc(viewer): load *.json if no *.lighthouse.report.json

### DIFF
--- a/lighthouse-viewer/app/src/github-api.js
+++ b/lighthouse-viewer/app/src/github-api.js
@@ -115,11 +115,12 @@ class GithubApi {
 
           const etag = resp.headers.get('ETag');
           return resp.json().then(json => {
+            const gistFiles = Object.keys(json.files);
             // Attempt to use first file in gist with report extension.
-            let filename = Object.keys(json.files)
-                .find(filename => filename.endsWith(GithubApi.LH_JSON_EXT));
+            let filename = gistFiles.find(filename => filename.endsWith(GithubApi.LH_JSON_EXT));
+            // Otherwise, fall back to first json file in gist
             if (!filename) {
-              filename = Object.keys(json.files).find(filename => filename.endsWith('.json'));
+              filename = gistFiles.find(filename => filename.endsWith('.json'));
             }
             if (!filename) {
               throw new Error(

--- a/lighthouse-viewer/app/src/github-api.js
+++ b/lighthouse-viewer/app/src/github-api.js
@@ -116,8 +116,11 @@ class GithubApi {
           const etag = resp.headers.get('ETag');
           return resp.json().then(json => {
             // Attempt to use first file in gist with report extension.
-            const filename = Object.keys(json.files)
+            let filename = Object.keys(json.files)
                 .find(filename => filename.endsWith(GithubApi.LH_JSON_EXT));
+            if (!filename) {
+              filename = Object.keys(json.files).find(filename => filename.endsWith('.json'));
+            }
             if (!filename) {
               throw new Error(
                 `Failed to find a Lighthouse report (*${GithubApi.LH_JSON_EXT}) in gist ${id}`


### PR DESCRIPTION
Right now if you have a gist it'll only consider files `*.lighthouse.report.json`
This is usually OK because when you 'save to gist' it uses this filename. but we can afford to be flexible here
