### PR TITLE
core: normalize URL before checking equality

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -65,7 +65,7 @@ class Runner {
         if (!requestedUrl) {
           throw new Error('Cannot run audit mode on empty URL');
         }
-        if (runOpts.url && runOpts.url !== requestedUrl) {
+        if (runOpts.url && !URL.equalWithExcludedFragments(runOpts.url, requestedUrl)) {
           throw new Error('Cannot run audit mode on different URL');
         }
       } else {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -101,7 +101,7 @@ describe('Runner', () => {
 
     it('-A throws if the URL changes', async () => {
       const settings = {auditMode: artifactsPath, disableDeviceEmulation: true};
-      const opts = {url: 'https://example.com', config: generateConfig(settings), driverMock};
+      const opts = {url: 'https://differenturl.com', config: generateConfig(settings), driverMock};
       try {
         await Runner.run(null, opts);
         assert.fail('should have thrown');


### PR DESCRIPTION
repro:

```sh
lighthouse http://paulirish.com --preset-perf -G
lighthouse http://paulirish.com --preset-perf -A

Error: Cannot run audit mode on different URL
```