### PR TITLE
report(vulnerable-jslibs): tweak snyk link for highlighted matches

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -153,7 +153,7 @@ class NoVulnerableLibrariesAudit extends Audit {
           vulnCount,
           detectedLib: {
             text: lib.name + '@' + version,
-            url: `https://snyk.io/vuln/npm:${lib.npmPkgName}?lh@${version}`,
+            url: `https://snyk.io/vuln/npm:${lib.npmPkgName}?lh=${version}`,
             type: 'link',
           },
         });

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -40,7 +40,7 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
     assert.equal(auditResult.details.items[0].highestSeverity, 'High');
     assert.equal(auditResult.details.items[0].detectedLib.type, 'link');
     assert.equal(auditResult.details.items[0].detectedLib.text, 'angular@1.1.4');
-    assert.equal(auditResult.details.items[0].detectedLib.url, 'https://snyk.io/vuln/npm:angular?lh@1.1.4');
+    assert.equal(auditResult.details.items[0].detectedLib.url, 'https://snyk.io/vuln/npm:angular?lh=1.1.4');
   });
 
   it('handles ill-specified versions', () => {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2386,7 +2386,7 @@
             "vulnCount": 1,
             "detectedLib": {
               "text": "jQuery@2.1.1",
-              "url": "https://snyk.io/vuln/npm:jquery?lh@2.1.1",
+              "url": "https://snyk.io/vuln/npm:jquery?lh=2.1.1",
               "type": "link"
             }
           }


### PR DESCRIPTION
setting up snyk to do some nice highlighting on their side

| before | after |
|-|-|
| ![image](https://user-images.githubusercontent.com/39191/45932830-6b5a8100-bf37-11e8-89ea-0ec2b86a2c8a.png) | ![image](https://user-images.githubusercontent.com/39191/45932835-8200d800-bf37-11e8-8ffb-b384e0e55254.png) | 

pretty sweet.


cc @aviadatsnyk 