### PR TITLE
core(fix): fix incorrect aspect ratio bug if the image is 1x1 pixel

### DIFF
--- a/lighthouse-core/audits/image-aspect-ratio.js
+++ b/lighthouse-core/audits/image-aspect-ratio.js
@@ -77,6 +77,8 @@ class ImageAspectRatio extends Audit {
       // - filter all svgs as they have no natural dimensions to audit
       return image.networkRecord &&
         image.networkRecord.mimeType !== 'image/svg+xml' &&
+        image.naturalHeight > 5 &&
+        image.naturalWidth > 5 &&
         image.width &&
         image.height &&
         !image.usesObjectFit;

--- a/lighthouse-core/test/audits/image-aspect-ratio-test.js
+++ b/lighthouse-core/test/audits/image-aspect-ratio-test.js
@@ -137,6 +137,16 @@ describe('Images: aspect-ratio audit', () => {
     },
   });
 
+  testImage('is placeholder image', {
+    rawValue: true,
+    clientSize: [300, 220],
+    naturalSize: [1, 1],
+    props: {
+      isCss: false,
+      usesObjectFit: false,
+    },
+  });
+
   it('skips svg images', () => {
     const result = ImageAspectRatioAudit.audit({
       ImageUsage: [

--- a/lighthouse-core/test/audits/image-aspect-ratio-test.js
+++ b/lighthouse-core/test/audits/image-aspect-ratio-test.js
@@ -137,17 +137,6 @@ describe('Images: aspect-ratio audit', () => {
     },
   });
 
-  testImage('has invalid natural sizing information', {
-    rawValue: true,
-    warning: 'Invalid image sizing information https://google.com/logo.png',
-    clientSize: [100, 100],
-    naturalSize: [0, 0],
-    props: {
-      isCss: false,
-      usesObjectFit: false,
-    },
-  });
-
   it('skips svg images', () => {
     const result = ImageAspectRatioAudit.audit({
       ImageUsage: [


### PR DESCRIPTION
fixes incorrect aspect ratio bug if the image is 1x1 pixel by filtering the image less than 5 * 5
pixels dimension


**Related Issues/PRs**
#6290
