### PR TITLE
i18n: speed up replacement regex

### DIFF
--- a/lighthouse-core/lib/i18n.js
+++ b/lighthouse-core/lib/i18n.js
@@ -15,6 +15,8 @@ const LOCALES = require('./locales');
 
 const LH_ROOT = path.join(__dirname, '../../');
 const MESSAGE_INSTANCE_ID_REGEX = /(.* \| .*) # (\d+)$/;
+// Above regex is very slow against large strings. Use QUICK_REGEX as a much quicker discriminator.
+const MESSAGE_INSTANCE_ID_QUICK_REGEX = / # \d+$/;
 
 (() => {
   // Node usually doesn't come with the locales we want built-in, so load the polyfill if we can.
@@ -235,7 +237,8 @@ function createMessageInstanceIdFn(filename, fileStrings) {
  * @return {string}
  */
 function getFormatted(icuMessageIdOrRawString, locale) {
-  if (MESSAGE_INSTANCE_ID_REGEX.test(icuMessageIdOrRawString)) {
+  if (MESSAGE_INSTANCE_ID_QUICK_REGEX.test(icuMessageIdOrRawString) &&
+      MESSAGE_INSTANCE_ID_REGEX.test(icuMessageIdOrRawString)) {
     return _resolveIcuMessageInstanceId(icuMessageIdOrRawString, locale).formattedString;
   }
 
@@ -278,7 +281,8 @@ function replaceIcuMessageInstanceIds(lhr, locale) {
       const currentPathInLHR = pathInLHR.concat([property]);
 
       // Check to see if the value in the LHR looks like a string reference. If it is, replace it.
-      if (typeof value === 'string' && MESSAGE_INSTANCE_ID_REGEX.test(value)) {
+      if (typeof value === 'string' && MESSAGE_INSTANCE_ID_QUICK_REGEX.test(value) &&
+          MESSAGE_INSTANCE_ID_REGEX.test(value)) {
         const {icuMessageInstance, formattedString} = _resolveIcuMessageInstanceId(value, locale);
         const messageInstancesInLHR = icuMessagePaths[icuMessageInstance.icuMessageId] || [];
         const currentPathAsString = _formatPathAsString(currentPathInLHR);


### PR DESCRIPTION
The regex we use for checking if there are strings in the LHR that need to be replaced with their localized version can be really slow against giant strings. Adding a pre-pass with a fast regex is one easy approach to speeding this up without changing our ID format or being too particular about the file paths we allow.

In a trace from the issues we're seeing in #6067, time for localization and report generation goes from ~3500ms to ~33ms.

Even time for localization in the much smaller artifacts in `yarn update:sample-json` goes from 150ms to 22ms :)