### PR TITLE
i18n: update test for new canonical locale codes

### DIFF
--- a/lighthouse-core/test/lib/i18n/locales-test.js
+++ b/lighthouse-core/test/lib/i18n/locales-test.js
@@ -11,10 +11,25 @@ const assert = require('assert');
 /* eslint-env jest */
 
 describe('locales', () => {
-  it('has only canonical language tags', () => {
+  it('has only canonical (or expected-deprecated) language tags', () => {
+    // Map of deprecated codes to their canonical version. Depending on the ICU
+    // version used to run Lighthouse/this test, these *may* come back as their
+    // substitute, not themselves.
+    const deprecatedCodes = {
+      in: 'id',
+      iw: 'he',
+    };
+
     for (const locale of Object.keys(locales)) {
       const canonicalLocale = Intl.getCanonicalLocales(locale)[0];
-      assert.strictEqual(locale, canonicalLocale);
+      const substitute = deprecatedCodes[locale];
+      assert.ok(locale === canonicalLocale || substitute === canonicalLocale,
+          `locale code '${locale}' not canonical`);
+    }
+
+    // Deprecation subsitutes should be removed from the test if no longer used.
+    for (const locale of Object.keys(deprecatedCodes)) {
+      assert.ok(locales[locale], `${locale} substitute should be removed from test`);
     }
   });
 


### PR DESCRIPTION
Some recent ICU update (maybe in [Node 10.7](https://nodejs.org/en/blog/release/v10.7.0/)?) now acts upon the [recommended deprecation of some locale codes](https://www.unicode.org/cldr/charts/latest/supplemental/aliases.html) (namely, `in` -> `id` and `iw` -> `he`), and so we have a failure on a test checking that all our supported locales use canonical codes in more recent versions of Node.

For now we still support the deprecated codes with explicit aliases in `locales.js` because existing versions of Node won't do that extra canonicalization step, so this PR updates the test to recognize both the old and new behavior.