### PR TITLE
deps(axe): bump axe to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "zone.js": "^0.7.3"
   },
   "dependencies": {
-    "axe-core": "3.0.0-beta.2",
+    "axe-core": "^3.0.3",
     "chrome-devtools-frontend": "1.0.422034",
     "chrome-launcher": "^0.10.2",
     "configstore": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,9 +437,9 @@ aws4@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.4.1.tgz#fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
 
-axe-core@3.0.0-beta.2:
-  version "3.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.0.0-beta.2.tgz#82a13d371268034352bba2bcb263c5625b3e4a09"
+axe-core@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.0.3.tgz#ce016fd01476e23f4f3199d48a3f07125450b5db"
 
 axios@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
changes here: https://github.com/dequelabs/axe-core/releases

Nothing in particular triggered me to bump, though "Prevent color rules from crashing Chrome 66+" looks certainly worthwhile. :)