### PR TITLE
core(byte-efficiency): combine multiple cache-control headers if found

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -185,7 +185,13 @@ class CacheHeaders extends Audit {
         /** @type {Map<string, string>} */
         const headers = new Map();
         for (const header of record.responseHeaders || []) {
-          headers.set(header.name.toLowerCase(), header.value);
+          if (headers.has(header.name.toLowerCase())) {
+            const previousHeaderValue = headers.get(header.name.toLowerCase());
+            headers.set(header.name.toLowerCase(),
+              `${previousHeaderValue}, ${header.value}`);
+          } else {
+            headers.set(header.name.toLowerCase(), header.value);
+          }
         }
 
         const cacheControl = parseCacheControl(headers.get('cache-control'));

--- a/lighthouse-core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js
@@ -119,6 +119,25 @@ describe('Cache headers audit', () => {
     });
   });
 
+  it('respects multiple cache-control headers', () => {
+    networkRecords = [
+      networkRecord({headers: {
+        'cache-control': 'max-age=31536000, public',
+        'Cache-control': 'no-transform',
+      }}),
+      networkRecord({headers: {
+        'Cache-Control': 'no-transform',
+        'cache-control': 'max-age=3600',
+        'Cache-control': 'public',
+      }}),
+    ];
+
+    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+      const items = result.extendedInfo.value.results;
+      assert.equal(items.length, 1);
+    });
+  });
+
   it('catches records with Etags', () => {
     networkRecords = [
       networkRecord({headers: {etag: 'md5hashhere'}}),


### PR DESCRIPTION
Per [rfc2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), _"Multiple message-header fields with the same field-name MAY be present in a message if and only if the entire field-value for that header field is defined as a comma-separated list [i.e., #(values)]"_. `cache-control` is defined as comma separated list, and as reported in #5742 this case is not handled correctly resulting in misreported files.

This PR fixes that denoted case within `uses-long-cache-ttl.js` and adds a test to verify this going forward.

![image](https://user-images.githubusercontent.com/643503/43351451-002d94dc-91c7-11e8-8c98-1e9b80640232.png)

Resolves #5742 