### PR TITLE
tests(jest): disable coverage collection by default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@
 'use strict';
 
 module.exports = {
-  collectCoverage: true,
+  collectCoverage: false,
   coverageReporters: ['none'],
   collectCoverageFrom: [
     '**/lighthouse-core/**/*.js',


### PR DESCRIPTION
since CI uses custom `*:ci` npm scripts that have `--coverage` included, i'm not sure why we defaulted to coverage collected in the config.

