### PR TITLE
Proposal: core: add top-level runtimeError

### DIFF
--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -12,18 +12,20 @@ const strings = require('./strings');
  * @property {string} code
  * @property {string} message
  * @property {RegExp} [pattern]
+ * @property {boolean} [lhrRuntimeError] True if it should appear in the top-level LHR.runtimeError property.
  */
 
 class LighthouseError extends Error {
   /**
    * @param {LighthouseErrorDefinition} errorDefinition
-   * @param {Record<string, string|undefined>=} properties
+   * @param {Record<string, string|boolean|undefined>=} properties
    */
   constructor(errorDefinition, properties) {
     super(errorDefinition.code);
     this.name = 'LHError';
     this.code = errorDefinition.code;
     this.friendlyMessage = errorDefinition.message;
+    this.lhrRuntimeError = !!errorDefinition.lhrRuntimeError;
     if (properties) Object.assign(this, properties);
 
     Error.captureStackTrace(this, LighthouseError);
@@ -75,17 +77,52 @@ class LighthouseError extends Error {
 
 const ERRORS = {
   // Screenshot/speedline errors
-  NO_SPEEDLINE_FRAMES: {code: 'NO_SPEEDLINE_FRAMES', message: strings.didntCollectScreenshots},
-  SPEEDINDEX_OF_ZERO: {code: 'SPEEDINDEX_OF_ZERO', message: strings.didntCollectScreenshots},
-  NO_SCREENSHOTS: {code: 'NO_SCREENSHOTS', message: strings.didntCollectScreenshots},
-  INVALID_SPEEDLINE: {code: 'INVALID_SPEEDLINE', message: strings.didntCollectScreenshots},
+  NO_SPEEDLINE_FRAMES: {
+    code: 'NO_SPEEDLINE_FRAMES',
+    message: strings.didntCollectScreenshots,
+    lhrRuntimeError: true,
+  },
+  SPEEDINDEX_OF_ZERO: {
+    code: 'SPEEDINDEX_OF_ZERO',
+    message: strings.didntCollectScreenshots,
+    lhrRuntimeError: true,
+  },
+  NO_SCREENSHOTS: {
+    code: 'NO_SCREENSHOTS',
+    message: strings.didntCollectScreenshots,
+    lhrRuntimeError: true,
+  },
+  INVALID_SPEEDLINE: {
+    code: 'INVALID_SPEEDLINE',
+    message: strings.didntCollectScreenshots,
+    lhrRuntimeError: true,
+  },
 
   // Trace parsing errors
-  NO_TRACING_STARTED: {code: 'NO_TRACING_STARTED', message: strings.badTraceRecording},
-  NO_NAVSTART: {code: 'NO_NAVSTART', message: strings.badTraceRecording},
-  NO_FCP: {code: 'NO_FCP', message: strings.badTraceRecording},
-  NO_FMP: {code: 'NO_FMP', message: strings.badTraceRecording},
-  NO_DCL: {code: 'NO_DCL', message: strings.badTraceRecording},
+  NO_TRACING_STARTED: {
+    code: 'NO_TRACING_STARTED',
+    message: strings.badTraceRecording,
+    lhrRuntimeError: true,
+  },
+  NO_NAVSTART: {
+    code: 'NO_NAVSTART',
+    message: strings.badTraceRecording,
+    lhrRuntimeError: true,
+  },
+  NO_FCP: {
+    code: 'NO_FCP',
+    message: strings.badTraceRecording,
+    lhrRuntimeError: true,
+  },
+  NO_DCL: {
+    code: 'NO_DCL',
+    message: strings.badTraceRecording,
+    lhrRuntimeError: true,
+  },
+  NO_FMP: {
+    code: 'NO_FMP',
+    message: strings.badTraceRecording,
+  },
 
   // TTI calculation failures
   FMP_TOO_LATE_FOR_FCPUI: {code: 'FMP_TOO_LATE_FOR_FCPUI', message: strings.pageLoadTookTooLong},
@@ -97,21 +134,36 @@ const ERRORS = {
   },
 
   // Page load failures
-  NO_DOCUMENT_REQUEST: {code: 'NO_DOCUMENT_REQUEST', message: strings.pageLoadFailed},
-  FAILED_DOCUMENT_REQUEST: {code: 'FAILED_DOCUMENT_REQUEST', message: strings.pageLoadFailed},
+  NO_DOCUMENT_REQUEST: {
+    code: 'NO_DOCUMENT_REQUEST',
+    message: strings.pageLoadFailed,
+    lhrRuntimeError: true,
+  },
+  FAILED_DOCUMENT_REQUEST: {
+    code: 'FAILED_DOCUMENT_REQUEST',
+    message: strings.pageLoadFailed,
+    lhrRuntimeError: true,
+  },
 
   // Protocol internal failures
   TRACING_ALREADY_STARTED: {
     code: 'TRACING_ALREADY_STARTED',
     message: strings.internalChromeError,
     pattern: /Tracing.*started/,
+    lhrRuntimeError: true,
   },
   PARSING_PROBLEM: {
     code: 'PARSING_PROBLEM',
     message: strings.internalChromeError,
     pattern: /Parsing problem/,
+    lhrRuntimeError: true,
   },
-  READ_FAILED: {code: 'READ_FAILED', message: strings.internalChromeError, pattern: /Read failed/},
+  READ_FAILED: {
+    code: 'READ_FAILED',
+    message: strings.internalChromeError,
+    pattern: /Read failed/,
+    lhrRuntimeError: true,
+  },
 
   // Protocol timeout failures
   REQUEST_CONTENT_TIMEOUT: {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -18,6 +18,7 @@ const path = require('path');
 const URL = require('./lib/url-shim');
 const Sentry = require('./lib/sentry');
 const generateReport = require('./report/report-generator').generateReport;
+const LHError = require('./lib/lh-error.js');
 
 /** @typedef {import('./gather/connections/connection.js')} Connection */
 /** @typedef {import('./config/config.js')} Config */
@@ -131,6 +132,7 @@ class Runner {
         requestedUrl: requestedUrl,
         finalUrl: artifacts.URL.finalUrl,
         runWarnings: lighthouseRunWarnings,
+        runtimeError: Runner.getArtifactRuntimeError(artifacts),
         audits: resultsById,
         configSettings: settings,
         categories,
@@ -289,6 +291,22 @@ class Runner {
 
     log.verbose('statusEnd', status);
     return auditResult;
+  }
+
+  /**
+   * Returns any runtimeError message found in artifacts.
+   * @param {LH.Artifacts} artifacts
+   * @return {string|undefined}
+   */
+  static getArtifactRuntimeError(artifacts) {
+    for (const possibleErrorArtifact of Object.values(artifacts)) {
+      if (possibleErrorArtifact instanceof LHError && possibleErrorArtifact.lhrRuntimeError) {
+        const errorMessage = possibleErrorArtifact.friendlyMessage ?
+          `${possibleErrorArtifact.friendlyMessage} (${possibleErrorArtifact.message})` :
+          possibleErrorArtifact.message;
+        return errorMessage;
+      }
+    }
   }
 
   /**

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -50,6 +50,8 @@ declare global {
       configSettings: Config.Settings;
       /** List of top-level warnings for this Lighthouse run. */
       runWarnings: string[];
+      /** A top-level error message that, if present, indicates a serious enough problem that the result may need to be discarded. */
+      runtimeError: string|undefined;
       /** The User-Agent string of the browser used run Lighthouse for these results. */
       userAgent: string;
       /** Information about the environment in which Lighthouse was run. */


### PR DESCRIPTION
@paulirish

Here's one simple approach to #5881. All artifact errors are caught, and any deemed `runtimeError` worthy are floated to the top-level property in the LHR. From that bug, this handles

> 2. tracing result failures: NO_tracing_start, no_navstart, NO_FCP, no_dcl = FATAL
> 4. Screenshot/speedline errors = all fatal. (unless its a pain. no big deal, really)

It sort of handles

> 1. defaultPass pageload error = runtimeError
>    * 500'd. 400'd. certificate error.  network disconnected / offline. 
>    * FAILED_DOCUMENT__REQUEST, NO_DOCUMENT__REQUEST

but if that pageload error affects enough audits (which it usually does) we throw from the whole Lighthouse run and don't ever return an LHR.

Like the idea mentioned in https://github.com/GoogleChrome/lighthouse/issues/5881#issuecomment-414914507, I'd prefer to continue throwing exceptions for these cases and then checking outside core in `runLighthouseForLR` that the thrown error has `lhrRuntimeError` set on it. Most of our clients just want a thrown error in those cases, not a pseudo-LHR, and dealing with a pseudo-LHR just makes tracking the LHR type and what's on it messier when we really just want an exception floated up.

So I don't think it's worth doing that inside core. In `runLighthouseForLR` we can create that pseudo-LHR with *just* the top-level `runtimeError` property.

Doing it that way will completely handle (1) above and
> 3. tracing recording failures: TRACING_ALREADY_STARTED, PARSING_problem, read_failed, (timeout_during_trace_retreival)
if you're still good with that idea.

If this is 👍 from you I can add that and tests.