### PR TITLE
report(i18n): localize CRC renderer strings

### DIFF
--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -436,7 +436,15 @@
     "description": "Label shown preceding any important warnings that may have invalidated the entire report. For example, if the user has Chrome extensions installed, they may add enough performance overhead that Lighthouse's performance metrics are unreliable. If shown, this will be displayed at the top of the report UI."
   },
   "lighthouse-core/report/html/renderer/util.js | scorescaleLabel": {
-    "message": "Score scale:",
-    "description": "Label preceding a pictorial explanation of the scoring scale: 0-50 is red (bad), 50-90 is orange (ok), 90-100 is green (good). These colors are used throughout the report to provide context for how good/bad a particular result is."
+    "message": "Score scale:"
+  },
+  "lighthouse-core/report/html/renderer/util.js | crcInitialNavigation": {
+    "message": "Initial Navigation"
+  },
+  "lighthouse-core/report/html/renderer/util.js | crcLongestDurationLabel": {
+    "message": "Longest chain:"
+  },
+  "lighthouse-core/report/html/renderer/util.js | crcTransferSizeLabel": {
+    "message": "Transfer Size:"
   }
 }

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -436,15 +436,15 @@
     "description": "Label shown preceding any important warnings that may have invalidated the entire report. For example, if the user has Chrome extensions installed, they may add enough performance overhead that Lighthouse's performance metrics are unreliable. If shown, this will be displayed at the top of the report UI."
   },
   "lighthouse-core/report/html/renderer/util.js | scorescaleLabel": {
-    "message": "Score scale:"
+    "message": "Score scale:",
+    "description": "Label preceding a pictorial explanation of the scoring scale: 0-50 is red (bad), 50-90 is orange (ok), 90-100 is green (good). These colors are used throughout the report to provide context for how good/bad a particular result is."
   },
   "lighthouse-core/report/html/renderer/util.js | crcInitialNavigation": {
-    "message": "Initial Navigation"
+    "message": "Initial Navigation",
+    "description": "String of text shown in a graphical representation of the flow of network requests for the web page. This label represents the initial network request that fetches an HTML page. This navigation may be redirected (eg. Initial navigation to http://example.com redirects to https://www.example.com)."
   },
   "lighthouse-core/report/html/renderer/util.js | crcLongestDurationLabel": {
-    "message": "Longest chain:"
-  },
-  "lighthouse-core/report/html/renderer/util.js | crcTransferSizeLabel": {
-    "message": "Transfer Size:"
+    "message": "Maximum critical path latency:",
+    "description": "Label of value shown in the summary of critical request chains. Refers to the total amount of time (milliseconds) of the longest critical path chain/sequence of network requests. Example value: 2310 ms"
   }
 }

--- a/lighthouse-core/lib/locales/en-XA.json
+++ b/lighthouse-core/lib/locales/en-XA.json
@@ -307,17 +307,5 @@
   },
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "[Ţĥéŕé ŵéŕé îššûéš åƒƒéçţîñĝ ţĥîš ŕûñ öƒ Ļîĝĥţĥöûšé: one two three four five six seven eight nine ten eleven]"
-  },
-  "lighthouse-core/report/html/renderer/util.js | scorescaleLabel": {
-    "message": "Ŝćôŕê śĉál̂é:"
-  },
-  "lighthouse-core/report/html/renderer/util.js | crcInitialNavigation": {
-    "message": "Îńît́îál̂ Ńâv́îǵât́îón̂"
-  },
-  "lighthouse-core/report/html/renderer/util.js | crcLongestDurationLabel": {
-    "message": "L̂ón̂ǵêśt̂ ćĥáîń:"
-  },
-  "lighthouse-core/report/html/renderer/util.js | crcTransferSizeLabel": {
-    "message": "T̂ŕâńŝf́êŕ Ŝíẑé:"
   }
 }

--- a/lighthouse-core/lib/locales/en-XA.json
+++ b/lighthouse-core/lib/locales/en-XA.json
@@ -308,10 +308,16 @@
   "lighthouse-core/report/html/renderer/util.js | toplevelWarningsMessage": {
     "message": "[Ţĥéŕé ŵéŕé îššûéš åƒƒéçţîñĝ ţĥîš ŕûñ öƒ Ļîĝĥţĥöûšé: one two three four five six seven eight nine ten eleven]"
   },
-  "lighthouse-core/report/html/renderer/util.js | varianceDisclaimer": {
-    "message": "[Våļûéš åŕé éšţîmåţéð åñð måý våŕý. one two three four five six seven]"
+  "lighthouse-core/report/html/renderer/util.js | scorescaleLabel": {
+    "message": "Ŝćôŕê śĉál̂é:"
   },
-  "lighthouse-core/report/html/renderer/util.js | warningHeader": {
-    "message": "[Ŵåŕñîñĝš:  one two]"
+  "lighthouse-core/report/html/renderer/util.js | crcInitialNavigation": {
+    "message": "Îńît́îál̂ Ńâv́îǵât́îón̂"
+  },
+  "lighthouse-core/report/html/renderer/util.js | crcLongestDurationLabel": {
+    "message": "L̂ón̂ǵêśt̂ ćĥáîń:"
+  },
+  "lighthouse-core/report/html/renderer/util.js | crcTransferSizeLabel": {
+    "message": "T̂ŕâńŝf́êŕ Ŝíẑé:"
   }
 }

--- a/lighthouse-core/report/html/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/html/renderer/crc-details-renderer.js
@@ -115,11 +115,11 @@ class CriticalRequestChainRenderer {
     dom.find('.crc-node__tree-hostname', treevalEl).textContent = hostname ? `(${hostname})` : '';
 
     if (!segment.hasChildren) {
+      const {startTime, endTime, transferSize} = segment.node.request;
       const span = dom.createElement('span', 'crc-node__chain-duration');
-      span.textContent = ' - ' + Util.chainDuration(
-          segment.node.request.startTime, segment.node.request.endTime) + 'ms, ';
+      span.textContent = ' - ' + Util.formatMilliseconds((endTime - startTime) * 1000) + ', ';
       const span2 = dom.createElement('span', 'crc-node__chain-duration');
-      span2.textContent = Util.formatBytesToKB(segment.node.request.transferSize, 0.01);
+      span2.textContent = Util.formatBytesToKB(transferSize, 0.01);
 
       treevalEl.appendChild(span);
       treevalEl.appendChild(span2);
@@ -157,9 +157,13 @@ class CriticalRequestChainRenderer {
     const containerEl = dom.find('.lh-crc', tmpl);
 
     // Fill in top summary.
+    dom.find('.crc-initial-nav', tmpl).textContent = Util.UIStrings.crcInitialNavigation;
+    dom.find('.lh-crc__longest_duration_label', tmpl).textContent =
+        Util.UIStrings.crcLongestDurationLabel;
     dom.find('.lh-crc__longest_duration', tmpl).textContent =
-        Util.formatNumber(details.longestChain.duration) + 'ms';
-    dom.find('.lh-crc__longest_length', tmpl).textContent = details.longestChain.length.toString();
+        Util.formatMilliseconds(details.longestChain.duration);
+    dom.find('.lh-crc__longest_transfersize_label', tmpl).textContent =
+        Util.UIStrings.crcTransferSizeLabel;
     dom.find('.lh-crc__longest_transfersize', tmpl).textContent =
         Util.formatBytesToKB(details.longestChain.transferSize);
 

--- a/lighthouse-core/report/html/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/html/renderer/crc-details-renderer.js
@@ -162,10 +162,6 @@ class CriticalRequestChainRenderer {
         Util.UIStrings.crcLongestDurationLabel;
     dom.find('.lh-crc__longest_duration', tmpl).textContent =
         Util.formatMilliseconds(details.longestChain.duration);
-    dom.find('.lh-crc__longest_transfersize_label', tmpl).textContent =
-        Util.UIStrings.crcTransferSizeLabel;
-    dom.find('.lh-crc__longest_transfersize', tmpl).textContent =
-        Util.formatBytesToKB(details.longestChain.transferSize);
 
     // Construct visual tree.
     const root = CriticalRequestChainRenderer.initTree(details.chains);

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -297,15 +297,6 @@ class Util {
   }
 
   /**
-   * @param {number} startTime
-   * @param {number} endTime
-   * @return {string}
-   */
-  static chainDuration(startTime, endTime) {
-    return Util.formatNumber((endTime - startTime) * 1000);
-  }
-
-  /**
    * @param {LH.Config.Settings} settings
    * @return {Array<{name: string, description: string}>}
    */
@@ -405,6 +396,10 @@ Util.UIStrings = {
   toplevelWarningsMessage: 'There were issues affecting this run of Lighthouse:',
   /** Label preceding a pictorial explanation of the scoring scale: 0-50 is red (bad), 50-90 is orange (ok), 90-100 is green (good). These colors are used throughout the report to provide context for how good/bad a particular result is. */
   scorescaleLabel: 'Score scale:',
+
+  crcInitialNavigation: 'Initial Navigation',
+  crcLongestDurationLabel: 'Longest chain:',
+  crcTransferSizeLabel: 'Transfer Size:',
 };
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -397,9 +397,10 @@ Util.UIStrings = {
   /** Label preceding a pictorial explanation of the scoring scale: 0-50 is red (bad), 50-90 is orange (ok), 90-100 is green (good). These colors are used throughout the report to provide context for how good/bad a particular result is. */
   scorescaleLabel: 'Score scale:',
 
+  /** String of text shown in a graphical representation of the flow of network requests for the web page. This label represents the initial network request that fetches an HTML page. This navigation may be redirected (eg. Initial navigation to http://example.com redirects to https://www.example.com). */
   crcInitialNavigation: 'Initial Navigation',
-  crcLongestDurationLabel: 'Longest chain:',
-  crcTransferSizeLabel: 'Transfer Size:',
+  /** Label of value shown in the summary of critical request chains. Refers to the total amount of time (milliseconds) of the longest critical path chain/sequence of network requests. Example value: 2310 ms */
+  crcLongestDurationLabel: 'Maximum critical path latency:',
 };
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -607,15 +607,20 @@ Unless required by applicable law or agreed to in writing, software distributed 
         color: #595959;
         font-style: italic;
       }
+      .lh-crc__summary-value {
+        margin-bottom: 10px;
+      }
     </style>
     <div>
-      <!-- TODO(i18n): remove CRC sentences or localize -->
-      Longest chain: <b class="lh-crc__longest_duration"><!-- fill me: longestChain.duration --></b>
-      over <b class="lh-crc__longest_length"><!-- fill me: longestChain.length --></b> requests, totalling
-      <b class="lh-crc__longest_transfersize"><!-- fill me: longestChain.length --></b>
+      <div class="lh-crc__summary-value">
+        <span class="lh-crc__longest_duration_label"></span> <b class="lh-crc__longest_duration"></b>
+      </div>
+      <div class="lh-crc__summary-value">
+        <span class="lh-crc__longest_transfersize_label"></span> <b class="lh-crc__longest_transfersize"></b>
+      </div>
     </div>
     <div class="lh-crc">
-      <div class="crc-initial-nav">Initial Navigation</div>
+      <div class="crc-initial-nav"></div>
       <!-- stamp for each chain -->
       <template id="tmpl-lh-crc__chains">
         <div class="crc-node">

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -615,9 +615,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
       <div class="lh-crc__summary-value">
         <span class="lh-crc__longest_duration_label"></span> <b class="lh-crc__longest_duration"></b>
       </div>
-      <div class="lh-crc__summary-value">
-        <span class="lh-crc__longest_transfersize_label"></span> <b class="lh-crc__longest_transfersize"></b>
-      </div>
     </div>
     <div class="lh-crc">
       <div class="crc-initial-nav"></div>

--- a/lighthouse-core/test/report/html/renderer/crc-details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/crc-details-renderer-test.js
@@ -103,7 +103,7 @@ describe('DetailsRenderer', () => {
     assert.equal(chains[1].querySelector('.crc-node__tree-file').textContent, '/b.js');
     assert.equal(chains[1].querySelector('.crc-node__tree-hostname').textContent, '(example.com)');
     const durationNodes = chains[1].querySelectorAll('.crc-node__chain-duration');
-    assert.equal(durationNodes[0].textContent, ' - 5,000ms, ');
+    assert.equal(durationNodes[0].textContent, ' - 5,000\xa0ms, ');
     // Note: actual transferSize is 2000 bytes but formatter formats to KBs.
     assert.equal(durationNodes[1].textContent, '1.95\xa0KB');
   });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3386,7 +3386,10 @@
       "notApplicableAuditsGroupTitle": "Not applicable",
       "manualAuditsGroupTitle": "Additional items to manually check",
       "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
-      "scorescaleLabel": "Score scale:"
+      "scorescaleLabel": "Score scale:",
+      "crcInitialNavigation": "Initial Navigation",
+      "crcLongestDurationLabel": "Longest chain:",
+      "crcTransferSizeLabel": "Transfer Size:"
     },
     "icuMessagePaths": {
       "lighthouse-core/audits/metrics/first-contentful-paint.js | title": [

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3388,8 +3388,7 @@
       "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
       "scorescaleLabel": "Score scale:",
       "crcInitialNavigation": "Initial Navigation",
-      "crcLongestDurationLabel": "Longest chain:",
-      "crcTransferSizeLabel": "Transfer Size:"
+      "crcLongestDurationLabel": "Maximum critical path latency:"
     },
     "icuMessagePaths": {
       "lighthouse-core/audits/metrics/first-contentful-paint.js | title": [


### PR DESCRIPTION
A lot of the text is actually just the path and origin of each request so there wasn't actually that much here.