### PR TITLE
extension: refactor option/flag passing (breaking change)

### DIFF
--- a/lighthouse-extension/app/src/lighthouse-background.js
+++ b/lighthouse-extension/app/src/lighthouse-background.js
@@ -16,26 +16,22 @@ const log = require('lighthouse-logger');
 /**
  * @param {Connection} connection
  * @param {string} url
- * @param {{flags: LH.Flags}} options Lighthouse options.
+ * @param {LH.Flags} flags Lighthouse flags.
  * @param {Array<string>} categoryIDs Name values of categories to include.
  * @param {(url?: string) => void} updateBadgeFn
  * @return {Promise<LH.RunnerResult|void>}
  */
-function runLighthouseForConnection(
-  connection, url, options, categoryIDs,
-  updateBadgeFn = function() { }) {
+function runLighthouseForConnection(connection, url, flags, categoryIDs, updateBadgeFn = _ => {}) {
   const config = new Config({
     extends: 'lighthouse:default',
     settings: {
       onlyCategories: categoryIDs,
     },
-  }, options.flags);
+  }, flags);
 
-  // Add url and config to fresh options object.
-  const runOptions = Object.assign({}, options, {url, config});
   updateBadgeFn(url);
 
-  return Runner.run(connection, runOptions) // Run Lighthouse.
+  return Runner.run(connection, {url, config}) // Run Lighthouse.
     .then(result => {
       updateBadgeFn();
       return result;
@@ -49,15 +45,15 @@ function runLighthouseForConnection(
 /**
  * @param {RawProtocol.Port} port
  * @param {string} url
- * @param {{flags: LH.Flags}} options Lighthouse options.
+ * @param {LH.Flags} flags Lighthouse flags.
  * @param {Array<string>} categoryIDs Name values of categories to include.
  * @return {Promise<LH.RunnerResult|void>}
  */
-function runLighthouseInWorker(port, url, options, categoryIDs) {
+function runLighthouseInWorker(port, url, flags, categoryIDs) {
   // Default to 'info' logging level.
   log.setLevel('info');
   const connection = new RawProtocol(port);
-  return runLighthouseForConnection(connection, url, options, categoryIDs);
+  return runLighthouseForConnection(connection, url, flags, categoryIDs);
 }
 
 /**

--- a/lighthouse-extension/app/src/lighthouse-ext-background.js
+++ b/lighthouse-extension/app/src/lighthouse-ext-background.js
@@ -47,18 +47,18 @@ function updateBadgeUI(optUrl) {
 }
 
 /**
- * @param {{flags: LH.Flags}} options Lighthouse options.
+ * @param {LH.Flags} flags Lighthouse flags.
  * @param {Array<string>} categoryIDs Name values of categories to include.
  * @return {Promise<LH.RunnerResult|void>}
  */
-async function runLighthouseInExtension(options, categoryIDs) {
+async function runLighthouseInExtension(flags, categoryIDs) {
   // Default to 'info' logging level.
   log.setLevel('info');
   const connection = new ExtensionProtocol();
-  options.flags = Object.assign({}, options.flags, {output: 'html'});
+  flags.output = 'html';
 
   const url = await connection.getCurrentTabURL();
-  const runnerResult = await background.runLighthouseForConnection(connection, url, options,
+  const runnerResult = await background.runLighthouseForConnection(connection, url, flags,
     categoryIDs, updateBadgeUI);
   if (!runnerResult) {
     // For now, should always be a runnerResult as the extension can't do `gatherMode`
@@ -73,19 +73,17 @@ async function runLighthouseInExtension(options, categoryIDs) {
  * Run lighthouse for connection and provide similar results as in CLI.
  * @param {Connection} connection
  * @param {string} url
- * @param {{flags: LH.Flags} & {outputFormat: string, logAssets: boolean}} options Lighthouse options.
+ * @param {LH.Flags & {logAssets: boolean}} flags Lighthouse flags plus logAssets
           Specify outputFormat to change the output format.
  * @param {Array<string>} categoryIDs Name values of categories to include.
  * @return {Promise<string|Array<string>|void>}
  */
-async function runLighthouseAsInCLI(connection, url, options, categoryIDs) {
+async function runLighthouseAsInCLI(connection, url, flags, categoryIDs) {
   log.setLevel('info');
-  options.flags = Object.assign({}, options.flags, {output: options.outputFormat});
-
-  const results = await background.runLighthouseForConnection(connection, url, options,
-    categoryIDs);
+  // TODO(paulirish): update LR to provide flags and map outputFormat -> output
+  const results = await background.runLighthouseForConnection(connection, url, flags, categoryIDs);
   if (results) {
-    if (options && options.logAssets) {
+    if (flags && flags.logAssets) {
       await assetSaver.logAssets(results.artifacts, results.lhr.audits);
     }
 

--- a/lighthouse-extension/app/src/lighthouse-ext-background.js
+++ b/lighthouse-extension/app/src/lighthouse-ext-background.js
@@ -73,22 +73,22 @@ async function runLighthouseInExtension(flags, categoryIDs) {
  * Run lighthouse for connection and provide similar results as in CLI.
  * @param {Connection} connection
  * @param {string} url
- * @param {LH.Flags & {logAssets: boolean}} flags Lighthouse flags plus logAssets
+ * @param {LH.Flags} flags Lighthouse flags plus logAssets
           Specify outputFormat to change the output format.
  * @param {Array<string>} categoryIDs Name values of categories to include.
+ * @param {{logAssets: boolean}} lrOpts Options coming from Lightrider
  * @return {Promise<string|Array<string>|void>}
  */
-async function runLighthouseAsInCLI(connection, url, flags, categoryIDs) {
+async function runLighthouseAsInCLI(connection, url, flags, categoryIDs, {logAssets}) {
   log.setLevel('info');
-  // TODO(paulirish): update LR to provide flags and map outputFormat -> output
   const results = await background.runLighthouseForConnection(connection, url, flags, categoryIDs);
-  if (results) {
-    if (flags && flags.logAssets) {
-      await assetSaver.logAssets(results.artifacts, results.lhr.audits);
-    }
+  if (!results) return;
 
-    return results.report;
+  if (logAssets) {
+    await assetSaver.logAssets(results.artifacts, results.lhr.audits);
   }
+
+  return results.report;
 }
 
 

--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -164,7 +164,7 @@ async function onGenerateReportButtonClick(background, settings) {
   const flags = /** @type {LH.Flags} */ ({throttlingMethod: useDevTools ? 'devtools' : 'simulate'});
 
   try {
-    await background.runLighthouseInExtension({flags}, selectedCategories);
+    await background.runLighthouseInExtension(flags, selectedCategories);
 
     // Close popup once report is opened in a new tab
     window.close();


### PR DESCRIPTION
disclaimer: This is a breaking change for our integrations with them so all the clients must also update for this to work.

So I'm okay with delaying this PR for a bit.

------

This simplifies how we were juggling "options" coming in from extension/devtools/LR. Basically we were passing around an `options` object in the 2 -background files and all we cared about was its `flags` property. And in the case of LR, 2 other props came in on `options` and eventually are delivered into `Runner.run`, despite our typing.

reviewers: 
runner.js only has a rename. boring.
the background files have all the good stuff.