### PR TITLE
core(emulation): set desktop viewport to 1350x940

### DIFF
--- a/lighthouse-core/lib/emulation.js
+++ b/lighthouse-core/lib/emulation.js
@@ -33,8 +33,8 @@ const NEXUS5X_EMULATION_METRICS = {
  */
 const DESKTOP_EMULATION_METRICS = {
   mobile: false,
-  width: 1366,
-  height: 768,
+  width: 1350,
+  height: 940,
   deviceScaleFactor: 1,
 };
 


### PR DESCRIPTION
data i guess:


![image](https://user-images.githubusercontent.com/39191/46187474-a262c680-c298-11e8-9461-a82c0acfdafd.png)


(this number is only used when `emulatedFormFactor: 'desktop'` which is mostly for headless scenarios.)