### PR TITLE
docs(headless-chrome): need to install npm

### DIFF
--- a/docs/headless-chrome.md
+++ b/docs/headless-chrome.md
@@ -7,7 +7,7 @@ Setup:
 ```sh
 # get node 6
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - &&\
-sudo apt-get install -y nodejs
+sudo apt-get install -y nodejs npm
 
 # get chromium (stable)
 apt-get install chromium-browser
@@ -29,7 +29,7 @@ Alternatively, you can run full Chrome + xvfb instead of headless mode. These st
 ```sh
 # get node 8
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-sudo apt-get install -y nodejs
+sudo apt-get install -y nodejs npm
 
 # get chromium (stable) and Xvfb
 apt-get install chromium-browser xvfb


### PR DESCRIPTION
Following documentation will result in an error when running any `npm` command as it appears like it's not installed along with node

<!-- Thank you for submitting a pull request! -->

**Summary**
Fixes an issue when following documentation for headless chrome.

Makes docs easier to follow

**Related Issues/PRs**
None that I know of.