### PR TITLE
core(driver): save performance.now() to avoid conflict

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1189,10 +1189,13 @@ class Driver {
    * @return {Promise<void>}
    */
   async cacheNatives() {
-    await this.evaluateScriptOnNewDocument(`window.__nativePromise = Promise;
+    await this.evaluateScriptOnNewDocument(`
+        window.__nativePromise = Promise;
         window.__nativeError = Error;
         window.__nativeURL = URL;
-        window.__ElementMatches = Element.prototype.matches;`);
+        window.__ElementMatches = Element.prototype.matches;
+        window.__perfNow = performance.now.bind(performance);
+    `);
   }
 
   /**

--- a/lighthouse-core/lib/page-functions.js
+++ b/lighthouse-core/lib/page-functions.js
@@ -37,7 +37,7 @@ function wrapRuntimeEvalErrorInBrowser(err) {
  */
 /* istanbul ignore next */
 function registerPerformanceObserverInPage() {
-  window.____lastLongTask = window.performance.now();
+  window.____lastLongTask = window.__perfNow();
   const observer = new window.PerformanceObserver(entryList => {
     const entries = entryList.getEntries();
     for (const entry of entries) {
@@ -64,12 +64,12 @@ function registerPerformanceObserverInPage() {
 function checkTimeSinceLastLongTask() {
   // Wait for a delta before returning so that we're sure the PerformanceObserver
   // has had time to register the last longtask
-  return new Promise(resolve => {
-    const timeoutRequested = window.performance.now() + 50;
+  return new window.__nativePromise(resolve => {
+    const timeoutRequested = window.__perfNow() + 50;
 
     setTimeout(() => {
       // Double check that a long task hasn't happened since setTimeout
-      const timeoutFired = window.performance.now();
+      const timeoutFired = window.__perfNow();
       const timeSinceLongTask = timeoutFired - timeoutRequested < 50 ?
           timeoutFired - window.____lastLongTask : 0;
       resolve(timeSinceLongTask);


### PR DESCRIPTION
much like #6283 I've found some more of these in our logs. `performance.now` in particular seems to be overwritten in some places. 

oh and fixed one spot where we weren't using our own `__nativePromise`.