### PR TITLE
Fix grocers apostrophe typo (API's v APIs)

### DIFF
--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -22,7 +22,7 @@ class Deprecations extends Audit {
     return {
       id: 'deprecations',
       title: 'Avoids deprecated APIs',
-      failureTitle: 'Uses deprecated API\'s',
+      failureTitle: 'Uses deprecated APIs',
       description: 'Deprecated APIs will eventually be removed from the browser. ' +
           '[Learn more](https://www.chromestatus.com/features#deprecated).',
       requiredArtifacts: ['ChromeConsoleMessages'],

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -593,7 +593,7 @@
     },
     "deprecations": {
       "id": "deprecations",
-      "title": "Uses deprecated API's",
+      "title": "Uses deprecated APIs",
       "description": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated).",
       "score": 0,
       "scoreDisplayMode": "binary",


### PR DESCRIPTION
**Summary**
Fix a typo in Best Practices summary - phrase should be "Uses deprecated APIs" not "Uses deprecated API's".