### PR TITLE
core(tsc): update to ts 3.1 for new protocol defs

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -151,8 +151,8 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
     }
 
     const usage = UnusedCSSRules.computeUsage(stylesheetInfo);
-    const result = {url}; // Assign to temporary to keep tsc happy about index signature.
-    return Object.assign(result, usage);
+    // @ts-ignore TODO(bckenny): fix index signature on ByteEfficiencyItem.
+    return Object.assign({url}, usage);
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -90,7 +90,6 @@ class ReportUIFeatures {
     this._setupHeaderAnimation();
     this._resetUIState();
     this._document.addEventListener('keydown', this.printShortCutDetect);
-    // @ts-ignore - TODO(bckenny): tsc thinks document can't listen for `copy`. Remove ignore in 3.1.
     this._document.addEventListener('copy', this.onCopy);
   }
 
@@ -114,7 +113,7 @@ class ReportUIFeatures {
 
   /**
    * Handle media query change events.
-   * @param {MediaQueryList} mql
+   * @param {MediaQueryList|MediaQueryListEvent} mql
    */
   onMediaQueryChange(mql) {
     const root = this._dom.find('.lh-root', this._document);

--- a/lighthouse-viewer/app/src/drag-and-drop.js
+++ b/lighthouse-viewer/app/src/drag-and-drop.js
@@ -38,7 +38,9 @@ class DragAndDrop {
     document.addEventListener('dragover', e => {
       e.stopPropagation();
       e.preventDefault();
-      e.dataTransfer.dropEffect = 'copy'; // Explicitly show as copy action.
+      if (e.dataTransfer) {
+        e.dataTransfer.dropEffect = 'copy'; // Explicitly show as copy action.
+      }
     });
 
     document.addEventListener('dragenter', _ => {
@@ -53,7 +55,9 @@ class DragAndDrop {
       this._resetDraggingUI();
 
       // Note, this ignores multiple files in the drop, only taking the first.
-      this._fileHandlerCallback(e.dataTransfer.files[0]);
+      if (e.dataTransfer) {
+        this._fileHandlerCallback(e.dataTransfer.files[0]);
+      }
     });
   }
 

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -156,7 +156,7 @@ class LighthouseReportViewer {
       let saveCallback = null;
       if (!this._reportIsFromGist) {
         saveCallback = this._onSaveJson;
-        history.pushState({}, undefined, LighthouseReportViewer.APP_URL);
+        history.pushState({}, '', LighthouseReportViewer.APP_URL);
       }
 
       const features = new ViewerUIFeatures(dom, saveCallback);
@@ -257,7 +257,7 @@ class LighthouseReportViewer {
       }
 
       this._reportIsFromGist = true;
-      history.pushState({}, undefined, `${LighthouseReportViewer.APP_URL}?gist=${id}`);
+      history.pushState({}, '', `${LighthouseReportViewer.APP_URL}?gist=${id}`);
 
       return id;
     }).catch(err => logger.log(err.message));
@@ -335,7 +335,7 @@ class LighthouseReportViewer {
 
       const match = url.pathname.match(/[a-f0-9]{5,}/);
       if (match) {
-        history.pushState({}, undefined, `${LighthouseReportViewer.APP_URL}?gist=${match[0]}`);
+        history.pushState({}, '', `${LighthouseReportViewer.APP_URL}?gist=${match[0]}`);
         this._loadFromDeepLink();
       }
     } catch (err) {

--- a/lighthouse-viewer/app/src/main.js
+++ b/lighthouse-viewer/app/src/main.js
@@ -17,6 +17,7 @@ function loadScript(src) {
     script.src = src;
     script.onload = resolve;
     script.onerror = reject;
+    // @ts-ignore document.head is there.
     document.head.appendChild(script);
   });
 }

--- a/lighthouse-viewer/app/src/main.js
+++ b/lighthouse-viewer/app/src/main.js
@@ -17,8 +17,8 @@ function loadScript(src) {
     script.src = src;
     script.onload = resolve;
     script.onerror = reject;
-    // @ts-ignore document.head is there.
-    document.head.appendChild(script);
+    // document.head is defined.
+    /** @type {HTMLHeadElement} */ (document.head).appendChild(script);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "1.4.0",
     "sinon": "^2.3.5",
-    "typescript": "3.0.1",
+    "typescript": "3.1.0-dev.20180831",
     "vscode-chrome-debug-core": "^3.23.8",
     "zone.js": "^0.7.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6199,9 +6199,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+typescript@3.1.0-dev.20180831:
+  version "3.1.0-dev.20180831"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.0-dev.20180831.tgz#d1c0c715f17368417cad96bda042cf26d56f3d61"
 
 uglify-js@^2.6:
   version "2.7.3"


### PR DESCRIPTION
As mentioned in https://github.com/GoogleChrome/lighthouse/pull/5836#issuecomment-417763577, in order to update to the new protocol definitions and the rest of the improvements in #5836 we need to be running typescript 3.1.

Luckily the work in #5873 means that the remaining change is small, just dealing with some kind of annoying extra strictness in dom methods (e.g. handling that [technically `document.head` can be null](https://html.spec.whatwg.org/multipage/dom.html#dom-document-head)...just not in practice).