### PR TITLE
core(icons): defer to manifest-icon type hint for image type

### DIFF
--- a/lighthouse-core/lib/icons.js
+++ b/lighthouse-core/lib/icons.js
@@ -33,13 +33,13 @@ function pngSizedAtLeast(sizeRequirement, manifest) {
   /** @type {Array<string>} */
   const flattenedSizes = [];
   iconValues
+    // filter out icons with no typehint + extension is not .png
     // filter out icons with a typehint that is not 'image/png'
-    .filter(icon => (!icon.value.type.value) ||
+    .filter(icon => (!icon.value.type.value && (icon.value.src.value &&
+      new URL(icon.value.src.value).pathname.endsWith('.png'))) ||
       (icon.value.type.value &&
       icon.value.type.value === 'image/png'))
     // filter out icons that are not png
-    .filter(icon => icon.value.src.value &&
-      new URL(icon.value.src.value).pathname.endsWith('.png'))
     .forEach(icon => {
       // check that the icon has a size
       if (icon.value.sizes.value) {

--- a/lighthouse-core/lib/icons.js
+++ b/lighthouse-core/lib/icons.js
@@ -33,13 +33,16 @@ function pngSizedAtLeast(sizeRequirement, manifest) {
   /** @type {Array<string>} */
   const flattenedSizes = [];
   iconValues
-    // filter out icons with no typehint + extension is not .png
-    // filter out icons with a typehint that is not 'image/png'
-    .filter(icon => (!icon.value.type.value && (icon.value.src.value &&
-      new URL(icon.value.src.value).pathname.endsWith('.png'))) ||
-      (icon.value.type.value &&
-      icon.value.type.value === 'image/png'))
-    // filter out icons that are not png
+    .filter(icon => {
+      const typeHint = icon.value.type.value;
+      if (typeHint) {
+        // If a type hint is present, filter out icons that are not 'image/png'.
+        return typeHint === 'image/png';
+      }
+      // Otherwise, fall back to filtering on the icons' extension.
+      const src = icon.value.src.value;
+      return src && new URL(src).pathname.endsWith('.png');
+    })
     .forEach(icon => {
       // check that the icon has a size
       if (icon.value.sizes.value) {

--- a/lighthouse-core/test/lib/icons-test.js
+++ b/lighthouse-core/test/lib/icons-test.js
@@ -278,7 +278,9 @@ describe('Icons helper', () => {
       assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 0);
     });
 
-    it('fails with an icon that has a png typehint but is not png', () => {
+    it('succeeds with an icon that has a png typehint but is not png', () => {
+      // We will believe your typehints until such time that we can fetch the image and decode it
+      // TODO: fetch images and decode them to check real filetype like in Chrome
       const manifestSrc = JSON.stringify({
         icons: [{
           src: 'path/to/image.jpg',
@@ -287,7 +289,7 @@ describe('Icons helper', () => {
         }],
       });
       const manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-      assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 0);
+      assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 1);
     });
 
     it('succeeds with a png icon that has query params in url', () => {
@@ -300,30 +302,6 @@ describe('Icons helper', () => {
       });
       const manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
       assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 1);
-    });
-
-    it('fails with a non-png icon that has query params in url', () => {
-      const manifestSrc = JSON.stringify({
-        icons: [{
-          src: 'path/to/image.jpg?param=true',
-          sizes: '200x200',
-          type: 'image/png',
-        }],
-      });
-      const manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-      assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 0);
-    });
-
-    it('fails with a non-png icon that has a .png extension in the middle', () => {
-      const manifestSrc = JSON.stringify({
-        icons: [{
-          src: 'path/to/image.png.jpg',
-          sizes: '200x200',
-          type: 'image/png',
-        }],
-      });
-      const manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-      assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 0);
     });
   });
 });

--- a/lighthouse-core/test/lib/icons-test.js
+++ b/lighthouse-core/test/lib/icons-test.js
@@ -278,9 +278,21 @@ describe('Icons helper', () => {
       assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 0);
     });
 
+    it('succeeds with a png icon that has query params in url', () => {
+      const manifestSrc = JSON.stringify({
+        icons: [{
+          src: 'path/to/image.png?param=true',
+          sizes: '200x200',
+          type: 'image/png',
+        }],
+      });
+      const manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
+      assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 1);
+    });
+
+    // Note on tests below: we will believe your typehints until we can fetch the image and decode it.
+    // See https://github.com/GoogleChrome/lighthouse/issues/789
     it('succeeds with an icon that has a png typehint but is not png', () => {
-      // We will believe your typehints until such time that we can fetch the image and decode it
-      // TODO: fetch images and decode them to check real filetype like in Chrome
       const manifestSrc = JSON.stringify({
         icons: [{
           src: 'path/to/image.jpg',
@@ -292,10 +304,22 @@ describe('Icons helper', () => {
       assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 1);
     });
 
-    it('succeeds with a png icon that has query params in url', () => {
+    it('succeeds with a non-png icon that has query params in url', () => {
       const manifestSrc = JSON.stringify({
         icons: [{
-          src: 'path/to/image.png?param=true',
+          src: 'path/to/image.jpg?param=true',
+          sizes: '200x200',
+          type: 'image/png',
+        }],
+      });
+      const manifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
+      assert.equal(icons.pngSizedAtLeast(192, manifest.value).length, 1);
+    });
+
+    it('succeeds with a non-png icon that has a .png extension in the middle', () => {
+      const manifestSrc = JSON.stringify({
+        icons: [{
+          src: 'path/to/image.png.jpg',
           sizes: '200x200',
           type: 'image/png',
         }],


### PR DESCRIPTION
**Summary**
Makes the icon pngSizedAtLeast function check the file extension _only if there is no typehint_ like Chrome does.

**Related Issues/PRs**
fixes: #6208 
