### PR TITLE
core(network-recorder): consider iframe responses finished

### DIFF
--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -107,7 +107,7 @@ class NetworkRecorder extends EventEmitter {
    */
   static _isFrameRootRequestAndFinished(record) {
     const isFrameRootRequest = record.url === record.documentURL;
-    const responseReceived = Number.isFinite(record.responseReceivedTime);
+    const responseReceived = record.responseReceivedTime > 0;
     return !!(isFrameRootRequest && responseReceived && record.endTime);
   }
 

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -100,6 +100,18 @@ class NetworkRecorder extends EventEmitter {
   }
 
   /**
+   * frame root network requests don't always "finish" even when they're done loading data, use responseReceived instead
+   * @see https://github.com/GoogleChrome/lighthouse/issues/6067#issuecomment-423211201
+   * @param {LH.Artifacts.NetworkRequest} record
+   * @return {boolean}
+   */
+  static _isFrameRootRequestAndFinished(record) {
+    const isFrameRootRequest = record.url === record.documentURL;
+    const responseReceived = Number.isFinite(record.responseReceivedTime);
+    return !!(isFrameRootRequest && responseReceived && record.endTime);
+  }
+
+  /**
    * Finds all time periods where the number of inflight requests is less than or equal to the
    * number of allowed concurrent requests.
    * @param {Array<LH.Artifacts.NetworkRequest>} networkRecords
@@ -119,7 +131,9 @@ class NetworkRecorder extends EventEmitter {
 
       // convert the network record timestamp to ms
       timeBoundaries.push({time: record.startTime * 1000, isStart: true});
-      if (record.finished || NetworkRecorder._isQUICAndFinished(record)) {
+      if (record.finished ||
+          NetworkRecorder._isQUICAndFinished(record) ||
+          NetworkRecorder._isFrameRootRequestAndFinished(record)) {
         timeBoundaries.push({time: record.endTime * 1000, isStart: false});
       }
     });

--- a/lighthouse-core/test/lib/network-recorder-test.js
+++ b/lighthouse-core/test/lib/network-recorder-test.js
@@ -118,6 +118,25 @@ describe('network recorder', function() {
       ]);
     });
 
+    it('should handle iframe requests', () => {
+      const iframeRequest = {
+        finished: false,
+        url: 'https://iframe.com',
+        documentURL: 'https://iframe.com',
+        responseReceivedTime: 1.2,
+      };
+
+      const records = [
+        record({startTime: 0, endTime: 1}),
+        record({startTime: 0, endTime: 1.2, ...iframeRequest}),
+      ];
+
+      const periods = NetworkRecorder.findNetworkQuietPeriods(records, 0);
+      assert.deepStrictEqual(periods, [
+        {start: 1200, end: Infinity},
+      ]);
+    });
+
     it('should handle QUIC requests', () => {
       const quicRequest = {
         finished: false,


### PR DESCRIPTION
**Summary**
root requests inside frames never fire a `loadingFinished` devtools event, we'll use the presence of a response as the criteria for finished instead.

**Related Issues/PRs**
#6067 
