### PR TITLE
core: expose LighthouseRunWarnings on audit context

### DIFF
--- a/lighthouse-core/audits/bootup-time.js
+++ b/lighthouse-core/audits/bootup-time.js
@@ -23,7 +23,7 @@ class BootupTime extends Audit {
       description: 'Consider reducing the time spent parsing, compiling, and executing JS. ' +
         'You may find delivering smaller JS payloads helps with this. [Learn ' +
         'more](https://developers.google.com/web/tools/lighthouse/audits/bootup).',
-      requiredArtifacts: ['traces', 'LighthouseRunWarnings'],
+      requiredArtifacts: ['traces'],
     };
   }
 
@@ -85,7 +85,6 @@ class BootupTime extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit(artifacts, context) {
-    const runWarnings = artifacts.LighthouseRunWarnings;
     const settings = context.settings || {};
     const trace = artifacts.traces[BootupTime.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[BootupTime.DEFAULT_PASS];
@@ -133,8 +132,8 @@ class BootupTime extends Audit {
 
     // TODO: consider moving this to core gathering so you don't need to run the audit for warning
     if (hadExcessiveChromeExtension) {
-      runWarnings.push('Chrome extensions negatively affected this page\'s load performance. ' +
-        'Try auditing the page in incognito mode or from a clean Chrome profile.');
+      context.LighthouseRunWarnings.push('Chrome extensions negatively affected this page\'s load' +
+        ' performance. Try auditing the page in incognito mode or from a clean Chrome profile.');
     }
 
     const summary = {wastedMs: totalBootupTime};

--- a/typings/audit.d.ts
+++ b/typings/audit.d.ts
@@ -7,8 +7,11 @@
 declare global {
   module LH.Audit {
     export interface Context {
-      options: Record<string, any>; // audit options
+      /** audit options */
+      options: Record<string, any>;
       settings: Config.Settings;
+      /** Push to this array to add top-level warnings to the LHR. */
+      LighthouseRunWarnings: Array<string>;
     }
 
     export interface ScoreOptions {

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -18,7 +18,7 @@ declare global {
       passConfig: Config.Pass
       settings: Config.Settings;
       options?: object;
-      /** Push to this array to add top-level warnings to the LHR.  */
+      /** Push to this array to add top-level warnings to the LHR. */
       LighthouseRunWarnings: Array<string>;
     }
 


### PR DESCRIPTION
I was thinking about #5666 this morning and realized we shouldn't be altering artifacts in audits. Instead, this exposes a way to push top-level warnings from audits via the `auditContext`, similar to [how gatherers can do so from the `passContext`](https://github.com/GoogleChrome/lighthouse/blob/098d28189ba33f292d4f06824d62116a372aa976/lighthouse-core/gather/gather-runner.js#L411-L412).

happy to bikeshed on anything