### PR TITLE
core(lhr): expose environment info

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -108,6 +108,13 @@ class Driver {
   }
 
   /**
+   * @return {Promise<number>}
+   */
+  getBenchmarkIndex() {
+    return this.evaluateAsync(`(${pageFunctions.ultradumbBenchmark.toString()})()`);
+  }
+
+  /**
    * @return {Promise<void>}
    */
   connect() {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -108,6 +108,7 @@ class Driver {
   }
 
   /**
+   * Computes the ULTRADUMB™ benchmark index to get a rough estimate of device class.
    * @return {Promise<number>}
    */
   getBenchmarkIndex() {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -376,7 +376,7 @@ class GatherRunner {
       LighthouseRunWarnings: [],
       HostUserAgent: await options.driver.getUserAgent(),
       NetworkUserAgent: '', // updated later
-      BenchmarkIndex: await options.driver.getBenchmarkIndex(),
+      BenchmarkIndex: 0, // updated later
       traces: {},
       devtoolsLogs: {},
       settings: options.settings,
@@ -399,6 +399,7 @@ class GatherRunner {
       await driver.connect();
       const baseArtifacts = await GatherRunner.getBaseArtifacts(options);
       await GatherRunner.loadBlank(driver);
+      baseArtifacts.BenchmarkIndex = await options.driver.getBenchmarkIndex();
       await GatherRunner.setupDriver(driver, options);
 
       // Run each pass

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -374,7 +374,9 @@ class GatherRunner {
     return {
       fetchTime: (new Date()).toJSON(),
       LighthouseRunWarnings: [],
-      UserAgent: await options.driver.getUserAgent(),
+      HostUserAgent: await options.driver.getUserAgent(),
+      NetworkUserAgent: '', // updated later
+      BenchmarkIndex: await options.driver.getBenchmarkIndex(),
       traces: {},
       devtoolsLogs: {},
       settings: options.settings,
@@ -419,6 +421,16 @@ class GatherRunner {
 
         // Save devtoolsLog, but networkRecords are discarded and not added onto artifacts.
         baseArtifacts.devtoolsLogs[passConfig.passName] = passData.devtoolsLog;
+
+        const userAgentEntry = passData.devtoolsLog.find(entry =>
+          entry.method === 'Network.requestWillBeSent' &&
+          !!entry.params.request.headers['User-Agent']
+        );
+
+        if (userAgentEntry && !baseArtifacts.NetworkUserAgent) {
+          // @ts-ignore - guaranteed to exist by the find above
+          baseArtifacts.NetworkUserAgent = userAgentEntry.params.request.headers['User-Agent'];
+        }
 
         // If requested by config, save pass's trace.
         if (passData.trace) {

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -121,9 +121,9 @@ function getOuterHTMLSnippet(element) {
  * @see https://docs.google.com/spreadsheets/d/1E0gZwKsxegudkjJl8Fki_sOwHKpqgXwt8aBAfuUaB8A/edit?usp=sharing
  *
  * The benchmark creates a string of length 100,000 in a loop.
- * The returned index is the number of numbers per second the string can be created.
+ * The returned index is the number of times per second the string can be created.
  *
- *  - 750+ is a desktop-class device, iPhone X, etc
+ *  - 750+ is a desktop-class device, Core i3 PC, iPhone X, etc
  *  - 300+ is a high-end Android phone, Galaxy S8, low-end Chromebook, etc
  *  - 75+ is a mid-tier Android phone, Nexus 5X, etc
  *  - <75 is a budget Android phone, Alcatel Ideal, Galaxy J2, etc

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -57,7 +57,6 @@ function registerPerformanceObserverInPage() {
   window.____lhPerformanceObserver = observer;
 }
 
-
 /**
  * Used by _waitForCPUIdle and executed in the context of the page, returns time since last long task.
  */
@@ -114,7 +113,35 @@ function getElementsInDocument(selector) {
 function getOuterHTMLSnippet(element) {
   const reOpeningTag = /^.*?>/;
   const match = element.outerHTML.match(reOpeningTag);
-  return match && match[0] || '';
+  return (match && match[0]) || '';
+}
+
+/**
+ * Computes a memory/CPU performance benchmark index to determine rough device class.
+ * @see https://docs.google.com/spreadsheets/d/1E0gZwKsxegudkjJl8Fki_sOwHKpqgXwt8aBAfuUaB8A/edit?usp=sharing
+ *
+ * The benchmark creates a string of length 100,000 in a loop.
+ * The returned index is the number of numbers per second the string can be created.
+ *
+ *  - 750+ is a desktop-class device, iPhone X, etc
+ *  - 300+ is a high-end Android phone, Galaxy S8, low-end Chromebook, etc
+ *  - 75+ is a mid-tier Android phone, Nexus 5X, etc
+ *  - <75 is a budget Android phone, Alcatel Ideal, Galaxy J2, etc
+ */
+/* istanbul ignore next */
+function ultradumbBenchmark() {
+  const start = Date.now();
+  let iterations = 0;
+
+  while (Date.now() - start < 500) {
+    let s = ''; // eslint-disable-line no-unused-vars
+    for (let j = 0; j < 100000; j++) s += 'a';
+
+    iterations++;
+  }
+
+  const durationInSeconds = (Date.now() - start) / 1000;
+  return iterations / durationInSeconds;
 }
 
 module.exports = {
@@ -123,4 +150,5 @@ module.exports = {
   checkTimeSinceLastLongTask,
   getElementsInDocument,
   getOuterHTMLSnippet,
+  ultradumbBenchmark,
 };

--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -115,8 +115,14 @@ class ReportRenderer {
       {name: 'URL', description: report.finalUrl},
       {name: 'Fetch time', description: Util.formatDateTime(report.fetchTime)},
       ...envValues,
-      {name: 'User agent', description: report.userAgent},
+      {name: 'User agent (host)', description: report.userAgent},
+      {name: 'User agent (network)', description: report.environment &&
+        report.environment.networkUserAgent},
+      {name: 'CPU/Memory Power', description: report.environment &&
+        report.environment.benchmarkIndex.toFixed(0)},
     ].forEach(runtime => {
+      if (!runtime.description) return;
+
       const item = this._dom.cloneTemplate('#tmpl-lh-env__items', env);
       this._dom.find('.lh-env__name', item).textContent = `${runtime.name}:`;
       this._dom.find('.lh-env__description', item).textContent = runtime.description;

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -122,7 +122,12 @@ class Runner {
 
       /** @type {LH.Result} */
       const lhr = {
-        userAgent: artifacts.UserAgent,
+        userAgent: artifacts.HostUserAgent,
+        environment: {
+          networkUserAgent: artifacts.NetworkUserAgent,
+          hostUserAgent: artifacts.HostUserAgent,
+          benchmarkIndex: artifacts.BenchmarkIndex,
+        },
         lighthouseVersion,
         fetchTime: artifacts.fetchTime,
         requestedUrl: requestedUrl,

--- a/lighthouse-core/scripts/benchmark.js
+++ b/lighthouse-core/scripts/benchmark.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-disable no-console */
+
+const ultradumbBenchmark = require('../lib/page-functions').ultradumbBenchmark;
+
+console.log('Running ULTRADUMB™ benchmark 10 times...')
+
+let total = 0;
+for (let i = 0; i < 10; i++) {
+  const result = ultradumbBenchmark();
+  console.log(`Result ${i + 1}: ${result.toFixed(0)}`);
+  total += result;
+}
+
+console.log('----------------------------------------');
+console.log('Final result:', (total / 10).toFixed(0));

--- a/lighthouse-core/scripts/benchmark.js
+++ b/lighthouse-core/scripts/benchmark.js
@@ -11,7 +11,7 @@
 
 const ultradumbBenchmark = require('../lib/page-functions').ultradumbBenchmark;
 
-console.log('Running ULTRADUMB™ benchmark 10 times...')
+console.log('Running ULTRADUMB™ benchmark 10 times...');
 
 let total = 0;
 for (let i = 0; i < 10; i++) {

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -9,6 +9,9 @@ module.exports = {
   getUserAgent() {
     return Promise.resolve('Fake user agent');
   },
+  getBenchmarkIndex() {
+    return Promise.resolve(125.2);
+  },
   connect() {
     return Promise.resolve();
   },

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -106,16 +106,37 @@ describe('GatherRunner', function() {
     });
   });
 
-  it('collects user agent as an artifact', () => {
+  it('collects benchmark as an artifact', async () => {
     const url = 'https://example.com';
     const driver = fakeDriver;
     const config = new Config({});
     const settings = {};
     const options = {url, driver, config, settings};
 
-    return GatherRunner.run([], options).then(results => {
-      assert.equal(results.UserAgent, 'Fake user agent', 'did not find expected user agent string');
-    });
+    const results = await GatherRunner.run([], options);
+    expect(Number.isFinite(results.BenchmarkIndex)).toBeTruthy();
+  });
+
+  it('collects host user agent as an artifact', async () => {
+    const url = 'https://example.com';
+    const driver = fakeDriver;
+    const config = new Config({});
+    const settings = {};
+    const options = {url, driver, config, settings};
+
+    const results = await GatherRunner.run([], options);
+    expect(results.HostUserAgent).toEqual('Fake user agent');
+  });
+
+  it('collects network user agent as an artifact', async () => {
+    const url = 'https://example.com';
+    const driver = fakeDriver;
+    const config = new Config({passes: [{}]});
+    const settings = {};
+    const options = {url, driver, config, settings};
+
+    const results = await GatherRunner.run(config.passes, options);
+    expect(results.NetworkUserAgent).toContain('Mozilla');
   });
 
   it('collects requested and final URLs as an artifact', () => {

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -1,6 +1,8 @@
 {
   "LighthouseRunWarnings": [],
-  "UserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
+  "BenchmarkIndex": 1000,
+  "HostUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
+  "NetworkUserAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/66.0.3359.30 Mobile Safari/537.36",
   "fetchTime": "2018-03-13T00:55:45.840Z",
   "URL": {
     "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1,5 +1,10 @@
 {
   "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
+  "environment": {
+    "networkUserAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/66.0.3359.30 Mobile Safari/537.36",
+    "hostUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
+    "benchmarkIndex": 1000
+  },
   "lighthouseVersion": "3.0.3",
   "fetchTime": "2018-03-13T00:55:45.840Z",
   "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "update:sample-json": "yarn i18n:collect-strings && node ./lighthouse-cli -A=./lighthouse-core/test/results/artifacts --throttling-method=devtools --output=json --output-path=./lighthouse-core/test/results/sample_v2.json && node lighthouse-core/scripts/cleanup-LHR-for-diff.js ./lighthouse-core/test/results/sample_v2.json --only-remove-timing",
     "diff:sample-json": "yarn i18n:checks && bash lighthouse-core/scripts/assert-golden-lhr-unchanged.sh",
     "update:crdp-typings": "node lighthouse-core/scripts/extract-crdp-mapping.js",
+    "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
     "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --preset=mixed-content",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json"
   },

--- a/typings/artifacts.d.ts
+++ b/typings/artifacts.d.ts
@@ -23,8 +23,12 @@ declare global {
       fetchTime: string;
       /** A set of warnings about unexpected things encountered while loading and testing the page. */
       LighthouseRunWarnings: string[];
-      /** The user agent string of the version of Chrome that was used by Lighthouse. */
-      UserAgent: string;
+      /** The user agent string of the version of Chrome used. */
+      HostUserAgent: string;
+      /** The user agent string that Lighthouse used to load the page. */
+      NetworkUserAgent: string;
+      /** The benchmark index that indicates rough device class. */
+      BenchmarkIndex: number;
       /** A set of page-load traces, keyed by passName. */
       traces: {[passName: string]: Trace};
       /** A set of DevTools debugger protocol records, keyed by passName. */

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -17,8 +17,11 @@ declare global {
     }
 
     export interface Environment {
+      /** The user agent string of the version of Chrome used. */
       hostUserAgent: string;
+      /** The user agent string that was sent over the network. */
       networkUserAgent: string;
+      /** The benchmark index number that indicates rough device class. */
       benchmarkIndex: number;
     }
 

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -16,6 +16,12 @@ declare global {
       [varName: string]: string;
     }
 
+    export interface Environment {
+      hostUserAgent: string;
+      networkUserAgent: string;
+      benchmarkIndex: number;
+    }
+
     /**
      * The full output of a Lighthouse run.
      */
@@ -43,6 +49,8 @@ declare global {
       runWarnings: string[];
       /** The User-Agent string of the browser used run Lighthouse for these results. */
       userAgent: string;
+      /** Information about the environment in which Lighthouse was run. */
+      environment: Environment;
       /** Execution timings for the Lighthouse run */
       timing: {total: number, [t: string]: number};
       /** The record of all formatted string locations in the LHR and their corresponding source values. */


### PR DESCRIPTION
**Summary**
Before we can start automatically adjusting throttling settings, we need to be collecting and detecting more environment information. This PR adds a `environment` property (proposed name) to the LHR that will contain the host machine information, detected device class, perhaps more network diagnostic information, etc.

Right now it has 3 properties

- `hostUserAgent` - This is just a copy of the lhr.userAgent property for now (assumed we can deprecate and remove in v4), the User Agent of the version of Chrome that Lighthouse is using.
- `networkUserAgent` - This is the user agent that was sent over the network to the site. It's been frequently requested and confused with the `hostUserAgent` so makes sense to provide both.
- `benchmarkIndex` - This is the ULTRADUMB™ benchmark value that will eventually be used to autoset throttling if it proves to be stable and reliable enough in our field testing (anecdotally it's already been much more volatile in the runs I've tried than it was on a refreshed Chrome page :/ we might need to have longer timespans and persist the value to user storage somewhere).

I've also added this information to the Runtime Settings section of the report.
![image](https://user-images.githubusercontent.com/2301202/44369710-35376680-a48c-11e8-9423-28247a209de2.png)


**Related Issues/PRs**
closes #5665
