### PR TITLE
core(i18n): always use formatted strings for extension popup

### DIFF
--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -9,6 +9,7 @@ const RawProtocol = require('../../../lighthouse-core/gather/connections/raw');
 const Runner = require('../../../lighthouse-core/runner');
 const Config = require('../../../lighthouse-core/config/config');
 const defaultConfig = require('../../../lighthouse-core/config/default-config.js');
+const i18n = require('../../../lighthouse-core/lib/i18n');
 const log = require('lighthouse-logger');
 
 /** @typedef {import('../../../lighthouse-core/gather/connections/connection.js')} Connection */
@@ -65,7 +66,9 @@ function runLighthouseInWorker(port, url, options, categoryIDs) {
  * @return {Array<{title: string, id: string}>}
  */
 function getDefaultCategories() {
-  return Config.getCategories(defaultConfig);
+  const categories = Config.getCategories(defaultConfig);
+  categories.forEach(cat => cat.title = i18n.getFormatted(cat.title, 'en-US'));
+  return categories;
 }
 
 /** @param {(status: [string, string, string]) => void} listenCallback */


### PR DESCRIPTION
similar to #5727

fixes this:
![image](https://user-images.githubusercontent.com/39191/43494501-0208cfbe-94e8-11e8-99de-23c3cf6ac22a.png)
