### PR TITLE
core(network): handle LR transferSize

### DIFF
--- a/lighthouse-extension/app/src/lighthouse-ext-background.js
+++ b/lighthouse-extension/app/src/lighthouse-ext-background.js
@@ -95,8 +95,7 @@ async function runLighthouseInExtension(flags, categoryIDs) {
  * @return {Promise<string|Array<string>|void>}
  */
 async function runLighthouseInLR(connection, url, flags, {lrDevice, categoryIDs, logAssets}) {
-  // @ts-ignore - hack to let certain LR overrides take effect
-  // see https://github.com/GoogleChrome/lighthouse/issues/5839
+  // Certain fixes need to kick-in under LR, see https://github.com/GoogleChrome/lighthouse/issues/5839
   global.isLightRider = true;
 
   // Override default device to be desktop, since LR default device has viewport 1x1.

--- a/lighthouse-extension/app/src/lighthouse-ext-background.js
+++ b/lighthouse-extension/app/src/lighthouse-ext-background.js
@@ -95,6 +95,10 @@ async function runLighthouseInExtension(flags, categoryIDs) {
  * @return {Promise<string|Array<string>|void>}
  */
 async function runLighthouseInLR(connection, url, flags, {lrDevice, categoryIDs, logAssets}) {
+  // @ts-ignore - hack to let certain LR overrides take effect
+  // see https://github.com/GoogleChrome/lighthouse/issues/5839
+  global.isLightRider = true;
+
   // Override default device to be desktop, since LR default device has viewport 1x1.
   connection.sendCommand('Emulation.setDeviceMetricsOverride',
     {width: 800, height: 600, deviceScaleFactor: 0, mobile: false});

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+declare module NodeJS {
+  interface Global {
+    isLightRider?: boolean;
+  }
+}


### PR DESCRIPTION
**Summary**
In LR's case we don't have real transfer size, we just have the header of original content length. I went with the `isLightRider` global var for a few reasons.

1. It's the clearest way to ensure this hack does not ever impact our other channels.
2. It's a convenient way to track progress through the life of a network request (transferSize is updated multiple places and we need to reset this a couple times.
3. I have a feeling this won't be the last time LR has some subtle difference that needs to be accounted for.

sizes now look good with the traces/devtoolslog paul provided
![image](https://user-images.githubusercontent.com/2301202/44490533-63937e00-a613-11e8-8b02-d0f2f3e713c1.png)


**Related Issues/PRs**
fixes #5839 
