### PR TITLE
fix: short_name shouldn't be required if the name is short

### DIFF
--- a/lighthouse-core/gather/computed/manifest-values.js
+++ b/lighthouse-core/gather/computed/manifest-values.js
@@ -65,12 +65,13 @@ class ManifestValues extends ComputedArtifact {
       {
         id: 'hasShortName',
         failureText: 'Manifest does not have `short_name`',
-        validate: manifestValue => !!manifestValue.short_name.value,
+        validate: manifestValue => !!manifestValue.short_name.value || !!manifestValue.name.value &&
+            manifestValue.name.value.length <= SUGGESTED_SHORTNAME_LENGTH,
       },
       {
         id: 'shortNameLength',
         failureText: 'Manifest `short_name` will be truncated when displayed on the homescreen',
-        validate: manifestValue => !!manifestValue.short_name.value &&
+        validate: manifestValue => !manifestValue.short_name.value ||
             manifestValue.short_name.value.length <= SUGGESTED_SHORTNAME_LENGTH,
       },
       {

--- a/lighthouse-core/test/audits/manifest-short-name-length-test.js
+++ b/lighthouse-core/test/audits/manifest-short-name-length-test.js
@@ -56,6 +56,17 @@ describe('Manifest: short_name_length audit', () => {
     });
   });
 
+  it('succeeds when a manifest contains a name that is already short', () => {
+    const artifacts = generateMockArtifacts();
+    const manifestSrc = JSON.stringify({
+      name: 'Lighthouse',
+    });
+    artifacts.Manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
+    return ManifestShortNameLengthAudit.audit(artifacts).then(result => {
+      assert.equal(result.rawValue, true);
+    });
+  });
+
   // Need to disable camelcase check for dealing with short_name.
   /* eslint-disable camelcase */
   it('fails when a manifest contains a too long short_name', () => {

--- a/lighthouse-core/test/fixtures/manifest-bom.json
+++ b/lighthouse-core/test/fixtures/manifest-bom.json
@@ -1,6 +1,6 @@
 ﻿{
   "short_name": "ExApp",
-  "name": "Example App",
+  "name": "Example Application",
   "start_url": "./",
   "icons": [
     {

--- a/lighthouse-core/test/fixtures/manifest.json
+++ b/lighthouse-core/test/fixtures/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "ExApp",
-  "name": "Example App",
+  "name": "Example Application",
   "start_url": "./",
   "icons": [
     {

--- a/lighthouse-core/test/gather/gatherers/manifest-test.js
+++ b/lighthouse-core/test/gather/gatherers/manifest-test.js
@@ -63,7 +63,7 @@ describe('Manifest gatherer', () => {
     promises.push(manifestGather.afterPass(getDriver(manifestWithBOM))
       .then(manifest => {
         assert.strictEqual(manifest.raw, Buffer.from(manifestWithBOM).slice(3).toString());
-        assert.strictEqual(manifest.value.name.value, 'Example App');
+        assert.strictEqual(manifest.value.name.value, 'Example Application');
         assert.strictEqual(manifest.value.short_name.value, 'ExApp');
       })
     );
@@ -71,7 +71,7 @@ describe('Manifest gatherer', () => {
     promises.push(manifestGather.afterPass(getDriver(manifestWithoutBOM))
       .then(manifest => {
         assert.strictEqual(manifest.raw, manifestWithoutBOM);
-        assert.strictEqual(manifest.value.name.value, 'Example App');
+        assert.strictEqual(manifest.value.name.value, 'Example Application');
         assert.strictEqual(manifest.value.short_name.value, 'ExApp');
       })
     );


### PR DESCRIPTION
fixes #2698 