### PR TITLE
core(fcp): fix scoring curve

### DIFF
--- a/lighthouse-core/audits/first-contentful-paint.js
+++ b/lighthouse-core/audits/first-contentful-paint.js
@@ -31,7 +31,7 @@ class FirstContentfulPaint extends Audit {
       // 75th and 95th percentiles HTTPArchive -> median and PODR
       // https://bigquery.cloud.google.com/table/httparchive:lighthouse.2018_04_01_mobile?pli=1
       // see https://www.desmos.com/calculator/2t1ugwykrl
-      scorePODR: 2900,
+      scorePODR: 2000,
       scoreMedian: 4000,
     };
   }


### PR DESCRIPTION
so slightly embarrassing here, but somehow in the shuffle of metric scoring curves I updated FCP to the wrong value. the calculator spreadsheet, desmos curve, HTTPArchive, and logic from the PODR of FMP all dictate that the FCP one should be 2000, but it's 2900 (like TTI). Oops 😞 

good thing it's still the beta release 😆 