### PR TITLE
report(html): replace Typed OM getComputedStyle() with CSSOM equivalent

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -130,8 +130,10 @@ class ReportUIFeatures {
 
   _setupHeaderAnimation() {
     const scoresWrapper = this._dom.find('.lh-scores-wrapper', this._document);
-    this.headerOverlap = /** @type {number} */
-      (Number(window.getComputedStyle(scoresWrapper).marginTop.replace('px', '')));
+    const computedMarginTop = scoresWrapper.style.marginTop ?
+      window.getComputedStyle(scoresWrapper).marginTop : '0px';
+    this.headerOverlap = computedMarginTop ?
+      /** @type {number} */ (Number(computedMarginTop.replace('px', ''))) : 0;
     this.headerSticky = this._dom.find('.lh-header-sticky', this._document);
     this.headerBackground = this._dom.find('.lh-header-bg', this._document);
     this.lighthouseIcon = this._dom.find('.lh-lighthouse', this._document);
@@ -139,8 +141,10 @@ class ReportUIFeatures {
     this.productInfo = this._dom.find('.lh-product-info', this._document);
     this.toolbar = this._dom.find('.lh-toolbar', this._document);
     this.toolbarMetadata = this._dom.find('.lh-toolbar__metadata', this._document);
-    this.headerHeight = /** @type {number} */
-      (Number(window.getComputedStyle(this.headerBackground).height.replace('px', '')));
+    const computedHeight = this.headerBackground.style.height ?
+      window.getComputedStyle(this.headerBackground).height : '0px';
+    this.headerHeight = computedHeight ?
+      /** @type {number} */ (Number(computedHeight.replace('px', ''))) : 0;
 
     this._document.addEventListener('scroll', this.onScroll, {passive: true});
 

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -131,7 +131,7 @@ class ReportUIFeatures {
   _setupHeaderAnimation() {
     const scoresWrapper = this._dom.find('.lh-scores-wrapper', this._document);
     const computedMarginTop = window.getComputedStyle(scoresWrapper).marginTop;
-    this.headerOverlap = /** @type {number} */ parseFloat(computedMarginTop || '0');
+    this.headerOverlap = /** @type {number} */ (parseFloat(computedMarginTop || '0'));
     this.headerSticky = this._dom.find('.lh-header-sticky', this._document);
     this.headerBackground = this._dom.find('.lh-header-bg', this._document);
     this.lighthouseIcon = this._dom.find('.lh-lighthouse', this._document);
@@ -140,7 +140,7 @@ class ReportUIFeatures {
     this.toolbar = this._dom.find('.lh-toolbar', this._document);
     this.toolbarMetadata = this._dom.find('.lh-toolbar__metadata', this._document);
     const computedHeight = window.getComputedStyle(this.headerBackground).height;
-    this.headerHeight = /** @type {number} */ parseFloat(computedHeight || '0');
+    this.headerHeight = /** @type {number} */ (parseFloat(computedHeight || '0'));
 
     this._document.addEventListener('scroll', this.onScroll, {passive: true});
 

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -130,10 +130,8 @@ class ReportUIFeatures {
 
   _setupHeaderAnimation() {
     const scoresWrapper = this._dom.find('.lh-scores-wrapper', this._document);
-    const computedMarginTop = scoresWrapper.style.marginTop ?
-      window.getComputedStyle(scoresWrapper).marginTop : '0px';
-    this.headerOverlap = computedMarginTop ?
-      /** @type {number} */ (Number(computedMarginTop.replace('px', ''))) : 0;
+    const computedMarginTop = window.getComputedStyle(scoresWrapper).marginTop;
+    this.headerOverlap = /** @type {number} */ parseFloat(computedMarginTop || '0');
     this.headerSticky = this._dom.find('.lh-header-sticky', this._document);
     this.headerBackground = this._dom.find('.lh-header-bg', this._document);
     this.lighthouseIcon = this._dom.find('.lh-lighthouse', this._document);
@@ -141,10 +139,8 @@ class ReportUIFeatures {
     this.productInfo = this._dom.find('.lh-product-info', this._document);
     this.toolbar = this._dom.find('.lh-toolbar', this._document);
     this.toolbarMetadata = this._dom.find('.lh-toolbar__metadata', this._document);
-    const computedHeight = this.headerBackground.style.height ?
-      window.getComputedStyle(this.headerBackground).height : '0px';
-    this.headerHeight = computedHeight ?
-      /** @type {number} */ (Number(computedHeight.replace('px', ''))) : 0;
+    const computedHeight = window.getComputedStyle(this.headerBackground).height;
+    this.headerHeight = /** @type {number} */ parseFloat(computedHeight || '0');
 
     this._document.addEventListener('scroll', this.onScroll, {passive: true});
 

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -130,10 +130,7 @@ class ReportUIFeatures {
 
   _setupHeaderAnimation() {
     const scoresWrapper = this._dom.find('.lh-scores-wrapper', this._document);
-    this.headerOverlap = /** @type {number} */
-      // @ts-ignore - TODO: move off CSSOM to support other browsers
-      (scoresWrapper.computedStyleMap().get('margin-top').value);
-
+    this.headerOverlap = /** @type {number} */ (Number(window.getComputedStyle(scoresWrapper).marginTop.replace('px', '')));
     this.headerSticky = this._dom.find('.lh-header-sticky', this._document);
     this.headerBackground = this._dom.find('.lh-header-bg', this._document);
     this.lighthouseIcon = this._dom.find('.lh-lighthouse', this._document);
@@ -141,9 +138,7 @@ class ReportUIFeatures {
     this.productInfo = this._dom.find('.lh-product-info', this._document);
     this.toolbar = this._dom.find('.lh-toolbar', this._document);
     this.toolbarMetadata = this._dom.find('.lh-toolbar__metadata', this._document);
-
-    // @ts-ignore - TODO: move off CSSOM to support other browsers
-    this.headerHeight = this.headerBackground.computedStyleMap().get('height').value;
+    this.headerHeight = /** @type {number} */ (Number(window.getComputedStyle(this.headerBackground).height.replace('px', '')));
 
     this._document.addEventListener('scroll', this.onScroll, {passive: true});
 

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -131,7 +131,7 @@ class ReportUIFeatures {
   _setupHeaderAnimation() {
     const scoresWrapper = this._dom.find('.lh-scores-wrapper', this._document);
     const computedMarginTop = window.getComputedStyle(scoresWrapper).marginTop;
-    this.headerOverlap = /** @type {number} */ (parseFloat(computedMarginTop || '0'));
+    this.headerOverlap = parseFloat(computedMarginTop || '0');
     this.headerSticky = this._dom.find('.lh-header-sticky', this._document);
     this.headerBackground = this._dom.find('.lh-header-bg', this._document);
     this.lighthouseIcon = this._dom.find('.lh-lighthouse', this._document);
@@ -140,7 +140,7 @@ class ReportUIFeatures {
     this.toolbar = this._dom.find('.lh-toolbar', this._document);
     this.toolbarMetadata = this._dom.find('.lh-toolbar__metadata', this._document);
     const computedHeight = window.getComputedStyle(this.headerBackground).height;
-    this.headerHeight = /** @type {number} */ (parseFloat(computedHeight || '0'));
+    this.headerHeight = parseFloat(computedHeight || '0');
 
     this._document.addEventListener('scroll', this.onScroll, {passive: true});
 

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -130,7 +130,8 @@ class ReportUIFeatures {
 
   _setupHeaderAnimation() {
     const scoresWrapper = this._dom.find('.lh-scores-wrapper', this._document);
-    this.headerOverlap = /** @type {number} */ (Number(window.getComputedStyle(scoresWrapper).marginTop.replace('px', '')));
+    this.headerOverlap = /** @type {number} */
+      (Number(window.getComputedStyle(scoresWrapper).marginTop.replace('px', '')));
     this.headerSticky = this._dom.find('.lh-header-sticky', this._document);
     this.headerBackground = this._dom.find('.lh-header-bg', this._document);
     this.lighthouseIcon = this._dom.find('.lh-lighthouse', this._document);
@@ -138,7 +139,8 @@ class ReportUIFeatures {
     this.productInfo = this._dom.find('.lh-product-info', this._document);
     this.toolbar = this._dom.find('.lh-toolbar', this._document);
     this.toolbarMetadata = this._dom.find('.lh-toolbar__metadata', this._document);
-    this.headerHeight = /** @type {number} */ (Number(window.getComputedStyle(this.headerBackground).height.replace('px', '')));
+    this.headerHeight = /** @type {number} */
+      (Number(window.getComputedStyle(this.headerBackground).height.replace('px', '')));
 
     this._document.addEventListener('scroll', this.onScroll, {passive: true});
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
Replace Typed OM's `element.getComputedStyle()` with CSSOM `window.getComputedStyle()`
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->
Typed OM is not widely supported yet. Our delivered JS should work properly in all major browsers
<!-- Link any documentation or information that would help understand this change -->
https://developers.google.com/web/updates/2018/03/cssom#computed
**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
fixes #5966

Yeah, this replacement looks a bit hacky. But I've not found a more elegant way