### PR TITLE
misc(proto): made default LighthouseError enum 'UNDEFINED'

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,5 +16,6 @@ lighthouse-extension/               @paulirish          @patrickhulce
 lighthouse-viewer/                  @ebidel             @brendankenny
 
 docs/                               @paulirish
+proto/                              @brendankenny       @exterkamp
 
 # no explicit owner for plots, travis, etc

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -6,7 +6,7 @@ import "google/protobuf/wrappers.proto";
 
 // Canonical list of errors created by Lighthouse.
 enum LighthouseError {
-  UNPARSEABLE_ERROR_CODE = 0;
+  UNDEFINED = 0;
   // No error in Lighthouse; the results are reliable.
   NO_ERROR = 1;
   // An uncategorized error occurred, likely a JavaScript exception.


### PR DESCRIPTION
**Summary**
Changed default LighthouseError enum to `UNDEFINED` and added proto/ to the CODEOWNERS.
