### PR TITLE
[SPIKE] report: add 3rd party filter toggle

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -940,6 +940,13 @@ summary.lh-passed-audits-summary {
   max-width: var(--bytes-col-width);
 }
 
+.filtered .lh-table-column--url + th.lh-table-column--bytes,
+.filtered .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--bytes,
+.filtered .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--timespanMs {
+  max-width: 1000px;
+  min-width: 50px;
+}
+
 .lh-table-column--code {
   max-width: var(--url-col-max-width);
 }

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -33,6 +33,41 @@ limitations under the License.
   </div>
 </template>
 
+<template id="tmpl-lh-3p-filter">
+  <style>
+  .lh-3p-filter {
+    position: absolute;
+    bottom: 30px;
+    left: 10px;
+  }
+
+  .filtered tr.third-party {
+    display: none;
+  }
+  </style>
+  <div class="lh-3p-filter">
+    <label for="lh-3p-filter-input">
+      Filter out 3rd-parties:
+      <input type="checkbox" id="lh-3p-filter-input">
+    </label>
+  </div>
+</template>
+
+<template id="tmpl-lh-3p-filter-replacement">
+    <style>
+    .lh-3p-filter-replacement {
+      display: none;
+      background: hsla(0, 0%, 100%, 0.7);
+      text-align: center;
+    }
+
+    .filtered .lh-3p-filter-replacement {
+      display: table-row;
+    }
+    </style>
+    <tr class="lh-3p-filter-replacement"><td colspan="10"></td></tr>
+</template>
+
 <!-- Toggle arrow chevron -->
 <template id="tmpl-lh-chevron">
   <svg class="lh-chevron" title="See audits" xmlns="http://www.w3.org/2000/svg"  viewbox="0 0 100 100">


### PR DESCRIPTION
**Summary**
Once again just a platform for discussion, not a real PR :) I noticed 3p was P1, unassigned, and coming up yet again in issues so I wanted to get a handle on what are the major challenges we'll face.

**The Ultra-Hacky Prototype**

![image](https://user-images.githubusercontent.com/2301202/46229948-df789880-c32c-11e8-93e9-e44c9a6a5652.png)


**The Cool**
- It seems pretty feasible to do it 100% in the report extra UI features without touching core at all.
- Our shared table structure made adding it everywhere super easy 🎉 

**The Challenges**

- We knew this already, but we won't be able to easily update score, labels saying "N resources found", etc. My "solution" to this is removing the rows but adding a single 3rd party placeholder row to remind folks the totals still include all that junk.
- Our nice CSS odd/even strategy doesn't work with just hiding the divs :(
- There are a few URL tables that don't count and special handling might be a bit awkward (i.e. preconnect to 3rd party origins obvs shouldn't be hiding the 3rd party origins)
- Placement in the score header that comes down feels weird, but it seems potentially real bad if we just hide it all the way at the top/another place a user has to scroll to.

**Other Ideas**
- If we were feeling extremely bold, third party resources would *always* start collapsed and you could click to expand them. in each table
- We could use a whitelist of third parties instead of throwing everything that doesn't match the origin.
- Hwi had a cool mock that just increases the visibility of each element as a 3rd party origin

**Related Issues/PRs**
#4516
