### PR TITLE
core: split out BaseArtifacts, those always provided by LH itself

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -236,8 +236,10 @@ class GatherRunner {
       // Abuse the passContext to pass through gatherer options
       passContext.options = gathererDefn.options || {};
       const artifactPromise = Promise.resolve().then(_ => gatherer.pass(passContext));
+
       const gathererResult = gathererResults[gatherer.name] || [];
       gathererResult.push(artifactPromise);
+      gathererResults[gatherer.name] = gathererResult;
       await GatherRunner.recoverOrThrow(artifactPromise);
     }
   }
@@ -302,8 +304,10 @@ class GatherRunner {
         Promise.reject(pageLoadError) :
         // Wrap gatherer response in promise, whether rejected or not.
         Promise.resolve().then(_ => gatherer.afterPass(passContext, passData));
+
       const gathererResult = gathererResults[gatherer.name] || [];
       gathererResult.push(artifactPromise);
+      gathererResults[gatherer.name] = gathererResult;
       await GatherRunner.recoverOrThrow(artifactPromise);
       log.verbose('statusEnd', status);
     }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -13,14 +13,14 @@ const constants = require('../config/constants');
 
 const Driver = require('../gather/driver.js'); // eslint-disable-line no-unused-vars
 
+/** @typedef {import('./gatherers/gatherer.js').PhaseResult} PhaseResult */
 /**
  * Each entry in each gatherer result array is the output of a gatherer phase:
  * `beforePass`, `pass`, and `afterPass`. Flattened into an `LH.Artifacts` in
  * `collectArtifacts`.
- * @typedef {{LighthouseRunWarnings: Array<string>, [artifactName: string]: Array<*>}} GathererResults
+ * @typedef {Record<keyof LH.GathererArtifacts, Array<PhaseResult|Promise<PhaseResult>>>} GathererResults
  */
-/** @typedef {{traces: Object<string, LH.Trace>, devtoolsLogs: Object<string, LH.DevtoolsLog>}} TracingData */
-
+/** @typedef {Array<[keyof GathererResults, GathererResults[keyof GathererResults]]>} GathererResultsEntries */
 /**
  * Class that drives browser to load the page and runs gatherer lifecycle hooks.
  * Execution sequence when GatherRunner.run() is called:
@@ -98,18 +98,16 @@ class GatherRunner {
 
   /**
    * @param {Driver} driver
-   * @param {GathererResults} gathererResults
+   * @param {LH.BaseArtifacts} baseArtifacts
    * @param {{requestedUrl: string, settings: LH.Config.Settings}} options
    * @return {Promise<void>}
    */
-  static async setupDriver(driver, gathererResults, options) {
+  static async setupDriver(driver, baseArtifacts, options) {
     log.log('status', 'Initializing…');
     const resetStorage = !options.settings.disableStorageReset;
     // Enable emulation based on settings
     await driver.assertNoSameOriginServiceWorkerClients(options.requestedUrl);
-    const userAgent = await driver.getUserAgent();
-    gathererResults.UserAgent = [userAgent];
-    GatherRunner.warnOnHeadless(userAgent, gathererResults);
+    GatherRunner.warnOnHeadless(baseArtifacts);
     await driver.beginEmulation(options.settings);
     await driver.enableRuntimeEvents();
     await driver.cacheNatives();
@@ -177,16 +175,15 @@ class GatherRunner {
 
   /**
    * Add run warning if running in Headless Chrome.
-   * @param {string} userAgent
-   * @param {GathererResults} gathererResults
+   * @param {LH.BaseArtifacts} baseArtifacts
    */
-  static warnOnHeadless(userAgent, gathererResults) {
-    const chromeVersion = userAgent.split(/HeadlessChrome\/(.*) /)[1];
+  static warnOnHeadless(baseArtifacts) {
+    const chromeVersion = baseArtifacts.UserAgent.split(/HeadlessChrome\/(.*) /)[1];
     // Headless Chrome gained throttling support in Chrome 63.
     // https://chromium.googlesource.com/chromium/src/+/8931a104b145ccf92390f6f48fba6553a1af92e4
     const minVersion = '63.0.3239.0';
     if (chromeVersion && chromeVersion < minVersion) {
-      gathererResults.LighthouseRunWarnings.push('Your site\'s mobile performance may be ' +
+      baseArtifacts.LighthouseRunWarnings.push('Your site\'s mobile performance may be ' +
           'worse than the numbers presented in this report. Lighthouse could not test on a ' +
           'mobile connection because Headless Chrome does not support network throttling ' +
           'prior to version ' + minVersion + '. The version used was ' + chromeVersion);
@@ -197,7 +194,7 @@ class GatherRunner {
    * Navigates to about:blank and calls beforePass() on gatherers before tracing
    * has started and before navigation to the target page.
    * @param {LH.Gatherer.PassContext} passContext
-   * @param {GathererResults} gathererResults
+   * @param {Partial<GathererResults>} gathererResults
    * @return {Promise<void>}
    */
   static async beforePass(passContext, gathererResults) {
@@ -226,7 +223,7 @@ class GatherRunner {
    * Navigates to requested URL and then runs pass() on gatherers while trace
    * (if requested) is still being recorded.
    * @param {LH.Gatherer.PassContext} passContext
-   * @param {GathererResults} gathererResults
+   * @param {Partial<GathererResults>} gathererResults
    * @return {Promise<void>}
    */
   static async pass(passContext, gathererResults) {
@@ -258,7 +255,8 @@ class GatherRunner {
       // Abuse the passContext to pass through gatherer options
       passContext.options = gathererDefn.options || {};
       const artifactPromise = Promise.resolve().then(_ => gatherer.pass(passContext));
-      gathererResults[gatherer.name].push(artifactPromise);
+      const gathererResult = gathererResults[gatherer.name] || [];
+      gathererResult.push(artifactPromise);
       await GatherRunner.recoverOrThrow(artifactPromise);
     }
   }
@@ -268,7 +266,7 @@ class GatherRunner {
    * afterPass() on gatherers with trace data passed in. Promise resolves with
    * object containing trace and network data.
    * @param {LH.Gatherer.PassContext} passContext
-   * @param {GathererResults} gathererResults
+   * @param {Partial<GathererResults>} gathererResults
    * @return {Promise<LH.Gatherer.LoadData>}
    */
   static async afterPass(passContext, gathererResults) {
@@ -294,7 +292,7 @@ class GatherRunner {
     if (!driver.online) pageLoadError = undefined;
 
     if (pageLoadError) {
-      gathererResults.LighthouseRunWarnings.push('Lighthouse was unable to reliably load the ' +
+      passContext.LighthouseRunWarnings.push('Lighthouse was unable to reliably load the ' +
         'page you requested. Make sure you are testing the correct URL and that the server is ' +
         'properly responding to all requests.');
     }
@@ -323,7 +321,8 @@ class GatherRunner {
         Promise.reject(pageLoadError) :
         // Wrap gatherer response in promise, whether rejected or not.
         Promise.resolve().then(_ => gatherer.afterPass(passContext, passData));
-      gathererResults[gatherer.name].push(artifactPromise);
+      const gathererResult = gathererResults[gatherer.name] || [];
+      gathererResult.push(artifactPromise);
       await GatherRunner.recoverOrThrow(artifactPromise);
       log.verbose('statusEnd', status);
     }
@@ -337,52 +336,65 @@ class GatherRunner {
    * last produced value (that's not undefined) as the artifact for that
    * gatherer. If a non-fatal error was rejected from a gatherer phase,
    * uses that error object as the artifact instead.
-   * @param {GathererResults} gathererResults
-   * @param {TracingData} tracingData
-   * @param {LH.Config.Settings} settings
+   * @param {Partial<GathererResults>} gathererResults
+   * @param {LH.BaseArtifacts} baseArtifacts
    * @return {Promise<LH.Artifacts>}
    */
-  static async collectArtifacts(gathererResults, tracingData, settings) {
-    // Can't handle dynamic GathererResults -> Artifacts, so explicitly make *
-    // and cast to Artifacts before returning.
-    /** @type {Object<string, *>} */
-    const artifacts = {
-      traces: tracingData.traces,
-      devtoolsLogs: tracingData.devtoolsLogs,
-      settings,
-      // Take only unique LighthouseRunWarnings, if any.
-      LighthouseRunWarnings: Array.from(new Set(gathererResults.LighthouseRunWarnings)),
-    };
+  static async collectArtifacts(gathererResults, baseArtifacts) {
+    /** @type {Partial<LH.GathererArtifacts>} */
+    const gathererArtifacts = {};
 
     const pageLoadFailures = [];
-    for (const [gathererName, phaseResultsPromises] of Object.entries(gathererResults)) {
-      if (artifacts[gathererName] !== undefined) continue;
+    const resultsEntries = /** @type {GathererResultsEntries} */ (Object.entries(gathererResults));
+    for (const [gathererName, phaseResultsPromises] of resultsEntries) {
+      if (gathererArtifacts[gathererName] !== undefined) continue;
 
       try {
         const phaseResults = await Promise.all(phaseResultsPromises);
         // Take last defined pass result as artifact.
         const definedResults = phaseResults.filter(element => element !== undefined);
         const artifact = definedResults[definedResults.length - 1];
-        artifacts[gathererName] = artifact;
+        // Typecast pretends artifact always provided here, but checked below for top-level `throw`.
+        gathererArtifacts[gathererName] = /** @type {NonVoid<PhaseResult>} */ (artifact);
       } catch (err) {
         // An error result must be non-fatal to not have caused an exit by now,
         // so return it to runner to handle turning it into an error audit.
-        artifacts[gathererName] = err;
+        gathererArtifacts[gathererName] = err;
         // Track page load errors separately, so we can fail loudly if needed.
         if (LHError.isPageLoadError(err)) pageLoadFailures.push(err);
       }
 
-      if (artifacts[gathererName] === undefined) {
+      if (gathererArtifacts[gathererName] === undefined) {
         throw new Error(`${gathererName} failed to provide an artifact.`);
       }
 
       // Fail the run if more than 50% of all artifacts failed due to page load failure.
-      if (pageLoadFailures.length > Object.keys(artifacts).length * 0.5) {
+      if (pageLoadFailures.length > Object.keys(gathererArtifacts).length * 0.5) {
         throw pageLoadFailures[0];
       }
     }
 
-    return /** @type {LH.Artifacts } */ (artifacts);
+    // Take only unique LighthouseRunWarnings.
+    baseArtifacts.LighthouseRunWarnings = Array.from(new Set(baseArtifacts.LighthouseRunWarnings));
+
+    // TODO(bckenny): drop cast when ComputedArtifacts not included in Artifacts
+    return /** @type {LH.Artifacts} */ ({...baseArtifacts, ...gathererArtifacts});
+  }
+
+  /**
+   * @param {{driver: Driver, requestedUrl: string, settings: LH.Config.Settings}} options
+   * @return {Promise<LH.BaseArtifacts>}
+   */
+  static async getBaseArtifacts(options) {
+    return {
+      fetchTime: (new Date()).toJSON(),
+      LighthouseRunWarnings: [],
+      UserAgent: await options.driver.getUserAgent(),
+      traces: {},
+      devtoolsLogs: {},
+      settings: options.settings,
+      URL: {requestedUrl: options.requestedUrl, finalUrl: ''},
+    };
   }
 
   /**
@@ -392,25 +404,18 @@ class GatherRunner {
    */
   static async run(passes, options) {
     const driver = options.driver;
-    /** @type {TracingData} */
-    const tracingData = {
-      traces: {},
-      devtoolsLogs: {},
-    };
 
-    /** @type {GathererResults} */
-    const gathererResults = {
-      LighthouseRunWarnings: [],
-      fetchTime: [(new Date()).toJSON()],
-      URL: [{requestedUrl: options.requestedUrl, finalUrl: ''}],
-    };
+    /** @type {Partial<GathererResults>} */
+    const gathererResults = {};
 
     try {
       await driver.connect();
+      const baseArtifacts = await GatherRunner.getBaseArtifacts(options);
       await GatherRunner.loadBlank(driver);
-      await GatherRunner.setupDriver(driver, gathererResults, options);
-      let firstPass = true;
+      await GatherRunner.setupDriver(driver, baseArtifacts, options);
+
       // Run each pass
+      let firstPass = true;
       for (const passConfig of passes) {
         const passContext = {
           driver: options.driver,
@@ -418,28 +423,31 @@ class GatherRunner {
           url: options.requestedUrl,
           settings: options.settings,
           passConfig,
+          // *pass() functions and gatherers can push to this warnings array.
+          LighthouseRunWarnings: baseArtifacts.LighthouseRunWarnings,
         };
 
         await driver.setThrottling(options.settings, passConfig);
         await GatherRunner.beforePass(passContext, gathererResults);
         await GatherRunner.pass(passContext, gathererResults);
         const passData = await GatherRunner.afterPass(passContext, gathererResults);
+
         // Save devtoolsLog, but networkRecords are discarded and not added onto artifacts.
-        tracingData.devtoolsLogs[passConfig.passName] = passData.devtoolsLog;
+        baseArtifacts.devtoolsLogs[passConfig.passName] = passData.devtoolsLog;
 
         // If requested by config, save pass's trace.
         if (passData.trace) {
-          tracingData.traces[passConfig.passName] = passData.trace;
+          baseArtifacts.traces[passConfig.passName] = passData.trace;
         }
 
         if (firstPass) {
           // Copy redirected URL to artifact in the first pass only.
-          gathererResults.URL[0].finalUrl = passContext.url;
+          baseArtifacts.URL.finalUrl = passContext.url;
           firstPass = false;
         }
       }
       await GatherRunner.disposeDriver(driver);
-      return GatherRunner.collectArtifacts(gathererResults, tracingData, options.settings);
+      return GatherRunner.collectArtifacts(gathererResults, baseArtifacts);
     } catch (err) {
       // cleanup on error
       GatherRunner.disposeDriver(driver);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -98,16 +98,14 @@ class GatherRunner {
 
   /**
    * @param {Driver} driver
-   * @param {LH.BaseArtifacts} baseArtifacts
    * @param {{requestedUrl: string, settings: LH.Config.Settings}} options
    * @return {Promise<void>}
    */
-  static async setupDriver(driver, baseArtifacts, options) {
+  static async setupDriver(driver, options) {
     log.log('status', 'Initializing…');
     const resetStorage = !options.settings.disableStorageReset;
     // Enable emulation based on settings
     await driver.assertNoSameOriginServiceWorkerClients(options.requestedUrl);
-    GatherRunner.warnOnHeadless(baseArtifacts);
     await driver.beginEmulation(options.settings);
     await driver.enableRuntimeEvents();
     await driver.cacheNatives();
@@ -170,23 +168,6 @@ class GatherRunner {
       const error = new LHError(errorCode, {reason: errorReason});
       log.error('GatherRunner', error.message, url);
       return error;
-    }
-  }
-
-  /**
-   * Add run warning if running in Headless Chrome.
-   * @param {LH.BaseArtifacts} baseArtifacts
-   */
-  static warnOnHeadless(baseArtifacts) {
-    const chromeVersion = baseArtifacts.UserAgent.split(/HeadlessChrome\/(.*) /)[1];
-    // Headless Chrome gained throttling support in Chrome 63.
-    // https://chromium.googlesource.com/chromium/src/+/8931a104b145ccf92390f6f48fba6553a1af92e4
-    const minVersion = '63.0.3239.0';
-    if (chromeVersion && chromeVersion < minVersion) {
-      baseArtifacts.LighthouseRunWarnings.push('Your site\'s mobile performance may be ' +
-          'worse than the numbers presented in this report. Lighthouse could not test on a ' +
-          'mobile connection because Headless Chrome does not support network throttling ' +
-          'prior to version ' + minVersion + '. The version used was ' + chromeVersion);
     }
   }
 
@@ -412,7 +393,7 @@ class GatherRunner {
       await driver.connect();
       const baseArtifacts = await GatherRunner.getBaseArtifacts(options);
       await GatherRunner.loadBlank(driver);
-      await GatherRunner.setupDriver(driver, baseArtifacts, options);
+      await GatherRunner.setupDriver(driver, options);
 
       // Run each pass
       let firstPass = true;

--- a/lighthouse-core/gather/gatherers/gatherer.js
+++ b/lighthouse-core/gather/gatherers/gatherer.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+/** @typedef {void|LH.GathererArtifacts[keyof LH.GathererArtifacts]} PhaseResult */
+
 /**
  * Base class for all gatherers; defines pass lifecycle methods. The artifact
  * from the gatherer is the last not-undefined value returned by a lifecycle
@@ -18,9 +20,10 @@
  */
 class Gatherer {
   /**
-   * @return {string}
+   * @return {keyof LH.GathererArtifacts}
    */
   get name() {
+    // @ts-ignore - assume that class name has been added to LH.GathererArtifacts.
     return this.constructor.name;
   }
 
@@ -29,7 +32,7 @@ class Gatherer {
   /**
    * Called before navigation to target url.
    * @param {LH.Gatherer.PassContext} passContext
-   * @return {*|!Promise<*>}
+   * @return {PhaseResult|Promise<PhaseResult>}
    */
   beforePass(passContext) { }
 
@@ -37,7 +40,7 @@ class Gatherer {
    * Called after target page is loaded. If a trace is enabled for this pass,
    * the trace is still being recorded.
    * @param {LH.Gatherer.PassContext} passContext
-   * @return {*|!Promise<*>}
+   * @return {PhaseResult|Promise<PhaseResult>}
    */
   pass(passContext) { }
 
@@ -47,7 +50,7 @@ class Gatherer {
    * and record of network activity are provided in `loadData`.
    * @param {LH.Gatherer.PassContext} passContext
    * @param {LH.Gatherer.LoadData} loadData
-   * @return {*|!Promise<*>}
+   * @return {PhaseResult|Promise<PhaseResult>}
    */
   afterPass(passContext, loadData) { }
 

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -154,9 +154,6 @@ describe('GatherRunner', function() {
     );
 
     return GatherRunner.setupDriver(driver, {
-      LighthouseRunWarnings: [],
-      UserAgent: 'Fake user agent',
-    }, {
       settings: {},
     }).then(_ => {
       assert.ok(tests.calledDeviceEmulation, 'did not call device emulation');
@@ -184,9 +181,6 @@ describe('GatherRunner', function() {
     );
 
     return GatherRunner.setupDriver(driver, {
-      LighthouseRunWarnings: [],
-      UserAgent: 'Fake user agent',
-    }, {
       settings: {
         disableDeviceEmulation: true,
         throttlingMethod: 'devtools',
@@ -216,9 +210,6 @@ describe('GatherRunner', function() {
     );
 
     return GatherRunner.setupDriver(driver, {
-      LighthouseRunWarnings: [],
-      UserAgent: 'Fake user agent',
-    }, {
       settings: {
         throttlingMethod: 'provided',
       },
@@ -248,9 +239,6 @@ describe('GatherRunner', function() {
     );
 
     return GatherRunner.setupDriver(driver, {
-      LighthouseRunWarnings: [],
-      UserAgent: 'Fake user agent',
-    }, {
       settings: {
         throttlingMethod: 'devtools',
         throttling: {
@@ -292,12 +280,8 @@ describe('GatherRunner', function() {
       blockUrlPatterns: asyncFunc,
       setExtraHTTPHeaders: asyncFunc,
     };
-    const baseArtifacts = {
-      LighthouseRunWarnings: [],
-      UserAgent: 'Fake user agent',
-    };
 
-    return GatherRunner.setupDriver(driver, baseArtifacts, {settings: {}}).then(_ => {
+    return GatherRunner.setupDriver(driver, {settings: {}}).then(_ => {
       assert.equal(tests.calledCleanBrowserCaches, false);
       assert.equal(tests.calledClearStorage, true);
     });
@@ -354,12 +338,8 @@ describe('GatherRunner', function() {
       blockUrlPatterns: asyncFunc,
       setExtraHTTPHeaders: asyncFunc,
     };
-    const baseArtifacts = {
-      LighthouseRunWarnings: [],
-      UserAgent: 'Fake user agent',
-    };
 
-    return GatherRunner.setupDriver(driver, baseArtifacts, {
+    return GatherRunner.setupDriver(driver, {
       settings: {disableStorageReset: true},
     }).then(_ => {
       assert.equal(tests.calledCleanBrowserCaches, false);
@@ -1038,23 +1018,5 @@ describe('GatherRunner', function() {
           assert.ok(true);
         });
     });
-  });
-
-  it('issues a lighthouseRunWarnings if running an old version of Headless', () => {
-    const baseArtifacts = {
-      LighthouseRunWarnings: [],
-    };
-
-    baseArtifacts.UserAgent =
-      'Mozilla/5.0 AppleWebKit/537.36 HeadlessChrome/63.0.3239.0 Safari/537.36';
-    GatherRunner.warnOnHeadless(baseArtifacts);
-    assert.strictEqual(baseArtifacts.LighthouseRunWarnings.length, 0);
-
-    baseArtifacts.UserAgent =
-      'Mozilla/5.0 AppleWebKit/537.36 HeadlessChrome/62.0.3239.0 Safari/537.36';
-    GatherRunner.warnOnHeadless(baseArtifacts);
-    assert.strictEqual(baseArtifacts.LighthouseRunWarnings.length, 1);
-    const warning = baseArtifacts.LighthouseRunWarnings[0];
-    assert.ok(/Headless Chrome/.test(warning));
   });
 });

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -153,7 +153,10 @@ describe('GatherRunner', function() {
       createEmulationCheck('calledCpuEmulation')
     );
 
-    return GatherRunner.setupDriver(driver, {}, {
+    return GatherRunner.setupDriver(driver, {
+      LighthouseRunWarnings: [],
+      UserAgent: 'Fake user agent',
+    }, {
       settings: {},
     }).then(_ => {
       assert.ok(tests.calledDeviceEmulation, 'did not call device emulation');
@@ -180,7 +183,10 @@ describe('GatherRunner', function() {
       createEmulationCheck('calledCpuEmulation', true)
     );
 
-    return GatherRunner.setupDriver(driver, {}, {
+    return GatherRunner.setupDriver(driver, {
+      LighthouseRunWarnings: [],
+      UserAgent: 'Fake user agent',
+    }, {
       settings: {
         disableDeviceEmulation: true,
         throttlingMethod: 'devtools',
@@ -209,7 +215,10 @@ describe('GatherRunner', function() {
       createEmulationCheck('calledCpuEmulation')
     );
 
-    return GatherRunner.setupDriver(driver, {}, {
+    return GatherRunner.setupDriver(driver, {
+      LighthouseRunWarnings: [],
+      UserAgent: 'Fake user agent',
+    }, {
       settings: {
         throttlingMethod: 'provided',
       },
@@ -238,7 +247,10 @@ describe('GatherRunner', function() {
       createEmulationCheck('calledCpuEmulation')
     );
 
-    return GatherRunner.setupDriver(driver, {}, {
+    return GatherRunner.setupDriver(driver, {
+      LighthouseRunWarnings: [],
+      UserAgent: 'Fake user agent',
+    }, {
       settings: {
         throttlingMethod: 'devtools',
         throttling: {
@@ -279,10 +291,13 @@ describe('GatherRunner', function() {
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
       setExtraHTTPHeaders: asyncFunc,
-      getUserAgent: () => Promise.resolve('Fake user agent'),
+    };
+    const baseArtifacts = {
+      LighthouseRunWarnings: [],
+      UserAgent: 'Fake user agent',
     };
 
-    return GatherRunner.setupDriver(driver, {}, {settings: {}}).then(_ => {
+    return GatherRunner.setupDriver(driver, baseArtifacts, {settings: {}}).then(_ => {
       assert.equal(tests.calledCleanBrowserCaches, false);
       assert.equal(tests.calledClearStorage, true);
     });
@@ -338,10 +353,13 @@ describe('GatherRunner', function() {
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
       setExtraHTTPHeaders: asyncFunc,
-      getUserAgent: () => Promise.resolve('Fake user agent'),
+    };
+    const baseArtifacts = {
+      LighthouseRunWarnings: [],
+      UserAgent: 'Fake user agent',
     };
 
-    return GatherRunner.setupDriver(driver, {}, {
+    return GatherRunner.setupDriver(driver, baseArtifacts, {
       settings: {disableStorageReset: true},
     }).then(_ => {
       assert.equal(tests.calledCleanBrowserCaches, false);
@@ -824,8 +842,6 @@ describe('GatherRunner', function() {
           Promise.reject(someOtherError),
           Promise.resolve(1729),
         ],
-
-        LighthouseRunWarnings: [],
       };
 
       return GatherRunner.collectArtifacts(gathererResults, {}).then(artifacts => {
@@ -843,11 +859,11 @@ describe('GatherRunner', function() {
         'warning2',
       ];
 
-      const gathererResults = {
+      const baseArtifacts = {
         LighthouseRunWarnings,
       };
 
-      return GatherRunner.collectArtifacts(gathererResults, {}).then(artifacts => {
+      return GatherRunner.collectArtifacts({}, baseArtifacts).then(artifacts => {
         assert.deepStrictEqual(artifacts.LighthouseRunWarnings, LighthouseRunWarnings);
       });
     });
@@ -1025,18 +1041,20 @@ describe('GatherRunner', function() {
   });
 
   it('issues a lighthouseRunWarnings if running an old version of Headless', () => {
-    const gathererResults = {
+    const baseArtifacts = {
       LighthouseRunWarnings: [],
     };
 
-    const userAgent = 'Mozilla/5.0 AppleWebKit/537.36 HeadlessChrome/63.0.3239.0 Safari/537.36';
-    GatherRunner.warnOnHeadless(userAgent, gathererResults);
-    assert.strictEqual(gathererResults.LighthouseRunWarnings.length, 0);
+    baseArtifacts.UserAgent =
+      'Mozilla/5.0 AppleWebKit/537.36 HeadlessChrome/63.0.3239.0 Safari/537.36';
+    GatherRunner.warnOnHeadless(baseArtifacts);
+    assert.strictEqual(baseArtifacts.LighthouseRunWarnings.length, 0);
 
-    const oldUserAgent = 'Mozilla/5.0 AppleWebKit/537.36 HeadlessChrome/62.0.3239.0 Safari/537.36';
-    GatherRunner.warnOnHeadless(oldUserAgent, gathererResults);
-    assert.strictEqual(gathererResults.LighthouseRunWarnings.length, 1);
-    const warning = gathererResults.LighthouseRunWarnings[0];
+    baseArtifacts.UserAgent =
+      'Mozilla/5.0 AppleWebKit/537.36 HeadlessChrome/62.0.3239.0 Safari/537.36';
+    GatherRunner.warnOnHeadless(baseArtifacts);
+    assert.strictEqual(baseArtifacts.LighthouseRunWarnings.length, 1);
+    const warning = baseArtifacts.LighthouseRunWarnings[0];
     assert.ok(/Headless Chrome/.test(warning));
   });
 });

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -12,18 +12,31 @@ type LanternSimulator = InstanceType<typeof _LanternSimulator>;
 
 declare global {
   module LH {
-    export interface Artifacts extends ComputedArtifacts {
-      // Created by by gather-runner
+    export interface Artifacts extends BaseArtifacts, GathererArtifacts, ComputedArtifacts {}
+
+    /** Artifacts always created by GatherRunner. */
+    export interface BaseArtifacts {
+      /** The ISO-8601 timestamp of when the test page was fetched and artifacts collected. */
       fetchTime: string;
+      /** A set of warnings about unexpected things encountered while loading and testing the page. */
       LighthouseRunWarnings: string[];
+      /** The user agent string of the version of Chrome that was used by Lighthouse. */
       UserAgent: string;
+      /** A set of page-load traces, keyed by passName. */
       traces: {[passName: string]: Trace};
+      /** A set of DevTools debugger protocol records, keyed by passName. */
       devtoolsLogs: {[passName: string]: DevtoolsLog};
+      /** An object containing information about the testing configuration used by Lighthouse. */
       settings: Config.Settings;
       /** The URL initially requested and the post-redirects URL that was actually loaded. */
       URL: {requestedUrl: string, finalUrl: string};
+    }
 
-      // Remaining are provided by default gatherers.
+    /**
+     * Artifacts provided by the default gatherers. Augment this interface when adding additional
+     * gatherers.
+     */
+    export interface GathererArtifacts {
       /** The results of running the aXe accessibility tests on the page. */
       Accessibility: Artifacts.Accessibility;
       /** Information on all anchors in the page that aren't nofollow or noreferrer. */

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -22,6 +22,11 @@ declare global {
     [P in K]+?: T[P]
   }
 
+  /**
+   * Exclude void from T
+   */
+  type NonVoid<T> = T extends void ? never : T;
+
   /** Remove properties K from T. */
   type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -19,6 +19,8 @@ declare global {
       passConfig: Config.Pass
       settings: Config.Settings;
       options?: object;
+      /** Push to this array to add top-level warnings to the LHR.  */
+      LighthouseRunWarnings: Array<string>;
     }
 
     export interface LoadData {


### PR DESCRIPTION
A small refactor of GatherRunner to split the types of the artifacts always provided by LH (`URL`, `fetchTime`, `LighthouseRunWarnings`, etc) from the artifacts provided by gatherers.

This gets rid of the awkward nested arrays around the base artifacts and allows tightening of the types a bit so that gatherers now only return `undefined` or the values of `LH.GathererArtifacts`.

Side effect: with the recent simplification of `passContext`, it seemed to make more sense to add `LighthouseRunWarnings` to the context rather than also pass in `baseArtifacts` to `beforePass`/`pass`/`afterPass`. This has the added benefit of solving how gatherers can raise top-level warnings...they can now just push to `passContext.LighthouseRunWarnings` :)