### PR TITLE
tests(smokehouse): update expectations for HTML Imports deprecation

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -101,7 +101,7 @@ module.exports = [
         score: 0,
         details: {
           items: {
-            length: 3,
+            length: 4,
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -101,7 +101,8 @@ module.exports = [
         score: 0,
         details: {
           items: {
-            length: 4,
+            // Note: HTML Imports added to deprecations in m70, so 3 before, 4 after.
+            length: '>=3',
           },
         },
       },


### PR DESCRIPTION
appveyor dbw smoke tests are failing because we now have an additional deprecation firing in Canary: HTML Imports :)

~(will switch to `>=3` to account for running Chrome stable on Travis after the Travis tests fail so I can verify that they fail :)~