### PR TITLE
extension(taburl): extension Error: couldn't resolve current tab

### DIFF
--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -257,9 +257,11 @@ async function initPopup() {
   // bind Generate Report button
   const generateReportButton = find('#generate-report');
   generateReportButton.addEventListener('click', () => {
-    background.loadSettings().then(settings => {
-      onGenerateReportButtonClick(background, settings);
-    });
+    if (!background.isRunning()) {
+      background.loadSettings().then(settings => {
+        onGenerateReportButtonClick(background, settings);
+      });
+    }
   });
 
   // bind View Options button

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -34,6 +34,8 @@ const subpageVisibleClass = 'subpage--visible';
 
 /** @type {?URL} */
 let siteURL = null;
+/** @type {boolean} */
+let isRunning = false;
 
 function getLighthouseVersion() {
   return chrome.runtime.getManifest().version;
@@ -147,6 +149,11 @@ function createOptionItem(text, id, isChecked) {
  * @param {{selectedCategories: Array<string>, useDevTools: boolean}} settings
  */
 async function onGenerateReportButtonClick(background, settings) {
+  if (isRunning) {
+    return;
+  }
+  isRunning = true;
+
   showRunningSubpage();
 
   const feedbackEl = find('.feedback');
@@ -185,6 +192,8 @@ async function onGenerateReportButtonClick(background, settings) {
     hideRunningSubpage();
     background.console.error(err);
   }
+
+  isRunning = false;
 }
 
 /**
@@ -257,11 +266,9 @@ async function initPopup() {
   // bind Generate Report button
   const generateReportButton = find('#generate-report');
   generateReportButton.addEventListener('click', () => {
-    if (!background.isRunning()) {
-      background.loadSettings().then(settings => {
-        onGenerateReportButtonClick(background, settings);
-      });
-    }
+    background.loadSettings().then(settings => {
+      onGenerateReportButtonClick(background, settings);
+    });
   });
 
   // bind View Options button


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
bugfix

<!-- Describe the need for this change -->
When you run the extension and hit enter immediately afterwards, lighthouse tries to start again which will start on about:blank and fails as it can't get an url from the tab.

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
https://github.com/GoogleChrome/lighthouse/issues?q=is%3Aissue+Error%3A+Couldn%27t+resolve+current+tab+is%3Aclosed