### PR TITLE
misc: bump bundlesize threshold a little more

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   "bundlesize": [
     {
       "path": "./lighthouse-extension/dist/scripts/lighthouse-background.js",
-      "threshold": "510 Kb"
+      "threshold": "520 Kb"
     },
     {
       "path": "./lighthouse-viewer/dist/src/viewer.js",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39191/45723043-37144880-bb64-11e8-808e-ebaba65c3796.png)


We're over by 0.3KB now. 

So this can is getting kicked. 👟🥫👉🛣