### PR TITLE
core(audits): clarify diff between load-fast-enough-for-pwa's TTI and perf TTI

### DIFF
--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -54,10 +54,12 @@ class LoadFastEnough4Pwa extends Audit {
 
     // Override settings for interactive if provided throttling was used and network
     // throttling was not consistent with standard `mobile network throttling`
-    const override = context.settings.throttlingMethod === 'provided' &&
-    !isDeepEqual(context.settings.throttling, mobileThrottling);
+    const override = context.settings.throttlingMethod === 'provided' ||
+      !isDeepEqual(context.settings.throttling, mobileThrottling);
 
-    const settings = override ? Object.assign({}, context.settings, settingOverrides): 
+    const displayValueFinal = override?displayValueTextWithOverride: displayValueText;
+
+    const settings = override ? Object.assign({}, context.settings, settingOverrides):
       context.settings;
 
     const metricComputationData = {trace, devtoolsLog, settings};
@@ -70,7 +72,7 @@ class LoadFastEnough4Pwa extends Audit {
     /** @type {string|undefined} */
     let explanation;
     if (!score) {
-      displayValue = [override?displayValueTextWithOverride: displayValueText, tti.timing / 1000];
+      displayValue = [displayValueFinal, tti.timing / 1000];
       explanation = 'Your page loads too slowly and is not interactive within 10 seconds. ' +
         'Look at the opportunities and diagnostics in the "Performance" section to learn how to ' +
         'improve.';

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -16,6 +16,9 @@ const Audit = require('./audit');
 const mobileThrottling = require('../config/constants').throttling.mobileSlow4G;
 const Interactive = require('../gather/computed/metrics/interactive.js');
 
+const displayValueText = `Interactive at %d\xa0s`;
+const displayValueTextWithOverride = `Interactive on simulated mobile network at %d\xa0s`;
+
 // Maximum TTI to be considered "fast" for PWA baseline checklist
 //   https://developers.google.com/web/progressive-web-apps/checklist
 const MAXIMUM_TTI = 10 * 1000;
@@ -48,11 +51,14 @@ class LoadFastEnough4Pwa extends Audit {
     // If throttling was default devtools or lantern slow 4G throttling, then reuse the given settings
     // Otherwise, we'll force the usage of lantern slow 4G.
     const settingOverrides = {throttlingMethod: 'simulate', throttling: mobileThrottling};
-    const settings =
-      context.settings.throttlingMethod !== 'provided' &&
-      isDeepEqual(context.settings.throttling, mobileThrottling)
-        ? context.settings
-        : Object.assign({}, context.settings, settingOverrides);
+
+    // Override settings for interactive if provided throttling was used and network
+    // throttling was not consistent with standard `mobile network throttling`
+    const override = context.settings.throttlingMethod === 'provided' &&
+    !isDeepEqual(context.settings.throttling, mobileThrottling);
+
+    const settings = !override? context.settings:
+      Object.assign({}, context.settings, settingOverrides);
 
     const metricComputationData = {trace, devtoolsLog, settings};
     const tti = await Interactive.request(metricComputationData, context);
@@ -64,7 +70,7 @@ class LoadFastEnough4Pwa extends Audit {
     /** @type {string|undefined} */
     let explanation;
     if (!score) {
-      displayValue = [`Interactive at %d\xa0s`, tti.timing / 1000];
+      displayValue = [override?displayValueTextWithOverride: displayValueText, tti.timing / 1000];
       explanation = 'Your page loads too slowly and is not interactive within 10 seconds. ' +
         'Look at the opportunities and diagnostics in the "Performance" section to learn how to ' +
         'improve.';

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -57,8 +57,8 @@ class LoadFastEnough4Pwa extends Audit {
     const override = context.settings.throttlingMethod === 'provided' &&
     !isDeepEqual(context.settings.throttling, mobileThrottling);
 
-    const settings = !override? context.settings:
-      Object.assign({}, context.settings, settingOverrides);
+    const settings = override ? Object.assign({}, context.settings, settingOverrides): 
+      context.settings;
 
     const metricComputationData = {trace, devtoolsLog, settings};
     const tti = await Interactive.request(metricComputationData, context);

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -52,12 +52,12 @@ class LoadFastEnough4Pwa extends Audit {
     // Otherwise, we'll force the usage of lantern slow 4G.
     const settingOverrides = {throttlingMethod: 'simulate', throttling: mobileThrottling};
 
-    // Override settings for interactive if provided throttling was used and network
+    // Override settings for interactive if provided throttling was used or network
     // throttling was not consistent with standard `mobile network throttling`
     const override = context.settings.throttlingMethod === 'provided' ||
       !isDeepEqual(context.settings.throttling, mobileThrottling);
 
-    const displayValueFinal = override?displayValueTextWithOverride: displayValueText;
+    const displayValueFinal = override ? displayValueTextWithOverride : displayValueText;
 
     const settings = override ? Object.assign({}, context.settings, settingOverrides):
       context.settings;

--- a/lighthouse-core/audits/load-fast-enough-for-pwa.js
+++ b/lighthouse-core/audits/load-fast-enough-for-pwa.js
@@ -59,7 +59,7 @@ class LoadFastEnough4Pwa extends Audit {
 
     const displayValueFinal = override ? displayValueTextWithOverride : displayValueText;
 
-    const settings = override ? Object.assign({}, context.settings, settingOverrides):
+    const settings = override ? Object.assign({}, context.settings, settingOverrides) :
       context.settings;
 
     const metricComputationData = {trace, devtoolsLog, settings};

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -79,6 +79,16 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     expect(Math.round(result.rawValue)).toMatchSnapshot();
   });
 
+  it('overrides when throttling is modified but method is not provided', async () => {
+    const artifacts = {
+      traces: {defaultPass: trace},
+      devtoolsLogs: {defaultPass: devtoolsLog},
+    };
+
+    const settings = {throttlingMethod: 'devtools', throttling: {rttMs: 40, throughput: 100000}};
+    const result = await FastPWAAudit.audit(artifacts, {settings, computedCache: new Map()});
+    expect(result.rawValue).toBeGreaterThan(2000);
+  });
 
   it('override with simulated result fails a bad simulated TTI value', async () => {
     const topLevelTasks = [

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -78,4 +78,27 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
     expect(result.rawValue).toBeGreaterThan(2000);
     expect(Math.round(result.rawValue)).toMatchSnapshot();
   });
+
+
+  it('override with simulated result fails a bad simulated TTI value', async () => {
+    const topLevelTasks = [
+      {ts: 1000, duration: 1000},
+      {ts: 3000, duration: 1000},
+      {ts: 5000, duration: 1000},
+      {ts: 9000, duration: 1000},
+      {ts: 12000, duration: 1000},
+      {ts: 14900, duration: 1000},
+    ];
+    const longTrace = createTestTrace({navigationStart: 0, traceEnd: 20000, topLevelTasks});
+
+    const artifacts = {
+      traces: {defaultPass: longTrace},
+      devtoolsLogs: {defaultPass: devtoolsLog},
+    };
+
+    const settings = {throttlingMethod: 'provided', throttling: {rttMs: 40, throughput: 100000}};
+    const result = await FastPWAAudit.audit(artifacts, {settings, computedCache: new Map()});
+    expect(result.displayValue).toContain('Interactive on simulated mobile network at %d\xa0s');
+    expect(result.rawValue).toBeGreaterThan(10000);
+  });
 });

--- a/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
+++ b/lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js
@@ -75,11 +75,11 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
 
     const settings = {throttlingMethod: 'provided', throttling: {rttMs: 40, throughput: 100000}};
     const result = await FastPWAAudit.audit(artifacts, {settings, computedCache: new Map()});
-    expect(result.rawValue).toBeGreaterThan(2000);
+    expect(result.rawValue).toBeGreaterThan(2000); // If not overridden this would be 1582
     expect(Math.round(result.rawValue)).toMatchSnapshot();
   });
 
-  it('overrides when throttling is modified but method is not provided', async () => {
+  it('overrides when throttling is modified but method is not "provided"', async () => {
     const artifacts = {
       traces: {defaultPass: trace},
       devtoolsLogs: {defaultPass: devtoolsLog},
@@ -87,10 +87,10 @@ describe('PWA: load-fast-enough-for-pwa audit', () => {
 
     const settings = {throttlingMethod: 'devtools', throttling: {rttMs: 40, throughput: 100000}};
     const result = await FastPWAAudit.audit(artifacts, {settings, computedCache: new Map()});
-    expect(result.rawValue).toBeGreaterThan(2000);
+    expect(result.rawValue).toBeGreaterThan(2000); // If not overridden this would be 1582
   });
 
-  it('override with simulated result fails a bad simulated TTI value', async () => {
+  it('overrides when throttling is "provided" and fails the simulated TTI value', async () => {
     const topLevelTasks = [
       {ts: 1000, duration: 1000},
       {ts: 3000, duration: 1000},


### PR DESCRIPTION
**Summary**
~In load-fast-enough-for-PWA the interactive when "provided" + mobile throttling is defaulted to force a simulated TTI, not the provided TTI (as shown in the top as the true TTI).  @brendankenny remembers this being purposeful, but it does make inconsistent numbers.  @patrickhulce do you have some context?~

Instead, will provide clearer explanation for why the TTIs might be different.

**TODO:** 
If we do want to revert to this pass through of settings we need to update a test in `lighthouse-core/test/audits/load-fast-enough-for-pwa-test.js`

**Related Issues/PRs**
fixes: #6284 
