### PR TITLE
core: bump to 3.0.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,47 @@
+<a name="3.0.2"></a>
+# 3.0.2 (2018-07-11)
+[Full Changelog](https://github.com/googlechrome/lighthouse/compare/v3.0.1...v3.0.2)
+
+## New Contributors!
+Thanks to @schalkneethling and @eduardosada for their first contributions!
+
+## New Audits
+
+* assert a present and valid doctype ([#5274](https://github.com/googlechrome/lighthouse/pull/5274
+))
+
+## Core
+
+* fonts: bump gatherer timeout to 5s ([#5643](https://github.com/googlechrome/lighthouse/pull/5643
+))
+* network-request: cleanup DevTools property names ([#5606](https://github.com/googlechrome/lighth
+ouse/pull/5606))
+* preload: remove blob protocol from preload audit ([#5409](https://github.com/googlechrome/lighth
+ouse/pull/5409))
+* without-javascript: allow noscript pages ([#5571](https://github.com/googlechrome/lighthouse/pul
+l/5571))
+
+## Docs
+
+* architecture: add diagram of module dependencies ([#5615](https://github.com/googlechrome/lighth
+ouse/pull/5615))
+* custom-audit: update custom-audit to 3.0.0 api ([#5612](https://github.com/googlechrome/lighthouse/pull/5612))
+* [minor] issue template tweaks ([#5641](https://github.com/googlechrome/lighthouse/pull/5641))
+
+## Extension
+
+* fix "extension Error: couldn't resolve current tab" ([#5591](https://github.com/googlechrome/lighthouse/pull/5591))
+* 3.0.0 as well ([#5584](https://github.com/googlechrome/lighthouse/pull/5584))
+
+## Tests
+
+* [minor] rename robots.txt test file ([#5610](https://github.com/googlechrome/lighthouse/pull/5610))
+* run the golden LHR check earlier ([#5609](https://github.com/googlechrome/lighthouse/pull/5609))
+
+## Misc
+
+* scripts: more succinct lantern output ([#5523](https://github.com/googlechrome/lighthouse/pull/5523))
+
  <a name="3.0.1"></a>
 # 3.0.1 (2018-07-02)
 [Full Changelog](https://github.com/googlechrome/lighthouse/compare/v3.0.0...v3.0.1)

--- a/changelog.md
+++ b/changelog.md
@@ -7,24 +7,18 @@ Thanks to @schalkneethling and @eduardosada for their first contributions!
 
 ## New Audits
 
-* assert a present and valid doctype ([#5274](https://github.com/googlechrome/lighthouse/pull/5274
-))
+* assert a present and valid doctype ([#5274](https://github.com/googlechrome/lighthouse/pull/5274))
 
 ## Core
 
-* fonts: bump gatherer timeout to 5s ([#5643](https://github.com/googlechrome/lighthouse/pull/5643
-))
-* network-request: cleanup DevTools property names ([#5606](https://github.com/googlechrome/lighth
-ouse/pull/5606))
-* preload: remove blob protocol from preload audit ([#5409](https://github.com/googlechrome/lighth
-ouse/pull/5409))
-* without-javascript: allow noscript pages ([#5571](https://github.com/googlechrome/lighthouse/pul
-l/5571))
+* fonts: bump gatherer timeout to 5s ([#5643](https://github.com/googlechrome/lighthouse/pull/5643))
+* network-request: cleanup DevTools property names ([#5606](https://github.com/googlechrome/lighthouse/pull/5606))
+* preload: remove blob protocol from preload audit ([#5409](https://github.com/googlechrome/lighthouse/pull/5409))
+* without-javascript: allow noscript pages ([#5571](https://github.com/googlechrome/lighthouse/pull/5571))
 
 ## Docs
 
-* architecture: add diagram of module dependencies ([#5615](https://github.com/googlechrome/lighth
-ouse/pull/5615))
+* architecture: add diagram of module dependencies ([#5615](https://github.com/googlechrome/lighthouse/pull/5615))
 * custom-audit: update custom-audit to 3.0.0 api ([#5612](https://github.com/googlechrome/lighthouse/pull/5612))
 * [minor] issue template tweaks ([#5641](https://github.com/googlechrome/lighthouse/pull/5641))
 

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1,6 +1,6 @@
 {
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
-  "lighthouseVersion": "3.0.1",
+  "lighthouseVersion": "3.0.2",
   "fetchTime": "2018-03-13T00:55:45.840Z",
   "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",

--- a/lighthouse-extension/app/manifest.json
+++ b/lighthouse-extension/app/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_appName__",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "minimum_chrome_version": "66",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Lighthouse",
   "main": "./lighthouse-core/index.js",
   "bin": {


### PR DESCRIPTION
Publishing 3.0.2 to get down our sentry timeouts hopefully, not publishing the extension since it's not a big deal for it.

@paulirish gave his blessing to ship the new audit even though it's just a patch release :)