### PR TITLE
core(tsc): NetworkRequest.RESOURCE_TYPES type fix

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -151,7 +151,7 @@ class CacheHeaders extends Audit {
   static isCacheableAsset(record) {
     const CACHEABLE_STATUS_CODES = new Set([200, 203, 206]);
 
-    /** @type {Set<string>} */
+    /** @type {Set<LH.Crdp.Page.ResourceType>} */
     const STATIC_RESOURCE_TYPES = new Set([
       NetworkRequest.TYPES.Font,
       NetworkRequest.TYPES.Image,

--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -151,6 +151,7 @@ class CacheHeaders extends Audit {
   static isCacheableAsset(record) {
     const CACHEABLE_STATUS_CODES = new Set([200, 203, 206]);
 
+    /** @type {Set<string>} */
     const STATIC_RESOURCE_TYPES = new Set([
       NetworkRequest.TYPES.Font,
       NetworkRequest.TYPES.Image,

--- a/lighthouse-core/gather/computed/critical-request-chains.js
+++ b/lighthouse-core/gather/computed/critical-request-chains.js
@@ -36,7 +36,7 @@ class CriticalRequestChains extends ComputedArtifact {
     // XHRs are fetched at High priority, but we exclude them, as they are unlikely to be critical
     // Images are also non-critical.
     // Treat any missed images, primarily favicons, as non-critical resources
-    /** @type {Array<string>} */
+    /** @type {Array<LH.Crdp.Page.ResourceType>} */
     const nonCriticalResourceTypes = [
       NetworkRequest.TYPES.Image,
       NetworkRequest.TYPES.XHR,

--- a/lighthouse-core/gather/computed/critical-request-chains.js
+++ b/lighthouse-core/gather/computed/critical-request-chains.js
@@ -36,6 +36,7 @@ class CriticalRequestChains extends ComputedArtifact {
     // XHRs are fetched at High priority, but we exclude them, as they are unlikely to be critical
     // Images are also non-critical.
     // Treat any missed images, primarily favicons, as non-critical resources
+    /** @type {Array<string>} */
     const nonCriticalResourceTypes = [
       NetworkRequest.TYPES.Image,
       NetworkRequest.TYPES.XHR,

--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -20,7 +20,7 @@ const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
 const compressionHeaders = ['content-encoding', 'x-original-content-encoding'];
 const compressionTypes = ['gzip', 'br', 'deflate'];
 const binaryMimeTypes = ['image', 'audio', 'video'];
-/** @type {Array<string>} */
+/** @type {Array<LH.Crdp.Page.ResourceType>} */
 const textResourceTypes = [
   NetworkRequest.TYPES.Document,
   NetworkRequest.TYPES.Script,

--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -20,6 +20,7 @@ const CHROME_EXTENSION_PROTOCOL = 'chrome-extension:';
 const compressionHeaders = ['content-encoding', 'x-original-content-encoding'];
 const compressionTypes = ['gzip', 'br', 'deflate'];
 const binaryMimeTypes = ['image', 'audio', 'video'];
+/** @type {Array<string>} */
 const textResourceTypes = [
   NetworkRequest.TYPES.Document,
   NetworkRequest.TYPES.Script,

--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -28,7 +28,7 @@ const SECURE_SCHEMES = ['data', 'https', 'wss', 'blob', 'chrome', 'chrome-extens
  * @property {string} securityOrigin
  */
 
-/** @type {Record<LH.Crdp.Page.ResourceType, LH.Crdp.Page.ResourceType>} */
+/** @type {SelfMap<LH.Crdp.Page.ResourceType>} */
 const RESOURCE_TYPES = {
   XHR: 'XHR',
   Fetch: 'Fetch',


### PR DESCRIPTION
After adding `SelfMap` in #5849, went through all our uses of `Record<>` to see if we actually meant that the keys need to be mapped to themselves. This is the only case I could find.

Unfortunately that meant that some other types needed to be widened to accommodate this, but good to have the type of `RESOURCE_TYPES.Fetch` be `'Fetch'` and not `'XHR'|'Fetch'|'EventSource'|'Script'|...` :)