### PR TITLE
misc(golden-lhr): exclude audit descriptions

### DIFF
--- a/lighthouse-core/scripts/cleanup-LHR-for-diff.js
+++ b/lighthouse-core/scripts/cleanup-LHR-for-diff.js
@@ -28,6 +28,7 @@ function cleanAndFormatLHR(lhrString) {
   delete lhr.timing;
   if (extraFlag !== '--only-remove-timing') {
     for (const auditResult of Object.values(lhr.audits)) {
+      auditResult.description = '**Excluded from diff**';
       auditResult.helpText = '**Excluded from diff**';
     }
   }


### PR DESCRIPTION
previously we excluded helpText from the differ, but the property name was changed for v3 to `description` that's also how kayce was bitten by the tests this time around accidentally :)