### PR TITLE
core: await js-libraries detection

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -138,6 +138,14 @@ module.exports = [
           ],
         },
       },
+      'js-libraries': {
+        score: 1,
+        details: {
+          items: [{
+            name: 'jQuery',
+          }],
+        },
+      },
     },
   },
 ];

--- a/lighthouse-core/gather/gatherers/dobetterweb/js-libraries.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/js-libraries.js
@@ -29,9 +29,9 @@ function detectLibraries() {
   // d41d8cd98f00b204e9800998ecf8427e_ is a consistent prefix used by the detect libraries
   // see https://github.com/HTTPArchive/httparchive/issues/77#issuecomment-291320900
   // @ts-ignore - injected libDetectorSource var
-  Object.entries(d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests).forEach(([name, lib]) => {
+  Object.entries(d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests).forEach(async ([name, lib]) => { // eslint-disable-line max-len
     try {
-      const result = lib.test(window);
+      const result = await lib.test(window);
       if (result) {
         libraries.push({
           name: name,


### PR DESCRIPTION
#6102 bumped our version of js-library-detector, but included in that latest version is the first async detector function, so we need to await the result (otherwise it always passes since the promise is truthy regardless of how it's resolved).

Arguably fixes #6125, as any other work will probably have to be upstream.