### PR TITLE
extension: update minimum Chrome version to 66

### DIFF
--- a/lighthouse-extension/app/manifest.json
+++ b/lighthouse-extension/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "version": "2.10.1.3000",
-  "minimum_chrome_version": "56",
+  "minimum_chrome_version": "66",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "icons": {


### PR DESCRIPTION
**Summary**
This should hopefully get some of those seeing emulation protocol errors to update Chrome and get the debugger protocol methods we need.

Stable is m67 now, but that seemed a bit harsh (only happened three days ago), and 66 should be sufficient for our uses.

**Related Issues/PRs**
#5398, #5397, #5395, #5334, #5307, #5305...
