### PR TITLE
core(traces): Enable V8 CPU Profiler in traces

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -92,9 +92,8 @@ class Driver {
       'disabled-by-default-devtools.timeline',
       'disabled-by-default-devtools.timeline.frame',
       'disabled-by-default-devtools.timeline.stack',
-      // Flipped off until bugs.chromium.org/p/v8/issues/detail?id=5820 is fixed in Stable
-      // 'disabled-by-default-v8.cpu_profiler',
-      // 'disabled-by-default-v8.cpu_profiler.hires',
+      'disabled-by-default-v8.cpu_profiler',
+      'disabled-by-default-v8.cpu_profiler.hires',
       'disabled-by-default-devtools.screenshot',
     ];
   }


### PR DESCRIPTION
I was writing a custom audit to check for specific functions that take a long time blocking resources and I couldn't understand why lighthouse traces didn't match those provided by dev tools performance.

It turns out the traces for V8 profiling were disabled in #1444 because of a [formatting bug in chrome traces](https://bugs.chromium.org/p/v8/issues/detail?id=5820). However, this was fixed over a year ago.

Here is a small change to re-enable them, it didn't seem to affect any tests on my machine.
