### PR TITLE
report: add html report viewing support for safari

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -164,11 +164,12 @@ class CategoryRenderer {
   renderAuditGroup(group, opts) {
     const expandable = opts.expandable;
     const groupEl = this.dom.createElement(expandable ? 'details' : 'div', 'lh-audit-group');
-    const summmaryEl = this.dom.createChildOf(groupEl, 'summary', 'lh-audit-group__summary');
-    const headerEl = this.dom.createChildOf(summmaryEl, 'div', 'lh-audit-group__header');
-    const itemCountEl = this.dom.createChildOf(summmaryEl, 'div', 'lh-audit-group__itemcount');
+    const summaryEl = this.dom.createChildOf(groupEl, 'summary');
+    const summaryInnerEl = this.dom.createChildOf(summaryEl, 'div', 'lh-audit-group__summary');
+    const headerEl = this.dom.createChildOf(summaryInnerEl, 'div', 'lh-audit-group__header');
+    const itemCountEl = this.dom.createChildOf(summaryInnerEl, 'div', 'lh-audit-group__itemcount');
     if (expandable) {
-      const chevronEl = summmaryEl.appendChild(this._createChevron());
+      const chevronEl = summaryInnerEl.appendChild(this._createChevron());
       chevronEl.title = Util.UIStrings.auditGroupExpandTooltip;
     }
 

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -218,8 +218,8 @@ class ReportUIFeatures {
   animateHeader() {
     const collapsedHeaderHeight = 50;
     const heightDiff = this.headerHeight - collapsedHeaderHeight + this.headerOverlap;
-    const scrollPct = Math.min(1,
-      this.latestKnownScrollY / (this.headerHeight - collapsedHeaderHeight));
+    const scrollPct = Math.max(0, Math.min(1,
+      this.latestKnownScrollY / (this.headerHeight - collapsedHeaderHeight)));
 
     const scoresContainer = /** @type {HTMLElement} */ (this.scoresWrapperBg.parentElement);
 
@@ -228,7 +228,7 @@ class ReportUIFeatures {
     this.lighthouseIcon.style.transform =
       `translate3d(calc(var(--report-width) / 2),` +
       ` calc(-100% - ${scrollPct * this.headerOverlap * -1}px), 0) scale(${1 - scrollPct})`;
-    this.lighthouseIcon.style.opacity = Math.max(0, 1 - scrollPct).toString();
+    this.lighthouseIcon.style.opacity = (1 - scrollPct).toString();
 
     // Switch up the score background & shadows
     this.scoresWrapperBg.style.opacity = (1 - scrollPct).toString();

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -77,8 +77,6 @@
   --lh-section-vpadding: 12px;
   --chevron-size: 12px;
 
-  /* Voodoo magic here to get narrow columns. 0 doesn't size the column like our friend 1px does */
-  --bytes-col-width: 1px;
   --pass-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>check</title><path fill="hsl(139, 70%, 30%)" d="M24 4C12.95 4 4 12.95 4 24c0 11.04 8.95 20 20 20 11.04 0 20-8.96 20-20 0-11.05-8.96-20-20-20zm-4 30L10 24l2.83-2.83L20 28.34l15.17-15.17L38 16 20 34z"/></svg>');
   --average-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>info</title><path fill="hsl(31, 100%, 45%)" d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm2 30h-4V22h4v12zm0-16h-4v-4h4v4z"/></svg>');
   --fail-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>warn</title><path fill="hsl(1, 73%, 45%)" d="M2 42h44L24 4 2 42zm24-6h-4v-4h4v4zm0-8h-4v-8h4v8z"/></svg>');
@@ -922,17 +920,13 @@
 }
 
 /* Keep columns narrow if they follow the URL column */
-/* 12% width was found to be a good width for en and i18n without being too wide */
+/* 12% was determined to be a decent narrow width, but wide enough for column headings */
 .lh-table-column--url + th.lh-table-column--bytes,
 .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--bytes,
 .lh-table-column--url + .lh-table-column--ms, 
 .lh-table-column--url + .lh-table-column--ms + th.lh-table-column--bytes,
 .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--timespanMs {
   width: 12%;
-}
-
-.lh-table-column--code {
-  max-width: var(--url-col-max-width);
 }
 
 .lh-text__url {

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -937,8 +937,11 @@ summary.lh-passed-audits-summary {
 /* Keep bytes columns narrow if they follow the URL column */
 .lh-table-column--url + th.lh-table-column--bytes,
 .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--bytes,
+.lh-table-column--url + .lh-table-column--ms, 
+.lh-table-column--url + .lh-table-column--ms + th.lh-table-column--bytes,
 .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--timespanMs {
-  max-width: var(--bytes-col-width);
+  /* max-width: var(--bytes-col-width); */
+  width: 12%;
 }
 
 .lh-table-column--code {

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -821,19 +821,6 @@
   line-height: var(--header-line-height);
 }
 
-.lh-passed-audits[open] summary.lh-passed-audits-summary {
-  margin-bottom: calc(var(--default-padding) * 2);
-}
-
-summary.lh-passed-audits-summary {
-  margin: calc(var(--default-padding) * 2) var(--default-padding);
-  margin-left: var(--default-padding);
-  margin-bottom: 0;
-  font-size: 15px;
-  display: flex;
-  align-items: center;
-}
-
 #lh-log {
   position: fixed;
   background-color: #323232;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -648,6 +648,7 @@
 }
 
 .lh-header-sticky {
+  position: -webkit-sticky;
   position: sticky;
   top: 0;
   width: 100%;

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -994,19 +994,19 @@ summary.lh-passed-audits-summary {
  transition: transform 300ms, stroke 300ms;
 }
 
-.lh-audit-group > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
-.lh-audit-group[open] > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-left,
+.lh-audit-group > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
+.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-left,
 .lh-audit > .lh-expandable-details .lh-chevron__line-right,
 .lh-audit > .lh-expandable-details[open] .lh-chevron__line-left {
  transform: rotate(calc(var(--chevron-angle) * -1));
 }
 
-.lh-audit-group[open] > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
+.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
 .lh-audit > .lh-expandable-details[open] .lh-chevron__line-right {
   transform: rotate(var(--chevron-angle));
 }
 
-.lh-audit-group[open] > .lh-audit-group__summary > .lh-chevron .lh-chevron__lines,
+.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__lines,
 .lh-audit > .lh-expandable-details[open] .lh-chevron__lines {
  transform: translateY(calc(var(--chevron-size) * -1));
 }

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -919,16 +919,15 @@
 .lh-table-column--url {
   min-width: 250px;
   white-space: nowrap;
-  /* max-width: 0; */
 }
 
-/* Keep bytes columns narrow if they follow the URL column */
+/* Keep columns narrow if they follow the URL column */
+/* 12% width was found to be a good width for en and i18n without being too wide */
 .lh-table-column--url + th.lh-table-column--bytes,
 .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--bytes,
 .lh-table-column--url + .lh-table-column--ms, 
 .lh-table-column--url + .lh-table-column--ms + th.lh-table-column--bytes,
 .lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--timespanMs {
-  /* max-width: var(--bytes-col-width); */
   width: 12%;
 }
 

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -312,8 +312,8 @@
   background-color: #F8F9FA;
 }
 
-.lh-audit-group__summary::-webkit-details-marker,
-.lh-expandable-details__summary::-webkit-details-marker {
+.lh-audit-group > summary::-webkit-details-marker,
+.lh-expandable-details > summary::-webkit-details-marker {
   display: none;
 }
 
@@ -895,6 +895,7 @@ summary.lh-passed-audits-summary {
 .lh-table thead th {
   color: var(--medium-75-gray);
   font-weight: normal;
+  word-wrap: normal;
 }
 
 .lh-table tbody tr:nth-child(even) {
@@ -930,7 +931,7 @@ summary.lh-passed-audits-summary {
 .lh-table-column--url {
   min-width: 250px;
   white-space: nowrap;
-  max-width: 0;
+  /* max-width: 0; */
 }
 
 /* Keep bytes columns narrow if they follow the URL column */

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -86,22 +86,22 @@ limitations under the License.
   <div class="lh-audit lh-audit--load-opportunity">
     <details class="lh-expandable-details">
         <summary>
-            <div class="lh-audit__header lh-expandable-details__summary">
-        <div class="lh-load-opportunity__cols">
-          <div class="lh-load-opportunity__col lh-load-opportunity__col--one">
-            <span class="lh-audit__index"></span>
-            <div class="lh-audit__title"></div>
-          </div>
-          <div class="lh-load-opportunity__col lh-load-opportunity__col--two">
-            <div class="lh-load-opportunity__sparkline">
-              <div class="lh-sparkline"><div class="lh-sparkline__bar"></div></div>
+          <div class="lh-audit__header lh-expandable-details__summary">
+            <div class="lh-load-opportunity__cols">
+              <div class="lh-load-opportunity__col lh-load-opportunity__col--one">
+                <span class="lh-audit__index"></span>
+                <div class="lh-audit__title"></div>
+              </div>
+              <div class="lh-load-opportunity__col lh-load-opportunity__col--two">
+                <div class="lh-load-opportunity__sparkline">
+                  <div class="lh-sparkline"><div class="lh-sparkline__bar"></div></div>
+                </div>
+                <div class="lh-audit__display-text"></div>
+                <div class="lh-chevron-container" title="See resources"></div>
+              </div>
             </div>
-            <div class="lh-audit__display-text"></div>
-            <div class="lh-chevron-container" title="See resources"></div>
           </div>
-        </div>
-        </div>
-      </summary>
+        </summary>
       <div class="lh-audit__description"></div>
     </details>
   </div>

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -56,12 +56,14 @@ limitations under the License.
 <template id="tmpl-lh-audit">
   <div class="lh-audit">
     <details class="lh-expandable-details">
-      <summary class="lh-audit__header lh-expandable-details__summary">
-        <span class="lh-audit__index"></span>
-        <span class="lh-audit__title"></span>
-        <span class="lh-audit__display-text"></span>
-        <div class="lh-audit__score-icon"></div>
-        <div class="lh-chevron-container"></div>
+      <summary>
+        <div class="lh-audit__header lh-expandable-details__summary">
+          <span class="lh-audit__index"></span>
+          <span class="lh-audit__title"></span>
+          <span class="lh-audit__display-text"></span>
+          <div class="lh-audit__score-icon"></div>
+          <div class="lh-chevron-container"></div>
+        </div>
       </summary>
       <div class="lh-audit__description"></div>
     </details>
@@ -83,7 +85,8 @@ limitations under the License.
 <template id="tmpl-lh-opportunity">
   <div class="lh-audit lh-audit--load-opportunity">
     <details class="lh-expandable-details">
-      <summary class="lh-audit__header lh-expandable-details__summary">
+        <summary>
+            <div class="lh-audit__header lh-expandable-details__summary">
         <div class="lh-load-opportunity__cols">
           <div class="lh-load-opportunity__col lh-load-opportunity__col--one">
             <span class="lh-audit__index"></span>
@@ -96,6 +99,7 @@ limitations under the License.
             <div class="lh-audit__display-text"></div>
             <div class="lh-chevron-container" title="See resources"></div>
           </div>
+        </div>
         </div>
       </summary>
       <div class="lh-audit__description"></div>

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -1,0 +1,107 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const assert = require('assert');
+const fs = require('fs');
+const jsdom = require('jsdom');
+const Util = require('../../../../report/html/renderer/util.js');
+const URL = require('../../../../lib/url-shim');
+const DOM = require('../../../../report/html/renderer/dom.js');
+const DetailsRenderer = require('../../../../report/html/renderer/details-renderer.js');
+const ReportUIFeatures = require('../../../../report/html/renderer/report-ui-features.js');
+const CategoryRenderer = require('../../../../report/html/renderer/category-renderer.js');
+// lazy loaded because it depends on CategoryRenderer to be available globally
+let PerformanceCategoryRenderer = null;
+const CriticalRequestChainRenderer = require(
+    '../../../../report/html/renderer/crc-details-renderer.js');
+const ReportRenderer = require('../../../../report/html/renderer/report-renderer.js');
+const sampleResultsOrig = require('../../../results/sample_v2.json');
+
+const TEMPLATE_FILE = fs.readFileSync(__dirname +
+    '/../../../../report/html/templates.html', 'utf8');
+const TEMPLATE_FILE_REPORT = fs.readFileSync(__dirname +
+  '/../../../../report/html/report-template.html', 'utf8');
+
+describe('ReportUIFeatures', () => {
+  let renderer;
+  let reportUIFeatures;
+  let sampleResults;
+
+  beforeAll(() => {
+    global.URL = URL;
+    global.Util = Util;
+    global.ReportUIFeatures = ReportUIFeatures;
+    global.CriticalRequestChainRenderer = CriticalRequestChainRenderer;
+    global.DetailsRenderer = DetailsRenderer;
+    global.CategoryRenderer = CategoryRenderer;
+    if (!PerformanceCategoryRenderer) {
+      PerformanceCategoryRenderer =
+        require('../../../../report/html/renderer/performance-category-renderer.js');
+    }
+    global.PerformanceCategoryRenderer = PerformanceCategoryRenderer;
+
+    // Stub out matchMedia for Node.
+    global.matchMedia = function() {
+      return {
+        addListener: function() {},
+      };
+    };
+
+    const document = jsdom.jsdom(TEMPLATE_FILE);
+    const documentReport = jsdom.jsdom(TEMPLATE_FILE_REPORT);
+    global.self = document.defaultView;
+    global.self.matchMedia = function() {
+      return {
+        addListener: function() {},
+      };
+    };
+
+    global.window = {};
+    global.window.getComputedStyle = function() {
+      return {
+        marginTop: '10px',
+        height: '10px',
+      };
+    };
+
+    const dom = new DOM(document);
+    const dom2 = new DOM(documentReport);
+    const detailsRenderer = new DetailsRenderer(dom);
+    const categoryRenderer = new CategoryRenderer(dom, detailsRenderer);
+    renderer = new ReportRenderer(dom, categoryRenderer);
+    sampleResults = Util.prepareReportResult(sampleResultsOrig);
+    reportUIFeatures = new ReportUIFeatures(dom2);
+  });
+
+  afterAll(() => {
+    global.self = undefined;
+    global.URL = undefined;
+    global.Util = undefined;
+    global.ReportUIFeatures = undefined;
+    global.matchMedia = undefined;
+    global.self.matchMedia = undefined;
+    global.CriticalRequestChainRenderer = undefined;
+    global.DetailsRenderer = undefined;
+    global.CategoryRenderer = undefined;
+    global.PerformanceCategoryRenderer = undefined;
+    global.window = undefined;
+  });
+
+  describe('initFeature', () => {
+    it('should init a report', () => {
+      // render a report onto the UIFeature dom
+      const container = reportUIFeatures._dom._document.body;
+      renderer.renderReport(sampleResults, container);
+
+      assert.equal(reportUIFeatures.json, undefined);
+      reportUIFeatures.initFeatures(Util.prepareReportResult(sampleResults));
+      assert.ok(reportUIFeatures.json);
+    });
+  });
+});


### PR DESCRIPTION
**Summary**
Added Safari support!  Main areas of focus were:
- fixing tables
- fixing header sticky-scrolling
- fixing scroll > 100% making LH icon scale too large