### PR TITLE
report: update score legend to match new threshold

### DIFF
--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -44,9 +44,9 @@ These weights are heuristics, and the Lighthouse team is working on formalizing 
 Once Lighthouse is done gathering the raw performance metrics for your website (metrics reported in miliseconds), it converts them into a score by mapping the raw performance number to a number between 0-100 by looking where your raw performance metric falls on the Lighthouse scoring distribution. The Lighthouse scoring distribution is a log normal distribution that is derived from the performance metrics of real website performance data (see sample distribution [here](https://www.desmos.com/calculator/zrjq6v1ihi)).
 
 Once we finish computing the percentile equivalent of your raw performance score, we take the weighted average of all the performance metrics (per the weighting above). Finally, we apply a coloring to the score (green, orange, and red) depending on what "bucket" your score falls in. This maps to:
-- Red (poor score): 0-44.
-- Orange (average): 45-74
-- Green (good): 75-100.
+- Red (poor score): 0-49
+- Orange (average): 50-89
+- Green (good): 90-100
 
 ### What can developers do to improve their performance score?
 *Note: we've built [a little calculator](https://docs.google.com/spreadsheets/d/1Cxzhy5ecqJCucdf1M0iOzM8mIxNc7mmx107o5nj38Eo/edit#gid=283330180) that can help you understand what thresholds you should be aiming for achieving a certain Lighthouse performance score. *

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -28,8 +28,8 @@ limitations under the License.
   <div class="lh-scorescale">
     <span class="lh-scorescale-label"></span>
     <span class="lh-scorescale-range lh-scorescale-range--fail">0-44</span>
-    <span class="lh-scorescale-range lh-scorescale-range--average">45-74</span>
-    <span class="lh-scorescale-range lh-scorescale-range--pass">75-100</span>
+    <span class="lh-scorescale-range lh-scorescale-range--average">45-89</span>
+    <span class="lh-scorescale-range lh-scorescale-range--pass">90-100</span>
   </div>
 </template>
 

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -27,8 +27,8 @@ limitations under the License.
 <template id="tmpl-lh-scorescale">
   <div class="lh-scorescale">
     <span class="lh-scorescale-label"></span>
-    <span class="lh-scorescale-range lh-scorescale-range--fail">0-44</span>
-    <span class="lh-scorescale-range lh-scorescale-range--average">45-89</span>
+    <span class="lh-scorescale-range lh-scorescale-range--fail">0-49</span>
+    <span class="lh-scorescale-range lh-scorescale-range--average">50-89</span>
     <span class="lh-scorescale-range lh-scorescale-range--pass">90-100</span>
   </div>
 </template>


### PR DESCRIPTION
Release 3.1 updated the threshold from 0.75 to 0.9 for green in the report but the score legend wasn't updated.

Very small update to bring the score legend inline with the new threshold.
