### PR TITLE
core: fix defaultConfig UIStrings and exit code for test

### DIFF
--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -441,10 +441,10 @@ const defaultConfig = {
   },
 };
 
+module.exports = defaultConfig;
+
 // Use `defineProperty` so that the strings are accesible from original but ignored when we copy it
 Object.defineProperty(module.exports, 'UIStrings', {
   enumerable: false,
   get: () => UIStrings,
 });
-
-module.exports = defaultConfig;

--- a/lighthouse-core/scripts/i18n/assert-strings-collected.sh
+++ b/lighthouse-core/scripts/i18n/assert-strings-collected.sh
@@ -30,7 +30,7 @@ cp "$collectedstringsPath" "$currentstringsPath"
 
 colorText "Collecting strings..." "$purple"
 set -x
-node "$lhroot_path/lighthouse-core/scripts/i18n/collect-strings.js"
+node "$lhroot_path/lighthouse-core/scripts/i18n/collect-strings.js" || exit 1
 set +x
 
 cp "$collectedstringsPath" "$freshstringsPath"


### PR DESCRIPTION
fix `module.exports` ordering issue introduced by #5858

Also makes the `i18n:checks` test fail if `collect-strings.js` throws an error