### PR TITLE
core(audit): make dom-size table prettier

### DIFF
--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -96,28 +96,46 @@ class DOMSize extends Audit {
     );
 
     const headings = [
-      {key: 'totalNodes', itemType: 'text', text: str_(UIStrings.columnDOMNodes)},
-      {key: 'depth', itemType: 'text', text: str_(UIStrings.columnDOMDepth)},
-      {key: 'width', itemType: 'text', text: str_(UIStrings.columnDOMWidth)},
+      // TODO i18n new UI text
+      {key: 'category', itemType: 'text', text: 'Category'},
+      {key: 'element', itemType: 'code', text: 'Element'},
+      {key: 'observed', itemType: 'text', text: 'Count'},
     ];
+
+    // get identifying snippet parts
+    const divMatcher = /<(\S+).*>/;
+    const identifierMatcher = /(id="\S+"|class="\S+")/;
+
+    const depthNode = divMatcher.exec(stats.depth.snippet);
+    const dIdentifier = identifierMatcher.exec(stats.depth.snippet);
+
+    const widthNode = divMatcher.exec(stats.width.snippet);
+    const wIdentifier = identifierMatcher.exec(stats.width.snippet);
 
     /** @type {Array<Object<string, LH.Audit.DetailsItem>>} */
     const items = [
       {
-        totalNodes: Util.formatNumber(stats.totalDOMNodes),
-        depth: Util.formatNumber(stats.depth.max),
-        width: Util.formatNumber(stats.width.max),
+        category: 'Total DOM Nodes',
+        element: '',
+        observed: Util.formatNumber(stats.totalDOMNodes),
       },
       {
-        totalNodes: '',
-        depth: {
+        category: 'Max Depth',
+        element: {
           type: 'code',
-          value: stats.depth.snippet,
+          value: '<' + (depthNode !== null? depthNode[1]: '') +
+            (dIdentifier !== null? ' ' + dIdentifier[1]: '') + '>',
         },
-        width: {
+        observed: Util.formatNumber(stats.depth.max),
+      },
+      {
+        category: 'Max Children',
+        element: {
           type: 'code',
-          value: stats.width.snippet,
+          value: '<' + (widthNode !== null? widthNode[1]: '') +
+            (wIdentifier !== null? ' ' + wIdentifier[1]: '') + '>',
         },
+        observed: Util.formatNumber(stats.width.max),
       },
     ];
 

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -32,17 +32,23 @@ const UIStrings = {
     'children/parent element. A large DOM can increase memory usage, cause longer ' +
     '[style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), ' +
     'and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size).',
-  /** Label for the total number of DOM nodes found in the page. */
-  columnDOMNodes: 'Total DOM Nodes',
-  /** Label for the numeric value of the maximum depth in the page's DOM tree. */
-  columnDOMDepth: 'Maximum DOM Depth',
-  /** Label for the value of the maximum number of children any DOM node in the page has. */
-  columnDOMWidth: 'Maximum Children',
+  /** Table column header for the type of analytic found. */
+  columnCategory: 'Category',
+  /** Table column header for DOM Element's snippet. */
+  columnElement: 'Element',
+  /** Table column header for the observed analytic's value. */
+  columnObserved: 'Observed',
   /** [ICU Syntax] Label for an audit identifying the number of DOM nodes found in the page. */
   displayValue: `{itemCount, plural,
     =1 {1 node}
     other {# nodes}
     }`,
+  /** Label for the total number of DOM nodes found in the page. */
+  categoryDOMNodes: 'Total DOM Nodes',
+  /** Label for the numeric value of the maximum depth in the page's DOM tree. */
+  categoryDOMDepth: 'Maximum DOM Depth',
+  /** Label for the value of the maximum number of children any DOM node in the page has. */
+  categoryDOMWidth: 'Maximum Children',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -96,21 +102,20 @@ class DOMSize extends Audit {
     );
 
     const headings = [
-      // TODO i18n new UI text
-      {key: 'category', itemType: 'text', text: 'Category'},
-      {key: 'element', itemType: 'code', text: 'Element'},
-      {key: 'observed', itemType: 'text', text: 'Count'},
+      {key: 'category', itemType: 'text', text: str_(UIStrings.columnCategory)},
+      {key: 'element', itemType: 'code', text: str_(UIStrings.columnElement)},
+      {key: 'observed', itemType: 'text', text: str_(UIStrings.columnObserved)},
     ];
 
     /** @type {Array<Object<string, LH.Audit.DetailsItem>>} */
     const items = [
       {
-        category: str_(UIStrings.columnDOMNodes),
+        category: str_(UIStrings.categoryDOMNodes),
         element: '',
         observed: Util.formatNumber(stats.totalDOMNodes),
       },
       {
-        category: str_(UIStrings.columnDOMDepth),
+        category: str_(UIStrings.categoryDOMDepth),
         element: {
           type: 'code',
           value: stats.depth.snippet,
@@ -118,7 +123,7 @@ class DOMSize extends Audit {
         observed: Util.formatNumber(stats.depth.max),
       },
       {
-        category: str_(UIStrings.columnDOMWidth),
+        category: str_(UIStrings.categoryDOMWidth),
         element: {
           type: 'code',
           value: stats.width.snippet,

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -47,7 +47,7 @@ const UIStrings = {
   categoryDOMNodes: 'Total DOM Nodes',
   /** Label for the numeric value of the maximum depth in the page's DOM tree. */
   categoryDOMDepth: 'Maximum DOM Depth',
-  /** Label for the value of the maximum number of children any DOM node in the page has. */
+  /** Label for the numeric value of the maximum number of children any DOM node in the page has. The element described will have the most children in the page. */
   categoryDOMWidth: 'Maximum Children',
 };
 

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -102,38 +102,26 @@ class DOMSize extends Audit {
       {key: 'observed', itemType: 'text', text: 'Count'},
     ];
 
-    // get identifying snippet parts
-    const divMatcher = /<(\S+).*>/;
-    const identifierMatcher = /(id="\S+"|class="\S+")/;
-
-    const depthNode = divMatcher.exec(stats.depth.snippet);
-    const dIdentifier = identifierMatcher.exec(stats.depth.snippet);
-
-    const widthNode = divMatcher.exec(stats.width.snippet);
-    const wIdentifier = identifierMatcher.exec(stats.width.snippet);
-
     /** @type {Array<Object<string, LH.Audit.DetailsItem>>} */
     const items = [
       {
-        category: 'Total DOM Nodes',
+        category: str_(UIStrings.columnDOMNodes),
         element: '',
         observed: Util.formatNumber(stats.totalDOMNodes),
       },
       {
-        category: 'Max Depth',
+        category: str_(UIStrings.columnDOMDepth),
         element: {
           type: 'code',
-          value: '<' + (depthNode !== null? depthNode[1]: '') +
-            (dIdentifier !== null? ' ' + dIdentifier[1]: '') + '>',
+          value: stats.depth.snippet,
         },
         observed: Util.formatNumber(stats.depth.max),
       },
       {
-        category: 'Max Children',
+        category: str_(UIStrings.columnDOMWidth),
         element: {
           type: 'code',
-          value: '<' + (widthNode !== null? widthNode[1]: '') +
-            (wIdentifier !== null? ' ' + wIdentifier[1]: '') + '>',
+          value: stats.width.snippet,
         },
         observed: Util.formatNumber(stats.width.max),
       },

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -33,22 +33,22 @@ const UIStrings = {
     '[style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), ' +
     'and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size).',
   /** Table column header for the type of statistic. These statistics describe how big the DOM is (count of DOM nodes, children, depth). */
-  columnCategory: 'Category',
+  columnStatistic: 'Statistic',
   /** Table column header for the DOM element. Each DOM element is described with its HTML representation. */
   columnElement: 'Element',
   /** Table column header for the observed value of the DOM statistic. */
-  columnObserved: 'Observed',
+  columnValue: 'Value',
   /** [ICU Syntax] Label for an audit identifying the number of DOM nodes found in the page. */
   displayValue: `{itemCount, plural,
     =1 {1 node}
     other {# nodes}
     }`,
   /** Label for the total number of DOM nodes found in the page. */
-  categoryDOMNodes: 'Total DOM Nodes',
+  statisticDOMNodes: 'Total DOM Nodes',
   /** Label for the numeric value of the maximum depth in the page's DOM tree. */
-  categoryDOMDepth: 'Maximum DOM Depth',
-  /** Label for the numeric value of the maximum number of children any DOM node in the page has. The element described will have the most children in the page. */
-  categoryDOMWidth: 'Maximum Children',
+  statisticDOMDepth: 'Maximum DOM Depth',
+  /** Label for the numeric value of the maximum number of children any DOM element in the page has. The element described will have the most children in the page. */
+  statisticDOMWidth: 'Maximum Child Elements',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -102,33 +102,33 @@ class DOMSize extends Audit {
     );
 
     const headings = [
-      {key: 'category', itemType: 'text', text: str_(UIStrings.columnCategory)},
+      {key: 'statistic', itemType: 'text', text: str_(UIStrings.columnStatistic)},
       {key: 'element', itemType: 'code', text: str_(UIStrings.columnElement)},
-      {key: 'observed', itemType: 'text', text: str_(UIStrings.columnObserved)},
+      {key: 'value', itemType: 'text', text: str_(UIStrings.columnValue)},
     ];
 
     /** @type {Array<Object<string, LH.Audit.DetailsItem>>} */
     const items = [
       {
-        category: str_(UIStrings.categoryDOMNodes),
+        statistic: str_(UIStrings.statisticDOMNodes),
         element: '',
-        observed: Util.formatNumber(stats.totalDOMNodes),
+        value: Util.formatNumber(stats.totalDOMNodes),
       },
       {
-        category: str_(UIStrings.categoryDOMDepth),
+        statistic: str_(UIStrings.statisticDOMDepth),
         element: {
           type: 'code',
           value: stats.depth.snippet,
         },
-        observed: Util.formatNumber(stats.depth.max),
+        value: Util.formatNumber(stats.depth.max),
       },
       {
-        category: str_(UIStrings.categoryDOMWidth),
+        statistic: str_(UIStrings.statisticDOMWidth),
         element: {
           type: 'code',
           value: stats.width.snippet,
         },
-        observed: Util.formatNumber(stats.width.max),
+        value: Util.formatNumber(stats.width.max),
       },
     ];
 

--- a/lighthouse-core/audits/dobetterweb/dom-size.js
+++ b/lighthouse-core/audits/dobetterweb/dom-size.js
@@ -32,11 +32,11 @@ const UIStrings = {
     'children/parent element. A large DOM can increase memory usage, cause longer ' +
     '[style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), ' +
     'and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size).',
-  /** Table column header for the type of analytic found. */
+  /** Table column header for the type of statistic. These statistics describe how big the DOM is (count of DOM nodes, children, depth). */
   columnCategory: 'Category',
-  /** Table column header for DOM Element's snippet. */
+  /** Table column header for the DOM element. Each DOM element is described with its HTML representation. */
   columnElement: 'Element',
-  /** Table column header for the observed analytic's value. */
+  /** Table column header for the observed value of the DOM statistic. */
   columnObserved: 'Observed',
   /** [ICU Syntax] Label for an audit identifying the number of DOM nodes found in the page. */
   displayValue: `{itemCount, plural,

--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -123,12 +123,13 @@ function getDOMStats(element, deep=true) {
     depth: {
       max: result.maxDepth,
       pathToElement: elementPathInDOM(deepestNode),
-      snippet: getOuterHTMLSnippet(deepestNode),
+      // ignore style since it will provide no additional context, and is often long
+      snippet: getOuterHTMLSnippet(deepestNode, ['style']),
     },
     width: {
       max: result.maxWidth,
       pathToElement: elementPathInDOM(parentWithMostChildren),
-      snippet: getOuterHTMLSnippet(parentWithMostChildren),
+      snippet: getOuterHTMLSnippet(parentWithMostChildren, ['style']),
     },
   };
 }

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -159,29 +159,17 @@
     "message": "Minimize Critical Requests Depth",
     "description": "Imperative title of a Lighthouse audit that tells the user to reduce the depth of critical network requests to enhance initial load of a page. Critical request chains are series of dependent network requests that are important for page rendering. For example, here's a 4-request-deep chain: The biglogo.jpg image is required, but is requested via the styles.css style code, which is requested by the initialize.js javascript, which is requested by the page's HTML. This is displayed in a list of audit titles that Lighthouse generates."
   },
-  "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMDepth": {
-    "message": "Maximum DOM Depth",
-    "description": "Label for the numeric value of the maximum depth in the page's DOM tree."
-  },
-  "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMNodes": {
-    "message": "Total DOM Nodes",
-    "description": "Label for the total number of DOM nodes found in the page."
-  },
-  "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMWidth": {
-    "message": "Maximum Children",
-    "description": "Label for the value of the maximum number of children any DOM node in the page has."
-  },
-  "lighthouse-core/audits/dobetterweb/dom-size.js | columnCategory": {
-    "message": "Category",
-    "description": "Table column header for the type of analytic found."
-  },
   "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
     "message": "Element",
-    "description": "Table column header for DOM Element's snippet."
+    "description": "Table column header for the DOM element. Each DOM element is described with its HTML representation."
   },
-  "lighthouse-core/audits/dobetterweb/dom-size.js | columnObserved": {
-    "message": "Observed",
-    "description": "Table column header for the observed analytic's value."
+  "lighthouse-core/audits/dobetterweb/dom-size.js | columnStatistic": {
+    "message": "Statistic",
+    "description": "Table column header for the type of statistic. These statistics describe how big the DOM is (count of DOM nodes, children, depth)."
+  },
+  "lighthouse-core/audits/dobetterweb/dom-size.js | columnValue": {
+    "message": "Value",
+    "description": "Table column header for the observed value of the DOM statistic."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
     "message": "Browser engineers recommend pages contain fewer than ~1,500 DOM nodes. The sweet spot is a tree depth < 32 elements and fewer than 60 children/parent element. A large DOM can increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size).",
@@ -194,6 +182,18 @@
   "lighthouse-core/audits/dobetterweb/dom-size.js | failureTitle": {
     "message": "Avoid an excessive DOM size",
     "description": "Title of a diagnostic audit that provides detail on the size of the web page's DOM. The size of a DOM is characterized by the total number of DOM nodes and greatest DOM depth. This imperative title is shown to users when there is a significant amount of execution time that could be reduced."
+  },
+  "lighthouse-core/audits/dobetterweb/dom-size.js | statisticDOMDepth": {
+    "message": "Maximum DOM Depth",
+    "description": "Label for the numeric value of the maximum depth in the page's DOM tree."
+  },
+  "lighthouse-core/audits/dobetterweb/dom-size.js | statisticDOMNodes": {
+    "message": "Total DOM Nodes",
+    "description": "Label for the total number of DOM nodes found in the page."
+  },
+  "lighthouse-core/audits/dobetterweb/dom-size.js | statisticDOMWidth": {
+    "message": "Maximum Child Elements",
+    "description": "Label for the numeric value of the maximum number of children any DOM element in the page has. The element described will have the most children in the page."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | title": {
     "message": "Avoids an excessive DOM size",

--- a/lighthouse-core/lib/locales/en-US.json
+++ b/lighthouse-core/lib/locales/en-US.json
@@ -159,17 +159,29 @@
     "message": "Minimize Critical Requests Depth",
     "description": "Imperative title of a Lighthouse audit that tells the user to reduce the depth of critical network requests to enhance initial load of a page. Critical request chains are series of dependent network requests that are important for page rendering. For example, here's a 4-request-deep chain: The biglogo.jpg image is required, but is requested via the styles.css style code, which is requested by the initialize.js javascript, which is requested by the page's HTML. This is displayed in a list of audit titles that Lighthouse generates."
   },
-  "lighthouse-core/audits/dobetterweb/dom-size.js | columnDOMDepth": {
+  "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMDepth": {
     "message": "Maximum DOM Depth",
     "description": "Label for the numeric value of the maximum depth in the page's DOM tree."
   },
-  "lighthouse-core/audits/dobetterweb/dom-size.js | columnDOMNodes": {
+  "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMNodes": {
     "message": "Total DOM Nodes",
     "description": "Label for the total number of DOM nodes found in the page."
   },
-  "lighthouse-core/audits/dobetterweb/dom-size.js | columnDOMWidth": {
+  "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMWidth": {
     "message": "Maximum Children",
     "description": "Label for the value of the maximum number of children any DOM node in the page has."
+  },
+  "lighthouse-core/audits/dobetterweb/dom-size.js | columnCategory": {
+    "message": "Category",
+    "description": "Table column header for the type of analytic found."
+  },
+  "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": {
+    "message": "Element",
+    "description": "Table column header for DOM Element's snippet."
+  },
+  "lighthouse-core/audits/dobetterweb/dom-size.js | columnObserved": {
+    "message": "Observed",
+    "description": "Table column header for the observed analytic's value."
   },
   "lighthouse-core/audits/dobetterweb/dom-size.js | description": {
     "message": "Browser engineers recommend pages contain fewer than ~1,500 DOM nodes. The sweet spot is a tree depth < 32 elements and fewer than 60 children/parent element. A large DOM can increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size).",

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -118,7 +118,7 @@ function getOuterHTMLSnippet(element, ignore=[]) {
 
   let prunedMatch = match[0];
   ignore.forEach(attribute =>{
-    const ignoreRegex = new RegExp(attribute + '=".*?"'); // /string=".*?"/;
+    const ignoreRegex = new RegExp(attribute + '=".*?"');
     prunedMatch = prunedMatch.split(ignoreRegex).join('');
   });
 

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -107,13 +107,22 @@ function getElementsInDocument(selector) {
 /**
  * Gets the opening tag text of the given node.
  * @param {Element} element
+ * @param {Array<string>} ignore
  * @return {string}
  */
 /* istanbul ignore next */
-function getOuterHTMLSnippet(element) {
+function getOuterHTMLSnippet(element, ignore=[]) {
   const reOpeningTag = /^.*?>/;
   const match = element.outerHTML.match(reOpeningTag);
-  return (match && match[0]) || '';
+  if (!(match && match[0])) return '';
+
+  let prunedMatch = match[0];
+  ignore.forEach(attribute =>{
+    const ignoreRegex = new RegExp(attribute + '=".*?"'); // /string=".*?"/;
+    prunedMatch = prunedMatch.split(ignoreRegex).join('');
+  });
+
+  return prunedMatch;
 }
 
 /**
@@ -150,6 +159,7 @@ module.exports = {
   checkTimeSinceLastLongTaskString: checkTimeSinceLastLongTask.toString(),
   getElementsInDocumentString: getElementsInDocument.toString(),
   getOuterHTMLSnippetString: getOuterHTMLSnippet.toString(),
+  getOuterHTMLSnippet: getOuterHTMLSnippet,
   ultradumbBenchmark: ultradumbBenchmark,
   ultradumbBenchmarkString: ultradumbBenchmark.toString(),
 };

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -111,18 +111,17 @@ function getElementsInDocument(selector) {
  * @return {string}
  */
 /* istanbul ignore next */
-function getOuterHTMLSnippet(element, ignore=[]) {
-  const reOpeningTag = /^.*?>/;
-  const match = element.outerHTML.match(reOpeningTag);
-  if (!(match && match[0])) return '';
+function getOuterHTMLSnippet(element, ignoreAttrs=[]) {
+  const clone = element.cloneNode();
 
-  let prunedMatch = match[0];
-  ignore.forEach(attribute =>{
-    const ignoreRegex = new RegExp(attribute + '=".*?"');
-    prunedMatch = prunedMatch.split(ignoreRegex).join('');
+  ignoreAttrs.forEach(attribute =>{
+    clone.removeAttribute(attribute);
   });
 
-  return prunedMatch;
+  const reOpeningTag = /^.*?>/;
+  const match = clone.outerHTML.match(reOpeningTag);
+
+  return (match && match[0]) || '';
 }
 
 /**

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -107,7 +107,7 @@ function getElementsInDocument(selector) {
 /**
  * Gets the opening tag text of the given node.
  * @param {Element} element
- * @param {Array<string>=} ignoreAttrs Optionally provides an array of attribute tags to not include in HTML the snippet
+ * @param {Array<string>=} ignoreAttrs An optional array of attribute tags to not include in the HTML snippet.
  * @return {string}
  */
 /* istanbul ignore next */

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -107,7 +107,7 @@ function getElementsInDocument(selector) {
 /**
  * Gets the opening tag text of the given node.
  * @param {Element} element
- * @param {Array<string>} ignore
+ * @param {Array<string>=} ignoreAttrs Optionally provides an array of attribute tags to not include in HTML the snippet
  * @return {string}
  */
 /* istanbul ignore next */

--- a/lighthouse-core/test/audits/dobetterweb/dom-size-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/dom-size-test.js
@@ -26,9 +26,9 @@ describe('Num DOM nodes audit', () => {
     assert.equal(auditResult.score, 0.43);
     assert.equal(auditResult.rawValue, numNodes);
     expect(auditResult.displayValue).toBeDisplayString('1,500 nodes');
-    assert.equal(auditResult.details.items[0].observed, numNodes.toLocaleString());
-    assert.equal(auditResult.details.items[1].observed, '1');
-    assert.equal(auditResult.details.items[2].observed, '2');
+    assert.equal(auditResult.details.items[0].value, numNodes.toLocaleString());
+    assert.equal(auditResult.details.items[1].value, '1');
+    assert.equal(auditResult.details.items[2].value, '2');
   });
 
   it('calculates score hitting top distribution', () => {

--- a/lighthouse-core/test/audits/dobetterweb/dom-size-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/dom-size-test.js
@@ -26,9 +26,9 @@ describe('Num DOM nodes audit', () => {
     assert.equal(auditResult.score, 0.43);
     assert.equal(auditResult.rawValue, numNodes);
     expect(auditResult.displayValue).toBeDisplayString('1,500 nodes');
-    assert.equal(auditResult.details.items[0].totalNodes, numNodes.toLocaleString());
-    assert.equal(auditResult.details.items[0].depth, '1');
-    assert.equal(auditResult.details.items[0].width, '2');
+    assert.equal(auditResult.details.items[0].observed, numNodes.toLocaleString());
+    assert.equal(auditResult.details.items[1].observed, '1');
+    assert.equal(auditResult.details.items[2].observed, '2');
   });
 
   it('calculates score hitting top distribution', () => {

--- a/lighthouse-core/test/lib/page-functions-test.js
+++ b/lighthouse-core/test/lib/page-functions-test.js
@@ -20,11 +20,6 @@ describe('DetailsRenderer', () => {
     dom = new DOM(document);
   });
 
-  afterAll(() => {
-    global.URL = undefined;
-    global.Util = undefined;
-  });
-
   describe('get outer HTML snippets', () => {
     it('gets full HTML snippet', () => {
       assert.equal(pageFunctions.getOuterHTMLSnippet(

--- a/lighthouse-core/test/lib/page-functions-test.js
+++ b/lighthouse-core/test/lib/page-functions-test.js
@@ -1,20 +1,14 @@
 /**
- * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 'use strict';
 
 const assert = require('assert');
-const fs = require('fs');
 const jsdom = require('jsdom');
-const URL = require( '../../lib/url-shim' );
 const DOM = require('../../report/html/renderer/dom.js');
-const Util = require('../../report/html/renderer/util.js');
 const pageFunctions = require('../../lib/page-functions');
-
-const TEMPLATE_FILE = fs.readFileSync(__dirname +
-    '/../../report/html/templates.html', 'utf8');
 
 /* eslint-env jest */
 
@@ -22,9 +16,7 @@ describe('DetailsRenderer', () => {
   let dom;
 
   beforeAll(() => {
-    global.URL = URL;
-    global.Util = Util;
-    const document = jsdom.jsdom(TEMPLATE_FILE);
+    const document = jsdom.jsdom();
     dom = new DOM(document);
   });
 
@@ -35,48 +27,27 @@ describe('DetailsRenderer', () => {
 
   describe('get outer HTML snippets', () => {
     it('gets full HTML snippet', () => {
-      const snippet = pageFunctions.getOuterHTMLSnippet(
-        dom.createElement('div', '', {id: '1', style: 'style'})
-      );
-      assert.ok(snippet.includes('div') &&
-        snippet.includes('id="1"') &&
-        snippet.includes('style="style"')
-      );
+      assert.equal(pageFunctions.getOuterHTMLSnippet(
+        dom.createElement('div', '', {id: '1', style: 'style'})), '<div id="1" style="style">');
     });
 
     it('removes a specific attribute', () => {
-      const snippet = pageFunctions.getOuterHTMLSnippet(
-        dom.createElement('div', '', {id: '1', style: 'style'}),
-        ['style']
-      );
-      assert.ok(snippet.includes('div') &&
-        snippet.includes('id="1"') &&
-        !snippet.includes('style="style"')
-      );
+      assert.equal(pageFunctions.getOuterHTMLSnippet(
+        dom.createElement('div', '', {id: '1', style: 'style'}), ['style']), '<div id="1">');
     });
 
     it('removes multiple attributes', () => {
-      const snippet = pageFunctions.getOuterHTMLSnippet(
+      assert.equal(pageFunctions.getOuterHTMLSnippet(
         dom.createElement('div', '', {'id': '1', 'style': 'style', 'aria-label': 'label'}),
         ['style', 'aria-label']
-      );
-      assert.ok(snippet.includes('div') &&
-        snippet.includes('id="1"') &&
-        !snippet.includes('style="style"') &&
-        !snippet.includes('aria-label="label"')
-      );
+      ), '<div id="1">');
     });
 
     it('ignores when attribute not found', () => {
-      const snippet = pageFunctions.getOuterHTMLSnippet(
+      assert.equal(pageFunctions.getOuterHTMLSnippet(
         dom.createElement('div', '', {'id': '1', 'style': 'style', 'aria-label': 'label'}),
         ['style-missing', 'aria-label-missing']
-      );
-      assert.ok(snippet.includes('div') &&
-        snippet.includes('id="1"') &&
-        snippet.includes('style="style"') &&
-        snippet.includes('aria-label="label"')
-      );
+      ), '<div id="1" style="style" aria-label="label">');
     });
   });
 });

--- a/lighthouse-core/test/lib/page-functions-test.js
+++ b/lighthouse-core/test/lib/page-functions-test.js
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const jsdom = require('jsdom');
+const URL = require( '../../lib/url-shim' );
+const DOM = require('../../report/html/renderer/dom.js');
+const Util = require('../../report/html/renderer/util.js');
+const pageFunctions = require('../../lib/page-functions');
+
+const TEMPLATE_FILE = fs.readFileSync(__dirname +
+    '/../../report/html/templates.html', 'utf8');
+
+/* eslint-env jest */
+
+describe('DetailsRenderer', () => {
+  let dom;
+
+  beforeAll(() => {
+    global.URL = URL;
+    global.Util = Util;
+    const document = jsdom.jsdom(TEMPLATE_FILE);
+    dom = new DOM(document);
+  });
+
+  afterAll(() => {
+    global.URL = undefined;
+    global.Util = undefined;
+  });
+
+  describe('get outer HTML snippets', () => {
+    it('gets full HTML snippet', () => {
+      const snippet = pageFunctions.getOuterHTMLSnippet(
+        dom.createElement('div', '', {id: '1', style: 'style'})
+      );
+      assert.ok(snippet.includes('div') &&
+        snippet.includes('id="1"') &&
+        snippet.includes('style="style"')
+      );
+    });
+
+    it('removes a specific attribute', () => {
+      const snippet = pageFunctions.getOuterHTMLSnippet(
+        dom.createElement('div', '', {id: '1', style: 'style'}),
+        ['style']
+      );
+      assert.ok(snippet.includes('div') &&
+        snippet.includes('id="1"') &&
+        !snippet.includes('style="style"')
+      );
+    });
+
+    it('removes multiple attributes', () => {
+      const snippet = pageFunctions.getOuterHTMLSnippet(
+        dom.createElement('div', '', {'id': '1', 'style': 'style', 'aria-label': 'label'}),
+        ['style', 'aria-label']
+      );
+      assert.ok(snippet.includes('div') &&
+        snippet.includes('id="1"') &&
+        !snippet.includes('style="style"') &&
+        !snippet.includes('aria-label="label"')
+      );
+    });
+
+    it('ignores when attribute not found', () => {
+      const snippet = pageFunctions.getOuterHTMLSnippet(
+        dom.createElement('div', '', {'id': '1', 'style': 'style', 'aria-label': 'label'}),
+        ['style-missing', 'aria-label-missing']
+      );
+      assert.ok(snippet.includes('div') &&
+        snippet.includes('id="1"') &&
+        snippet.includes('style="style"') &&
+        snippet.includes('aria-label="label"')
+      );
+    });
+  });
+});

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2190,9 +2190,9 @@
         "type": "table",
         "headings": [
           {
-            "key": "category",
+            "key": "statistic",
             "itemType": "text",
-            "text": "Category"
+            "text": "Statistic"
           },
           {
             "key": "element",
@@ -2200,30 +2200,30 @@
             "text": "Element"
           },
           {
-            "key": "observed",
+            "key": "value",
             "itemType": "text",
-            "text": "Observed"
+            "text": "Value"
           }
         ],
         "items": [
           {
-            "category": "Total DOM Nodes",
+            "statistic": "Total DOM Nodes",
             "element": "",
-            "observed": "53"
+            "value": "53"
           },
           {
-            "category": "Maximum DOM Depth",
+            "statistic": "Maximum DOM Depth",
             "element": {
               "type": "code"
             },
-            "observed": "4"
+            "value": "4"
           },
           {
-            "category": "Maximum Children",
+            "statistic": "Maximum Child Elements",
             "element": {
               "type": "code"
             },
-            "observed": "22"
+            "value": "22"
           }
         ]
       }
@@ -3761,23 +3761,23 @@
           "path": "audits[dom-size].displayValue"
         }
       ],
-      "lighthouse-core/audits/dobetterweb/dom-size.js | columnCategory": [
+      "lighthouse-core/audits/dobetterweb/dom-size.js | columnStatistic": [
         "audits[dom-size].details.headings[0].text"
       ],
       "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": [
         "audits[dom-size].details.headings[1].text"
       ],
-      "lighthouse-core/audits/dobetterweb/dom-size.js | columnObserved": [
+      "lighthouse-core/audits/dobetterweb/dom-size.js | columnValue": [
         "audits[dom-size].details.headings[2].text"
       ],
-      "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMNodes": [
-        "audits[dom-size].details.items[0].category"
+      "lighthouse-core/audits/dobetterweb/dom-size.js | statisticDOMNodes": [
+        "audits[dom-size].details.items[0].statistic"
       ],
-      "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMDepth": [
-        "audits[dom-size].details.items[1].category"
+      "lighthouse-core/audits/dobetterweb/dom-size.js | statisticDOMDepth": [
+        "audits[dom-size].details.items[1].statistic"
       ],
-      "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMWidth": [
-        "audits[dom-size].details.items[2].category"
+      "lighthouse-core/audits/dobetterweb/dom-size.js | statisticDOMWidth": [
+        "audits[dom-size].details.items[2].statistic"
       ],
       "lighthouse-core/config/default-config.js | performanceCategoryTitle": [
         "categories.performance.title"

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2190,35 +2190,40 @@
         "type": "table",
         "headings": [
           {
-            "key": "totalNodes",
+            "key": "category",
             "itemType": "text",
-            "text": "Total DOM Nodes"
+            "text": "Category"
           },
           {
-            "key": "depth",
-            "itemType": "text",
-            "text": "Maximum DOM Depth"
+            "key": "element",
+            "itemType": "code",
+            "text": "Element"
           },
           {
-            "key": "width",
+            "key": "observed",
             "itemType": "text",
-            "text": "Maximum Children"
+            "text": "Observed"
           }
         ],
         "items": [
           {
-            "totalNodes": "53",
-            "depth": "4",
-            "width": "22"
+            "category": "Total DOM Nodes",
+            "element": "",
+            "observed": "53"
           },
           {
-            "totalNodes": "",
-            "depth": {
+            "category": "Maximum DOM Depth",
+            "element": {
               "type": "code"
             },
-            "width": {
+            "observed": "4"
+          },
+          {
+            "category": "Maximum Children",
+            "element": {
               "type": "code"
-            }
+            },
+            "observed": "22"
           }
         ]
       }
@@ -3756,14 +3761,23 @@
           "path": "audits[dom-size].displayValue"
         }
       ],
-      "lighthouse-core/audits/dobetterweb/dom-size.js | columnDOMNodes": [
+      "lighthouse-core/audits/dobetterweb/dom-size.js | columnCategory": [
         "audits[dom-size].details.headings[0].text"
       ],
-      "lighthouse-core/audits/dobetterweb/dom-size.js | columnDOMDepth": [
+      "lighthouse-core/audits/dobetterweb/dom-size.js | columnElement": [
         "audits[dom-size].details.headings[1].text"
       ],
-      "lighthouse-core/audits/dobetterweb/dom-size.js | columnDOMWidth": [
+      "lighthouse-core/audits/dobetterweb/dom-size.js | columnObserved": [
         "audits[dom-size].details.headings[2].text"
+      ],
+      "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMNodes": [
+        "audits[dom-size].details.items[0].category"
+      ],
+      "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMDepth": [
+        "audits[dom-size].details.items[1].category"
+      ],
+      "lighthouse-core/audits/dobetterweb/dom-size.js | categoryDOMWidth": [
+        "audits[dom-size].details.items[2].category"
       ],
       "lighthouse-core/config/default-config.js | performanceCategoryTitle": [
         "categories.performance.title"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Reformatted the dom-size output table.  Converted the table to be more row-centric vs column centric.  See issue #5220 for discussion and screenshots.  Some CSS changes required from #6049 to format the `code` snippets and the left alignment of the text.

**Related Issues/PRs**
fixes: #5220 
requires: #6049