### PR TITLE
core(tracing-processor): throw on no top level events

### DIFF
--- a/lighthouse-core/gather/computed/metrics/metric.js
+++ b/lighthouse-core/gather/computed/metrics/metric.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const ComputedArtifact = require('../computed-artifact');
+const TracingProcessor = require('../../../lib/traces/tracing-processor');
 
 /**
  * @fileOverview Encapsulates logic for choosing the correct metric computation method based on the
@@ -57,6 +58,8 @@ class ComputedMetric extends ComputedArtifact {
       networkRecords: await computedArtifacts.requestNetworkRecords(devtoolsLog),
       traceOfTab: await computedArtifacts.requestTraceOfTab(trace),
     }, data);
+
+    TracingProcessor.assertHasToplevelEvents(augmentedData.traceOfTab.mainThreadEvents);
 
     switch (settings.throttlingMethod) {
       case 'simulate':

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -83,6 +83,8 @@ class PageDependencyGraphArtifact extends ComputedArtifact {
     const nodes = [];
     let i = 0;
 
+    TracingProcessor.assertHasToplevelEvents(traceOfTab.mainThreadEvents);
+
     const minimumEvtDur = MINIMUM_TASK_DURATION_OF_INTEREST * 1000;
     while (i < traceOfTab.mainThreadEvents.length) {
       const evt = traceOfTab.mainThreadEvents[i];

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -19,7 +19,7 @@ const LHError = require('../errors');
 class TraceProcessor {
   /**
    * There should *always* be at least one top level event, having 0 typically means something is
-   * drastically wrong with the trace and would should just give up early and loudly.
+   * drastically wrong with the trace and we should just give up early and loudly.
    *
    * @param {LH.TraceEvent[]} events
    */

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -18,6 +18,20 @@ const LHError = require('../errors');
 
 class TraceProcessor {
   /**
+   * There should *always* be at least one top level event, having 0 typically means something is
+   * drastically wrong with the trace and would should just give up early and loudly.
+   *
+   * @param {LH.TraceEvent[]} events
+   */
+  static assertHasToplevelEvents(events) {
+    const hasToplevelTask = events.some(TraceProcessor.isScheduleableTask);
+    if (!hasToplevelTask) {
+      throw new Error('Could not find any top level events');
+    }
+  }
+
+
+  /**
    * Calculate duration at specified percentiles for given population of
    * durations.
    * If one of the durations overlaps the end of the window, the full
@@ -173,12 +187,6 @@ class TraceProcessor {
         end,
         duration: event.dur / 1000,
       });
-    }
-
-    // There should *always* be at least one top level event, having 0 typically means something is
-    // drastically wrong with the trace and would should just give up early and loudly.
-    if (!topLevelEvents.length) {
-      throw new Error('Could not find any top level events');
     }
 
     return topLevelEvents;

--- a/lighthouse-core/test/gather/computed/metrics/first-meaningful-paint-test.js
+++ b/lighthouse-core/test/gather/computed/metrics/first-meaningful-paint-test.js
@@ -26,6 +26,15 @@ describe('Metrics: FMP', () => {
   let trace;
   let devtoolsLog;
 
+  function addEmptyTask() {
+    const mainThreadEvt = trace.traceEvents.find(e => e.name === 'TracingStartedInPage');
+    trace.traceEvents.push({
+      ...mainThreadEvt,
+      cat: 'toplevel',
+      name: 'TaskQueueManager::ProcessTaskFromWorkQueue',
+    });
+  }
+
   beforeEach(() => {
     artifacts = Runner.instantiateComputedArtifacts();
     settings = {throttlingMethod: 'provided'};
@@ -60,6 +69,7 @@ describe('Metrics: FMP', () => {
 
   it('handles cases when there was a tracingStartedInPage after navStart', async () => {
     trace = lateTracingStartedTrace;
+    addEmptyTask();
     const result = await artifacts.requestFirstMeaningfulPaint({trace, devtoolsLog, settings});
     assert.equal(Math.round(result.timing), 530);
     assert.equal(result.timestamp, 29344070867);
@@ -67,6 +77,7 @@ describe('Metrics: FMP', () => {
 
   it('handles cases when there was a tracingStartedInPage after navStart #2', async () => {
     trace = badNavStartTrace;
+    addEmptyTask();
     const result = await artifacts.requestFirstMeaningfulPaint({trace, devtoolsLog, settings});
     assert.equal(Math.round(result.timing), 632);
     assert.equal(result.timestamp, 8886056891);
@@ -74,6 +85,7 @@ describe('Metrics: FMP', () => {
 
   it('handles cases when it appears before FCP', async () => {
     trace = preactTrace;
+    addEmptyTask();
     const result = await artifacts.requestFirstMeaningfulPaint({trace, devtoolsLog, settings});
     assert.equal(Math.round(result.timing), 878);
     assert.equal(result.timestamp, 1805797262960);
@@ -81,6 +93,7 @@ describe('Metrics: FMP', () => {
 
   it('handles cases when no FMP exists', async () => {
     trace = noFMPtrace;
+    addEmptyTask();
     const result = await artifacts.requestFirstMeaningfulPaint({trace, devtoolsLog, settings});
     assert.equal(Math.round(result.timing), 4461);
     assert.equal(result.timestamp, 2146740268666);
@@ -88,6 +101,7 @@ describe('Metrics: FMP', () => {
 
   it('handles cases when no FCP exists', async () => {
     trace = noFCPtrace;
+    addEmptyTask();
     const result = await artifacts.requestFirstMeaningfulPaint({trace, devtoolsLog, settings});
     assert.equal(Math.round(result.timing), 482);
     assert.equal(result.timestamp, 2149509604903);

--- a/lighthouse-core/test/gather/computed/page-dependency-graph-test.js
+++ b/lighthouse-core/test/gather/computed/page-dependency-graph-test.js
@@ -27,6 +27,8 @@ function createRequest(
   return {requestId, url, startTime, endTime, initiator, resourceType};
 }
 
+const TOPLEVEL_TASK_NAME = 'TaskQueueManager::ProcessTaskFromWorkQueue';
+
 /* eslint-env jest */
 describe('PageDependencyGraph computed artifact:', () => {
   let computedArtifacts;
@@ -34,7 +36,7 @@ describe('PageDependencyGraph computed artifact:', () => {
 
   function addTaskEvents(startTs, duration, evts) {
     const mainEvent = {
-      name: 'TaskQueueManager::ProcessTaskFromWorkQueue',
+      name: TOPLEVEL_TASK_NAME,
       tid: 1,
       ts: startTs * 1000,
       dur: duration * 1000,
@@ -149,6 +151,8 @@ describe('PageDependencyGraph computed artifact:', () => {
       const request4 = createRequest(4, '4', 10, {url: '2'});
       const networkRecords = [request1, request2, request3, request4];
 
+      addTaskEvents(0, 0, []);
+
       const graph = PageDependencyGraph.createGraph(traceOfTab, networkRecords);
       const nodes = [];
       graph.traverse(node => nodes.push(node));
@@ -201,6 +205,8 @@ describe('PageDependencyGraph computed artifact:', () => {
       const request3 = createRequest(3, '2', 5); // duplicate URL
       const request4 = createRequest(4, '4', 10, {url: '2'});
       const networkRecords = [request1, request2, request3, request4];
+
+      addTaskEvents(0, 0, []);
 
       const graph = PageDependencyGraph.createGraph(traceOfTab, networkRecords);
       const nodes = [];
@@ -260,6 +266,8 @@ describe('PageDependencyGraph computed artifact:', () => {
       const request1 = createRequest(1, '1', 0, null, NetworkRequest.TYPES.Image);
       const request2 = createRequest(2, '2', 5);
       const networkRecords = [request1, request2];
+
+      addTaskEvents(0, 0, []);
 
       const graph = PageDependencyGraph.createGraph(traceOfTab, networkRecords);
       const nodes = [];


### PR DESCRIPTION
We were throwing on no toplevel events but only in the observed case, this PR adds the check in more places so we should fail all metrics all things that rely on the page dependency graph if there are no toplevel events.