### PR TITLE
core(driver): recover from rejection on handleJavaScriptDialog

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1196,17 +1196,16 @@ class Driver {
    * @return {Promise<void>}
    */
   async dismissJavaScriptDialogs() {
-    await this.sendCommand('Page.enable');
-
     this.on('Page.javascriptDialogOpening', data => {
       log.warn('Driver', `${data.type} dialog opened by the page automatically suppressed.`);
 
-      // rejection intentionally unhandled
       this.sendCommand('Page.handleJavaScriptDialog', {
         accept: true,
         promptText: 'Lighthouse prompt response',
       }).catch(err => log.warn('Driver', err));
     });
+
+    await this.sendCommand('Page.enable');
   }
 }
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1205,7 +1205,7 @@ class Driver {
       this.sendCommand('Page.handleJavaScriptDialog', {
         accept: true,
         promptText: 'Lighthouse prompt response',
-      });
+      }).catch(err => log.warn('Driver', err));
     });
   }
 }


### PR DESCRIPTION
On LR I'm seeing a lot of errors to do with handleJavaScriptDialog. The error response is typically this:
> {"error":{"code":-32602,"message":"No dialog is showing"},

For whatever reason, on LR, this error will reject starting inside the connection and then terminate the entire run.


The comment about intentionally unhandled comes from here: https://github.com/GoogleChrome/lighthouse/pull/2106#discussion_r114204201 which seems irrelevant at this point. I don't see why we wouldn't catch this.

closes #2402 
ref #2141