### PR TITLE
core(driver): stringify protocol error messages

### DIFF
--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -59,7 +59,7 @@ class LighthouseError extends Error {
     }
 
     // otherwise fallback to building a generic Error
-    let errMsg = `(${method}): ${protocolError.message}`;
+    let errMsg = `(${method}): ${JSON.stringify(protocolError.message)}`;
     if (protocolError.data) errMsg += ` (${protocolError.data})`;
     const error = new Error(`Protocol error ${errMsg}`);
     return Object.assign(error, {protocolMethod: method, protocolError: protocolError.message});

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -60,7 +60,7 @@ class LighthouseError extends Error {
 
     // otherwise fallback to building a generic Error
     let errMsg = `(${method}): ${JSON.stringify(protocolError.message)}`;
-    if (protocolError.data) errMsg += ` (${protocolError.data})`;
+    if (protocolError.data) errMsg += ` (${JSON.stringify(protocolError.data)})`;
     const error = new Error(`Protocol error ${errMsg}`);
     return Object.assign(error, {protocolMethod: method, protocolError: protocolError.message});
   }


### PR DESCRIPTION
This is an actual log from LR:

> `LHError: UNKNOWN_ERROR Unknown error encountered with message 'Protocol error (Tracing.start): [object Object]'`


The true origin is most likely... (_drumroll..._)

> [**Tracing is already started**](https://cs.chromium.org/chromium/src/content/browser/devtools/protocol/tracing_handler.cc?l=379&rcl=6c1d24539cea713814a538600c5f298f0d7d1e25)

Our best friend. 👨‍❤️‍👨

----------

As to why this PR makes sense.. Well... I can't really explain why `message` here is sometimes an object (and otherwise a string)... but the log above seems to indicate that's precisely what's happening. Could be the flu shot making me crazy though. 🤷‍♂️ 