### PR TITLE
core(driver): reduce required traceCategories again

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -82,22 +82,38 @@ class Driver {
 
   static get traceCategories() {
     return [
-      '-*', // exclude default
-      'disabled-by-default-lighthouse', // used instead of 'toplevel' in Chrome 71+
+      // Exclude default categories. We'll be selective to minimize trace size
+      '-*',
+
+      // Used instead of 'toplevel' in Chrome 71+
+      'disabled-by-default-lighthouse',
+
+      // All compile/execute events are captured by parent events in devtools.timeline..
+      // But the v8 category provides some nice context for only <0.5% of the trace size
+      'v8',
+      // Same situation here. This category is there for RunMicrotasks only, but with other teams
+      // accidentally excluding microtasks, we don't want to assume a parent event will always exist
       'v8.execute',
-      'blink.console',
+
+      // For extracting UserTiming marks/measures
       'blink.user_timing',
-      'benchmark',
-      'loading',
-      'latencyInfo',
+
+      // Not mandatory but not used much
+      'blink.console',
+
+      // Most the events we need come in on these two
       'devtools.timeline',
       'disabled-by-default-devtools.timeline',
-      'disabled-by-default-devtools.timeline.frame',
+
+      // Up to 450 (https://goo.gl/rBfhn4) JPGs added to the trace
+      'disabled-by-default-devtools.screenshot',
+
+      // This doesn't add its own events, but adds a `stackTrace` property to devtools.timeline events
       'disabled-by-default-devtools.timeline.stack',
-      // Flipped off until bugs.chromium.org/p/v8/issues/detail?id=5820 is fixed in Stable
+
+      // CPU sampling profiler data only enabled for debugging purposes
       // 'disabled-by-default-v8.cpu_profiler',
       // 'disabled-by-default-v8.cpu_profiler.hires',
-      'disabled-by-default-devtools.screenshot',
     ];
   }
 

--- a/lighthouse-core/lib/task-groups.js
+++ b/lighthouse-core/lib/task-groups.js
@@ -31,8 +31,7 @@ const taskGroups = {
     label: 'Style & Layout',
     traceEventNames: [
       'ScheduleStyleRecalculation',
-      'RecalculateStyles',
-      'UpdateLayoutTree',
+      'UpdateLayoutTree', // previously RecalculateStyles
       'InvalidateLayout',
       'Layout',
     ],
@@ -42,15 +41,11 @@ const taskGroups = {
     label: 'Rendering',
     traceEventNames: [
       'Animation',
-      'RequestMainThreadFrame',
-      'ActivateLayerTree',
-      'DrawFrame',
       'HitTest',
       'PaintSetup',
       'Paint',
       'PaintImage',
-      'Rasterize',
-      'RasterTask',
+      'RasterTask', // Previously Rasterize
       'ScrollLayer',
       'UpdateLayer',
       'UpdateLayerTree',
@@ -81,9 +76,11 @@ const taskGroups = {
     id: 'garbageCollection',
     label: 'Garbage Collection',
     traceEventNames: [
-      'GCEvent',
-      'MinorGC',
+      'MinorGC', // Previously GCEvent
       'MajorGC',
+      'BlinkGC.AtomicPhase', // Previously ThreadState::performIdleLazySweep, ThreadState::completeSweep, BlinkGCMarking
+
+      // Kept for compatibility on older traces
       'ThreadState::performIdleLazySweep',
       'ThreadState::completeSweep',
       'BlinkGCMarking',


### PR DESCRIPTION
After #6117 allowed us to remove `toplevel`, I had a feeling we could remove more, like `loading` or `benchmark` trace categories.

Tried some things and... we can! It knocks another 20% off the trace size. :)

Details follow..

-------------------

### What trace events do we _need?_

I started by auditing all the trace events I can tell we care about. And I grabbed the category they're currently traced with in Chromium:

<details>

Trace events _required_ by Lighthouse and their assigned categories


| trace event name | categories |
|-|-|
| ActivateLayerTree | disabled-by-default-devtools.timeline.frame |
| Animation | blink.animations,devtools.timeline,benchmark,rail |
| BlinkGCMarking | _(not used anymore, removing)_ |
| CompositeLayers | disabled-by-default-devtools.timeline |
| domContentLoadedEventEnd | blink.user_timing,rail |
| DrawFrame | disabled-by-default-devtools.timeline.frame |
| EvaluateScript | disabled-by-default-devtools.timeline |
| EventDispatch | devtools.timeline |
| FireAnimationFrame | devtools.timeline |
| FireIdleCallback | devtools.timeline |
| firstContentfulPaint | loading,rail,devtools.timeline |
| firstMeaningfulPaint | loading,rail,devtools.timeline |
| firstMeaningfulPaintCandidate | loading,rail,devtools.timeline |
| firstPaint | loading,rail,devtools.timeline |
| FunctionCall | devtools.timeline |
| GCEvent | _(not used anymore, removing)_ |
| HitTest | blink,devtools.timeline |
| InvalidateLayout | disabled-by-default-devtools.timeline |
| Layout | devtools.timeline |
| loadEventEnd | blink.user_timing |
| MajorGC | devtools.timeline,v8 |
| MessageLoop::RunTask | toplevel |
| MinorGC | devtools.timeline,v8 |
| navigationStart | blink.user_timing |
| Paint | devtools.timeline,rail |
| PaintImage | disabled-by-default-devtools.timeline |
| PaintSetup | _(not used anymore)_ |
| ParseAuthorStyleSheet | blink,devtools.timeline |
| ParseHTML | devtools.timeline |
| PlatformResourceSendRequest | devtools.timeline |
| Rasterize | _(not used anymore, removing)_ |
| RasterTask | cc,disabled-by-default-devtools.timeline |
| RecalculateStyles | _(not used anymore, removing)_ |
| RequestMainThreadFrame | disabled-by-default-devtools.timeline.frame |
| ResourceFinish | devtools.timeline |
| ResourceReceivedData | devtools.timeline |
| ResourceReceiveResponse | devtools.timeline |
| ResourceSendRequest | devtools.timeline |
| RunMicrotasks | v8.execute |
| RunTask | disabled-by-default-lighthouse |
| ScheduleStyleRecalculation | disabled-by-default-devtools.timeline |
| Screenshot | disabled-by-default-devtools.screenshot |
| ScrollLayer | devtools.timeline |
| TaskQueueManager:: ProcessTaskFromWorkQueue | _(not a thing anymore)_ |
| ThreadControllerImpl::DoWork | _(not a thing anymore)_ |
| ThreadControllerImpl::RunTask | toplevel _(swapped, you know)_ |
| ThreadState::completeSweep | _(not a thing anymore, removed)_ |
| ThreadState::performIdleLazySweep | _(not a thing anymore, removed)_ |
| TimerFire | devtools.timeline |
| TimerInstall | devtools.timeline |
| TracingStartedInBrowser | disabled-by-default-devtools.timeline |
| TracingStartedInPage | _(not emitted anymore, we synthesize it ourselves)_ |
| UpdateLayer | disabled-by-default-devtools.timeline |
| UpdateLayerTree | devtools.timeline |
| UpdateLayoutTree | blink,devtools.timeline |
| v8.compile | v8,devtools.timeline |
| v8.compileModule | v8,devtools.timeline |
| v8.evaluateModule | v8,devtools.timeline |
| V8.Execute | v8 |
| v8.parseOnBackground | v8,devtools.timeline |
| XHRReadyStateChange | devtools.timeline |

</details>

### Then, what trace categories do we _need_?

If you then take all the required categories and list em out, you get:

* **disabled-by-default-devtools.timeline**
* **disabled-by-default-devtools.screenshot**
* **disabled-by-default-lighthouse**
* **devtools.timeline**
* **v8.execute**
* **blink.user_timing**
* blink,devtools.timeline
* blink.animations,devtools.timeline,benchmark,rail
* blink.user_timing,rail
* devtools.timeline,rail
* devtools.timeline,v8
* loading,rail,devtools.timeline
* v8,devtools.timeline

And turns out all the non-bold items all include either 'devtools.timeline' or 'blink.user_timing'. 

This means we can stop tracing the following categories:

❌ benchmark
❌ loading
❌ latencyInfo

💣  BOOM!  These account for **~20%** of some of our larger traces.

-------

Also `disabled-by-default-devtools.timeline.frame` only is [used for three trace events](https://cs.chromium.org/chromium/src/cc/base/devtools_instrumentation.cc?type=cs&q=TRACE_EVENT+timeline.frame&g=0&l=12-13). And we've only been collecting them to sum up our mainthread-work-breakdown numbers. However these 3 events are INSTANT events with zero duration, so.. they don't add to the numbers.


Lastly I cleaned up some of the trace events mentioned in task-groups, since I now know these events like best friends. :)



------

<details>
<summary>Addendum: What's _still_ taking up space in the trace?</summary>

First, top events, then top categories:
![image](https://user-images.githubusercontent.com/39191/46911729-73e01f00-cf19-11e8-9cd5-7387719f4e16.png)

Basically: 

* screenshots are big. This trace has 398 screenshots. That'll do it. Next is throttling the screenshot capture, i think.
* the `UpdateLayer` event from `disabled-by-default-devtools.timeline` is SUPER chatty. It's worth hunting down why devtools cares about it. perhaps there's a parent task we can use instead? ALL of them are under 0.3ms long, though 15,000 of them do add up to 376ms. But still.... 
![image](https://user-images.githubusercontent.com/39191/46911752-20ba9c00-cf1a-11e8-92a2-96dbf21d6396.png)
* that's all that stands out to me, the next biggest things don't seem worth it to deal with.


</details>