### PR TITLE
tests(smokehouse): update passive listener expectations

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -209,12 +209,12 @@ function websqlTest() {
 }
 
 function passiveEventsListenerTest() {
-  // FAIL
+  // FAIL or PASS - field trial for document level defaulting to passive M71+
   window.addEventListener('wheel', function(e) {
     console.log('wheel');
   });
 
-  // FAIL
+  // PASS - document level defaults to passive M56+
   window.addEventListener('touchstart', function(e) {
     console.log('touchstart');
   });
@@ -224,12 +224,12 @@ function passiveEventsListenerTest() {
     console.log('mousewheel');
   }, {passive: false});
 
-  // FAIL
+  // PASS - document level defaults to passive M56+
   document.addEventListener('touchstart', function(e) {
     console.log('touchstart document');
   });
 
-  // FAIL
+  // PASS - document level defaults to passive M56+
   document.body.addEventListener('touchmove', function(e) {
     console.log('touchmove');
   });

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
@@ -17,8 +17,9 @@ if (location.search === '' || params.has('dateNow')) {
 
 if (location.search === '' || params.has('passiveEvents')) {
   // FAIL - non-passive listener usage in another file.
-  document.addEventListener('wheel', e => {
-    console.log('wheel: arrow function');
+  const el = document.querySelector('#touchmove-section');
+  el.addEventListener('touchmove', function(e) {
+    console.log('touchmove');
   });
 }
 

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
@@ -16,10 +16,12 @@ if (location.search === '' || params.has('dateNow')) {
 }
 
 if (location.search === '' || params.has('passiveEvents')) {
-  // FAIL - non-passive listener usage in another file.
-  const el = document.querySelector('#touchmove-section');
-  el.addEventListener('touchmove', function(e) {
-    console.log('touchmove');
+  document.addEventListener('load', () => {
+    // FAIL - non-passive listener usage in another file.
+    const el = document.querySelector('#touchmove-section');
+    el.addEventListener('touchmove', function(e) {
+      console.log('touchmove');
+    });
   });
 }
 

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
@@ -15,16 +15,6 @@ if (location.search === '' || params.has('dateNow')) {
   const d = Date.now();
 }
 
-if (location.search === '' || params.has('passiveEvents')) {
-  document.addEventListener('load', () => {
-    // FAIL - non-passive listener usage in another file.
-    const el = document.querySelector('#touchmove-section');
-    el.addEventListener('touchmove', function(e) {
-      console.log('touchmove');
-    });
-  });
-}
-
 if (location.search === '' || params.has('deprecations')) {
   const div = document.createElement('div');
   div.createShadowRoot();

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -93,7 +93,7 @@ module.exports = [
             // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
             // Note: It was 4, but {passive:false} doesn't get a warning as of M63: https://crbug.com/770208
             // Note: It was 3, but wheel events are now also passive as of field trial in M71 https://crbug.com/626196
-            length: '>=2',
+            length: '>=1',
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -91,9 +91,9 @@ module.exports = [
           items: {
             // Note: Originally this was 7 but M56 defaults document-level
             // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
-            // Note: It was 4, but {passive:false} doesn't get a warning as of M63: crbug.com/770208
-            // COMPAT: This can be set to 3 when m63 is stable.
-            length: '>=3',
+            // Note: It was 4, but {passive:false} doesn't get a warning as of M63: https://crbug.com/770208
+            // Note: It was 3, but wheel events are now also passive as of field trial in M71 https://crbug.com/626196
+            length: '>=2',
           },
         },
       },


### PR DESCRIPTION
appveyor has been failing to find enough passive event listener failures. turns out there's a field trial to make wheel listeners passive by default too :) https://crbug.com/626196 (thanks @brendankenny for hunting the bug down!)