### PR TITLE
core(tsc): use Config class to define Config type

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -18,12 +18,13 @@ const URL = require('./lib/url-shim');
 const Sentry = require('./lib/sentry');
 const generateReport = require('./report/report-generator').generateReport;
 
-const Connection = require('./gather/connections/connection.js'); // eslint-disable-line no-unused-vars
+/** @typedef {import('./gather/connections/connection.js')} Connection */
+/** @typedef {import('./config/config.js')} Config */
 
 class Runner {
   /**
    * @param {Connection} connection
-   * @param {{config: LH.Config, url?: string, driverMock?: Driver}} opts
+   * @param {{config: Config, url?: string, driverMock?: Driver}} opts
    * @return {Promise<LH.RunnerResult|undefined>}
    */
   static async run(connection, opts) {
@@ -145,7 +146,7 @@ class Runner {
   /**
    * Establish connection, load page and collect all required artifacts
    * @param {string} requestedUrl
-   * @param {{config: LH.Config, driverMock?: Driver}} runnerOpts
+   * @param {{config: Config, driverMock?: Driver}} runnerOpts
    * @param {Connection} connection
    * @return {Promise<LH.Artifacts>}
    */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "checkJs": true,
     "strict": true,
     // "listFiles": true,
+    // "noErrorTruncation": true,
     "typeRoots": [
       "@types",
       "./typings"

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -9,17 +9,6 @@ import Audit = require('../lighthouse-core/audits/audit.js');
 
 declare global {
   module LH {
-    /**
-     * The full, normalized Lighthouse Config.
-     */
-    export interface Config extends Config.Json {
-      settings: Config.Settings;
-      passes: Config.Pass[] | null;
-      audits: Config.AuditDefn[] | null;
-      categories: Record<string, Config.Category> | null;
-      groups: Record<string, Config.Group> | null;
-    }
-
     module Config {
       /**
        * The pre-normalization Lighthouse Config format.


### PR DESCRIPTION
Previously there was the `Config` class (in `config.js`) and the `LH.Config` type (in `config.d.ts`). The `LH.Config` type implemented `LH.Config.Json`, ensuring that any `LH.Config` was also a valid `LH.Config.Json`.

When passing around an instance of `Config` we called it an `LH.Config`, which meant the compiler was enforcing that it implemented both interfaces, but that means two sources of truth for what a "Config" is and indirect errors if those interfaces were violated.

Based on @patrickhulce's idea in #5451 to enforce interfaces until tsc [supports `@implements` tags](https://github.com/Microsoft/TypeScript/issues/17498), we can eliminate the `d.ts` declaration of `LH.Config` and just use the `Config` class directly, just asserting that the object is a valid `LH.Config.Json` near the end of the constructor in a throwaway variable.

(the rest of the config interfaces staying separate for now because `@typedef` [doesn't support inheritance yet](https://github.com/Microsoft/TypeScript/issues/20077) 🙄 and they aren't clearly defined anywhere with a constructor or single object literal)