### PR TITLE
core: make offscreen-images audit work without TTI

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -165,7 +165,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
    * @param {LH.Audit.Context} context
    * @return {Promise<ByteEfficiencyAudit.ByteEfficiencyProduct>}
    */
-  static audit_(artifacts, networkRecords, context) {
+  static async audit_(artifacts, networkRecords, context) {
     const images = artifacts.ImageUsage;
     const viewportDimensions = artifacts.ViewportDimensions;
     const trace = artifacts.traces[ByteEfficiencyAudit.DEFAULT_PASS];
@@ -195,29 +195,39 @@ class OffscreenImages extends ByteEfficiencyAudit {
     }, /** @type {Map<string, WasteResult>} */ (new Map()));
 
     const settings = context.settings;
-    return artifacts.requestInteractive({trace, devtoolsLog, settings}).then(interactive => {
-      const unfilteredResults = Array.from(resultsMap.values());
+
+    let items;
+    const unfilteredResults = Array.from(resultsMap.values());
+    // get the interactive time or fallback to getting the end of trace time
+    try {
+      const interactive = await artifacts.requestInteractive({trace, devtoolsLog, settings});
+
+      // use interactive to generate items
       const lanternInteractive = /** @type {LH.Artifacts.LanternMetric} */ (interactive);
       // Filter out images that were loaded after all CPU activity
-      const items = context.settings.throttlingMethod === 'simulate' ?
+      items = context.settings.throttlingMethod === 'simulate' ?
         OffscreenImages.filterLanternResults(unfilteredResults, lanternInteractive) :
         // @ts-ignore - .timestamp will exist if throttlingMethod isn't lantern
         OffscreenImages.filterObservedResults(unfilteredResults, interactive.timestamp);
+    } catch (err) {
+      // use end of trace as a substitute for finding interactive time
+      items = OffscreenImages.filterObservedResults(unfilteredResults,
+        await artifacts.requestTraceOfTab(trace).then(tot => tot.timings.traceEnd));
+    }
 
-      /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
-      const headings = [
-        {key: 'url', valueType: 'thumbnail', label: ''},
-        {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
-        {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},
-        {key: 'wastedBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnWastedBytes)},
-      ];
+    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    const headings = [
+      {key: 'url', valueType: 'thumbnail', label: ''},
+      {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
+      {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},
+      {key: 'wastedBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnWastedBytes)},
+    ];
 
-      return {
-        warnings,
-        items,
-        headings,
-      };
-    });
+    return {
+      warnings,
+      items,
+      headings,
+    };
   }
 }
 

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -212,7 +212,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
     } catch (err) {
       // use end of trace as a substitute for finding interactive time
       items = OffscreenImages.filterObservedResults(unfilteredResults,
-        await artifacts.requestTraceOfTab(trace).then(tot => tot.timings.traceEnd));
+        await artifacts.requestTraceOfTab(trace).then(tot => tot.timestamps.traceEnd));
     }
 
     /** @type {LH.Result.Audit.OpportunityDetails['headings']} */

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -210,7 +210,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
         // @ts-ignore - .timestamp will exist if throttlingMethod isn't lantern
         OffscreenImages.filterObservedResults(unfilteredResults, interactive.timestamp);
     } catch (err) {
-      // if the error is during a Lantern run, the result is irrevocable, so rethrow
+      // if the error is during a Lantern run, end of trace may also be inaccurate, so rethrow
       if (context.settings.throttlingMethod === 'simulate') {
         throw err;
       }

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -210,6 +210,10 @@ class OffscreenImages extends ByteEfficiencyAudit {
         // @ts-ignore - .timestamp will exist if throttlingMethod isn't lantern
         OffscreenImages.filterObservedResults(unfilteredResults, interactive.timestamp);
     } catch (err) {
+      // if the error is during a Lantern run, the result is irrevocable, so rethrow
+      if (context.settings.throttlingMethod === 'simulate') {
+        throw err;
+      }
       // use end of trace as a substitute for finding interactive time
       items = OffscreenImages.filterObservedResults(unfilteredResults,
         await artifacts.requestTraceOfTab(trace).then(tot => tot.timestamps.traceEnd));

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -10,6 +10,7 @@ const UnusedImages =
 const NetworkNode = require('../../../lib/dependency-graph/network-node');
 const CPUNode = require('../../../lib/dependency-graph/cpu-node');
 const assert = require('assert');
+const LHError = require('../../../lib/lh-error');
 
 /* eslint-env jest */
 function generateRecord(resourceSizeInKb, startTime = 0, mimeType = 'image/png') {
@@ -47,6 +48,20 @@ function generateImage(size, coords, networkRecord, src = 'https://google.com/lo
 function generateInteractiveFunc(desiredTimeInSeconds) {
   return () => Promise.resolve({
     timestamp: desiredTimeInSeconds * 1000000,
+  });
+}
+
+function generateInteractiveFuncError() {
+  return () => Promise.reject(
+    new LHError.errors.NO_TTI_NETWORK_IDLE_PERIOD()
+  );
+}
+
+function generateTraceOfTab(desiredTimeInSeconds) {
+  return () => Promise.resolve({
+    timings: {
+      traceEnd: desiredTimeInSeconds * 1000000,
+    },
   });
 }
 
@@ -162,6 +177,38 @@ describe('OffscreenImages audit', () => {
     });
   });
 
+  it('disregards images loaded after Trace of Tab when interactive throws error', () => {
+    return UnusedImages.audit_({
+      ViewportDimensions: DEFAULT_DIMENSIONS,
+      ImageUsage: [
+        // offscreen to the right
+        generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 3)),
+      ],
+      traces: {},
+      devtoolsLogs: {},
+      requestInteractive: generateInteractiveFuncError(),
+      requestTraceOfTab: generateTraceOfTab(2),
+    }, [], context, [], context).then(auditResult => {
+      assert.equal(auditResult.items.length, 0);
+    });
+  });
+
+  it('finds images loaded before Trace of Tab when TTI when interactive throws error', () => {
+    return UnusedImages.audit_({
+      ViewportDimensions: DEFAULT_DIMENSIONS,
+      ImageUsage: [
+        // offscreen to the right
+        generateImage(generateSize(100, 100), [0, 2000], generateRecord(100)),
+      ],
+      traces: {},
+      devtoolsLogs: {},
+      requestInteractive: generateInteractiveFuncError(),
+      requestTraceOfTab: generateTraceOfTab(2),
+    }, [], context, [], context).then(auditResult => {
+      assert.equal(auditResult.items.length, 1);
+    });
+  });
+
   it('disregards images loaded after last long task (Lantern)', () => {
     context = {settings: {throttlingMethod: 'simulate'}};
     const recordA = {url: 'a', resourceSize: 100 * 1024, requestId: 'a'};
@@ -185,6 +232,72 @@ describe('OffscreenImages audit', () => {
       traces: {},
       devtoolsLogs: {},
       requestInteractive: async () => ({pessimisticEstimate: {nodeTimings: timings}}),
+    }, [], context, [], context).then(auditResult => {
+      assert.equal(auditResult.items.length, 1);
+      assert.equal(auditResult.items[0].url, 'a');
+    });
+  });
+
+  it('finds images loaded before last long task (Lantern)', () => {
+    context = {settings: {throttlingMethod: 'simulate'}};
+    const recordA = {url: 'a', resourceSize: 100 * 1024, requestId: 'a'};
+    const recordB = {url: 'b', resourceSize: 100 * 1024, requestId: 'b'};
+
+    const networkA = new NetworkNode(recordA);
+    const networkB = new NetworkNode(recordB);
+    const cpu = new CPUNode({}, []);
+    const timings = new Map([
+      [networkA, {startTime: 3000}],
+      [networkB, {startTime: 4000}],
+      [cpu, {startTime: 1975, endTime: 2025, duration: 50}],
+    ]);
+
+    return UnusedImages.audit_({
+      ViewportDimensions: DEFAULT_DIMENSIONS,
+      ImageUsage: [
+        generateImage(generateSize(0, 0), [0, 0], recordA, recordA.url),
+        generateImage(generateSize(200, 200), [3000, 0], recordB, recordB.url),
+      ],
+      traces: {},
+      devtoolsLogs: {},
+      requestInteractive: async () => ({pessimisticEstimate: {nodeTimings: timings}}),
+      requestTraceOfTab: generateTraceOfTab(2),
+    }, [], context, [], context).then(auditResult => {
+      assert.equal(auditResult.items.length, 0);
+    });
+  });
+
+  it('disregards images loaded after ToT when interactive throws error (Lantern)', () => {
+    context = {settings: {throttlingMethod: 'simulate'}};
+
+    return UnusedImages.audit_({
+      ViewportDimensions: DEFAULT_DIMENSIONS,
+      ImageUsage: [
+        generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 3), 'a'),
+        generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
+      ],
+      traces: {},
+      devtoolsLogs: {},
+      requestInteractive: generateInteractiveFuncError(),
+      requestTraceOfTab: generateTraceOfTab(2),
+    }, [], context, [], context).then(auditResult => {
+      assert.equal(auditResult.items.length, 0);
+    });
+  });
+
+  it('finds images loaded after ToT when interactive throws error (Lantern)', () => {
+    context = {settings: {throttlingMethod: 'simulate'}};
+
+    return UnusedImages.audit_({
+      ViewportDimensions: DEFAULT_DIMENSIONS,
+      ImageUsage: [
+        generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 1), 'a'),
+        generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
+      ],
+      traces: {},
+      devtoolsLogs: {},
+      requestInteractive: generateInteractiveFuncError(),
+      requestTraceOfTab: generateTraceOfTab(2),
     }, [], context, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 1);
       assert.equal(auditResult.items[0].url, 'a');

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -193,7 +193,7 @@ describe('OffscreenImages audit', () => {
     });
   });
 
-  it('finds images loaded before Trace of Tab when TTI when interactive throws error', () => {
+  it('finds images loaded before Trace End when TTI when interactive throws error', () => {
     return UnusedImages.audit_({
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
@@ -287,7 +287,7 @@ describe('OffscreenImages audit', () => {
     });
   });
 
-  it('finds images loaded after ToT when interactive throws error (Lantern)', () => {
+  it('finds images loaded before Trace End when interactive throws error (Lantern)', () => {
     context = {settings: {throttlingMethod: 'simulate'}};
 
     return UnusedImages.audit_({

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -59,7 +59,7 @@ function generateInteractiveFuncError() {
 
 function generateTraceOfTab(desiredTimeInSeconds) {
   return () => Promise.resolve({
-    timings: {
+    timestamps: {
       traceEnd: desiredTimeInSeconds * 1000000,
     },
   });

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -177,7 +177,7 @@ describe('OffscreenImages audit', () => {
     });
   });
 
-  it('disregards images loaded after Trace of Tab when interactive throws error', () => {
+  it('disregards images loaded after Trace End when interactive throws error', () => {
     return UnusedImages.audit_({
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
@@ -247,8 +247,8 @@ describe('OffscreenImages audit', () => {
     const networkB = new NetworkNode(recordB);
     const cpu = new CPUNode({}, []);
     const timings = new Map([
-      [networkA, {startTime: 3000}],
-      [networkB, {startTime: 4000}],
+      [networkA, {startTime: 1000}],
+      [networkB, {startTime: 1500}],
       [cpu, {startTime: 1975, endTime: 2025, duration: 50}],
     ]);
 
@@ -263,11 +263,13 @@ describe('OffscreenImages audit', () => {
       requestInteractive: async () => ({pessimisticEstimate: {nodeTimings: timings}}),
       requestTraceOfTab: generateTraceOfTab(2),
     }, [], context, [], context).then(auditResult => {
-      assert.equal(auditResult.items.length, 0);
+      assert.equal(auditResult.items.length, 2);
+      assert.equal(auditResult.items[0].url, 'a');
+      assert.equal(auditResult.items[1].url, 'b');
     });
   });
 
-  it('disregards images loaded after ToT when interactive throws error (Lantern)', () => {
+  it('disregards images loaded after Trace End when interactive throws error (Lantern)', () => {
     context = {settings: {throttlingMethod: 'simulate'}};
 
     return UnusedImages.audit_({

--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -53,7 +53,7 @@ function generateInteractiveFunc(desiredTimeInSeconds) {
 
 function generateInteractiveFuncError() {
   return () => Promise.reject(
-    new LHError.errors.NO_TTI_NETWORK_IDLE_PERIOD()
+    new LHError(LHError.errors.NO_TTI_NETWORK_IDLE_PERIOD)
   );
 }
 
@@ -269,40 +269,43 @@ describe('OffscreenImages audit', () => {
     });
   });
 
-  it('disregards images loaded after Trace End when interactive throws error (Lantern)', () => {
+  it('rethrow error when interactive throws error in Lantern', async () => {
     context = {settings: {throttlingMethod: 'simulate'}};
-
-    return UnusedImages.audit_({
-      ViewportDimensions: DEFAULT_DIMENSIONS,
-      ImageUsage: [
-        generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 3), 'a'),
-        generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
-      ],
-      traces: {},
-      devtoolsLogs: {},
-      requestInteractive: generateInteractiveFuncError(),
-      requestTraceOfTab: generateTraceOfTab(2),
-    }, [], context, [], context).then(auditResult => {
-      assert.equal(auditResult.items.length, 0);
-    });
+    try {
+      await UnusedImages.audit_({
+        ViewportDimensions: DEFAULT_DIMENSIONS,
+        ImageUsage: [
+          generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 3), 'a'),
+          generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
+        ],
+        traces: {},
+        devtoolsLogs: {},
+        requestInteractive: generateInteractiveFuncError(),
+        requestTraceOfTab: generateTraceOfTab(2),
+      }, [], context, [], context);
+    } catch (err) {
+      return;
+    }
+    assert.ok(false);
   });
 
-  it('finds images loaded before Trace End when interactive throws error (Lantern)', () => {
+  it('finds images loaded before Trace End when interactive throws error (Lantern)', async () => {
     context = {settings: {throttlingMethod: 'simulate'}};
-
-    return UnusedImages.audit_({
-      ViewportDimensions: DEFAULT_DIMENSIONS,
-      ImageUsage: [
-        generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 1), 'a'),
-        generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
-      ],
-      traces: {},
-      devtoolsLogs: {},
-      requestInteractive: generateInteractiveFuncError(),
-      requestTraceOfTab: generateTraceOfTab(2),
-    }, [], context, [], context).then(auditResult => {
-      assert.equal(auditResult.items.length, 1);
-      assert.equal(auditResult.items[0].url, 'a');
-    });
+    try {
+      await UnusedImages.audit_({
+        ViewportDimensions: DEFAULT_DIMENSIONS,
+        ImageUsage: [
+          generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 1), 'a'),
+          generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
+        ],
+        traces: {},
+        devtoolsLogs: {},
+        requestInteractive: generateInteractiveFuncError(),
+        requestTraceOfTab: generateTraceOfTab(2),
+      }, [], context, [], context);
+    } catch (err) {
+      return;
+    }
+    assert.ok(false);
   });
 });


### PR DESCRIPTION
fixes: #5955 

**Summary**
Makes it so that when TTI derivation throws an error, the offscreen-image audit will fallback to using EndOfTab trace for cutoff instead of erroring out.
