### PR TITLE
core(trace-of-tab): only use navstart of chrome/http documents

### DIFF
--- a/lighthouse-core/audits/metrics/first-contentful-paint.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint.js
@@ -14,9 +14,6 @@ const UIStrings = {
   /** Description of the First Contentful Paint (FCP) metric, which marks the time at which the first text or image is painted by the browser. This is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'First Contentful Paint marks the time at which the first text or image is ' +
       `painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).`,
-  /** Warning message shown to the user when they audited a URL that had multiple navigations that could throw off metrics. */
-  multipleNavigationWarning: 'The page you audited was redirected. This can skew ' +
-      'performance metrics. Try auditing the final URL directly instead.',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -56,13 +53,8 @@ class FirstContentfulPaint extends Audit {
   static async audit(artifacts, context) {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
-    const traceOfTab = await artifacts.requestTraceOfTab(trace);
     const metricComputationData = {trace, devtoolsLog, settings: context.settings};
     const metricResult = await artifacts.requestFirstContentfulPaint(metricComputationData);
-
-    if (traceOfTab.hadMultipleNavigations) {
-      context.LighthouseRunWarnings.push(str_(UIStrings.multipleNavigationWarning));
-    }
 
     return {
       score: Audit.computeLogNormalScore(

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -80,19 +80,19 @@ class TraceOfTab extends ComputedArtifact {
 
     // Our navStart will be the navigation start closest to the first outbound request
     const requestSentEvt = keyEvents.find(e => e.name === 'ResourceSendRequest');
-    const navigationStartCandidates = frameEvents.filter(e => e.name === 'navigationStart');
-    const navigationStart = navigationStartCandidates
-        .sort((a, b) => Math.abs(a.ts - requestSentEvt.ts) - Math.abs(b.ts - requestSentEvt.ts))
-        .shift();
+    const navigationStart = frameEvents.
+        filter(e => e.name === 'navigationStart').
+        sort((a, b) => Math.abs(a.ts - requestSentEvt.ts) - Math.abs(b.ts - requestSentEvt.ts)).
+        shift();
     if (!navigationStart) throw new LHError(LHError.errors.NO_NAVSTART);
 
     // Find our first paint of this frame
     const firstPaint = frameEvents.find(e => e.name === 'firstPaint' && e.ts > navigationStart.ts);
 
     // FCP will follow at/after the FP. Used in so many places we require it.
-    const firstContentfulPaint = frameEvents.find(
-      e => e.name === 'firstContentfulPaint' && e.ts > navigationStart.ts
-    );
+    const firstContentfulPaints = frameEvents.
+        filter(e => e.name === 'firstContentfulPaint' && e.ts > navigationStart.ts);
+    const firstContentfulPaint = firstContentfulPaints[0];
     if (!firstContentfulPaint) throw new LHError(LHError.errors.NO_FCP);
 
     // fMP will follow at/after the FP
@@ -181,6 +181,7 @@ class TraceOfTab extends ComputedArtifact {
       loadEvt: load,
       domContentLoadedEvt: domContentLoaded,
       fmpFellBack,
+      hadMultipleNavigations: firstContentfulPaints.length > 1,
     };
   }
 }

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -36,7 +36,7 @@ class TraceOfTab extends ComputedArtifact {
    */
   static isNavigationStartOfInterest(event) {
     return event.name === 'navigationStart' &&
-      (!event.args.data || !event.args.documentLoaderURL ||
+      (!event.args.data || !event.args.data.documentLoaderURL ||
         ACCEPTABLE_NAVIGATION_URL_REGEX.test(event.args.data.documentLoaderURL));
   }
 

--- a/lighthouse-core/gather/computed/trace-of-tab.js
+++ b/lighthouse-core/gather/computed/trace-of-tab.js
@@ -29,6 +29,11 @@ class TraceOfTab extends ComputedArtifact {
     return 'TraceOfTab';
   }
 
+  /**
+   * Returns true if the event is a navigation start event of a document whose URL seems valid.
+   *
+   * @param {LH.TraceEvent} event
+   */
   static isNavigationStartOfInterest(event) {
     return event.name === 'navigationStart' &&
       (!event.args.data || !event.args.documentLoaderURL ||

--- a/lighthouse-core/test/fixtures/traces/preactjs.com_ts_of_undefined.json
+++ b/lighthouse-core/test/fixtures/traces/preactjs.com_ts_of_undefined.json
@@ -72,6 +72,19 @@
       },
       "tts": 826016
     },
+    {
+      "pid": 6117,
+      "tid": 775,
+      "ts": 1805897263653,
+      "ph": "R",
+      "cat": "blink.user_timing",
+      "name": "navigationStart",
+      "args": {
+        "frame": "0x25edaa521e58",
+        "data": {"documentLoaderURL": "intent://this-one-should-be-ignored"}
+      },
+      "tts": 673412
+    },
       {
       "pid": 6117,
       "tid": 775,

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -166,6 +166,7 @@ declare global {
         fileName?: string;
         snapshot?: string;
         data?: {
+          documentLoaderURL?: string;
           frames?: {
             frame: string;
             parent?: string;


### PR DESCRIPTION
**Summary**
The underlying issue in #3838 is that we use the navstart of a navigation that is immediately cancelled and never takes place. Thus, we end up looking for all of our events of importance in the wrong timeframe.

The redirect comment (https://github.com/GoogleChrome/lighthouse/issues/3838#issuecomment-377514597) got me thinking about the correct navstart to be using though, and it seems like we should be capturing that performance hit and warning folks that they have multiple navigations. I wrote out a nice long argument for why we should do this, but I couldn't even convince myself it was the right thing to do since we'll break many existing customers that are ignorant of client-side redirects today.

Instead I've installed a quick fix that ignores navigations to targets that we're not interested in. i.e. only HTTP navigationStart events count. This fixes the taobao case and should fix the other custom protocol cases where this has popped up.

**Related Issues/PRs**
fixes #3838 
