### PR TITLE
tests: remove more mock computed artifacts

### DIFF
--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -10,80 +10,76 @@
 const Runner = require('../../runner.js');
 const CriticalRequestChains = require('../../audits/critical-request-chains.js');
 const assert = require('assert');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 
-const FAILING_REQUEST_CHAIN = {
-  0: {
-    request: {
-      endTime: 1,
-      responseReceivedTime: 5,
-      startTime: 0,
+const FAILING_CHAIN_RECORDS = [
+  {
+    endTime: 5,
+    responseReceivedTime: 5,
+    startTime: 0,
+    url: 'https://example.com/',
+    priority: 'VeryHigh',
+  }, {
+    endTime: 16,
+    responseReceivedTime: 14,
+    startTime: 11,
+    url: 'https://example.com/b.js',
+    priority: 'VeryHigh',
+    initiator: {
+      type: 'parser',
       url: 'https://example.com/',
     },
-    children: {
-      1: {
-        request: {
-          endTime: 16,
-          responseReceivedTime: 14,
-          startTime: 11,
-          url: 'https://example.com/b.js',
-        },
-        children: {
-        },
-      },
-      2: {
-        request: {
-          endTime: 17,
-          responseReceivedTime: 15,
-          startTime: 12,
-          url: 'https://example.com/c.js',
-        },
-        children: {},
-      },
-    },
-  },
-};
-
-const PASSING_REQUEST_CHAIN = {
-  0: {
-    request: {
-      endTime: 1,
-      responseReceivedTime: 5,
-      startTime: 0,
+  }, {
+    endTime: 17,
+    responseReceivedTime: 15,
+    startTime: 12,
+    url: 'https://example.com/c.js',
+    priority: 'VeryHigh',
+    initiator: {
+      type: 'parser',
       url: 'https://example.com/',
     },
-    children: {},
   },
-};
+];
 
-const PASSING_REQUEST_CHAIN_2 = {
-  13653.1: {
-    request: {
-      url: 'http://localhost:10503/offline-ready.html',
-      startTime: 33552.036878,
-      endTime: 33552.285438,
-      responseReceivedTime: 33552.275677,
-      transferSize: 1849,
-    },
-    children: {},
+const PASSING_CHAIN_RECORDS = [
+  {
+    endTime: 1,
+    responseReceivedTime: 1,
+    startTime: 0,
+    url: 'https://example.com/',
+    priority: 'VeryHigh',
   },
-};
+];
 
-const EMPTY_REQUEST_CHAIN = {};
+const PASSING_CHAIN_RECORDS_2 = [
+  {
+    url: 'http://localhost:10503/offline-ready.html',
+    startTime: 33552.036878,
+    endTime: 33552.285438,
+    responseReceivedTime: 33552.275677,
+    transferSize: 1849,
+    priority: 'VeryHigh',
+  },
+];
 
-const mockArtifacts = (mockChain) => {
+const EMPTY_CHAIN_RECORDS = [];
+
+const mockArtifacts = (chainNetworkRecords) => {
+  const devtoolsLog = networkRecordsToDevtoolsLog(chainNetworkRecords);
+  const finalUrl = chainNetworkRecords[0] ? chainNetworkRecords[0].url : 'https://example.com';
+
   return Object.assign(Runner.instantiateComputedArtifacts(), {
     devtoolsLogs: {
-      [CriticalRequestChains.DEFAULT_PASS]: [],
+      [CriticalRequestChains.DEFAULT_PASS]: devtoolsLog,
     },
-    requestCriticalRequestChains: function() {
-      return Promise.resolve(mockChain);
-    },
+    URL: {finalUrl},
   });
 };
 
 describe('Performance: critical-request-chains audit', () => {
   it('calculates the correct chain result for failing example', () => {
-    return CriticalRequestChains.audit(mockArtifacts(FAILING_REQUEST_CHAIN)).then(output => {
+    return CriticalRequestChains.audit(mockArtifacts(FAILING_CHAIN_RECORDS)).then(output => {
       expect(output.displayValue).toBeDisplayString('2 chains found');
       assert.equal(output.rawValue, false);
       assert.ok(output.details);
@@ -91,7 +87,7 @@ describe('Performance: critical-request-chains audit', () => {
   });
 
   it('calculates the correct chain result for passing example', () => {
-    return CriticalRequestChains.audit(mockArtifacts(PASSING_REQUEST_CHAIN)).then(output => {
+    return CriticalRequestChains.audit(mockArtifacts(PASSING_CHAIN_RECORDS)).then(output => {
       assert.equal(output.details.longestChain.duration, 1000);
       assert.equal(output.displayValue, '');
       assert.equal(output.rawValue, true);
@@ -99,16 +95,17 @@ describe('Performance: critical-request-chains audit', () => {
   });
 
   it('calculates the correct chain result for passing example (no 2.)', () => {
-    return CriticalRequestChains.audit(mockArtifacts(PASSING_REQUEST_CHAIN_2)).then(output => {
+    return CriticalRequestChains.audit(mockArtifacts(PASSING_CHAIN_RECORDS_2)).then(output => {
       assert.equal(output.displayValue, '');
       assert.equal(output.rawValue, true);
     });
   });
 
-  it('calculates the correct chain result for empty example', () => {
-    return CriticalRequestChains.audit(mockArtifacts(EMPTY_REQUEST_CHAIN)).then(output => {
-      assert.equal(output.displayValue, '');
-      assert.equal(output.rawValue, true);
+  it('throws an error for no main resource found for empty example', () => {
+    return CriticalRequestChains.audit(mockArtifacts(EMPTY_CHAIN_RECORDS)).then(_ => {
+      throw new Error('should have failed');
+    }).catch(err => {
+      assert.ok(err.message.includes('Unable to identify the main resource'));
     });
   });
 });

--- a/lighthouse-core/test/audits/metrics/speed-index-test.js
+++ b/lighthouse-core/test/audits/metrics/speed-index-test.js
@@ -28,19 +28,4 @@ describe('Performance: speed-index audit', () => {
       assert.equal(result.rawValue, 605);
     });
   }, 10000);
-
-  it('scores speed index of 845 as 100', () => {
-    const artifacts = {
-      traces: {},
-      devtoolsLogs: {},
-      requestSpeedIndex() {
-        return Promise.resolve({timing: 845});
-      },
-    };
-
-    return Audit.audit(artifacts, {options}).then(result => {
-      assert.equal(result.score, 1);
-      assert.equal(result.rawValue, 845);
-    });
-  });
 });

--- a/lighthouse-core/test/audits/screenshot-thumbnails-test.js
+++ b/lighthouse-core/test/audits/screenshot-thumbnails-test.js
@@ -72,7 +72,6 @@ describe('Screenshot thumbnails', () => {
     const artifacts = Object.assign({
       traces: {defaultPass: pwaTrace},
     }, computedArtifacts);
-    computedArtifacts.requestInteractive = () => ({timing: 20000});
 
     return ScreenshotThumbnailsAudit.audit(artifacts, {settings, options}).then(results => {
       assert.equal(results.details.items[0].timing, 82);
@@ -93,12 +92,17 @@ describe('Screenshot thumbnails', () => {
   });
 
   it('should handle nonsense times', async () => {
+    const infiniteTrace = JSON.parse(JSON.stringify(pwaTrace));
+    infiniteTrace.traceEvents.forEach(event => {
+      if (event.name === 'Screenshot') {
+        event.ts = Infinity;
+      }
+    });
+
     const settings = {throttlingMethod: 'simulate'};
-    const artifacts = {
-      traces: {},
-      requestSpeedline: () => ({frames: [], complete: false, beginning: -1}),
-      requestInteractive: () => ({timing: NaN}),
-    };
+    const artifacts = Object.assign({
+      traces: {defaultPass: infiniteTrace},
+    }, computedArtifacts);
 
     try {
       await ScreenshotThumbnailsAudit.audit(artifacts, {settings, options: {}});

--- a/lighthouse-core/test/audits/seo/canonical-test.js
+++ b/lighthouse-core/test/audits/seo/canonical-test.js
@@ -7,21 +7,25 @@
 
 const CanonicalAudit = require('../../../audits/seo/canonical.js');
 const assert = require('assert');
+const Runner = require('../../../runner.js');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
 describe('SEO: Document has valid canonical link', () => {
   it('succeeds when there are no canonical links', () => {
+    const finalUrl = 'https://example.com/';
     const mainResource = {
-      url: 'https://example.com/',
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: [],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -29,19 +33,21 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('fails when there are multiple canonical links', () => {
+    const finalUrl = 'http://www.example.com/';
     const mainResource = {
-      url: 'http://www.example.com/',
+      url: finalUrl,
       responseHeaders: [{
         name: 'Link',
         value: '<https://example.com>; rel="canonical"',
       }],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: ['https://www.example.com'],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, false);
@@ -50,16 +56,18 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('fails when canonical url is invalid', () => {
+    const finalUrl = 'http://www.example.com';
     const mainResource = {
-      url: 'http://www.example.com',
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: ['https:// example.com'],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, false);
@@ -68,16 +76,18 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('fails when canonical url is relative', () => {
+    const finalUrl = 'https://example.com/de/';
     const mainResource = {
-      url: 'https://example.com/de/',
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: ['/'],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, false);
@@ -86,19 +96,21 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('fails when canonical points to a different hreflang', () => {
+    const finalUrl = 'https://example.com';
     const mainResource = {
-      url: 'https://example.com',
+      url: finalUrl,
       responseHeaders: [{
         name: 'Link',
         value: '<https://example.com/>; rel="alternate"; hreflang="xx"',
       }],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: ['https://example.com/fr/'],
       Hreflang: [{href: 'https://example.com/fr/'}],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, false);
@@ -107,16 +119,18 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('fails when canonical points to a different domain', () => {
+    const finalUrl = 'http://localhost.test';
     const mainResource = {
-      url: 'http://localhost.test',
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: ['https://example.com/'],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, false);
@@ -125,16 +139,18 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('fails when canonical points to the root while current URL is not the root', () => {
+    const finalUrl = 'https://example.com/articles/cats-and-you';
     const mainResource = {
-      url: 'https://example.com/articles/cats-and-you',
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: ['https://example.com/'],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, false);
@@ -143,19 +159,21 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('succeeds when there are multiple identical canonical links', () => {
+    const finalUrl = 'http://www.example.com/';
     const mainResource = {
-      url: 'http://www.example.com/',
+      url: finalUrl,
       responseHeaders: [{
         name: 'Link',
         value: '<https://www.example.com>; rel="canonical"',
       }],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: ['https://www.example.com'],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -163,16 +181,18 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('succeeds when valid canonical is provided via meta tag', () => {
+    const finalUrl = 'http://example.com/articles/cats-and-you?utm_source=twitter';
     const mainResource = {
-      url: 'http://example.com/articles/cats-and-you?utm_source=twitter',
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: ['https://example.com/articles/cats-and-you'],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -180,19 +200,21 @@ describe('SEO: Document has valid canonical link', () => {
   });
 
   it('succeeds when valid canonical is provided via header', () => {
+    const finalUrl = 'http://example.com/articles/cats-and-you?utm_source=twitter';
     const mainResource = {
-      url: 'http://example.com/articles/cats-and-you?utm_source=twitter',
+      url: finalUrl,
       responseHeaders: [{
         name: 'Link',
         value: '<http://example.com/articles/cats-and-you>; rel="canonical"',
       }],
     };
-    const artifacts = {
-      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[CanonicalAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Canonical: [],
       Hreflang: [],
-    };
+    });
 
     return CanonicalAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);

--- a/lighthouse-core/test/audits/seo/hreflang-test.js
+++ b/lighthouse-core/test/audits/seo/hreflang-test.js
@@ -7,6 +7,8 @@
 
 const HreflangAudit = require('../../../audits/seo/hreflang.js');
 const assert = require('assert');
+const Runner = require('../../../runner.js');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
@@ -21,17 +23,20 @@ describe('SEO: Document has valid hreflang code', () => {
     ];
 
     const allRuns = hreflangValues.map(hreflangValue => {
+      const finalUrl = 'https://example.com';
       const mainResource = {
+        url: finalUrl,
         responseHeaders: [],
       };
-      const artifacts = {
-        devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
-        requestMainResource: () => Promise.resolve(mainResource),
+      const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+      const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+        devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: devtoolsLog},
+        URL: {finalUrl},
         Hreflang: [{
           hreflang: hreflangValue,
           href: 'https://example.com',
         }],
-      };
+      });
 
       return HreflangAudit.audit(artifacts).then(auditResult => {
         assert.equal(auditResult.rawValue, false);
@@ -43,12 +48,15 @@ describe('SEO: Document has valid hreflang code', () => {
   });
 
   it('succeeds when language code provided via link element is valid', () => {
+    const finalUrl = 'https://example.com';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Hreflang: [
         {hreflang: 'pl'},
         {hreflang: 'nl-be'},
@@ -56,7 +64,7 @@ describe('SEO: Document has valid hreflang code', () => {
         {hreflang: 'x-default'},
         {hreflang: 'FR-BE'},
       ],
-    };
+    });
 
     return HreflangAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -64,14 +72,17 @@ describe('SEO: Document has valid hreflang code', () => {
   });
 
   it('succeeds when there are no rel=alternate link elements nor headers', () => {
+    const finalUrl = 'https://example.com';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Hreflang: [],
-    };
+    });
 
     return HreflangAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -99,14 +110,17 @@ describe('SEO: Document has valid hreflang code', () => {
     ];
 
     const allRuns = linkHeaders.map(headers => {
+      const finalUrl = 'https://example.com';
       const mainResource = {
+        url: finalUrl,
         responseHeaders: headers,
       };
-      const artifacts = {
-        devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
-        requestMainResource: () => Promise.resolve(mainResource),
+      const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+      const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+        devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: devtoolsLog},
+        URL: {finalUrl},
         Hreflang: null,
-      };
+      });
 
       return HreflangAudit.audit(artifacts).then(auditResult => {
         assert.equal(auditResult.rawValue, false);
@@ -118,7 +132,9 @@ describe('SEO: Document has valid hreflang code', () => {
   });
 
   it('succeeds when language codes provided via Link header are valid', () => {
+    const finalUrl = 'https://example.com';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [
         {name: 'link', value: ''},
         {name: 'link', value: 'garbage'},
@@ -128,11 +144,12 @@ describe('SEO: Document has valid hreflang code', () => {
         {name: 'LINK', value: '<http://es.example.com/>; rel="alternate"; hreflang="es",<http://fr.example.com/>; rel="alternate"; Hreflang="fr-be"'},
       ],
     };
-    const artifacts = {
-      devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Hreflang: null,
-    };
+    });
 
     return HreflangAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -140,21 +157,24 @@ describe('SEO: Document has valid hreflang code', () => {
   });
 
   it('returns all failing items', () => {
+    const finalUrl = 'https://example.com';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [
         {name: 'link', value: '<http://xx1.example.com/>; rel="alternate"; hreflang="xx1"'},
         {name: 'Link', value: '<http://xx2.example.com/>; rel="alternate"; hreflang="xx2"'},
       ],
     };
-    const artifacts = {
-      devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[HreflangAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       Hreflang: [{
         hreflang: 'xx3',
       }, {
         hreflang: 'xx4',
       }],
-    };
+    });
 
     return HreflangAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, false);

--- a/lighthouse-core/test/audits/seo/is-crawlable-test.js
+++ b/lighthouse-core/test/audits/seo/is-crawlable-test.js
@@ -7,6 +7,8 @@
 
 const IsCrawlableAudit = require('../../../audits/seo/is-crawlable.js');
 const assert = require('assert');
+const Runner = require('../../../runner.js');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 
@@ -23,15 +25,18 @@ describe('SEO: Is page crawlable audit', () => {
     ];
 
     const allRuns = robotsValues.map(robotsValue => {
+      const finalUrl = 'https://example.com/';
       const mainResource = {
+        url: finalUrl,
         responseHeaders: [],
       };
-      const artifacts = {
-        devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-        requestMainResource: () => Promise.resolve(mainResource),
+      const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+      const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+        devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+        URL: {finalUrl},
         MetaRobots: robotsValue,
         RobotsTxt: {},
-      };
+      });
 
       return IsCrawlableAudit.audit(artifacts).then(auditResult => {
         assert.equal(auditResult.rawValue, false);
@@ -43,15 +48,19 @@ describe('SEO: Is page crawlable audit', () => {
   });
 
   it('succeeds when there are no blocking directives in the metatag', () => {
+    const finalUrl = 'https://example.com/';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       requestMainResource: () => Promise.resolve(mainResource),
       MetaRobots: 'all, noarchive',
       RobotsTxt: {},
-    };
+    });
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -59,15 +68,18 @@ describe('SEO: Is page crawlable audit', () => {
   });
 
   it('succeeds when there is no robots metatag', () => {
+    const finalUrl = 'https://example.com/';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       MetaRobots: null,
       RobotsTxt: {},
-    };
+    });
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -98,15 +110,18 @@ describe('SEO: Is page crawlable audit', () => {
     ];
 
     const allRuns = robotsHeaders.map(headers => {
+      const finalUrl = 'https://example.com/';
       const mainResource = {
+        url: finalUrl,
         responseHeaders: headers,
       };
-      const artifacts = {
-        devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-        requestMainResource: () => Promise.resolve(mainResource),
+      const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+      const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+        devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+        URL: {finalUrl},
         MetaRobots: null,
         RobotsTxt: {},
-      };
+      });
 
       return IsCrawlableAudit.audit(artifacts).then(auditResult => {
         assert.equal(auditResult.rawValue, false);
@@ -118,18 +133,21 @@ describe('SEO: Is page crawlable audit', () => {
   });
 
   it('succeeds when there are no blocking directives in the robots header', () => {
+    const finalUrl = 'https://example.com/';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [
         {name: 'X-Robots-Tag', value: 'all, nofollow'},
         {name: 'X-Robots-Tag', value: 'unavailable_after: 25 Jun 2045 15:00:00 PST'},
       ],
     };
-    const artifacts = {
-      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       MetaRobots: null,
       RobotsTxt: {},
-    };
+    });
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -137,15 +155,18 @@ describe('SEO: Is page crawlable audit', () => {
   });
 
   it('succeeds when there is no robots header and robots.txt is unavailable', () => {
+    const finalUrl = 'https://example.com/';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [],
     };
-    const artifacts = {
-      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       MetaRobots: null,
       RobotsTxt: {},
-    };
+    });
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -153,18 +174,21 @@ describe('SEO: Is page crawlable audit', () => {
   });
 
   it('ignores UA specific directives', () => {
+    const finalUrl = 'https://example.com/';
     const mainResource = {
+      url: finalUrl,
       responseHeaders: [
         {name: 'x-robots-tag', value: 'googlebot: unavailable_after: 25 Jun 2007 15:00:00 PST'},
         {name: 'x-robots-tag', value: 'unavailable_after: 25 Jun 2045 15:00:00 PST'},
       ],
     };
-    const artifacts = {
-      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       MetaRobots: null,
       RobotsTxt: {},
-    };
+    });
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, true);
@@ -200,16 +224,18 @@ describe('SEO: Is page crawlable audit', () => {
     ];
 
     const allRuns = robotsTxts.map(robotsTxt => {
+      const finalUrl = 'http://example.com/test/page.html';
       const mainResource = {
-        url: 'http://example.com/test/page.html',
+        url: finalUrl,
         responseHeaders: [],
       };
-      const artifacts = {
-        devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-        requestMainResource: () => Promise.resolve(mainResource),
+      const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+      const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+        devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+        URL: {finalUrl},
         MetaRobots: null,
         RobotsTxt: robotsTxt,
-      };
+      });
 
       return IsCrawlableAudit.audit(artifacts).then(auditResult => {
         assert.equal(auditResult.rawValue, false);
@@ -236,16 +262,18 @@ describe('SEO: Is page crawlable audit', () => {
     ];
 
     const allRuns = robotsTxts.map(robotsTxt => {
+      const finalUrl = 'http://example.com/test/page.html';
       const mainResource = {
-        url: 'http://example.com/test/page.html',
+        url: finalUrl,
         responseHeaders: [],
       };
-      const artifacts = {
-        devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-        requestMainResource: () => Promise.resolve(mainResource),
+      const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+      const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+        devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+        URL: {finalUrl},
         MetaRobots: null,
         RobotsTxt: robotsTxt,
-      };
+      });
 
       return IsCrawlableAudit.audit(artifacts).then(auditResult => {
         assert.equal(auditResult.rawValue, true);
@@ -256,8 +284,9 @@ describe('SEO: Is page crawlable audit', () => {
   });
 
   it('returns all failing items', () => {
+    const finalUrl = 'http://example.com/test/page.html';
     const mainResource = {
-      url: 'http://example.com/test/page.html',
+      url: finalUrl,
       responseHeaders: [
         {name: 'x-robots-tag', value: 'none'},
         {name: 'x-robots-tag', value: 'noindex'},
@@ -267,12 +296,13 @@ describe('SEO: Is page crawlable audit', () => {
       content: `User-agent: *
       Disallow: /`,
     };
-    const artifacts = {
-      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[IsCrawlableAudit.DEFAULT_PASS]: devtoolsLog},
+      URL: {finalUrl},
       MetaRobots: 'noindex',
       RobotsTxt: robotsTxt,
-    };
+    });
 
     return IsCrawlableAudit.audit(artifacts).then(auditResult => {
       assert.equal(auditResult.rawValue, false);

--- a/lighthouse-core/test/audits/time-to-first-byte-test.js
+++ b/lighthouse-core/test/audits/time-to-first-byte-test.js
@@ -7,6 +7,8 @@
 
 const TimeToFirstByte = require('../../audits/time-to-first-byte.js');
 const assert = require('assert');
+const Runner = require('../../runner.js');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 describe('Performance: time-to-first-byte audit', () => {
@@ -16,12 +18,12 @@ describe('Performance: time-to-first-byte audit', () => {
       requestId: '0',
       timing: {receiveHeadersEnd: 830, sendEnd: 200},
     };
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
 
-    const artifacts = {
-      devtoolsLogs: {[TimeToFirstByte.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[TimeToFirstByte.DEFAULT_PASS]: devtoolsLog},
       URL: {finalUrl: 'https://example.com/'},
-    };
+    });
 
     return TimeToFirstByte.audit(artifacts).then(result => {
       assert.strictEqual(result.rawValue, 630);
@@ -35,12 +37,12 @@ describe('Performance: time-to-first-byte audit', () => {
       requestId: '0',
       timing: {receiveHeadersEnd: 400, sendEnd: 200},
     };
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
 
-    const artifacts = {
-      devtoolsLogs: {[TimeToFirstByte.DEFAULT_PASS]: []},
-      requestMainResource: () => Promise.resolve(mainResource),
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      devtoolsLogs: {[TimeToFirstByte.DEFAULT_PASS]: devtoolsLog},
       URL: {finalUrl: 'https://example.com/'},
-    };
+    });
 
     return TimeToFirstByte.audit(artifacts).then(result => {
       assert.strictEqual(result.rawValue, 200);

--- a/lighthouse-core/test/audits/uses-rel-preconnect-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preconnect-test.js
@@ -22,31 +22,20 @@ const mainResource = {
 };
 
 describe('Performance: uses-rel-preconnect audit', () => {
-  let simulator;
-  let simulatorOptions;
-
-  beforeEach(() => {
-    simulator = {getOptions: () => simulatorOptions};
-    simulatorOptions = {
-      rtt: 100,
-      additionalRttByOrigin: new Map(),
-    };
-  });
-
   it(`shouldn't suggest preconnect for same origin`, async () => {
     const networkRecords = [
       mainResource,
       {
         url: 'https://www.example.com/request',
+        timing: {receiveHeadersEnd: 3},
       },
     ];
     const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
-      requestMainResource: () => Promise.resolve(mainResource),
-      requestLoadSimulator: () => Promise.resolve(simulator),
+      URL: {finalUrl: mainResource.url},
     });
 
-    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
+    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {settings: {}});
     assert.equal(score, 1);
     assert.equal(rawValue, 0);
     assert.equal(details.items.length, 0);
@@ -57,16 +46,19 @@ describe('Performance: uses-rel-preconnect audit', () => {
       mainResource,
       {
         url: 'https://cdn.example.com/request',
-        initiator: mainResource,
+        initiator: {
+          type: 'parser',
+          url: mainResource.url,
+        },
+        timing: {receiveHeadersEnd: 3},
       },
     ];
     const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
-      requestMainResource: () => Promise.resolve(mainResource),
-      requestLoadSimulator: () => Promise.resolve(simulator),
+      URL: {finalUrl: mainResource.url},
     });
 
-    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
+    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {settings: {}});
     assert.equal(score, 1);
     assert.equal(rawValue, 0);
     assert.equal(details.items.length, 0);
@@ -78,15 +70,15 @@ describe('Performance: uses-rel-preconnect audit', () => {
       {
         url: 'data:text/plain;base64,hello',
         initiator: {},
+        timing: {receiveHeadersEnd: 3},
       },
     ];
     const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
-      requestMainResource: () => Promise.resolve(mainResource),
-      requestLoadSimulator: () => Promise.resolve(simulator),
+      URL: {finalUrl: mainResource.url},
     });
 
-    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
+    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {settings: {}});
     assert.equal(score, 1);
     assert.equal(rawValue, 0);
     assert.equal(details.items.length, 0);
@@ -103,16 +95,16 @@ describe('Performance: uses-rel-preconnect audit', () => {
           dnsEnd: -1,
           connectEnd: -1,
           connectStart: -1,
+          receiveHeadersEnd: 3,
         },
       },
     ];
     const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
-      requestMainResource: () => Promise.resolve(mainResource),
-      requestLoadSimulator: () => Promise.resolve(simulator),
+      URL: {finalUrl: mainResource.url},
     });
 
-    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
+    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {settings: {}});
     assert.equal(score, 1);
     assert.equal(rawValue, 0);
     assert.equal(details.items.length, 0);
@@ -125,15 +117,15 @@ describe('Performance: uses-rel-preconnect audit', () => {
         url: 'https://cdn.example.com/request',
         initiator: {},
         startTime: 16,
+        timing: {receiveHeadersEnd: 20},
       },
     ];
     const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
-      requestMainResource: () => Promise.resolve(mainResource),
-      requestLoadSimulator: () => Promise.resolve(simulator),
+      URL: {finalUrl: mainResource.url},
     });
 
-    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {});
+    const {score, rawValue, details} = await UsesRelPreconnect.audit(artifacts, {settings: {}});
     assert.equal(score, 1);
     assert.equal(rawValue, 0);
     assert.equal(details.items.length, 0);
@@ -150,6 +142,7 @@ describe('Performance: uses-rel-preconnect audit', () => {
           dnsStart: 100,
           connectStart: 150,
           connectEnd: 300,
+          receiveHeadersEnd: 2.3,
         },
       },
       {
@@ -160,20 +153,20 @@ describe('Performance: uses-rel-preconnect audit', () => {
           dnsStart: 300,
           connectStart: 350,
           connectEnd: 400,
+          receiveHeadersEnd: 3.4,
         },
       },
     ];
     const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
-      requestMainResource: () => Promise.resolve(mainResource),
-      requestLoadSimulator: () => Promise.resolve(simulator),
+      URL: {finalUrl: mainResource.url},
     });
 
-    const {rawValue, extendedInfo} = await UsesRelPreconnect.audit(artifacts, {});
-    assert.equal(rawValue, 200);
+    const {rawValue, extendedInfo} = await UsesRelPreconnect.audit(artifacts, {settings: {}});
+    assert.equal(rawValue, 300);
     assert.equal(extendedInfo.value.length, 1);
     assert.deepStrictEqual(extendedInfo.value, [
-      {url: 'https://cdn.example.com', wastedMs: 200},
+      {url: 'https://cdn.example.com', wastedMs: 300},
     ]);
   });
 
@@ -188,6 +181,7 @@ describe('Performance: uses-rel-preconnect audit', () => {
           dnsStart: 100,
           connectStart: 250,
           connectEnd: 300,
+          receiveHeadersEnd: 2.3,
         },
       },
       {
@@ -198,26 +192,21 @@ describe('Performance: uses-rel-preconnect audit', () => {
           dnsStart: 100,
           connectStart: 200,
           connectEnd: 600,
+          receiveHeadersEnd: 1.8,
         },
       },
     ];
     const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       devtoolsLogs: {[UsesRelPreconnect.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
-      requestMainResource: () => Promise.resolve(mainResource),
-      requestLoadSimulator: () => Promise.resolve(simulator),
+      URL: {finalUrl: mainResource.url},
     });
 
-    simulatorOptions = {
-      rtt: 100,
-      additionalRttByOrigin: new Map([['https://othercdn.example.com', 50]]),
-    };
-
-    const {rawValue, extendedInfo} = await UsesRelPreconnect.audit(artifacts, {});
+    const {rawValue, extendedInfo} = await UsesRelPreconnect.audit(artifacts, {settings: {}});
     assert.equal(rawValue, 300);
     assert.equal(extendedInfo.value.length, 2);
     assert.deepStrictEqual(extendedInfo.value, [
       {url: 'https://othercdn.example.com', wastedMs: 300},
-      {url: 'http://cdn.example.com', wastedMs: 100},
+      {url: 'http://cdn.example.com', wastedMs: 150},
     ]);
   });
 });


### PR DESCRIPTION
Follow up to #6171, using the `networkRecordsToDevtoolsLog` utility and passing in the resulting devtoolsLog instead of mocking network records directly. Also removed some other low hanging `request*()` mocks in these files.

Sorry for the test noise :)