### PR TITLE
Escape percent sign in format string

### DIFF
--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -266,7 +266,7 @@ class FontSize extends Audit {
     }
 
     /** @type {LH.Audit.DisplayValue} */
-    const displayValue = ['%.1d% legible text', percentageOfPassingText];
+    const displayValue = ['%.1d%% legible text', percentageOfPassingText];
     const details = Audit.makeTableDetails(headings, tableData);
     const passed = percentageOfPassingText >= MINIMAL_PERCENTAGE_OF_LEGIBLE_TEXT;
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

Bugfix.

<!-- Describe the need for this change -->

Needed to allow the value in the JSON to be formatted by languages other than JavaScript, such as Python, C, C++, PHP, Bash, etc.

The JSON output includes something like this:

```json
      "displayValue": [
        "%.1d% legible text",
        98.93973419725361
      ],
```

This should be displayed as "98% legible text".

I'm consuming the JSON in Python, which can't format that (macOS High Sierra/Python 3.7):

```python
>>> "%.1d% legible text" % 98.93973419725361
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not enough arguments for format string
```

That last percent needs escaping:
```
>>> "%.1d%% legible text" % 98.93973419725361
'98% legible text'
```

Both methods work for JavaScript (macOS, Chrome 69 console):
```js
> console.log('%.1d% legible text', 98.93973419725361);
98% legible text

> console.log('%.1d%% legible text', 98.93973419725361);
98% legible text
```

Documentation of `%%`:

* https://www.promotic.eu/en/pmdoc/Appendix/FormatStringSpec.htm
* https://en.wikibooks.org/wiki/C%2B%2B_Programming/Code/Standard_C_Library/Functions/printf
* https://www.ibm.com/support/knowledgecenter/en/SSB23S_1.1.0.15/gtpc2/cpp_fprintf-printf-sprintf.html
* https://secure.php.net/manual/en/function.sprintf.php#refsect1-function.sprintf-examples
* http://wiki.bash-hackers.org/commands/builtin/printf#format_strings
