### PR TITLE
deps: depend on speedline-core, rather than the cli

### DIFF
--- a/lighthouse-core/gather/computed/speedline.js
+++ b/lighthouse-core/gather/computed/speedline.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const ComputedArtifact = require('./computed-artifact');
-const speedline = require('speedline');
+const speedline = require('speedline-core');
 const LHError = require('../../lib/errors');
 
 class Speedline extends ComputedArtifact {

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "rimraf": "^2.6.1",
     "robots-parser": "^2.0.1",
     "semver": "^5.3.0",
-    "speedline": "1.3.3",
+    "speedline-core": "1.4.0",
     "update-notifier": "^2.1.0",
     "ws": "3.3.2",
     "yargs": "3.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,12 +532,6 @@ axios@^0.16.2:
     follow-redirects "^1.2.3"
     is-buffer "^1.1.5"
 
-babar@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/babar/-/babar-0.2.0.tgz#79bc0f029721467207f2b6baedf96b3938ad7db0"
-  dependencies:
-    colors "~0.6.2"
-
 babel-code-frame@^6.16.0:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.16.0.tgz#f90e60da0862909d3ce098733b5d3987c97cb8de"
@@ -1168,10 +1162,6 @@ color-name@^1.1.1:
 colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
-
-colors@~0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
 
 combined-stream@1.0.6:
   version "1.0.6"
@@ -4178,7 +4168,7 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^1.0.1"
 
-loud-rejection@^1.0.0, loud-rejection@^1.6.0:
+loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
   dependencies:
@@ -5789,16 +5779,13 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-speedline@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/speedline/-/speedline-1.3.3.tgz#c5b38f7ba81a1e1cc34ed3e9cc0ac9b6260a20ed"
+speedline-core@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/speedline-core/-/speedline-core-1.4.0.tgz#884831eaef66ddc928dd7d4c9e844c5d28bad7db"
   dependencies:
     "@types/node" "*"
-    babar "0.2.0"
     image-ssim "^0.2.0"
     jpeg-js "^0.1.2"
-    loud-rejection "^1.6.0"
-    meow "^3.7.0"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
removes a few deps from yarn.lock

`meow` is no longer in the deps tree, though it does still get pulled in for devDeps via `conventional-changelog-cli`.

