### PR TITLE
misc: enforce linting for infix-op spacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,7 @@ module.exports = {
       argsIgnorePattern: '(^reject$|^_$)',
       varsIgnorePattern: '(^_$)',
     }],
+    'space-infix-ops': 2,
     'strict': [2, 'global'],
     'prefer-const': 2,
     'curly': [2, 'multi-line'],

--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -130,7 +130,7 @@ class UsesRelPreconnectAudit extends Audit {
       // Sometimes requests are done simultaneous and the connection has not been made
       // chrome will try to connect for each network record, we get the first record
       const firstRecordOfOrigin = records.reduce((firstRecord, record) => {
-        return (record.startTime < firstRecord.startTime) ? record: firstRecord;
+        return (record.startTime < firstRecord.startTime) ? record : firstRecord;
       });
 
       // Skip the origin if we don't have timing information

--- a/lighthouse-core/gather/computed/page-dependency-graph.js
+++ b/lighthouse-core/gather/computed/page-dependency-graph.js
@@ -89,7 +89,7 @@ class PageDependencyGraph {
 
       // Skip all trace events that aren't schedulable tasks with sizable duration
       if (
-        !TracingProcessor.isScheduleableTask(evt)||
+        !TracingProcessor.isScheduleableTask(evt) ||
         !evt.dur ||
         evt.dur < minimumEvtDur
       ) {

--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -84,7 +84,7 @@ function elementPathInDOM(element) {
  * @return {LH.Artifacts.DOMStats}
  */
 /* istanbul ignore next */
-function getDOMStats(element, deep=true) {
+function getDOMStats(element, deep = true) {
   let deepestNode = null;
   let maxDepth = 0;
   let maxWidth = 0;
@@ -94,7 +94,7 @@ function getDOMStats(element, deep=true) {
    * @param {Element} element
    * @param {number} depth
    */
-  const _calcDOMWidthAndHeight = function(element, depth=1) {
+  const _calcDOMWidthAndHeight = function(element, depth = 1) {
     if (depth > maxDepth) {
       deepestNode = element;
       maxDepth = depth;

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -111,7 +111,7 @@ function getElementsInDocument(selector) {
  * @return {string}
  */
 /* istanbul ignore next */
-function getOuterHTMLSnippet(element, ignoreAttrs=[]) {
+function getOuterHTMLSnippet(element, ignoreAttrs = []) {
   const clone = element.cloneNode();
 
   ignoreAttrs.forEach(attribute =>{

--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -106,12 +106,12 @@ class Log {
     Log._logToStdErr(`${prefix}:${level || ''}`, [method, snippet]);
   }
 
-  static time({msg, id, args=[]}, level='log') {
+  static time({msg, id, args = []}, level = 'log') {
     marky.mark(id);
     Log[level]('status', msg, ...args);
   }
 
-  static timeEnd({msg, id, args=[]}, level='verbose') {
+  static timeEnd({msg, id, args = []}, level = 'verbose') {
     Log[level]('statusEnd', msg, ...args);
     marky.stop(id);
   }


### PR DESCRIPTION
based on this: https://github.com/GoogleChrome/lighthouse/pull/6286#pullrequestreview-167563083 :)

It's surprising we don't enforce spacing around ternary operators, etc already. Enabled the [eslint rule](https://eslint.org/docs/rules/space-infix-ops) to enforce it. The few places where we were breaking seem like things we would normally correct anyways, so it seems reasonable to leave it enforced.