### PR TITLE
core(tsc): type check config files

### DIFF
--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -35,7 +35,8 @@ const UIStrings = {
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
-module.exports = {
+/** @type {LH.Config.Json} */
+const defaultConfig = {
   settings: constants.defaultSettings,
   passes: [{
     passName: 'defaultPass',
@@ -445,3 +446,5 @@ Object.defineProperty(module.exports, 'UIStrings', {
   enumerable: false,
   get: () => UIStrings,
 });
+
+module.exports = defaultConfig;

--- a/lighthouse-core/config/full-config.js
+++ b/lighthouse-core/config/full-config.js
@@ -5,7 +5,8 @@
  */
 'use strict';
 
-module.exports = {
+/** @type {LH.Config.Json} */
+const fullConfig = {
   extends: 'lighthouse:default',
   settings: {},
   passes: [
@@ -19,6 +20,7 @@ module.exports = {
   audits: [
     'byte-efficiency/unused-javascript',
   ],
+  // @ts-ignore TODO(bckenny): type extended Config where e.g. category.title isn't required
   categories: {
     'performance': {
       auditRefs: [
@@ -27,3 +29,5 @@ module.exports = {
     },
   },
 };
+
+module.exports = fullConfig;

--- a/lighthouse-core/config/mixed-content-config.js
+++ b/lighthouse-core/config/mixed-content-config.js
@@ -5,7 +5,8 @@
  */
 'use strict';
 
-module.exports = {
+/** @type {LH.Config.Json} */
+const mixedContentConfig = {
   // This performs two passes:
   // (1) Gather the default resources requested by the page, and
   // (2) Re-load page but attempt to upgrade each request to HTTPS.
@@ -35,3 +36,5 @@ module.exports = {
     },
   },
 };
+
+module.exports = mixedContentConfig;

--- a/lighthouse-core/config/perf-config.js
+++ b/lighthouse-core/config/perf-config.js
@@ -5,10 +5,13 @@
  */
 'use strict';
 
-module.exports = {
+/** @type {LH.Config.Json} */
+const perfConfig = {
   extends: 'lighthouse:default',
   settings: {
     throttlingMethod: 'devtools',
     onlyCategories: ['performance'],
   },
 };
+
+module.exports = perfConfig;

--- a/lighthouse-core/config/plots-config.js
+++ b/lighthouse-core/config/plots-config.js
@@ -5,7 +5,8 @@
  */
 'use strict';
 
-module.exports = {
+/** @type {LH.Config.Json} */
+const plotsConfig = {
   extends: 'lighthouse:default',
   settings: {
     onlyAudits: [
@@ -17,3 +18,5 @@ module.exports = {
     ],
   },
 };
+
+module.exports = plotsConfig;

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -52,13 +52,14 @@ declare global {
 
       export interface CategoryJson {
         title: string;
-        description: string;
         auditRefs: AuditRefJson[];
+        description?: string;
+        manualDescription?: string;
       }
 
       export interface GroupJson {
         title: string;
-        description: string;
+        description?: string;
       }
 
       export type AuditJson = {


### PR DESCRIPTION
This was flagged testing the typescript nightly against the current code base. `LH.Config.Category.description` and `LH.Config.Group.description` should both be optional [as they are in the LHR](https://github.com/GoogleChrome/lighthouse/blob/d1031575f3f79d7bedbe0f8d5e45a51e16189853/typings/lhr.d.ts#L60), and `LH.Config.Category.manualDescription` should also exist.

Also adds type annotations to the files themselves so that they're checked directly, rather than indirectly through their use in `config.js`.