### PR TITLE
core(gather-runner): include error status codes in pageLoadError

### DIFF
--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -78,8 +78,8 @@ module.exports = [
     },
   },
   {
-    requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403&' + failureHeaders,
-    finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403&' + failureHeaders,
+    requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+    finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
     audits: {
       'viewport': {
         score: 0,
@@ -91,8 +91,7 @@ module.exports = [
         score: 0,
       },
       'http-status-code': {
-        score: 0,
-        displayValue: '403',
+        score: 1,
       },
       'font-size': {
         rawValue: false,
@@ -134,6 +133,44 @@ module.exports = [
       'canonical': {
         score: 0,
         explanation: 'Multiple conflicting URLs (https://example.com, https://example.com/)',
+      },
+    },
+  },
+  {
+    // Note: most scores are null (audit error) because the page 403ed.
+    requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+    finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+    audits: {
+      'http-status-code': {
+        score: 0,
+        displayValue: '403',
+      },
+      'viewport': {
+        score: null,
+      },
+      'document-title': {
+        score: null,
+      },
+      'meta-description': {
+        score: null,
+      },
+      'font-size': {
+        score: null,
+      },
+      'link-text': {
+        score: null,
+      },
+      'is-crawlable': {
+        score: null,
+      },
+      'hreflang': {
+        score: null,
+      },
+      'plugins': {
+        score: null,
+      },
+      'canonical': {
+        score: null,
       },
     },
   },

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -163,6 +163,9 @@ class GatherRunner {
     } else if (mainRecord.failed) {
       errorCode = LHError.errors.FAILED_DOCUMENT_REQUEST;
       errorReason = mainRecord.localizedFailDescription;
+    } else if (mainRecord.hasErrorStatusCode()) {
+      errorCode = LHError.errors.ERROR_STATUS_CODE_RESPONSE;
+      errorReason = `Request returned with status code ${mainRecord.statusCode}`;
     }
 
     if (errorCode) {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -164,7 +164,7 @@ class GatherRunner {
       errorCode = LHError.errors.FAILED_DOCUMENT_REQUEST;
       errorReason = mainRecord.localizedFailDescription;
     } else if (mainRecord.hasErrorStatusCode()) {
-      errorCode = LHError.errors.ERROR_STATUS_CODE_RESPONSE;
+      errorCode = LHError.errors.ERRORED_DOCUMENT_REQUEST;
       errorReason = `Request returned with status code ${mainRecord.statusCode}`;
     }
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -165,7 +165,7 @@ class GatherRunner {
       errorReason = mainRecord.localizedFailDescription;
     } else if (mainRecord.hasErrorStatusCode()) {
       errorCode = LHError.errors.ERRORED_DOCUMENT_REQUEST;
-      errorReason = `Request returned with status code ${mainRecord.statusCode}`;
+      errorReason = `Status code: ${mainRecord.statusCode}`;
     }
 
     if (errorCode) {

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -144,6 +144,11 @@ const ERRORS = {
     message: strings.pageLoadFailed,
     lhrRuntimeError: true,
   },
+  ERROR_STATUS_CODE_RESPONSE: {
+    code: 'ERROR_STATUS_CODE_RESPONSE',
+    message: strings.pageLoadFailed,
+    lhrRuntimeError: true,
+  },
 
   // Protocol internal failures
   TRACING_ALREADY_STARTED: {

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -139,13 +139,15 @@ const ERRORS = {
     message: strings.pageLoadFailed,
     lhrRuntimeError: true,
   },
+  /* Used when DevTools reports loading failed. Usually an internal (Chrome) issue. */
   FAILED_DOCUMENT_REQUEST: {
     code: 'FAILED_DOCUMENT_REQUEST',
     message: strings.pageLoadFailed,
     lhrRuntimeError: true,
   },
-  ERROR_STATUS_CODE_RESPONSE: {
-    code: 'ERROR_STATUS_CODE_RESPONSE',
+  /* Used when status code is 4xx or 5xx. */
+  ERRORED_DOCUMENT_REQUEST: {
+    code: 'ERRORED_DOCUMENT_REQUEST',
     message: strings.pageLoadFailed,
     lhrRuntimeError: true,
   },

--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -106,6 +106,13 @@ module.exports = class NetworkRequest {
   }
 
   /**
+   * @return {boolean}
+   */
+  hasErrorStatusCode() {
+    return this.statusCode >= 400;
+  }
+
+  /**
    * @param {NetworkRequest} initiator
    */
   setInitiatorRequest(initiator) {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -12,6 +12,7 @@ const GatherRunner = require('../../gather/gather-runner');
 const assert = require('assert');
 const Config = require('../../config/config');
 const unresolvedPerfLog = require('./../fixtures/unresolved-perflog.json');
+const NetworkRequest = require('../../lib/network-request.js');
 
 class TestGatherer extends Gatherer {
   constructor() {
@@ -606,29 +607,54 @@ describe('GatherRunner', function() {
   describe('#getPageLoadError', () => {
     it('passes when the page is loaded', () => {
       const url = 'http://the-page.com';
-      const records = [{url}];
-      assert.ok(!GatherRunner.getPageLoadError(url, records));
+      const mainRecord = new NetworkRequest();
+      mainRecord.url = url;
+      assert.ok(!GatherRunner.getPageLoadError(url, [mainRecord]));
     });
 
     it('passes when the page is loaded, ignoring any fragment', () => {
       const url = 'http://example.com/#/page/list';
-      const records = [{url: 'http://example.com'}];
-      assert.ok(!GatherRunner.getPageLoadError(url, records));
+      const mainRecord = new NetworkRequest();
+      mainRecord.url = 'http://example.com';
+      assert.ok(!GatherRunner.getPageLoadError(url, [mainRecord]));
     });
 
-    it('throws when page fails to load', () => {
+    it('fails when page fails to load', () => {
       const url = 'http://the-page.com';
-      const records = [{url, failed: true, localizedFailDescription: 'foobar'}];
-      const error = GatherRunner.getPageLoadError(url, records);
+      const mainRecord = new NetworkRequest();
+      mainRecord.url = url;
+      mainRecord.failed = true;
+      mainRecord.localizedFailDescription = 'foobar';
+      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
       assert.equal(error.message, 'FAILED_DOCUMENT_REQUEST');
       assert.ok(/Your page failed to load/.test(error.friendlyMessage));
     });
 
-    it('throws when page times out', () => {
+    it('fails when page times out', () => {
       const url = 'http://the-page.com';
       const records = [];
       const error = GatherRunner.getPageLoadError(url, records);
       assert.equal(error.message, 'NO_DOCUMENT_REQUEST');
+      assert.ok(/Your page failed to load/.test(error.friendlyMessage));
+    });
+
+    it('fails when page returns with a 404', () => {
+      const url = 'http://the-page.com';
+      const mainRecord = new NetworkRequest();
+      mainRecord.url = url;
+      mainRecord.statusCode = 404;
+      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
+      assert.equal(error.message, 'ERROR_STATUS_CODE_RESPONSE');
+      assert.ok(/Your page failed to load/.test(error.friendlyMessage));
+    });
+
+    it('fails when page returns with a 500', () => {
+      const url = 'http://the-page.com';
+      const mainRecord = new NetworkRequest();
+      mainRecord.url = url;
+      mainRecord.statusCode = 500;
+      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
+      assert.equal(error.message, 'ERROR_STATUS_CODE_RESPONSE');
       assert.ok(/Your page failed to load/.test(error.friendlyMessage));
     });
   });

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -644,7 +644,7 @@ describe('GatherRunner', function() {
       mainRecord.url = url;
       mainRecord.statusCode = 404;
       const error = GatherRunner.getPageLoadError(url, [mainRecord]);
-      assert.equal(error.message, 'ERROR_STATUS_CODE_RESPONSE');
+      assert.equal(error.message, 'ERRORED_DOCUMENT_REQUEST');
       assert.ok(/Your page failed to load/.test(error.friendlyMessage));
     });
 
@@ -654,7 +654,7 @@ describe('GatherRunner', function() {
       mainRecord.url = url;
       mainRecord.statusCode = 500;
       const error = GatherRunner.getPageLoadError(url, [mainRecord]);
-      assert.equal(error.message, 'ERROR_STATUS_CODE_RESPONSE');
+      assert.equal(error.message, 'ERRORED_DOCUMENT_REQUEST');
       assert.ok(/Your page failed to load/.test(error.friendlyMessage));
     });
   });

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -41,7 +41,7 @@ declare global {
       lighthouseVersion: string;
       /** An object containing the results of the audits, keyed by the audits' `id` identifier. */
       audits: Record<string, Audit.Result>;
-      /** The top-level categories, their overall scores, and member audits. */
+    /** The top-level categories, their overall scores, and member audits. */
       categories: Record<string, Result.Category>;
       /** Descriptions of the groups referenced by CategoryMembers. */
       categoryGroups?: Record<string, Result.ReportGroup>;

--- a/typings/lhr.d.ts
+++ b/typings/lhr.d.ts
@@ -41,7 +41,7 @@ declare global {
       lighthouseVersion: string;
       /** An object containing the results of the audits, keyed by the audits' `id` identifier. */
       audits: Record<string, Audit.Result>;
-    /** The top-level categories, their overall scores, and member audits. */
+      /** The top-level categories, their overall scores, and member audits. */
       categories: Record<string, Result.Category>;
       /** Descriptions of the groups referenced by CategoryMembers. */
       categoryGroups?: Record<string, Result.ReportGroup>;


### PR DESCRIPTION
Adds a pageLoadError for 400/500 http status codes. Fixes #4082; depends on #6014 (see https://github.com/GoogleChrome/lighthouse/commit/dcb468ab16ce71f0566fbca46e7ec41b604ad365 for actual diff).

[Example Report](https://googlechrome.github.io/lighthouse/viewer/?gist=4295b586ef6b9724aea0825ae1a8836d)
<img width="898" alt="screen shot 2018-09-18 at 12 32 48" src="https://user-images.githubusercontent.com/316891/45711611-ff46da00-bb3e-11e8-906b-956c58f644d9.png">

Good:
- catches the error
- warns user at the top of the report that it happened and they should fix their URL
- issues `runtimeError`

Less good:
- redundant with the `http-status-code` SEO audit (#3311). That audit successfully marks the page as 404ing (or whatever), but all the other audits around it are marked as `Error!` (since no gatherers in that pass return an artifact), so it's pretty much lost in the noise

<img width="833" alt="screen shot 2018-09-18 at 12 31 02" src="https://user-images.githubusercontent.com/316891/45711568-da526700-bb3e-11e8-9acc-cebd11ffe933.png">


- the [SEO 403 smokehouse test](https://github.com/GoogleChrome/lighthouse/blob/25457c1e0980af7e54ab5958041c46acda6b41ee/lighthouse-cli/test/smokehouse/seo/expectations.js#L81-L139) is pretty much all broken, as another example of this