### PR TITLE
report: reframe Fast 3G as Slow 4G

### DIFF
--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -1,13 +1,13 @@
 
-## The network throttling preset
+## The mobile network throttling preset
 
-This is the standard recommendation for Slow 4G throttling:
+This is the standard recommendation for mobile throttling:
 
 - Latency: 150ms
 - Throughput: 1.6Mbps down / 750 Kbps up.
 - Packet loss: none.
 
-These exact figures are used as the [WebPageTest "Mobile 3G - Fast" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample) and [Lighthouse's throttling default](https://github.com/GoogleChrome/lighthouse/blob/8f500e00243e07ef0a80b39334bedcc8ddc8d3d0/lighthouse-core/config/constants.js#L19-L26). These values represent roughly the bottom 25% of 4G connections and top 25% of 3G connections.
+These exact figures are used as [Lighthouse's throttling default](https://github.com/GoogleChrome/lighthouse/blob/8f500e00243e07ef0a80b39334bedcc8ddc8d3d0/lighthouse-core/config/constants.js#L19-L26) and represent roughly the bottom 25% of 4G connections and top 25% of 3G connections. They are identical to the [WebPageTest "Mobile 3G - Fast" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample) and slightly faster for many pages than [WebPageTest "4G" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample).
 
 ## Throttling basics
 

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -7,7 +7,7 @@ This is the standard recommendation for mobile throttling:
 - Throughput: 1.6Mbps down / 750 Kbps up.
 - Packet loss: none.
 
-These exact figures are used as [Lighthouse's throttling default](https://github.com/GoogleChrome/lighthouse/blob/8f500e00243e07ef0a80b39334bedcc8ddc8d3d0/lighthouse-core/config/constants.js#L19-L26) and represent roughly the bottom 25% of 4G connections and top 25% of 3G connections. They are identical to the [WebPageTest "Mobile 3G - Fast" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample) and slightly faster for many pages than [WebPageTest "4G" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample).
+These exact figures are used as [Lighthouse's throttling default](https://github.com/GoogleChrome/lighthouse/blob/8f500e00243e07ef0a80b39334bedcc8ddc8d3d0/lighthouse-core/config/constants.js#L19-L26) and represent roughly the bottom 25% of 4G connections and top 25% of 3G connections. They are identical to the [WebPageTest "Mobile 3G - Fast" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample) and, due to a lower latency, slightly faster for some pages than the [WebPageTest "4G" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample).
 
 ## Throttling basics
 

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -1,13 +1,13 @@
 
-## The 3G network throttling preset
+## The network throttling preset
 
-This is the standard recommendation for 3G throttling:
+This is the standard recommendation for Slow 4G throttling:
 
 - Latency: 150ms
 - Throughput: 1.6Mbps down / 750 Kbps up.
 - Packet loss: none.
 
-These exact figures are used as the [WebPageTest "Mobile 3G - Fast" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample) and [Lighthouse's throttling default](https://github.com/GoogleChrome/lighthouse/blob/8f500e00243e07ef0a80b39334bedcc8ddc8d3d0/lighthouse-core/config/constants.js#L19-L26).
+These exact figures are used as the [WebPageTest "Mobile 3G - Fast" preset](https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/connectivity.ini.sample) and [Lighthouse's throttling default](https://github.com/GoogleChrome/lighthouse/blob/8f500e00243e07ef0a80b39334bedcc8ddc8d3d0/lighthouse-core/config/constants.js#L19-L26). These values represent roughly the bottom 25% of 4G connections and top 25% of 3G connections.
 
 ## Throttling basics
 

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -13,7 +13,7 @@
 
 const isDeepEqual = require('lodash.isequal');
 const Audit = require('./audit');
-const mobile3GThrottling = require('../config/constants').throttling.mobile3G;
+const mobileThrottling = require('../config/constants').throttling.mobileSlow4G;
 
 // Maximum TTI to be considered "fast" for PWA baseline checklist
 //   https://developers.google.com/web/progressive-web-apps/checklist
@@ -26,10 +26,10 @@ class LoadFastEnough4Pwa extends Audit {
   static get meta() {
     return {
       id: 'load-fast-enough-for-pwa',
-      title: 'Page load is fast enough on 3G',
-      failureTitle: 'Page load is not fast enough on 3G',
+      title: 'Page load is fast enough on mobile networks',
+      failureTitle: 'Page load is not fast enough on mobile networks',
       description:
-        'A fast page load over a 3G network ensures a good mobile user experience. ' +
+        'A fast page load over a cellular network ensures a good mobile user experience. ' +
         '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g).',
       requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
@@ -44,12 +44,12 @@ class LoadFastEnough4Pwa extends Audit {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
 
-    // If throttling was default devtools or lantern 3G throttling, then reuse the given settings
-    // Otherwise, we'll force the usage of lantern 3G.
-    const settingOverrides = {throttlingMethod: 'simulate', throttling: mobile3GThrottling};
+    // If throttling was default devtools or lantern slow 4G throttling, then reuse the given settings
+    // Otherwise, we'll force the usage of lantern slow 4G.
+    const settingOverrides = {throttlingMethod: 'simulate', throttling: mobileThrottling};
     const settings =
       context.settings.throttlingMethod !== 'provided' &&
-      isDeepEqual(context.settings.throttling, mobile3GThrottling)
+      isDeepEqual(context.settings.throttling, mobileThrottling)
         ? context.settings
         : Object.assign({}, context.settings, settingOverrides);
 

--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -23,7 +23,7 @@ class PredictivePerf extends Audit {
       title: 'Predicted Performance (beta)',
       description:
         'Predicted performance evaluates how your site will perform under ' +
-        'a 3G connection on a mobile device.',
+        'a cellular connection on a mobile device.',
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces', 'devtoolsLogs'],
     };

--- a/lighthouse-core/config/constants.js
+++ b/lighthouse-core/config/constants.js
@@ -16,7 +16,7 @@ const DEVTOOLS_THROUGHPUT_ADJUSTMENT_FACTOR = 0.9;
 const throttling = {
   DEVTOOLS_RTT_ADJUSTMENT_FACTOR,
   DEVTOOLS_THROUGHPUT_ADJUSTMENT_FACTOR,
-  mobile3G: {
+  mobileSlow4G: {
     rttMs: 150,
     throughputKbps: 1.6 * 1024,
     requestLatencyMs: 150 * DEVTOOLS_RTT_ADJUSTMENT_FACTOR,
@@ -31,7 +31,7 @@ const defaultSettings = {
   output: 'json',
   maxWaitForLoad: 45 * 1000,
   throttlingMethod: 'simulate',
-  throttling: throttling.mobile3G,
+  throttling: throttling.mobileSlow4G,
   auditMode: false,
   gatherMode: false,
   disableStorageReset: false,

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -9,7 +9,7 @@ const BaseNode = require('../base-node');
 const TcpConnection = require('./tcp-connection');
 const ConnectionPool = require('./connection-pool');
 const DNSCache = require('./dns-cache');
-const mobile3G = require('../../../config/constants').throttling.mobile3G;
+const mobileSlow4G = require('../../../config/constants').throttling.mobileSlow4G;
 
 /** @typedef {BaseNode.Node} Node */
 /** @typedef {import('../network-node')} NetworkNode */
@@ -40,10 +40,10 @@ class Simulator {
     /** @type {Required<LH.Gatherer.Simulation.Options>} */
     this._options = Object.assign(
       {
-        rtt: mobile3G.rttMs,
-        throughput: mobile3G.throughputKbps * 1024,
+        rtt: mobileSlow4G.rttMs,
+        throughput: mobileSlow4G.throughputKbps * 1024,
         maximumConcurrentRequests: DEFAULT_MAXIMUM_CONCURRENT_REQUESTS,
-        cpuSlowdownMultiplier: mobile3G.cpuSlowdownMultiplier,
+        cpuSlowdownMultiplier: mobileSlow4G.cpuSlowdownMultiplier,
         layoutTaskMultiplier: DEFAULT_LAYOUT_TASK_MULTIPLIER,
         additionalRttByOrigin: new Map(),
         serverResponseTimeByOrigin: new Map(),

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -448,7 +448,7 @@
     "description": "Title of the lab data section of the Performance category. Within this section are various speed metrics which quantify the pageload performance into values presented in seconds and milliseconds. \"Lab\" is an abbreviated form of \"laboratory\", and refers to the fact that the data is from a controlled test of a website, not measurements from real users visiting that site."
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 4G. Values are estimated and may vary.",
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
     "description": "Explanation shown to users below performance results to inform them that the test was done with a 4G network connection and to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. 'Lighthouse' becomes link text to additional documentation."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -448,8 +448,8 @@
     "description": "Title of the lab data section of the Performance category. Within this section are various speed metrics which quantify the pageload performance into values presented in seconds and milliseconds. \"Lab\" is an abbreviated form of \"laboratory\", and refers to the fact that the data is from a controlled test of a website, not measurements from real users visiting that site."
   },
   "lighthouse-core/report/html/renderer/util.js | lsPerformanceCategoryDescription": {
-    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 3G. Values are estimated and may vary.",
-    "description": "Explanation shown to users below performance results to inform them that the test was done with a 3G network connection and to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. 'Lighthouse' becomes link text to additional documentation."
+    "message": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 4G. Values are estimated and may vary.",
+    "description": "Explanation shown to users below performance results to inform them that the test was done with a 4G network connection and to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. 'Lighthouse' becomes link text to additional documentation."
   },
   "lighthouse-core/report/html/renderer/util.js | manualAuditsGroupTitle": {
     "message": "Additional items to manually check",

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -485,7 +485,7 @@ Util.UIStrings = {
   crcLongestDurationLabel: 'Maximum critical path latency:',
 
   /** Explanation shown to users below performance results to inform them that the test was done with a 4G network connection and to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. 'Lighthouse' becomes link text to additional documentation. */
-  lsPerformanceCategoryDescription: '[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 4G. Values are estimated and may vary.',
+  lsPerformanceCategoryDescription: '[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.',
   /** Title of the lab data section of the Performance category. Within this section are various speed metrics which quantify the pageload performance into values presented in seconds and milliseconds. "Lab" is an abbreviated form of "laboratory", and refers to the fact that the data is from a controlled test of a website, not measurements from real users visiting that site.  */
   labDataTitle: 'Lab Data',
 };

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -398,7 +398,7 @@ class Util {
         networkThrottling = `${Util.formatNumber(requestLatencyMs)}${NBSP}ms HTTP RTT, ` +
           `${Util.formatNumber(throttling.downloadThroughputKbps)}${NBSP}Kbps down, ` +
           `${Util.formatNumber(throttling.uploadThroughputKbps)}${NBSP}Kbps up (DevTools)`;
-        summary = 'Throttled Fast 3G network';
+        summary = 'Throttled Slow 4G network';
         break;
       }
       case 'simulate': {
@@ -406,7 +406,7 @@ class Util {
         cpuThrottling = `${Util.formatNumber(cpuSlowdownMultiplier)}x slowdown (Simulated)`;
         networkThrottling = `${Util.formatNumber(rttMs)}${NBSP}ms TCP RTT, ` +
           `${Util.formatNumber(throughputKbps)}${NBSP}Kbps throughput (Simulated)`;
-        summary = 'Simulated Fast 3G network';
+        summary = 'Simulated Slow 4G network';
         break;
       }
       default:
@@ -484,8 +484,8 @@ Util.UIStrings = {
   /** Label of value shown in the summary of critical request chains. Refers to the total amount of time (milliseconds) of the longest critical path chain/sequence of network requests. Example value: 2310 ms */
   crcLongestDurationLabel: 'Maximum critical path latency:',
 
-  /** Explanation shown to users below performance results to inform them that the test was done with a 3G network connection and to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. 'Lighthouse' becomes link text to additional documentation. */
-  lsPerformanceCategoryDescription: '[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 3G. Values are estimated and may vary.',
+  /** Explanation shown to users below performance results to inform them that the test was done with a 4G network connection and to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. 'Lighthouse' becomes link text to additional documentation. */
+  lsPerformanceCategoryDescription: '[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 4G. Values are estimated and may vary.',
   /** Title of the lab data section of the Performance category. Within this section are various speed metrics which quantify the pageload performance into values presented in seconds and milliseconds. "Lab" is an abbreviated form of "laboratory", and refers to the fact that the data is from a controlled test of a website, not measurements from real users visiting that site.  */
   labDataTitle: 'Lab Data',
 };

--- a/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/render-blocking-resources-test.js
@@ -7,7 +7,7 @@
 
 const RenderBlockingResourcesAudit = require('../../../audits/byte-efficiency/render-blocking-resources.js'); // eslint-disable-line max-len
 
-const mobile3G = require('../../../config/constants').throttling.mobile3G;
+const mobileSlow4G = require('../../../config/constants').throttling.mobileSlow4G;
 const Runner = require('../../../runner');
 const NetworkNode = require('../../../lib/dependency-graph/network-node');
 const CPUNode = require('../../../lib/dependency-graph/cpu-node');
@@ -36,7 +36,7 @@ describe('Render blocking resources audit', () => {
       Runner.instantiateComputedArtifacts()
     );
 
-    const settings = {throttlingMethod: 'simulate', throttling: mobile3G};
+    const settings = {throttlingMethod: 'simulate', throttling: mobileSlow4G};
     const result = await RenderBlockingResourcesAudit.audit(artifacts, {settings});
     assert.equal(result.score, 1);
     assert.equal(result.rawValue, 0);

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -8,7 +8,7 @@
 const FastPWAAudit = require('../../audits/load-fast-enough-for-pwa');
 const Runner = require('../../runner.js');
 const Audit = require('../../audits/audit.js');
-const mobile3GThrottling = require('../../config/constants').throttling.mobile3G;
+const mobileSlow4GThrottling = require('../../config/constants').throttling.mobileSlow4G;
 const assert = require('assert');
 
 const trace = require('../fixtures/traces/progressive-app-m60.json');
@@ -31,7 +31,7 @@ function generateArtifacts(ttiValue) {
 /* eslint-env jest */
 describe('PWA: load-fast-enough-for-pwa audit', () => {
   it('returns boolean based on TTI value', () => {
-    const settings = {throttlingMethod: 'devtools', throttling: mobile3GThrottling};
+    const settings = {throttlingMethod: 'devtools', throttling: mobileSlow4GThrottling};
     return FastPWAAudit.audit(generateArtifacts(5000), {settings}).then(result => {
       assert.equal(result.score, true, 'fixture trace is not passing audit');
       assert.equal(result.rawValue, 5000);
@@ -39,7 +39,7 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
   });
 
   it('fails a bad TTI value', () => {
-    const settings = {throttlingMethod: 'devtools', throttling: mobile3GThrottling};
+    const settings = {throttlingMethod: 'devtools', throttling: mobileSlow4GThrottling};
     return FastPWAAudit.audit(generateArtifacts(15000), {settings}).then(result => {
       assert.equal(result.score, false, 'not failing a long TTI value');
       assert.equal(result.rawValue, 15000);
@@ -54,7 +54,7 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
       devtoolsLogs: {defaultPass: devtoolsLog},
     }, Runner.instantiateComputedArtifacts());
 
-    const settings = {throttlingMethod: 'devtools', throttling: mobile3GThrottling};
+    const settings = {throttlingMethod: 'devtools', throttling: mobileSlow4GThrottling};
     const result = await FastPWAAudit.audit(artifacts, {settings});
     assert.equal(Math.round(result.rawValue), 1582);
   });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3448,7 +3448,7 @@
       "errorLabel": "Error!",
       "errorMissingAuditInfo": "Report error: no audit information",
       "labDataTitle": "Lab Data",
-      "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 4G. Values are estimated and may vary.",
+      "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
       "manualAuditsGroupTitle": "Additional items to manually check",
       "notApplicableAuditsGroupTitle": "Not applicable",
       "opportunityResourceColumnLabel": "Opportunity",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -101,8 +101,8 @@
     },
     "load-fast-enough-for-pwa": {
       "id": "load-fast-enough-for-pwa",
-      "title": "Page load is fast enough on 3G",
-      "description": "A fast page load over a 3G network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g).",
+      "title": "Page load is fast enough on mobile networks",
+      "description": "A fast page load over a cellular network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g).",
       "score": 1,
       "scoreDisplayMode": "binary",
       "rawValue": 4927.278
@@ -3448,7 +3448,7 @@
       "errorLabel": "Error!",
       "errorMissingAuditInfo": "Report error: no audit information",
       "labDataTitle": "Lab Data",
-      "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 3G. Values are estimated and may vary.",
+      "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on emulated 4G. Values are estimated and may vary.",
       "manualAuditsGroupTitle": "Additional items to manually check",
       "notApplicableAuditsGroupTitle": "Not applicable",
       "opportunityResourceColumnLabel": "Opportunity",

--- a/readme.md
+++ b/readme.md
@@ -304,7 +304,7 @@ Yes! Details in [Lighthouse configuration](./docs/configuration.md).
 ### How does Lighthouse use network throttling, and how can I make it better?
 
 Good question. Network and CPU throttling are applied by default in a Lighthouse run. The network
-attempts to emulate 3G and the CPU is slowed down 4x from your machine's default speed. If you
+attempts to emulate slow 4G and the CPU is slowed down 4x from your machine's default speed. If you
 prefer to run Lighthouse without throttling, you'll have to use the CLI and disable it with the
 `--throttling.*` flags mentioned above.
 


### PR DESCRIPTION
Good summary copied from @paulirish below:
> The goal of a good mobile throttling preset is never to accurately reflect the conditions of a cellular telecommunications system. It's to reflect the conditions that real users experience.

> The preset here attempts to capture latency/throughput of ~80 percentile observed connection data from the wild. As people globally acquire faster connections, this preset should be updated to keep pace.

> Right now, we have no changes to make in the latency/throughput numbers.

> However given the recent adoption of 4G, this preset actually now captures a 4G experience moreso than a 3G experience.

--------------------------------------------


We don't actually reference 3G in *that* many places, I think this effort will be mostly about docs and how we talk to folks.

The biggest change I'm not 100% sure on how to navigate is the PWA audit and our docs linking to WPT - Fast 3G preset.

re: PWA check
I took the approach of just saying "mobile networks" and "cellular networks" since that is in fact the motivation of the check. The checklist does specifically call out "first visit on a simulated 3G network." though, so not sure if we should update it there or what :)
