### PR TITLE
core(preload): remove CRC dependency

### DIFF
--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -8,6 +8,7 @@
 const URL = require('../lib/url-shim');
 const Audit = require('./audit');
 const UnusedBytes = require('./byte-efficiency/byte-efficiency-audit');
+const CriticalRequestChains = require('../gather/computed/critical-request-chains');
 const i18n = require('../lib/i18n');
 
 const UIStrings = {
@@ -70,16 +71,49 @@ class UsesRelPreloadAudit extends Audit {
   }
 
   /**
+   * @param {LH.Artifacts.NetworkRequest} mainResource
+   * @param {LH.Gatherer.Simulation.GraphNode} graph
+   * @return {Set<string>}
+   */
+  static getURLsToPreload(mainResource, graph) {
+    /** @type {Set<string>} */
+    const urls = new Set();
+
+    graph.traverse((node, traversalPath) => {
+      if (node.type !== 'network') return;
+      // Don't include the node itself or any CPU nodes in the initiatorPath
+      const path = traversalPath.slice(1).filter(initiator => initiator.type === 'network');
+      if (!UsesRelPreloadAudit.shouldPreloadRequest(node.record, mainResource, path)) return;
+      urls.add(node.record.url);
+    });
+
+    return urls;
+  }
+
+  /**
+   * We want to preload all first party critical requests at depth 2.
+   * Third party requests can be tricky to know the URL ahead of time.
+   * Critical requests at depth 1 would already be identified by the browser for preloading.
+   * Critical requests deeper than depth 2 are more likely to be a case-by-case basis such that it
+   * would be a little risky to recommend blindly.
    *
    * @param {LH.Artifacts.NetworkRequest} request
    * @param {LH.Artifacts.NetworkRequest} mainResource
+   * @param {Array<LH.Gatherer.Simulation.GraphNode>} initiatorPath
    * @return {boolean}
    */
-  static shouldPreload(request, mainResource) {
-    if (request.isLinkPreload || URL.NON_NETWORK_PROTOCOLS.includes(request.protocol)) {
-      return false;
-    }
+  static shouldPreloadRequest(request, mainResource, initiatorPath) {
+    const mainResourceDepth = mainResource.redirects ? mainResource.redirects.length : 0;
 
+    // If it's already preloaded, no need to recommend it.
+    if (request.isLinkPreload) return false;
+    // It's not critical, don't recommend it.
+    if (!CriticalRequestChains.isCritical(request, mainResource)) return false;
+    // It's not a request loaded over the network, don't recommend it.
+    if (URL.NON_NETWORK_PROTOCOLS.includes(request.protocol)) return false;
+    // It's not at the right depth, don't recommend it.
+    if (initiatorPath.length !== mainResourceDepth + 2) return false;
+    // We survived everything else, just check that it's a first party request.
     return URL.rootDomainsMatch(request.url, mainResource.url);
   }
 
@@ -168,28 +202,13 @@ class UsesRelPreloadAudit extends Audit {
     const URL = artifacts.URL;
     const simulatorOptions = {trace, devtoolsLog, settings: context.settings};
 
-    const [critChains, mainResource, graph, simulator] = await Promise.all([
-      // TODO(phulce): eliminate dependency on CRC
-      artifacts.requestCriticalRequestChains({devtoolsLog, URL}),
+    const [mainResource, graph, simulator] = await Promise.all([
       artifacts.requestMainResource({devtoolsLog, URL}),
       artifacts.requestPageDependencyGraph({trace, devtoolsLog}),
       artifacts.requestLoadSimulator(simulatorOptions),
     ]);
 
-    // get all critical requests 2 + mainResourceIndex levels deep
-    const mainResourceIndex = mainResource.redirects ? mainResource.redirects.length : 0;
-
-    const criticalRequests = UsesRelPreloadAudit._flattenRequests(critChains,
-      3 + mainResourceIndex, 2 + mainResourceIndex);
-
-    /** @type {Set<string>} */
-    const urls = new Set();
-    for (const networkRecord of criticalRequests) {
-      if (UsesRelPreloadAudit.shouldPreload(networkRecord, mainResource)) {
-        urls.add(networkRecord.url);
-      }
-    }
-
+    const urls = UsesRelPreloadAudit.getURLsToPreload(mainResource, graph);
     const {results, wastedMs} = UsesRelPreloadAudit.computeWasteWithGraph(urls, graph, simulator);
     // sort results by wastedTime DESC
     results.sort((a, b) => b.wastedMs - a.wastedMs);

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -38,39 +38,6 @@ class UsesRelPreloadAudit extends Audit {
   }
 
   /**
-   * @param {LH.Artifacts.CriticalRequestNode} chains
-   * @param {number} maxLevel
-   * @param {number=} minLevel
-   */
-  static _flattenRequests(chains, maxLevel, minLevel = 0) {
-    /** @type {Array<LH.Artifacts.NetworkRequest>} */
-    const requests = [];
-
-    /**
-     * @param {LH.Artifacts.CriticalRequestNode} chains
-     * @param {number} level
-     */
-    const flatten = (chains, level) => {
-      Object.keys(chains).forEach(chain => {
-        if (chains[chain]) {
-          const currentChain = chains[chain];
-          if (level >= minLevel) {
-            requests.push(currentChain.request);
-          }
-
-          if (level < maxLevel) {
-            flatten(currentChain.children, level + 1);
-          }
-        }
-      });
-    };
-
-    flatten(chains, 0);
-
-    return requests;
-  }
-
-  /**
    * @param {LH.Artifacts.NetworkRequest} mainResource
    * @param {LH.Gatherer.Simulation.GraphNode} graph
    * @return {Set<string>}


### PR DESCRIPTION
Leftover cleanup from Lantern changes that happened while the preload PR was ongoing. Just removes the dependency on the CRC computed artifact, so that CRC can move to be based on the graph much more easily.