### PR TITLE
tests(smoke): remove console.timeline() call

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -302,9 +302,6 @@ function deprecationsTest() {
 
   // TODO: some deprecated API messages are not currently being logged correctly.
   // See: https://crbug.com/680832
-  try {
-    MediaStreamTrack.getSources(); // Should eventually FAIL
-  } catch(e) {}
 
   // FAIL
   const xhr = new XMLHttpRequest();

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -306,8 +306,6 @@ function deprecationsTest() {
     MediaStreamTrack.getSources(); // Should eventually FAIL
   } catch(e) {}
 
-  console.timeline(); // Should eventually FAIL
-
   // FAIL
   const xhr = new XMLHttpRequest();
   xhr.open('GET', 'dbw_tester.html', false);

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -17,7 +17,7 @@ module.exports = [
         score: 0,
         details: {
           items: {
-            length: '>3',
+            length: 5,
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -17,7 +17,7 @@ module.exports = [
         score: 0,
         details: {
           items: {
-            length: 5,
+            length: 6,
           },
         },
       },


### PR DESCRIPTION
@paulirish bisected the regression to a V8 roll that removed console.timeline, we call this method in our smoke tests so the test script was erroring and not actually executing our intentional failures :)