### PR TITLE
core(critical-request-chain): remove empty children from LHR

### DIFF
--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -74,7 +74,9 @@ class CriticalRequestChains extends Audit {
         });
 
         // Carry on walking.
-        walk(child.children, depth + 1, startTime);
+        if (child.children) {
+          walk(child.children, depth + 1, startTime);
+        }
       }, '');
     }
 
@@ -132,21 +134,25 @@ class CriticalRequestChains extends Audit {
       } else {
         chain = {
           request: simpleRequest,
-          children: {},
+          // children: {},
         };
         flattendChains[opts.id] = chain;
       }
 
-      for (const chainId of Object.keys(opts.node.children)) {
-        // Note: cast should be Partial<>, but filled in when child node is traversed.
-        const childChain = /** @type {LH.Audit.SimpleCriticalRequestNode[string]} */ ({
-          request: {},
-          children: {},
-        });
-        chainMap.set(chainId, childChain);
-        chain.children[chainId] = childChain;
+      if (opts.node.children) {
+        for (const chainId of Object.keys(opts.node.children)) {
+          // Note: cast should be Partial<>, but filled in when child node is traversed.
+          const childChain = /** @type {LH.Audit.SimpleCriticalRequestNode[string]} */ ({
+            request: {},
+            // children: {},
+          });
+          chainMap.set(chainId, childChain);
+          if (!chain.children) {
+            chain.children = {};
+          }
+          chain.children[chainId] = childChain;
+        }
       }
-
       chainMap.set(opts.id, chain);
     }
 
@@ -172,15 +178,14 @@ class CriticalRequestChains extends Audit {
       function walk(node, depth) {
         const children = Object.keys(node);
 
-        // Since a leaf node indicates the end of a chain, we can inspect the number
-        // of child nodes, and, if the count is zero, increment the count.
-        if (children.length === 0) {
-          chainCount++;
-        }
-
         children.forEach(id => {
           const child = node[id];
-          walk(child.children, depth + 1);
+          if (child.children) {
+            walk(child.children, depth + 1);
+          } else {
+            // if the node doesn't have a children field, then it is a leaf, so +1
+            chainCount++;
+          }
         }, '');
       }
       // Convert

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -174,9 +174,9 @@ class CriticalRequestChains extends Audit {
        * @param {number} depth
        */
       function walk(node, depth) {
-        const children = Object.keys(node);
+        const childIds = Object.keys(node);
 
-        children.forEach(id => {
+        childIds.forEach(id => {
           const child = node[id];
           if (child.children) {
             walk(child.children, depth + 1);

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -134,7 +134,6 @@ class CriticalRequestChains extends Audit {
       } else {
         chain = {
           request: simpleRequest,
-          // children: {},
         };
         flattendChains[opts.id] = chain;
       }
@@ -144,7 +143,6 @@ class CriticalRequestChains extends Audit {
           // Note: cast should be Partial<>, but filled in when child node is traversed.
           const childChain = /** @type {LH.Audit.SimpleCriticalRequestNode[string]} */ ({
             request: {},
-            // children: {},
           });
           chainMap.set(chainId, childChain);
           if (!chain.children) {

--- a/lighthouse-core/report/html/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/html/renderer/crc-details-renderer.js
@@ -59,7 +59,7 @@ class CriticalRequestChainRenderer {
     const node = parent[id];
     const siblings = Object.keys(parent);
     const isLastChild = siblings.indexOf(id) === (siblings.length - 1);
-    const hasChildren = Object.keys(node.children).length > 0;
+    const hasChildren = !!node.children && Object.keys(node.children).length > 0;
 
     // Copy the tree markers so that we don't change by reference.
     const newTreeMarkers = Array.isArray(treeMarkers) ? treeMarkers.slice(0) : [];
@@ -149,11 +149,12 @@ class CriticalRequestChainRenderer {
    */
   static buildTree(dom, tmpl, segment, elem, details) {
     elem.appendChild(CriticalRequestChainRenderer.createChainNode(dom, tmpl, segment));
-
-    for (const key of Object.keys(segment.node.children)) {
-      const childSegment = CriticalRequestChainRenderer.createSegment(segment.node.children, key,
-         segment.startTime, segment.transferSize, segment.treeMarkers, segment.isLastChild);
-      CriticalRequestChainRenderer.buildTree(dom, tmpl, childSegment, elem, details);
+    if (segment.node.children) {
+      for (const key of Object.keys(segment.node.children)) {
+        const childSegment = CriticalRequestChainRenderer.createSegment(segment.node.children, key,
+          segment.startTime, segment.transferSize, segment.treeMarkers, segment.isLastChild);
+        CriticalRequestChainRenderer.buildTree(dom, tmpl, childSegment, elem, details);
+      }
     }
   }
 

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -325,8 +325,7 @@
                   "endTime": 185604.52588,
                   "responseReceivedTime": 185604.52470399998,
                   "transferSize": 821
-                },
-                "children": {}
+                }
               },
               "75994.4": {
                 "request": {
@@ -335,8 +334,7 @@
                   "endTime": 185604.534512,
                   "responseReceivedTime": 185604.532778,
                   "transferSize": 139
-                },
-                "children": {}
+                }
               },
               "75994.5": {
                 "request": {
@@ -345,8 +343,7 @@
                   "endTime": 185606.170588,
                   "responseReceivedTime": 185606.169761,
                   "transferSize": 821
-                },
-                "children": {}
+                }
               },
               "75994.6": {
                 "request": {
@@ -355,8 +352,7 @@
                   "endTime": 185604.541262,
                   "responseReceivedTime": 185604.54052399998,
                   "transferSize": 1108
-                },
-                "children": {}
+                }
               },
               "75994.7": {
                 "request": {
@@ -365,8 +361,7 @@
                   "endTime": 185604.549739,
                   "responseReceivedTime": 185604.54903999998,
                   "transferSize": 736
-                },
-                "children": {}
+                }
               },
               "75994.8": {
                 "request": {
@@ -375,8 +370,7 @@
                   "endTime": 185605.097653,
                   "responseReceivedTime": 185605.096858,
                   "transferSize": 733
-                },
-                "children": {}
+                }
               },
               "75994.9": {
                 "request": {
@@ -385,8 +379,7 @@
                   "endTime": 185607.537382,
                   "responseReceivedTime": 185607.53660999998,
                   "transferSize": 821
-                },
-                "children": {}
+                }
               },
               "75994.10": {
                 "request": {
@@ -395,8 +388,7 @@
                   "endTime": 185605.113307,
                   "responseReceivedTime": 185605.104776,
                   "transferSize": 1703
-                },
-                "children": {}
+                }
               },
               "75994.11": {
                 "request": {
@@ -405,8 +397,7 @@
                   "endTime": 185604.557407,
                   "responseReceivedTime": 185604.556719,
                   "transferSize": 144
-                },
-                "children": {}
+                }
               },
               "75994.21": {
                 "request": {
@@ -415,8 +406,7 @@
                   "endTime": 185607.28227,
                   "responseReceivedTime": 185606.742005,
                   "transferSize": 71654
-                },
-                "children": {}
+                }
               },
               "75994.22": {
                 "request": {
@@ -425,8 +415,7 @@
                   "endTime": 185608.117509,
                   "responseReceivedTime": 185607.822806,
                   "transferSize": 30174
-                },
-                "children": {}
+                }
               },
               "75994.28": {
                 "request": {
@@ -435,8 +424,7 @@
                   "endTime": 185607.285454,
                   "responseReceivedTime": 185606.82147599998,
                   "transferSize": 821
-                },
-                "children": {}
+                }
               }
             }
           },
@@ -447,8 +435,7 @@
               "endTime": 185608.857719,
               "responseReceivedTime": 185608.85586200003,
               "transferSize": 221
-            },
-            "children": {}
+            }
           }
         },
         "longestChain": {

--- a/typings/audit.d.ts
+++ b/typings/audit.d.ts
@@ -171,7 +171,7 @@ declare global {
           responseReceivedTime: number;
           transferSize: number;
         };
-        children: SimpleCriticalRequestNode;
+        children?: SimpleCriticalRequestNode;
       }
     }
 


### PR DESCRIPTION
**Summary**
Removes empty children object from the crc details LHR.  This will allow the proto struct to parse the crc details object 1:1.

**Related Issues/PRs**
#6183 
