### PR TITLE
deps: bump speedline to 1.4.2 (faster sort)

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "rimraf": "^2.6.1",
     "robots-parser": "^2.0.1",
     "semver": "^5.3.0",
-    "speedline-core": "1.4.0",
+    "speedline-core": "1.4.2",
     "update-notifier": "^2.1.0",
     "ws": "3.3.2",
     "yargs": "3.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,9 +5782,9 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-speedline-core@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/speedline-core/-/speedline-core-1.4.0.tgz#884831eaef66ddc928dd7d4c9e844c5d28bad7db"
+speedline-core@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/speedline-core/-/speedline-core-1.4.2.tgz#bb061444a218d67b4cd52f63a262386197b90c8a"
   dependencies:
     "@types/node" "*"
     image-ssim "^0.2.0"


### PR DESCRIPTION
witness this fine work by @brendankenny: https://github.com/paulirish/speedline/pull/70
