### PR TITLE
core(non native url): fail test when url is not a native implementation

### DIFF
--- a/lighthouse-cli/test/fixtures/seo/seo-tester.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester.html
@@ -44,6 +44,8 @@
   <script class='small'>
     // text from SCRIPT tags should be ignored by the font-size audit
   </script>
+  <!-- override global URL - bug #5701 -->
+  <script>URL = '';</script>
   <!-- PASS(plugins): external content does not require java, flash or silverlight -->
   <object data="test.pdf" type="application/pdf" width="300" height="200"></object>
 </body>

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -222,6 +222,7 @@ class Driver {
         //    so that they can be serialized properly b/c JSON.stringify(new Error('foo')) === '{}'
         expression: `(function wrapInNativePromise() {
           const __nativePromise = window.__nativePromise || Promise;
+          const URL = window.__nativeURL || window.URL;
           return new __nativePromise(function (resolve) {
             return __nativePromise.resolve()
               .then(_ => ${expression})
@@ -1068,7 +1069,8 @@ class Driver {
    */
   async cacheNatives() {
     await this.evaluateScriptOnNewDocument(`window.__nativePromise = Promise;
-        window.__nativeError = Error;`);
+        window.__nativeError = Error;
+        window.__nativeURL = URL;`);
   }
 
   /**


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
Bugfix: fixes websites overriding URL variable with something custom
When running `node  lighthouse-cli/index.js https://www.dailyo.in -G --verbose --devtools.throttling=provided` you get the following output:
```
Sat, 28 Jul 2018 11:14:27 GMT method <= browser OK:verbose Runtime.evaluate {"result":{"type":"object","value":[{"err":{"message":"URL is not a constructor","stack":"TypeError: URL is not a constructor\n    at matches.forE
Sat, 28 Jul 2018 11:14:27 GMT method <= browser OK:verbose Runtime.evaluate {"result":{"type":"object","value":[{"err":{"message":"URL is not a constructor","stack":"TypeError: URL is not a constructor\n    at matches.forE
```

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
#5701 
