### PR TITLE
core(lhr): add metrics type to details

### DIFF
--- a/lighthouse-core/audits/estimated-input-latency.js
+++ b/lighthouse-core/audits/estimated-input-latency.js
@@ -57,6 +57,10 @@ class EstimatedInputLatency extends Audit {
       ),
       rawValue: metricResult.timing,
       displayValue: ['%d\xa0ms', metricResult.timing],
+      details: {
+        type: 'metric',
+        timespanMs: metricResult.timing,
+      },
     };
   }
 }

--- a/lighthouse-core/audits/first-contentful-paint.js
+++ b/lighthouse-core/audits/first-contentful-paint.js
@@ -55,6 +55,10 @@ class FirstContentfulPaint extends Audit {
       ),
       rawValue: metricResult.timing,
       displayValue: [Util.MS_DISPLAY_VALUE, metricResult.timing],
+      details: {
+        type: 'metric',
+        timespanMs: metricResult.timing,
+      },
     };
   }
 }

--- a/lighthouse-core/audits/first-cpu-idle.js
+++ b/lighthouse-core/audits/first-cpu-idle.js
@@ -59,6 +59,10 @@ class FirstCPUIdle extends Audit {
       ),
       rawValue: metricResult.timing,
       displayValue: [Util.MS_DISPLAY_VALUE, metricResult.timing],
+      details: {
+        type: 'metric',
+        timespanMs: metricResult.timing,
+      },
     };
   }
 }

--- a/lighthouse-core/audits/first-meaningful-paint.js
+++ b/lighthouse-core/audits/first-meaningful-paint.js
@@ -58,6 +58,10 @@ class FirstMeaningfulPaint extends Audit {
       ),
       rawValue: metricResult.timing,
       displayValue: [Util.MS_DISPLAY_VALUE, metricResult.timing],
+      details: {
+        type: 'metric',
+        timespanMs: metricResult.timing,
+      },
     };
   }
 }

--- a/lighthouse-core/audits/interactive.js
+++ b/lighthouse-core/audits/interactive.js
@@ -73,6 +73,10 @@ class InteractiveMetric extends Audit {
       extendedInfo: {
         value: extendedInfo,
       },
+      details: {
+        type: 'metric',
+        timespanMs: timeInMs,
+      },
     };
   }
 }

--- a/lighthouse-core/audits/speed-index.js
+++ b/lighthouse-core/audits/speed-index.js
@@ -57,6 +57,10 @@ class SpeedIndex extends Audit {
       ),
       rawValue: metricResult.timing,
       displayValue: [Util.MS_DISPLAY_VALUE, metricResult.timing],
+      details: {
+        type: 'metric',
+        timespanMs: metricResult.timing,
+      },
     };
   }
 }

--- a/lighthouse-core/test/audits/estimated-input-latency-test.js
+++ b/lighthouse-core/test/audits/estimated-input-latency-test.js
@@ -29,6 +29,8 @@ describe('Performance: estimated-input-latency audit', () => {
     const settings = {throttlingMethod: 'provided'};
     return Audit.audit(artifacts, {options, settings}).then(output => {
       assert.equal(Math.round(output.rawValue * 10) / 10, 17.1);
+      assert.equal(output.details.type, 'metric');
+      assert.equal(Math.round(output.details.timespanMs * 10) / 10, 17.1);
       assert.equal(Util.formatDisplayValue(output.displayValue), '17\xa0ms');
       assert.equal(output.score, 1);
     });

--- a/lighthouse-core/test/audits/first-contentful-paint-test.js
+++ b/lighthouse-core/test/audits/first-contentful-paint-test.js
@@ -30,5 +30,7 @@ describe('Performance: first-contentful-paint audit', () => {
     const result = await Audit.audit(artifacts, {settings, options});
     assert.equal(result.score, 1);
     assert.equal(result.rawValue, 498.87);
+    assert.equal(result.details.timespanMs, 498.87);
+    assert.equal(result.details.type, 'metric');
   });
 });

--- a/lighthouse-core/test/audits/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/audits/first-meaningful-paint-test.js
@@ -42,5 +42,7 @@ describe('Performance: first-meaningful-paint audit', () => {
     assert.equal(fmpResult.score, 0.96);
     assert.equal(Util.formatDisplayValue(fmpResult.displayValue), '1,950\xa0ms');
     assert.equal(Math.round(fmpResult.rawValue), 1949);
+    assert.equal(Math.round(fmpResult.details.timespanMs), 1949);
+    assert.equal(fmpResult.details.type, 'metric');
   });
 });

--- a/lighthouse-core/test/audits/interactive-test.js
+++ b/lighthouse-core/test/audits/interactive-test.js
@@ -34,6 +34,8 @@ describe('Performance: interactive audit', () => {
     return Interactive.audit(artifacts, {options, settings}).then(output => {
       assert.equal(output.score, 1);
       assert.equal(Math.round(output.rawValue), 1582);
+      assert.equal(Math.round(output.details.timespanMs), 1582);
+      assert.equal(output.details.type, 'metric');
       assert.equal(Util.formatDisplayValue(output.displayValue), '1,580\xa0ms');
     });
   });

--- a/lighthouse-core/test/audits/speed-index-test.js
+++ b/lighthouse-core/test/audits/speed-index-test.js
@@ -26,6 +26,8 @@ describe('Performance: speed-index audit', () => {
     return Audit.audit(artifacts, {options, settings}).then(result => {
       assert.equal(result.score, 1);
       assert.equal(result.rawValue, 605);
+      assert.equal(result.details.timespanMs, 605);
+      assert.equal(result.details.type, 'metric');
     });
   }).timeout(10000);
 

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -83,6 +83,8 @@ declare global {
       }
 
       export module Audit {
+        export type MetricDetails = ResultLite.Audit.MetricDetails;
+
         export interface OpportunityDetailsItem {
           url: string;
           wastedBytes?: number;


### PR DESCRIPTION
ref #5008

```js
metricAudit.details.type // 'metric'
metricAudit.details.timespanMs // numeric value
```

Interestingly we don't have any code that consumes metricAudit.rawValue, so no place to have it start consuming this details.timespanMs. 
