### PR TITLE
core(response-compression): graceful recovery

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-text-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-text-compression.js
@@ -41,6 +41,9 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
     /** @type {Array<LH.Audit.ByteEfficiencyItem>} */
     const items = [];
     uncompressedResponses.forEach(record => {
+      // Ignore invalid GZIP size values (undefined, NaN, 0, -n, etc)
+      if (!record.gzipSize || record.gzipSize < 0) return;
+
       const originalSize = record.resourceSize;
       const gzipSize = record.gzipSize;
       const gzipSavings = originalSize - gzipSize;

--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -11,6 +11,8 @@
 'use strict';
 
 const Gatherer = require('../gatherer');
+const URL = require('../../../lib/url-shim');
+const Sentry = require('../../../lib/sentry');
 const NetworkRequest = require('../../../lib/network-request');
 const gzip = require('zlib').gzip;
 
@@ -99,6 +101,16 @@ class ResponseCompression extends Gatherer {
             resolve(record);
           });
         });
+      }).catch(err => {
+        // @ts-ignore TODO(bckenny): Sentry type checking
+        Sentry.captureException(err, {
+          tags: {gatherer: 'ResponseCompression'},
+          extra: {url: URL.elideDataURI(record.url)},
+          level: 'warning',
+        });
+
+        record.gzipSize = undefined;
+        return record;
       });
     }));
   }

--- a/lighthouse-core/test/gather/gatherers/dobetterweb/response-compression-test.js
+++ b/lighthouse-core/test/gather/gatherers/dobetterweb/response-compression-test.js
@@ -140,6 +140,16 @@ describe('Optimized responses', () => {
       });
   });
 
+  it('recovers from driver errors', () => {
+    options.driver.getRequestContent = () => Promise.reject(new Error('Failed'));
+    return responseCompression.afterPass(options, createNetworkRequests(traceData))
+      .then(artifact => {
+        assert.equal(artifact.length, 2);
+        assert.equal(artifact[0].resourceSize, 6);
+        assert.equal(artifact[0].gzipSize, undefined);
+      });
+  });
+
   it('ignores responses from installed Chrome extensions', () => {
     const traceData = {
       networkRecords: [

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -90,7 +90,7 @@ declare global {
       /** HTML snippets from any password inputs that prevent pasting. */
       PasswordInputsWithPreventedPaste: {snippet: string}[];
       /** Size info of all network records sent without compression and their size after gzipping. */
-      ResponseCompression: {requestId: string, url: string, mimeType: string, transferSize: number, resourceSize: number, gzipSize: number}[];
+      ResponseCompression: {requestId: string, url: string, mimeType: string, transferSize: number, resourceSize: number, gzipSize?: number}[];
       /** Information on fetching and the content of the /robots.txt file. */
       RobotsTxt: {status: number|null, content: string|null};
       /** Set of exceptions thrown during page load. */


### PR DESCRIPTION
While testing out 3.0 I noticed quite a few response-compression errors, this will handle partial failure and beacon to sentry without failing the whole audit.