### PR TITLE
core(tsc): refactor and add type checking to config.js

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -3,7 +3,6 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-// @ts-nocheck
 'use strict';
 
 const defaultConfigPath = './default-config.js';
@@ -34,7 +33,7 @@ function validatePasses(passes, audits) {
   // Log if we are running gathers that are not needed by the audits listed in the config
   passes.forEach(pass => {
     pass.gatherers.forEach(gathererDefn => {
-      const gatherer = gathererDefn.instance || gathererDefn.implementation;
+      const gatherer = gathererDefn.instance;
       const isGatherRequiredByAudits = requiredGatherers.has(gatherer.name);
       if (!isGatherRequiredByAudits) {
         const msg = `${gatherer.name} gatherer requested, however no audit requires it.`;
@@ -165,10 +164,14 @@ function assertValidGatherer(gathererInstance, gathererName) {
  * @return {Partial<LH.Config.Settings>}
  */
 function cleanFlagsForSettings(flags = {}) {
+  /** @type {Partial<LH.Config.Settings>} */
   const settings = {};
+
   for (const key of Object.keys(flags)) {
+    // @ts-ignore - intentionally testing some keys not on defaultSettings to discard them.
     if (typeof constants.defaultSettings[key] !== 'undefined') {
-      settings[key] = flags[key];
+      const safekey = /** @type {keyof LH.SharedFlagsSettings} */ (key);
+      settings[safekey] = flags[safekey];
     }
   }
 
@@ -327,46 +330,31 @@ class Config {
       configJSON = Config.extendConfigJSON(deepCloneConfigJson(defaultConfig), configJSON);
     }
 
-    // Augment config with necessary defaults
-    configJSON = Config.augmentWithDefaults(configJSON);
+    // The directory of the config path, if one was provided.
+    const configDir = configPath ? path.dirname(configPath) : undefined;
 
-    // Expand audit/gatherer short-hand representations and merge in defaults
-    configJSON.audits = Config.expandAuditShorthandAndMergeOptions(configJSON.audits);
-    configJSON.passes = Config.expandGathererShorthandAndMergeOptions(configJSON.passes);
+    const settings = Config.initSettings(configJSON.settings, flags);
 
-    // Override any applicable settings with CLI flags
-    configJSON.settings = merge(configJSON.settings || {}, cleanFlagsForSettings(flags), true);
-
-    // Generate a limited config if specified
-    if (Array.isArray(configJSON.settings.onlyCategories) ||
-        Array.isArray(configJSON.settings.onlyAudits) ||
-        Array.isArray(configJSON.settings.skipAudits)) {
-      const categoryIds = configJSON.settings.onlyCategories;
-      const auditIds = configJSON.settings.onlyAudits;
-      const skipAuditIds = configJSON.settings.skipAudits;
-      configJSON = Config.generateNewFilteredConfig(configJSON, categoryIds, auditIds,
-          skipAuditIds);
-    }
-
-    Config.adjustDefaultPassForThrottling(configJSON);
-
-    // Store the directory of the config path, if one was provided.
-    this._configDir = configPath ? path.dirname(configPath) : undefined;
+    // Augment passes with necessary defaults and require gatherers.
+    const passesWithDefaults = Config.augmentPassesWithDefaults(configJSON.passes);
+    Config.adjustDefaultPassForThrottling(settings, passesWithDefaults);
+    const passes = Config.requireGatherers(passesWithDefaults, configDir);
 
     /** @type {LH.Config['settings']} */
-    this._settings = configJSON.settings || {};
+    this.settings = settings;
     /** @type {LH.Config['passes']} */
-    this._passes = Config.requireGatherers(configJSON.passes, this._configDir);
+    this.passes = passes;
     /** @type {LH.Config['audits']} */
-    this._audits = Config.requireAudits(configJSON.audits, this._configDir);
+    this.audits = Config.requireAudits(configJSON.audits, configDir);
     /** @type {LH.Config['categories']} */
-    this._categories = configJSON.categories;
+    this.categories = configJSON.categories || null;
     /** @type {LH.Config['groups']} */
-    this._groups = configJSON.groups;
+    this.groups = configJSON.groups || null;
 
-    // validatePasses must follow after audits are required
-    validatePasses(configJSON.passes, this._audits);
-    validateCategories(configJSON.categories, this._audits, this._groups);
+    Config.filterConfigIfNeeded(this);
+
+    validatePasses(this.passes, this.audits);
+    validateCategories(this.categories, this.audits, this.groups);
   }
 
   /**
@@ -395,17 +383,32 @@ class Config {
   }
 
   /**
-   * @param {LH.Config} config
-   * @return {LH.Config}
+   * @param {LH.Config.Json['passes']} passes
+   * @return {?Array<Required<LH.Config.PassJson>>}
    */
-  static augmentWithDefaults(config) {
-    const {defaultSettings, defaultPassConfig} = constants;
-    config.settings = merge(deepClone(defaultSettings), config.settings, true);
-    if (config.passes) {
-      config.passes = config.passes.map(pass => merge(deepClone(defaultPassConfig), pass));
+  static augmentPassesWithDefaults(passes) {
+    if (!passes) {
+      return null;
     }
 
-    return config;
+    const {defaultPassConfig} = constants;
+    return passes.map(pass => merge(deepClone(defaultPassConfig), pass));
+  }
+
+  /**
+   * @param {LH.Config.SettingsJson=} settings
+   * @param {LH.Flags=} flags
+   * @return {LH.Config.Settings}
+   */
+  static initSettings(settings = {}, flags) {
+    // Fill in missing settings with defaults
+    const {defaultSettings} = constants;
+    const settingWithDefaults = merge(deepClone(defaultSettings), settings, true);
+
+    // Override any applicable settings with CLI flags
+    const settingsWithFlags = merge(settingWithDefaults || {}, cleanFlagsForSettings(flags), true);
+
+    return settingsWithFlags;
   }
 
   /**
@@ -413,7 +416,7 @@ class Config {
    * @param {LH.Config.Json['audits']} audits
    * @return {?Array<{path: string, options?: {}} | {implementation: typeof Audit, path?: string, options?: {}}>}
    */
-  static expandAuditShorthandAndMergeOptions(audits) {
+  static expandAuditShorthand(audits) {
     if (!audits) {
       return null;
     }
@@ -421,14 +424,18 @@ class Config {
     const newAudits = audits.map(audit => {
       if (typeof audit === 'string') {
         return {path: audit, options: {}};
-      } else if (audit && typeof audit.audit === 'function') {
+      } else if ('implementation' in audit && typeof audit.implementation.audit === 'function') {
+        return audit;
+      } else if ('path' in audit && typeof audit.path === 'string') {
+        return audit;
+      } else if ('audit' in audit && typeof audit.audit === 'function') {
         return {implementation: audit, options: {}};
       } else {
-        return audit;
+        throw new Error('Invalid Audit type ' + JSON.stringify(audit));
       }
     });
 
-    return mergeOptionsOfItems(newAudits);
+    return newAudits;
   }
 
   /**
@@ -439,48 +446,51 @@ class Config {
    *  - class MyGatherer extends Gatherer { }
    *  - {instance: myGathererInstance}
    *
-   * @param {Array<{gatherers: Array<LH.Config.GathererJson>}>} passes
-   * @return {Array<{gatherers: Array<{instance?: Gatherer, implementation?: GathererConstructor, path?: string, options?: {}}>}>} passes
+   * @param {Array<LH.Config.GathererJson>} gatherers
+   * @return {Array<{instance?: Gatherer, implementation?: GathererConstructor, path?: string, options?: {}}>} passes
    */
-  static expandGathererShorthandAndMergeOptions(passes) {
-    if (!passes) {
-      return passes;
-    }
-
-    passes.forEach(pass => {
-      pass.gatherers = pass.gatherers.map(gatherer => {
-        if (typeof gatherer === 'string') {
-          return {path: gatherer, options: {}};
-        } else if (typeof gatherer === 'function') {
-          return {implementation: gatherer, options: {}};
-        } else if (gatherer && typeof gatherer.beforePass === 'function') {
-          return {instance: gatherer, options: {}};
-        } else {
-          return gatherer;
+  static expandGathererShorthand(gatherers) {
+    const expanded = gatherers.map(gatherer => {
+      if (typeof gatherer === 'string') {
+        // just 'path/to/gatherer'
+        return {path: gatherer, options: {}};
+      } else if ('implementation' in gatherer || 'instance' in gatherer) {
+        // {implementation: GathererConstructor, ...} or {instance: GathererInstance, ...}
+        return gatherer;
+      } else if ('path' in gatherer) {
+        // {path: 'path/to/gatherer', ...}
+        if (typeof gatherer.path !== 'string') {
+          throw new Error('Invalid Gatherer type ' + JSON.stringify(gatherer));
         }
-      });
-
-      pass.gatherers = mergeOptionsOfItems(pass.gatherers);
+        return gatherer;
+      } else if (typeof gatherer === 'function') {
+        // just GathererConstructor
+        return {implementation: gatherer, options: {}};
+      } else if (gatherer && typeof gatherer.beforePass === 'function') {
+        // just GathererInstance
+        return {instance: gatherer, options: {}};
+      } else {
+        throw new Error('Invalid Gatherer type ' + JSON.stringify(gatherer));
+      }
     });
 
-    return passes;
+    return expanded;
   }
 
   /**
    * Observed throttling methods (devtools/provided) require at least 5s of quiet for the metrics to
    * be computed. This method adjusts the quiet thresholds to the required minimums if necessary.
-   *
-   * @param {LH.Config.Json} config
+   * @param {LH.Config.Settings} settings
+   * @param {?Array<Required<LH.Config.PassJson>>} passes
    */
-  static adjustDefaultPassForThrottling(config) {
-    if (config.settings.throttlingMethod !== 'devtools' &&
-        config.settings.throttlingMethod !== 'provided') {
+  static adjustDefaultPassForThrottling(settings, passes) {
+    if (!passes ||
+        (settings.throttlingMethod !== 'devtools' && settings.throttlingMethod !== 'provided')) {
       return;
     }
 
-    const defaultPass = config.passes.find(pass => pass.passName === 'defaultPass');
+    const defaultPass = passes.find(pass => pass.passName === 'defaultPass');
     if (!defaultPass) return;
-
     const overrides = constants.nonSimulatedPassConfigOverrides;
     defaultPass.pauseAfterLoadMs =
       Math.max(overrides.pauseAfterLoadMs, defaultPass.pauseAfterLoadMs);
@@ -491,70 +501,56 @@ class Config {
   }
 
   /**
-   * Filter out any unrequested items from the config, based on requested top-level categories.
-   * @param {LH.Config.Json} oldConfig Lighthouse config object
-   * @param {!Array<string>=} categoryIds ID values of categories to include
-   * @param {!Array<string>=} auditIds ID values of categories to include
-   * @param {!Array<string>=} skipAuditIds ID values of categories to exclude
-   * @return {LH.Config.Json} A new config
+   * Filter out any unrequested items from the config, based on requested categories or audits.
+   * @param {Config} config
    */
-  static generateNewFilteredConfig(oldConfig, categoryIds, auditIds, skipAuditIds) {
-    // 0. Clone config to avoid mutating it
-    const config = deepCloneConfigJson(oldConfig);
-    config.audits = Config.expandAuditShorthandAndMergeOptions(config.audits);
-    config.passes = Config.expandGathererShorthandAndMergeOptions(config.passes);
-    config.passes = Config.requireGatherers(config.passes);
+  static filterConfigIfNeeded(config) {
+    const settings = config.settings;
+    if (!settings.onlyCategories && !settings.onlyAudits && !settings.skipAudits) {
+      return config;
+    }
 
     // 1. Filter to just the chosen categories/audits
-    const {categories, audits: requestedAuditNames} = Config.filterCategoriesAndAudits(
-      config.categories,
-      categoryIds,
-      auditIds,
-      skipAuditIds
-    );
-
-    config.categories = categories;
+    const {categories, requestedAuditNames} = Config.filterCategoriesAndAudits(config.categories,
+      settings);
 
     // 2. Resolve which audits will need to run
-    const auditPathToNameMap = Config.getMapOfAuditPathToName(config);
-    const getAuditName = auditDefn => auditDefn.implementation ?
-      auditDefn.implementation.meta.name :
-      auditPathToNameMap.get(auditDefn.path);
-    config.audits = config.audits.filter(auditDefn =>
-        requestedAuditNames.has(getAuditName(auditDefn)));
+    const audits = config.audits && config.audits.filter(auditDefn =>
+        requestedAuditNames.has(auditDefn.implementation.meta.name));
 
     // 3. Resolve which gatherers will need to run
-    const auditObjectsSelected = Config.requireAudits(config.audits);
-    const requiredGatherers = Config.getGatherersNeededByAudits(auditObjectsSelected);
+    const requiredGathererIds = Config.getGatherersNeededByAudits(audits);
 
     // 4. Filter to only the neccessary passes
-    config.passes = Config.generatePassesNeededByGatherers(config.passes, requiredGatherers);
-    return config;
+    const passes = Config.generatePassesNeededByGatherers(config.passes, requiredGathererIds);
+
+    config.categories = categories;
+    config.audits = audits;
+    config.passes = passes;
   }
 
   /**
    * Filter out any unrequested categories or audits from the categories object.
    * @param {LH.Config['categories']} oldCategories
-   * @param {Array<string>=} categoryIds
-   * @param {Array<string>=} auditIds
-   * @param {Array<string>=} skipAuditIds
+   * @param {LH.Config.Settings} settings
    * @return {{categories: LH.Config['categories'], requestedAuditNames: Set<string>}}
    */
-  static filterCategoriesAndAudits(oldCategories, categoryIds, auditIds, skipAuditIds) {
+  static filterCategoriesAndAudits(oldCategories, settings) {
     if (!oldCategories) {
       return {categories: null, requestedAuditNames: new Set()};
     }
 
-    if (auditIds && skipAuditIds) {
+    if (settings.onlyAudits && settings.skipAudits) {
       throw new Error('Cannot set both skipAudits and onlyAudits');
     }
 
+    /** @type {NonNullable<LH.Config['categories']>} */
     const categories = {};
-    const filterByIncludedCategory = !!categoryIds;
-    const filterByIncludedAudit = !!auditIds;
-    categoryIds = categoryIds || [];
-    auditIds = auditIds || [];
-    skipAuditIds = skipAuditIds || [];
+    const filterByIncludedCategory = !!settings.onlyCategories;
+    const filterByIncludedAudit = !!settings.onlyAudits;
+    const categoryIds = settings.onlyCategories || [];
+    const auditIds = settings.onlyAudits || [];
+    const skipAuditIds = settings.skipAudits || [];
 
     // warn if the category is not found
     categoryIds.forEach(categoryId => {
@@ -568,17 +564,17 @@ class Config {
     for (const auditId of auditsToValidate) {
       const foundCategory = Object.keys(oldCategories).find(categoryId => {
         const auditRefs = oldCategories[categoryId].auditRefs;
-        return auditRefs.find(candidate => candidate.id === auditId);
+        return !!auditRefs.find(candidate => candidate.id === auditId);
       });
 
       if (!foundCategory) {
         const parentKeyName = skipAuditIds.includes(auditId) ? 'skipAudits' : 'onlyAudits';
         log.warn('config', `unrecognized audit in '${parentKeyName}': ${auditId}`);
-      }
-
-      if (auditIds.includes(auditId) && categoryIds.includes(foundCategory)) {
-        log.warn('config', `${auditId} in 'onlyAudits' is already included by ` +
-            `${foundCategory} in 'onlyCategories'`);
+      } else {
+        if (auditIds.includes(auditId) && categoryIds.includes(foundCategory)) {
+          log.warn('config', `${auditId} in 'onlyAudits' is already included by ` +
+              `${foundCategory} in 'onlyCategories'`);
+        }
       }
     }
 
@@ -611,7 +607,7 @@ class Config {
       }
     });
 
-    return {categories, audits: includedAudits};
+    return {categories, requestedAuditNames: includedAudits};
   }
 
   /**
@@ -628,26 +624,6 @@ class Config {
       const title = categories[id].title;
       return {id, title};
     });
-  }
-
-  /**
-   * Creates mapping from audit path (used in config.audits) to audit.name (used in categories)
-   * @param {LH.Config.Json} config Lighthouse config object.
-   * @return {Map<string, string>}
-   */
-  static getMapOfAuditPathToName(config) {
-    const auditObjectsAll = Config.requireAudits(config.audits);
-    if (!auditObjectsAll) {
-      return new Map();
-    }
-
-    const auditPathToName = new Map(auditObjectsAll.map((auditDefn, index) => {
-      const AuditClass = auditDefn.implementation;
-      const auditPath = config.audits[index];
-      const auditName = AuditClass.meta.name;
-      return [auditPath, auditName];
-    }));
-    return auditPathToName;
   }
 
   /**
@@ -683,7 +659,7 @@ class Config {
     const filteredPasses = passes.map(pass => {
       // remove any unncessary gatherers from within the passes
       pass.gatherers = pass.gatherers.filter(gathererDefn => {
-        const gatherer = gathererDefn.instance || gathererDefn.implementation;
+        const gatherer = gathererDefn.instance;
         return requiredGatherers.has(gatherer.name);
       });
 
@@ -714,28 +690,38 @@ class Config {
    * @return {LH.Config['audits']}
    */
   static requireAudits(audits, configPath) {
-    if (!audits) {
+    const expandedAudits = Config.expandAuditShorthand(audits);
+    if (!expandedAudits) {
       return null;
     }
 
     const coreList = Runner.getAuditList();
-    return audits.map(auditDefn => {
-      if (!auditDefn.implementation) {
-        const path = auditDefn.path;
+    const auditDefns = expandedAudits.map(audit => {
+      let implementation;
+      if ('implementation' in audit) {
+        implementation = audit.implementation;
+      } else {
         // See if the audit is a Lighthouse core audit.
-        const coreAudit = coreList.find(a => a === `${path}.js`);
-        let requirePath = `../audits/${path}`;
+        const auditPathJs = `${audit.path}.js`;
+        const coreAudit = coreList.find(a => a === auditPathJs);
+        let requirePath = `../audits/${audit.path}`;
         if (!coreAudit) {
           // Otherwise, attempt to find it elsewhere. This throws if not found.
-          requirePath = Runner.resolvePlugin(path, configPath, 'audit');
+          requirePath = Runner.resolvePlugin(audit.path, configPath, 'audit');
         }
-
-        auditDefn.implementation = require(requirePath);
+        implementation = /** @type {typeof Audit} */ (require(requirePath));
       }
 
-      assertValidAudit(auditDefn.implementation, auditDefn.path);
-      return auditDefn;
+      return {
+        implementation,
+        path: audit.path,
+        options: audit.options || {},
+      };
     });
+
+    const mergedAuditDefns = mergeOptionsOfItems(auditDefns);
+    mergedAuditDefns.forEach(audit => assertValidAudit(audit.implementation, audit.path));
+    return mergedAuditDefns;
   }
 
   /**
@@ -752,63 +738,54 @@ class Config {
     }
 
     const coreList = Runner.getGathererList();
-    passes.forEach(pass => {
-      pass.gatherers.forEach(gathererDefn => {
-        if (!gathererDefn.instance) {
-          let GathererClass = gathererDefn.implementation;
-          if (!GathererClass) {
-            // See if the gatherer is a Lighthouse core gatherer
-            const name = gathererDefn.path;
-            const coreGatherer = coreList.find(a => a === `${name}.js`);
+    const fullPasses = passes.map(pass => {
+      const gathererDefns = Config.expandGathererShorthand(pass.gatherers).map(gathererDefn => {
+        if (gathererDefn.instance) {
+          return {
+            instance: gathererDefn.instance,
+            implementation: gathererDefn.implementation,
+            path: gathererDefn.path,
+            options: gathererDefn.options || {},
+          };
+        } else if (gathererDefn.implementation) {
+          const GathererClass = gathererDefn.implementation;
+          return {
+            instance: new GathererClass(),
+            implementation: gathererDefn.implementation,
+            path: gathererDefn.path,
+            options: gathererDefn.options || {},
+          };
+        } else if (gathererDefn.path) {
+          // See if the gatherer is a Lighthouse core gatherer
+          const path = gathererDefn.path;
+          const coreGatherer = coreList.find(a => a === `${path}.js`);
 
-            let requirePath = `../gather/gatherers/${name}`;
-            if (!coreGatherer) {
-              // Otherwise, attempt to find it elsewhere. This throws if not found.
-              requirePath = Runner.resolvePlugin(name, configPath, 'gatherer');
-            }
-
-            GathererClass = require(requirePath);
+          let requirePath = `../gather/gatherers/${path}`;
+          if (!coreGatherer) {
+            // Otherwise, attempt to find it elsewhere. This throws if not found.
+            requirePath = Runner.resolvePlugin(path, configPath, 'gatherer');
           }
 
-          gathererDefn.implementation = GathererClass;
-          gathererDefn.instance = new GathererClass();
-        }
+          const GathererClass = /** @type {GathererConstructor} */ (require(requirePath));
 
-        assertValidGatherer(gathererDefn.instance, gathererDefn.path);
+          return {
+            instance: new GathererClass(),
+            implementation: GathererClass,
+            path,
+            options: gathererDefn.options || {},
+          };
+        } else {
+          throw new Error('Invalid expanded Gatherer: ' + JSON.stringify(gathererDefn));
+        }
       });
+
+      const mergedDefns = mergeOptionsOfItems(gathererDefns);
+      mergedDefns.forEach(gatherer => assertValidGatherer(gatherer.instance, gatherer.path));
+
+      return Object.assign(pass, {gatherers: mergedDefns});
     });
 
-    return passes;
-  }
-
-  /** @type {string} */
-  get configDir() {
-    return this._configDir;
-  }
-
-  /** @type {LH.Config['passes']} */
-  get passes() {
-    return this._passes;
-  }
-
-  /** @type {LH.Config['audits']} */
-  get audits() {
-    return this._audits;
-  }
-
-  /** @type {LH.Config['categories']} */
-  get categories() {
-    return this._categories;
-  }
-
-  /** @type {LH.Config['groups']} */
-  get groups() {
-    return this._groups;
-  }
-
-  /** @type {LH.Config['settings']} */
-  get settings() {
-    return this._settings;
+    return fullPasses;
   }
 }
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -229,8 +229,47 @@ describe('Config', () => {
     }), /meta.description property/);
 
     assert.throws(_ => new Config({
+      audits: [
+        class BinaryButNoFailureDescAudit extends Audit {
+          static get meta() {
+            return {
+              name: 'no-failure-description',
+              description: 'description',
+              helpText: 'help',
+              requiredArtifacts: [],
+              scoreDisplayMode: 'binary',
+            };
+          }
+
+          static audit() {
+            throw new Error('Unimplemented');
+          }
+        },
+      ],
+    }), /no failureDescription and should/);
+
+    assert.throws(_ => new Config({
       audits: [basePath + '/missing-help-text'],
     }), /meta.helpText property/);
+
+    assert.throws(_ => new Config({
+      audits: [
+        class EmptyStringHelpTextAudit extends Audit {
+          static get meta() {
+            return {
+              name: 'empty-string-help-text',
+              description: 'description',
+              helpText: '',
+              requiredArtifacts: [],
+            };
+          }
+
+          static audit() {
+            throw new Error('Unimplemented');
+          }
+        },
+      ],
+    }), /empty meta.helpText string/);
 
     assert.throws(_ => new Config({
       audits: [basePath + '/missing-required-artifacts'],
@@ -558,6 +597,27 @@ describe('Config', () => {
     assert.ok(typeof config.settings.maxWaitForLoad === 'number', 'missing setting from default');
   });
 
+  it('is idempotent when accepting a canonicalized Config as valid ConfigJson input', () => {
+    const config = new Config(defaultConfig);
+    const configAgain = new Config(config);
+    assert.deepEqual(config, configAgain);
+  });
+
+  it('is idempotent accepting a canonicalized filtered Config as valid ConfigJson input', () => {
+    const extendedJson = {
+      extends: 'lighthouse:default',
+      settings: {
+        onlyCategories: ['pwa'],
+      },
+    };
+    const config = new Config(extendedJson);
+    assert.equal(config.passes.length, 3, 'did not filter config');
+    assert.equal(Object.keys(config.categories).length, 1, 'did not filter config');
+    assert.deepEqual(config.settings.onlyCategories, ['pwa']);
+    const configAgain = new Config(config);
+    assert.deepEqual(config, configAgain);
+  });
+
   describe('#extendConfigJSON', () => {
     it('should merge passes', () => {
       const configA = {
@@ -623,16 +683,42 @@ describe('Config', () => {
     });
   });
 
-  describe('generateNewFilteredConfig', () => {
+  describe('filterConfigIfNeeded', () => {
     it('should not mutate the original config', () => {
       const configCopy = JSON.parse(JSON.stringify(origConfig));
-      Config.generateNewFilteredConfig(configCopy, ['performance']);
+      configCopy.settings.onlyCategories = ['performance'];
+      const config = new Config(configCopy);
+      configCopy.settings.onlyCategories = null;
+      assert.equal(config.passes.length, 1, 'did not filter config');
       assert.deepStrictEqual(configCopy, origConfig, 'no mutations');
+    });
+
+    it('should generate the same filtered config, extended or original', () => {
+      const configCopy = JSON.parse(JSON.stringify(origConfig));
+      configCopy.settings.onlyCategories = ['performance'];
+      const config = new Config(configCopy);
+
+      const extended = {
+        extends: 'lighthouse:default',
+        settings: {
+          onlyCategories: ['performance'],
+        },
+      };
+      const extendedConfig = new Config(extended);
+
+      assert.equal(config.passes.length, 1, 'did not filter config');
+      assert.deepStrictEqual(config, extendedConfig, 'no mutations');
     });
 
     it('should filter out other passes if passed Performance', () => {
       const totalAuditCount = origConfig.audits.length;
-      const config = Config.generateNewFilteredConfig(origConfig, ['performance']);
+      const extended = {
+        extends: 'lighthouse:default',
+        settings: {
+          onlyCategories: ['performance'],
+        },
+      };
+      const config = new Config(extended);
       assert.equal(Object.keys(config.categories).length, 1, 'other categories are present');
       assert.equal(config.passes.length, 1, 'incorrect # of passes');
       assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
@@ -640,21 +726,39 @@ describe('Config', () => {
 
     it('should filter out other passes if passed PWA', () => {
       const totalAuditCount = origConfig.audits.length;
-      const config = Config.generateNewFilteredConfig(origConfig, ['pwa']);
+      const extended = {
+        extends: 'lighthouse:default',
+        settings: {
+          onlyCategories: ['pwa'],
+        },
+      };
+      const config = new Config(extended);
       assert.equal(Object.keys(config.categories).length, 1, 'other categories are present');
       assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
     });
 
     it('should filter out other passes if passed Best Practices', () => {
       const totalAuditCount = origConfig.audits.length;
-      const config = Config.generateNewFilteredConfig(origConfig, ['best-practices']);
+      const extended = {
+        extends: 'lighthouse:default',
+        settings: {
+          onlyCategories: ['best-practices'],
+        },
+      };
+      const config = new Config(extended);
       assert.equal(Object.keys(config.categories).length, 1, 'other categories are present');
       assert.equal(config.passes.length, 1, 'incorrect # of passes');
       assert.ok(config.audits.length < totalAuditCount, 'audit filtering probably failed');
     });
 
     it('should only run audits for ones named by the category', () => {
-      const config = Config.generateNewFilteredConfig(origConfig, ['performance']);
+      const extended = {
+        extends: 'lighthouse:default',
+        settings: {
+          onlyCategories: ['performance'],
+        },
+      };
+      const config = new Config(extended);
       const selectedCategory = origConfig.categories.performance;
       const auditCount = Object.keys(selectedCategory.auditRefs).length;
 
@@ -662,14 +766,26 @@ describe('Config', () => {
     });
 
     it('should only run specified audits', () => {
-      const config = Config.generateNewFilteredConfig(origConfig, [], ['works-offline']);
+      const extended = {
+        extends: 'lighthouse:default',
+        settings: {
+          onlyAudits: ['works-offline'],
+        },
+      };
+      const config = new Config(extended);
       assert.equal(config.passes.length, 2, 'incorrect # of passes');
       assert.equal(config.audits.length, 1, 'audit filtering failed');
     });
 
     it('should combine audits and categories additively', () => {
-      const config = Config.generateNewFilteredConfig(origConfig, ['performance'],
-          ['works-offline']);
+      const extended = {
+        extends: 'lighthouse:default',
+        settings: {
+          onlyCategories: ['performance'],
+          onlyAudits: ['works-offline'],
+        },
+      };
+      const config = new Config(extended);
       const selectedCategory = origConfig.categories.performance;
       const auditCount = Object.keys(selectedCategory.auditRefs).length + 1;
       assert.equal(config.passes.length, 2, 'incorrect # of passes');
@@ -677,7 +793,14 @@ describe('Config', () => {
     });
 
     it('should support redundant filtering', () => {
-      const config = Config.generateNewFilteredConfig(origConfig, ['pwa'], ['is-on-https']);
+      const extended = {
+        extends: 'lighthouse:default',
+        settings: {
+          onlyCategories: ['pwa'],
+          onlyAudits: ['is-on-https'],
+        },
+      };
+      const config = new Config(extended);
       const selectedCategory = origConfig.categories.pwa;
       const auditCount = Object.keys(selectedCategory.auditRefs).length;
       assert.equal(config.passes.length, 3, 'incorrect # of passes');
@@ -685,15 +808,31 @@ describe('Config', () => {
     });
   });
 
-  describe('expandAuditShorthandAndMergeOptions', () => {
+  describe('#requireAudits', () => {
     it('should merge audits', () => {
-      const audits = ['a', {path: 'b', options: {x: 1, y: 1}}, {path: 'b', options: {x: 2}}];
-      const merged = Config.expandAuditShorthandAndMergeOptions(audits);
-      assert.deepEqual(merged, [{path: 'a', options: {}}, {path: 'b', options: {x: 2, y: 1}}]);
+      const audits = [
+        'user-timings',
+        {path: 'is-on-https', options: {x: 1, y: 1}},
+        {path: 'is-on-https', options: {x: 2}},
+      ];
+      const merged = Config.requireAudits(audits);
+      // Round-trip through JSON to drop live 'implementation' prop.
+      const mergedJson = JSON.parse(JSON.stringify(merged));
+      assert.deepEqual(mergedJson,
+        [{path: 'user-timings', options: {}}, {path: 'is-on-https', options: {x: 2, y: 1}}]);
+    });
+
+    it('throws for invalid auditDefns', () => {
+      const configJson = {
+        audits: [
+          new Gatherer(),
+        ],
+      };
+      assert.throws(_ => new Config(configJson), /Invalid Audit type/);
     });
   });
 
-  describe('expandGathererShorthandAndMergeOptions', () => {
+  describe('#requireGatherers', () => {
     it('should merge gatherers', () => {
       const gatherers = [
         'viewport-dimensions',
@@ -701,12 +840,14 @@ describe('Config', () => {
         {path: 'viewport-dimensions', options: {y: 1}},
       ];
 
-      const merged = Config.expandGathererShorthandAndMergeOptions([{gatherers}]);
-      assert.deepEqual(merged[0].gatherers, [{path: 'viewport-dimensions', options: {x: 1, y: 1}}]);
-    });
-  });
+      const merged = Config.requireGatherers([{gatherers}]);
+      // Round-trip through JSON to drop live 'instance'/'implementation' props.
+      const mergedJson = JSON.parse(JSON.stringify(merged));
 
-  describe('#requireGatherers', () => {
+      assert.deepEqual(mergedJson[0].gatherers,
+        [{path: 'viewport-dimensions', options: {x: 1, y: 1}, instance: {}}]);
+    });
+
     function loadGatherer(gathererEntry) {
       const config = new Config({passes: [{gatherers: [gathererEntry]}]});
       return config.passes[0].gatherers[0];
@@ -738,6 +879,20 @@ describe('Config', () => {
     it('returns gatherer when gatherer class, not package-name string, is provided', () => {
       class TestGatherer extends Gatherer {}
       const gatherer = loadGatherer(TestGatherer);
+      assert.equal(gatherer.instance.name, 'TestGatherer');
+      assert.equal(typeof gatherer.instance.beforePass, 'function');
+    });
+
+    it('returns gatherer when gatherer instance, not package-name string, is provided', () => {
+      class TestGatherer extends Gatherer {}
+      const gatherer = loadGatherer(new TestGatherer());
+      assert.equal(gatherer.instance.name, 'TestGatherer');
+      assert.equal(typeof gatherer.instance.beforePass, 'function');
+    });
+
+    it('returns gatherer when `gathererDefn` with instance is provided', () => {
+      class TestGatherer extends Gatherer {}
+      const gatherer = loadGatherer({instance: new TestGatherer()});
       assert.equal(gatherer.instance.name, 'TestGatherer');
       assert.equal(typeof gatherer.instance.beforePass, 'function');
     });
@@ -774,6 +929,12 @@ describe('Config', () => {
             // our own custom locate gatherer error, not the usual MODULE_NOT_FOUND.
             return !/locate gatherer/.test(err) && err.code === 'MODULE_NOT_FOUND';
           });
+    });
+
+    it('throws for invalid gathererDefns', () => {
+      assert.throws(_ => loadGatherer({path: 55}), /Invalid Gatherer type/);
+
+      assert.throws(_ => loadGatherer(new Audit()), /Invalid Gatherer type/);
     });
 
     it('throws for invalid gatherers', () => {

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -690,7 +690,7 @@ describe('Config', () => {
       const config = new Config(configCopy);
       configCopy.settings.onlyCategories = null;
       assert.equal(config.passes.length, 1, 'did not filter config');
-      assert.deepStrictEqual(configCopy, origConfig, 'no mutations');
+      assert.deepStrictEqual(configCopy, origConfig, 'had mutations');
     });
 
     it('should generate the same filtered config, extended or original', () => {
@@ -707,7 +707,7 @@ describe('Config', () => {
       const extendedConfig = new Config(extended);
 
       assert.equal(config.passes.length, 1, 'did not filter config');
-      assert.deepStrictEqual(config, extendedConfig, 'no mutations');
+      assert.deepStrictEqual(config, extendedConfig, 'had mutations');
     });
 
     it('should filter out other passes if passed Performance', () => {


### PR DESCRIPTION
even with #5481 out of the way, this is still kind of a doozy to review, *but*

- With most of the rest of lighthouse type checked, this involved significantly fewer changes than a few months ago
- With @patrickhulce's work to unify CLI flags and the config and adding defaults for everything, a lot of simplification was already done and more was possible

Main starting change is eliminating `generateNewFilteredConfig()` as kind of an externally-facing API. We have a way of expressing that in the config itself now (`onlyCategories`, etc), so it makes sense to not expose a function for it anymore (and the extension, etc moved on to using `onlyCategories`, etc a while ago).

With that gone, the constructor is really the only entry point, and control flow becomes just a simple tree (ignoring `deepClone` and `mergeOptionsOfItems`):
  - make a copy of input config json
  - (optional) extend from a base config
  - clean settings and set defaults
  - clean passes and require gatherers
  - require audits
  - filter if needed
  - validate internal connections between audits, gatherers, etc

This means configs are always in one of two states, a `ConfigJson` -- possibly missing values and needing to extend something or be filtered -- and a `Config` -- all defaults set, filtered and extended. As mentioned in #5481, conveniently a `Config` is also a `ConfigJson`, enforced by the type system and some tests here.