### PR TITLE
core: update chrome-devtools-frontend to latest

### DIFF
--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -91,7 +91,7 @@ function getEffectiveRule(property, node, {
   const matchingRule = nodeStyles
     .find(style =>
       // the applicable property will be the only one that isn't in the "overloaded" state.
-      style.allProperties.some(item => item.name === property &&
+      style.allProperties().some(item => item.name === property &&
         matchedStyles.propertyState(item) !== CSSMatchedStyles.PropertyState.Overloaded)
     );
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "dependencies": {
     "axe-core": "3.0.0-beta.2",
-    "chrome-devtools-frontend": "1.0.422034",
+    "chrome-devtools-frontend": "1.0.593291",
     "chrome-launcher": "^0.10.4",
     "configstore": "^3.1.1",
     "cssstyle": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,9 +1029,9 @@ chrome-devtools-frontend@1.0.401423:
   version "1.0.401423"
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.401423.tgz#32a89b8d04e378a494be3c8d63271703be1c04ea"
 
-chrome-devtools-frontend@1.0.422034:
-  version "1.0.422034"
-  resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.422034.tgz#071c8ce14466b7653032fcd1ad1a4a68d5e3cbd9"
+chrome-devtools-frontend@1.0.593291:
+  version "1.0.593291"
+  resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.593291.tgz#72ed2e488e4ab8c5df9f35a5ce6bb128eb3c5e74"
 
 chrome-launcher@^0.10.4:
   version "0.10.4"


### PR DESCRIPTION
Update is easy now :) Fulfills the dream of #1535, though the problems it would have fixed back then don't exist anymore.

Hopefully this update will make it easier for whoever takes that last webinspector step, either completely isolating the WebInspector global pollution (cc @castilloandres) or reimplementing the font functionality in Lighthouse. With the updates to the fontend, the first should be quite a bit easier and the second should at least be at least a little easier to follow since the implementation will match current DevTools.