### PR TITLE
core(gather-runner): call clearDataForOrigin on teardown

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -54,8 +54,9 @@ const Driver = require('../gather/driver.js'); // eslint-disable-line no-unused-
  *     ii. all gatherers' afterPass()
  *
  * 3. Teardown
- *   A. GatherRunner.disposeDriver()
- *   B. collect all artifacts and return them
+ *   A. clearDataForOrigin
+ *   B. GatherRunner.disposeDriver()
+ *   C. collect all artifacts and return them
  *     i. collectArtifacts() from completed passes on each gatherer
  *     ii. add trace data and computed artifact methods
  */
@@ -444,6 +445,7 @@ class GatherRunner {
           firstPass = false;
         }
       }
+      await driver.clearDataForOrigin(options.requestedUrl);
       await GatherRunner.disposeDriver(driver);
       return GatherRunner.collectArtifacts(gathererResults, baseArtifacts);
     } catch (err) {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -447,7 +447,6 @@ class GatherRunner {
       }
       const resetStorage = !options.settings.disableStorageReset;
       if (resetStorage) await driver.clearDataForOrigin(options.requestedUrl);
-      await driver.clearDataForOrigin(options.requestedUrl);
       await GatherRunner.disposeDriver(driver);
       return GatherRunner.collectArtifacts(gathererResults, baseArtifacts);
     } catch (err) {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -445,6 +445,8 @@ class GatherRunner {
           firstPass = false;
         }
       }
+      const resetStorage = !options.settings.disableStorageReset;
+      if (resetStorage) await driver.clearDataForOrigin(options.requestedUrl);
       await driver.clearDataForOrigin(options.requestedUrl);
       await GatherRunner.disposeDriver(driver);
       return GatherRunner.collectArtifacts(gathererResults, baseArtifacts);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
Hi all :)

**Summary**
<!-- What kind of change does this PR introduce? -->
What this change does: always clear browser cache for reqested URL after successfull lighthouse run.
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->
See issue below. Besides, it's always good advice to free resources in computing after specific task is done properly.

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
https://github.com/GoogleChrome/lighthouse/issues/4889

I'm off for now. Support on this PR is welcome :)

Cheers
midzer