### PR TITLE
tests: add networkRecord-to-devtoolsLog mocking utility

### DIFF
--- a/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/total-byte-weight-test.js
@@ -9,6 +9,8 @@ const TotalByteWeight = require('../../../audits/byte-efficiency/total-byte-weig
 const assert = require('assert');
 const URL = require('url').URL;
 const options = TotalByteWeight.defaultOptions;
+const Runner = require('../../../runner.js');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
@@ -32,10 +34,9 @@ function generateArtifacts(records) {
     records = records.map(args => generateRequest(...args));
   }
 
-  return {
-    devtoolsLogs: {defaultPass: []},
-    requestNetworkRecords: () => Promise.resolve(records),
-  };
+  return Object.assign(Runner.instantiateComputedArtifacts(), {
+    devtoolsLogs: {defaultPass: networkRecordsToDevtoolsLog(records)},
+  });
 }
 
 describe('Total byte weight audit', () => {

--- a/lighthouse-core/test/audits/byte-efficiency/unused-css-rules-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/unused-css-rules-test.js
@@ -7,6 +7,8 @@
 
 const UnusedCSSAudit = require('../../../audits/byte-efficiency/unused-css-rules.js');
 const assert = require('assert');
+const Runner = require('../../../runner.js');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
@@ -117,33 +119,32 @@ describe('Best Practices: unused css rules audit', () => {
   });
 
   describe('#audit', () => {
-    const devtoolsLogs = {defaultPass: []};
-    const requestNetworkRecords = () => {
-      return Promise.resolve([
-        {
-          url: 'file://a.css',
-          transferSize: 10 * 1024,
-          resourceType: 'Stylesheet',
-        },
-      ]);
-    };
+    const networkRecords = [
+      {
+        url: 'file://a.css',
+        transferSize: 10 * 1024,
+        resourceType: 'Stylesheet',
+      },
+    ];
+
+    function getArtifacts({CSSUsage}) {
+      return Object.assign(Runner.instantiateComputedArtifacts(), {
+        devtoolsLogs: {defaultPass: networkRecordsToDevtoolsLog(networkRecords)},
+        URL: {finalUrl: ''},
+        CSSUsage,
+      });
+    }
 
     it('ignores missing stylesheets', () => {
-      return UnusedCSSAudit.audit_({
-        devtoolsLogs,
-        requestNetworkRecords,
-        URL: {finalUrl: ''},
+      return UnusedCSSAudit.audit_(getArtifacts({
         CSSUsage: {rules: [{styleSheetId: 'a', used: false}], stylesheets: []},
-      }).then(result => {
+      })).then(result => {
         assert.equal(result.items.length, 0);
       });
     });
 
     it('ignores stylesheets that are 100% used', () => {
-      return UnusedCSSAudit.audit_({
-        devtoolsLogs,
-        requestNetworkRecords,
-        URL: {finalUrl: ''},
+      return UnusedCSSAudit.audit_(getArtifacts({
         CSSUsage: {rules: [
           {styleSheetId: 'a', used: true},
           {styleSheetId: 'a', used: true},
@@ -158,16 +159,13 @@ describe('Best Practices: unused css rules audit', () => {
             content: '.my.favorite.selector { rule: content; }',
           },
         ]},
-      }).then(result => {
+      })).then(result => {
         assert.equal(result.items.length, 0);
       });
     });
 
     it('fails when lots of rules are unused', () => {
-      return UnusedCSSAudit.audit_({
-        devtoolsLogs,
-        requestNetworkRecords,
-        URL: {finalUrl: ''},
+      return UnusedCSSAudit.audit_(getArtifacts({
         CSSUsage: {rules: [
           {styleSheetId: 'a', used: true, startOffset: 0, endOffset: 11}, // 44 * 1 / 4
           {styleSheetId: 'b', used: true, startOffset: 0, endOffset: 6000}, // 4000 * 3 / 2
@@ -185,7 +183,7 @@ describe('Best Practices: unused css rules audit', () => {
             content: `${generate('123', 450)}`, // will be filtered out
           },
         ]},
-      }).then(result => {
+      })).then(result => {
         assert.equal(result.items.length, 2);
         assert.equal(result.items[0].totalBytes, 10 * 1024);
         assert.equal(result.items[1].totalBytes, 6000);
@@ -195,10 +193,7 @@ describe('Best Practices: unused css rules audit', () => {
     });
 
     it('does not include empty or small sheets', () => {
-      return UnusedCSSAudit.audit_({
-        devtoolsLogs,
-        requestNetworkRecords,
-        URL: {finalUrl: ''},
+      return UnusedCSSAudit.audit_(getArtifacts({
         CSSUsage: {rules: [
           {styleSheetId: 'a', used: true, startOffset: 0, endOffset: 8000}, // 4000 * 3 / 2
           {styleSheetId: 'b', used: true, startOffset: 0, endOffset: 500}, // 500 * 3 / 3
@@ -224,7 +219,7 @@ describe('Best Practices: unused css rules audit', () => {
             content: '       ',
           },
         ]},
-      }).then(result => {
+      })).then(result => {
         assert.equal(result.items.length, 1);
         assert.equal(Math.floor(result.items[0].wastedPercent), 33);
       });

--- a/lighthouse-core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js
@@ -9,6 +9,8 @@ const CacheHeadersAudit = require('../../../audits/byte-efficiency/uses-long-cac
 const assert = require('assert');
 const NetworkRequest = require('../../../lib/network-request');
 const options = CacheHeadersAudit.defaultOptions;
+const Runner = require('../../../runner.js');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
@@ -28,20 +30,20 @@ function networkRecord(options = {}) {
 }
 
 describe('Cache headers audit', () => {
-  let artifacts;
-  let networkRecords;
+  function getArtifacts(networkRecords) {
+    const devtoolLogs = networkRecordsToDevtoolsLog(networkRecords);
 
-  beforeEach(() => {
-    artifacts = {
-      devtoolsLogs: {},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    return Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {
+        [CacheHeadersAudit.DEFAULT_PASS]: devtoolLogs,
+      },
       requestNetworkThroughput: () => Promise.resolve(1000),
-    };
-  });
+    });
+  }
 
   it('detects missing cache headers', () => {
-    networkRecords = [networkRecord()];
-    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+    const networkRecords = [networkRecord()];
+    return CacheHeadersAudit.audit(getArtifacts(networkRecords), {options}).then(result => {
       const items = result.extendedInfo.value.results;
       assert.equal(items.length, 1);
       assert.equal(items[0].cacheLifetimeMs, 0);
@@ -51,14 +53,14 @@ describe('Cache headers audit', () => {
   });
 
   it('detects low value max-age headers', () => {
-    networkRecords = [
+    const networkRecords = [
       networkRecord({headers: {'cache-control': 'max-age=3600'}}), // an hour
       networkRecord({headers: {'cache-control': 'max-age=3600'}, transferSize: 100000}), // an hour
       networkRecord({headers: {'cache-control': 'max-age=86400'}}), // a day
       networkRecord({headers: {'cache-control': 'max-age=31536000'}}), // a year
     ];
 
-    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+    return CacheHeadersAudit.audit(getArtifacts(networkRecords), {options}).then(result => {
       const items = result.details.items;
       assert.equal(items.length, 3);
       assert.equal(items[0].cacheLifetimeMs, 3600 * 1000);
@@ -76,14 +78,14 @@ describe('Cache headers audit', () => {
     const expiresIn = seconds => new Date(Date.now() + seconds * 1000).toGMTString();
     const closeEnough = (actual, exp) => assert.ok(Math.abs(actual - exp) <= 1, 'invalid expires');
 
-    networkRecords = [
+    const networkRecords = [
       networkRecord({headers: {expires: expiresIn(86400 * 365)}}), // a year
       networkRecord({headers: {expires: expiresIn(86400 * 90)}}), // 3 months
       networkRecord({headers: {expires: expiresIn(86400)}}), // a day
       networkRecord({headers: {expires: expiresIn(3600)}}), // an hour
     ];
 
-    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+    return CacheHeadersAudit.audit(getArtifacts(networkRecords), {options}).then(result => {
       const items = result.extendedInfo.value.results;
       assert.equal(items.length, 3);
       closeEnough(items[0].cacheLifetimeMs, 3600 * 1000);
@@ -98,7 +100,7 @@ describe('Cache headers audit', () => {
   it('respects expires/cache-control priority', () => {
     const expiresIn = seconds => new Date(Date.now() + seconds * 1000).toGMTString();
 
-    networkRecords = [
+    const networkRecords = [
       networkRecord({headers: {
         'cache-control': 'must-revalidate,max-age=3600',
         'expires': expiresIn(86400),
@@ -109,7 +111,7 @@ describe('Cache headers audit', () => {
       }}),
     ];
 
-    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+    return CacheHeadersAudit.audit(getArtifacts(networkRecords), {options}).then(result => {
       const items = result.extendedInfo.value.results;
       assert.equal(items.length, 2);
       assert.ok(Math.abs(items[0].cacheLifetimeMs - 3600 * 1000) <= 1, 'invalid expires parsing');
@@ -120,7 +122,7 @@ describe('Cache headers audit', () => {
   });
 
   it('respects multiple cache-control headers', () => {
-    networkRecords = [
+    const networkRecords = [
       networkRecord({headers: {
         'cache-control': 'max-age=31536000, public',
         'Cache-control': 'no-transform',
@@ -132,26 +134,26 @@ describe('Cache headers audit', () => {
       }}),
     ];
 
-    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+    return CacheHeadersAudit.audit(getArtifacts(networkRecords), {options}).then(result => {
       const items = result.extendedInfo.value.results;
       assert.equal(items.length, 1);
     });
   });
 
   it('catches records with Etags', () => {
-    networkRecords = [
+    const networkRecords = [
       networkRecord({headers: {etag: 'md5hashhere'}}),
       networkRecord({headers: {'etag': 'md5hashhere', 'cache-control': 'max-age=60'}}),
     ];
 
-    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+    return CacheHeadersAudit.audit(getArtifacts(networkRecords), {options}).then(result => {
       const items = result.extendedInfo.value.results;
       assert.equal(items.length, 2);
     });
   });
 
   it('ignores explicit no-cache policies', () => {
-    networkRecords = [
+    const networkRecords = [
       networkRecord({headers: {expires: '-1'}}),
       networkRecord({headers: {'cache-control': 'no-store'}}),
       networkRecord({headers: {'cache-control': 'no-cache'}}),
@@ -159,7 +161,7 @@ describe('Cache headers audit', () => {
       networkRecord({headers: {pragma: 'no-cache'}}),
     ];
 
-    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+    return CacheHeadersAudit.audit(getArtifacts(networkRecords), {options}).then(result => {
       const items = result.extendedInfo.value.results;
       assert.equal(result.score, 1);
       assert.equal(items.length, 0);
@@ -167,14 +169,14 @@ describe('Cache headers audit', () => {
   });
 
   it('ignores potentially uncacheable records', () => {
-    networkRecords = [
+    const networkRecords = [
       networkRecord({statusCode: 500}),
       networkRecord({url: 'https://example.com/dynamic.js?userId=crazy', transferSize: 10}),
       networkRecord({url: 'data:image/jpeg;base64,what'}),
       networkRecord({resourceType: NetworkRequest.TYPES.XHR}),
     ];
 
-    return CacheHeadersAudit.audit(artifacts, {options}).then(result => {
+    return CacheHeadersAudit.audit(getArtifacts(networkRecords), {options}).then(result => {
       assert.equal(result.score, 1);
       const items = result.extendedInfo.value.results;
       assert.equal(items.length, 1);

--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -7,7 +7,9 @@
 
 /* eslint-env jest */
 
+const Runner = require('../../runner.js');
 const CriticalRequestChains = require('../../audits/critical-request-chains.js');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 const assert = require('assert');
 
 const FAILING_REQUEST_CHAIN = {
@@ -70,17 +72,14 @@ const PASSING_REQUEST_CHAIN_2 = {
 const EMPTY_REQUEST_CHAIN = {};
 
 const mockArtifacts = (mockChain) => {
-  return {
+  return Object.assign(Runner.instantiateComputedArtifacts(), {
     devtoolsLogs: {
       [CriticalRequestChains.DEFAULT_PASS]: [],
-    },
-    requestNetworkRecords: () => {
-      return Promise.resolve([]);
     },
     requestCriticalRequestChains: function() {
       return Promise.resolve(mockChain);
     },
-  };
+  });
 };
 
 describe('Performance: critical-request-chains audit', () => {

--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -9,7 +9,6 @@
 
 const Runner = require('../../runner.js');
 const CriticalRequestChains = require('../../audits/critical-request-chains.js');
-const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 const assert = require('assert');
 
 const FAILING_REQUEST_CHAIN = {

--- a/lighthouse-core/test/audits/font-display-test.js
+++ b/lighthouse-core/test/audits/font-display-test.js
@@ -8,6 +8,8 @@
 const NetworkRequest = require('../../lib/network-request');
 const Audit = require('../../audits/font-display.js');
 const assert = require('assert');
+const Runner = require('../../runner.js');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 const openSansFont = {
@@ -34,11 +36,10 @@ const openSansFontBold = {
 
 describe('Performance: Font Display audit', () => {
   function getArtifacts(networkRecords, fonts) {
-    return {
-      devtoolsLogs: {[Audit.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    return Object.assign({
+      devtoolsLogs: {[Audit.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       Fonts: fonts,
-    };
+    }, Runner.instantiateComputedArtifacts());
   }
 
   it('fails when not all fonts have a correct font-display rule', () => {

--- a/lighthouse-core/test/audits/is-on-https-test.js
+++ b/lighthouse-core/test/audits/is-on-https-test.js
@@ -5,17 +5,19 @@
  */
 'use strict';
 
+const Runner = require('../../runner.js');
 const Audit = require('../../audits/is-on-https.js');
 const assert = require('assert');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
 describe('Security: HTTPS audit', () => {
   function getArtifacts(networkRecords) {
-    return {
-      devtoolsLogs: {[Audit.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
-    };
+    const devtoolsLog = networkRecordsToDevtoolsLog(networkRecords);
+    return Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[Audit.DEFAULT_PASS]: devtoolsLog},
+    });
   }
 
   it('fails when there is more than one insecure record', () => {

--- a/lighthouse-core/test/audits/mixed-content-test.js
+++ b/lighthouse-core/test/audits/mixed-content-test.js
@@ -7,22 +7,23 @@
 
 const Audit = require('../../audits/mixed-content.js');
 const assert = require('assert');
+const Runner = require('../../runner');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
 describe('Mixed Content audit', () => {
   function getArtifacts(baseUrl, defaultPassRecords, mixedContentPassRecords) {
-    return {
+    const defaultDevtoolsLog = networkRecordsToDevtoolsLog(defaultPassRecords);
+    const mixedContentDevtoolsLog = networkRecordsToDevtoolsLog(mixedContentPassRecords);
+
+    return Object.assign(Runner.instantiateComputedArtifacts(), {
       MixedContent: {url: baseUrl},
-      devtoolsLogs: {[Audit.DEFAULT_PASS]: true, ['mixedContentPass']: false},
-      requestNetworkRecords: (pass) => {
-        if (pass) {
-          return Promise.resolve(defaultPassRecords);
-        } else {
-          return Promise.resolve(mixedContentPassRecords);
-        }
+      devtoolsLogs: {
+        [Audit.DEFAULT_PASS]: defaultDevtoolsLog,
+        ['mixedContentPass']: mixedContentDevtoolsLog,
       },
-    };
+    });
   }
 
   it('passes when there are no insecure resources by default', () => {
@@ -55,7 +56,7 @@ describe('Mixed Content audit', () => {
       {url: 'https://example.org/', isSecure: true, finished: true, documentURL: 'http://example.org/'},
       {url: 'https://example.org/resource1.js', isSecure: true, finished: true, documentURL: 'https://example.org'},
       {url: 'https://third-party.example.com/resource2.js', isSecure: true, finished: true, documentURL: 'https://example.org'},
-      {url: 'https://fourth-party.example.com/resource3.js', isSecure: false, finished: true, documentURL: 'https://third-party.example.com'},
+      {url: 'https://fourth-party.example.com/resource3.js', isSecure: true, finished: true, documentURL: 'https://third-party.example.com'},
     ];
     return Audit.audit(
       getArtifacts('http://example.org', defaultRecords, upgradeRecords)

--- a/lighthouse-core/test/audits/network-requests-test.js
+++ b/lighthouse-core/test/audits/network-requests-test.js
@@ -8,6 +8,7 @@
 const NetworkRequests = require('../../audits/network-requests');
 const Runner = require('../../runner.js');
 const assert = require('assert');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 
 const acceptableDevToolsLog = require('../fixtures/traces/progressive-app-m60.devtools.log.json');
 
@@ -38,7 +39,11 @@ describe('Network requests audit', () => {
       {url: 'https://example.com/1', startTime: 15.5, endTime: -1},
     ];
 
-    const artifacts = {devtoolsLogs: {}, requestNetworkRecords: () => Promise.resolve(records)};
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {
+        [NetworkRequests.DEFAULT_PASS]: networkRecordsToDevtoolsLog(records),
+      },
+    });
     const output = await NetworkRequests.audit(artifacts);
     assert.equal(output.details.items[0].startTime, 0);
     assert.equal(output.details.items[0].endTime, 500);

--- a/lighthouse-core/test/audits/seo/http-status-code-test.js
+++ b/lighthouse-core/test/audits/seo/http-status-code-test.js
@@ -7,6 +7,8 @@
 
 const HTTPStatusCodeAudit = require('../../../audits/seo/http-status-code.js');
 const assert = require('assert');
+const Runner = require('../../../runner.js');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
@@ -15,14 +17,17 @@ describe('SEO: HTTP code audit', () => {
     const statusCodes = [403, 404, 500];
 
     const allRuns = statusCodes.map(statusCode => {
+      const finalUrl = 'https://example.com';
       const mainResource = {
+        url: finalUrl,
         statusCode,
       };
-      const artifacts = {
-        devtoolsLogs: {[HTTPStatusCodeAudit.DEFAULT_PASS]: []},
-        requestNetworkRecords: () => Promise.resolve(),
-        requestMainResource: () => Promise.resolve(mainResource),
-      };
+      const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+
+      const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+        devtoolsLogs: {[HTTPStatusCodeAudit.DEFAULT_PASS]: devtoolsLog},
+        URL: {finalUrl},
+      });
 
       return HTTPStatusCodeAudit.audit(artifacts).then(auditResult => {
         assert.equal(auditResult.rawValue, false);
@@ -34,15 +39,17 @@ describe('SEO: HTTP code audit', () => {
   });
 
   it('passes when status code is successful', () => {
+    const finalUrl = 'https://example.com';
     const mainResource = {
+      url: finalUrl,
       statusCode: 200,
     };
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
 
-    const artifacts = {
-      devtoolsLogs: {[HTTPStatusCodeAudit.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(),
-      requestMainResource: () => Promise.resolve(mainResource),
-    };
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[HTTPStatusCodeAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
+    });
 
     return HTTPStatusCodeAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);

--- a/lighthouse-core/test/audits/uses-rel-preconnect-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preconnect-test.js
@@ -10,6 +10,8 @@
 
 const UsesRelPreconnect = require('../../audits/uses-rel-preconnect.js');
 const assert = require('assert');
+const Runner = require('../../runner.js');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 
 const mainResource = {
   url: 'https://www.example.com/',
@@ -36,17 +38,13 @@ describe('Performance: uses-rel-preconnect audit', () => {
       mainResource,
       {
         url: 'https://www.example.com/request',
-        parsedURL: {
-          securityOrigin: 'https://www.example.com',
-        },
       },
     ];
-    const artifacts = {
-      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       requestMainResource: () => Promise.resolve(mainResource),
       requestLoadSimulator: () => Promise.resolve(simulator),
-    };
+    });
 
     const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
     assert.equal(score, 1);
@@ -62,12 +60,11 @@ describe('Performance: uses-rel-preconnect audit', () => {
         initiator: mainResource,
       },
     ];
-    const artifacts = {
-      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       requestMainResource: () => Promise.resolve(mainResource),
       requestLoadSimulator: () => Promise.resolve(simulator),
-    };
+    });
 
     const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
     assert.equal(score, 1);
@@ -83,12 +80,11 @@ describe('Performance: uses-rel-preconnect audit', () => {
         initiator: {},
       },
     ];
-    const artifacts = {
-      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       requestMainResource: () => Promise.resolve(mainResource),
       requestLoadSimulator: () => Promise.resolve(simulator),
-    };
+    });
 
     const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
     assert.equal(score, 1);
@@ -110,12 +106,11 @@ describe('Performance: uses-rel-preconnect audit', () => {
         },
       },
     ];
-    const artifacts = {
-      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       requestMainResource: () => Promise.resolve(mainResource),
       requestLoadSimulator: () => Promise.resolve(simulator),
-    };
+    });
 
     const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
     assert.equal(score, 1);
@@ -129,15 +124,14 @@ describe('Performance: uses-rel-preconnect audit', () => {
       {
         url: 'https://cdn.example.com/request',
         initiator: {},
-        _startTime: 16,
+        startTime: 16,
       },
     ];
-    const artifacts = {
-      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       requestMainResource: () => Promise.resolve(mainResource),
       requestLoadSimulator: () => Promise.resolve(simulator),
-    };
+    });
 
     const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
     assert.equal(score, 1);
@@ -151,10 +145,6 @@ describe('Performance: uses-rel-preconnect audit', () => {
       {
         url: 'https://cdn.example.com/first',
         initiator: {},
-        parsedURL: {
-          scheme: 'https',
-          securityOrigin: 'https://cdn.example.com',
-        },
         startTime: 2,
         timing: {
           dnsStart: 100,
@@ -165,10 +155,6 @@ describe('Performance: uses-rel-preconnect audit', () => {
       {
         url: 'https://cdn.example.com/second',
         initiator: {},
-        parsedURL: {
-          scheme: 'https',
-          securityOrigin: 'https://cdn.example.com',
-        },
         startTime: 3,
         timing: {
           dnsStart: 300,
@@ -177,12 +163,11 @@ describe('Performance: uses-rel-preconnect audit', () => {
         },
       },
     ];
-    const artifacts = {
-      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       requestMainResource: () => Promise.resolve(mainResource),
       requestLoadSimulator: () => Promise.resolve(simulator),
-    };
+    });
 
     const {rawValue, extendedInfo} = await UsesRelPreconnect.audit(artifacts, {});
     assert.equal(rawValue, 200);
@@ -196,12 +181,8 @@ describe('Performance: uses-rel-preconnect audit', () => {
     const networkRecords = [
       mainResource,
       {
-        url: 'https://cdn.example.com/first',
+        url: 'http://cdn.example.com/first',
         initiator: {},
-        parsedURL: {
-          scheme: 'http',
-          securityOrigin: 'http://cdn.example.com',
-        },
         startTime: 2,
         timing: {
           dnsStart: 100,
@@ -212,10 +193,6 @@ describe('Performance: uses-rel-preconnect audit', () => {
       {
         url: 'https://othercdn.example.com/second',
         initiator: {},
-        parsedURL: {
-          scheme: 'https',
-          securityOrigin: 'https://othercdn.example.com',
-        },
         startTime: 1.2,
         timing: {
           dnsStart: 100,
@@ -224,12 +201,11 @@ describe('Performance: uses-rel-preconnect audit', () => {
         },
       },
     ];
-    const artifacts = {
-      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: []},
-      requestNetworkRecords: () => Promise.resolve(networkRecords),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       requestMainResource: () => Promise.resolve(mainResource),
       requestLoadSimulator: () => Promise.resolve(simulator),
-    };
+    });
 
     simulatorOptions = {
       rtt: 100,

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -15,6 +15,7 @@ const assert = require('assert');
 const Runner = require('../../runner');
 const pwaTrace = require('../fixtures/traces/progressive-app-m60.json');
 const pwaDevtoolsLog = require('../fixtures/traces/progressive-app-m60.devtools.log.json');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 
 const defaultMainResource = {
   _endTime: 1,
@@ -25,16 +26,15 @@ describe('Performance: uses-rel-preload audit', () => {
   let mockSimulator;
 
   const mockArtifacts = (networkRecords, mainResource = defaultMainResource) => {
-    return {
+    return Object.assign(Runner.instantiateComputedArtifacts(), {
       traces: {[UsesRelPreload.DEFAULT_PASS]: {traceEvents: []}},
-      devtoolsLogs: {[UsesRelPreload.DEFAULT_PASS]: []},
+      devtoolsLogs: {[UsesRelPreload.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
       requestLoadSimulator: () => mockSimulator,
       requestPageDependencyGraph: () => mockGraph,
-      requestNetworkRecords: () => networkRecords,
       requestMainResource: () => {
         return Promise.resolve(mainResource);
       },
-    };
+    });
   };
 
   afterEach(() => {
@@ -50,11 +50,9 @@ describe('Performance: uses-rel-preload audit', () => {
     const networkRecords = [
       {
         requestId: '2',
-        resourceType: 'Document',
         priority: 'High',
         isLinkPreload: false,
         url: 'http://example.com:3000',
-        redirects: [''],
       },
       {
         requestId: '2:redirect',
@@ -62,7 +60,6 @@ describe('Performance: uses-rel-preload audit', () => {
         priority: 'High',
         isLinkPreload: false,
         url: 'http://www.example.com:3000',
-        redirects: [''],
       },
       {
         requestId: '3',
@@ -160,7 +157,7 @@ describe('Performance: uses-rel-preload audit', () => {
     const networkRecords = [
       {
         requestId: '3',
-        _startTime: 10,
+        startTime: 10,
         isLinkPreload: true,
         url: 'http://www.example.com/script.js',
       },
@@ -177,7 +174,7 @@ describe('Performance: uses-rel-preload audit', () => {
       {
         requestId: '3',
         protocol: 'data',
-        _startTime: 10,
+        startTime: 10,
       },
     ];
 
@@ -192,7 +189,7 @@ describe('Performance: uses-rel-preload audit', () => {
       {
         requestId: '3',
         protocol: 'blob',
-        _startTime: 10,
+        startTime: 10,
       },
     ];
 

--- a/lighthouse-core/test/gather/computed/main-resource-test.js
+++ b/lighthouse-core/test/gather/computed/main-resource-test.js
@@ -9,6 +9,7 @@
 
 const Runner = require('../../../runner.js');
 const assert = require('assert');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 describe('MainResource computed artifact', () => {
   let computedArtifacts;
@@ -25,11 +26,11 @@ describe('MainResource computed artifact', () => {
       {url: 'http://example.com'},
       record,
     ];
-    computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
     const URL = {finalUrl: 'https://example.com'};
+    const devtoolsLog = networkRecordsToDevtoolsLog(networkRecords);
 
-    return computedArtifacts.requestMainResource({URL}).then(output => {
-      assert.equal(output, record);
+    return computedArtifacts.requestMainResource({URL, devtoolsLog}).then(output => {
+      assert.equal(output.url, record.url);
     });
   });
 
@@ -37,10 +38,10 @@ describe('MainResource computed artifact', () => {
     const networkRecords = [
       {url: 'https://example.com'},
     ];
-    computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
     const URL = {finalUrl: 'https://m.example.com'};
+    const devtoolsLog = networkRecordsToDevtoolsLog(networkRecords);
 
-    return computedArtifacts.requestMainResource({URL}).then(() => {
+    return computedArtifacts.requestMainResource({URL, devtoolsLog}).then(() => {
       assert.ok(false, 'should have thrown');
     }).catch(err => {
       assert.equal(err.message, 'Unable to identify the main resource');
@@ -63,9 +64,9 @@ describe('MainResource computed artifact', () => {
       {url: 'https://beta.httparchive.org/reports/state-of-the-web'},
     ];
 
-    computedArtifacts.requestNetworkRecords = _ => Promise.resolve(networkRecords);
     const URL = {finalUrl: 'https://beta.httparchive.org/reports/state-of-the-web#pctHttps'};
-    const artifacts = {URL};
+    const devtoolsLog = networkRecordsToDevtoolsLog(networkRecords);
+    const artifacts = {URL, devtoolsLog};
 
     return computedArtifacts.requestMainResource(artifacts).then(output => {
       assert.equal(output.url, 'https://beta.httparchive.org/reports/state-of-the-web');

--- a/lighthouse-core/test/network-records-to-devtools-log.js
+++ b/lighthouse-core/test/network-records-to-devtools-log.js
@@ -1,0 +1,210 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const NetworkRecorder = require('../../lighthouse-core/lib/network-recorder.js');
+/** @typedef {import('../../lighthouse-core/lib/network-request.js')} NetworkRequest */
+
+const idBase = '127122';
+const exampleUrl = 'https://testingurl.com/';
+const redirectSuffix = ':redirect';
+
+/* eslint-env jest */
+
+/**
+ * Extract requestId without any `:redirect` strings.
+ * @param {Partial<NetworkRequest>} requestId
+ */
+function getBaseRequestId(record) {
+  if (!record.requestId) return;
+
+  const match = /^([\w.]+)(?::redirect)*$/.exec(record.requestId);
+  return match && match[1];
+}
+
+/**
+ * @param {Array<HeaderEntry>=} headersArray
+ * @return {LH.Crdp.Network.Headers}
+ */
+function headersArrayToHeadersDict(headersArray = []) {
+  const headersDict = {};
+  headersArray.forEach(headerItem => {
+    const value = headersDict[headerItem.name] ? headersDict[headerItem.name] + '\n' : '';
+    headersDict[headerItem.name] = value + headerItem.value;
+  });
+
+  return headersDict;
+}
+
+/**
+ * @param {Partial<NetworkRequest>} networkRecord
+ * @return {LH.Protocol.RawEventMessage}
+ */
+function getRequestWillBeSentEvent(networkRecord, index) {
+  const initiator = networkRecord.isLinkPreload ? {type: 'preload'} :
+      networkRecord.initiator || {type: 'other'};
+
+  return {
+    method: 'Network.requestWillBeSent',
+    params: {
+      requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
+      documentURL: networkRecord.documentURL || exampleUrl,
+      request: {
+        url: networkRecord.url || exampleUrl,
+        method: networkRecord.requestMethod || 'GET',
+        headers: {},
+        initialPriority: networkRecord.priority || 'Low',
+      },
+      timestamp: networkRecord.startTime || 0,
+      wallTime: 0,
+      initiator: initiator,
+      type: networkRecord.resourceType || 'Document',
+      frameId: `${idBase}.1`,
+      redirectResponse: networkRecord.redirectResponse,
+    },
+  };
+}
+
+/**
+ * @param {Partial<NetworkRequest>} networkRecord
+ * @return {LH.Protocol.RawEventMessage}
+ */
+function getResponseReceivedEvent(networkRecord, index) {
+  const headers = headersArrayToHeadersDict(networkRecord.responseHeaders);
+  const timing = networkRecord.timing;
+  if (timing && timing.requestTime === undefined) {
+    timing.requestTime = networkRecord.startTime || 0;
+  }
+
+  return {
+    method: 'Network.responseReceived',
+    params: {
+      requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
+      timestamp: networkRecord.responseReceivedTime || 1,
+      type: networkRecord.resourceType || undefined,
+      response: {
+        url: networkRecord.url || exampleUrl,
+        status: networkRecord.statusCode || 200,
+        headers,
+        mimeType: networkRecord.mimeType || 'text/html',
+        connectionReused: networkRecord.connectionReused || false,
+        connectionId: networkRecord.connectionId || 140,
+        fromDiskCache: networkRecord.fromDiskCache || undefined,
+        fromServiceWorker: networkRecord.fromServiceWorker || undefined,
+        encodedDataLength: networkRecord.transferSize || 0,
+        timing,
+        protocol: networkRecord.protocol || 'http/1.1',
+      },
+      frameId: `${idBase}.1`,
+    },
+  };
+}
+
+/**
+ * @param {Partial<NetworkRequest>} networkRecord
+ * @return {LH.Protocol.RawEventMessage}
+ */
+function getDataReceivedEvent(networkRecord, index) {
+  return {
+    method: 'Network.dataReceived',
+    params: {
+      requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
+      dataLength: networkRecord.resourceSize || 0,
+      encodedDataLength: networkRecord.transferSize || 0,
+    },
+  };
+}
+
+/**
+ * @param {Partial<NetworkRequest>} networkRecord
+ * @return {LH.Protocol.RawEventMessage}
+ */
+function getLoadingFinishedEvent(networkRecord, index) {
+  return {
+    method: 'Network.loadingFinished',
+    params: {
+      requestId: getBaseRequestId(networkRecord) || `${idBase}.${index}`,
+      timestamp: networkRecord.endTime || 3,
+      encodedDataLength: networkRecord.transferSize || 0,
+    },
+  };
+}
+
+/**
+ * Returns true if `record` is redirected by another record.
+ * @param {Array<Partial<NetworkRequest>>} networkRecords
+ * @param {Partial<NetworkRequest>} record
+ * @return {boolean}
+ */
+function willBeRedirected(networkRecords, record) {
+  if (!record.requestId) {
+    return false;
+  }
+
+  const redirectId = record.requestId + redirectSuffix;
+  return networkRecords.some(otherRecord => otherRecord.requestId === redirectId);
+}
+
+/**
+ * If `record` is a redirect of another record, create a fake redirect respose
+ * to keep the original request defined correctly.
+ * @param {Array<Partial<NetworkRequest>>} networkRecords
+ * @param {Partial<NetworkRequest>} record
+ * @return {Partial<NetworkRequest>}
+ */
+function addRedirectResponseIfNeeded(networkRecords, record) {
+  if (!record.requestId || !record.requestId.endsWith(redirectSuffix)) {
+    return record;
+  }
+
+  const originalId = record.requestId.slice(0, -redirectSuffix.length);
+  const originalRecord = networkRecords.find(record => record.requestId === originalId);
+  if (!originalRecord) {
+    throw new Error(`redirect with id ${record.requestId} has no original request`);
+  }
+
+  // populate `redirectResponse` with original's data, more or less.
+  const originalResponse = getResponseReceivedEvent(originalRecord).params.response;
+  originalResponse.status = originalRecord.statusCode || 302;
+  return Object.assign({}, record, {redirectResponse: originalResponse});
+}
+
+/**
+ * Generate a devtoolsLog that can regenerate the passed-in `networkRecords`.
+ * Generally best at replicating artificial or pruned networkRecords used for
+ * testing. If run from a test runner, verifies that everything in
+ * `networkRecords` will be in any network records generated from the output
+ * (use `skipVerification` to manually skip this assertion).
+ * @param {Array<Partial<NetworkRequest>>} networkRecords
+ * @param {{skipVerification?: boolean}=} options
+ * @return {LH.DevtoolsLog}
+ */
+function networkRecordsToDevtoolsLog(networkRecords, options = {}) {
+  const devtoolsLog = [];
+  networkRecords.forEach((networkRecord, index) => {
+    networkRecord = addRedirectResponseIfNeeded(networkRecords, networkRecord);
+    devtoolsLog.push(getRequestWillBeSentEvent(networkRecord, index));
+
+    if (willBeRedirected(networkRecords, networkRecord)) {
+      // If record is going to redirect, only issue the first event.
+      return;
+    }
+
+    devtoolsLog.push(getResponseReceivedEvent(networkRecord, index));
+    devtoolsLog.push(getDataReceivedEvent(networkRecord, index));
+    devtoolsLog.push(getLoadingFinishedEvent(networkRecord, index));
+  });
+
+  // If in a test, assert that the log will turn into an equivalent networkRecords.
+  if (global.expect && !options.skipVerification) {
+    const roundTrippedNetworkRecords = NetworkRecorder.recordsFromLogs(devtoolsLog);
+    expect(roundTrippedNetworkRecords).toMatchObject(networkRecords);
+  }
+
+  return devtoolsLog;
+}
+
+module.exports = networkRecordsToDevtoolsLog;


### PR DESCRIPTION
This came up while refactoring computed artifacts and I've separated it to keep the PRs simpler. Since we'll be requiring files normally, we can't just inject `requestNetworkRecords` into tests anymore (at least not as easily).

We have a lot of places that we want to pass in example/simplified `networkRecords`, however our core artifact for network activity is the `devtoolsLog`. This PR adds a simple test utility that will create a `devtoolsLog` that, when passed back into `NetworkRecorder`, will create `networkRecords` with all the same properties.

Very simple records can be passed in (good for tests! e.g. just `[{url: 'https://example.com}]`) and the rest of the needed properties will be filled in with reasonable-ish defaults.

I've gone through all the existing tests that were mocking `requestNetworkRecords: () => Promise.resolve(records)` to use a generated devtoolsLog instead.