### PR TITLE
core(tsc): add initial trivial type info to config.js

### DIFF
--- a/lighthouse-core/config/constants.js
+++ b/lighthouse-core/config/constants.js
@@ -47,6 +47,7 @@ const defaultSettings = {
   skipAudits: null,
 };
 
+/** @type {LH.Config.Pass} */
 const defaultPassConfig = {
   passName: 'defaultPass',
   recordTrace: false,

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -40,8 +40,7 @@ async function lighthouse(url, flags, configJSON) {
   log.setLevel(flags.logLevel);
 
   // Use ConfigParser to generate a valid config file
-  // @ts-ignore - TODO(bckenny): type checking for Config
-  const config = /** @type {LH.Config} */ (new Config(configJSON, flags));
+  const config = new Config(configJSON, flags);
   const connection = new ChromeProtocol(flags.port, flags.hostname);
 
   // kick off a lighthouse run

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -131,7 +131,7 @@ class Runner {
         audits: resultsById,
         configSettings: settings,
         categories,
-        categoryGroups: opts.config.groups,
+        categoryGroups: opts.config.groups || undefined,
         timing: {total: Date.now() - startTime},
       };
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -70,7 +70,7 @@ describe('Config', () => {
       passes: [{
         gatherers: [
           myGatherer1,
-          {instance: myGatherer2}
+          {instance: myGatherer2},
         ],
       }],
     };

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -57,6 +57,31 @@ describe('Config', () => {
     assert.equal(MyAudit, newConfig.audits[0].implementation);
   });
 
+  it('doesn\'t change directly injected plugin instances', () => {
+    class MyGatherer extends Gatherer {
+      constructor(secretVal) {
+        super();
+        this.secret = secretVal;
+      }
+    }
+    const myGatherer1 = new MyGatherer(1729);
+    const myGatherer2 = new MyGatherer(6);
+    const config = {
+      passes: [{
+        gatherers: [
+          myGatherer1,
+          {instance: myGatherer2}
+        ],
+      }],
+    };
+    const newConfig = new Config(config);
+    const configGatherers = newConfig.passes[0].gatherers;
+    assert(configGatherers[0].instance instanceof MyGatherer);
+    assert.equal(configGatherers[0].instance.secret, 1729);
+    assert(configGatherers[1].instance instanceof MyGatherer);
+    assert.equal(configGatherers[1].instance.secret, 6);
+  });
+
   it('uses the default config when no config is provided', () => {
     const config = new Config();
     assert.deepStrictEqual(config.categories, origConfig.categories);

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -24,11 +24,10 @@ const log = require('lighthouse-logger');
 function runLighthouseForConnection(
   connection, url, options, categoryIDs,
   updateBadgeFn = function() { }) {
-  // @ts-ignore - TODO(bckenny): type checking for Config
-  const config = /** @type {LH.Config} */ (new Config({
+  const config = new Config({
     extends: 'lighthouse:default',
     settings: {onlyCategories: categoryIDs},
-  }, options.flags));
+  }, options.flags);
 
   // Add url and config to fresh options object.
   const runOptions = Object.assign({}, options, {url, config});

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -7,18 +7,17 @@
 import Gatherer = require('../lighthouse-core/gather/gatherers/gatherer.js');
 import Audit = require('../lighthouse-core/audits/audit.js');
 
-
 declare global {
   module LH {
     /**
      * The full, normalized Lighthouse Config.
      */
-    export interface Config {
+    export interface Config extends Config.Json {
       settings: Config.Settings;
-      passes?: Config.Pass[];
-      audits?: Config.AuditDefn[];
-      categories?: Record<string, Config.Category>;
-      groups?: Record<string, Config.Group>;
+      passes: Config.Pass[] | null;
+      audits: Config.AuditDefn[] | null;
+      categories: Record<string, Config.Category> | null;
+      groups: Record<string, Config.Group> | null;
     }
 
     module Config {
@@ -26,10 +25,12 @@ declare global {
        * The pre-normalization Lighthouse Config format.
        */
       export interface Json {
+        extends?: 'lighthouse:default' | 'lighthouse:full' | string | boolean;
         settings?: SettingsJson;
-        passes?: PassJson[];
-        categories?: Record<string, CategoryJson>;
-        groups?: GroupJson[];
+        passes?: PassJson[] | null;
+        audits?: Config.AuditJson[] | null;
+        categories?: Record<string, CategoryJson> | null;
+        groups?: Record<string, Config.GroupJson> | null;
       }
 
       export interface SettingsJson extends SharedFlagsSettings {
@@ -58,7 +59,7 @@ declare global {
       } | {
         instance: InstanceType<typeof Gatherer>;
         options?: {};
-      } | string;
+      } | Gatherer | typeof Gatherer | string;
 
       export interface CategoryJson {
         title: string;
@@ -71,6 +72,14 @@ declare global {
         description: string;
       }
 
+      export type AuditJson = {
+        path: string,
+        options?: {};
+      } | {
+        implementation: typeof Audit;
+        options?: {};
+      } | typeof Audit | string;
+
       /**
        * Reference to an audit member of a category and how its score should be
        * weighted and how its results grouped with other members.
@@ -81,7 +90,6 @@ declare global {
         group?: string;
       }
 
-      // TODO(bckenny): we likely don't want to require all these
       export interface Settings extends Required<SettingsJson> {
         throttling: Required<ThrottlingSettings>;
       }
@@ -91,13 +99,15 @@ declare global {
       }
 
       export interface GathererDefn {
-        implementation: typeof Gatherer;
+        implementation?: typeof Gatherer;
         instance: InstanceType<typeof Gatherer>;
+        path?: string;
         options: {};
       }
 
       export interface AuditDefn {
         implementation: typeof Audit;
+        path?: string;
         options: {};
       }
 
@@ -107,6 +117,13 @@ declare global {
         auditRefs: AuditRef[];
       }
       export interface Group extends GroupJson {}
+
+      export type MergeOptionsOfItems = <T extends {path?: string, options: Record<string, any>}>(items: T[]) => T[];
+
+      export type Merge = {
+        <T extends Record<string, any>, U extends Record<string, any>>(base: T|null|undefined, extension: U, overwriteArrays?: boolean): T & U;
+        <T extends Array<any>, U extends Array<any>>(base: T|null|undefined, extension: T, overwriteArrays?: boolean): T & U;
+      }
     }
   }
 }


### PR DESCRIPTION
Part 1 of 2 to add type checking to `config.js`

This is an attempt to reduce noise around the more major changes by pulling out the trivial type annotations/changes needed without changing any functionality. Some of these types are slightly white lies, but will be correct with part 2.

Main trickiness here is some of the generic functions, like `merge()` and `deepClone()`, but they maintain their earlier behavior (except `deepCloneConfigJson()` is split out), it's mostly just convincing the compiler that they do what they say they do.