### PR TITLE
tests: fix getFlags test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
     - node_js: "8"
     - node_js: "9"
-      if: head_branch IS blank AND branch = master
+    - node_js: "10"
 dist: trusty
 cache:
   yarn: true

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -49,7 +49,8 @@ describe('CLI run', function() {
 
 describe('flag coercing', () => {
   it('should force to array', () => {
-    assert.deepStrictEqual(getFlags(`--only-audits foo chrome://version`).onlyAudits, ['foo']);
+    const argv = getFlags(`chrome://version --only-audits foo bar`);
+    assert.deepStrictEqual(argv.onlyAudits, ['foo', 'bar']);
   });
 });
 


### PR DESCRIPTION
started looking into this because of #4395

found that jest was silently exiting on this:

```sh
./node_modules/jest/bin/jest.js lighthouse-cli/test/cli/run-test.js
```



CLI options MUST follow the url because of our use of arrays. you can't put the URL at the end or middle