### PR TITLE
core: bump to v3.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+ <a name="3.0.1"></a>
+# 3.0.1 (2018-07-02)
+[Full Changelog](https://github.com/googlechrome/lighthouse/compare/v3.0.0...v3.0.1)
+
+## Core
+
+* fonts: handle CORS cssRules ([#5592](https://github.com/googlechrome/lighthouse/pull/5592))
+
+## Tests
+
+* adopt jest (leaving mocha) for core & cli ([#5386](https://github.com/googlechrome/lighthouse/pull/5386))
+
  <a name="3.0.0"></a>
 # 3.0.0 Final (2018-06-29)
 [Changelog of v3.0.0-beta.0 to 3.0 final](https://github.com/googlechrome/lighthouse/compare/v3.0.0-beta.0...v3.0.0)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -38,7 +38,8 @@ yarn install-all
 
 # * Bump it *
 yarn version --no-git-tag-version
-# then manually bump extension v in extension/app/manifest.json
+# manually bump extension v in extension/app/manifest.json
+yarn update:sample-json
 
 # * Build it *
 yarn build-all

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1,6 +1,6 @@
 {
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
-  "lighthouseVersion": "3.0.0",
+  "lighthouseVersion": "3.0.1",
   "fetchTime": "2018-03-13T00:55:45.840Z",
   "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",

--- a/lighthouse-extension/app/manifest.json
+++ b/lighthouse-extension/app/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_appName__",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "minimum_chrome_version": "66",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Lighthouse",
   "main": "./lighthouse-core/index.js",
   "bin": {


### PR DESCRIPTION
~This is going to the 3.0.x branch`, only to exclude the jest commit, right now.~

jk. master branch. I dbl-checked the jest commit and feel fine about it rolling into the patch rls.

