### PR TITLE
deps: update to tsc 3.1.1

### DIFF
--- a/lighthouse-core/gather/computed/metrics/lantern-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-interactive.js
@@ -97,7 +97,6 @@ class Interactive extends MetricArtifact {
    * @return {number}
    */
   static getLastLongTaskEndTime(nodeTimings, duration = 50) {
-    // @ts-ignore TS can't infer how the object invariants change
     return Array.from(nodeTimings.entries())
       .filter(([node, timing]) => {
         if (node.type !== BaseNode.TYPES.CPU) return false;

--- a/lighthouse-core/lib/file-namer.js
+++ b/lighthouse-core/lib/file-namer.js
@@ -44,7 +44,7 @@ function getUrlConstructor() {
   }
 }
 
-// @ts-ignore - suppress `module` error for type-checking in a browser context.
+// don't attempt to export in the browser.
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {getFilenamePrefix};
 }

--- a/lighthouse-core/lib/i18n/locales.js
+++ b/lighthouse-core/lib/i18n/locales.js
@@ -18,7 +18,6 @@
 /** @type {Record<LH.Locale, LocaleMessages>} */
 const locales = {
   'en-US': require('./en-US.json'), // The 'source' strings, with descriptions
-  // @ts-ignore - tsc bug, something about en/en-US pointing to same file. https://github.com/Microsoft/TypeScript/issues/26307
   'en': require('./en-US.json'), // According to CLDR/ICU, 'en' == 'en-US' dates/numbers (Why?!)
 
   // TODO: en-GB has just ~10 messages that are different from en-US. We should only ship those.

--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -80,9 +80,8 @@ class ReportGenerator {
       });
     });
 
-    // @ts-ignore TS loses track of type Array
-    const flattedTable = [].concat(...table);
-    return [header, ...flattedTable].map(row => row.join(separator)).join(CRLF);
+    return [header].concat(...table)
+      .map(row => row.join(separator)).join(CRLF);
   }
 
   /**

--- a/lighthouse-core/scripts/update-report-fixtures.js
+++ b/lighthouse-core/scripts/update-report-fixtures.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const cli = require('../../lighthouse-cli/run');
+const cliFlags = require('../../lighthouse-cli/cli-flags.js');
 
 const {server} = require('../../lighthouse-cli/test/fixtures/static-server');
 
@@ -18,10 +19,7 @@ async function update() {
   const port = await new Promise(res => server.on('listening', () => res(server.address().port)));
 
   const url = `http://localhost:${port}/dobetterweb/dbw_tester.html`;
-  const flags = {
-    gatherMode: 'lighthouse-core/test/results/artifacts',
-  };
-  // @ts-ignore Remove when we fix Flags typing
+  const flags = cliFlags.getFlags(`--gather-mode=lighthouse-core/test/results/artifacts ${url}`);
   await cli.runLighthouse(url, flags, undefined);
   await new Promise(res => server.close(res));
 }

--- a/lighthouse-viewer/app/src/firebase-auth.js
+++ b/lighthouse-viewer/app/src/firebase-auth.js
@@ -91,7 +91,7 @@ class FirebaseAuth {
   }
 }
 
-// @ts-ignore - node export for testing.
+// node export for testing.
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = FirebaseAuth;
 }

--- a/lighthouse-viewer/app/src/github-api.js
+++ b/lighthouse-viewer/app/src/github-api.js
@@ -150,7 +150,7 @@ class GithubApi {
   }
 }
 
-// @ts-ignore - node export for testing.
+// node export for testing.
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = GithubApi;
 }

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -368,7 +368,7 @@ class LighthouseReportViewer {
   }
 }
 
-// @ts-ignore - node export for testing.
+// node export for testing.
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = LighthouseReportViewer;
 }

--- a/lighthouse-viewer/app/src/viewer-ui-features.js
+++ b/lighthouse-viewer/app/src/viewer-ui-features.js
@@ -62,7 +62,7 @@ class ViewerUIFeatures extends ReportUIFeatures {
   }
 }
 
-// @ts-ignore - node export for testing.
+// node export for testing.
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = ViewerUIFeatures;
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "1.4.0",
     "sinon": "^2.3.5",
-    "typescript": "3.1.0-dev.20180831",
+    "typescript": "3.1.1",
     "zone.js": "^0.7.3"
   },
   "dependencies": {

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -69,7 +69,7 @@ declare global {
       cpuSlowdownMultiplier?: number
     }
 
-    export type Locale = 'en-US'|'en'|'en-AU'|'en-GB'|'en-IE'|'en-SG'|'en-ZA'|'en-IN'|'ar-XB'|'ar'|'bg'|'bs'|'ca'|'cs'|'da'|'de'|'el'|'en-XA'|'es'|'fi'|'fil'|'fr'|'he'|'hi'|'hr'|'hu'|'gsw'|'id'|'in'|'it'|'iw'|'ja'|'ko'|'lt'|'lv'|'mo'|'nl'|'nb'|'no'|'pl'|'pt'|'pt-PT'|'ro'|'ru'|'sk'|'sl'|'sr'|'sr-Latn'|'sv'|'ta'|'te'|'th'|'tl'|'tr'|'uk'|'vi'|'zh'|'zh-HK'|'zh-TW';
+    export type Locale = 'en-US'|'en'|'en-AU'|'en-GB'|'en-IE'|'en-SG'|'en-ZA'|'en-IN'|'ar-XB'|'ar'|'bg'|'bs'|'ca'|'cs'|'da'|'de'|'el'|'en-XA'|'es'|'fi'|'fil'|'fr'|'he'|'hi'|'hr'|'hu'|'gsw'|'id'|'in'|'it'|'iw'|'ja'|'ko'|'ln'|'lt'|'lv'|'mo'|'nl'|'nb'|'no'|'pl'|'pt'|'pt-PT'|'ro'|'ru'|'sk'|'sl'|'sr'|'sr-Latn'|'sv'|'ta'|'te'|'th'|'tl'|'tr'|'uk'|'vi'|'zh'|'zh-HK'|'zh-TW';
 
     export type OutputMode = 'json' | 'html' | 'csv';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6208,9 +6208,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.1.0-dev.20180831:
-  version "3.1.0-dev.20180831"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.0-dev.20180831.tgz#d1c0c715f17368417cad96bda042cf26d56f3d61"
+typescript@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
 
 uglify-js@^2.6:
   version "2.7.3"


### PR DESCRIPTION
Typescript 3.1 is out, time to move off a nightly version and to the official release :)

Also removed a few outdated `@ts-ignore` comments.