### PR TITLE
core: bail if encounter insecure ssl cert, to avoid hanging forever

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -850,6 +850,24 @@ class Driver {
   }
 
   /**
+   * @param {number} [timeout]
+   * @return {Promise<LH.Crdp.Security.SecurityStateChangedEvent>}
+   */
+  getSecurityState(timeout = 1000) {
+    return new Promise((resolve, reject) => {
+      const err = new LHError(LHError.errors.SECURITY_STATE_TIMEOUT);
+      const asyncTimeout = setTimeout((_ => reject(err)), timeout);
+
+      this.sendCommand('Security.enable');
+      this.once('Security.securityStateChanged', (e) => {
+        clearTimeout(asyncTimeout);
+        resolve(e);
+        this.sendCommand('Security.disable').catch(reject);
+      });
+    });
+  }
+
+  /**
    * @param {string} name The name of API whose permission you wish to query
    * @return {Promise<string>} The state of permissions, resolved in a promise.
    *    See https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query.

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -859,10 +859,10 @@ class Driver {
       const asyncTimeout = setTimeout((_ => reject(err)), timeout);
 
       this.sendCommand('Security.enable');
-      this.once('Security.securityStateChanged', (e) => {
+      this.once('Security.securityStateChanged', state => {
         clearTimeout(asyncTimeout);
-        resolve(e);
-        this.sendCommand('Security.disable').catch(reject);
+        resolve(state);
+        this.sendCommand('Security.disable');
       });
     });
   }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -849,22 +849,19 @@ class Driver {
     });
   }
 
-  /**
-   * @param {number} [timeout]
-   * @return {Promise<LH.Crdp.Security.SecurityStateChangedEvent>}
-   */
-  getSecurityState(timeout = 1000) {
-    return new Promise((resolve, reject) => {
-      const err = new LHError(LHError.errors.SECURITY_STATE_TIMEOUT);
-      const asyncTimeout = setTimeout((_ => reject(err)), timeout);
-
-      this.once('Security.securityStateChanged', state => {
-        clearTimeout(asyncTimeout);
-        resolve(state);
-        this.sendCommand('Security.disable');
-      });
-      this.sendCommand('Security.enable');
+  async listenForSecurityStateChanges() {
+    this.on('Security.securityStateChanged', state => {
+      this.lastSecurityState = state;
     });
+    await this.sendCommand('Security.enable');
+  }
+
+  /**
+   * @return {LH.Crdp.Security.SecurityStateChangedEvent}
+   */
+  getSecurityState() {
+    // @ts-ignore
+    return this.lastSecurityState;
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -858,12 +858,12 @@ class Driver {
       const err = new LHError(LHError.errors.SECURITY_STATE_TIMEOUT);
       const asyncTimeout = setTimeout((_ => reject(err)), timeout);
 
-      this.sendCommand('Security.enable');
       this.once('Security.securityStateChanged', state => {
         clearTimeout(asyncTimeout);
         resolve(state);
         this.sendCommand('Security.disable');
       });
+      this.sendCommand('Security.enable');
     });
   }
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -860,7 +860,12 @@ class Driver {
    * @return {LH.Crdp.Security.SecurityStateChangedEvent}
    */
   getSecurityState() {
-    // @ts-ignore
+    if (!this.lastSecurityState) {
+      // happens if 'listenForSecurityStateChanges' is not called,
+      // or if some assumptions about the Security domain are wrong
+      throw new Error('Expected a security state.');
+    }
+
     return this.lastSecurityState;
   }
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -78,6 +78,13 @@ class Driver {
       // properties. See https://github.com/Microsoft/TypeScript/pull/22348.
       this._eventEmitter.emit(event.method, event.params);
     });
+
+    /**
+     * Used for monitoring network status events during gotoURL.
+     * @type {?LH.Crdp.Security.SecurityStateChangedEvent}
+     * @private
+     */
+    this._lastSecurityState = null;
   }
 
   static get traceCategories() {
@@ -851,7 +858,7 @@ class Driver {
 
   async listenForSecurityStateChanges() {
     this.on('Security.securityStateChanged', state => {
-      this.lastSecurityState = state;
+      this._lastSecurityState = state;
     });
     await this.sendCommand('Security.enable');
   }
@@ -860,13 +867,13 @@ class Driver {
    * @return {LH.Crdp.Security.SecurityStateChangedEvent}
    */
   getSecurityState() {
-    if (!this.lastSecurityState) {
+    if (!this._lastSecurityState) {
       // happens if 'listenForSecurityStateChanges' is not called,
       // or if some assumptions about the Security domain are wrong
       throw new Error('Expected a security state.');
     }
 
-    return this.lastSecurityState;
+    return this._lastSecurityState;
   }
 
   /**

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -310,12 +310,7 @@ class GatherRunner {
       trace,
     };
 
-    if (!pageLoadError) {
-      // Disable throttling so the afterPass analysis isn't throttled
-      // This will hang if there was a security error. But, there is no
-      // need to throttle if there is such an error. See #6287
-      await driver.setThrottling(passContext.settings, {useThrottling: false});
-    }
+    await driver.setThrottling(passContext.settings, {useThrottling: false});
 
     for (const gathererDefn of gatherers) {
       const gatherer = gathererDefn.instance;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -174,7 +174,7 @@ class GatherRunner {
   }
 
   /**
-   * Returns an error if the original network request failed or wasn't found.
+   * Returns an error if the security state is insecure.
    * @param {LH.Crdp.Security.SecurityStateChangedEvent} securityState
    * @return {LHError|undefined}
    */
@@ -185,7 +185,7 @@ class GatherRunner {
         .filter(exp => exp.securityState === 'insecure')
         .map(exp => exp.description);
       errorDef.message += ` ${insecureDescriptions.join(' ')}`;
-      return new LHError(errorDef, {fatal: true});
+      return new LHError(errorDef);
     }
   }
 
@@ -310,6 +310,7 @@ class GatherRunner {
       trace,
     };
 
+    // Disable throttling so the afterPass analysis isn't throttled
     await driver.setThrottling(passContext.settings, {useThrottling: false});
 
     for (const gathererDefn of gatherers) {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -176,16 +176,16 @@ class GatherRunner {
   /**
    * Returns an error if the security state is insecure.
    * @param {LH.Crdp.Security.SecurityStateChangedEvent} securityState
-   * @return {LHError|undefined}
+   * @throws {LHError}
    */
-  static checkForSecurityIssue({securityState, explanations}) {
+  static assertNoSecurityIssues({securityState, explanations}) {
     if (securityState === 'insecure') {
       const errorDef = {...LHError.errors.INSECURE_DOCUMENT_REQUEST};
       const insecureDescriptions = explanations
         .filter(exp => exp.securityState === 'insecure')
         .map(exp => exp.description);
       errorDef.message += ` ${insecureDescriptions.join(' ')}`;
-      return new LHError(errorDef);
+      throw new LHError(errorDef);
     }
   }
 
@@ -297,10 +297,7 @@ class GatherRunner {
       passContext.LighthouseRunWarnings.push(pageLoadError.friendlyMessage);
     }
 
-    const securityError = this.checkForSecurityIssue(driver.getSecurityState());
-    if (securityError) {
-      throw securityError;
-    }
+    this.assertNoSecurityIssues(driver.getSecurityState());
 
     // Expose devtoolsLog, networkRecords, and trace (if present) to gatherers
     /** @type {LH.Gatherer.LoadData} */

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -151,7 +151,7 @@ class GatherRunner {
    * @param {LH.Crdp.Security.SecurityStateChangedEvent} securityState
    * @return {LHError|undefined}
    */
-  static getPageLoadError(url, networkRecords, securityState) {
+  static getPageLoadError(url, networkRecords, {securityState, explanations}) {
     const mainRecord = networkRecords.find(record => {
       // record.url is actual request url, so needs to be compared without any URL fragment.
       return URL.equalWithExcludedFragments(record.url, url);
@@ -166,9 +166,9 @@ class GatherRunner {
     } else if (mainRecord.hasErrorStatusCode()) {
       errorDef = {...LHError.errors.ERRORED_DOCUMENT_REQUEST};
       errorDef.message += ` Status code: ${mainRecord.statusCode}.`;
-    } else if (securityState.securityState === 'insecure') {
+    } else if (securityState === 'insecure') {
       errorDef = {...LHError.errors.INSECURE_DOCUMENT_REQUEST};
-      const insecureDescriptions = securityState.explanations
+      const insecureDescriptions = explanations
         .filter(exp => exp.securityState === 'insecure')
         .map(exp => exp.description);
       errorDef.message += ` ${insecureDescriptions.join(' ')}`;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -112,6 +112,7 @@ class GatherRunner {
     await driver.cacheNatives();
     await driver.registerPerformanceObserver();
     await driver.dismissJavaScriptDialogs();
+    await driver.listenForSecurityStateChanges();
     if (resetStorage) await driver.clearDataForOrigin(options.requestedUrl);
   }
 
@@ -296,8 +297,7 @@ class GatherRunner {
       passContext.LighthouseRunWarnings.push(pageLoadError.friendlyMessage);
     }
 
-    const securityState = await driver.getSecurityState();
-    const securityError = this.checkForSecurityIssue(securityState);
+    const securityError = this.checkForSecurityIssue(driver.getSecurityState());
     if (securityError) {
       throw securityError;
     }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -174,7 +174,7 @@ class GatherRunner {
   }
 
   /**
-   * Returns an error if the security state is insecure.
+   * Throws an error if the security state is insecure.
    * @param {LH.Crdp.Security.SecurityStateChangedEvent} securityState
    * @throws {LHError}
    */

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -175,12 +175,6 @@ const ERRORS = {
     message: strings.requestContentTimeout,
   },
 
-  // Protocol timeout failures
-  SECURITY_STATE_TIMEOUT: {
-    code: 'SECURITY_STATE_TIMEOUT',
-    message: strings.securityStateTimeout,
-  },
-
   // URL parsing failures
   INVALID_URL: {
     code: 'INVALID_URL',

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -142,6 +142,12 @@ const ERRORS = {
     message: strings.pageLoadFailed,
     lhrRuntimeError: true,
   },
+  /* Used when security error prevents page load. */
+  INSECURE_DOCUMENT_REQUEST: {
+    code: 'INSECURE_DOCUMENT_REQUEST',
+    message: strings.pageLoadFailedInsecure,
+    lhrRuntimeError: true,
+  },
 
   // Protocol internal failures
   TRACING_ALREADY_STARTED: {
@@ -167,6 +173,12 @@ const ERRORS = {
   REQUEST_CONTENT_TIMEOUT: {
     code: 'REQUEST_CONTENT_TIMEOUT',
     message: strings.requestContentTimeout,
+  },
+
+  // Protocol timeout failures
+  SECURITY_STATE_TIMEOUT: {
+    code: 'SECURITY_STATE_TIMEOUT',
+    message: strings.securityStateTimeout,
   },
 
   // URL parsing failures

--- a/lighthouse-core/lib/strings.js
+++ b/lighthouse-core/lib/strings.js
@@ -11,7 +11,7 @@ module.exports = {
   badTraceRecording: `Something went wrong with recording the trace over your page load. Please run Lighthouse again.`,
   pageLoadTookTooLong: `Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse.`,
   pageLoadFailed: `Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests.`,
-  pageLoadFailedInsecure: `The URL you have provided does not have a valid security certificate.`,
+  pageLoadFailedInsecure: `The URL you have provided does not have valid security credentials.`,
   internalChromeError: `An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse.`,
   requestContentTimeout: 'Fetching resource content has exceeded the allotted time',
   securityStateTimeout: 'Fetching security state has exceeded the allotted time',

--- a/lighthouse-core/lib/strings.js
+++ b/lighthouse-core/lib/strings.js
@@ -11,7 +11,9 @@ module.exports = {
   badTraceRecording: `Something went wrong with recording the trace over your page load. Please run Lighthouse again.`,
   pageLoadTookTooLong: `Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse.`,
   pageLoadFailed: `Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests.`,
+  pageLoadFailedInsecure: `The URL you have provided does not have a valid security certificate.`,
   internalChromeError: `An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse.`,
   requestContentTimeout: 'Fetching resource content has exceeded the allotted time',
+  securityStateTimeout: 'Fetching security state has exceeded the allotted time',
   urlInvalid: `The URL you have provided appears to be invalid.`,
 };

--- a/lighthouse-core/lib/strings.js
+++ b/lighthouse-core/lib/strings.js
@@ -14,6 +14,5 @@ module.exports = {
   pageLoadFailedInsecure: `The URL you have provided does not have valid security credentials.`,
   internalChromeError: `An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse.`,
   requestContentTimeout: 'Fetching resource content has exceeded the allotted time',
-  securityStateTimeout: 'Fetching security state has exceeded the allotted time',
   urlInvalid: `The URL you have provided appears to be invalid.`,
 };

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -81,6 +81,9 @@ const fakeDriver = {
   setExtraHTTPHeaders() {
     return Promise.resolve();
   },
+  listenForSecurityStateChanges() {
+    return Promise.resolve();
+  },
   getSecurityState() {
     return Promise.resolve({
       securityState: 'secure',

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -81,6 +81,11 @@ const fakeDriver = {
   setExtraHTTPHeaders() {
     return Promise.resolve();
   },
+  getSecurityState() {
+    return Promise.resolve({
+      securityState: 'secure',
+    });
+  },
 };
 
 module.exports = fakeDriver;

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -497,11 +497,10 @@ describe('GatherRunner', function() {
       ],
     };
 
-    return GatherRunner.afterPass({url, driver, passConfig}, {TestGatherer: []})
-      .then(([passData]) => {
-        assert.equal(calledTrace, true);
-        assert.equal(passData.trace, fakeTraceData);
-      });
+    return GatherRunner.afterPass({url, driver, passConfig}, {TestGatherer: []}).then(passData => {
+      assert.equal(calledTrace, true);
+      assert.equal(passData.trace, fakeTraceData);
+    });
   });
 
   it('tells the driver to begin devtoolsLog collection', () => {
@@ -548,11 +547,10 @@ describe('GatherRunner', function() {
       ],
     };
 
-    return GatherRunner.afterPass({url, driver, passConfig}, {TestGatherer: []})
-      .then(([passData]) => {
-        assert.equal(calledDevtoolsLogCollect, true);
-        assert.strictEqual(passData.devtoolsLog[0], fakeDevtoolsMessage);
-      });
+    return GatherRunner.afterPass({url, driver, passConfig}, {TestGatherer: []}).then(passData => {
+      assert.equal(calledDevtoolsLogCollect, true);
+      assert.strictEqual(passData.devtoolsLog[0], fakeDevtoolsMessage);
+    });
   });
 
   it('does as many passes as are required', () => {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -686,7 +686,7 @@ describe('GatherRunner', function() {
       const secureSecurityState = {
         securityState: 'secure',
       };
-      assert.ok(!GatherRunner.checkForSecurityIssue(secureSecurityState));
+      GatherRunner.assertNoSecurityIssues(secureSecurityState);
     });
 
     it('fails when page is insecure', () => {
@@ -707,10 +707,14 @@ describe('GatherRunner', function() {
         ],
         securityState: 'insecure',
       };
-      const error = GatherRunner.checkForSecurityIssue(insecureSecurityState);
-      assert.equal(error.message, 'INSECURE_DOCUMENT_REQUEST');
-      /* eslint-disable-next-line max-len */
-      assert.equal(error.friendlyMessage, 'The URL you have provided does not have valid security credentials. reason 1. reason 2.');
+      try {
+        GatherRunner.assertNoSecurityIssues(insecureSecurityState);
+        assert.fail('expected INSECURE_DOCUMENT_REQUEST LHError');
+      } catch (err) {
+        assert.equal(err.message, 'INSECURE_DOCUMENT_REQUEST');
+        /* eslint-disable-next-line max-len */
+        assert.equal(err.friendlyMessage, 'The URL you have provided does not have valid security credentials. reason 1. reason 2.');
+      }
     });
   });
 

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -685,7 +685,7 @@ describe('GatherRunner', function() {
     });
   });
 
-  describe('#checkForSecurityIssue', () => {
+  describe('#assertNoSecurityIssues', () => {
     it('succeeds when page is secure', () => {
       const secureSecurityState = {
         securityState: 'secure',

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -649,6 +649,7 @@ describe('GatherRunner', function() {
       mainRecord.localizedFailDescription = 'foobar';
       const error = GatherRunner.getPageLoadError(url, [mainRecord]);
       assert.equal(error.message, 'FAILED_DOCUMENT_REQUEST');
+      assert.equal(error.code, 'FAILED_DOCUMENT_REQUEST');
       assert.ok(/^Lighthouse was unable to reliably load/.test(error.friendlyMessage));
     });
 
@@ -657,6 +658,7 @@ describe('GatherRunner', function() {
       const records = [];
       const error = GatherRunner.getPageLoadError(url, records);
       assert.equal(error.message, 'NO_DOCUMENT_REQUEST');
+      assert.equal(error.code, 'NO_DOCUMENT_REQUEST');
       assert.ok(/^Lighthouse was unable to reliably load/.test(error.friendlyMessage));
     });
 
@@ -667,6 +669,7 @@ describe('GatherRunner', function() {
       mainRecord.statusCode = 404;
       const error = GatherRunner.getPageLoadError(url, [mainRecord]);
       assert.equal(error.message, 'ERRORED_DOCUMENT_REQUEST');
+      assert.equal(error.code, 'ERRORED_DOCUMENT_REQUEST');
       assert.ok(/^Lighthouse was unable to reliably load/.test(error.friendlyMessage));
     });
 
@@ -677,6 +680,7 @@ describe('GatherRunner', function() {
       mainRecord.statusCode = 500;
       const error = GatherRunner.getPageLoadError(url, [mainRecord]);
       assert.equal(error.message, 'ERRORED_DOCUMENT_REQUEST');
+      assert.equal(error.code, 'ERRORED_DOCUMENT_REQUEST');
       assert.ok(/^Lighthouse was unable to reliably load/.test(error.friendlyMessage));
     });
   });
@@ -712,6 +716,7 @@ describe('GatherRunner', function() {
         assert.fail('expected INSECURE_DOCUMENT_REQUEST LHError');
       } catch (err) {
         assert.equal(err.message, 'INSECURE_DOCUMENT_REQUEST');
+        assert.equal(err.code, 'INSECURE_DOCUMENT_REQUEST');
         /* eslint-disable-next-line max-len */
         assert.equal(err.friendlyMessage, 'The URL you have provided does not have valid security credentials. reason 1. reason 2.');
       }

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -321,6 +321,7 @@ describe('GatherRunner', function() {
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
       setExtraHTTPHeaders: asyncFunc,
+      listenForSecurityStateChanges: asyncFunc,
     };
 
     return GatherRunner.setupDriver(driver, {settings: {}}).then(_ => {
@@ -379,6 +380,7 @@ describe('GatherRunner', function() {
       clearDataForOrigin: createCheck('calledClearStorage'),
       blockUrlPatterns: asyncFunc,
       setExtraHTTPHeaders: asyncFunc,
+      listenForSecurityStateChanges: asyncFunc,
     };
 
     return GatherRunner.setupDriver(driver, {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -34,10 +34,6 @@ class TestGathererNoArtifact extends Gatherer {
 
 const fakeDriver = require('./fake-driver');
 
-const secureSecurityState = {
-  securityState: 'secure',
-};
-
 function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn,
   blockUrlFn, extraHeadersFn) {
   const Driver = require('../../gather/driver');
@@ -633,14 +629,14 @@ describe('GatherRunner', function() {
       const url = 'http://the-page.com';
       const mainRecord = new NetworkRequest();
       mainRecord.url = url;
-      assert.ok(!GatherRunner.getPageLoadError(url, [mainRecord], secureSecurityState));
+      assert.ok(!GatherRunner.getPageLoadError(url, [mainRecord]));
     });
 
     it('passes when the page is loaded, ignoring any fragment', () => {
       const url = 'http://example.com/#/page/list';
       const mainRecord = new NetworkRequest();
       mainRecord.url = 'http://example.com';
-      assert.ok(!GatherRunner.getPageLoadError(url, [mainRecord], secureSecurityState));
+      assert.ok(!GatherRunner.getPageLoadError(url, [mainRecord]));
     });
 
     it('fails when page fails to load', () => {
@@ -649,7 +645,7 @@ describe('GatherRunner', function() {
       mainRecord.url = url;
       mainRecord.failed = true;
       mainRecord.localizedFailDescription = 'foobar';
-      const error = GatherRunner.getPageLoadError(url, [mainRecord], secureSecurityState);
+      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
       assert.equal(error.message, 'FAILED_DOCUMENT_REQUEST');
       assert.ok(/^Lighthouse was unable to reliably load/.test(error.friendlyMessage));
     });
@@ -657,7 +653,7 @@ describe('GatherRunner', function() {
     it('fails when page times out', () => {
       const url = 'http://the-page.com';
       const records = [];
-      const error = GatherRunner.getPageLoadError(url, records, secureSecurityState);
+      const error = GatherRunner.getPageLoadError(url, records);
       assert.equal(error.message, 'NO_DOCUMENT_REQUEST');
       assert.ok(/^Lighthouse was unable to reliably load/.test(error.friendlyMessage));
     });
@@ -667,7 +663,7 @@ describe('GatherRunner', function() {
       const mainRecord = new NetworkRequest();
       mainRecord.url = url;
       mainRecord.statusCode = 404;
-      const error = GatherRunner.getPageLoadError(url, [mainRecord], secureSecurityState);
+      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
       assert.equal(error.message, 'ERRORED_DOCUMENT_REQUEST');
       assert.ok(/^Lighthouse was unable to reliably load/.test(error.friendlyMessage));
     });
@@ -677,9 +673,18 @@ describe('GatherRunner', function() {
       const mainRecord = new NetworkRequest();
       mainRecord.url = url;
       mainRecord.statusCode = 500;
-      const error = GatherRunner.getPageLoadError(url, [mainRecord], secureSecurityState);
+      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
       assert.equal(error.message, 'ERRORED_DOCUMENT_REQUEST');
       assert.ok(/^Lighthouse was unable to reliably load/.test(error.friendlyMessage));
+    });
+  });
+
+  describe('#checkForSecurityIssue', () => {
+    it('succeeds when page is secure', () => {
+      const secureSecurityState = {
+        securityState: 'secure',
+      };
+      assert.ok(!GatherRunner.checkForSecurityIssue(secureSecurityState));
     });
 
     it('fails when page is insecure', () => {
@@ -700,10 +705,7 @@ describe('GatherRunner', function() {
         ],
         securityState: 'insecure',
       };
-      const url = 'http://the-page.com';
-      const mainRecord = new NetworkRequest();
-      mainRecord.url = url;
-      const error = GatherRunner.getPageLoadError(url, [mainRecord], insecureSecurityState);
+      const error = GatherRunner.checkForSecurityIssue(insecureSecurityState);
       assert.equal(error.message, 'INSECURE_DOCUMENT_REQUEST');
       /* eslint-disable-next-line max-len */
       assert.equal(error.friendlyMessage, 'The URL you have provided does not have valid security credentials. reason 1. reason 2.');

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -26,6 +26,7 @@ declare global {
       networkRecords: Array<Artifacts.NetworkRequest>;
       devtoolsLog: DevtoolsLog;
       trace?: Trace;
+      pageLoadError?: LighthouseError;
     }
 
     namespace Simulation {

--- a/typings/gatherer.d.ts
+++ b/typings/gatherer.d.ts
@@ -26,7 +26,6 @@ declare global {
       networkRecords: Array<Artifacts.NetworkRequest>;
       devtoolsLog: DevtoolsLog;
       trace?: Trace;
-      pageLoadError?: LighthouseError;
     }
 
     namespace Simulation {


### PR DESCRIPTION
After encountering an SSL error, some commands to the Network/Page domains either took awhile to timeout, or hung forever (only seemed to happen for `ERR_CERT_SYMANTEC_LEGACY`). You can see this at https://ilkayuyarkaba.av.tr/tag/istifaya-zorlanan-iscinin-kidem-tazminati (use canary).

If one of the passes generates an SSL error, just bail. A report is generated with a useful error message at the top.

Fixes #6287.