### PR TITLE
core(i18n): keep Intl.* methods in extension build

### DIFF
--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -21,9 +21,9 @@ try {
   // @ts-ignore
   const IntlPolyfill = require('intl');
   // @ts-ignore
-  Intl.NumberFormat = IntlPolyfill.NumberFormat;
+  Intl.NumberFormat = (Intl && Intl.NumberFormat) || IntlPolyfill.NumberFormat;
   // @ts-ignore
-  Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
+  Intl.DateTimeFormat = (Intl && Intl.DateTimeFormat) || IntlPolyfill.DateTimeFormat;
 } catch (_) {}
 
 const UIStrings = {


### PR DESCRIPTION
repro: build the extension from master. the TTI audit will get an error saying Intl.NumberFormat is not a constructor.

it's set to undefined as the `require('intl');` doesnt throw but returns an empty object.

