### PR TITLE
Remove meta  X-UA-Compatible - not needed

### DIFF
--- a/lighthouse-extension/app/popup.html
+++ b/lighthouse-extension/app/popup.html
@@ -8,7 +8,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <html>
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="author" content="Lighthouse Team">
   <meta name="viewport" content="width=device-width">
   <title>Lighthouse Report</title>


### PR DESCRIPTION
`  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">`
This tag was only ever needed for old ChromeFrame plugin (long since discontinued) and IE9 and lower (not needed)

<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
