### PR TITLE
core(i18n): reframe the ICU message descriptions with placeholders

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
+++ b/lighthouse-core/audits/byte-efficiency/total-byte-weight.js
@@ -15,7 +15,7 @@ const UIStrings = {
   'Large network payloads cost users real money and are highly correlated with ' +
   'long load times. [Learn ' +
   'more](https://developers.google.com/web/tools/lighthouse/audits/network-payloads).',
-  /** [ICU Syntax] Used to summarize the total byte size of the page and all its network requests */
+  /** Used to summarize the total byte size of the page and all its network requests. The `{totalBytes}` placeholder will be replaced with the total byte sizes, shown in kilobytes (e.g. 142 KB) */
   displayValue: 'Total size was {totalBytes, number, bytes}\xa0KB',
 };
 

--- a/lighthouse-core/audits/time-to-first-byte.js
+++ b/lighthouse-core/audits/time-to-first-byte.js
@@ -13,7 +13,7 @@ const UIStrings = {
   failureTitle: 'Reduce server response times (TTFB)',
   description: 'Time To First Byte identifies the time at which your server sends a response.' +
     ' [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).',
-  /** [ICU Syntax] Used to summarize the total Time to First Byte duration for the primary HTML response */
+  /** Used to summarize the total Time to First Byte duration for the primary HTML response. The `{timeInMs}` placeholder will be replaced with the time duration, shown in milliseconds (e.g. 210 ms) */
   displayValue: `Root document took {timeInMs, number, milliseconds}\xa0ms`,
 };
 

--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -35,11 +35,11 @@ const MESSAGE_INSTANCE_ID_REGEX = /(.* \| .*) # (\d+)$/;
 
 
 const UIStrings = {
-  /** [ICU Syntax] Used to show the duration in milliseconds that something lasted */
+  /** Used to show the duration in milliseconds that something lasted. The `{timeInMs}` placeholder will be replaced with the time duration, shown in milliseconds (e.g. 63 ms) */
   ms: '{timeInMs, number, milliseconds}\xa0ms',
-  /** [ICU Syntax] Used to show how many bytes the user could reduce their page by if they implemented the suggestions */
+  /** Used to show how many bytes the user could reduce their page by if they implemented the suggestions. The `{wastedBytes}` placeholder will be replaced with the number of bytes, shown in kilobytes (e.g. 148 KB) */
   displayValueByteSavings: 'Potential savings of {wastedBytes, number, bytes}\xa0KB',
-  /** [ICU Syntax] Used to show how many milliseconds the user could reduce page load by if they implemented the suggestions */
+  /** Used to show how many milliseconds the user could reduce page load by if they implemented the suggestions. The `{wastedMs}` placeholder will be replaced with the time duration, shown in milliseconds (e.g. 140 ms) */
   displayValueMsSavings: 'Potential savings of {wastedMs, number, milliseconds}\xa0ms',
   /** Label for the URL column in data tables, entries will be the URL of a web resource */
   columnURL: 'URL',

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -51,7 +51,7 @@
   },
   "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | displayValue": {
     "message": "Total size was {totalBytes, number, bytes} KB",
-    "description": "[ICU Syntax] Used to summarize the total byte size of the page and all its network requests"
+    "description": "Used to summarize the total byte size of the page and all its network requests. The `{totalBytes}` placeholder will be replaced with the total byte sizes, shown in kilobytes (e.g. 142 KB)"
   },
   "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": {
     "message": "Minify CSS"
@@ -222,7 +222,7 @@
   },
   "lighthouse-core/audits/time-to-first-byte.js | displayValue": {
     "message": "Root document took {timeInMs, number, milliseconds} ms",
-    "description": "[ICU Syntax] Used to summarize the total Time to First Byte duration for the primary HTML response"
+    "description": "Used to summarize the total Time to First Byte duration for the primary HTML response. The `{timeInMs}` placeholder will be replaced with the time duration, shown in milliseconds (e.g. 210 ms)"
   },
   "lighthouse-core/audits/user-timings.js | title": {
     "message": "User Timing marks and measures"
@@ -265,15 +265,15 @@
   },
   "lighthouse-core/lib/i18n.js | ms": {
     "message": "{timeInMs, number, milliseconds} ms",
-    "description": "[ICU Syntax] Used to show the duration in milliseconds that something lasted"
+    "description": "Used to show the duration in milliseconds that something lasted. The `{timeInMs}` placeholder will be replaced with the time duration, shown in milliseconds (e.g. 63 ms)"
   },
   "lighthouse-core/lib/i18n.js | displayValueByteSavings": {
     "message": "Potential savings of {wastedBytes, number, bytes} KB",
-    "description": "[ICU Syntax] Used to show how many bytes the user could reduce their page by if they implemented the suggestions"
+    "description": "Used to show how many bytes the user could reduce their page by if they implemented the suggestions. The `{wastedBytes}` placeholder will be replaced with the number of bytes, shown in kilobytes (e.g. 148 KB)"
   },
   "lighthouse-core/lib/i18n.js | displayValueMsSavings": {
     "message": "Potential savings of {wastedMs, number, milliseconds} ms",
-    "description": "[ICU Syntax] Used to show how many milliseconds the user could reduce page load by if they implemented the suggestions"
+    "description": "Used to show how many milliseconds the user could reduce page load by if they implemented the suggestions. The `{wastedMs}` placeholder will be replaced with the time duration, shown in milliseconds (e.g. 140 ms)"
   },
   "lighthouse-core/lib/i18n.js | columnURL": {
     "message": "URL",


### PR DESCRIPTION
First, a word from the docs:

> The industry standard, ICU MessageFormat Syntax, is used to format these messages internally. However, only select parts of that syntax work at Google.

lol thx. So #5736 was a waste and doesn't work. So we'll describe the placeholders this way.