### PR TITLE
report: expose prepareLabData directly as a fn

### DIFF
--- a/lighthouse-core/report/html/renderer/psi.js
+++ b/lighthouse-core/report/html/renderer/psi.js
@@ -69,8 +69,6 @@ function _getFinalScreenshot(perfCategory) {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = prepareLabData;
-  module.exports._getFinalScreenshot = _getFinalScreenshot;
 } else {
-  // @ts-ignore we avoid exposing _getFinalScreenshot to the browser
   self.prepareLabData = prepareLabData;
 }

--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -165,7 +165,6 @@ class ReportRenderer {
       header = this._renderReportHeader(report);
     }
     headerContainer.appendChild(header);
-    const scoresContainer = this._dom.find('.lh-scores-container', headerContainer);
 
     const container = this._dom.createElement('div', 'lh-container');
     const reportSection = container.appendChild(this._dom.createElement('div', 'lh-report'));
@@ -204,6 +203,7 @@ class ReportRenderer {
       const scoreScale = this._dom.cloneTemplate('#tmpl-lh-scorescale', this._templateContext);
       this._dom.find('.lh-scorescale-label', scoreScale).textContent =
         Util.UIStrings.scorescaleLabel;
+      const scoresContainer = this._dom.find('.lh-scores-container', headerContainer);
       scoresContainer.appendChild(scoreHeader);
       scoresContainer.appendChild(scoreScale);
     }

--- a/lighthouse-core/test/report/html/renderer/psi-test.js
+++ b/lighthouse-core/test/report/html/renderer/psi-test.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const jsdom = require('jsdom');
 
 const URL = require('../../../../lib/url-shim');
-const PSI = require('../../../../report/html/renderer/psi.js');
+const prepareLabData = require('../../../../report/html/renderer/psi.js');
 const Util = require('../../../../report/html/renderer/util.js');
 const DOM = require('../../../../report/html/renderer/dom.js');
 const CategoryRenderer = require('../../../../report/html/renderer/category-renderer');
@@ -60,7 +60,7 @@ describe('DOM', () => {
   describe('psi prepareLabData helpers', () => {
     describe('prepareLabData', () => {
       it('reports expected data', () => {
-        const result = PSI.prepareLabData(sampleResultsStr, document);
+        const result = prepareLabData(sampleResultsStr, document);
         assert.ok(result.scoreGaugeEl instanceof document.defaultView.Element);
         assert.equal(result.scoreGaugeEl.querySelector('.lh-gauge__wrapper').href, '');
         assert.ok(result.scoreGaugeEl.outerHTML.includes('<style>'), 'score gauge comes with CSS');
@@ -81,7 +81,7 @@ describe('DOM', () => {
         const lhrWithoutPerfStr = JSON.stringify(lhrWithoutPerf);
 
         assert.throws(() => {
-          PSI.prepareLabData(lhrWithoutPerfStr, document);
+          prepareLabData(lhrWithoutPerfStr, document);
         }, /no performance category/i);
       });
 
@@ -91,17 +91,17 @@ describe('DOM', () => {
         const lhrWithoutGroupsStr = JSON.stringify(lhrWithoutGroups);
 
         assert.throws(() => {
-          PSI.prepareLabData(lhrWithoutGroupsStr, document);
+          prepareLabData(lhrWithoutGroupsStr, document);
         }, /no category groups/i);
       });
     });
   });
 
-  describe('getFinalScreenshot', () => {
+  describe('_getFinalScreenshot', () => {
     it('gets a datauri as a string', () => {
       const cloneResults = Util.prepareReportResult(sampleResults);
       const perfCategory = cloneResults.reportCategories.find(cat => cat.id === 'performance');
-      const datauri = PSI.getFinalScreenshot(perfCategory);
+      const datauri = prepareLabData._getFinalScreenshot(perfCategory);
       assert.equal(typeof datauri, 'string');
       assert.ok(datauri.startsWith('data:image/jpeg;base64,'));
     });
@@ -112,7 +112,7 @@ describe('DOM', () => {
       const lhrNoFinalSS = Util.prepareReportResult(clonedResults);
       const perfCategory = lhrNoFinalSS.reportCategories.find(cat => cat.id === 'performance');
 
-      const datauri = PSI.getFinalScreenshot(perfCategory);
+      const datauri = prepareLabData._getFinalScreenshot(perfCategory);
       assert.equal(datauri, null);
     });
   });

--- a/lighthouse-core/test/report/html/renderer/psi-test.js
+++ b/lighthouse-core/test/report/html/renderer/psi-test.js
@@ -99,9 +99,8 @@ describe('DOM', () => {
 
   describe('_getFinalScreenshot', () => {
     it('gets a datauri as a string', () => {
-      const cloneResults = Util.prepareReportResult(sampleResults);
-      const perfCategory = cloneResults.reportCategories.find(cat => cat.id === 'performance');
-      const datauri = prepareLabData._getFinalScreenshot(perfCategory);
+      const LHResultJsonString = JSON.stringify(sampleResults);
+      const datauri = prepareLabData(LHResultJsonString, document).finalScreenshotDataUri;
       assert.equal(typeof datauri, 'string');
       assert.ok(datauri.startsWith('data:image/jpeg;base64,'));
     });
@@ -109,10 +108,8 @@ describe('DOM', () => {
     it('returns null if there is no final-screenshot audit', () => {
       const clonedResults = JSON.parse(JSON.stringify(sampleResults));
       delete clonedResults.audits['final-screenshot'];
-      const lhrNoFinalSS = Util.prepareReportResult(clonedResults);
-      const perfCategory = lhrNoFinalSS.reportCategories.find(cat => cat.id === 'performance');
-
-      const datauri = prepareLabData._getFinalScreenshot(perfCategory);
+      const LHResultJsonString = JSON.stringify(clonedResults);
+      const datauri = prepareLabData(LHResultJsonString, document).finalScreenshotDataUri;
       assert.equal(datauri, null);
     });
   });

--- a/typings/html-renderer.d.ts
+++ b/typings/html-renderer.d.ts
@@ -12,7 +12,7 @@ import _PerformanceCategoryRenderer = require('../lighthouse-core/report/html/re
 import _ReportRenderer = require('../lighthouse-core/report/html/renderer/report-renderer.js');
 import _ReportUIFeatures = require('../lighthouse-core/report/html/renderer/report-ui-features.js');
 import _Util = require('../lighthouse-core/report/html/renderer/util.js');
-import _PSI = require('../lighthouse-core/report/html/renderer/psi.js');
+import _prepareLabData = require('../lighthouse-core/report/html/renderer/psi.js');
 import _FileNamer = require('../lighthouse-core/lib/file-namer.js');
 
 declare global {
@@ -25,7 +25,7 @@ declare global {
   var ReportRenderer: typeof _ReportRenderer;
   var ReportUIFeatures: typeof _ReportUIFeatures;
   var Util: typeof _Util;
-  var PSI: typeof _PSI;
+  var prepareLabData: typeof _prepareLabData;
 
   interface Window {
     CategoryRenderer: typeof _CategoryRenderer;
@@ -36,7 +36,7 @@ declare global {
     ReportRenderer: typeof _ReportRenderer;
     ReportUIFeatures: typeof _ReportUIFeatures;
     Util: typeof _Util;
-    PSI: typeof _PSI;
+    prepareLabData: typeof _prepareLabData;
   }
 
   module LH {


### PR DESCRIPTION
requested by PSI

[ignore whitespace](https://github.com/GoogleChrome/lighthouse/compare/preparefn?w=1) in the diff.