### PR TITLE
report(psi): reset template styles on every call of prepareLabData

### DIFF
--- a/lighthouse-core/report/html/renderer/psi.js
+++ b/lighthouse-core/report/html/renderer/psi.js
@@ -37,6 +37,9 @@ function prepareLabData(LHResultJsonString, document) {
   const lhResult = /** @type {LH.Result} */ JSON.parse(LHResultJsonString);
   const dom = new DOM(document);
 
+  // Assume fresh styles needed on every call, so mark all template styles as unused.
+  dom.resetTemplates();
+
   const reportLHR = Util.prepareReportResult(lhResult);
   const perfCategory = reportLHR.reportCategories.find(cat => cat.id === 'performance');
   if (!perfCategory) throw new Error(`No performance category. Can't make lab data section`);


### PR DESCRIPTION
@paulirish 

Since re-running was happening in the same page, `<style>` elements for the old report div were being removed but not added to the new report div (since they were flagged as already added).

Now, `prepareLabData()` always resets the attribute flag that marks `<style>`s as used, so styles will always be included in the returned element. As long as the entire div from a previous call to `prepareLabData()` has been removed this should be fine.