### PR TITLE
[WIP] report: i18n spike

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -75,10 +75,10 @@ class CategoryRenderer {
     if (audit.result.scoreDisplayMode === 'error') {
       auditEl.classList.add(`lh-audit--error`);
       const textEl = this.dom.find('.lh-audit__display-text', auditEl);
-      textEl.textContent = 'Error!';
+      textEl.textContent = Util.i18n(CR.strings.errorBang);
       textEl.classList.add('tooltip-boundary');
       const tooltip = this.dom.createChildOf(textEl, 'div', 'tooltip tooltip--error');
-      tooltip.textContent = audit.result.errorMessage || 'Report error: no audit information';
+      tooltip.textContent = audit.result.errorMessage || Util.i18n(CR.strings.errNoAuditInfo);
     } else if (audit.result.explanation) {
       const explEl = this.dom.createChildOf(titleEl, 'div', 'lh-audit-explanation');
       explEl.textContent = audit.result.explanation;
@@ -89,9 +89,10 @@ class CategoryRenderer {
     // Add list of warnings or singular warning
     const warningsEl = this.dom.createChildOf(titleEl, 'div', 'lh-warnings');
     if (warnings.length === 1) {
-      warningsEl.textContent = `Warning: ${warnings.join('')}`;
+      // TODO(i18n): Maybe need to construct this differently
+      warningsEl.textContent = `${Util.i18n(CR.strings.warningsColon)} ${warnings.join('')}`;
     } else {
-      warningsEl.textContent = 'Warnings: ';
+      warningsEl.textContent = Util.i18n(CR.strings.warningsColon);
       const warningsUl = this.dom.createChildOf(warningsEl, 'ul');
       for (const warning of warnings) {
         const item = this.dom.createChildOf(warningsUl, 'li');
@@ -158,7 +159,7 @@ class CategoryRenderer {
     const itemCountEl = this.dom.createChildOf(summmaryEl, 'div', 'lh-audit-group__itemcount');
     if (expandable) {
       const chevronEl = summmaryEl.appendChild(this._createChevron());
-      chevronEl.title = 'Show audits';
+      chevronEl.title = Util.i18n(CR.strings.showAudits);
     }
 
     if (group.description) {
@@ -168,8 +169,9 @@ class CategoryRenderer {
     }
     headerEl.textContent = group.title;
 
-    if (opts.itemCount) {
-      itemCountEl.textContent = `${opts.itemCount} audits`;
+    const itemCount = opts.itemCount;
+    if (itemCount) {
+      itemCountEl.textContent = Util.i18n(CR.strings.itemCountAudits, {itemCount});
     }
     return groupEl;
   }
@@ -211,7 +213,7 @@ class CategoryRenderer {
    */
   renderPassedAuditsSection(elements) {
     const passedElem = this.renderAuditGroup({
-      title: `Passed audits`,
+      title: Util.i18n(CR.strings.passedAudits),
     }, {expandable: true, itemCount: this._getTotalAuditsLength(elements)});
     passedElem.classList.add('lh-passed-audits');
     elements.forEach(elem => passedElem.appendChild(elem));
@@ -223,9 +225,10 @@ class CategoryRenderer {
    * @return {Element}
    */
   _renderNotApplicableAuditsSection(elements) {
+    elements = elements.slice(0, 1);
     const notApplicableElem = this.renderAuditGroup({
-      title: `Not applicable`,
-    }, {expandable: true, itemCount: this._getTotalAuditsLength(elements)});
+      title: Util.i18n(CR.strings.notApplicable),
+    }, {expandable: true, itemCount: 1});
     notApplicableElem.classList.add('lh-audit-group--not-applicable');
     elements.forEach(elem => notApplicableElem.appendChild(elem));
     return notApplicableElem;
@@ -237,7 +240,7 @@ class CategoryRenderer {
    * @return {Element}
    */
   _renderManualAudits(manualAudits, manualDescription) {
-    const group = {title: 'Additional items to manually check', description: manualDescription};
+    const group = {title: Util.i18n(CR.strings.addtlItems), description: manualDescription};
     const auditGroupElem = this.renderAuditGroup(group,
         {expandable: true, itemCount: manualAudits.length});
     auditGroupElem.classList.add('lh-audit-group--manual');
@@ -282,7 +285,7 @@ class CategoryRenderer {
     percentageEl.textContent = scoreOutOf100.toString();
     if (category.score === null) {
       percentageEl.textContent = '?';
-      percentageEl.title = 'Errors occurred while auditing';
+      percentageEl.title = Util.i18n(CR.strings.errorsDuringAuditing);
     }
 
     this.dom.find('.lh-gauge__label', tmpl).textContent = category.title;
@@ -403,6 +406,24 @@ class CategoryRenderer {
     permalinkEl.id = id;
   }
 }
+
+const CR = CategoryRenderer;
+CategoryRenderer.strings = {
+  errNoAuditInfo: 'Report error: no audit information',
+  errorBang: 'Error!',
+  warningColor: 'Warning',
+  warningsColon: 'Warnings: ',
+  showAudits: 'Show audits',
+  itemCountAudits: `{itemCount, plural,
+    =0 {0 audits}
+    one {1 audit}
+    other {{itemCount} audits}
+}`,
+  passedAudits: 'Passed audits',
+  notApplicable: 'Not applicable',
+  addtlItems: 'Additional items to manually check',
+  errorsDuringAuditing: 'Errors occurred while auditing',
+};
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = CategoryRenderer;

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -28,6 +28,22 @@ class Util {
   }
 
   /**
+   *
+   * @param {string} message
+   * @param {any=} values
+   * @param {string | string[]=} locales
+   * @param {any=} formats
+   * @return string
+   */
+  static i18n(message, values, locales, formats) {
+    /** @type {typeof IntlMessageFormat} */
+    const MessageFormat = IntlMessageFormat; // eslint-disable-line no-undef
+    // TODO(i18n): create a cache of these msgs
+    const msg = new MessageFormat(message, locales || MessageFormat.defaultLocale, formats);
+    return msg.format(values);
+  }
+
+  /**
    * @param {string|Array<string|number>=} displayValue
    * @return {string}
    */

--- a/lighthouse-core/report/html/report-template.html
+++ b/lighthouse-core/report/html/report-template.html
@@ -23,6 +23,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
   <script>%%LIGHTHOUSE_JAVASCRIPT%%
   //# sourceURL=compiled-reportrenderer.js
   </script>
+  <script src="https://unpkg.com/intl-messageformat@2.2.0/dist//intl-messageformat.js"></script>
   <script src="file:///Users/paulirish/code/lighthouse/psi-renderer.js"></script>
   <script>window.__LIGHTHOUSE_JSON__ = %%LIGHTHOUSE_JSON%%;</script>
   <script>

--- a/package.json
+++ b/package.json
@@ -23,16 +23,13 @@
     "build-viewer": "cd ./lighthouse-viewer && yarn build",
     "clean": "rimraf *.report.html *.report.dom.html *.report.json *.screenshots.html *.screenshots.json *.devtoolslog.json *.trace.json || true",
     "lint": "[ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .",
-
     "smoke": "node lighthouse-cli/test/smokehouse/run-smoke.js",
-
     "debug": "node --inspect-brk ./lighthouse-cli/index.js",
     "start": "node ./lighthouse-cli/index.js",
     "test": "yarn lint --quiet && yarn unit && yarn type-check && yarn diff:sample-json",
     "test-extension": "cd lighthouse-extension && yarn test",
     "test-viewer": "cd lighthouse-viewer && yarn pptr-test",
     "test-lantern": "bash lighthouse-core/scripts/test-lantern.sh",
-
     "unit-core": "mocha --reporter dot \"lighthouse-core/test/**/*-test.js\"",
     "unit-cli": "mocha --reporter dot \"lighthouse-cli/test/**/*-test.js\"",
     "unit-viewer": "mocha --reporter dot \"lighthouse-viewer/test/**/*-test.js\"",
@@ -41,14 +38,12 @@
     "cli-unit": "yarn unit-cli",
     "viewer-unit": "yarn unit-viewer",
     "watch": "yarn unit-core --watch",
-
     "unit:silentcoverage": "nyc --silent yarn unit && nyc report --reporter text-lcov > unit-coverage.lcov",
     "coverage": "nyc yarn unit && nyc report --reporter html",
     "smoke:silentcoverage": "nyc --silent yarn smoke && nyc report --reporter text-lcov > smoke-coverage.lcov",
     "coverage:smoke": "nyc yarn smoke && nyc report --reporter html",
     "coveralls": "cat unit-coverage.lcov | coveralls",
     "codecov": "codecov -f unit-coverage.lcov -F unit && codecov -f smoke-coverage.lcov -F smoke",
-
     "devtools": "bash lighthouse-core/scripts/roll-to-devtools.sh",
     "compile-devtools": "bash lighthouse-core/scripts/compile-against-devtools.sh",
     "chrome": "node lighthouse-core/scripts/manual-chrome-launcher.js",
@@ -71,6 +66,7 @@
     "@types/configstore": "^2.1.1",
     "@types/css-font-loading-module": "^0.0.2",
     "@types/inquirer": "^0.0.35",
+    "@types/intl-messageformat": "^1.3.0",
     "@types/jpeg-js": "^0.3.0",
     "@types/lodash.isequal": "^4.5.2",
     "@types/node": "*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   "include": [
     // TODO(bckenny): unnecessary workaround until https://github.com/Microsoft/TypeScript/issues/24062
     "node_modules/@types/node/index.d.ts",
+    "node_modules/@types/intl-messageformat/index.d.ts",
     "third-party/devtools/*.js",
 
     "lighthouse-cli/**/*.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,10 @@
     "@types/rx" "*"
     "@types/through" "*"
 
+"@types/intl-messageformat@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/intl-messageformat/-/intl-messageformat-1.3.0.tgz#6af7144802b13d62ade9ad68f8420cdb33b75916"
+
 "@types/jpeg-js@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/jpeg-js/-/jpeg-js-0.3.0.tgz#5971f0aa50900194e9565711c265c10027385e89"


### PR DESCRIPTION
There appears to be at least 3 primary libraries for working with the icu messageformat.

1. [`format-message`](https://github.com/format-message/format-message) - which made the very useful [Online ICU Message Editor](http://format-message.github.io/icu-message-format-for-translators/editor.html)
1. [`messageformat`](https://github.com/messageformat/messageformat) - which has these [pretty docs](https://messageformat.github.io/messageformat/)
1. [`intl-messageformat`](https://github.com/yahoo/intl-messageformat) - which is part of the larger [FormatJS](https://formatjs.io/) effort.

Also found [ttag/c-3po](https://c-3po.js.org/) which seems cool, though it has more opinionated integrations, afaict.

I chose `intl-messageformat`, originally made by yahoo. It's API follows the ES proposal, so its a prollyfill. Size/dependency-wise it seems good.  

------------

Nothing terribly interesting in the PR, I think. Not yet at least.

- L174/L417 (_anagram!_ 😮 ) is the only use of plurals.
- I added a `Util.i18n()` method, but am happy to handle it differently.

Next move is to extract strings from the rest of the renderer, especially including the `templates.html` file. 