### PR TITLE
docs(recipes): fix custom-audit recipe

### DIFF
--- a/docs/recipes/custom-audit/package.json
+++ b/docs/recipes/custom-audit/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "lighthouse": "^2.x"
+    "lighthouse": "^3.x"
   }
 }


### PR DESCRIPTION
**Summary**
This PR fixes the Custom audit recipe under docs as the code was updated to use the v3 API but `package.json` wasn't.
