### PR TITLE
misc(logger): add time/timeEnd methods

### DIFF
--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -219,7 +219,7 @@ class Log {
 }
 
 Log.events = new Emitter();
-Log.getTimeEntries = _ => {
+Log.takeTimeEntries = _ => {
   const entries = marky.getEntries();
   marky.clear();
   return entries;

--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -113,7 +113,7 @@ class Log {
 
   static timeEnd({msg, id, args=[]}, level='verbose') {
     Log[level]('statusEnd', msg, ...args);
-    return marky.stop(id);
+    marky.stop(id);
   }
 
   static log(title, ...args) {
@@ -219,7 +219,7 @@ class Log {
 }
 
 Log.events = new Emitter();
-Log.getEntries = _ => {
+Log.getTimeEntries = _ => {
   const entries = marky.getEntries();
   marky.clear();
   return entries;

--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -6,6 +6,8 @@
 'use strict';
 
 const debug = require('debug');
+const marky = require('marky');
+
 const EventEmitter = require('events').EventEmitter;
 const isWindows = process.platform === 'win32';
 
@@ -102,6 +104,16 @@ class Log {
     const snippet = (data.params && method !== 'IO.read') ?
       JSON.stringify(data.params).substr(0, maxLength) : '';
     Log._logToStdErr(`${prefix}:${level || ''}`, [method, snippet]);
+  }
+
+  static time({msg, id, args=[]}, level='log') {
+    marky.mark(id);
+    Log[level]('status', msg, ...args);
+  }
+
+  static timeEnd({msg, id, args=[]}, level='verbose') {
+    Log[level]('statusEnd', msg, ...args);
+    return marky.stop(id);
   }
 
   static log(title, ...args) {
@@ -207,5 +219,10 @@ class Log {
 }
 
 Log.events = new Emitter();
+Log.getEntries = _ => {
+  const entries = marky.getEntries();
+  marky.clear();
+  return entries;
+};
 
 module.exports = Log;

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-logger",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^2.6.8",

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "license": "Apache-2.0",
   "dependencies": {
-    "debug": "^2.6.8"
+    "debug": "^2.6.8",
+    "marky": "^1.2.0"
   }
 }

--- a/lighthouse-logger/yarn.lock
+++ b/lighthouse-logger/yarn.lock
@@ -8,6 +8,10 @@ debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+marky@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.0.tgz#9617ed647bbbea8f45d19526da33dec70606df42"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"

--- a/typings/lighthouse-logger/index.d.ts
+++ b/typings/lighthouse-logger/index.d.ts
@@ -5,12 +5,21 @@
  */
 
 declare module 'lighthouse-logger' {
+  interface Status {
+    msg: string;
+    id: string;
+    args?: any[];
+  }
   export function setLevel(level: string): void;
   export function formatProtocol(prefix: string, data: Object, level?: string): void;
   export function log(title: string, ...args: any[]): void;
   export function warn(title: string, ...args: any[]): void;
   export function error(title: string, ...args: any[]): void;
   export function verbose(title: string, ...args: any[]): void;
+  export function time(status: Status, level?: string): void;
+  export function timeEnd(status: Status, level?: string): void;
   export function reset(): string;
+  export function clearEntries(): void;
+  export function getEntries(): PerformanceEntry[];
   export var events: import('events').EventEmitter;
 }

--- a/typings/lighthouse-logger/index.d.ts
+++ b/typings/lighthouse-logger/index.d.ts
@@ -19,7 +19,7 @@ declare module 'lighthouse-logger' {
   export function time(status: Status, level?: string): void;
   export function timeEnd(status: Status, level?: string): void;
   export function reset(): string;
-  export function clearEntries(): void;
+  /** Retrieves and clears all stored time entries */
   export function getEntries(): PerformanceEntry[];
   export var events: import('events').EventEmitter;
 }

--- a/typings/lighthouse-logger/index.d.ts
+++ b/typings/lighthouse-logger/index.d.ts
@@ -20,6 +20,6 @@ declare module 'lighthouse-logger' {
   export function timeEnd(status: Status, level?: string): void;
   export function reset(): string;
   /** Retrieves and clears all stored time entries */
-  export function getTimeEntries(): PerformanceEntry[];
+  export function takeTimeEntries(): PerformanceEntry[];
   export var events: import('events').EventEmitter;
 }

--- a/typings/lighthouse-logger/index.d.ts
+++ b/typings/lighthouse-logger/index.d.ts
@@ -20,6 +20,6 @@ declare module 'lighthouse-logger' {
   export function timeEnd(status: Status, level?: string): void;
   export function reset(): string;
   /** Retrieves and clears all stored time entries */
-  export function getEntries(): PerformanceEntry[];
+  export function getTimeEntries(): PerformanceEntry[];
   export var events: import('events').EventEmitter;
 }


### PR DESCRIPTION
In order to land #3745, we need logger to be published with the new functionality. This is just the `lighthouse-logger` portion of #3745 with a version bump to `1.1.0`