### PR TITLE
extension(feedback): keep feedback class

### DIFF
--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -185,7 +185,7 @@ async function onGenerateReportButtonClick(background, settings) {
     feedbackEl.textContent = message;
 
     if (includeReportLink) {
-      feedbackEl.className = 'feedback-error';
+      feedbackEl.className = 'feedback feedback-error';
       feedbackEl.appendChild(buildReportErrorLink(err));
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
bugfix
<!-- Describe the need for this change -->
We append the feedback-error to the feedback element instead of replacing the classname so we can trigger a new run.

![image](https://user-images.githubusercontent.com/1120926/44369800-efa08b00-a4d7-11e8-8f06-67387b2103fe.png)
![lighthouse-feedback](https://user-images.githubusercontent.com/1120926/44370035-d51ae180-a4d8-11e8-99f7-5b37c7378a3f.gif)


<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
