### PR TITLE
 report: refactor UI string logic

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -86,10 +86,10 @@ class CategoryRenderer {
     if (audit.result.scoreDisplayMode === 'error') {
       auditEl.classList.add(`lh-audit--error`);
       const textEl = this.dom.find('.lh-audit__display-text', auditEl);
-      textEl.textContent = Util.UIStrings.errorLabel;
+      textEl.textContent = Util.str(Util.UIStrings.errorLabel);
       textEl.classList.add('tooltip-boundary');
       const tooltip = this.dom.createChildOf(textEl, 'div', 'tooltip tooltip--error');
-      tooltip.textContent = audit.result.errorMessage || Util.UIStrings.errorMissingAuditInfo;
+      tooltip.textContent = audit.result.errorMessage || Util.str(Util.UIStrings.errorMissingAuditInfo);
     } else if (audit.result.explanation) {
       const explEl = this.dom.createChildOf(titleEl, 'div', 'lh-audit-explanation');
       explEl.textContent = audit.result.explanation;
@@ -100,9 +100,9 @@ class CategoryRenderer {
     // Add list of warnings or singular warning
     const warningsEl = this.dom.createChildOf(titleEl, 'div', 'lh-warnings');
     if (warnings.length === 1) {
-      warningsEl.textContent = `${Util.UIStrings.warningHeader} ${warnings.join('')}`;
+      warningsEl.textContent = `${Util.str(Util.UIStrings.warningHeader)} ${warnings.join('')}`;
     } else {
-      warningsEl.textContent = Util.UIStrings.warningHeader;
+      warningsEl.textContent = Util.str(Util.UIStrings.warningHeader);
       const warningsUl = this.dom.createChildOf(warningsEl, 'ul');
       for (const warning of warnings) {
         const item = this.dom.createChildOf(warningsUl, 'li');
@@ -169,7 +169,7 @@ class CategoryRenderer {
     const itemCountEl = this.dom.createChildOf(summmaryEl, 'div', 'lh-audit-group__itemcount');
     if (expandable) {
       const chevronEl = summmaryEl.appendChild(this._createChevron());
-      chevronEl.title = Util.UIStrings.auditGroupExpandTooltip;
+      chevronEl.title = Util.str(Util.UIStrings.auditGroupExpandTooltip);
     }
 
     if (group.description) {
@@ -223,7 +223,7 @@ class CategoryRenderer {
    */
   renderPassedAuditsSection(elements) {
     const passedElem = this.renderAuditGroup({
-      title: Util.UIStrings.passedAuditsGroupTitle,
+      title: Util.str(Util.UIStrings.passedAuditsGroupTitle),
     }, {expandable: true, itemCount: this._getTotalAuditsLength(elements)});
     passedElem.classList.add('lh-passed-audits');
     elements.forEach(elem => passedElem.appendChild(elem));
@@ -236,7 +236,7 @@ class CategoryRenderer {
    */
   _renderNotApplicableAuditsSection(elements) {
     const notApplicableElem = this.renderAuditGroup({
-      title: Util.UIStrings.notApplicableAuditsGroupTitle,
+      title: Util.str(Util.UIStrings.notApplicableAuditsGroupTitle),
     }, {expandable: true, itemCount: this._getTotalAuditsLength(elements)});
     notApplicableElem.classList.add('lh-audit-group--not-applicable');
     elements.forEach(elem => notApplicableElem.appendChild(elem));
@@ -249,7 +249,7 @@ class CategoryRenderer {
    * @return {Element}
    */
   _renderManualAudits(manualAudits, manualDescription) {
-    const group = {title: Util.UIStrings.manualAuditsGroupTitle, description: manualDescription};
+    const group = {title: Util.str(Util.UIStrings.manualAuditsGroupTitle), description: manualDescription};
     const auditGroupElem = this.renderAuditGroup(group,
         {expandable: true, itemCount: manualAudits.length});
     auditGroupElem.classList.add('lh-audit-group--manual');
@@ -294,7 +294,7 @@ class CategoryRenderer {
     percentageEl.textContent = scoreOutOf100.toString();
     if (category.score === null) {
       percentageEl.textContent = '?';
-      percentageEl.title = Util.UIStrings.errorLabel;
+      percentageEl.title = Util.str(Util.UIStrings.errorLabel);
     }
 
     this.dom.find('.lh-gauge__label', tmpl).textContent = category.title;

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -89,7 +89,8 @@ class CategoryRenderer {
       textEl.textContent = Util.str(Util.UIStrings.errorLabel);
       textEl.classList.add('tooltip-boundary');
       const tooltip = this.dom.createChildOf(textEl, 'div', 'tooltip tooltip--error');
-      tooltip.textContent = audit.result.errorMessage || Util.str(Util.UIStrings.errorMissingAuditInfo);
+      tooltip.textContent = audit.result.errorMessage ||
+          Util.str(Util.UIStrings.errorMissingAuditInfo);
     } else if (audit.result.explanation) {
       const explEl = this.dom.createChildOf(titleEl, 'div', 'lh-audit-explanation');
       explEl.textContent = audit.result.explanation;
@@ -249,7 +250,10 @@ class CategoryRenderer {
    * @return {Element}
    */
   _renderManualAudits(manualAudits, manualDescription) {
-    const group = {title: Util.str(Util.UIStrings.manualAuditsGroupTitle), description: manualDescription};
+    const group = {
+      title: Util.str(Util.UIStrings.manualAuditsGroupTitle),
+      description: manualDescription,
+    };
     const auditGroupElem = this.renderAuditGroup(group,
         {expandable: true, itemCount: manualAudits.length});
     auditGroupElem.classList.add('lh-audit-group--manual');

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -139,7 +139,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     });
     const estValuesEl = this.dom.createChildOf(metricsColumn2El, 'div',
         'lh-metrics__disclaimer lh-metrics__disclaimer');
-    estValuesEl.textContent = Util.UIStrings.varianceDisclaimer;
+    estValuesEl.textContent = Util.str(Util.UIStrings.varianceDisclaimer);
 
     metricAuditsEl.classList.add('lh-audit-group--metrics');
     element.appendChild(metricAuditsEl);
@@ -169,9 +169,9 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
       const tmpl = this.dom.cloneTemplate('#tmpl-lh-opportunity-header', this.templateContext);
 
       this.dom.find('.lh-load-opportunity__col--one', tmpl).textContent =
-        Util.UIStrings.opportunityResourceColumnLabel;
+        Util.str(Util.UIStrings.opportunityResourceColumnLabel);
       this.dom.find('.lh-load-opportunity__col--two', tmpl).textContent =
-        Util.UIStrings.opportunitySavingsColumnLabel;
+        Util.str(Util.UIStrings.opportunitySavingsColumnLabel);
 
       const headerEl = this.dom.find('.lh-load-opportunity__header', tmpl);
       groupEl.appendChild(headerEl);

--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -46,15 +46,13 @@ class ReportRenderer {
   renderReport(report, container) {
     // If any mutations happen to the report within the renderers, we want the original object untouched
     const clone = /** @type {LH.ReportResult} */ (JSON.parse(JSON.stringify(report)));
-    // Mutate the UIStrings if necessary (while saving originals)
-    const originalUIStrings = JSON.parse(JSON.stringify(Util.UIStrings));
     // If LHR is older (≤3.0.3), it has no locale setting. Set default.
     if (!clone.configSettings.locale) {
       clone.configSettings.locale = 'en-US';
     }
     Util.setNumberDateLocale(clone.configSettings.locale);
     if (clone.i18n && clone.i18n.rendererFormattedStrings) {
-      ReportRenderer.updateAllUIStrings(clone.i18n.rendererFormattedStrings);
+      Util.rendererFormattedStrings = clone.i18n.rendererFormattedStrings;
     }
 
     // TODO(phulce): we all agree this is technical debt we should fix
@@ -64,9 +62,6 @@ class ReportRenderer {
 
     container.textContent = ''; // Remove previous report.
     container.appendChild(this._renderReport(clone));
-
-    // put the UIStrings back into original state
-    ReportRenderer.updateAllUIStrings(originalUIStrings);
 
     return /** @type {Element} **/ (container);
   }
@@ -152,7 +147,7 @@ class ReportRenderer {
 
     const container = this._dom.cloneTemplate('#tmpl-lh-warnings--toplevel', this._templateContext);
     const message = this._dom.find('.lh-warnings__msg', container);
-    message.textContent = Util.UIStrings.toplevelWarningsMessage;
+    message.textContent = Util.str(Util.UIStrings.toplevelWarningsMessage);
 
     const warnings = this._dom.find('ul', container);
     for (const warningString of report.runWarnings) {
@@ -216,7 +211,7 @@ class ReportRenderer {
     if (scoreHeader) {
       const scoreScale = this._dom.cloneTemplate('#tmpl-lh-scorescale', this._templateContext);
       this._dom.find('.lh-scorescale-label', scoreScale).textContent =
-        Util.UIStrings.scorescaleLabel;
+        Util.str(Util.UIStrings.scorescaleLabel);
       scoresContainer.appendChild(scoreHeader);
       scoresContainer.appendChild(scoreScale);
     }
@@ -241,16 +236,6 @@ class ReportRenderer {
         const result = audits[auditMeta.id];
         auditMeta.result = result;
       });
-    }
-  }
-
-  /**
-   * @param {LH.I18NRendererStrings} rendererFormattedStrings
-   */
-  static updateAllUIStrings(rendererFormattedStrings) {
-    // TODO(i18n): don't mutate these here but on the LHR and pass that around everywhere
-    for (const [key, value] of Object.entries(rendererFormattedStrings)) {
-      Util.UIStrings[key] = value;
     }
   }
 }

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -39,20 +39,6 @@ class Util {
   }
 
   /**
-   * @param {string} sourceString
-   * @return {string}
-   */
-  static str_(sourceString) {
-    // If the renderer was provided new strings, we'll use those
-    if (Util.rendererFormattedStrings) {
-      const keyName = Object.keys(Util.UIStrings).find(key => Util.UIStrings[key] === sourceString);
-      return Util.rendererFormattedStrings[/** @type {string} */ (keyName)];
-    }
-    // Otherwise, continue using the source string already referenced
-    return sourceString;
-  }
-
-  /**
    * @param {string|Array<string|number>=} displayValue
    * @return {string}
    */
@@ -413,6 +399,21 @@ class Util {
       networkThrottling,
       summary: `${deviceEmulation}, ${summary}`,
     };
+  }
+
+  /**
+   * @param {string} sourceString
+   * @return {string}
+   */
+  static str(sourceString) {
+    // If the renderer was provided new strings, we'll use those
+    if (Util.rendererFormattedStrings) {
+      const keyName = Object.keys(Util.UIStrings).find(key => Util.UIStrings[key] === sourceString);
+      const localizedString = Util.rendererFormattedStrings[/** @type {string} */ (keyName)];
+      if (localizedString) return localizedString;
+    }
+    // Otherwise, continue using the source string already referenced
+    return sourceString;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -39,6 +39,20 @@ class Util {
   }
 
   /**
+   * @param {string} sourceString
+   * @return {string}
+   */
+  static str_(sourceString) {
+    // If the renderer was provided new strings, we'll use those
+    if (Util.rendererFormattedStrings) {
+      const keyName = Object.keys(Util.UIStrings).find(key => Util.UIStrings[key] === sourceString);
+      return Util.rendererFormattedStrings[/** @type {string} */ (keyName)];
+    }
+    // Otherwise, continue using the source string already referenced
+    return sourceString;
+  }
+
+  /**
    * @param {string|Array<string|number>=} displayValue
    * @return {string}
    */
@@ -413,6 +427,11 @@ class Util {
     if (Util.numberDateLocale === 'en-XA') Util.numberDateLocale = 'de-DE';
   }
 }
+
+/**
+ * @type {LH.I18NRendererStrings | undefined}
+ */
+Util.rendererFormattedStrings = undefined;
 
 /**
  * This value is updated on each run to the locale of the report

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -168,6 +168,21 @@ describe('util helpers', () => {
     assert.deepStrictEqual(displayValue, cloned, 'displayValue was mutated');
   });
 
+  describe('str()', () => {
+    it('returns original string if no localized ones were provided', () => {
+      const sampleUIString = Util.UIStrings.passedAuditsGroupTitle;
+      assert.equal(Util.str(Util.UIStrings.passedAuditsGroupTitle), sampleUIString);
+    });
+
+    it('returns localized UI string if it was in the LHR', () => {
+      const cloneResults = JSON.parse(JSON.stringify(sampleResults));
+      const localizedStr = 'Våļûéš åŕé éšţîmåţéð';
+      cloneResults.i18n.rendererFormattedStrings.varianceDisclaimer = localizedStr;
+      Util.rendererFormattedStrings = cloneResults.i18n.rendererFormattedStrings;
+      assert.equal(Util.str(Util.UIStrings.varianceDisclaimer), localizedStr);
+    });
+  });
+
   describe('getFinalScreenshot', () => {
     const cloneResults = JSON.parse(JSON.stringify(sampleResults));
     cloneResults.reportCategories = Object.values(cloneResults.categories);


### PR DESCRIPTION
cf. #5179 

* all uses of Util.UIString in the renderer pass through `Util.str()`
* this fn will use the supplied localized string, if that was provided. otherwise it'll fall back to the original string in the `util.js` source file. (which is en-us)
* no more mutate/restore dance on this data
