### PR TITLE
core(tsc): make CPUNode and NetworkNode a discriminated union

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -10,7 +10,7 @@ const linearInterpolation = require('../../lib/statistics').linearInterpolation;
 const Interactive = require('../../gather/computed/metrics/lantern-interactive');
 
 /** @typedef {import('../../lib/dependency-graph/simulator/simulator')} Simulator */
-/** @typedef {import('../../lib/dependency-graph/base-node.js').NodeType} NodeType */
+/** @typedef {import('../../lib/dependency-graph/base-node.js').Node} Node */
 
 const KB_IN_BYTES = 1024;
 
@@ -125,7 +125,7 @@ class UnusedBytes extends Audit {
    * - (if includeLoad is true or not provided) end time of the last node in the graph
    *
    * @param {Array<LH.Audit.ByteEfficiencyItem>} results The array of byte savings results per resource
-   * @param {NodeType} graph
+   * @param {Node} graph
    * @param {Simulator} simulator
    * @param {{includeLoad?: boolean, label?: string}=} options
    * @return {number}
@@ -180,7 +180,7 @@ class UnusedBytes extends Audit {
 
   /**
    * @param {ByteEfficiencyProduct} result
-   * @param {NodeType} graph
+   * @param {Node} graph
    * @param {Simulator} simulator
    * @return {LH.Audit.Product}
    */

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -10,7 +10,7 @@ const linearInterpolation = require('../../lib/statistics').linearInterpolation;
 const Interactive = require('../../gather/computed/metrics/lantern-interactive');
 
 /** @typedef {import('../../lib/dependency-graph/simulator/simulator')} Simulator */
-/** @typedef {import('../../lib/dependency-graph/node.js').NodeType} NodeType */
+/** @typedef {import('../../lib/dependency-graph/base-node.js').NodeType} NodeType */
 
 const KB_IN_BYTES = 1024;
 

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -10,13 +10,13 @@
 'use strict';
 
 const Audit = require('../audit');
-const Node = require('../../lib/dependency-graph/node');
+const BaseNode = require('../../lib/dependency-graph/base-node');
 const ByteEfficiencyAudit = require('./byte-efficiency-audit');
 const UnusedCSS = require('./unused-css-rules');
 const WebInspector = require('../../lib/web-inspector');
 
 /** @typedef {import('../../lib/dependency-graph/simulator/simulator')} Simulator */
-/** @typedef {import('../../lib/dependency-graph/node.js').NodeType} NodeType */
+/** @typedef {import('../../lib/dependency-graph/base-node.js').NodeType} NodeType */
 /** @typedef {import('../../lib/dependency-graph/network-node.js')} NetworkNode */
 
 // Because of the way we detect blocking stylesheets, asynchronously loaded
@@ -149,7 +149,7 @@ class RenderBlockingResources extends Audit {
     const minimalFCPGraph = /** @type {NetworkNode} */ (fcpGraph.cloneWithRelationships(node => {
       // If a node can be deferred, exclude it from the new FCP graph
       const canDeferRequest = deferredIds.has(node.id);
-      if (node.type !== Node.TYPES.NETWORK) return !canDeferRequest;
+      if (node.type !== BaseNode.TYPES.NETWORK) return !canDeferRequest;
 
       const isStylesheet =
         node.record._resourceType === WebInspector.resourceTypes.Stylesheet;

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -16,7 +16,7 @@ const UnusedCSS = require('./unused-css-rules');
 const WebInspector = require('../../lib/web-inspector');
 
 /** @typedef {import('../../lib/dependency-graph/simulator/simulator')} Simulator */
-/** @typedef {import('../../lib/dependency-graph/base-node.js').NodeType} NodeType */
+/** @typedef {import('../../lib/dependency-graph/base-node.js').Node} Node */
 /** @typedef {import('../../lib/dependency-graph/network-node.js')} NetworkNode */
 
 // Because of the way we detect blocking stylesheets, asynchronously loaded
@@ -28,10 +28,10 @@ const MINIMUM_WASTED_MS = 50;
 /**
  * Given a simulation's nodeTimings, return an object with the nodes/timing keyed by network URL
  * @param {LH.Gatherer.Simulation.Result['nodeTimings']} nodeTimings
- * @return {Object<string, {node: NodeType, nodeTiming: LH.Gatherer.Simulation.NodeTiming}>}
+ * @return {Object<string, {node: Node, nodeTiming: LH.Gatherer.Simulation.NodeTiming}>}
  */
 function getNodesAndTimingByUrl(nodeTimings) {
-  /** @type {Object<string, {node: NodeType, nodeTiming: LH.Gatherer.Simulation.NodeTiming}>} */
+  /** @type {Object<string, {node: Node, nodeTiming: LH.Gatherer.Simulation.NodeTiming}>} */
   const urlMap = {};
   const nodes = Array.from(nodeTimings.keys());
   nodes.forEach(node => {
@@ -137,7 +137,7 @@ class RenderBlockingResources extends Audit {
    * thing.
    *
    * @param {Simulator} simulator
-   * @param {NodeType} fcpGraph
+   * @param {Node} fcpGraph
    * @param {Set<string>} deferredIds
    * @param {Map<string, number>} wastedCssBytesByUrl
    * @return {number}

--- a/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
@@ -9,7 +9,7 @@ const LanternMetricArtifact = require('./lantern-metric');
 const BaseNode = require('../../../lib/dependency-graph/base-node');
 const EstimatedInputLatency = require('./estimated-input-latency');
 
-/** @typedef {BaseNode.NodeType} NodeType */
+/** @typedef {BaseNode.Node} Node */
 
 class LanternEstimatedInputLatency extends LanternMetricArtifact {
   get name() {
@@ -28,16 +28,16 @@ class LanternEstimatedInputLatency extends LanternMetricArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
-   * @return {NodeType}
+   * @param {Node} dependencyGraph
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph) {
     return dependencyGraph;
   }
 
   /**
-   * @param {NodeType} dependencyGraph
-   * @return {NodeType}
+   * @param {Node} dependencyGraph
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph) {
     return dependencyGraph;

--- a/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
@@ -6,10 +6,10 @@
 'use strict';
 
 const LanternMetricArtifact = require('./lantern-metric');
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 const EstimatedInputLatency = require('./estimated-input-latency');
 
-/** @typedef {Node.NodeType} NodeType */
+/** @typedef {BaseNode.NodeType} NodeType */
 
 class LanternEstimatedInputLatency extends LanternMetricArtifact {
   get name() {
@@ -84,7 +84,7 @@ class LanternEstimatedInputLatency extends LanternMetricArtifact {
     /** @type {Array<{start: number, end: number, duration: number}>} */
     const events = [];
     for (const [node, timing] of nodeTimings.entries()) {
-      if (node.type !== Node.TYPES.CPU) continue;
+      if (node.type !== BaseNode.TYPES.CPU) continue;
       if (timing.endTime < fmpTimeInMs) continue;
 
       events.push({

--- a/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
@@ -9,6 +9,8 @@ const LanternMetricArtifact = require('./lantern-metric');
 const Node = require('../../../lib/dependency-graph/node');
 const EstimatedInputLatency = require('./estimated-input-latency');
 
+/** @typedef {Node.NodeType} NodeType */
+
 class LanternEstimatedInputLatency extends LanternMetricArtifact {
   get name() {
     return 'LanternEstimatedInputLatency';
@@ -26,16 +28,16 @@ class LanternEstimatedInputLatency extends LanternMetricArtifact {
   }
 
   /**
-   * @param {Node} dependencyGraph
-   * @return {Node}
+   * @param {NodeType} dependencyGraph
+   * @return {NodeType}
    */
   getOptimisticGraph(dependencyGraph) {
     return dependencyGraph;
   }
 
   /**
-   * @param {Node} dependencyGraph
-   * @return {Node}
+   * @param {NodeType} dependencyGraph
+   * @return {NodeType}
    */
   getPessimisticGraph(dependencyGraph) {
     return dependencyGraph;

--- a/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
@@ -8,7 +8,7 @@
 const MetricArtifact = require('./lantern-metric');
 const BaseNode = require('../../../lib/dependency-graph/base-node');
 
-/** @typedef {BaseNode.NodeType} NodeType */
+/** @typedef {BaseNode.Node} Node */
 
 class FirstContentfulPaint extends MetricArtifact {
   get name() {
@@ -27,9 +27,9 @@ class FirstContentfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {NodeType}
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) {
     const fcp = traceOfTab.timestamps.firstContentfulPaint;
@@ -52,9 +52,9 @@ class FirstContentfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {NodeType}
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) {
     const fcp = traceOfTab.timestamps.firstContentfulPaint;

--- a/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
@@ -6,9 +6,9 @@
 'use strict';
 
 const MetricArtifact = require('./lantern-metric');
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 
-/** @typedef {Node.NodeType} NodeType */
+/** @typedef {BaseNode.NodeType} NodeType */
 
 class FirstContentfulPaint extends MetricArtifact {
   get name() {
@@ -42,7 +42,7 @@ class FirstContentfulPaint extends MetricArtifact {
     return dependencyGraph.cloneWithRelationships(node => {
       if (node.endTime > fcp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
-      if (node.type === Node.TYPES.CPU) {
+      if (node.type === BaseNode.TYPES.CPU) {
         return node.isEvaluateScriptFor(blockingScriptUrls);
       }
 
@@ -65,7 +65,7 @@ class FirstContentfulPaint extends MetricArtifact {
     return dependencyGraph.cloneWithRelationships(node => {
       if (node.endTime > fcp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
-      if (node.type === Node.TYPES.CPU) {
+      if (node.type === BaseNode.TYPES.CPU) {
         return node.isEvaluateScriptFor(blockingScriptUrls);
       }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-contentful-paint.js
@@ -7,8 +7,8 @@
 
 const MetricArtifact = require('./lantern-metric');
 const Node = require('../../../lib/dependency-graph/node');
-const CPUNode = require('../../../lib/dependency-graph/cpu-node'); // eslint-disable-line no-unused-vars
-const NetworkNode = require('../../../lib/dependency-graph/network-node'); // eslint-disable-line no-unused-vars
+
+/** @typedef {Node.NodeType} NodeType */
 
 class FirstContentfulPaint extends MetricArtifact {
   get name() {
@@ -27,9 +27,9 @@ class FirstContentfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {Node} dependencyGraph
+   * @param {NodeType} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {Node}
+   * @return {NodeType}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) {
     const fcp = traceOfTab.timestamps.firstContentfulPaint;
@@ -43,19 +43,18 @@ class FirstContentfulPaint extends MetricArtifact {
       if (node.endTime > fcp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
       if (node.type === Node.TYPES.CPU) {
-        return /** @type {CPUNode} */ (node).isEvaluateScriptFor(blockingScriptUrls);
+        return node.isEvaluateScriptFor(blockingScriptUrls);
       }
 
-      const asNetworkNode = /** @type {NetworkNode} */ (node);
       // Include non-script-initiated network requests with a render-blocking priority
-      return asNetworkNode.hasRenderBlockingPriority() && asNetworkNode.initiatorType !== 'script';
+      return node.hasRenderBlockingPriority() && node.initiatorType !== 'script';
     });
   }
 
   /**
-   * @param {Node} dependencyGraph
+   * @param {NodeType} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {Node}
+   * @return {NodeType}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) {
     const fcp = traceOfTab.timestamps.firstContentfulPaint;
@@ -67,11 +66,11 @@ class FirstContentfulPaint extends MetricArtifact {
       if (node.endTime > fcp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
       if (node.type === Node.TYPES.CPU) {
-        return /** @type {CPUNode} */ (node).isEvaluateScriptFor(blockingScriptUrls);
+        return node.isEvaluateScriptFor(blockingScriptUrls);
       }
 
       // Include non-script-initiated network requests with a render-blocking priority
-      return /** @type {NetworkNode} */ (node).hasRenderBlockingPriority();
+      return node.hasRenderBlockingPriority();
     });
   }
 }

--- a/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 const FirstCPUIdle = require('./first-cpu-idle');
 const LanternInteractive = require('./lantern-interactive');
 
@@ -39,7 +39,7 @@ class LanternFirstCPUIdle extends LanternInteractive {
     /** @type {Array<{start: number, end: number}>} */
     const longTasks = [];
     for (const [node, timing] of nodeTimings.entries()) {
-      if (node.type !== Node.TYPES.CPU) continue;
+      if (node.type !== BaseNode.TYPES.CPU) continue;
       if (timing.duration < longTaskLength) continue;
       longTasks.push({start: timing.startTime, end: timing.endTime});
     }

--- a/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
@@ -6,9 +6,6 @@
 'use strict';
 
 const Node = require('../../../lib/dependency-graph/node');
-const CPUNode = require('../../../lib/dependency-graph/cpu-node'); // eslint-disable-line no-unused-vars
-const NetworkNode = require('../../../lib/dependency-graph/network-node'); // eslint-disable-line no-unused-vars
-
 const FirstCPUIdle = require('./first-cpu-idle');
 const LanternInteractive = require('./lantern-interactive');
 

--- a/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
@@ -8,7 +8,7 @@
 const MetricArtifact = require('./lantern-metric');
 const BaseNode = require('../../../lib/dependency-graph/base-node');
 
-/** @typedef {BaseNode.NodeType} NodeType */
+/** @typedef {BaseNode.Node} Node */
 
 class FirstMeaningfulPaint extends MetricArtifact {
   get name() {
@@ -27,9 +27,9 @@ class FirstMeaningfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {NodeType}
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) {
     const fmp = traceOfTab.timestamps.firstMeaningfulPaint;
@@ -52,9 +52,9 @@ class FirstMeaningfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {NodeType}
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) {
     const fmp = traceOfTab.timestamps.firstMeaningfulPaint;

--- a/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
@@ -6,9 +6,9 @@
 'use strict';
 
 const MetricArtifact = require('./lantern-metric');
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 
-/** @typedef {Node.NodeType} NodeType */
+/** @typedef {BaseNode.NodeType} NodeType */
 
 class FirstMeaningfulPaint extends MetricArtifact {
   get name() {
@@ -42,7 +42,7 @@ class FirstMeaningfulPaint extends MetricArtifact {
     return dependencyGraph.cloneWithRelationships(node => {
       if (node.endTime > fmp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
-      if (node.type === Node.TYPES.CPU) {
+      if (node.type === BaseNode.TYPES.CPU) {
         return node.isEvaluateScriptFor(blockingScriptUrls);
       }
 
@@ -66,7 +66,7 @@ class FirstMeaningfulPaint extends MetricArtifact {
       if (node.endTime > fmp && !node.isMainDocument()) return false;
 
       // Include CPU tasks that performed a layout or were evaluations of required scripts
-      if (node.type === Node.TYPES.CPU) {
+      if (node.type === BaseNode.TYPES.CPU) {
         return node.didPerformLayout() || node.isEvaluateScriptFor(requiredScriptUrls);
       }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-meaningful-paint.js
@@ -7,8 +7,8 @@
 
 const MetricArtifact = require('./lantern-metric');
 const Node = require('../../../lib/dependency-graph/node');
-const CPUNode = require('../../../lib/dependency-graph/cpu-node'); // eslint-disable-line no-unused-vars
-const NetworkNode = require('../../../lib/dependency-graph/network-node'); // eslint-disable-line no-unused-vars
+
+/** @typedef {Node.NodeType} NodeType */
 
 class FirstMeaningfulPaint extends MetricArtifact {
   get name() {
@@ -27,9 +27,9 @@ class FirstMeaningfulPaint extends MetricArtifact {
   }
 
   /**
-   * @param {Node} dependencyGraph
+   * @param {NodeType} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {Node}
+   * @return {NodeType}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) {
     const fmp = traceOfTab.timestamps.firstMeaningfulPaint;
@@ -43,19 +43,18 @@ class FirstMeaningfulPaint extends MetricArtifact {
       if (node.endTime > fmp && !node.isMainDocument()) return false;
       // Include EvaluateScript tasks for blocking scripts
       if (node.type === Node.TYPES.CPU) {
-        return /** @type {CPUNode} */ (node).isEvaluateScriptFor(blockingScriptUrls);
+        return node.isEvaluateScriptFor(blockingScriptUrls);
       }
 
-      const asNetworkNode = /** @type {NetworkNode} */ (node);
       // Include non-script-initiated network requests with a render-blocking priority
-      return asNetworkNode.hasRenderBlockingPriority() && asNetworkNode.initiatorType !== 'script';
+      return node.hasRenderBlockingPriority() && node.initiatorType !== 'script';
     });
   }
 
   /**
-   * @param {Node} dependencyGraph
+   * @param {NodeType} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {Node}
+   * @return {NodeType}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) {
     const fmp = traceOfTab.timestamps.firstMeaningfulPaint;
@@ -68,12 +67,11 @@ class FirstMeaningfulPaint extends MetricArtifact {
 
       // Include CPU tasks that performed a layout or were evaluations of required scripts
       if (node.type === Node.TYPES.CPU) {
-        const asCpuNode = /** @type {CPUNode} */ (node);
-        return asCpuNode.didPerformLayout() || asCpuNode.isEvaluateScriptFor(requiredScriptUrls);
+        return node.didPerformLayout() || node.isEvaluateScriptFor(requiredScriptUrls);
       }
 
       // Include all network requests that had render-blocking priority (even script-initiated)
-      return /** @type {NetworkNode} */ (node).hasRenderBlockingPriority();
+      return node.hasRenderBlockingPriority();
     });
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-interactive.js
@@ -6,10 +6,10 @@
 'use strict';
 
 const MetricArtifact = require('./lantern-metric');
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 const WebInspector = require('../../../lib/web-inspector');
 
-/** @typedef {Node.NodeType} NodeType */
+/** @typedef {BaseNode.NodeType} NodeType */
 
 // Any CPU task of 20 ms or more will end up being a critical long task on mobile
 const CRITICAL_LONG_TASK_THRESHOLD = 20;
@@ -40,7 +40,7 @@ class Interactive extends MetricArtifact {
 
     return dependencyGraph.cloneWithRelationships(node => {
       // Include everything that might be a long task
-      if (node.type === Node.TYPES.CPU) {
+      if (node.type === BaseNode.TYPES.CPU) {
         return node.event.dur > minimumCpuTaskDuration;
       }
 
@@ -100,7 +100,7 @@ class Interactive extends MetricArtifact {
     // @ts-ignore TS can't infer how the object invariants change
     return Array.from(nodeTimings.entries())
       .filter(([node, timing]) => {
-        if (node.type !== Node.TYPES.CPU) return false;
+        if (node.type !== BaseNode.TYPES.CPU) return false;
         return timing.duration > duration;
       })
       .map(([_, timing]) => timing.endTime)

--- a/lighthouse-core/gather/computed/metrics/lantern-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-interactive.js
@@ -9,7 +9,7 @@ const MetricArtifact = require('./lantern-metric');
 const BaseNode = require('../../../lib/dependency-graph/base-node');
 const WebInspector = require('../../../lib/web-inspector');
 
-/** @typedef {BaseNode.NodeType} NodeType */
+/** @typedef {BaseNode.Node} Node */
 
 // Any CPU task of 20 ms or more will end up being a critical long task on mobile
 const CRITICAL_LONG_TASK_THRESHOLD = 20;
@@ -31,8 +31,8 @@ class Interactive extends MetricArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
-   * @return {NodeType}
+   * @param {Node} dependencyGraph
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph) {
     // Adjust the critical long task threshold for microseconds
@@ -57,8 +57,8 @@ class Interactive extends MetricArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
-   * @return {NodeType}
+   * @param {Node} dependencyGraph
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph) {
     return dependencyGraph;

--- a/lighthouse-core/gather/computed/metrics/lantern-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-interactive.js
@@ -7,9 +7,9 @@
 
 const MetricArtifact = require('./lantern-metric');
 const Node = require('../../../lib/dependency-graph/node');
-const CPUNode = require('../../../lib/dependency-graph/cpu-node'); // eslint-disable-line no-unused-vars
-const NetworkNode = require('../../../lib/dependency-graph/network-node'); // eslint-disable-line no-unused-vars
 const WebInspector = require('../../../lib/web-inspector');
+
+/** @typedef {Node.NodeType} NodeType */
 
 // Any CPU task of 20 ms or more will end up being a critical long task on mobile
 const CRITICAL_LONG_TASK_THRESHOLD = 20;
@@ -31,8 +31,8 @@ class Interactive extends MetricArtifact {
   }
 
   /**
-   * @param {Node} dependencyGraph
-   * @return {Node}
+   * @param {NodeType} dependencyGraph
+   * @return {NodeType}
    */
   getOptimisticGraph(dependencyGraph) {
     // Adjust the critical long task threshold for microseconds
@@ -41,25 +41,24 @@ class Interactive extends MetricArtifact {
     return dependencyGraph.cloneWithRelationships(node => {
       // Include everything that might be a long task
       if (node.type === Node.TYPES.CPU) {
-        return /** @type {CPUNode} */ (node).event.dur > minimumCpuTaskDuration;
+        return node.event.dur > minimumCpuTaskDuration;
       }
 
-      const asNetworkNode = /** @type {NetworkNode} */ (node);
       // Include all scripts and high priority requests, exclude all images
-      const isImage = asNetworkNode.record._resourceType === WebInspector.resourceTypes.Image;
-      const isScript = asNetworkNode.record._resourceType === WebInspector.resourceTypes.Script;
+      const isImage = node.record._resourceType === WebInspector.resourceTypes.Image;
+      const isScript = node.record._resourceType === WebInspector.resourceTypes.Script;
       return (
         !isImage &&
         (isScript ||
-          asNetworkNode.record.priority() === 'High' ||
-          asNetworkNode.record.priority() === 'VeryHigh')
+          node.record.priority() === 'High' ||
+          node.record.priority() === 'VeryHigh')
       );
     });
   }
 
   /**
-   * @param {Node} dependencyGraph
-   * @return {Node}
+   * @param {NodeType} dependencyGraph
+   * @return {NodeType}
    */
   getPessimisticGraph(dependencyGraph) {
     return dependencyGraph;

--- a/lighthouse-core/gather/computed/metrics/lantern-metric.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-metric.js
@@ -6,10 +6,10 @@
 'use strict';
 
 const ComputedArtifact = require('../computed-artifact');
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 const ResourceType = require('../../../../third-party/devtools/ResourceType');
 
-/** @typedef {import('../../../lib/dependency-graph/node').NodeType} NodeType */
+/** @typedef {BaseNode.NodeType} NodeType */
 /** @typedef {import('../../../lib/dependency-graph/network-node')} NetworkNode */
 /** @typedef {import('../../../lib/dependency-graph/simulator/simulator')} Simulator */
 
@@ -24,7 +24,7 @@ class LanternMetricArtifact extends ComputedArtifact {
     const scriptUrls = new Set();
 
     dependencyGraph.traverse(node => {
-      if (node.type === Node.TYPES.CPU) return;
+      if (node.type === BaseNode.TYPES.CPU) return;
       if (node.record._resourceType !== ResourceType.TYPES.Script) return;
       if (condition && !condition(node)) return;
       scriptUrls.add(node.record.url);

--- a/lighthouse-core/gather/computed/metrics/lantern-metric.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-metric.js
@@ -9,13 +9,13 @@ const ComputedArtifact = require('../computed-artifact');
 const BaseNode = require('../../../lib/dependency-graph/base-node');
 const ResourceType = require('../../../../third-party/devtools/ResourceType');
 
-/** @typedef {BaseNode.NodeType} NodeType */
+/** @typedef {BaseNode.Node} Node */
 /** @typedef {import('../../../lib/dependency-graph/network-node')} NetworkNode */
 /** @typedef {import('../../../lib/dependency-graph/simulator/simulator')} Simulator */
 
 class LanternMetricArtifact extends ComputedArtifact {
   /**
-   * @param {NodeType} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {function(NetworkNode):boolean=} condition
    * @return {Set<string>}
    */
@@ -41,18 +41,18 @@ class LanternMetricArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {NodeType}
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) { // eslint-disable-line no-unused-vars
     throw new Error('Optimistic graph unimplemented!');
   }
 
   /**
-   * @param {NodeType} dependencyGraph
+   * @param {Node} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {NodeType}
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) { // eslint-disable-line no-unused-vars
     throw new Error('Pessmistic graph unimplemented!');

--- a/lighthouse-core/gather/computed/metrics/lantern-metric.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-metric.js
@@ -7,25 +7,27 @@
 
 const ComputedArtifact = require('../computed-artifact');
 const Node = require('../../../lib/dependency-graph/node');
-const NetworkNode = require('../../../lib/dependency-graph/network-node'); // eslint-disable-line no-unused-vars
-const Simulator = require('../../../lib/dependency-graph/simulator/simulator'); // eslint-disable-line no-unused-vars
-const WebInspector = require('../../../lib/web-inspector');
+const ResourceType = require('../../../../third-party/devtools/ResourceType');
+
+/** @typedef {import('../../../lib/dependency-graph/node').NodeType} NodeType */
+/** @typedef {import('../../../lib/dependency-graph/network-node')} NetworkNode */
+/** @typedef {import('../../../lib/dependency-graph/simulator/simulator')} Simulator */
 
 class LanternMetricArtifact extends ComputedArtifact {
   /**
-   * @param {Node} dependencyGraph
+   * @param {NodeType} dependencyGraph
    * @param {function(NetworkNode):boolean=} condition
    * @return {Set<string>}
    */
   static getScriptUrls(dependencyGraph, condition) {
+    /** @type {Set<string>} */
     const scriptUrls = new Set();
 
     dependencyGraph.traverse(node => {
       if (node.type === Node.TYPES.CPU) return;
-      const asNetworkNode = /** @type {NetworkNode} */ (node);
-      if (asNetworkNode.record._resourceType !== WebInspector.resourceTypes.Script) return;
-      if (condition && !condition(asNetworkNode)) return;
-      scriptUrls.add(asNetworkNode.record.url);
+      if (node.record._resourceType !== ResourceType.TYPES.Script) return;
+      if (condition && !condition(node)) return;
+      scriptUrls.add(node.record.url);
     });
 
     return scriptUrls;
@@ -39,18 +41,18 @@ class LanternMetricArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {Node} dependencyGraph
+   * @param {NodeType} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {Node}
+   * @return {NodeType}
    */
   getOptimisticGraph(dependencyGraph, traceOfTab) { // eslint-disable-line no-unused-vars
     throw new Error('Optimistic graph unimplemented!');
   }
 
   /**
-   * @param {Node} dependencyGraph
+   * @param {NodeType} dependencyGraph
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
-   * @return {Node}
+   * @return {NodeType}
    */
   getPessimisticGraph(dependencyGraph, traceOfTab) { // eslint-disable-line no-unused-vars
     throw new Error('Pessmistic graph unimplemented!');

--- a/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
@@ -8,7 +8,7 @@
 const MetricArtifact = require('./lantern-metric');
 const BaseNode = require('../../../lib/dependency-graph/base-node');
 
-/** @typedef {BaseNode.NodeType} NodeType */
+/** @typedef {BaseNode.Node} Node */
 
 class SpeedIndex extends MetricArtifact {
   get name() {
@@ -30,16 +30,16 @@ class SpeedIndex extends MetricArtifact {
   }
 
   /**
-   * @param {NodeType} dependencyGraph
-   * @return {NodeType}
+   * @param {Node} dependencyGraph
+   * @return {Node}
    */
   getOptimisticGraph(dependencyGraph) {
     return dependencyGraph;
   }
 
   /**
-   * @param {NodeType} dependencyGraph
-   * @return {NodeType}
+   * @param {Node} dependencyGraph
+   * @return {Node}
    */
   getPessimisticGraph(dependencyGraph) {
     return dependencyGraph;

--- a/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
@@ -6,9 +6,9 @@
 'use strict';
 
 const MetricArtifact = require('./lantern-metric');
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 
-/** @typedef {Node.NodeType} NodeType */
+/** @typedef {BaseNode.NodeType} NodeType */
 
 class SpeedIndex extends MetricArtifact {
   get name() {
@@ -96,7 +96,7 @@ class SpeedIndex extends MetricArtifact {
     /** @type {Array<{time: number, weight: number}>} */
     const layoutWeights = [];
     for (const [node, timing] of nodeTimings.entries()) {
-      if (node.type !== Node.TYPES.CPU) continue;
+      if (node.type !== BaseNode.TYPES.CPU) continue;
 
       if (node.childEvents.some(x => x.name === 'Layout')) {
         const timingWeight = Math.max(Math.log2(timing.endTime - timing.startTime), 0);

--- a/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
@@ -7,7 +7,8 @@
 
 const MetricArtifact = require('./lantern-metric');
 const Node = require('../../../lib/dependency-graph/node');
-const CPUNode = require('../../../lib/dependency-graph/cpu-node'); // eslint-disable-line no-unused-vars
+
+/** @typedef {Node.NodeType} NodeType */
 
 class SpeedIndex extends MetricArtifact {
   get name() {
@@ -29,16 +30,16 @@ class SpeedIndex extends MetricArtifact {
   }
 
   /**
-   * @param {Node} dependencyGraph
-   * @return {Node}
+   * @param {NodeType} dependencyGraph
+   * @return {NodeType}
    */
   getOptimisticGraph(dependencyGraph) {
     return dependencyGraph;
   }
 
   /**
-   * @param {Node} dependencyGraph
-   * @return {Node}
+   * @param {NodeType} dependencyGraph
+   * @return {NodeType}
    */
   getPessimisticGraph(dependencyGraph) {
     return dependencyGraph;
@@ -97,8 +98,7 @@ class SpeedIndex extends MetricArtifact {
     for (const [node, timing] of nodeTimings.entries()) {
       if (node.type !== Node.TYPES.CPU) continue;
 
-      const cpuNode = /** @type {CPUNode} */ (node);
-      if (cpuNode.childEvents.some(x => x.name === 'Layout')) {
+      if (node.childEvents.some(x => x.name === 'Layout')) {
         const timingWeight = Math.max(Math.log2(timing.endTime - timing.startTime), 0);
         layoutWeights.push({time: timing.endTime, weight: timingWeight});
       }

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -12,7 +12,7 @@ const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-an
 const TracingProcessor = require('../../lib/traces/tracing-processor');
 const WebInspector = require('../../lib/web-inspector');
 
-/** @typedef {import('../../lib/dependency-graph/node.js').NodeType} NodeType */
+/** @typedef {import('../../lib/dependency-graph/base-node.js').NodeType} NodeType */
 
 // Tasks smaller than 10 ms have minimal impact on simulation
 const MINIMUM_TASK_DURATION_OF_INTEREST = 10;

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -12,7 +12,7 @@ const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-an
 const TracingProcessor = require('../../lib/traces/tracing-processor');
 const WebInspector = require('../../lib/web-inspector');
 
-/** @typedef {import('../../lib/dependency-graph/base-node.js').NodeType} NodeType */
+/** @typedef {import('../../lib/dependency-graph/base-node.js').Node} Node */
 
 // Tasks smaller than 10 ms have minimal impact on simulation
 const MINIMUM_TASK_DURATION_OF_INTEREST = 10;
@@ -114,7 +114,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {NodeType} rootNode
+   * @param {Node} rootNode
    * @param {NetworkNodeOutput} networkNodeOutput
    */
   static linkNetworkNodes(rootNode, networkNodeOutput) {
@@ -145,7 +145,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {NodeType} rootNode
+   * @param {Node} rootNode
    * @param {NetworkNodeOutput} networkNodeOutput
    * @param {Array<CPUNode>} cpuNodes
    */
@@ -261,7 +261,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   /**
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
    * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
-   * @return {NodeType}
+   * @return {Node}
    */
   static createGraph(traceOfTab, networkRecords) {
     const networkNodeOutput = PageDependencyGraphArtifact.getNetworkNodeOutput(networkRecords);
@@ -290,7 +290,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
 
   /**
    *
-   * @param {NodeType} rootNode
+   * @param {Node} rootNode
    */
   static printGraph(rootNode, widthInCharacters = 100) {
     /** @param {string} str @param {number} target */
@@ -298,7 +298,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       return str + padChar.repeat(Math.max(target - str.length, 0));
     }
 
-    /** @type {Array<NodeType>} */
+    /** @type {Array<Node>} */
     const nodes = [];
     rootNode.traverse(node => nodes.push(node));
     nodes.sort((a, b) => a.startTime - b.startTime);
@@ -323,7 +323,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   /**
    * @param {{trace: LH.Trace, devtoolsLog: LH.DevtoolsLog}} data
    * @param {LH.ComputedArtifacts} artifacts
-   * @return {Promise<NodeType>}
+   * @return {Promise<Node>}
    */
   async compute_(data, artifacts) {
     const trace = data.trace;

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -12,7 +12,7 @@ const NetworkAnalyzer = require('../../lib/dependency-graph/simulator/network-an
 const TracingProcessor = require('../../lib/traces/tracing-processor');
 const WebInspector = require('../../lib/web-inspector');
 
-const Node = require('../../lib/dependency-graph/node.js'); // eslint-disable-line no-unused-vars
+/** @typedef {import('../../lib/dependency-graph/node.js').NodeType} NodeType */
 
 // Tasks smaller than 10 ms have minimal impact on simulation
 const MINIMUM_TASK_DURATION_OF_INTEREST = 10;
@@ -114,7 +114,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {Node} rootNode
+   * @param {NodeType} rootNode
    * @param {NetworkNodeOutput} networkNodeOutput
    */
   static linkNetworkNodes(rootNode, networkNodeOutput) {
@@ -145,7 +145,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   }
 
   /**
-   * @param {Node} rootNode
+   * @param {NodeType} rootNode
    * @param {NetworkNodeOutput} networkNodeOutput
    * @param {Array<CPUNode>} cpuNodes
    */
@@ -261,7 +261,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   /**
    * @param {LH.Artifacts.TraceOfTab} traceOfTab
    * @param {Array<LH.WebInspector.NetworkRequest>} networkRecords
-   * @return {Node}
+   * @return {NodeType}
    */
   static createGraph(traceOfTab, networkRecords) {
     const networkNodeOutput = PageDependencyGraphArtifact.getNetworkNodeOutput(networkRecords);
@@ -290,7 +290,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
 
   /**
    *
-   * @param {Node} rootNode
+   * @param {NodeType} rootNode
    */
   static printGraph(rootNode, widthInCharacters = 100) {
     /** @param {string} str @param {number} target */
@@ -298,7 +298,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
       return str + padChar.repeat(Math.max(target - str.length, 0));
     }
 
-    /** @type {Array<Node>} */
+    /** @type {Array<NodeType>} */
     const nodes = [];
     rootNode.traverse(node => nodes.push(node));
     nodes.sort((a, b) => a.startTime - b.startTime);
@@ -323,7 +323,7 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
   /**
    * @param {{trace: LH.Trace, devtoolsLog: LH.DevtoolsLog}} data
    * @param {LH.ComputedArtifacts} artifacts
-   * @return {Promise<Node>}
+   * @return {Promise<NodeType>}
    */
   async compute_(data, artifacts) {
     const trace = data.trace;

--- a/lighthouse-core/lib/dependency-graph/base-node.js
+++ b/lighthouse-core/lib/dependency-graph/base-node.js
@@ -6,7 +6,7 @@
 'use strict';
 
 /**
- * A union of all types derived from Node, allowing type check disrimination
+ * A union of all types derived from Node, allowing type check discrimination
  * based on `node.type`. If a new node type is created, it should be added here.
  * @typedef {import('./cpu-node.js') | import('./network-node.js')} NodeType
  */
@@ -23,7 +23,7 @@
  * This allows particular optimizations in this class so that we do no need to check for cycles as
  * these methods are called and we can always start traversal at the root node.
  */
-class Node {
+class BaseNode {
   /**
    * @param {string} id
    */
@@ -44,7 +44,7 @@ class Node {
   }
 
   /**
-   * @return {typeof Node.TYPES[keyof typeof Node.TYPES]}
+   * @return {typeof BaseNode.TYPES[keyof typeof BaseNode.TYPES]}
    */
   get type() {
     throw new Error('Unimplemented');
@@ -103,7 +103,7 @@ class Node {
    * @return {NodeType}
    */
   getRootNode() {
-    let rootNode = /** @type {NodeType} */ (/** @type {Node} */ (this));
+    let rootNode = /** @type {NodeType} */ (/** @type {BaseNode} */ (this));
     while (rootNode._dependencies.length) {
       rootNode = rootNode._dependencies[0];
     }
@@ -115,7 +115,7 @@ class Node {
    * @param {NodeType} node
    */
   addDependent(node) {
-    node.addDependency(/** @type {NodeType} */ (/** @type {Node} */ (this)));
+    node.addDependency(/** @type {NodeType} */ (/** @type {BaseNode} */ (this)));
   }
 
   /**
@@ -126,7 +126,7 @@ class Node {
       return;
     }
 
-    node._dependents.push(/** @type {NodeType} */ (/** @type {Node} */ (this)));
+    node._dependents.push(/** @type {NodeType} */ (/** @type {BaseNode} */ (this)));
     this._dependencies.push(node);
   }
 
@@ -134,7 +134,7 @@ class Node {
    * @param {NodeType} node
    */
   removeDependent(node) {
-    node.removeDependency(/** @type {NodeType} */ (/** @type {Node} */ (this)));
+    node.removeDependency(/** @type {NodeType} */ (/** @type {BaseNode} */ (this)));
   }
 
   /**
@@ -145,7 +145,7 @@ class Node {
       return;
     }
 
-    const thisIndex = node._dependents.indexOf(/** @type {NodeType} */ (/** @type {Node} */(this)));
+    const thisIndex = node._dependents.indexOf(/** @type {NodeType} */ (/** @type {BaseNode} */(this)));
     node._dependents.splice(thisIndex, 1);
     this._dependencies.splice(this._dependencies.indexOf(node), 1);
   }
@@ -161,7 +161,7 @@ class Node {
    * @return {NodeType}
    */
   cloneWithoutRelationships() {
-    const node = /** @type {NodeType} */ (new Node(this.id));
+    const node = /** @type {NodeType} */ (new BaseNode(this.id));
     node.setIsMainDocument(this._isMainDocument);
     return node;
   }
@@ -220,7 +220,7 @@ class Node {
    * @param {function(NodeType): NodeType[]} getNext
    */
   _traversePaths(iterator, getNext) {
-    const stack = [[/** @type {NodeType} */(/** @type {Node} */(this))]];
+    const stack = [[/** @type {NodeType} */(/** @type {BaseNode} */(this))]];
     while (stack.length) {
       /** @type {NodeType[]} */
       // @ts-ignore - stack has length so it's guaranteed to have an item
@@ -269,7 +269,7 @@ class Node {
   static hasCycle(node, direction = 'both') {
     // Checking 'both' is the default entrypoint to recursively check both directions
     if (direction === 'both') {
-      return Node.hasCycle(node, 'dependents') || Node.hasCycle(node, 'dependencies');
+      return BaseNode.hasCycle(node, 'dependents') || BaseNode.hasCycle(node, 'dependencies');
     }
 
     const visited = new Set();
@@ -313,9 +313,9 @@ class Node {
   }
 }
 
-Node.TYPES = /** @type {{NETWORK: 'network', CPU: 'cpu'}} */({
+BaseNode.TYPES = /** @type {{NETWORK: 'network', CPU: 'cpu'}} */({
   NETWORK: 'network',
   CPU: 'cpu',
 });
 
-module.exports = Node;
+module.exports = BaseNode;

--- a/lighthouse-core/lib/dependency-graph/base-node.js
+++ b/lighthouse-core/lib/dependency-graph/base-node.js
@@ -6,7 +6,7 @@
 'use strict';
 
 /**
- * A union of all types derived from Node, allowing type check discrimination
+ * A union of all types derived from BaseNode, allowing type check discrimination
  * based on `node.type`. If a new node type is created, it should be added here.
  * @typedef {import('./cpu-node.js') | import('./network-node.js')} Node
  */

--- a/lighthouse-core/lib/dependency-graph/cpu-node.js
+++ b/lighthouse-core/lib/dependency-graph/cpu-node.js
@@ -5,9 +5,9 @@
  */
 'use strict';
 
-const Node = require('./node');
+const BaseNode = require('./base-node');
 
-class CPUNode extends Node {
+class CPUNode extends BaseNode {
   /**
    * @param {LH.TraceEvent} parentEvent
    * @param {LH.TraceEvent[]=} childEvents
@@ -21,7 +21,7 @@ class CPUNode extends Node {
   }
 
   get type() {
-    return Node.TYPES.CPU;
+    return BaseNode.TYPES.CPU;
   }
 
   /**

--- a/lighthouse-core/lib/dependency-graph/cpu-node.js
+++ b/lighthouse-core/lib/dependency-graph/cpu-node.js
@@ -20,9 +20,6 @@ class CPUNode extends Node {
     this._childEvents = childEvents;
   }
 
-  /**
-   * @return {string}
-   */
   get type() {
     return Node.TYPES.CPU;
   }

--- a/lighthouse-core/lib/dependency-graph/network-node.js
+++ b/lighthouse-core/lib/dependency-graph/network-node.js
@@ -5,10 +5,10 @@
  */
 'use strict';
 
-const Node = require('./node');
+const BaseNode = require('./base-node');
 const WebInspector = require('../web-inspector');
 
-class NetworkNode extends Node {
+class NetworkNode extends BaseNode {
   /**
    * @param {LH.WebInspector.NetworkRequest} networkRecord
    */
@@ -19,7 +19,7 @@ class NetworkNode extends Node {
   }
 
   get type() {
-    return Node.TYPES.NETWORK;
+    return BaseNode.TYPES.NETWORK;
   }
 
   /**

--- a/lighthouse-core/lib/dependency-graph/network-node.js
+++ b/lighthouse-core/lib/dependency-graph/network-node.js
@@ -14,12 +14,10 @@ class NetworkNode extends Node {
    */
   constructor(networkRecord) {
     super(networkRecord.requestId);
+    /** @private */
     this._record = networkRecord;
   }
 
-  /**
-   * @return {string}
-   */
   get type() {
     return Node.TYPES.NETWORK;
   }

--- a/lighthouse-core/lib/dependency-graph/node.js
+++ b/lighthouse-core/lib/dependency-graph/node.js
@@ -220,7 +220,7 @@ class Node {
    * @param {function(NodeType): NodeType[]} getNext
    */
   _traversePaths(iterator, getNext) {
-    const stack = [[/** @type {NodeType} */ (/** @type {Node} */ (this))]];
+    const stack = [[/** @type {NodeType} */(/** @type {Node} */(this))]];
     while (stack.length) {
       /** @type {NodeType[]} */
       // @ts-ignore - stack has length so it's guaranteed to have an item

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -6,13 +6,13 @@
 'use strict';
 
 const BaseNode = require('../base-node');
-const NetworkNode = require('../network-node'); // eslint-disable-line no-unused-vars
-const CpuNode = require('../cpu-node'); // eslint-disable-line no-unused-vars
 const TcpConnection = require('./tcp-connection');
 const ConnectionPool = require('./connection-pool');
 const mobile3G = require('../../../config/constants').throttling.mobile3G;
 
 /** @typedef {BaseNode.Node} Node */
+/** @typedef {import('../network-node')} NetworkNode */
+/** @typedef {import('../cpu-node')} CpuNode */
 
 // see https://cs.chromium.org/search/?q=kDefaultMaxNumDelayableRequestsPerClient&sq=package:chromium&type=cs
 const DEFAULT_MAXIMUM_CONCURRENT_REQUESTS = 10;

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -12,7 +12,7 @@ const TcpConnection = require('./tcp-connection');
 const ConnectionPool = require('./connection-pool');
 const mobile3G = require('../../../config/constants').throttling.mobile3G;
 
-/** @typedef {BaseNode.NodeType} NodeType */
+/** @typedef {BaseNode.Node} Node */
 
 // see https://cs.chromium.org/search/?q=kDefaultMaxNumDelayableRequestsPerClient&sq=package:chromium&type=cs
 const DEFAULT_MAXIMUM_CONCURRENT_REQUESTS = 10;
@@ -61,7 +61,7 @@ class Simulator {
 
     // Properties reset on every `.simulate` call but duplicated here for type checking
     this._flexibleOrdering = false;
-    /** @type {Map<NodeType, NodeTimingIntermediate>} */
+    /** @type {Map<Node, NodeTimingIntermediate>} */
     this._nodeTimings = new Map();
     /** @type {Map<string, number>} */
     this._numberInProgressByType = new Map();
@@ -71,7 +71,7 @@ class Simulator {
   }
 
   /**
-   * @param {NodeType} graph
+   * @param {Node} graph
    */
   _initializeConnectionPool(graph) {
     /** @type {LH.WebInspector.NetworkRequest[]} */
@@ -107,7 +107,7 @@ class Simulator {
   }
 
   /**
-   * @param {NodeType} node
+   * @param {Node} node
    * @param {NodeTimingIntermediate} values
    */
   _setTimingData(node, values) {
@@ -117,7 +117,7 @@ class Simulator {
   }
 
   /**
-   * @param {NodeType} node
+   * @param {Node} node
    * @return {NodeTimingIntermediate}
    */
   _getTimingData(node) {
@@ -127,7 +127,7 @@ class Simulator {
   }
 
   /**
-   * @param {NodeType} node
+   * @param {Node} node
    * @param {number} queuedTime
    */
   _markNodeAsReadyToStart(node, queuedTime) {
@@ -137,7 +137,7 @@ class Simulator {
   }
 
   /**
-   * @param {NodeType} node
+   * @param {Node} node
    * @param {number} startTime
    */
   _markNodeAsInProgress(node, startTime) {
@@ -148,7 +148,7 @@ class Simulator {
   }
 
   /**
-   * @param {NodeType} node
+   * @param {Node} node
    * @param {number} endTime
    */
   _markNodeAsComplete(node, endTime) {
@@ -179,7 +179,7 @@ class Simulator {
   }
 
   /**
-   * @param {NodeType} node
+   * @param {Node} node
    * @param {number} totalElapsedTime
    */
   _startNodeIfPossible(node, totalElapsedTime) {
@@ -224,7 +224,7 @@ class Simulator {
 
   /**
    * Estimates the number of milliseconds remaining given current condidtions before the node is complete.
-   * @param {NodeType} node
+   * @param {Node} node
    * @return {number}
    */
   _estimateTimeRemaining(node) {
@@ -299,7 +299,7 @@ class Simulator {
 
   /**
    * Given a time period, computes the progress toward completion that the node made durin that time.
-   * @param {NodeType} node
+   * @param {Node} node
    * @param {number} timePeriodLength
    * @param {number} totalElapsedTime
    */
@@ -341,7 +341,7 @@ class Simulator {
   }
 
   _computeFinalNodeTimings() {
-    /** @type {Map<NodeType, LH.Gatherer.Simulation.NodeTiming>} */
+    /** @type {Map<Node, LH.Gatherer.Simulation.NodeTiming>} */
     const nodeTimings = new Map();
     for (const [node, timing] of this._nodeTimings) {
       nodeTimings.set(node, {
@@ -370,7 +370,7 @@ class Simulator {
    * wait around for a warm connection to be available if the original record was fetched on a warm
    * connection).
    *
-   * @param {NodeType} graph
+   * @param {Node} graph
    * @param {{flexibleOrdering?: boolean, label?: string}=} options
    * @return {LH.Gatherer.Simulation.Result}
    */

--- a/lighthouse-core/test/gather/computed/page-dependency-graph-test.js
+++ b/lighthouse-core/test/gather/computed/page-dependency-graph-test.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const PageDependencyGraph = require('../../../gather/computed/page-dependency-graph');
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 const Runner = require('../../../runner.js');
 const WebInspector = require('../../../lib/web-inspector');
 
@@ -65,7 +65,7 @@ describe('PageDependencyGraph computed artifact:', () => {
         trace: sampleTrace,
         devtoolsLog: sampleDevtoolsLog,
       }).then(output => {
-        assert.ok(output instanceof Node, 'did not return a graph');
+        assert.ok(output instanceof BaseNode, 'did not return a graph');
 
         const dependents = output.getDependents();
         const nodeWithNestedDependents = dependents.find(node => node.getDependents().length);

--- a/lighthouse-core/test/lib/dependency-graph/base-node-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/base-node-test.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const Node = require('../../../lib/dependency-graph/node');
+const BaseNode = require('../../../lib/dependency-graph/base-node');
 const NetworkNode = require('../../../lib/dependency-graph/network-node');
 
 const assert = require('assert');
@@ -21,14 +21,14 @@ function createComplexGraph() {
   //  \ /     \
   //   C       G - H
 
-  const nodeA = new Node('A');
-  const nodeB = new Node('B');
-  const nodeC = new Node('C');
-  const nodeD = new Node('D');
-  const nodeE = new Node('E');
-  const nodeF = new Node('F');
-  const nodeG = new Node('G');
-  const nodeH = new Node('H');
+  const nodeA = new BaseNode('A');
+  const nodeB = new BaseNode('B');
+  const nodeC = new BaseNode('C');
+  const nodeD = new BaseNode('D');
+  const nodeE = new BaseNode('E');
+  const nodeF = new BaseNode('F');
+  const nodeG = new BaseNode('G');
+  const nodeH = new BaseNode('H');
 
   nodeA.addDependent(nodeB);
   nodeA.addDependent(nodeC);
@@ -55,15 +55,15 @@ function createComplexGraph() {
 describe('DependencyGraph/Node', () => {
   describe('#constructor', () => {
     it('should set the ID', () => {
-      const node = new Node('foo');
+      const node = new BaseNode('foo');
       assert.equal(node.id, 'foo');
     });
   });
 
   describe('.addDependent', () => {
     it('should add the correct edge', () => {
-      const nodeA = new Node(1);
-      const nodeB = new Node(2);
+      const nodeA = new BaseNode(1);
+      const nodeB = new BaseNode(2);
       nodeA.addDependent(nodeB);
 
       assert.deepEqual(nodeA.getDependents(), [nodeB]);
@@ -73,8 +73,8 @@ describe('DependencyGraph/Node', () => {
 
   describe('.addDependency', () => {
     it('should add the correct edge', () => {
-      const nodeA = new Node(1);
-      const nodeB = new Node(2);
+      const nodeA = new BaseNode(1);
+      const nodeB = new BaseNode(2);
       nodeA.addDependency(nodeB);
 
       assert.deepEqual(nodeA.getDependencies(), [nodeB]);
@@ -95,8 +95,8 @@ describe('DependencyGraph/Node', () => {
 
   describe('.cloneWithoutRelationships', () => {
     it('should create a copy', () => {
-      const node = new Node(1);
-      const neighbor = new Node(2);
+      const node = new BaseNode(1);
+      const neighbor = new BaseNode(2);
       node.addDependency(neighbor);
       const clone = node.cloneWithoutRelationships();
 
@@ -106,7 +106,7 @@ describe('DependencyGraph/Node', () => {
     });
 
     it('should copy isMainDocument', () => {
-      const node = new Node(1);
+      const node = new BaseNode(1);
       node.setIsMainDocument(true);
       const networkNode = new NetworkNode({});
       networkNode.setIsMainDocument(true);
@@ -118,8 +118,8 @@ describe('DependencyGraph/Node', () => {
 
   describe('.cloneWithRelationships', () => {
     it('should create a copy of a basic graph', () => {
-      const node = new Node(1);
-      const neighbor = new Node(2);
+      const node = new BaseNode(1);
+      const neighbor = new BaseNode(2);
       node.addDependency(neighbor);
       const clone = node.cloneWithRelationships();
 
@@ -162,12 +162,12 @@ describe('DependencyGraph/Node', () => {
       //   C - D - E - F
       //  /             \
       // A - - - - - - - B
-      const nodeA = new Node('A');
-      const nodeB = new Node('B');
-      const nodeC = new Node('C');
-      const nodeD = new Node('D');
-      const nodeE = new Node('E');
-      const nodeF = new Node('F');
+      const nodeA = new BaseNode('A');
+      const nodeB = new BaseNode('B');
+      const nodeC = new BaseNode('C');
+      const nodeD = new BaseNode('D');
+      const nodeE = new BaseNode('E');
+      const nodeF = new BaseNode('F');
 
       nodeA.addDependent(nodeB);
       nodeF.addDependent(nodeB);
@@ -233,64 +233,64 @@ describe('DependencyGraph/Node', () => {
   describe('#hasCycle', () => {
     it('should return false for DAGs', () => {
       const graph = createComplexGraph();
-      assert.equal(Node.hasCycle(graph.nodeA), false);
+      assert.equal(BaseNode.hasCycle(graph.nodeA), false);
     });
 
     it('should return false for triangular DAGs', () => {
       //   B
       //  / \
       // A - C
-      const nodeA = new Node('A');
-      const nodeB = new Node('B');
-      const nodeC = new Node('C');
+      const nodeA = new BaseNode('A');
+      const nodeB = new BaseNode('B');
+      const nodeC = new BaseNode('C');
 
       nodeA.addDependent(nodeC);
       nodeA.addDependent(nodeB);
       nodeB.addDependent(nodeC);
 
-      assert.equal(Node.hasCycle(nodeA), false);
+      assert.equal(BaseNode.hasCycle(nodeA), false);
     });
 
     it('should return true for basic cycles', () => {
       // A - B - C - A!
-      const nodeA = new Node('A');
-      const nodeB = new Node('B');
-      const nodeC = new Node('C');
+      const nodeA = new BaseNode('A');
+      const nodeB = new BaseNode('B');
+      const nodeC = new BaseNode('C');
 
       nodeA.addDependent(nodeB);
       nodeB.addDependent(nodeC);
       nodeC.addDependent(nodeA);
 
-      assert.equal(Node.hasCycle(nodeA), true);
+      assert.equal(BaseNode.hasCycle(nodeA), true);
     });
 
     it('should return true for children', () => {
       //       A!
       //      /
       // A - B - C
-      const nodeA = new Node('A');
-      const nodeB = new Node('B');
-      const nodeC = new Node('C');
+      const nodeA = new BaseNode('A');
+      const nodeB = new BaseNode('B');
+      const nodeC = new BaseNode('C');
 
       nodeA.addDependent(nodeB);
       nodeB.addDependent(nodeC);
       nodeB.addDependent(nodeA);
 
-      assert.equal(Node.hasCycle(nodeC), true);
+      assert.equal(BaseNode.hasCycle(nodeC), true);
     });
 
     it('should return true for complex cycles', () => {
       //   B - D - F - G - C!
       //  /      /
       // A - - C - E - H
-      const nodeA = new Node('A');
-      const nodeB = new Node('B');
-      const nodeC = new Node('C');
-      const nodeD = new Node('D');
-      const nodeE = new Node('E');
-      const nodeF = new Node('F');
-      const nodeG = new Node('G');
-      const nodeH = new Node('H');
+      const nodeA = new BaseNode('A');
+      const nodeB = new BaseNode('B');
+      const nodeC = new BaseNode('C');
+      const nodeD = new BaseNode('D');
+      const nodeE = new BaseNode('E');
+      const nodeF = new BaseNode('F');
+      const nodeG = new BaseNode('G');
+      const nodeH = new BaseNode('H');
 
       nodeA.addDependent(nodeB);
       nodeA.addDependent(nodeC);
@@ -302,28 +302,28 @@ describe('DependencyGraph/Node', () => {
       nodeF.addDependent(nodeG);
       nodeG.addDependent(nodeC);
 
-      assert.equal(Node.hasCycle(nodeA), true);
-      assert.equal(Node.hasCycle(nodeB), true);
-      assert.equal(Node.hasCycle(nodeC), true);
-      assert.equal(Node.hasCycle(nodeD), true);
-      assert.equal(Node.hasCycle(nodeE), true);
-      assert.equal(Node.hasCycle(nodeF), true);
-      assert.equal(Node.hasCycle(nodeG), true);
-      assert.equal(Node.hasCycle(nodeH), true);
+      assert.equal(BaseNode.hasCycle(nodeA), true);
+      assert.equal(BaseNode.hasCycle(nodeB), true);
+      assert.equal(BaseNode.hasCycle(nodeC), true);
+      assert.equal(BaseNode.hasCycle(nodeD), true);
+      assert.equal(BaseNode.hasCycle(nodeE), true);
+      assert.equal(BaseNode.hasCycle(nodeF), true);
+      assert.equal(BaseNode.hasCycle(nodeG), true);
+      assert.equal(BaseNode.hasCycle(nodeH), true);
     });
 
     it('works for very large graphs', () => {
-      const root = new Node('root');
+      const root = new BaseNode('root');
 
       let lastNode = root;
       for (let i = 0; i < 10000; i++) {
-        const nextNode = new Node(`child${i}`);
+        const nextNode = new BaseNode(`child${i}`);
         lastNode.addDependent(nextNode);
         lastNode = nextNode;
       }
 
       lastNode.addDependent(root);
-      assert.equal(Node.hasCycle(root), true);
+      assert.equal(BaseNode.hasCycle(root), true);
     });
   });
 });

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -29,7 +29,7 @@ declare global {
     }
 
     namespace Simulation {
-      export type GraphNode = import('../lighthouse-core/lib/dependency-graph/node').NodeType;
+      export type GraphNode = import('../lighthouse-core/lib/dependency-graph/base-node').NodeType;
       export type GraphNetworkNode = _NetworkNode;
       export type GraphCPUNode = _CPUNode;
       export type Simulator = _Simulator;

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -29,7 +29,7 @@ declare global {
     }
 
     namespace Simulation {
-      export type GraphNode = import('../lighthouse-core/lib/dependency-graph/base-node').NodeType;
+      export type GraphNode = import('../lighthouse-core/lib/dependency-graph/base-node').Node;
       export type GraphNetworkNode = _NetworkNode;
       export type GraphCPUNode = _CPUNode;
       export type Simulator = _Simulator;

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -4,7 +4,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import _Node = require('../lighthouse-core/lib/dependency-graph/node');
 import _NetworkNode = require('../lighthouse-core/lib/dependency-graph/network-node');
 import _CPUNode = require('../lighthouse-core/lib/dependency-graph/cpu-node');
 import _Simulator = require('../lighthouse-core/lib/dependency-graph/simulator/simulator');
@@ -14,7 +13,7 @@ declare global {
   module LH.Gatherer {
     export interface PassContext {
       url: string;
-      driver: InstanceType<typeof Driver>;
+      driver: Driver;
       disableJavaScript?: boolean;
       passConfig: Config.Pass
       settings: Config.Settings;
@@ -30,11 +29,10 @@ declare global {
     }
 
     namespace Simulation {
-      // HACK: TS treats 'import * as Foo' as namespace instead of a type, use typeof and prototype
-      export type GraphNode = InstanceType<typeof _Node>;
-      export type GraphNetworkNode = InstanceType<typeof _NetworkNode>;
-      export type GraphCPUNode = InstanceType<typeof _CPUNode>;
-      export type Simulator = InstanceType<typeof _Simulator>;
+      export type GraphNode = import('../lighthouse-core/lib/dependency-graph/node').NodeType;
+      export type GraphNetworkNode = _NetworkNode;
+      export type GraphCPUNode = _CPUNode;
+      export type Simulator = _Simulator;
 
       export interface MetricCoefficients {
         intercept: number;


### PR DESCRIPTION
@patrickhulce this is what I mentioned a while back (in #5072). The Node type passed around becomes a union of `CPUNode | NetworkNode`, which means things inside e.g. an `if (node.type !== 'network')` block that `node` becomes a `CPUNode` with no cast or anything.

The downsides are
a) naming (but we can tweak) and
b) double casts of `this` within the `Node` class since the compiler doesn't *know* that `this` isn't an incompatible subclass of `Node` (so first cast to `Node`, then cast to `CPUNode | NetworkNode`.