### PR TITLE
core(driver): add check to make sure Runtime.evaluate result exists

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -316,7 +316,7 @@ class Driver {
 
         if (response.exceptionDetails) {
           // An error occurred before we could even create a Promise, should be *very* rare
-          return reject(new Error('Evaluation exception: ${response.exceptionDetails.text}'));
+          return reject(new Error(`Evaluation exception: ${response.exceptionDetails.text}`));
         }
 
         // Protocol should always return a 'result' object, but it is sometimes undefined.  See #6026.

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -313,6 +313,13 @@ class Driver {
 
       this.sendCommand('Runtime.evaluate', evaluationParams).then(result => {
         clearTimeout(asyncTimeout);
+
+        // Protocol should always return a 'result' object, but it is sometimes undefined
+        // see https://github.com/GoogleChrome/lighthouse/issues/6026
+        if (result.result === undefined) {
+          return reject(new Error('Driver did not sent a result object'));
+        }
+
         const value = result.result.value;
 
         if (result.exceptionDetails) {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -314,6 +314,11 @@ class Driver {
       this.sendCommand('Runtime.evaluate', evaluationParams).then(response => {
         clearTimeout(asyncTimeout);
 
+        if (response.exceptionDetails) {
+          // An error occurred before we could even create a Promise, should be *very* rare
+          return reject(new Error('an unexpected driver error occurred'));
+        }
+
         // Protocol should always return a 'result' object, but it is sometimes undefined
         // see https://github.com/GoogleChrome/lighthouse/issues/6026
         if (response.result === undefined) {
@@ -322,10 +327,7 @@ class Driver {
 
         const value = response.result.value;
 
-        if (response.exceptionDetails) {
-          // An error occurred before we could even create a Promise, should be *very* rare
-          reject(new Error('an unexpected driver error occurred'));
-        } else if (value && value.__failedInBrowser) {
+        if (value && value.__failedInBrowser) {
           reject(Object.assign(new Error(), value));
         } else {
           resolve(value);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -328,7 +328,7 @@ class Driver {
         const value = response.result.value;
 
         if (value && value.__failedInBrowser) {
-          reject(Object.assign(new Error(), value));
+          return reject(Object.assign(new Error(), value));
         } else {
           resolve(value);
         }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -321,7 +321,7 @@ class Driver {
 
         // Protocol should always return a 'result' object, but it is sometimes undefined.  See #6026.
         if (response.result === undefined) {
-          return reject(new Error('Runtime.evaluate response omits a result'));
+          return reject(new Error('Runtime.evaluate response did not contain a "result" object'));
         }
 
         const value = response.result.value;

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -316,13 +316,12 @@ class Driver {
 
         if (response.exceptionDetails) {
           // An error occurred before we could even create a Promise, should be *very* rare
-          return reject(new Error('an unexpected driver error occurred'));
+          return reject(new Error('Evaluation exception: ${response.exceptionDetails.text}'));
         }
 
-        // Protocol should always return a 'result' object, but it is sometimes undefined
-        // see https://github.com/GoogleChrome/lighthouse/issues/6026
+        // Protocol should always return a 'result' object, but it is sometimes undefined.  See #6026.
         if (response.result === undefined) {
-          return reject(new Error('Driver did not sent a result object'));
+          return reject(new Error('Runtime.evaluate response omits a result'));
         }
 
         const value = response.result.value;

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -311,21 +311,21 @@ class Driver {
         contextId,
       };
 
-      this.sendCommand('Runtime.evaluate', evaluationParams).then(result => {
+      this.sendCommand('Runtime.evaluate', evaluationParams).then(response => {
         clearTimeout(asyncTimeout);
 
         // Protocol should always return a 'result' object, but it is sometimes undefined
         // see https://github.com/GoogleChrome/lighthouse/issues/6026
-        if (result.result === undefined) {
+        if (response.result === undefined) {
           return reject(new Error('Driver did not sent a result object'));
         }
 
-        const value = result.result.value;
+        const value = response.result.value;
 
-        if (result.exceptionDetails) {
+        if (response.exceptionDetails) {
           // An error occurred before we could even create a Promise, should be *very* rare
           reject(new Error('an unexpected driver error occurred'));
-        } if (value && value.__failedInBrowser) {
+        } else if (value && value.__failedInBrowser) {
           reject(Object.assign(new Error(), value));
         } else {
           resolve(value);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Added an undefined check for driver results to catch an undefined result coming back from the Protocol, which shouldn't happen, but we check anyway to catch if it does.

[Relevant Protocol](https://chromedevtools.github.io/devtools-protocol/tot/Runtime#method-evaluate)

**Related Issues/PRs**
addresses: #6026 
