### PR TITLE
Add audit mode and timings.

### DIFF
--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -206,6 +206,9 @@ message LighthouseResult {
     // List of the audits that were skipped, empty if all were run
     // nullable list of strings
     google.protobuf.Value skip_audits = 15;
+
+    // Flag indidcating this audit was audit only or not
+    google.protobuf.BoolValue audit_mode = 16;
   }
 
   // The settings that were used to run this audit
@@ -213,6 +216,15 @@ message LighthouseResult {
 
   // i18n info in version 1 message format
   I18n i18n = 13;
+
+  // Message containing timing information about the LHR
+  message Timing {
+    // The total time taken by the LHR
+     google.protobuf.DoubleValue total = 1;
+  }
+
+  // The timing information for the LHR
+  Timing timing = 14;
 }
 
 // Message containing a category 


### PR DESCRIPTION
**Summary**
Adds two missing fields to the proto definition.  
 - audit_mode
 - timing + total

**Related Issues/PRs**
fixes: #6362 
