### PR TITLE
core(fonts): [minor] bump timeout to 5s

### DIFF
--- a/lighthouse-core/gather/gatherers/fonts.js
+++ b/lighthouse-core/gather/gatherers/fonts.js
@@ -140,8 +140,8 @@ function getFontFaceFromStylesheets() {
       oldNode.parentNode && oldNode.parentNode.insertBefore(newNode, oldNode);
       oldNode.remove();
 
-      // Give each stylesheet 1s to load before giving up
-      setTimeout(() => resolve([{err: {message: 'Could not load stylesheet (timeout)'}}]), 1000);
+      // Give each stylesheet 5s to load before giving up
+      setTimeout(() => resolve([{err: {message: 'Could not load stylesheet (timeout)'}}]), 5000);
     });
   }
 


### PR DESCRIPTION
fonts timing out is one of our most popular errors on sentry right now, this bumps the timeout to 5s to give WPT a bit more time to load it (since they're still throttling even in afterPass)