### PR TITLE
core(driver): fix spelling error in driver method

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -173,7 +173,7 @@ class Driver {
    * @param {string} scriptSource
    * @return {Promise<LH.Crdp.Page.AddScriptToEvaluateOnLoadResponse>} Identifier of the added script.
    */
-  evaluteScriptOnNewDocument(scriptSource) {
+  evaluateScriptOnNewDocument(scriptSource) {
     return this.sendCommand('Page.addScriptToEvaluateOnLoad', {
       scriptSource,
     });
@@ -1064,7 +1064,7 @@ class Driver {
    * @return {Promise<void>}
    */
   async cacheNatives() {
-    await this.evaluteScriptOnNewDocument(`window.__nativePromise = Promise;
+    await this.evaluateScriptOnNewDocument(`window.__nativePromise = Promise;
         window.__nativeError = Error;`);
   }
 
@@ -1074,7 +1074,7 @@ class Driver {
    */
   async registerPerformanceObserver() {
     const scriptStr = `(${pageFunctions.registerPerformanceObserverInPage.toString()})()`;
-    await this.evaluteScriptOnNewDocument(scriptStr);
+    await this.evaluateScriptOnNewDocument(scriptStr);
   }
 
   /**

--- a/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
@@ -174,7 +174,7 @@ class TagsBlockingFirstPaint extends Gatherer {
    * @param {LH.Gatherer.PassContext} passContext
    */
   beforePass(passContext) {
-    return passContext.driver.evaluteScriptOnNewDocument(`(${installMediaListener.toString()})()`);
+    return passContext.driver.evaluateScriptOnNewDocument(`(${installMediaListener.toString()})()`);
   }
 
   /**


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
The driver method `evaluateScriptOnNewDocument` was spelled `evalute`. This PR corrects that change across the repo.
<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
