### PR TITLE
report: make red/orange/green score color thresholds tougher

### DIFF
--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -20,11 +20,11 @@
 
 const ELLIPSIS = '\u2026';
 const NBSP = '\xa0';
-const PASS_THRESHOLD = 0.75;
+const PASS_THRESHOLD = 0.9;
 
 const RATINGS = {
   PASS: {label: 'pass', minScore: PASS_THRESHOLD},
-  AVERAGE: {label: 'average', minScore: 0.45},
+  AVERAGE: {label: 'average', minScore: 0.5},
   FAIL: {label: 'fail'},
   ERROR: {label: 'error'},
 };

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -84,9 +84,10 @@ describe('util helpers', () => {
     assert.equal(Util.calculateRating(0.0), 'fail');
     assert.equal(Util.calculateRating(0.10), 'fail');
     assert.equal(Util.calculateRating(0.45), 'fail');
-    assert.equal(Util.calculateRating(0.55), 'average');
+    assert.equal(Util.calculateRating(0.5), 'average');
     assert.equal(Util.calculateRating(0.75), 'average');
     assert.equal(Util.calculateRating(0.80), 'average');
+    assert.equal(Util.calculateRating(0.90), 'pass');
     assert.equal(Util.calculateRating(1.00), 'pass');
   });
 

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -83,10 +83,10 @@ describe('util helpers', () => {
   it('calculates a score ratings', () => {
     assert.equal(Util.calculateRating(0.0), 'fail');
     assert.equal(Util.calculateRating(0.10), 'fail');
-    assert.equal(Util.calculateRating(0.45), 'average');
+    assert.equal(Util.calculateRating(0.45), 'fail');
     assert.equal(Util.calculateRating(0.55), 'average');
-    assert.equal(Util.calculateRating(0.75), 'pass');
-    assert.equal(Util.calculateRating(0.80), 'pass');
+    assert.equal(Util.calculateRating(0.75), 'average');
+    assert.equal(Util.calculateRating(0.80), 'average');
     assert.equal(Util.calculateRating(1.00), 'pass');
   });
 


### PR DESCRIPTION
For harmony with PSI thresholds.

note that `Util.PASS_THRESHOLD` also affects when [`title` vs `failureTitle` is selected for an audit](https://github.com/GoogleChrome/lighthouse/blob/049af195ab33d40718e6fe39a278de1c2ec07ec5/lighthouse-core/audits/audit.js#L192-L196)

@paulirish