### PR TITLE
core: enable async stacks

### DIFF
--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -30,9 +30,17 @@ class PageDependencyGraph {
   static getNetworkInitiators(record) {
     if (!record.initiator) return [];
     if (record.initiator.url) return [record.initiator.url];
-    if (record.initiator.type === 'script' && record.initiator.stack) {
-      const frames = record.initiator.stack.callFrames;
-      return Array.from(new Set(frames.map(frame => frame.url))).filter(Boolean);
+    if (record.initiator.type === 'script') {
+      /** @type {Set<string>} */
+      const scriptURLs = new Set();
+      for (let stack = record.initiator.stack; stack; stack = stack.parent) {
+        const callFrames = stack.callFrames || [];
+        for (const frame of callFrames) {
+          if (frame.url) scriptURLs.add(frame.url)
+        }
+      }
+
+      return Array.from(scriptURLs);
     }
 
     return [];

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -36,7 +36,7 @@ class PageDependencyGraph {
       for (let stack = record.initiator.stack; stack; stack = stack.parent) {
         const callFrames = stack.callFrames || [];
         for (const frame of callFrames) {
-          if (frame.url) scriptURLs.add(frame.url)
+          if (frame.url) scriptURLs.add(frame.url);
         }
       }
 

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -31,13 +31,19 @@ class PageDependencyGraph {
     if (!record.initiator) return [];
     if (record.initiator.url) return [record.initiator.url];
     if (record.initiator.type === 'script') {
+      // Script initiators have the stack of callFrames from all functions that led to this request.
+      // If async stacks are enabled, then the stack will also have the parent functions that asynchronously
+      // led to this request chained in the `parent` property.
       /** @type {Set<string>} */
       const scriptURLs = new Set();
-      for (let stack = record.initiator.stack; stack; stack = stack.parent) {
+      let stack = record.initiator.stack;
+      while (stack) {
         const callFrames = stack.callFrames || [];
         for (const frame of callFrames) {
           if (frame.url) scriptURLs.add(frame.url);
         }
+
+        stack = stack.parent
       }
 
       return Array.from(scriptURLs);

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -43,7 +43,7 @@ class PageDependencyGraph {
           if (frame.url) scriptURLs.add(frame.url);
         }
 
-        stack = stack.parent
+        stack = stack.parent;
       }
 
       return Array.from(scriptURLs);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1333,9 +1333,6 @@ class Driver {
     const uniqueCategories = Array.from(new Set(traceCategories));
 
     // Check any domains that could interfere with or add overhead to the trace.
-    if (this.isDomainEnabled('Debugger')) {
-      throw new Error('Debugger domain enabled when starting trace');
-    }
     if (this.isDomainEnabled('CSS')) {
       throw new Error('CSS domain enabled when starting trace');
     }
@@ -1399,6 +1396,15 @@ class Driver {
    */
   enableRuntimeEvents() {
     return this.sendCommand('Runtime.enable');
+  }
+
+  /**
+   * @return {Promise<void>}
+   */
+  async enableAsyncStacks() {
+    await this.sendCommand('Debugger.enable');
+    await this.sendCommand('Debugger.setSkipAllPauses', {skip: true});
+    await this.sendCommand('Debugger.setAsyncCallStackDepth', {maxDepth: 8});
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1399,6 +1399,9 @@ class Driver {
   }
 
   /**
+   * Enables `Debugger` domain to receive async stacktrace information on network request initiators.
+   * This is critical for tracing certain performance simulation situations.
+   *
    * @return {Promise<void>}
    */
   async enableAsyncStacks() {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -32,7 +32,7 @@ const Driver = require('../gather/driver.js'); // eslint-disable-line no-unused-
  *     i. assertNoSameOriginServiceWorkerClients
  *     ii. retrieve and save userAgent
  *     iii. beginEmulation
- *     iv. enableRuntimeEvents
+ *     iv. enableRuntimeEvents/enableAsyncStacks
  *     v. evaluateScriptOnLoad rescue native Promise from potential polyfill
  *     vi. register a performance observer
  *     vii. register dialog dismisser
@@ -108,6 +108,7 @@ class GatherRunner {
     await driver.assertNoSameOriginServiceWorkerClients(options.requestedUrl);
     await driver.beginEmulation(options.settings);
     await driver.enableRuntimeEvents();
+    await driver.enableAsyncStacks();
     await driver.cacheNatives();
     await driver.registerPerformanceObserver();
     await driver.dismissJavaScriptDialogs();

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -43,6 +43,9 @@ function makeFakeDriver({protocolGetVersionResponse}) {
     enableRuntimeEvents() {
       return Promise.resolve();
     },
+    enableAsyncStacks() {
+      return Promise.resolve();
+    },
     evaluateScriptOnLoad() {
       return Promise.resolve();
     },

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -43,6 +43,9 @@ function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn,
     enableRuntimeEvents() {
       return Promise.resolve();
     }
+    enableAsyncStacks() {
+      return Promise.resolve();
+    }
     assertNoSameOriginServiceWorkerClients() {
       return Promise.resolve();
     }
@@ -360,6 +363,7 @@ describe('GatherRunner', function() {
       setThrottling: asyncFunc,
       dismissJavaScriptDialogs: asyncFunc,
       enableRuntimeEvents: asyncFunc,
+      enableAsyncStacks: asyncFunc,
       cacheNatives: asyncFunc,
       gotoURL: asyncFunc,
       registerPerformanceObserver: asyncFunc,
@@ -419,6 +423,7 @@ describe('GatherRunner', function() {
       setThrottling: asyncFunc,
       dismissJavaScriptDialogs: asyncFunc,
       enableRuntimeEvents: asyncFunc,
+      enableAsyncStacks: asyncFunc,
       cacheNatives: asyncFunc,
       gotoURL: asyncFunc,
       registerPerformanceObserver: asyncFunc,


### PR DESCRIPTION
**Summary**
Initiator information can fallback to `parser` in cases when elements were added inside a microtask/Promise chain. This hurts the fidelity of the lantern graph.

Even though async stacks are enabled by default in stable Chrome now in v8 (https://v8.dev/blog/v8-release-73), it doesn't apply to the initiator information we get from Chrome which still requires explicitly setting the async stack depth.

I would love to get this in for 5.0 as it enables a lot of performance accuracy improvements and better attribution for bootup-time/third-party-web

**Related Issues/PRs**
fixes #5494 
closes #3375


