### PR TITLE
core(driver): request smaller trace in m71+

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -918,11 +918,10 @@ class Driver {
   }
 
   /**
-   * @param {LH.Gatherer.PassContext} passContext
+   * @param {{additionalTraceCategories?: string|null}=} settings
    * @return {Promise<void>}
    */
-  async beginTrace(passContext) {
-    const settings = passContext.settings;
+  async beginTrace(settings) {
     const additionalCategories = (settings && settings.additionalTraceCategories &&
         settings.additionalTraceCategories.split(',')) || [];
     const traceCategories = this._traceCategories.concat(additionalCategories);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -106,7 +106,7 @@ class Driver {
    */
   async getBrowserVersion() {
     const version = await this.sendCommand('Browser.getVersion');
-    const match = version.product.match(/\/(\d+)/);
+    const match = version.product.match(/\/(\d+)/); // eg 'Chrome/71.0.3577.0'
     const milestone = match ? parseInt(match[1]) : 0;
     return Object.assign(version, {milestone});
   }
@@ -928,7 +928,7 @@ class Driver {
 
     // In Chrome <71, gotta use the chatty 'toplevel' cat instead of our own.
     // TODO(COMPAT): Once m71 ships to stable, drop this section
-    const milestone = (await this.getBrowserVersion()).milestone; // eg 'Chrome/71.0.3577.0'
+    const milestone = (await this.getBrowserVersion()).milestone;
     if (milestone < 71) {
       const toplevelIndex = traceCategories.indexOf('disabled-by-default-lighthouse');
       traceCategories.splice(toplevelIndex, 1, 'toplevel');

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -365,7 +365,7 @@ class GatherRunner {
     return {
       fetchTime: (new Date()).toJSON(),
       LighthouseRunWarnings: [],
-      HostUserAgent: await options.driver.getUserAgent(),
+      HostUserAgent: (await options.driver.getBrowserVersion()).userAgent,
       NetworkUserAgent: '', // updated later
       BenchmarkIndex: 0, // updated later
       traces: {},

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -211,10 +211,11 @@ class GatherRunner {
   static async pass(passContext, gathererResults) {
     const driver = passContext.driver;
     const config = passContext.passConfig;
+    const settings = passContext.settings;
     const gatherers = config.gatherers;
+
     const recordTrace = config.recordTrace;
-    const isPerfRun = !passContext.settings.disableStorageReset && recordTrace &&
-        config.useThrottling;
+    const isPerfRun = !settings.disableStorageReset && recordTrace && config.useThrottling;
 
     const gatherernames = gatherers.map(g => g.instance.name).join(', ');
     const status = 'Loading page & waiting for onload';
@@ -225,7 +226,7 @@ class GatherRunner {
     // Always record devtoolsLog
     await driver.beginDevtoolsLog();
     // Begin tracing if requested by config.
-    if (recordTrace) await driver.beginTrace(passContext);
+    if (recordTrace) await driver.beginTrace(settings);
 
     // Navigate.
     await GatherRunner.loadPage(driver, passContext);
@@ -401,7 +402,6 @@ class GatherRunner {
           // If the main document redirects, we'll update this to keep track
           url: options.requestedUrl,
           settings: options.settings,
-          hostUserAgent: baseArtifacts.HostUserAgent,
           passConfig,
           // *pass() functions and gatherers can push to this warnings array.
           LighthouseRunWarnings: baseArtifacts.LighthouseRunWarnings,

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -211,11 +211,10 @@ class GatherRunner {
   static async pass(passContext, gathererResults) {
     const driver = passContext.driver;
     const config = passContext.passConfig;
-    const settings = passContext.settings;
     const gatherers = config.gatherers;
-
     const recordTrace = config.recordTrace;
-    const isPerfRun = !settings.disableStorageReset && recordTrace && config.useThrottling;
+    const isPerfRun = !passContext.settings.disableStorageReset && recordTrace &&
+        config.useThrottling;
 
     const gatherernames = gatherers.map(g => g.instance.name).join(', ');
     const status = 'Loading page & waiting for onload';
@@ -226,7 +225,7 @@ class GatherRunner {
     // Always record devtoolsLog
     await driver.beginDevtoolsLog();
     // Begin tracing if requested by config.
-    if (recordTrace) await driver.beginTrace(settings);
+    if (recordTrace) await driver.beginTrace(passContext);
 
     // Navigate.
     await GatherRunner.loadPage(driver, passContext);
@@ -402,6 +401,7 @@ class GatherRunner {
           // If the main document redirects, we'll update this to keep track
           url: options.requestedUrl,
           settings: options.settings,
+          hostUserAgent: baseArtifacts.HostUserAgent,
           passConfig,
           // *pass() functions and gatherers can push to this warnings array.
           LighthouseRunWarnings: baseArtifacts.LighthouseRunWarnings,

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -8,12 +8,16 @@
 // The ideal input response latency, the time between the input task and the
 // first frame of the response.
 const BASE_RESPONSE_LATENCY = 16;
-// m65 and earlier
-const SCHEDULABLE_TASK_TITLE = 'TaskQueueManager::ProcessTaskFromWorkQueue';
+// m71+ We added RunTask to `disabled-by-default-lighthouse`
+const SCHEDULABLE_TASK_TITLE_LH = 'RunTask';
+// m69-70 DoWork is different and we now need RunTask, see https://bugs.chromium.org/p/chromium/issues/detail?id=871204#c11
+const SCHEDULABLE_TASK_TITLE_ALT1 = 'ThreadControllerImpl::RunTask';
 // In m66-68 refactored to this task title, https://crrev.com/c/883346
-const SCHEDULABLE_TASK_TITLE_ALT1 = 'ThreadControllerImpl::DoWork';
-// m69+ DoWork is different and we now need RunTask, see https://bugs.chromium.org/p/chromium/issues/detail?id=871204#c11
-const SCHEDULABLE_TASK_TITLE_ALT2 = 'ThreadControllerImpl::RunTask';
+const SCHEDULABLE_TASK_TITLE_ALT2 = 'ThreadControllerImpl::DoWork';
+// m65 and earlier
+const SCHEDULABLE_TASK_TITLE_ALT3 = 'TaskQueueManager::ProcessTaskFromWorkQueue';
+
+
 const LHError = require('../lh-error');
 
 class TraceProcessor {
@@ -234,9 +238,10 @@ class TraceProcessor {
    * @return {boolean}
    */
   static isScheduleableTask(evt) {
-    return evt.name === SCHEDULABLE_TASK_TITLE ||
-      evt.name === SCHEDULABLE_TASK_TITLE_ALT1 ||
-      evt.name === SCHEDULABLE_TASK_TITLE_ALT2;
+    return evt.name === SCHEDULABLE_TASK_TITLE_LH ||
+    evt.name === SCHEDULABLE_TASK_TITLE_ALT1 ||
+    evt.name === SCHEDULABLE_TASK_TITLE_ALT2 ||
+    evt.name === SCHEDULABLE_TASK_TITLE_ALT3;
   }
 }
 

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -5,9 +5,18 @@
  */
 'use strict';
 
-module.exports = {
+const browserVersion = {
+  protocolVersion: '1.3',
+  product: 'Chrome/71.0.3577.0',
+  revision: '@fc334a55a70eec12fc77853c53979f81e8496c21',
+  // eslint-disable-next-line max-len
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3577.0 Safari/537.36',
+  jsVersion: '7.1.314',
+};
+
+const fakeDriver = {
   getBrowserVersion() {
-    return Promise.resolve({userAgent: 'Fake user agent'});
+    return Promise.resolve(browserVersion);
   },
   getBenchmarkIndex() {
     return Promise.resolve(125.2);
@@ -72,3 +81,6 @@ module.exports = {
     return Promise.resolve();
   },
 };
+
+module.exports = fakeDriver;
+module.exports.browserVersion = browserVersion;

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -6,8 +6,8 @@
 'use strict';
 
 module.exports = {
-  getUserAgent() {
-    return Promise.resolve('Fake user agent');
+  getBrowserVersion() {
+    return Promise.resolve({userAgent: 'Fake user agent'});
   },
   getBenchmarkIndex() {
     return Promise.resolve(125.2);

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -5,7 +5,8 @@
  */
 'use strict';
 
-const browserVersion = {
+// https://chromedevtools.github.io/devtools-protocol/tot/Browser#method-getVersion
+const protocolGetVersionResponse = {
   protocolVersion: '1.3',
   product: 'Chrome/71.0.3577.0',
   revision: '@fc334a55a70eec12fc77853c53979f81e8496c21',
@@ -16,7 +17,7 @@ const browserVersion = {
 
 const fakeDriver = {
   getBrowserVersion() {
-    return Promise.resolve(browserVersion);
+    return Promise.resolve(Object.assign({}, protocolGetVersionResponse, {milestone: 71}));
   },
   getBenchmarkIndex() {
     return Promise.resolve(125.2);
@@ -83,4 +84,4 @@ const fakeDriver = {
 };
 
 module.exports = fakeDriver;
-module.exports.browserVersion = browserVersion;
+module.exports.protocolGetVersionResponse = protocolGetVersionResponse;

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -53,9 +53,6 @@ function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn,
     }
     cleanBrowserCaches() {}
     clearDataForOrigin() {}
-    getBrowserVersion() {
-      return Promise.resolve({userAgent: 'Fake user agent'});
-    }
   };
   const EmulationMock = class extends Connection {
     sendCommand(command, params) {
@@ -126,7 +123,8 @@ describe('GatherRunner', function() {
     const options = {url, driver, config, settings};
 
     const results = await GatherRunner.run([], options);
-    expect(results.HostUserAgent).toEqual('Fake user agent');
+    expect(results.HostUserAgent).toEqual(fakeDriver.browserVersion.userAgent);
+    expect(results.HostUserAgent).toMatch(/Chrome\/\d+/);
   });
 
   it('collects network user agent as an artifact', async () => {
@@ -272,6 +270,7 @@ describe('GatherRunner', function() {
     };
     const createEmulationCheck = variable => (...args) => {
       tests[variable] = args;
+
       return true;
     };
     const driver = getMockedEmulationDriver(

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -53,8 +53,8 @@ function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn,
     }
     cleanBrowserCaches() {}
     clearDataForOrigin() {}
-    getUserAgent() {
-      return Promise.resolve('Fake user agent');
+    getBrowserVersion() {
+      return Promise.resolve({userAgent: 'Fake user agent'});
     }
   };
   const EmulationMock = class extends Connection {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -123,7 +123,7 @@ describe('GatherRunner', function() {
     const options = {url, driver, config, settings};
 
     const results = await GatherRunner.run([], options);
-    expect(results.HostUserAgent).toEqual(fakeDriver.browserVersion.userAgent);
+    expect(results.HostUserAgent).toEqual(fakeDriver.protocolGetVersionResponse.userAgent);
     expect(results.HostUserAgent).toMatch(/Chrome\/\d+/);
   });
 

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -18,6 +18,7 @@ declare global {
       passConfig: Config.Pass
       settings: Config.Settings;
       options?: object;
+      hostUserAgent: string;
       /** Push to this array to add top-level warnings to the LHR. */
       LighthouseRunWarnings: Array<string>;
     }

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -18,7 +18,6 @@ declare global {
       passConfig: Config.Pass
       settings: Config.Settings;
       options?: object;
-      hostUserAgent: string;
       /** Push to this array to add top-level warnings to the LHR. */
       LighthouseRunWarnings: Array<string>;
     }


### PR DESCRIPTION
Backstory in #3596. 

Results: cnn.com's trace goes from 69M to 47M.


--

* Using `Browser.getVersion` and parsing out the chrome milestone. We can augment this pattern later for `isMobile` and `os` like @patrickhulce suggested.
* I made a lil sendCommand mock response helper in driver-test. There are similar stubs for `on()` and `once()`. 
* we now default to the new `disabled-by-default-lighthouse` category and fallback to 'toplevel', as @brendankenny very wisely suggested
* ideally i'd like to drop the `SCHEDULABLE_TASK_TITLE` possibilities from _FOUR_ down to 2. But it requires updating a lot of fixture data. So we can do that in a followup.