### PR TITLE
extension: stop report bug prompt for file:// urls

### DIFF
--- a/lighthouse-extension/app/src/popup.js
+++ b/lighthouse-extension/app/src/popup.js
@@ -26,6 +26,8 @@ const NON_BUG_ERROR_MESSAGES = {
       'are trying to review.',
   'Cannot access contents of the page': 'Lighthouse can only audit URLs that start' +
       ' with http:// or https://.',
+  'INVALID_URL': 'Lighthouse can only audit URLs that start' +
+      ' with http:// or https://.',
 };
 
 const MAX_ISSUE_ERROR_LENGTH = 60;


### PR DESCRIPTION
**Summary**
I think someone's already mentioned this but we don't need to prompt folks to file bugs for this one.

![image](https://user-images.githubusercontent.com/2301202/46968903-27602500-d07a-11e8-870b-3198d3db7b2d.png)
