### PR TITLE
fix(axe): disable unused audits

### DIFF
--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -33,8 +33,9 @@ function runA11yChecks() {
     resultTypes: ['violations', 'inapplicable'],
     rules: {
       'tabindex': {enabled: true},
-      'table-fake-caption': {enabled: true},
-      'td-has-header': {enabled: true},
+      'table-fake-caption': {enabled: false},
+      'td-has-header': {enabled: false},
+      'marquee': {enabled: false},
       'area-alt': {enabled: false},
       'blink': {enabled: false},
       'server-side-image-map': {enabled: false},


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Disable axe audits:
table-fake-caption
td-has-header
marquee

diff can be found here
https://www.diffchecker.com/1S1zqgRH
```
axeResult.violations.map(x => x.id).concat(axeResult.inapplicable.map(x => x.id)).concat(axeResult.incomplete.map(x => x.id)).concat(axeResult.passes.map(x => x.id))
```

<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
#6169