### PR TITLE
misc: lantern script path resolution fix

### DIFF
--- a/lighthouse-core/scripts/lantern/run-once.js
+++ b/lighthouse-core/scripts/lantern/run-once.js
@@ -15,9 +15,9 @@ const traceSaver = require('../../../lighthouse-core/lib/lantern-trace-saver');
 if (process.argv.length !== 4) throw new Error('Usage $0 <trace file> <devtools file>');
 
 async function run() {
-  const tracePath = require.resolve(process.argv[2]);
+  const tracePath = path.resolve(process.cwd(), process.argv[2]);
   const traces = {defaultPass: require(tracePath)};
-  const devtoolsLogs = {defaultPass: require(process.argv[3])};
+  const devtoolsLogs = {defaultPass: require(path.resolve(process.cwd(), process.argv[3]))};
   const artifacts = {traces, devtoolsLogs};
 
   const context = {computedCache: new Map()};


### PR DESCRIPTION
**Summary**
easier if the path is resolved against, cwd instead of relative to scripts directory, the only usage in our codebase of run-once already fully resolves the path anyway.

**Related Issues/PRs**
#6378
