### PR TITLE
 tests: run node 10 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ script:
   - yarn test-viewer
   - yarn test-lantern
   - yarn i18n:checks
+  # _JAVA_OPTIONS is breaking parsing of `compile-devtools` output. See #3338.
+  - unset _JAVA_OPTIONS
   # FIXME(paulirish): re-enable after a roll of LH->CDT
   # - yarn compile-devtools
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 matrix:
   include:
     - node_js: "8"
-    - node_js: "9"
+    - node_js: "10"
       if: head_branch IS blank AND branch = master
 dist: trusty
 cache:
@@ -42,8 +42,6 @@ script:
   - yarn test-viewer
   - yarn test-lantern
   - yarn i18n:checks
-  # _JAVA_OPTIONS is breaking parsing of compiler output. See #3338.
-  - unset _JAVA_OPTIONS
   # FIXME(paulirish): re-enable after a roll of LH->CDT
   # - yarn compile-devtools
 before_cache:


### PR DESCRIPTION
Node 10 is rapidly approaching LTS. We should be running our tests on Node 8 and 10, not 8 and 9 :)