### PR TITLE
i18n: add i18n 'type' for prlint

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -13,6 +13,7 @@ module.exports = {
     {value: 'new_audit',  name: 'new_audit: A new audit'},
     {value: 'core',       name: 'core:      Driver, gather, (non-new) audits, LHR JSON, etc'},
     {value: 'tests',      name: 'tests:     Tests, smokehouse, etc'},
+    {value: 'i18n',       name: 'i18n:      Internationalization'},
     {value: 'docs',       name: 'docs:      Documentation'},
     {value: 'deps',       name: 'deps:      Dependency bumps only'},
     {value: 'report',     name: 'report:    Report, UI, renderers'},


### PR DESCRIPTION
Seems better to have all that separated from `Core` in the changelog.