### PR TITLE
core(simulator): convert node timings to trace

### DIFF
--- a/lighthouse-core/gather/computed/metrics/lantern-metric.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-metric.js
@@ -73,6 +73,7 @@ class LanternMetricArtifact extends ComputedArtifact {
    */
   async computeMetricWithGraphs(data, artifacts, extras) {
     const {trace, devtoolsLog, settings} = data;
+    const metricName = this.name.replace('Lantern', '');
     const graph = await artifacts.requestPageDependencyGraph({trace, devtoolsLog});
     const traceOfTab = await artifacts.requestTraceOfTab(trace);
     /** @type {Simulator} */
@@ -82,9 +83,14 @@ class LanternMetricArtifact extends ComputedArtifact {
     const optimisticGraph = this.getOptimisticGraph(graph, traceOfTab);
     const pessimisticGraph = this.getPessimisticGraph(graph, traceOfTab);
 
-    const optimisticSimulation = simulator.simulate(optimisticGraph);
-    const optimisticFlexSimulation = simulator.simulate(optimisticGraph, {flexibleOrdering: true});
-    const pessimisticSimulation = simulator.simulate(pessimisticGraph);
+    let simulateOptions = {label: `optimistic${metricName}`};
+    const optimisticSimulation = simulator.simulate(optimisticGraph, simulateOptions);
+
+    simulateOptions = {label: `optimisticFlex${metricName}`, flexibleOrdering: true};
+    const optimisticFlexSimulation = simulator.simulate(optimisticGraph, simulateOptions);
+
+    simulateOptions = {label: `pessimistic${metricName}`};
+    const pessimisticSimulation = simulator.simulate(pessimisticGraph, simulateOptions);
 
     const optimisticEstimate = this.getEstimateFromSimulation(
       optimisticSimulation.timeInMs < optimisticFlexSimulation.timeInMs ?

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -292,6 +292,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
       cat: 'disabled-by-default-devtools.timeline',
       name: 'TracingStartedInPage',
       args: {data},
+      dur: 0,
     };
   }
 
@@ -336,7 +337,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
 
     const requestData = {requestId: requestId.toString(), frame};
     /** @type {Omit<LH.TraceEvent, 'name'|'ts'|'args'>} */
-    const baseRequestEvent = {...baseEvent, ph: 'I', s: 't'}; // s: 't'
+    const baseRequestEvent = {...baseEvent, ph: 'I', s: 't', dur: 0};
 
     const sendRequestData = {
       ...requestData,

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -10,6 +10,7 @@ const path = require('path');
 const log = require('lighthouse-logger');
 const stream = require('stream');
 const Simulator = require('./dependency-graph/simulator/simulator');
+const lanternTraceSaver = require('./lantern-trace-saver');
 const Metrics = require('./traces/pwmetrics-events');
 const TraceParser = require('./traces/trace-parser');
 const rimraf = require('rimraf');
@@ -18,8 +19,6 @@ const mkdirp = require('mkdirp');
 const artifactsFilename = 'artifacts.json';
 const traceSuffix = '.trace.json';
 const devtoolsLogSuffix = '.devtoolslog.json';
-
-const LANTERN_TRACES_TO_SAVE = ['optimisticFirstContentfulPaint', 'pessimisticInteractive'];
 
 /** @typedef {{timestamp: number, datauri: string}} Screenshot */
 /**
@@ -233,156 +232,6 @@ function* traceJsonGenerator(traceData) {
 }
 
 /**
- * @param {LH.Gatherer.Simulation.Result['nodeTimings']} nodeTimings
- * @return {LH.Trace}
- */
-function convertNodeTimingsToTrace(nodeTimings) {
-  /** @type {LH.TraceEvent[]} */
-  const traceEvents = [];
-  const baseTs = 1e9;
-  const baseEvent = {pid: 1, tid: 1, cat: 'devtools.timeline'};
-  const frame = 'A00001';
-  /** @param {number} ms */
-  const ts = ms => baseTs + ms * 1000;
-
-  traceEvents.push(createFakeTracingStarted());
-  traceEvents.push({...createFakeTracingStarted(), name: 'TracingStartedInBrowser'});
-
-  // Create a fake requestId counter
-  let requestId = 1;
-  let lastEventEndTime = 0;
-  for (const [node, timing] of nodeTimings.entries()) {
-    lastEventEndTime = Math.max(lastEventEndTime, timing.endTime);
-    if (node.type === 'cpu') {
-      // EvaluateScript
-      const cpuNode = /** @type {LH.Gatherer.Simulation.GraphCPUNode} */ (node);
-      traceEvents.push(createFakeEvaluateScript(cpuNode, timing));
-    } else {
-      const networkNode = /** @type {LH.Gatherer.Simulation.GraphNetworkNode} */ (node);
-      // Ignore data URIs as they don't really add much value
-      if (/^data/.test(networkNode.record.url)) continue;
-      traceEvents.push(...createFakeNetwork(networkNode.record, timing));
-    }
-  }
-
-  traceEvents.push(createFakeEvaluateScript({childEvents: []}, {
-    startTime: lastEventEndTime + 1000,
-    endTime: lastEventEndTime + 1001,
-  }));
-
-  return {traceEvents};
-
-  /**
-   * @return {LH.TraceEvent}
-   */
-  function createFakeTracingStarted() {
-    const data = {
-      frameTreeNodeId: 1,
-      sessionId: '1.1',
-      page: frame,
-      persistentIds: true,
-      frames: [{frame, url: 'about:blank', name: '', processId: 1}],
-    };
-
-    return {
-      ...baseEvent,
-      ts: baseTs - 1e5,
-      ph: 'I',
-      s: 't',
-      cat: 'disabled-by-default-devtools.timeline',
-      name: 'TracingStartedInPage',
-      args: {data},
-      dur: 0,
-    };
-  }
-
-  /**
-   * @param {{childEvents: LH.TraceEvent[]}} cpuNode
-   * @param {{startTime: number, endTime: number}} timing
-   * @return {LH.TraceEvent}
-   */
-  function createFakeEvaluateScript(cpuNode, timing) {
-    const realEvaluateScriptEvent = cpuNode.childEvents.find(e => e.name === 'EvaluateScript' &&
-      !!e.args.data && !!e.args.data.url);
-    // @ts-ignore
-    const scriptUrl = realEvaluateScriptEvent && realEvaluateScriptEvent.args.data.url;
-    const data = {
-      url: scriptUrl || '',
-      frame,
-      lineNumber: 0,
-      columnNumber: 0,
-    };
-
-    return {
-      ...baseEvent,
-      ph: 'X',
-      name: 'EvaluateScript',
-      ts: ts(timing.startTime),
-      dur: (timing.endTime - timing.startTime) * 1000,
-      args: {data},
-    };
-  }
-
-  /**
-   * @param {LH.WebInspector.NetworkRequest} record
-   * @param {LH.Gatherer.Simulation.NodeTiming} timing
-   * @return {LH.TraceEvent[]}
-   */
-  function createFakeNetwork(record, timing) {
-    requestId++;
-
-    // 0ms requests get super-messed up rendering, make it look like they took 20ms
-    let {startTime, endTime} = timing; // eslint-disable-line prefer-const
-    if (startTime === endTime) endTime += 20;
-
-    const requestData = {requestId: requestId.toString(), frame};
-    /** @type {Omit<LH.TraceEvent, 'name'|'ts'|'args'>} */
-    const baseRequestEvent = {...baseEvent, ph: 'I', s: 't', dur: 0};
-
-    const sendRequestData = {
-      ...requestData,
-      requestMethod: record.requestMethod,
-      url: record.url,
-      priority: record.priority(),
-    };
-
-    const receiveResponseData = {
-      ...requestData,
-      statusCode: record.statusCode,
-      mimeType: record._mimeType,
-      encodedDataLength: record._transferSize,
-      fromCache: false,
-      fromServiceWorker: false,
-    };
-
-    const resourceFinishData = {
-      ...requestData,
-    };
-
-    return [
-      {
-        ...baseRequestEvent,
-        name: 'ResourceSendRequest',
-        ts: ts(startTime),
-        args: {data: sendRequestData},
-      },
-      {
-        ...baseRequestEvent,
-        name: 'ResourceReceiveResponse',
-        ts: ts(endTime),
-        args: {data: receiveResponseData},
-      },
-      {
-        ...baseRequestEvent,
-        name: 'ResourceFinish',
-        ts: ts(endTime),
-        args: {data: resourceFinishData},
-      },
-    ];
-  }
-}
-
-/**
  * Save a trace as JSON by streaming to disk at traceFilename.
  * @param {LH.Trace} traceData
  * @param {string} traceFilename
@@ -406,6 +255,22 @@ function saveTrace(traceData, traceFilename) {
 
     traceStream.pipe(writeStream);
   });
+}
+
+/**
+ * @param {string} pathWithBasename
+ * @return {Promise<void>}
+ */
+async function saveLanternDebugTraces(pathWithBasename) {
+  if (!process.env.LANTERN_DEBUG) return;
+
+  for (const [label, nodeTimings] of Simulator.ALL_NODE_TIMINGS) {
+    if (lanternTraceSaver.simulationNamesToIgnore.includes(label)) continue;
+
+    const traceFilename = `${pathWithBasename}-${label}${traceSuffix}`;
+    await saveTrace(lanternTraceSaver.convertNodeTimingsToTrace(nodeTimings), traceFilename);
+    log.log('saveAssets', `${label} lantern trace file streamed to disk: ${traceFilename}`);
+  }
 }
 
 /**
@@ -436,14 +301,8 @@ async function saveAssets(artifacts, audits, pathWithBasename) {
     log.log('saveAssets', 'trace file streamed to disk: ' + streamTraceFilename);
   });
 
-  for (const [label, nodeTimings] of Simulator.COMPUTED_NODE_TIMINGS) {
-    if (!LANTERN_TRACES_TO_SAVE.includes(label) && !process.env.LANTERN_DEBUG) continue;
-    const traceFilename = `${pathWithBasename}-${label}${traceSuffix}`;
-    await saveTrace(convertNodeTimingsToTrace(nodeTimings), traceFilename);
-    log.log('saveAssets', `${label} lantern trace file streamed to disk: ${traceFilename}`);
-  }
-
   await Promise.all(saveAll);
+  await saveLanternDebugTraces(pathWithBasename);
 }
 
 /**

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -26,7 +26,8 @@ const NodeState = {
   Complete: 3,
 };
 
-const GLOBAL_COMPUTED_NODE_TIMINGS = new Map();
+/** @type {Map<string, LH.Gatherer.Simulation.Result['nodeTimings']>} */
+const ALL_SIMULATION_NODE_TIMINGS = new Map();
 
 class Simulator {
   /**
@@ -382,7 +383,7 @@ class Simulator {
     }
 
     options = Object.assign({
-      label: 'unlabeled',
+      label: undefined,
       flexibleOrdering: false,
     }, options);
 
@@ -438,7 +439,7 @@ class Simulator {
     }
 
     const nodeTimings = this._computeFinalNodeTimings();
-    GLOBAL_COMPUTED_NODE_TIMINGS.set(options.label, nodeTimings);
+    ALL_SIMULATION_NODE_TIMINGS.set(options.label || 'unlabeled', nodeTimings);
 
     return {
       timeInMs: totalElapsedTime,
@@ -447,8 +448,8 @@ class Simulator {
   }
 
   /** @return {Map<string, LH.Gatherer.Simulation.Result['nodeTimings']>} */
-  static get COMPUTED_NODE_TIMINGS() {
-    return GLOBAL_COMPUTED_NODE_TIMINGS;
+  static get ALL_NODE_TIMINGS() {
+    return ALL_SIMULATION_NODE_TIMINGS;
   }
 }
 

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -245,10 +245,8 @@ class Simulator {
     const multiplier = cpuNode.didPerformLayout()
       ? this._layoutTaskMultiplier
       : this._cpuSlowdownMultiplier;
-    // toplevel tasks always have an evt.dur
-    const observedDuration = /** @type {number} */ (cpuNode.event.dur);
     const totalDuration = Math.min(
-      Math.round(observedDuration / 1000 * multiplier),
+      Math.round(cpuNode.event.dur  / 1000 * multiplier),
       DEFAULT_MAXIMUM_CPU_TASK_DURATION
     );
     const estimatedTimeElapsed = totalDuration - timingData.timeElapsed;

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -246,7 +246,7 @@ class Simulator {
       ? this._layoutTaskMultiplier
       : this._cpuSlowdownMultiplier;
     const totalDuration = Math.min(
-      Math.round(cpuNode.event.dur  / 1000 * multiplier),
+      Math.round(cpuNode.event.dur / 1000 * multiplier),
       DEFAULT_MAXIMUM_CPU_TASK_DURATION
     );
     const estimatedTimeElapsed = totalDuration - timingData.timeElapsed;

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -1,0 +1,186 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * @param {LH.Gatherer.Simulation.Result['nodeTimings']} nodeTimings
+ * @return {LH.Trace}
+ */
+function convertNodeTimingsToTrace(nodeTimings) {
+  /** @type {LH.TraceEvent[]} */
+  const traceEvents = [];
+  const baseTs = 1e9;
+  const baseEvent = {pid: 1, tid: 1, cat: 'devtools.timeline'};
+  const frame = 'A00001';
+  /** @param {number} ms */
+  const toMicroseconds = ms => baseTs + ms * 1000;
+
+  traceEvents.push(createFakeTracingStartedEvent());
+  traceEvents.push({...createFakeTracingStartedEvent(), name: 'TracingStartedInBrowser'});
+
+  // Create a fake requestId counter
+  let requestId = 1;
+  let lastEventEndTime = 0;
+  for (const [node, timing] of nodeTimings.entries()) {
+    lastEventEndTime = Math.max(lastEventEndTime, timing.endTime);
+    if (node.type === 'cpu') {
+      // Represent all CPU work that was bundled in a task as an EvaluateScript event
+      const cpuNode = /** @type {LH.Gatherer.Simulation.GraphCPUNode} */ (node);
+      traceEvents.push(createFakeEvaluateScriptEvent(cpuNode, timing));
+    } else {
+      const networkNode = /** @type {LH.Gatherer.Simulation.GraphNetworkNode} */ (node);
+      // Ignore data URIs as they don't really add much value
+      if (/^data/.test(networkNode.record.url)) continue;
+      traceEvents.push(...createFakeNetworkEvents(networkNode.record, timing));
+    }
+  }
+
+  // Create a fake evaluate script event ~1s after the trace ends for a sane default bounds in DT
+  traceEvents.push(
+    createFakeEvaluateScriptEvent(
+      {childEvents: []},
+      {
+        startTime: lastEventEndTime + 1000,
+        endTime: lastEventEndTime + 1001,
+      }
+    )
+  );
+
+  return {traceEvents};
+
+  /**
+   * @return {LH.TraceEvent}
+   */
+  function createFakeTracingStartedEvent() {
+    const argsData = {
+      frameTreeNodeId: 1,
+      sessionId: '1.1',
+      page: frame,
+      persistentIds: true,
+      frames: [{frame, url: 'about:blank', name: '', processId: 1}],
+    };
+
+    return {
+      ...baseEvent,
+      ts: baseTs - 1e5,
+      ph: 'I',
+      s: 't',
+      cat: 'disabled-by-default-devtools.timeline',
+      name: 'TracingStartedInPage',
+      args: {data: argsData},
+      dur: 0,
+    };
+  }
+
+  /**
+   * @param {{childEvents: LH.TraceEvent[]}} cpuNode
+   * @param {{startTime: number, endTime: number}} timing
+   * @return {LH.TraceEvent}
+   */
+  function createFakeEvaluateScriptEvent(cpuNode, timing) {
+    const realEvaluateScriptEvent = cpuNode.childEvents.find(
+      e => e.name === 'EvaluateScript' && !!e.args.data && !!e.args.data.url
+    );
+    // @ts-ignore
+    const scriptUrl = realEvaluateScriptEvent && realEvaluateScriptEvent.args.data.url;
+    const argsData = {
+      url: scriptUrl || '',
+      frame,
+      lineNumber: 0,
+      columnNumber: 0,
+    };
+
+    return {
+      ...baseEvent,
+      ph: 'X',
+      name: 'EvaluateScript',
+      ts: toMicroseconds(timing.startTime),
+      dur: (timing.endTime - timing.startTime) * 1000,
+      args: {data: argsData},
+    };
+  }
+
+  /**
+   * @param {LH.WebInspector.NetworkRequest} record
+   * @param {LH.Gatherer.Simulation.NodeTiming} timing
+   * @return {LH.TraceEvent[]}
+   */
+  function createFakeNetworkEvents(record, timing) {
+    requestId++;
+
+    // 0ms requests get super-messed up rendering
+    // Use 20ms instead so they're still hoverable
+    let {startTime, endTime} = timing; // eslint-disable-line prefer-const
+    if (startTime === endTime) endTime += 20;
+
+    const requestData = {requestId: requestId.toString(), frame};
+    /** @type {Omit<LH.TraceEvent, 'name'|'ts'|'args'>} */
+    const baseRequestEvent = {...baseEvent, ph: 'I', s: 't', dur: 0};
+
+    const sendRequestData = {
+      ...requestData,
+      requestMethod: record.requestMethod,
+      url: record.url,
+      priority: record.priority(),
+    };
+
+    const receiveResponseData = {
+      ...requestData,
+      statusCode: record.statusCode,
+      mimeType: record._mimeType,
+      encodedDataLength: record._transferSize,
+      fromCache: record._fromDiskCache,
+      fromServiceWorker: record._fetchedViaServiceWorker,
+    };
+
+    const resourceFinishData = {
+      ...requestData,
+      decodedBodyLength: record._resourceSize,
+      didFail: !!record.failed,
+      finishTime: endTime,
+    };
+
+    /** @type {LH.TraceEvent[]} */
+    const events = [
+      {
+        ...baseRequestEvent,
+        name: 'ResourceSendRequest',
+        ts: toMicroseconds(startTime),
+        args: {data: sendRequestData},
+      },
+      {
+        ...baseRequestEvent,
+        name: 'ResourceFinish',
+        ts: toMicroseconds(endTime),
+        args: {data: resourceFinishData},
+      },
+    ];
+
+    if (!record.failed) {
+      events.push({
+        ...baseRequestEvent,
+        name: 'ResourceReceiveResponse',
+        ts: toMicroseconds((startTime + endTime) / 2),
+        args: {data: receiveResponseData},
+      });
+    }
+
+    return events;
+  }
+}
+
+module.exports = {
+  simulationNamesToIgnore: [
+    'unlabeled',
+    'optimisticSpeedIndex',
+    'optimisticFlexSpeedIndex',
+    'pessimisticSpeedIndex',
+    'optimisticEstimatedInputLatency',
+    'optimisticFlexEstimatedInputLatency',
+    'pessimisticEstimatedInputLatency',
+  ],
+  convertNodeTimingsToTrace,
+};

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -29,7 +29,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
     if (node.type === 'cpu') {
       // Represent all CPU work that was bundled in a task as an EvaluateScript event
       const cpuNode = /** @type {LH.Gatherer.Simulation.GraphCPUNode} */ (node);
-      traceEvents.push(createFakeEvaluateScriptEvent(cpuNode, timing));
+      traceEvents.push(createFakeTaskEvent(cpuNode, timing));
     } else {
       const networkNode = /** @type {LH.Gatherer.Simulation.GraphNetworkNode} */ (node);
       // Ignore data URIs as they don't really add much value
@@ -40,7 +40,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
 
   // Create a fake evaluate script event ~1s after the trace ends for a sane default bounds in DT
   traceEvents.push(
-    createFakeEvaluateScriptEvent(
+    createFakeTaskEvent(
       {childEvents: []},
       {
         startTime: lastEventEndTime + 1000,
@@ -80,7 +80,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
    * @param {{startTime: number, endTime: number}} timing
    * @return {LH.TraceEvent}
    */
-  function createFakeEvaluateScriptEvent(cpuNode, timing) {
+  function createFakeTaskEvent(cpuNode, timing) {
     const realEvaluateScriptEvent = cpuNode.childEvents.find(
       e => e.name === 'EvaluateScript' && !!e.args.data && !!e.args.data.url
     );
@@ -96,7 +96,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
     return {
       ...baseEvent,
       ph: 'X',
-      name: 'EvaluateScript',
+      name: 'Task',
       ts: toMicroseconds(timing.startTime),
       dur: (timing.endTime - timing.startTime) * 1000,
       args: {data: argsData},

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -175,6 +175,10 @@ function convertNodeTimingsToTrace(nodeTimings) {
 module.exports = {
   simulationNamesToIgnore: [
     'unlabeled',
+    // These node timings should be nearly identical to the ones produced for Interactive
+    'optimisticFirstCPUIdle',
+    'optimisticFlexFirstCPUIdle',
+    'pessimisticFirstCPUIdle',
     'optimisticSpeedIndex',
     'optimisticFlexSpeedIndex',
     'pessimisticSpeedIndex',

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -105,7 +105,9 @@ function convertNodeTimingsToTrace(nodeTimings) {
 
     const nestedBaseTs = cpuNode.event.ts || 0;
     const multiplier = (timing.endTime - timing.startTime) * 1000 / cpuNode.event.dur;
+    const netReqEvents = ['ResourceSendRequest', 'ResourceFinish','ResourceReceiveResponse'];
     for (const event of cpuNode.childEvents) {
+      if (netReqEvents.includes(event.name)) continue;
       const ts = eventTs + (event.ts - nestedBaseTs) * multiplier;
       const newEvent = {...event, ...{pid: baseEvent.pid, tid: baseEvent.tid}, ts};
       if (event.dur) newEvent.dur = event.dur * multiplier;

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -104,11 +104,10 @@ function convertNodeTimingsToTrace(nodeTimings) {
     ];
 
     const nestedBaseTs = cpuNode.event.ts || 0;
-    const multiplier = (timing.endTime - timing.startTime) / cpuNode.event.dur;
-    for (let event of cpuNode.childEvents) {
-      if (event.cat !== 'devtools.timeline') continue;
+    const multiplier = (timing.endTime - timing.startTime) * 1000 / cpuNode.event.dur;
+    for (const event of cpuNode.childEvents) {
       const ts = eventTs + (event.ts - nestedBaseTs) * multiplier;
-      const newEvent = {...event, ...baseEvent, ts};
+      const newEvent = {...event, ...{pid: baseEvent.pid, tid: baseEvent.tid}, ts};
       if (event.dur) newEvent.dur = event.dur * multiplier;
       events.push(newEvent);
     }

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -112,9 +112,9 @@ function convertNodeTimingsToTrace(nodeTimings) {
     requestId++;
 
     // 0ms requests get super-messed up rendering
-    // Use 20ms instead so they're still hoverable
+    // Use 0.3ms instead so they're still hoverable, https://github.com/GoogleChrome/lighthouse/pull/5350#discussion_r194563201
     let {startTime, endTime} = timing; // eslint-disable-line prefer-const
-    if (startTime === endTime) endTime += 20;
+    if (startTime === endTime) endTime += 0.3;
 
     const requestData = {requestId: requestId.toString(), frame};
     /** @type {Omit<LH.TraceEvent, 'name'|'ts'|'args'>} */

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -105,9 +105,11 @@ function convertNodeTimingsToTrace(nodeTimings) {
 
     const nestedBaseTs = cpuNode.event.ts || 0;
     const multiplier = (timing.endTime - timing.startTime) * 1000 / cpuNode.event.dur;
-    const netReqEvents = ['ResourceSendRequest', 'ResourceFinish','ResourceReceiveResponse'];
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/5429ac8a61ad4fa/front_end/timeline_model/TimelineModel.js#L1129-L1130
+    const netReqEvents = new Set(['ResourceSendRequest', 'ResourceFinish',
+      'ResourceReceiveResponse', 'ResourceReceivedData']);
     for (const event of cpuNode.childEvents) {
-      if (netReqEvents.includes(event.name)) continue;
+      if (netReqEvents.has(event.name)) continue;
       const ts = eventTs + (event.ts - nestedBaseTs) * multiplier;
       const newEvent = {...event, ...{pid: baseEvent.pid, tid: baseEvent.tid}, ts};
       if (event.dur) newEvent.dur = event.dur * multiplier;

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -158,8 +158,9 @@ declare global {
       pid: number;
       tid: number;
       ts: number;
-      dur: number;
+      dur?: number;
       ph: 'B'|'b'|'D'|'E'|'e'|'F'|'I'|'M'|'N'|'n'|'O'|'R'|'S'|'T'|'X';
+      s?: 't';
     }
 
     export interface DevToolsJsonTarget {

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -158,7 +158,7 @@ declare global {
       pid: number;
       tid: number;
       ts: number;
-      dur?: number;
+      dur: number;
       ph: 'B'|'b'|'D'|'E'|'e'|'F'|'I'|'M'|'N'|'n'|'O'|'R'|'S'|'T'|'X';
       s?: 't';
     }


### PR DESCRIPTION
note: test failures blocked on #5377

running the CLI with `--save-assets` will now output the optimistic FCP and pessimistic TTI traces that lantern computed, waaaaaaay easier for debugging and whatnot

next steps I'll add labels for the various opportunities so those are easier to debug as well

the code's a bit big for asset-saver so it might make sense to pull it out, but I'm drawing a blank where it should live, straight in lib? next to simulator? what do we call it?


#### CNN TTI
![image](https://user-images.githubusercontent.com/2301202/40519075-91381948-5f72-11e8-8c0e-d40af3ff9640.png)

#### CNN FCP
![image](https://user-images.githubusercontent.com/2301202/40519090-a43704be-5f72-11e8-9681-dc24b346f195.png)
