### PR TITLE
misc(externs): import crdp from root node_modules

### DIFF
--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import _Crdp from '../node_modules/vscode-chrome-debug-core/lib/crdp/crdp';
+import _Crdp from 'vscode-chrome-debug-core/lib/crdp/crdp';
 import _StrictEventEmitter from '../third-party/strict-event-emitter-types/index';
 import { EventEmitter } from 'events';
 


### PR DESCRIPTION
**Summary**
Import crdp directly from package.
Fix for using LH types.
If LH installed as dependency, then `vscode-chrome-debug-core` isn't and can't be found via `../node_modules/vscode-chrome-debug-core/lib/crdp/crdp` path. Then I as user adding it manually  to my package.json will be able to use `externs.d.ts` types. 
