### PR TITLE
core(tsc): don't rely on index signatures in load-simulator/simulator.js

### DIFF
--- a/lighthouse-core/gather/computed/load-simulator.js
+++ b/lighthouse-core/gather/computed/load-simulator.js
@@ -23,6 +23,7 @@ class LoadSimulatorArtifact extends ComputedArtifact {
     const {throttlingMethod, throttling} = data.settings;
     const networkAnalysis = await artifacts.requestNetworkAnalysis(data.devtoolsLog);
 
+    /** @type {LH.Gatherer.Simulation.Options} */
     const options = {
       additionalRttByOrigin: networkAnalysis.additionalRttByOrigin,
       serverResponseTimeByOrigin: networkAnalysis.serverResponseTimeByOrigin,

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -66,6 +66,7 @@ class Simulator {
     this._nodeTimings = new Map();
     /** @type {Map<string, number>} */
     this._numberInProgressByType = new Map();
+    /** @type {Record<number, Set<Node>>} */
     this._nodes = {};
     this._dns = new DNSCache({rtt: this._rtt});
     // @ts-ignore
@@ -95,8 +96,8 @@ class Simulator {
     this._numberInProgressByType = new Map();
 
     this._nodes = {};
-    for (const key of Object.keys(NodeState)) {
-      this._nodes[NodeState[key]] = new Set();
+    for (const state of Object.values(NodeState)) {
+      this._nodes[state] = new Set();
     }
   }
 


### PR DESCRIPTION
part of #5873 (only `DetailsItem` remaining now...)

These two were causing a lot of errors so I put off looking into them, but turns out the fixes were so simple that I should have just included them in the earlier grab bag PR :)