### PR TITLE
tests: add test trace creator

### DIFF
--- a/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/offscreen-images-test.js
@@ -7,10 +7,10 @@
 
 const UnusedImages =
     require('../../../audits/byte-efficiency/offscreen-images.js');
-const NetworkNode = require('../../../lib/dependency-graph/network-node');
-const CPUNode = require('../../../lib/dependency-graph/cpu-node');
 const assert = require('assert');
-const LHError = require('../../../lib/lh-error');
+const Runner = require('../../../runner.js');
+const createTestTrace = require('../../create-test-trace.js');
+const networkRecordsToDevtoolsLog = require('../../network-records-to-devtools-log.js');
 
 /* eslint-env jest */
 function generateRecord(resourceSizeInKb, startTime = 0, mimeType = 'image/png') {
@@ -45,26 +45,6 @@ function generateImage(size, coords, networkRecord, src = 'https://google.com/lo
   return image;
 }
 
-function generateInteractiveFunc(desiredTimeInSeconds) {
-  return () => Promise.resolve({
-    timestamp: desiredTimeInSeconds * 1000000,
-  });
-}
-
-function generateInteractiveFuncError() {
-  return () => Promise.reject(
-    new LHError(LHError.errors.NO_TTI_NETWORK_IDLE_PERIOD)
-  );
-}
-
-function generateTraceOfTab(desiredTimeInSeconds) {
-  return () => Promise.resolve({
-    timestamps: {
-      traceEnd: desiredTimeInSeconds * 1000000,
-    },
-  });
-}
-
 describe('OffscreenImages audit', () => {
   let context;
   const DEFAULT_DIMENSIONS = {innerWidth: 1920, innerHeight: 1080};
@@ -74,15 +54,17 @@ describe('OffscreenImages audit', () => {
   });
 
   it('handles images without network record', () => {
-    return UnusedImages.audit_({
+    const topLevelTasks = [{ts: 1900, duration: 100}];
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         generateImage(generateSize(100, 100), [0, 0]),
       ],
-      traces: {},
+      traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
-      requestInteractive: generateInteractiveFunc(2),
-    }, [], context).then(auditResult => {
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 0);
     });
   });
@@ -90,24 +72,27 @@ describe('OffscreenImages audit', () => {
   it('does not find used images', () => {
     const urlB = 'https://google.com/logo2.png';
     const urlC = 'data:image/jpeg;base64,foobar';
-    return UnusedImages.audit_({
+    const topLevelTasks = [{ts: 1900, duration: 100}];
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         generateImage(generateSize(200, 200), [0, 0], generateRecord(100)),
         generateImage(generateSize(100, 100), [0, 1080], generateRecord(100), urlB),
         generateImage(generateSize(400, 400), [1720, 1080], generateRecord(3), urlC),
       ],
-      traces: {},
+      traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
-      requestInteractive: generateInteractiveFunc(2),
-    }, [], context).then(auditResult => {
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 0);
     });
   });
 
   it('finds unused images', () => {
     const url = s => `https://google.com/logo${s}.png`;
-    return UnusedImages.audit_({
+    const topLevelTasks = [{ts: 1900, duration: 100}];
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         // offscreen to the right
@@ -121,24 +106,27 @@ describe('OffscreenImages audit', () => {
         // half offscreen to the top, should not warn
         generateImage(generateSize(1000, 1000), [0, -500], generateRecord(100), url('E')),
       ],
-      traces: {},
+      traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
-      requestInteractive: generateInteractiveFunc(2),
-    }, [], context).then(auditResult => {
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 4);
     });
   });
 
   it('finds images with 0 area', () => {
-    return UnusedImages.audit_({
+    const topLevelTasks = [{ts: 1900, duration: 100}];
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         generateImage(generateSize(0, 0), [0, 0], generateRecord(100)),
       ],
-      traces: {},
+      traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
-      requestInteractive: generateInteractiveFunc(2),
-    }, [], context).then(auditResult => {
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 1);
       assert.equal(auditResult.items[0].wastedBytes, 100 * 1024);
     });
@@ -146,7 +134,8 @@ describe('OffscreenImages audit', () => {
 
   it('de-dupes images', () => {
     const urlB = 'https://google.com/logo2.png';
-    return UnusedImages.audit_({
+    const topLevelTasks = [{ts: 1900, duration: 100}];
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         generateImage(generateSize(50, 50), [0, 0], generateRecord(50)),
@@ -154,156 +143,167 @@ describe('OffscreenImages audit', () => {
         generateImage(generateSize(50, 50), [0, 1500], generateRecord(200), urlB),
         generateImage(generateSize(400, 400), [0, 1500], generateRecord(90), urlB),
       ],
-      traces: {},
+      traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
-      requestInteractive: generateInteractiveFunc(2),
-    }, [], context).then(auditResult => {
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 1);
     });
   });
 
   it('disregards images loaded after TTI', () => {
-    return UnusedImages.audit_({
+    const topLevelTasks = [{ts: 1900, duration: 100}];
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         // offscreen to the right
         generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 3)),
       ],
-      traces: {},
+      traces: {defaultPass: createTestTrace({topLevelTasks})},
       devtoolsLogs: {},
-      requestInteractive: generateInteractiveFunc(2),
-    }, [], context, [], context).then(auditResult => {
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 0);
     });
   });
 
   it('disregards images loaded after Trace End when interactive throws error', () => {
-    return UnusedImages.audit_({
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         // offscreen to the right
         generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 3)),
       ],
-      traces: {},
+      traces: {defaultPass: createTestTrace({traceEnd: 2000})},
       devtoolsLogs: {},
-      requestInteractive: generateInteractiveFuncError(),
-      requestTraceOfTab: generateTraceOfTab(2),
-    }, [], context, [], context).then(auditResult => {
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 0);
     });
   });
 
   it('finds images loaded before Trace End when TTI when interactive throws error', () => {
-    return UnusedImages.audit_({
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         // offscreen to the right
         generateImage(generateSize(100, 100), [0, 2000], generateRecord(100)),
       ],
-      traces: {},
+      traces: {defaultPass: createTestTrace({traceEnd: 2000})},
       devtoolsLogs: {},
-      requestInteractive: generateInteractiveFuncError(),
-      requestTraceOfTab: generateTraceOfTab(2),
-    }, [], context, [], context).then(auditResult => {
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 1);
     });
   });
 
   it('disregards images loaded after last long task (Lantern)', () => {
     context = {settings: {throttlingMethod: 'simulate'}};
-    const recordA = {url: 'a', resourceSize: 100 * 1024, requestId: 'a'};
-    const recordB = {url: 'b', resourceSize: 100 * 1024, requestId: 'b'};
+    const wastedSize = 100 * 1024;
+    const recordA = {
+      url: 'https://example.com/a',
+      resourceSize: wastedSize,
+      requestId: 'a',
+      startTime: 1,
+      priority: 'High',
+      timing: {receiveHeadersEnd: 1.25},
+    };
+    const recordB = {
+      url: 'https://example.com/b',
+      resourceSize: wastedSize,
+      requestId: 'b',
+      startTime: 2.25,
+      priority: 'High',
+      timing: {receiveHeadersEnd: 2.5},
+    };
+    const devtoolsLog = networkRecordsToDevtoolsLog([recordA, recordB]);
 
-    const networkA = new NetworkNode(recordA);
-    const networkB = new NetworkNode(recordB);
-    const cpu = new CPUNode({}, []);
-    const timings = new Map([
-      [networkA, {startTime: 1000}],
-      [networkB, {startTime: 2000}],
-      [cpu, {startTime: 1975, endTime: 2025, duration: 50}],
-    ]);
-
-    return UnusedImages.audit_({
+    const topLevelTasks = [
+      {ts: 1975, duration: 50},
+    ];
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         generateImage(generateSize(0, 0), [0, 0], recordA, recordA.url),
         generateImage(generateSize(200, 200), [3000, 0], recordB, recordB.url),
       ],
-      traces: {},
-      devtoolsLogs: {},
-      requestInteractive: async () => ({pessimisticEstimate: {nodeTimings: timings}}),
-    }, [], context, [], context).then(auditResult => {
+      traces: {defaultPass: createTestTrace({topLevelTasks})},
+      devtoolsLogs: {defaultPass: devtoolsLog},
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 1);
-      assert.equal(auditResult.items[0].url, 'a');
+      assert.equal(auditResult.items[0].url, recordA.url);
+      assert.equal(auditResult.items[0].wastedBytes, wastedSize);
     });
   });
 
   it('finds images loaded before last long task (Lantern)', () => {
     context = {settings: {throttlingMethod: 'simulate'}};
-    const recordA = {url: 'a', resourceSize: 100 * 1024, requestId: 'a'};
-    const recordB = {url: 'b', resourceSize: 100 * 1024, requestId: 'b'};
+    const wastedSize = 100 * 1024;
+    const recordA = {
+      url: 'https://example.com/a',
+      resourceSize: wastedSize,
+      requestId: 'a',
+      startTime: 1,
+      priority: 'High',
+      timing: {receiveHeadersEnd: 1.25},
+    };
+    const recordB = {
+      url: 'https://example.com/b',
+      resourceSize: wastedSize,
+      requestId: 'b',
+      startTime: 1.25,
+      priority: 'High',
+      timing: {receiveHeadersEnd: 1.5},
+    };
+    const devtoolsLog = networkRecordsToDevtoolsLog([recordA, recordB]);
 
-    const networkA = new NetworkNode(recordA);
-    const networkB = new NetworkNode(recordB);
-    const cpu = new CPUNode({}, []);
-    const timings = new Map([
-      [networkA, {startTime: 1000}],
-      [networkB, {startTime: 1500}],
-      [cpu, {startTime: 1975, endTime: 2025, duration: 50}],
-    ]);
-
-    return UnusedImages.audit_({
+    // Enough tasks to spread out graph.
+    const topLevelTasks = [
+      {ts: 1000, duration: 10},
+      {ts: 1050, duration: 10},
+      {ts: 1975, duration: 50},
+    ];
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
       ViewportDimensions: DEFAULT_DIMENSIONS,
       ImageUsage: [
         generateImage(generateSize(0, 0), [0, 0], recordA, recordA.url),
         generateImage(generateSize(200, 200), [3000, 0], recordB, recordB.url),
       ],
-      traces: {},
-      devtoolsLogs: {},
-      requestInteractive: async () => ({pessimisticEstimate: {nodeTimings: timings}}),
-      requestTraceOfTab: generateTraceOfTab(2),
-    }, [], context, [], context).then(auditResult => {
+      traces: {defaultPass: createTestTrace({topLevelTasks})},
+      devtoolsLogs: {defaultPass: devtoolsLog},
+    });
+
+    return UnusedImages.audit_(artifacts, [], context).then(auditResult => {
       assert.equal(auditResult.items.length, 2);
-      assert.equal(auditResult.items[0].url, 'a');
-      assert.equal(auditResult.items[1].url, 'b');
+      assert.equal(auditResult.items[0].url, recordA.url);
+      assert.equal(auditResult.items[0].wastedBytes, wastedSize);
+      assert.equal(auditResult.items[1].url, recordB.url);
+      assert.equal(auditResult.items[1].wastedBytes, wastedSize);
     });
   });
 
   it('rethrow error when interactive throws error in Lantern', async () => {
     context = {settings: {throttlingMethod: 'simulate'}};
-    try {
-      await UnusedImages.audit_({
-        ViewportDimensions: DEFAULT_DIMENSIONS,
-        ImageUsage: [
-          generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 3), 'a'),
-          generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
-        ],
-        traces: {},
-        devtoolsLogs: {},
-        requestInteractive: generateInteractiveFuncError(),
-        requestTraceOfTab: generateTraceOfTab(2),
-      }, [], context, [], context);
-    } catch (err) {
-      return;
-    }
-    assert.ok(false);
-  });
+    const artifacts = Object.assign(Runner.instantiateComputedArtifacts(), {
+      ViewportDimensions: DEFAULT_DIMENSIONS,
+      ImageUsage: [
+        generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 3), 'a'),
+        generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
+      ],
+      traces: {defaultPass: createTestTrace({traceEnd: 2000})},
+      devtoolsLogs: {},
+    });
 
-  it('finds images loaded before Trace End when interactive throws error (Lantern)', async () => {
-    context = {settings: {throttlingMethod: 'simulate'}};
     try {
-      await UnusedImages.audit_({
-        ViewportDimensions: DEFAULT_DIMENSIONS,
-        ImageUsage: [
-          generateImage(generateSize(0, 0), [0, 0], generateRecord(100, 1), 'a'),
-          generateImage(generateSize(200, 200), [3000, 0], generateRecord(100, 4), 'b'),
-        ],
-        traces: {},
-        devtoolsLogs: {},
-        requestInteractive: generateInteractiveFuncError(),
-        requestTraceOfTab: generateTraceOfTab(2),
-      }, [], context, [], context);
+      await UnusedImages.audit_(artifacts, [], context);
     } catch (err) {
+      assert.ok(err.message.includes('Did not provide necessary metric computation data'));
       return;
     }
     assert.ok(false);

--- a/lighthouse-core/test/audits/redirects-test.js
+++ b/lighthouse-core/test/audits/redirects-test.js
@@ -8,118 +8,122 @@
 const Runner = require('../../runner.js');
 const RedirectsAudit = require('../../audits/redirects.js');
 const assert = require('assert');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
+const createTestTrace = require('../create-test-trace.js');
 
 /* eslint-env jest */
-const FAILING_THREE_REDIRECTS = {
+
+const FAILING_THREE_REDIRECTS = [{
+  requestId: '1',
+  startTime: 0,
+  priority: 'VeryHigh',
+  url: 'http://example.com/',
+  timing: {receiveHeadersEnd: 11},
+}, {
+  requestId: '1:redirect',
+  startTime: 11,
+  priority: 'VeryHigh',
+  url: 'https://example.com/',
+  timing: {receiveHeadersEnd: 12},
+}, {
+  requestId: '1:redirect:redirect',
+  startTime: 12,
+  priority: 'VeryHigh',
+  url: 'https://m.example.com/',
+  timing: {receiveHeadersEnd: 17},
+}, {
+  requestId: '1:redirect:redirect:redirect',
   startTime: 17,
+  priority: 'VeryHigh',
   url: 'https://m.example.com/final',
-  redirects: [
-    {
-      startTime: 0,
-      url: 'http://example.com/',
-    },
-    {
-      startTime: 11,
-      url: 'https://example.com/',
-    },
-    {
-      startTime: 12,
-      url: 'https://m.example.com/',
-    },
-  ],
-};
+  timing: {receiveHeadersEnd: 19},
+}];
 
-const FAILING_TWO_REDIRECTS = {
-  startTime: 446.286,
+const FAILING_TWO_REDIRECTS = [{
+  requestId: '1',
+  startTime: 445,
+  priority: 'VeryHigh',
+  url: 'http://lisairish.com/',
+  timing: {receiveHeadersEnd: 446},
+}, {
+  requestId: '1:redirect',
+  startTime: 446,
+  priority: 'VeryHigh',
+  url: 'https://lisairish.com/',
+  timing: {receiveHeadersEnd: 447},
+}, {
+  requestId: '1:redirect:redirect',
+  startTime: 447,
+  priority: 'VeryHigh',
   url: 'https://www.lisairish.com/',
-  redirects: [
-    {
-      startTime: 445.648,
-      url: 'http://lisairish.com/',
-    },
-    {
-      startTime: 445.757,
-      url: 'https://lisairish.com/',
-    },
-  ],
-};
+  timing: {receiveHeadersEnd: 448},
+}];
 
-const SUCCESS_ONE_REDIRECT = {
-  startTime: 136.383,
+const SUCCESS_ONE_REDIRECT = [{
+  requestId: '1',
+  startTime: 135,
+  priority: 'VeryHigh',
+  url: 'https://lisairish.com/',
+  timing: {receiveHeadersEnd: 136},
+}, {
+  requestId: '1:redirect',
+  startTime: 136,
+  priority: 'VeryHigh',
   url: 'https://www.lisairish.com/',
-  redirects: [{
-    startTime: 135.873,
-    url: 'https://lisairish.com/',
-  }],
-};
+  timing: {receiveHeadersEnd: 139},
+}];
 
-const SUCCESS_NOREDIRECT = {
+const SUCCESS_NOREDIRECT = [{
+  requestId: '1',
   startTime: 135.873,
+  priority: 'VeryHigh',
   url: 'https://www.google.com/',
-  redirects: [],
-};
+  timing: {receiveHeadersEnd: 140},
+}];
 
 describe('Performance: Redirects audit', () => {
-  let nodeTimings;
+  const mockArtifacts = (networkRecords, finalUrl) => {
+    const devtoolsLog = networkRecordsToDevtoolsLog(networkRecords);
 
-  const mockArtifacts = (mockChain) => {
     return Object.assign(Runner.instantiateComputedArtifacts(), {
-      traces: {},
-      devtoolsLogs: {defaultPass: []},
-      requestLanternInteractive: () => ({pessimisticEstimate: {nodeTimings}}),
-      requestTraceOfTab: () => {},
-      requestMainResource: function() {
-        return Promise.resolve(mockChain);
-      },
+      traces: {defaultPass: createTestTrace({traceEnd: 5000})},
+      devtoolsLogs: {defaultPass: devtoolsLog},
+      URL: {finalUrl},
     });
   };
 
   it('fails when 3 redirects detected', () => {
-    nodeTimings = new Map([
-      [{type: 'network', record: {url: 'http://example.com/'}}, {startTime: 0}],
-      [{type: 'network', record: {url: 'https://example.com/'}}, {startTime: 5000}],
-      [{type: 'network', record: {url: 'https://m.example.com/'}}, {startTime: 10000}],
-      [{type: 'network', record: {url: 'https://m.example.com/final'}}, {startTime: 17000}],
-    ]);
-
-    return RedirectsAudit.audit(mockArtifacts(FAILING_THREE_REDIRECTS), {}).then(output => {
-      assert.equal(output.score, 0);
+    const artifacts = mockArtifacts(FAILING_THREE_REDIRECTS, 'https://m.example.com/final');
+    return RedirectsAudit.audit(artifacts, {settings: {}}).then(output => {
+      assert.equal(Math.round(output.score * 100) / 100, 0.37);
       assert.equal(output.details.items.length, 4);
-      assert.equal(output.rawValue, 17000);
+      assert.equal(output.rawValue, 1890);
     });
   });
 
   it('fails when 2 redirects detected', () => {
-    nodeTimings = new Map([
-      [{type: 'network', record: {url: 'http://lisairish.com/'}}, {startTime: 0}],
-      [{type: 'network', record: {url: 'https://lisairish.com/'}}, {startTime: 300}],
-      [{type: 'network', record: {url: 'https://www.lisairish.com/'}}, {startTime: 638}],
-    ]);
-
-    return RedirectsAudit.audit(mockArtifacts(FAILING_TWO_REDIRECTS), {}).then(output => {
-      assert.equal(Math.round(output.score * 100) / 100, 0.56);
+    const artifacts = mockArtifacts(FAILING_TWO_REDIRECTS, 'https://www.lisairish.com/');
+    return RedirectsAudit.audit(artifacts, {settings: {}}).then(output => {
+      assert.equal(Math.round(output.score * 100) / 100, 0.46);
       assert.equal(output.details.items.length, 3);
-      assert.equal(Math.round(output.rawValue), 638);
+      assert.equal(Math.round(output.rawValue), 1110);
     });
   });
 
   it('passes when one redirect detected', () => {
-    nodeTimings = new Map([
-      [{type: 'network', record: {url: 'https://lisairish.com/'}}, {startTime: 0}],
-      [{type: 'network', record: {url: 'https://www.lisairish.com/'}}, {startTime: 510}],
-    ]);
-
-    return RedirectsAudit.audit(mockArtifacts(SUCCESS_ONE_REDIRECT), {}).then(output => {
+    const artifacts = mockArtifacts(SUCCESS_ONE_REDIRECT, 'https://www.lisairish.com/');
+    return RedirectsAudit.audit(artifacts, {settings: {}}).then(output => {
       // If === 1 redirect, perfect score is expected, regardless of latency
       assert.equal(output.score, 1);
       // We will still generate a table and show wasted time
       assert.equal(output.details.items.length, 2);
-      assert.equal(Math.round(output.rawValue), 510);
+      assert.equal(Math.round(output.rawValue), 780);
     });
   });
 
   it('passes when no redirect detected', () => {
-    return RedirectsAudit.audit(mockArtifacts(SUCCESS_NOREDIRECT), {}).then(output => {
+    const artifacts = mockArtifacts(SUCCESS_NOREDIRECT, 'https://www.google.com/');
+    return RedirectsAudit.audit(artifacts, {settings: {}}).then(output => {
       assert.equal(output.score, 1);
       assert.equal(output.details.items.length, 0);
       assert.equal(output.rawValue, 0);

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -9,191 +9,198 @@
 /* eslint-env jest */
 
 const UsesRelPreload = require('../../audits/uses-rel-preload.js');
-const NetworkNode = require('../../lib/dependency-graph/network-node');
 const assert = require('assert');
 
 const Runner = require('../../runner');
 const pwaTrace = require('../fixtures/traces/progressive-app-m60.json');
 const pwaDevtoolsLog = require('../fixtures/traces/progressive-app-m60.devtools.log.json');
 const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
+const createTestTrace = require('../create-test-trace.js');
 
+const defaultMainResourceUrl = 'http://www.example.com/';
 const defaultMainResource = {
-  _endTime: 1,
+  requestId: '1',
+  url: defaultMainResourceUrl,
+  startTime: 0,
+  priority: 'VeryHigh',
+  timing: {
+    connectStart: 147.848,
+    connectEnd: 180.71,
+    sslStart: 151.87,
+    sslEnd: 180.704,
+    sendStart: 181.443,
+    sendEnd: 181.553,
+    receiveHeadersEnd: 500,
+  },
 };
 
 describe('Performance: uses-rel-preload audit', () => {
-  let mockGraph;
-  let mockSimulator;
-
-  const mockArtifacts = (networkRecords, mainResource = defaultMainResource) => {
+  const mockArtifacts = (networkRecords, finalUrl) => {
     return Object.assign(Runner.instantiateComputedArtifacts(), {
-      traces: {[UsesRelPreload.DEFAULT_PASS]: {traceEvents: []}},
+      traces: {[UsesRelPreload.DEFAULT_PASS]: createTestTrace({traceEnd: 5000})},
       devtoolsLogs: {[UsesRelPreload.DEFAULT_PASS]: networkRecordsToDevtoolsLog(networkRecords)},
-      requestLoadSimulator: () => mockSimulator,
-      requestPageDependencyGraph: () => mockGraph,
-      requestMainResource: () => {
-        return Promise.resolve(mainResource);
-      },
+      URL: {finalUrl},
     });
   };
 
-  afterEach(() => {
-    mockSimulator = undefined;
-  });
+  function getMockNetworkRecords() {
+    const secondRecordUrl = 'http://www.example.com/script.js';
+    return [
+      defaultMainResource,
+      {
+        requestId: '2',
+        startTime: 10,
+        isLinkPreload: false,
+        url: secondRecordUrl,
+        timing: defaultMainResource.timing,
+        priority: 'High',
+        initiator: {
+          type: 'parser',
+          url: defaultMainResourceUrl,
+        },
+      }, {
+        // Normally this request would be flagged for preloading.
+        requestId: '3',
+        startTime: 20,
+        isLinkPreload: false,
+        url: 'http://www.example.com/a-different-script.js',
+        timing: defaultMainResource.timing,
+        priority: 'High',
+        initiator: {
+          type: 'parser',
+          url: secondRecordUrl,
+        },
+      },
+    ];
+  }
 
   it('should suggest preload resource', () => {
-    const mainResource = Object.assign({}, defaultMainResource, {
-      url: 'http://www.example.com:3000',
-      redirects: [''],
-    });
+    const rootNodeUrl = 'http://example.com:3000';
+    const mainDocumentNodeUrl = 'http://www.example.com:3000';
+    const scriptNodeUrl = 'http://www.example.com/script.js';
+    const scriptAddedNodeUrl = 'http://www.example.com/script-added.js';
+    const scriptSubNodeUrl = 'http://sub.example.com/script-sub.js';
+    const scriptOtherNodeUrl = 'http://otherdomain.com/script-other.js';
 
     const networkRecords = [
       {
         requestId: '2',
         priority: 'High',
         isLinkPreload: false,
-        url: 'http://example.com:3000',
+        startTime: 0,
+        endTime: 0.5,
+        timing: {receiveHeadersEnd: 500},
+        url: rootNodeUrl,
       },
       {
         requestId: '2:redirect',
         resourceType: 'Document',
         priority: 'High',
         isLinkPreload: false,
-        url: 'http://www.example.com:3000',
+        startTime: 0.5,
+        endTime: 1,
+        timing: {receiveHeadersEnd: 500},
+        url: mainDocumentNodeUrl,
       },
       {
         requestId: '3',
         resourceType: 'Script',
         priority: 'High',
         isLinkPreload: false,
-        url: 'http://www.example.com/script.js',
+        startTime: 1,
+        endTime: 2,
+        timing: {receiveHeadersEnd: 1000},
+        url: scriptNodeUrl,
+        initiator: {type: 'parser', url: mainDocumentNodeUrl},
       },
       {
         requestId: '4',
         resourceType: 'Script',
         priority: 'High',
         isLinkPreload: false,
-        url: 'http://www.example.com/script-added.js',
+        startTime: 2,
+        endTime: 3.25,
+        timing: {receiveHeadersEnd: 1250},
+        url: scriptAddedNodeUrl,
+        initiator: {type: 'script', url: scriptNodeUrl},
       },
       {
         requestId: '5',
         resourceType: 'Script',
         priority: 'High',
         isLinkPreload: false,
-        url: 'http://sub.example.com/script-sub.js',
+        startTime: 2,
+        endTime: 3,
+        timing: {receiveHeadersEnd: 1000},
+        url: scriptSubNodeUrl,
+        initiator: {type: 'script', url: scriptNodeUrl},
       },
       {
         requestId: '6',
         resourceType: 'Script',
         priority: 'High',
         isLinkPreload: false,
-        url: 'http://otherdomain.com/script-other.js',
+        startTime: 2,
+        endTime: 3.5,
+        timing: {receiveHeadersEnd: 1500},
+        url: scriptOtherNodeUrl,
+        initiator: {type: 'script', url: scriptNodeUrl},
       },
     ];
 
-    const rootNode = new NetworkNode(networkRecords[0]);
-    const mainDocumentNode = new NetworkNode(networkRecords[1]);
-    const scriptNode = new NetworkNode(networkRecords[2]);
-    const scriptAddedNode = new NetworkNode(networkRecords[3]);
-    const scriptSubNode = new NetworkNode(networkRecords[4]);
-    const scriptOtherNode = new NetworkNode(networkRecords[5]);
-
-    mainDocumentNode.setIsMainDocument(true);
-    mainDocumentNode.addDependency(rootNode);
-    scriptNode.addDependency(mainDocumentNode);
-    scriptAddedNode.addDependency(scriptNode);
-    scriptSubNode.addDependency(scriptNode);
-    scriptOtherNode.addDependency(scriptNode);
-
-    mockGraph = rootNode;
-    mockSimulator = {
-      simulate(graph) {
-        const nodesByUrl = new Map();
-        graph.traverse(node => nodesByUrl.set(node.record.url, node));
-
-        const rootNodeLocal = nodesByUrl.get(rootNode.record.url);
-        const mainDocumentNodeLocal = nodesByUrl.get(mainDocumentNode.record.url);
-        const scriptNodeLocal = nodesByUrl.get(scriptNode.record.url);
-        const scriptAddedNodeLocal = nodesByUrl.get(scriptAddedNode.record.url);
-        const scriptSubNodeLocal = nodesByUrl.get(scriptSubNode.record.url);
-        const scriptOtherNodeLocal = nodesByUrl.get(scriptOtherNode.record.url);
-
-        const nodeTimings = new Map([
-          [rootNodeLocal, {starTime: 0, endTime: 500}],
-          [mainDocumentNodeLocal, {startTime: 500, endTime: 1000}],
-          [scriptNodeLocal, {startTime: 1000, endTime: 2000}],
-          [scriptAddedNodeLocal, {startTime: 2000, endTime: 3250}],
-          [scriptSubNodeLocal, {startTime: 2000, endTime: 3000}],
-          [scriptOtherNodeLocal, {startTime: 2000, endTime: 3500}],
-        ]);
-
-        if (scriptAddedNodeLocal.getDependencies()[0] === mainDocumentNodeLocal) {
-          nodeTimings.set(scriptAddedNodeLocal, {startTime: 1000, endTime: 2000});
-        }
-
-        if (scriptSubNodeLocal.getDependencies()[0] === mainDocumentNodeLocal) {
-          nodeTimings.set(scriptSubNodeLocal, {startTime: 1000, endTime: 2000});
-        }
-
-        if (scriptOtherNodeLocal.getDependencies()[0] === mainDocumentNodeLocal) {
-          nodeTimings.set(scriptOtherNodeLocal, {startTime: 1000, endTime: 2500});
-        }
-
-        return {timeInMs: 3500, nodeTimings};
-      },
-    };
-
-    return UsesRelPreload.audit(mockArtifacts(networkRecords, mainResource), {}).then(
+    const artifacts = mockArtifacts(networkRecords, mainDocumentNodeUrl);
+    return UsesRelPreload.audit(artifacts, {settings: {}}).then(
       output => {
-        assert.equal(output.rawValue, 1250);
+        assert.equal(output.details.overallSavingsMs, 330);
         assert.equal(output.details.items.length, 2);
-        assert.equal(output.details.items[0].url, 'http://www.example.com/script-added.js');
-        assert.equal(output.details.items[1].url, 'http://sub.example.com/script-sub.js');
+        assert.equal(output.details.items[0].url, scriptSubNodeUrl);
+        assert.equal(output.details.items[0].wastedMs, 330);
+        assert.equal(output.details.items[1].url, scriptAddedNodeUrl);
+        assert.equal(output.details.items[1].wastedMs, 180);
       }
     );
   });
 
-  it(`shouldn't suggest preload for already preloaded records`, () => {
-    const networkRecords = [
-      {
-        requestId: '3',
-        startTime: 10,
-        isLinkPreload: true,
-        url: 'http://www.example.com/script.js',
-      },
-    ];
+  it(`should suggest preload for worthy records`, () => {
+    const networkRecords = getMockNetworkRecords();
 
-    return UsesRelPreload.audit(mockArtifacts(networkRecords), {}).then(output => {
-      assert.equal(output.rawValue, 0);
+    const artifacts = mockArtifacts(networkRecords, defaultMainResourceUrl);
+    return UsesRelPreload.audit(artifacts, {settings: {}}).then(output => {
+      assert.equal(output.details.overallSavingsMs, 314);
+      assert.equal(output.details.items.length, 1);
+    });
+  });
+
+  it(`shouldn't suggest preload for already preloaded records`, () => {
+    const networkRecords = getMockNetworkRecords();
+    networkRecords[2].isLinkPreload = true;
+
+    const artifacts = mockArtifacts(networkRecords, defaultMainResourceUrl);
+    return UsesRelPreload.audit(artifacts, {settings: {}}).then(output => {
+      assert.equal(output.score, 1);
+      assert.equal(output.details.overallSavingsMs, 0);
       assert.equal(output.details.items.length, 0);
     });
   });
 
   it(`shouldn't suggest preload for protocol data`, () => {
-    const networkRecords = [
-      {
-        requestId: '3',
-        protocol: 'data',
-        startTime: 10,
-      },
-    ];
+    const networkRecords = getMockNetworkRecords();
+    networkRecords[2].protocol = 'data';
 
-    return UsesRelPreload.audit(mockArtifacts(networkRecords), {}).then(output => {
-      assert.equal(output.rawValue, 0);
+    const artifacts = mockArtifacts(networkRecords, defaultMainResourceUrl);
+    return UsesRelPreload.audit(artifacts, {settings: {}}).then(output => {
+      assert.equal(output.score, 1);
+      assert.equal(output.details.overallSavingsMs, 0);
       assert.equal(output.details.items.length, 0);
     });
   });
 
   it(`shouldn't suggest preload for protocol blob`, () => {
-    const networkRecords = [
-      {
-        requestId: '3',
-        protocol: 'blob',
-        startTime: 10,
-      },
-    ];
+    const networkRecords = getMockNetworkRecords();
+    networkRecords[2].protocol = 'blob';
 
-    return UsesRelPreload.audit(mockArtifacts(networkRecords), {}).then(output => {
+    const artifacts = mockArtifacts(networkRecords, defaultMainResourceUrl);
+    return UsesRelPreload.audit(artifacts, {settings: {}}).then(output => {
       assert.equal(output.rawValue, 0);
       assert.equal(output.details.items.length, 0);
     });

--- a/lighthouse-core/test/create-test-trace.js
+++ b/lighthouse-core/test/create-test-trace.js
@@ -1,0 +1,117 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const pid = 1111;
+const tid = 222;
+const frame = '3EFC2700D7BC3F4734CAF2F726EFB78C';
+
+/** @typedef {{ts: number, duration: number}} TopLevelTaskDef */
+
+/**
+ * @param {TopLevelTaskDef} options
+ */
+function getTopLevelTask({ts, duration}) {
+  return {
+    name: 'ThreadControllerImpl::RunTask',
+    ts: ts * 1000,
+    dur: duration * 1000,
+    pid,
+    tid,
+    ph: 'X',
+    cat: 'toplevel',
+    args: {
+      src_file: '../../third_party/blink/renderer/core/fake_runner.cc',
+      src_func: 'FakeRunnerFinished',
+    },
+  };
+}
+
+/**
+ * Creates a simple trace that fits the desired options. Useful for basic trace
+ * generation, e.g a trace that will result in particular long-task quiet
+ * periods. Input times should be in milliseconds.
+ * @param {{navigationStart?: number, traceEnd?: number, topLevelTasks?: Array<TopLevelTaskDef>}} options
+ */
+function createTestTrace(options) {
+  const navStart = (options.navigationStart || 0) * 1000;
+
+  const traceEvents = [{
+    name: 'navigationStart',
+    ts: navStart,
+    pid,
+    tid,
+    ph: 'R',
+    cat: 'blink.user_timing',
+    args: {
+      frame,
+      data: {documentLoaderURL: ''},
+    },
+  }, {
+    name: 'TracingStartedInBrowser',
+    ts: navStart,
+    pid,
+    tid,
+    ph: 'I',
+    cat: 'disabled-by-default-devtools.timeline',
+    args: {
+      data: {
+        frameTreeNodeId: 6,
+        persistentIds: true,
+        frames: [{frame, url: 'about:blank', name: '', processId: pid}],
+      },
+    },
+    s: 't',
+  }, {
+    // Needed to identify main thread for TracingStartedInBrowser.
+    name: 'thread_name',
+    ts: navStart,
+    pid,
+    tid,
+    ph: 'M',
+    cat: '__metadata',
+    args: {name: 'CrRendererMain'},
+  }, {
+    name: 'domContentLoadedEventEnd',
+    ts: navStart + 10,
+    pid,
+    tid,
+    ph: 'R',
+    cat: 'blink.user_timing,rail',
+    args: {frame},
+  }, {
+    name: 'firstContentfulPaint',
+    ts: navStart + 10,
+    pid,
+    tid,
+    ph: 'R',
+    cat: 'loading,rail,devtools.timeline',
+    args: {frame},
+  }, {
+    name: 'firstMeaningfulPaint',
+    ts: navStart + 15,
+    pid,
+    tid,
+    ph: 'R',
+    cat: 'loading,rail,devtools.timeline',
+    args: {frame},
+  }];
+
+  if (options.topLevelTasks) {
+    for (const task of options.topLevelTasks) {
+      traceEvents.push(getTopLevelTask(task));
+    }
+  }
+
+  if (options.traceEnd) {
+    // Insert a top level short task to extend trace to requested end.
+    traceEvents.push(getTopLevelTask({ts: options.traceEnd - 1, duration: 1}));
+  }
+
+  return {traceEvents};
+}
+
+module.exports = createTestTrace;


### PR DESCRIPTION
other half #6195. This PR adds a simple trace creator to easily create test traces that match the needed characteristics. Right now it accepts timestamps for navStart and the end of the trace, and then a set of timestamps and durations for top-level tasks (but the options can easily be expanded).

The allows easy replacement of a bunch of computed artifact mocks relying on a specific TTI or just needed a dummy trace so the computed artifacts don't throw while another aspect of the audit is being tested.

Some of these are a little more sensitive to future changes than what was found in #6195, but we do get a bit more robustness in that these files now test with real computed artifacts rather than just testing the quality of our mocks (which can be particularly risky when testing just simple pass/fail conditions without testing *why*).