### PR TITLE
core(i18n): localize strings at end of run

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -206,7 +206,7 @@ class RenderBlockingResources extends Audit {
 
     let displayValue = '';
     if (results.length > 0) {
-      displayValue = str_(i18n.UIStrings.columnWastedMs, {wastedMs});
+      displayValue = str_(i18n.UIStrings.displayValueWastedMs, {wastedMs});
     }
 
     /** @type {LH.Result.Audit.OpportunityDetails['headings']} */

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -31,10 +31,6 @@ const UIStrings = {
   description: 'Resources are blocking the first paint of your page. Consider ' +
     'delivering critical JS/CSS inline and deferring all non-critical ' +
     'JS/styles. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',
-  displayValue: `{itemCount, plural,
-    one {1 resource}
-    other {# resources}
-    } delayed first paint by {timeInMs, number, milliseconds} ms`,
 };
 
 const str_ = i18n.createStringFormatter(__filename, UIStrings);
@@ -210,14 +206,14 @@ class RenderBlockingResources extends Audit {
 
     let displayValue = '';
     if (results.length > 0) {
-      displayValue = str_(UIStrings.displayValue, {timeInMs: wastedMs, itemCount: results.length});
+      displayValue = str_(i18n.UIStrings.columnWastedMs, {wastedMs});
     }
 
     /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},
-      {key: 'wastedMs', valueType: 'timespanMs', label: str_(i18n.UIStrings.columnWastedTime)},
+      {key: 'wastedMs', valueType: 'timespanMs', label: str_(i18n.UIStrings.columnWastedMs)},
     ];
 
     const details = Audit.makeOpportunityDetails(headings, results, wastedMs);

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -33,7 +33,7 @@ const UIStrings = {
     'JS/styles. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).',
 };
 
-const str_ = i18n.createStringFormatter(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
 /**
  * Given a simulation's nodeTimings, return an object with the nodes/timing keyed by network URL

--- a/lighthouse-core/audits/metrics/interactive.js
+++ b/lighthouse-core/audits/metrics/interactive.js
@@ -14,7 +14,7 @@ const UIStrings = {
     '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive).',
 };
 
-const str_ = i18n.createStringFormatter(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
 /**
  * @fileoverview This audit identifies the time the page is "consistently interactive".

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -5,9 +5,21 @@
  */
 'use strict';
 
-const constants = require('./constants');
-
 /* eslint-disable max-len */
+
+const constants = require('./constants');
+const i18n = require('../lib/i18n');
+
+const UIStrings = {
+  performanceCategoryTitle: 'Performance',
+  metricGroupTitle: 'Metrics',
+  loadOpportunitiesGroupTitle: 'Opportunities',
+  loadOpportunitiesGroupDescription: 'These are opportunities to speed up your application by optimizing the following resources.',
+  diagnosticsGroupTitle: 'Diagnostics',
+  diagnosticsGroupDescription: 'More information about the performance of your application.',
+};
+
+const str_ = i18n.createStringFormatter(__filename, UIStrings);
 
 module.exports = {
   settings: constants.defaultSettings,
@@ -188,15 +200,15 @@ module.exports = {
 
   groups: {
     'metrics': {
-      title: 'Metrics',
+      title: str_(UIStrings.metricGroupTitle),
     },
     'load-opportunities': {
-      title: 'Opportunities',
-      description: 'These are opportunities to speed up your application by optimizing the following resources.',
+      title: str_(UIStrings.loadOpportunitiesGroupTitle),
+      description: str_(UIStrings.loadOpportunitiesGroupDescription),
     },
     'diagnostics': {
-      title: 'Diagnostics',
-      description: 'More information about the performance of your application.',
+      title: str_(UIStrings.diagnosticsGroupTitle),
+      description: str_(UIStrings.diagnosticsGroupDescription),
     },
     'a11y-color-contrast': {
       title: 'Color Contrast Is Satisfactory',
@@ -246,7 +258,7 @@ module.exports = {
   },
   categories: {
     'performance': {
-      title: 'Performance',
+      title: str_(UIStrings.performanceCategoryTitle),
       auditRefs: [
         {id: 'first-contentful-paint', weight: 3, group: 'metrics'},
         {id: 'first-meaningful-paint', weight: 1, group: 'metrics'},
@@ -409,3 +421,9 @@ module.exports = {
     },
   },
 };
+
+// Use `defineProperty` so that the strings are accesible from original but ignored when we copy it
+Object.defineProperty(module.exports, 'UIStrings', {
+  enumerable: false,
+  get: () => UIStrings,
+});

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -19,7 +19,7 @@ const UIStrings = {
   diagnosticsGroupDescription: 'More information about the performance of your application.',
 };
 
-const str_ = i18n.createStringFormatter(__filename, UIStrings);
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
 module.exports = {
   settings: constants.defaultSettings,

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -35,7 +35,7 @@ const Config = require('./config/config');
 async function lighthouse(url, flags, configJSON) {
   // TODO(bckenny): figure out Flags types.
   flags = flags || /** @type {LH.Flags} */ ({});
-  i18n.setLocale(flags.locale);
+  flags.locale = flags.locale || i18n.getDefaultLocale();
 
   // set logging preferences, assume quiet
   flags.logLevel = flags.logLevel || 'error';

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -35,7 +35,6 @@ const Config = require('./config/config');
 async function lighthouse(url, flags, configJSON) {
   // TODO(bckenny): figure out Flags types.
   flags = flags || /** @type {LH.Flags} */ ({});
-  flags.locale = flags.locale || i18n.getDefaultLocale();
 
   // set logging preferences, assume quiet
   flags.logLevel = flags.logLevel || 'error';

--- a/lighthouse-core/index.js
+++ b/lighthouse-core/index.js
@@ -8,7 +8,6 @@
 const Runner = require('./runner');
 const log = require('lighthouse-logger');
 const ChromeProtocol = require('./gather/connections/cri.js');
-const i18n = require('./lib/i18n');
 const Config = require('./config/config');
 
 /*

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -7,25 +7,31 @@
 
 const path = require('path');
 const isDeepEqual = require('lodash.isequal');
+const log = require('lighthouse-logger');
 const MessageFormat = require('intl-messageformat').default;
 const MessageParser = require('intl-messageformat-parser');
 const LOCALES = require('./locales');
 
 const LH_ROOT = path.join(__dirname, '../../');
 
-try {
-  // Node usually doesn't come with the locales we want built-in, so load the polyfill.
-  // In browser environments, we won't need the polyfill, and this will throw so wrap in try/catch.
+(() => {
+  // Node usually doesn't come with the locales we want built-in, so load the polyfill if we can.
 
-  // @ts-ignore
-  const IntlPolyfill = require('intl');
-  if (!IntlPolyfill.NumberFormat) throw new Error('Invalid polyfill');
+  try {
+    // @ts-ignore
+    const IntlPolyfill = require('intl');
+    // In browser environments where we don't need the polyfill, this won't exist
+    if (!IntlPolyfill.NumberFormat) return;
 
-  // @ts-ignore
-  Intl.NumberFormat = IntlPolyfill.NumberFormat;
-  // @ts-ignore
-  Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
-} catch (_) {}
+    // @ts-ignore
+    Intl.NumberFormat = IntlPolyfill.NumberFormat;
+    // @ts-ignore
+    Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
+  } catch (_) {
+    log.warn('i18n', 'Failed to install `intl` polyfill');
+  }
+})();
+
 
 const UIStrings = {
   ms: '{timeInMs, number, milliseconds}\xa0ms',

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -135,7 +135,8 @@ module.exports = {
       if (!keyname) throw new Error(`Could not locate: ${template}`);
 
       const filenameToLookup = keyname in UIStrings ? __filename : filename;
-      const key = path.relative(LH_ROOT, filenameToLookup) + '!#' + keyname;
+      const unixStyleFilename = path.relative(LH_ROOT, filenameToLookup).replace(/\\/g, '/');
+      const key = unixStyleFilename + '!#' + keyname;
       const keyUsages = formattedStringUsages.get(key) || [];
       keyUsages.push({key, template, values});
       formattedStringUsages.set(key, keyUsages);

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -161,6 +161,7 @@ function replaceLocaleStringReferences(lhr, locale) {
     for (const [property, value] of Object.entries(objectInLHR)) {
       const currentPathInLHR = pathInLHR.concat([property]);
 
+      // Check to see if the value in the LHR looks like a string reference. If it is, replace it.
       if (typeof value === 'string' && /.* \| .* # \d+$/.test(value)) {
         // @ts-ignore - Guaranteed to match from .test call above
         const [_, templateID, usageIndex] = value.match(/(.*) # (\d+)$/);

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -10,8 +10,6 @@ const MessageFormat = require('intl-messageformat').default;
 const MessageParser = require('intl-messageformat-parser');
 const LOCALES = require('./locales');
 
-let locale = MessageFormat.defaultLocale;
-
 const LH_ROOT = path.join(__dirname, '../../');
 
 try {
@@ -43,23 +41,87 @@ const formats = {
 
 /**
  * @param {string} msg
- * @param {Record<string, *>} values
+ * @param {Record<string, *>} [values]
  */
 function preprocessMessageValues(msg, values) {
+  if (!values) return;
+
+  const clonedValues = JSON.parse(JSON.stringify(values));
   const parsed = MessageParser.parse(msg);
   // Round all milliseconds to 10s place
   parsed.elements
     .filter(el => el.format && el.format.style === 'milliseconds')
-    .forEach(el => (values[el.id] = Math.round(values[el.id] / 10) * 10));
+    .forEach(el => (clonedValues[el.id] = Math.round(clonedValues[el.id] / 10) * 10));
 
   // Replace all the bytes with KB
   parsed.elements
     .filter(el => el.format && el.format.style === 'bytes')
-    .forEach(el => (values[el.id] = values[el.id] / 1024));
+    .forEach(el => (clonedValues[el.id] = clonedValues[el.id] / 1024));
+
+  return clonedValues;
+}
+
+/**
+ * @typedef StringUsage
+ * @prop {string} key
+ * @prop {string} template
+ * @prop {*} [values]
+ */
+
+/** @type {Map<string, StringUsage[]>} */
+const formattedStringUsages = new Map();
+
+/**
+ *
+ * @param {LH.Locale} locale
+ * @param {string} templateKey
+ * @param {string} template
+ * @param {*} [values]
+ */
+function formatTemplate(locale, templateKey, template, values) {
+  const localeTemplates = LOCALES[locale] || {};
+  const localeTemplate = localeTemplates[templateKey] && localeTemplates[templateKey].message;
+  // fallback to the original english message if we couldn't find a message in the specified locale
+  // better to have an english message than no message at all, in some number cases it won't even matter
+  const templateForMessageFormat = localeTemplate || template;
+  // when using accented english, force the use of a different locale for number formatting
+  const localeForMessageFormat = locale === 'en-XA' ? 'de-DE' : locale;
+  // pre-process values for the message format like KB and milliseconds
+  const valuesForMessageFormat = preprocessMessageValues(template, values);
+
+  const formatter = new MessageFormat(templateForMessageFormat, localeForMessageFormat, formats);
+  const message = formatter.format(valuesForMessageFormat);
+
+  return {message, template: templateForMessageFormat};
+}
+
+/** @param {string[]} path */
+function formatPathAsString(path) {
+  let pathAsString = '';
+  for (const property of path) {
+    if (/^[a-z]+$/i.test(property)) {
+      if (pathAsString.length) pathAsString += '.';
+      pathAsString += property;
+    } else {
+      if (/]|"|'/.test(property)) throw new Error(`Cannot handle "${property}" in i18n`);
+      pathAsString += `[${property}]`;
+    }
+  }
+
+  return pathAsString;
 }
 
 module.exports = {
   UIStrings,
+  formatPathAsString,
+  /**
+   * @return {LH.Locale}
+   */
+  getDefaultLocale() {
+    const defaultLocale = MessageFormat.defaultLocale;
+    if (defaultLocale in LOCALES) return /** @type {LH.Locale} */ (defaultLocale);
+    return 'en-US';
+  },
   /**
    * @param {string} filename
    * @param {Record<string, string>} fileStrings
@@ -67,33 +129,61 @@ module.exports = {
   createStringFormatter(filename, fileStrings) {
     const mergedStrings = {...UIStrings, ...fileStrings};
 
-    /** @param {string} msg @param {*} [values] */
-    const formatFn = (msg, values) => {
-      const keyname = Object.keys(mergedStrings).find(key => mergedStrings[key] === msg);
-      if (!keyname) throw new Error(`Could not locate: ${msg}`);
-      preprocessMessageValues(msg, values);
+    /** @param {string} template @param {*} [values] */
+    const formatFn = (template, values) => {
+      const keyname = Object.keys(mergedStrings).find(key => mergedStrings[key] === template);
+      if (!keyname) throw new Error(`Could not locate: ${template}`);
 
       const filenameToLookup = keyname in UIStrings ? __filename : filename;
-      const lookupKey = path.relative(LH_ROOT, filenameToLookup) + '!#' + keyname;
-      const localeStrings = LOCALES[locale] || {};
-      const localeString = localeStrings[lookupKey] && localeStrings[lookupKey].message;
-      // fallback to the original english message if we couldn't find a message in the specified locale
-      // better to have an english message than no message at all, in some number cases it won't even matter
-      const messageForMessageFormat = localeString || msg;
-      // when using accented english, force the use of a different locale for number formatting
-      const localeForMessageFormat = locale === 'en-XA' ? 'de-DE' : locale;
+      const key = path.relative(LH_ROOT, filenameToLookup) + '!#' + keyname;
+      const keyUsages = formattedStringUsages.get(key) || [];
+      keyUsages.push({key, template, values});
+      formattedStringUsages.set(key, keyUsages);
 
-      const formatter = new MessageFormat(messageForMessageFormat, localeForMessageFormat, formats);
-      return formatter.format(values);
+      return `${key}#${keyUsages.length - 1}`;
     };
 
     return formatFn;
   },
   /**
-   * @param {LH.Locale|null} [newLocale]
+   * @param {LH.Result} lhr
+   * @param {LH.Locale} locale
    */
-  setLocale(newLocale) {
-    if (!newLocale) return;
-    locale = newLocale;
+  replaceLocaleStringReferences(lhr, locale) {
+    /**
+     * @param {*} objectInLHR
+     * @param {LH.LocaleLog} log
+     * @param {string[]} path
+     */
+    function replaceInObject(objectInLHR, log, path = []) {
+      if (typeof objectInLHR !== 'object' || !objectInLHR) return;
+
+      for (const [property, value] of Object.entries(objectInLHR)) {
+        const currentPath = path.concat([property]);
+
+        if (typeof value === 'string' && /.*!#.*#\d+$/.test(value)) {
+          // @ts-ignore - Guaranteed to match from .test call above
+          const [_, templateKey, usageIndex] = value.match(/(.*)#(\d+)$/);
+          const templateLogRecord = log[templateKey] || [];
+          const usages = formattedStringUsages.get(templateKey) || [];
+          const usage = usages[Number(usageIndex)];
+          const pathAsString = formatPathAsString(currentPath);
+          templateLogRecord.push(
+            usage.values ? {values: usage.values, path: pathAsString} : pathAsString
+          );
+
+          const {message} = formatTemplate(locale, templateKey, usage.template, usage.values);
+
+          objectInLHR[property] = message;
+          log[templateKey] = templateLogRecord;
+        } else {
+          replaceInObject(value, log, currentPath);
+        }
+      }
+    }
+
+    const log = {};
+    replaceInObject(lhr, log);
+    lhr.localeLog = log;
   },
 };

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -18,6 +18,8 @@ try {
 
   // @ts-ignore
   const IntlPolyfill = require('intl');
+  if (!IntlPolyfill.NumberFormat) throw new Error('Invalid polyfill');
+
   // @ts-ignore
   Intl.NumberFormat = IntlPolyfill.NumberFormat;
   // @ts-ignore

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -30,7 +30,7 @@ const UIStrings = {
   ms: '{timeInMs, number, milliseconds}\xa0ms',
   columnURL: 'URL',
   columnSize: 'Size (KB)',
-  columnWastedTime: 'Potential Savings (ms)',
+  columnWastedMs: 'Potential Savings (ms)',
 };
 
 const formats = {

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -161,6 +161,8 @@ function createMessageInstanceIdFn(filename, fileStrings) {
  * @param {LH.Locale} locale
  */
 function replaceIcuMessageInstanceIds(lhr, locale) {
+  const MESSAGE_INSTANCE_ID_REGEX = /(.* \| .*) # (\d+)$/;
+
   /**
    * @param {*} objectInLHR
    * @param {LH.I18NMessages} icuMessagePaths
@@ -173,9 +175,9 @@ function replaceIcuMessageInstanceIds(lhr, locale) {
       const currentPathInLHR = pathInLHR.concat([property]);
 
       // Check to see if the value in the LHR looks like a string reference. If it is, replace it.
-      if (typeof value === 'string' && /.* \| .* # \d+$/.test(value)) {
+      if (typeof value === 'string' && MESSAGE_INSTANCE_ID_REGEX.test(value)) {
         // @ts-ignore - Guaranteed to match from .test call above
-        const [_, icuMessageId, icuMessageInstanceIndex] = value.match(/(.*) # (\d+)$/);
+        const [_, icuMessageId, icuMessageInstanceIndex] = value.match(MESSAGE_INSTANCE_ID_REGEX);
         const messageInstancesInLHR = icuMessagePaths[icuMessageId] || [];
         const icuMessageInstances = _icuMessageInstanceMap.get(icuMessageId) || [];
         const icuMessageInstance = icuMessageInstances[Number(icuMessageInstanceIndex)];

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const path = require('path');
+const isDeepEqual = require('lodash.isequal');
 const MessageFormat = require('intl-messageformat').default;
 const MessageParser = require('intl-messageformat-parser');
 const LOCALES = require('./locales');
@@ -138,10 +139,16 @@ function createStringFormatter(filename, fileStrings) {
     const unixStyleFilename = path.relative(LH_ROOT, filenameToLookup).replace(/\\/g, '/');
     const templateID = `${unixStyleFilename} | ${keyname}`;
     const templateUsages = formattedStringUsages.get(templateID) || [];
-    templateUsages.push({templateID, template, values});
+
+    let indexOfUsage = templateUsages.findIndex(usage => isDeepEqual(usage.values, values));
+    if (indexOfUsage === -1) {
+      templateUsages.push({templateID, template, values});
+      indexOfUsage = templateUsages.length - 1;
+    }
+
     formattedStringUsages.set(templateID, templateUsages);
 
-    return `${templateID} # ${templateUsages.length - 1}`;
+    return `${templateID} # ${indexOfUsage}`;
   };
 
   return formatFn;

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -32,6 +32,7 @@ const UIStrings = {
   columnURL: 'URL',
   columnSize: 'Size (KB)',
   columnWastedMs: 'Potential Savings (ms)',
+  displayValueWastedMs: 'Potential savings of {wastedMs, number, milliseconds}\xa0ms',
 };
 
 const formats = {

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -5,9 +5,6 @@
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
     "message": "Resources are blocking the first paint of your page. Consider delivering critical JS/CSS inline and deferring all non-critical JS/styles. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
-  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | displayValue": {
-    "message": "{itemCount, plural,\n    one {1 resource}\n    other {# resources}\n    } delayed first paint by {timeInMs, number, milliseconds} ms"
-  },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Time to Interactive"
   },
@@ -41,7 +38,7 @@
   "lighthouse-core/lib/i18n.js | columnSize": {
     "message": "Size (KB)"
   },
-  "lighthouse-core/lib/i18n.js | columnWastedTime": {
+  "lighthouse-core/lib/i18n.js | columnWastedMs": {
     "message": "Potential Savings (ms)"
   }
 }

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -14,11 +14,23 @@
   "lighthouse-core/audits/metrics/interactive.js!#description": {
     "message": "Interactive marks the time at which the page is fully interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
+  "lighthouse-core/config/default-config.js!#performanceCategoryTitle": {
+    "message": "Performance"
+  },
   "lighthouse-core/config/default-config.js!#metricGroupTitle": {
     "message": "Metrics"
   },
   "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupTitle": {
     "message": "Opportunities"
+  },
+  "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupDescription": {
+    "message": "These are opportunities to speed up your application by optimizing the following resources."
+  },
+  "lighthouse-core/config/default-config.js!#diagnosticsGroupTitle": {
+    "message": "Diagnostics"
+  },
+  "lighthouse-core/config/default-config.js!#diagnosticsGroupDescription": {
+    "message": "More information about the performance of your application."
   },
   "lighthouse-core/lib/i18n.js!#ms": {
     "message": "{timeInMs, number, milliseconds} ms"

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -1,47 +1,47 @@
 {
-  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#title": {
+  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Eliminate render-blocking resources"
   },
-  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#description": {
+  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
     "message": "Resources are blocking the first paint of your page. Consider delivering critical JS/CSS inline and deferring all non-critical JS/styles. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources)."
   },
-  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#displayValue": {
+  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | displayValue": {
     "message": "{itemCount, plural,\n    one {1 resource}\n    other {# resources}\n    } delayed first paint by {timeInMs, number, milliseconds} ms"
   },
-  "lighthouse-core/audits/metrics/interactive.js!#title": {
+  "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "Time to Interactive"
   },
-  "lighthouse-core/audits/metrics/interactive.js!#description": {
+  "lighthouse-core/audits/metrics/interactive.js | description": {
     "message": "Interactive marks the time at which the page is fully interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
-  "lighthouse-core/config/default-config.js!#performanceCategoryTitle": {
+  "lighthouse-core/config/default-config.js | performanceCategoryTitle": {
     "message": "Performance"
   },
-  "lighthouse-core/config/default-config.js!#metricGroupTitle": {
+  "lighthouse-core/config/default-config.js | metricGroupTitle": {
     "message": "Metrics"
   },
-  "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupTitle": {
+  "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Opportunities"
   },
-  "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupDescription": {
+  "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
     "message": "These are opportunities to speed up your application by optimizing the following resources."
   },
-  "lighthouse-core/config/default-config.js!#diagnosticsGroupTitle": {
+  "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "Diagnostics"
   },
-  "lighthouse-core/config/default-config.js!#diagnosticsGroupDescription": {
+  "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
     "message": "More information about the performance of your application."
   },
-  "lighthouse-core/lib/i18n.js!#ms": {
+  "lighthouse-core/lib/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },
-  "lighthouse-core/lib/i18n.js!#columnURL": {
+  "lighthouse-core/lib/i18n.js | columnURL": {
     "message": "URL"
   },
-  "lighthouse-core/lib/i18n.js!#columnSize": {
+  "lighthouse-core/lib/i18n.js | columnSize": {
     "message": "Size (KB)"
   },
-  "lighthouse-core/lib/i18n.js!#columnWastedTime": {
+  "lighthouse-core/lib/i18n.js | columnWastedTime": {
     "message": "Potential Savings (ms)"
   }
 }

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -14,6 +14,12 @@
   "lighthouse-core/audits/metrics/interactive.js!#description": {
     "message": "Interactive marks the time at which the page is fully interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive)."
   },
+  "lighthouse-core/config/default-config.js!#metricGroupTitle": {
+    "message": "Metrics"
+  },
+  "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupTitle": {
+    "message": "Opportunities"
+  },
   "lighthouse-core/lib/i18n.js!#ms": {
     "message": "{timeInMs, number, milliseconds} ms"
   },

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -40,5 +40,8 @@
   },
   "lighthouse-core/lib/i18n.js | columnWastedMs": {
     "message": "Potential Savings (ms)"
+  },
+  "lighthouse-core/lib/i18n.js | displayValueWastedMs": {
+    "message": "Potential savings of {wastedMs, number, milliseconds} ms"
   }
 }

--- a/lighthouse-core/lib/locales/en-XA.json
+++ b/lighthouse-core/lib/locales/en-XA.json
@@ -14,11 +14,23 @@
   "lighthouse-core/audits/metrics/interactive.js!#description": {
     "message": "Îńt̂ér̂áĉt́îv́ê ḿâŕk̂ś t̂h́ê t́îḿê át̂ ẃĥíĉh́ t̂h́ê ṕâǵê íŝ f́ûĺl̂ý îńt̂ér̂áĉt́îv́ê. [Ĺêár̂ń m̂ór̂é](ĥt́t̂ṕŝ://d́êv́êĺôṕêŕŝ.ǵôóĝĺê.ćôḿ/ŵéb̂/t́ôól̂ś/l̂íĝh́t̂h́ôúŝé/âúd̂ít̂ś/ĉón̂śîśt̂én̂t́l̂ý-îńt̂ér̂áĉt́îv́ê)."
   },
+  "lighthouse-core/config/default-config.js!#performanceCategoryTitle": {
+    "message": "P̂ér̂f́ôŕm̂án̂ćê"
+  },
   "lighthouse-core/config/default-config.js!#metricGroupTitle": {
     "message": "M̂ét̂ŕîćŝ"
   },
   "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupTitle": {
     "message": "Ôṕp̂ór̂t́ûńît́îéŝ"
+  },
+  "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupDescription": {
+    "message": "T̂h́êśê ár̂é ôṕp̂ór̂t́ûńît́îéŝ t́ô śp̂éêd́ ûṕ ŷóûŕ âṕp̂ĺîćât́îón̂ b́ŷ óp̂t́îḿîźîńĝ t́ĥé f̂ól̂ĺôẃîńĝ ŕêśôúr̂ćêś."
+  },
+  "lighthouse-core/config/default-config.js!#diagnosticsGroupTitle": {
+    "message": "D̂íâǵn̂óŝt́îćŝ"
+  },
+  "lighthouse-core/config/default-config.js!#diagnosticsGroupDescription": {
+    "message": "M̂ór̂é îńf̂ór̂ḿât́îón̂ áb̂óût́ t̂h́ê ṕêŕf̂ór̂ḿâńĉé ôf́ ŷóûŕ âṕp̂ĺîćât́îón̂."
   },
   "lighthouse-core/lib/i18n.js!#ms": {
     "message": "{timeInMs, number, milliseconds} m̂ś"

--- a/lighthouse-core/lib/locales/en-XA.json
+++ b/lighthouse-core/lib/locales/en-XA.json
@@ -14,6 +14,12 @@
   "lighthouse-core/audits/metrics/interactive.js!#description": {
     "message": "Îńt̂ér̂áĉt́îv́ê ḿâŕk̂ś t̂h́ê t́îḿê át̂ ẃĥíĉh́ t̂h́ê ṕâǵê íŝ f́ûĺl̂ý îńt̂ér̂áĉt́îv́ê. [Ĺêár̂ń m̂ór̂é](ĥt́t̂ṕŝ://d́êv́êĺôṕêŕŝ.ǵôóĝĺê.ćôḿ/ŵéb̂/t́ôól̂ś/l̂íĝh́t̂h́ôúŝé/âúd̂ít̂ś/ĉón̂śîśt̂én̂t́l̂ý-îńt̂ér̂áĉt́îv́ê)."
   },
+  "lighthouse-core/config/default-config.js!#metricGroupTitle": {
+    "message": "M̂ét̂ŕîćŝ"
+  },
+  "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupTitle": {
+    "message": "Ôṕp̂ór̂t́ûńît́îéŝ"
+  },
   "lighthouse-core/lib/i18n.js!#ms": {
     "message": "{timeInMs, number, milliseconds} m̂ś"
   },

--- a/lighthouse-core/lib/locales/en-XA.json
+++ b/lighthouse-core/lib/locales/en-XA.json
@@ -40,5 +40,8 @@
   },
   "lighthouse-core/lib/i18n.js | columnWastedMs": {
     "message": "P̂ót̂én̂t́îál̂ Śâv́îńĝś (m̂ś)"
+  },
+  "lighthouse-core/lib/i18n.js | displayValueWastedMs": {
+    "message": "P̂ót̂én̂t́îál̂ śâv́îńĝś ôf́ {wastedMs, number, milliseconds} m̂ś"
   }
 }

--- a/lighthouse-core/lib/locales/en-XA.json
+++ b/lighthouse-core/lib/locales/en-XA.json
@@ -1,47 +1,47 @@
 {
-  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#title": {
+  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": {
     "message": "Êĺîḿîńât́ê ŕêńd̂ér̂-b́l̂óĉḱîńĝ ŕêśôúr̂ćêś"
   },
-  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#description": {
+  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
     "message": "R̂éŝóûŕĉéŝ ár̂é b̂ĺôćk̂ín̂ǵ t̂h́ê f́îŕŝt́ p̂áîńt̂ óf̂ ýôúr̂ ṕâǵê. Ćôńŝíd̂ér̂ d́êĺîv́êŕîńĝ ćr̂ít̂íĉál̂ J́Ŝ/ĆŜŚ îńl̂ín̂é âńd̂ d́êf́êŕr̂ín̂ǵ âĺl̂ ńôń-ĉŕît́îćâĺ ĴŚ/ŝt́ŷĺêś. [L̂éâŕn̂ ḿôŕê](h́t̂t́p̂ś://d̂év̂él̂óp̂ér̂ś.ĝóôǵl̂é.ĉóm̂/ẃêb́/t̂óôĺŝ/ĺîǵĥt́ĥóûśê/áûd́ît́ŝ/b́l̂óĉḱîńĝ-ŕêśôúr̂ćêś)."
   },
-  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#displayValue": {
+  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | displayValue": {
     "message": "{itemCount, plural,\n    one {1 resource}\n    other {# resources}\n    } d̂él̂áŷéd̂ f́îŕŝt́ p̂áîńt̂ b́ŷ {timeInMs, number, milliseconds} ḿŝ"
   },
-  "lighthouse-core/audits/metrics/interactive.js!#title": {
+  "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "T̂ím̂é t̂ó Îńt̂ér̂áĉt́îv́ê"
   },
-  "lighthouse-core/audits/metrics/interactive.js!#description": {
+  "lighthouse-core/audits/metrics/interactive.js | description": {
     "message": "Îńt̂ér̂áĉt́îv́ê ḿâŕk̂ś t̂h́ê t́îḿê át̂ ẃĥíĉh́ t̂h́ê ṕâǵê íŝ f́ûĺl̂ý îńt̂ér̂áĉt́îv́ê. [Ĺêár̂ń m̂ór̂é](ĥt́t̂ṕŝ://d́êv́êĺôṕêŕŝ.ǵôóĝĺê.ćôḿ/ŵéb̂/t́ôól̂ś/l̂íĝh́t̂h́ôúŝé/âúd̂ít̂ś/ĉón̂śîśt̂én̂t́l̂ý-îńt̂ér̂áĉt́îv́ê)."
   },
-  "lighthouse-core/config/default-config.js!#performanceCategoryTitle": {
+  "lighthouse-core/config/default-config.js | performanceCategoryTitle": {
     "message": "P̂ér̂f́ôŕm̂án̂ćê"
   },
-  "lighthouse-core/config/default-config.js!#metricGroupTitle": {
+  "lighthouse-core/config/default-config.js | metricGroupTitle": {
     "message": "M̂ét̂ŕîćŝ"
   },
-  "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupTitle": {
+  "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": {
     "message": "Ôṕp̂ór̂t́ûńît́îéŝ"
   },
-  "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupDescription": {
+  "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": {
     "message": "T̂h́êśê ár̂é ôṕp̂ór̂t́ûńît́îéŝ t́ô śp̂éêd́ ûṕ ŷóûŕ âṕp̂ĺîćât́îón̂ b́ŷ óp̂t́îḿîźîńĝ t́ĥé f̂ól̂ĺôẃîńĝ ŕêśôúr̂ćêś."
   },
-  "lighthouse-core/config/default-config.js!#diagnosticsGroupTitle": {
+  "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": {
     "message": "D̂íâǵn̂óŝt́îćŝ"
   },
-  "lighthouse-core/config/default-config.js!#diagnosticsGroupDescription": {
+  "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
     "message": "M̂ór̂é îńf̂ór̂ḿât́îón̂ áb̂óût́ t̂h́ê ṕêŕf̂ór̂ḿâńĉé ôf́ ŷóûŕ âṕp̂ĺîćât́îón̂."
   },
-  "lighthouse-core/lib/i18n.js!#ms": {
+  "lighthouse-core/lib/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} m̂ś"
   },
-  "lighthouse-core/lib/i18n.js!#columnURL": {
+  "lighthouse-core/lib/i18n.js | columnURL": {
     "message": "ÛŔL̂"
   },
-  "lighthouse-core/lib/i18n.js!#columnSize": {
+  "lighthouse-core/lib/i18n.js | columnSize": {
     "message": "Ŝíẑé (K̂B́)"
   },
-  "lighthouse-core/lib/i18n.js!#columnWastedTime": {
+  "lighthouse-core/lib/i18n.js | columnWastedTime": {
     "message": "P̂ót̂én̂t́îál̂ Śâv́îńĝś (m̂ś)"
   }
 }

--- a/lighthouse-core/lib/locales/en-XA.json
+++ b/lighthouse-core/lib/locales/en-XA.json
@@ -5,9 +5,6 @@
   "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": {
     "message": "R̂éŝóûŕĉéŝ ár̂é b̂ĺôćk̂ín̂ǵ t̂h́ê f́îŕŝt́ p̂áîńt̂ óf̂ ýôúr̂ ṕâǵê. Ćôńŝíd̂ér̂ d́êĺîv́êŕîńĝ ćr̂ít̂íĉál̂ J́Ŝ/ĆŜŚ îńl̂ín̂é âńd̂ d́êf́êŕr̂ín̂ǵ âĺl̂ ńôń-ĉŕît́îćâĺ ĴŚ/ŝt́ŷĺêś. [L̂éâŕn̂ ḿôŕê](h́t̂t́p̂ś://d̂év̂él̂óp̂ér̂ś.ĝóôǵl̂é.ĉóm̂/ẃêb́/t̂óôĺŝ/ĺîǵĥt́ĥóûśê/áûd́ît́ŝ/b́l̂óĉḱîńĝ-ŕêśôúr̂ćêś)."
   },
-  "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | displayValue": {
-    "message": "{itemCount, plural,\n    one {1 resource}\n    other {# resources}\n    } d̂él̂áŷéd̂ f́îŕŝt́ p̂áîńt̂ b́ŷ {timeInMs, number, milliseconds} ḿŝ"
-  },
   "lighthouse-core/audits/metrics/interactive.js | title": {
     "message": "T̂ím̂é t̂ó Îńt̂ér̂áĉt́îv́ê"
   },
@@ -41,7 +38,7 @@
   "lighthouse-core/lib/i18n.js | columnSize": {
     "message": "Ŝíẑé (K̂B́)"
   },
-  "lighthouse-core/lib/i18n.js | columnWastedTime": {
+  "lighthouse-core/lib/i18n.js | columnWastedMs": {
     "message": "P̂ót̂én̂t́îál̂ Śâv́îńĝś (m̂ś)"
   }
 }

--- a/lighthouse-core/lib/locales/index.js
+++ b/lighthouse-core/lib/locales/index.js
@@ -7,5 +7,6 @@
 'use strict';
 
 module.exports = {
+  'en-US': require('./en-US.json'),
   'en-XA': require('./en-XA.json'),
 };

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -32,7 +32,7 @@ class Runner {
     try {
       const startTime = Date.now();
       const settings = opts.config.settings;
-      settings.locale = settings.locale || i18n.getDefaultLocale()
+      settings.locale = settings.locale || i18n.getDefaultLocale();
 
       /**
        * List of top-level warnings for this Lighthouse run.

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -32,6 +32,7 @@ class Runner {
     try {
       const startTime = Date.now();
       const settings = opts.config.settings;
+      settings.locale = settings.locale || i18n.getDefaultLocale()
 
       /**
        * List of top-level warnings for this Lighthouse run.

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -11,6 +11,7 @@ const GatherRunner = require('./gather/gather-runner');
 const ReportScoring = require('./scoring');
 const Audit = require('./audits/audit');
 const log = require('lighthouse-logger');
+const i18n = require('./lib/i18n');
 const assetSaver = require('./lib/asset-saver');
 const fs = require('fs');
 const path = require('path');
@@ -133,6 +134,8 @@ class Runner {
         categoryGroups: opts.config.groups || undefined,
         timing: {total: Date.now() - startTime},
       };
+
+      i18n.replaceLocaleStringReferences(lhr, settings.locale);
 
       const report = generateReport(lhr, settings.output);
       return {lhr, artifacts, report};

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -137,7 +137,7 @@ class Runner {
         timing: {total: Date.now() - startTime},
       };
 
-      i18n.replaceLocaleStringReferences(lhr, settings.locale);
+      i18n.replaceIcuMessageInstanceIds(lhr, settings.locale);
 
       const report = generateReport(lhr, settings.output);
       return {lhr, artifacts, report};

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -40,7 +40,7 @@ function collectAllStringsInDir(dir, strings = {}) {
         const mod = require(fullPath);
         if (!mod.UIStrings) continue;
         for (const [key, value] of Object.entries(mod.UIStrings)) {
-          strings[`${relativePath}!#${key}`] = value;
+          strings[`${relativePath} | ${key}`] = value;
         }
       }
     }

--- a/lighthouse-core/test/audits/metrics/interactive-test.js
+++ b/lighthouse-core/test/audits/metrics/interactive-test.js
@@ -7,7 +7,6 @@
 
 const Interactive = require('../../../audits/metrics/interactive.js');
 const Runner = require('../../../runner.js');
-const Util = require('../../../report/html/renderer/util');
 const assert = require('assert');
 const options = Interactive.defaultOptions;
 
@@ -35,7 +34,7 @@ describe('Performance: interactive audit', () => {
     return Interactive.audit(artifacts, {options, settings}).then(output => {
       assert.equal(output.score, 1);
       assert.equal(Math.round(output.rawValue), 1582);
-      assert.equal(Util.formatDisplayValue(output.displayValue), '1,580\xa0ms');
+      assert.ok(output.displayValue);
     });
   });
 
@@ -53,7 +52,7 @@ describe('Performance: interactive audit', () => {
     return Interactive.audit(artifacts, {options, settings}).then(output => {
       assert.equal(output.score, 0.97);
       assert.equal(Math.round(output.rawValue), 2712);
-      assert.equal(Util.formatDisplayValue(output.displayValue), '2,710\xa0ms');
+      assert.ok(output.displayValue);
     });
   });
 });

--- a/lighthouse-core/test/lib/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n-test.js
@@ -1,0 +1,57 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const path = require('path');
+const i18n = require('../../lib/i18n');
+
+/* eslint-env jest */
+
+describe('i18n', () => {
+  describe('#formatPathAsString', () => {
+    it('handles simple paths', () => {
+      expect(i18n.formatPathAsString(['foo'])).toBe('foo');
+      expect(i18n.formatPathAsString(['foo', 'bar', 'baz'])).toBe('foo.bar.baz');
+    });
+
+    it('handles array paths', () => {
+      expect(i18n.formatPathAsString(['foo', 0])).toBe('foo[0]');
+    });
+
+    it('handles complex paths', () => {
+      const propertyPath = ['foo', 'what-the', 'bar', 0, 'no'];
+      expect(i18n.formatPathAsString(propertyPath)).toBe('foo[what-the].bar[0].no');
+    });
+
+    it('throws on unhandleable paths', () => {
+      expect(() => i18n.formatPathAsString(['Bobby "DROP TABLE'])).toThrow(/Cannot handle/);
+    });
+  });
+
+  describe('#createStringFormatter', () => {
+    it('returns a string reference', () => {
+      const fakeFile = path.join(__dirname, 'fake-file.js');
+      const templates = {daString: 'use me!'};
+      const formatter = i18n.createStringFormatter(fakeFile, templates);
+
+      const expected = 'lighthouse-core/test/lib/fake-file.js!#daString#0';
+      expect(formatter(templates.daString, {x: 1})).toBe(expected);
+    });
+  });
+
+  describe('#replaceLocaleStringReferences', () => {
+    it('replaces the references in the LHR', () => {
+      const templateID = 'lighthouse-core/test/lib/fake-file.js!#daString';
+      const reference = templateID + '#0';
+      const lhr = {audits: {'fake-audit': {title: reference}}};
+
+      i18n.replaceLocaleStringReferences(lhr, 'en-US');
+      expect(lhr.audits['fake-audit'].title).toBe('use me!');
+      expect(lhr.localeLog).toEqual({
+        [templateID]: [{path: 'audits[fake-audit].title', values: {x: 1}}]});
+    });
+  });
+});

--- a/lighthouse-core/test/lib/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n-test.js
@@ -11,23 +11,23 @@ const i18n = require('../../lib/i18n');
 /* eslint-env jest */
 
 describe('i18n', () => {
-  describe('#formatPathAsString', () => {
+  describe('#_formatPathAsString', () => {
     it('handles simple paths', () => {
-      expect(i18n.formatPathAsString(['foo'])).toBe('foo');
-      expect(i18n.formatPathAsString(['foo', 'bar', 'baz'])).toBe('foo.bar.baz');
+      expect(i18n._formatPathAsString(['foo'])).toBe('foo');
+      expect(i18n._formatPathAsString(['foo', 'bar', 'baz'])).toBe('foo.bar.baz');
     });
 
     it('handles array paths', () => {
-      expect(i18n.formatPathAsString(['foo', 0])).toBe('foo[0]');
+      expect(i18n._formatPathAsString(['foo', 0])).toBe('foo[0]');
     });
 
     it('handles complex paths', () => {
       const propertyPath = ['foo', 'what-the', 'bar', 0, 'no'];
-      expect(i18n.formatPathAsString(propertyPath)).toBe('foo[what-the].bar[0].no');
+      expect(i18n._formatPathAsString(propertyPath)).toBe('foo[what-the].bar[0].no');
     });
 
     it('throws on unhandleable paths', () => {
-      expect(() => i18n.formatPathAsString(['Bobby "DROP TABLE'])).toThrow(/Cannot handle/);
+      expect(() => i18n._formatPathAsString(['Bobby "DROP TABLE'])).toThrow(/Cannot handle/);
     });
   });
 
@@ -37,20 +37,20 @@ describe('i18n', () => {
       const templates = {daString: 'use me!'};
       const formatter = i18n.createStringFormatter(fakeFile, templates);
 
-      const expected = 'lighthouse-core/test/lib/fake-file.js!#daString#0';
+      const expected = 'lighthouse-core/test/lib/fake-file.js | daString # 0';
       expect(formatter(templates.daString, {x: 1})).toBe(expected);
     });
   });
 
   describe('#replaceLocaleStringReferences', () => {
     it('replaces the references in the LHR', () => {
-      const templateID = 'lighthouse-core/test/lib/fake-file.js!#daString';
-      const reference = templateID + '#0';
+      const templateID = 'lighthouse-core/test/lib/fake-file.js | daString';
+      const reference = templateID + ' # 0';
       const lhr = {audits: {'fake-audit': {title: reference}}};
 
       i18n.replaceLocaleStringReferences(lhr, 'en-US');
       expect(lhr.audits['fake-audit'].title).toBe('use me!');
-      expect(lhr.localeLog).toEqual({
+      expect(lhr.i18n.messages).toEqual({
         [templateID]: [{path: 'audits[fake-audit].title', values: {x: 1}}]});
     });
   });

--- a/lighthouse-core/test/lib/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n-test.js
@@ -42,15 +42,15 @@ describe('i18n', () => {
     });
   });
 
-  describe('#replaceLocaleStringReferences', () => {
+  describe('#replaceIcuMessageInstanceIds', () => {
     it('replaces the references in the LHR', () => {
       const templateID = 'lighthouse-core/test/lib/fake-file.js | daString';
       const reference = templateID + ' # 0';
       const lhr = {audits: {'fake-audit': {title: reference}}};
 
-      i18n.replaceLocaleStringReferences(lhr, 'en-US');
+      i18n.replaceIcuMessageInstanceIds(lhr, 'en-US');
       expect(lhr.audits['fake-audit'].title).toBe('use me!');
-      expect(lhr.i18n.messages).toEqual({
+      expect(lhr.i18n.icuMessagePaths).toEqual({
         [templateID]: [{path: 'audits[fake-audit].title', values: {x: 1}}]});
     });
   });

--- a/lighthouse-core/test/lib/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n-test.js
@@ -31,11 +31,11 @@ describe('i18n', () => {
     });
   });
 
-  describe('#createStringFormatter', () => {
+  describe('#createMessageInstanceIdFn', () => {
     it('returns a string reference', () => {
       const fakeFile = path.join(__dirname, 'fake-file.js');
       const templates = {daString: 'use me!'};
-      const formatter = i18n.createStringFormatter(fakeFile, templates);
+      const formatter = i18n.createMessageInstanceIdFn(fakeFile, templates);
 
       const expected = 'lighthouse-core/test/lib/fake-file.js | daString # 0';
       expect(formatter(templates.daString, {x: 1})).toBe(expected);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3429,62 +3429,64 @@
       "description": "To appear in search results, crawlers need access to your app."
     }
   },
-  "localeLog": {
-    "lighthouse-core/audits/metrics/interactive.js!#title": [
-      "audits.interactive.title"
-    ],
-    "lighthouse-core/audits/metrics/interactive.js!#description": [
-      "audits.interactive.description"
-    ],
-    "lighthouse-core/lib/i18n.js!#ms": [
-      {
-        "values": {
-          "timeInMs": 4927.278
-        },
-        "path": "audits.interactive.displayValue"
-      }
-    ],
-    "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#title": [
-      "audits[render-blocking-resources].title"
-    ],
-    "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#description": [
-      "audits[render-blocking-resources].description"
-    ],
-    "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#displayValue": [
-      {
-        "values": {
-          "timeInMs": 1129,
-          "itemCount": 5
-        },
-        "path": "audits[render-blocking-resources].displayValue"
-      }
-    ],
-    "lighthouse-core/lib/i18n.js!#columnURL": [
-      "audits[render-blocking-resources].details.headings[0].label"
-    ],
-    "lighthouse-core/lib/i18n.js!#columnSize": [
-      "audits[render-blocking-resources].details.headings[1].label"
-    ],
-    "lighthouse-core/lib/i18n.js!#columnWastedTime": [
-      "audits[render-blocking-resources].details.headings[2].label"
-    ],
-    "lighthouse-core/config/default-config.js!#performanceCategoryTitle": [
-      "categories.performance.title"
-    ],
-    "lighthouse-core/config/default-config.js!#metricGroupTitle": [
-      "categoryGroups.metrics.title"
-    ],
-    "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupTitle": [
-      "categoryGroups[load-opportunities].title"
-    ],
-    "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupDescription": [
-      "categoryGroups[load-opportunities].description"
-    ],
-    "lighthouse-core/config/default-config.js!#diagnosticsGroupTitle": [
-      "categoryGroups.diagnostics.title"
-    ],
-    "lighthouse-core/config/default-config.js!#diagnosticsGroupDescription": [
-      "categoryGroups.diagnostics.description"
-    ]
+  "i18n": {
+    "messages": {
+      "lighthouse-core/audits/metrics/interactive.js | title": [
+        "audits.interactive.title"
+      ],
+      "lighthouse-core/audits/metrics/interactive.js | description": [
+        "audits.interactive.description"
+      ],
+      "lighthouse-core/lib/i18n.js | ms": [
+        {
+          "values": {
+            "timeInMs": 4927.278
+          },
+          "path": "audits.interactive.displayValue"
+        }
+      ],
+      "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": [
+        "audits[render-blocking-resources].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": [
+        "audits[render-blocking-resources].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | displayValue": [
+        {
+          "values": {
+            "timeInMs": 1129,
+            "itemCount": 5
+          },
+          "path": "audits[render-blocking-resources].displayValue"
+        }
+      ],
+      "lighthouse-core/lib/i18n.js | columnURL": [
+        "audits[render-blocking-resources].details.headings[0].label"
+      ],
+      "lighthouse-core/lib/i18n.js | columnSize": [
+        "audits[render-blocking-resources].details.headings[1].label"
+      ],
+      "lighthouse-core/lib/i18n.js | columnWastedTime": [
+        "audits[render-blocking-resources].details.headings[2].label"
+      ],
+      "lighthouse-core/config/default-config.js | performanceCategoryTitle": [
+        "categories.performance.title"
+      ],
+      "lighthouse-core/config/default-config.js | metricGroupTitle": [
+        "categoryGroups.metrics.title"
+      ],
+      "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": [
+        "categoryGroups[load-opportunities].title"
+      ],
+      "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": [
+        "categoryGroups[load-opportunities].description"
+      ],
+      "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": [
+        "categoryGroups.diagnostics.title"
+      ],
+      "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": [
+        "categoryGroups.diagnostics.description"
+      ]
+    }
   }
 }

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2771,7 +2771,7 @@
     "gatherMode": false,
     "disableStorageReset": false,
     "disableDeviceEmulation": false,
-    "locale": null,
+    "locale": "en-US",
     "blockedUrlPatterns": null,
     "additionalTraceCategories": null,
     "extraHeaders": null,
@@ -3428,5 +3428,63 @@
       "title": "Crawling and Indexing",
       "description": "To appear in search results, crawlers need access to your app."
     }
+  },
+  "localeLog": {
+    "lighthouse-core/audits/metrics/interactive.js!#title": [
+      "audits.interactive.title"
+    ],
+    "lighthouse-core/audits/metrics/interactive.js!#description": [
+      "audits.interactive.description"
+    ],
+    "lighthouse-core/lib/i18n.js!#ms": [
+      {
+        "values": {
+          "timeInMs": 4927.278
+        },
+        "path": "audits.interactive.displayValue"
+      }
+    ],
+    "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#title": [
+      "audits[render-blocking-resources].title"
+    ],
+    "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#description": [
+      "audits[render-blocking-resources].description"
+    ],
+    "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js!#displayValue": [
+      {
+        "values": {
+          "timeInMs": 1129,
+          "itemCount": 5
+        },
+        "path": "audits[render-blocking-resources].displayValue"
+      }
+    ],
+    "lighthouse-core/lib/i18n.js!#columnURL": [
+      "audits[render-blocking-resources].details.headings[0].label"
+    ],
+    "lighthouse-core/lib/i18n.js!#columnSize": [
+      "audits[render-blocking-resources].details.headings[1].label"
+    ],
+    "lighthouse-core/lib/i18n.js!#columnWastedTime": [
+      "audits[render-blocking-resources].details.headings[2].label"
+    ],
+    "lighthouse-core/config/default-config.js!#performanceCategoryTitle": [
+      "categories.performance.title"
+    ],
+    "lighthouse-core/config/default-config.js!#metricGroupTitle": [
+      "categoryGroups.metrics.title"
+    ],
+    "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupTitle": [
+      "categoryGroups[load-opportunities].title"
+    ],
+    "lighthouse-core/config/default-config.js!#loadOpportunitiesGroupDescription": [
+      "categoryGroups[load-opportunities].description"
+    ],
+    "lighthouse-core/config/default-config.js!#diagnosticsGroupTitle": [
+      "categoryGroups.diagnostics.title"
+    ],
+    "lighthouse-core/config/default-config.js!#diagnosticsGroupDescription": [
+      "categoryGroups.diagnostics.description"
+    ]
   }
 }

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1920,7 +1920,7 @@
       "score": 0.46,
       "scoreDisplayMode": "numeric",
       "rawValue": 1129,
-      "displayValue": "5 resources delayed first paint by 1,130 ms",
+      "displayValue": "Potential savings of 1,130 ms",
       "details": {
         "type": "opportunity",
         "headings": [
@@ -3451,11 +3451,10 @@
       "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": [
         "audits[render-blocking-resources].description"
       ],
-      "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | displayValue": [
+      "lighthouse-core/lib/i18n.js | displayValueWastedMs": [
         {
           "values": {
-            "timeInMs": 1129,
-            "itemCount": 5
+            "wastedMs": 1129
           },
           "path": "audits[render-blocking-resources].displayValue"
         }
@@ -3466,7 +3465,7 @@
       "lighthouse-core/lib/i18n.js | columnSize": [
         "audits[render-blocking-resources].details.headings[1].label"
       ],
-      "lighthouse-core/lib/i18n.js | columnWastedTime": [
+      "lighthouse-core/lib/i18n.js | columnWastedMs": [
         "audits[render-blocking-resources].details.headings[2].label"
       ],
       "lighthouse-core/config/default-config.js | performanceCategoryTitle": [

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3430,7 +3430,7 @@
     }
   },
   "i18n": {
-    "messages": {
+    "icuMessagePaths": {
       "lighthouse-core/audits/metrics/interactive.js | title": [
         "audits.interactive.title"
       ],

--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -8,6 +8,7 @@
 const RawProtocol = require('../../../lighthouse-core/gather/connections/raw');
 const Runner = require('../../../lighthouse-core/runner');
 const Config = require('../../../lighthouse-core/config/config');
+const i18n = require('../../../lighthouse-core/lib/i18n');
 const defaultConfig = require('../../../lighthouse-core/config/default-config.js');
 const log = require('lighthouse-logger');
 
@@ -26,7 +27,10 @@ function runLighthouseForConnection(
   updateBadgeFn = function() { }) {
   const config = new Config({
     extends: 'lighthouse:default',
-    settings: {onlyCategories: categoryIDs},
+    settings: {
+      locale: i18n.getDefaultLocale(),
+      onlyCategories: categoryIDs,
+    },
   }, options.flags);
 
   // Add url and config to fresh options object.

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -6,10 +6,10 @@
 
 declare global {
   module LH {
-    export type LocaleLogEntry = string | {path: string, values: any};
+    export type I18NMessageEntry = string | {path: string, values: any};
 
-    export interface LocaleLog {
-      [templateID: string]: LocaleLogEntry[];
+    export interface I18NMessages {
+      [templateID: string]: I18NMessageEntry[];
     }
 
     /**
@@ -41,8 +41,8 @@ declare global {
       userAgent: string;
       /** Execution timings for the Lighthouse run */
       timing: {total: number, [t: string]: number};
-      /** The log of all localized strings and their corresponding template values. */
-      localeLog?: LocaleLog;
+      /** The record of all localized strings and their corresponding template values. */
+      i18n?: {messages: I18NMessages};
     }
 
     // Result namespace

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -41,8 +41,8 @@ declare global {
       userAgent: string;
       /** Execution timings for the Lighthouse run */
       timing: {total: number, [t: string]: number};
-      /** The record of all localized strings and their corresponding template values. */
-      i18n?: {messages: I18NMessages};
+      /** The record of all formatted string locations in the LHR and their corresponding source values. */
+      i18n?: {icuMessagePaths: I18NMessages};
     }
 
     // Result namespace

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -6,6 +6,12 @@
 
 declare global {
   module LH {
+    export type LocaleLogEntry = string | {path: string, values: any};
+
+    export interface LocaleLog {
+      [templateID: string]: LocaleLogEntry[];
+    }
+
     /**
      * The full output of a Lighthouse run.
      */
@@ -35,6 +41,8 @@ declare global {
       userAgent: string;
       /** Execution timings for the Lighthouse run */
       timing: {total: number, [t: string]: number};
+      /** The log of all localized strings and their corresponding template values. */
+      localeLog?: LocaleLog;
     }
 
     // Result namespace


### PR DESCRIPTION
An example of how we might be able to "fix" the strings before shipping the LHR, basically the i18n formatting function just returns a reference to the string to be used which is stored in a map, then at the end before returning, runner asks i18n to replace all the references in the LHR with the string of the appropriate locale. BOOM done! a log is kept of what replacements were made and added to the LHR as `localeLog` so that later the report could be translated again without re-running.

![image](https://user-images.githubusercontent.com/2301202/42592201-b021805a-84fd-11e8-95da-0dcb7c13a375.png)
