### PR TITLE
deps: chrome-launcher to 0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "dependencies": {
     "axe-core": "3.0.0-beta.2",
     "chrome-devtools-frontend": "1.0.422034",
-    "chrome-launcher": "^0.10.2",
+    "chrome-launcher": "^0.10.4",
     "configstore": "^3.1.1",
     "devtools-timeline-model": "1.1.6",
     "esprima": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,9 +1033,9 @@ chrome-devtools-frontend@1.0.422034:
   version "1.0.422034"
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.422034.tgz#071c8ce14466b7653032fcd1ad1a4a68d5e3cbd9"
 
-chrome-launcher@^0.10.2:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.10.2.tgz#f7d860ddec627b6f01015736b5ae1e33b3d165b1"
+chrome-launcher@^0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.10.4.tgz#8d4d99724110f8bbf00b00fa3c1e93fd7f1e188a"
   dependencies:
     "@types/core-js" "^0.9.41"
     "@types/mkdirp" "^0.3.29"


### PR DESCRIPTION

changelog

* `35842ba4` fix: ignore stdio on `which` call (#121)
* `f126c3a0` fix: reject promise on failed kill() (#112)
* `5ee0fde2` Set custom error codes for all errors.
* `841bdf3f` Fix picking CHROME_PATH priority over other matches.
* `6b10d748` Fix Travis CI build: GCE for chrome bug (#87)
* `d4aa8295` Fix readme's default logLevel (#85)
* `5be71243` Type improvements (#102)
* `dd5fdd49` Stricter typing for logLevel (#105)
* `c9394cf7` Fix README typo: booelan ==> boolean (#104)
* Update chrome-flags-for-tools.md