### PR TITLE
core: throttling=none, formFactor=provided

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -122,8 +122,8 @@ function getFlags(manualArgv) {
         'list-trace-categories', 'view', 'verbose', 'quiet', 'help', 'print-config',
       ])
       .choices('output', printer.getValidOutputOptions())
-      .choices('emulated-form-factor', ['mobile', 'desktop', 'none'])
-      .choices('throttling-method', ['devtools', 'provided', 'simulate'])
+      .choices('emulated-form-factor', ['mobile', 'desktop', 'provided', 'none'])
+      .choices('throttling-method', ['devtools', 'provided', 'simulate', 'none'])
       .choices('preset', ['full', 'perf', 'mixed-content'])
       // force as an array
       // note MUST use camelcase versions or only the kebab-case version will be forced

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -464,6 +464,10 @@ class Config {
     // Locale is special and comes only from flags/settings/lookupLocale.
     settingsWithFlags.locale = locale;
 
+    // Normalize throttlingMethod
+    settingsWithFlags.throttlingMethod = settingsWithFlags.throttlingMethod === 'none' ?
+      'provided' : settingsWithFlags.throttlingMethod;
+
     return settingsWithFlags;
   }
 

--- a/typings/externs.d.ts
+++ b/typings/externs.d.ts
@@ -87,8 +87,8 @@ declare global {
       gatherMode?: boolean | string;
       disableStorageReset?: boolean;
       disableDeviceEmulation?: boolean;
-      emulatedFormFactor?: 'mobile'|'desktop'|'none';
-      throttlingMethod?: 'devtools'|'simulate'|'provided';
+      emulatedFormFactor?: 'mobile'|'desktop'|'provided'|'none';
+      throttlingMethod?: 'devtools'|'simulate'|'provided'|'none';
       throttling?: ThrottlingSettings;
       onlyAudits?: string[] | null;
       onlyCategories?: string[] | null;


### PR DESCRIPTION
OK, so I don't really believe in this change so much, but I think it's a good forum to discuss what we actually want to happen.

**Backstory**

When we were creating the `throttlingMethod` values I pushed for `provided` instead of `none` to apply a psychological element to the idea that disabling throttling altogether will start to degrade LH performance results and saying "I am now responsible for throttling" might discourage folks from casually messing with throttling method. 'provided' though is functionally identical to 'none' from our perspective.

In emulated form factor, I see no such strong incentive to discourage folks and 'none' seems fine to me.

There is now a disparity between them.

**This PR**

Adds 'provided' as an alias for 'none' to emulatedFormFactor.
Adds 'none' as an alias for 'provided' to throttlingMethod.

**Alternatives**
* Standardize on 'none' (with temporary backcompat)
* Standardize on 'provided' (with temporary backcompat)
* Leave as-is

Thoughts?