### PR TITLE
core(driver): deliver trace as events rather than a stream

### DIFF
--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -36,7 +36,7 @@ class AxeAudit extends Audit {
     const impact = rule && rule.impact;
     const tags = rule && rule.tags;
 
-    /** @type {Array<{node: LH.Audit.DetailsRendererNodeDetailsJSON}>}>} */
+    /** @type {Array<{node: LH.Audit.DetailsRendererNodeDetailsJSON}>} */
     let items = [];
     if (rule && rule.nodes) {
       items = rule.nodes.map(node => ({

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -936,7 +936,7 @@ class Driver {
       throw new Error('DOM domain enabled when starting trace');
     }
 
-    // setup listener to listen for when trace a data bundle is collected
+    // setup listener for when a trace bundle is sent
     this.on('Tracing.dataCollected', data => {
       this._traceEvents.traceEvents.push(...data.value);
     });

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -943,15 +943,21 @@ class Driver {
     /** @type {Array<LH.TraceEvent>} */
     const traceEvents = [];
 
-    // setup listener for when a trace bundle is sent
-    this.on('Tracing.dataCollected', data => {
+    /**
+     * Make function to fire when tracing bundle is collected.
+     * @param {LH.Crdp.Tracing.DataCollectedEvent} data
+     */
+    const dataListener = function(data) {
       traceEvents.push(...data.value);
-    });
+    };
+    this.on('Tracing.dataCollected', dataListener);
 
     return new Promise((resolve, reject) => {
       this.once('Tracing.tracingComplete', _ => {
+        this.off('Tracing.dataCollected', dataListener);
         resolve({traceEvents});
       });
+
 
       // Issue the command to stop tracing.
       return this.sendCommand('Tracing.end').catch(reject);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -940,7 +940,7 @@ class Driver {
    * @return {Promise<LH.Trace>}
    */
   endTrace() {
-    /** @type {Array<LH.TraceEvent>}>} */
+    /** @type {Array<LH.TraceEvent>} */
     const traceEvents = [];
 
     // setup listener for when a trace bundle is sent

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -944,7 +944,7 @@ class Driver {
     const traceEvents = [];
 
     /**
-     * Make function to fire when tracing bundle is collected.
+     * Listener for when dataCollected events fire for each trace chunk
      * @param {LH.Crdp.Tracing.DataCollectedEvent} data
      */
     const dataListener = function(data) {
@@ -958,8 +958,6 @@ class Driver {
         resolve({traceEvents});
       });
 
-
-      // Issue the command to stop tracing.
       return this.sendCommand('Tracing.end').catch(reject);
     });
   }


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
This changes the Tracing.start protocol command to use the `ReportEvents` transferMode instead of `ReturnAsStream`.  This makes the trace gathering much faster, as observed in some automated run timings:

| URL | ReturnAsStream | ReportEvents | Difference |
|---|---|---|---|
| http://cnn.com | 3410ms | 1202ms | (2208ms) |
|http://paulirish.com| 174ms | 87ms | (~86ms) |

Note: timings are averages of 5 seperate runs with each method.

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
fixes #5968
closes #5939
Based on code in [old driver implementation](https://github.com/GoogleChrome/lighthouse/blame/0e8982ab037d928a37d8dddd00aa7f1e913f5414/helpers/browser/driver.js)