### PR TITLE
Revert "core(driver): stringify protocol error messages (#6302)"

### DIFF
--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -59,8 +59,8 @@ class LighthouseError extends Error {
     }
 
     // otherwise fallback to building a generic Error
-    let errMsg = `(${method}): ${JSON.stringify(protocolError.message)}`;
-    if (protocolError.data) errMsg += ` (${JSON.stringify(protocolError.data)})`;
+    let errMsg = `(${method}): ${protocolError.message}`;
+    if (protocolError.data) errMsg += ` (${protocolError.data})`;
     const error = new Error(`Protocol error ${errMsg}`);
     return Object.assign(error, {protocolMethod: method, protocolError: protocolError.message});
   }


### PR DESCRIPTION
The fix actually belong in a nearly-identical line of code in the Lightrider connection class. :)
