### PR TITLE
deps: js-library-detector@5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "intl-messageformat": "^2.2.0",
     "intl-messageformat-parser": "^1.4.0",
     "jpeg-js": "0.1.2",
-    "js-library-detector": "^4.3.1",
+    "js-library-detector": "^5.1.0",
     "lighthouse-logger": "^1.0.0",
     "lodash.isequal": "^4.5.0",
     "lookup-closest-locale": "6.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,9 +3707,9 @@ jpeg-js@0.1.2, jpeg-js@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
 
-js-library-detector@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-4.3.1.tgz#6d34f55002813bc0a7543deef53faa4e2e79767b"
+js-library-detector@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-5.1.0.tgz#1e2e88b119bb91e6581b28f4a90018ea1320de73"
 
 js-tokens@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
changes: https://github.com/johnmichel/Library-Detector-for-Chrome/compare/v4.3.1...v5.1.0

most notably: 

* better detection for react
* new detections added for preact/workbox/amp
