### PR TITLE
tests(dbw): remove createShadowRoot call

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -308,7 +308,7 @@ function deprecationsTest() {
   xhr.open('GET', 'dbw_tester.html', false);
   xhr.send();
 
-  window.webkitStorageInfo.PERSISTENT // FAIL
+  // One more failure in dbw_tester.js
 }
 
 function isOnHttps() {

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
@@ -10,17 +10,8 @@
 
 const params = new URLSearchParams(location.search);
 
-if (location.search === '' || params.has('dateNow')) {
-  // FAIL - Date.now() usage in another file.
-  const d = Date.now();
-}
-
 if (location.search === '' || params.has('deprecations')) {
-  const div = document.createElement('div');
-  div.createShadowRoot();
-  // FAIL(errors-in-console) - multiple shadow v0 roots.
-  // TODO: disabled until m64 is stable (when moved from deprecation warning to error)
-  // div.createShadowRoot();
+  window.webkitStorageInfo.PERSISTENT; // FAIL
 }
 
 })();

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.js
@@ -11,7 +11,7 @@
 const params = new URLSearchParams(location.search);
 
 if (location.search === '' || params.has('deprecations')) {
-  window.webkitStorageInfo.PERSISTENT; // FAIL
+  window.webkitStorageInfo.PERSISTENT; // FAIL(deprecations)
 }
 
 })();


### PR DESCRIPTION
master is failing again because of another canary change, `createShadowRoot` is going to be removed in M73, so I just swapped it for one of our other deprecations