### PR TITLE
core(config): faster category validation

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -64,13 +64,18 @@ function validateCategories(categories, audits, groups) {
     return;
   }
 
+  const auditsKeyedById = new Map((audits || []).map(a =>
+    /** @type {[string, LH.Config.AuditDefn]} */
+    ([a.implementation.meta.id, a]))
+  );
+
   Object.keys(categories).forEach(categoryId => {
     categories[categoryId].auditRefs.forEach((auditRef, index) => {
       if (!auditRef.id) {
         throw new Error(`missing an audit id at ${categoryId}[${index}]`);
       }
 
-      const audit = audits && audits.find(a => a.implementation.meta.id === auditRef.id);
+      const audit = auditsKeyedById.get(auditRef.id);
       if (!audit) {
         throw new Error(`could not find ${auditRef.id} audit for category ${categoryId}`);
       }

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -66,8 +66,8 @@ function validateCategories(categories, audits, groups) {
 
   const auditsKeyedById = new Map((audits || []).map(audit =>
     /** @type {[string, LH.Config.AuditDefn]} */
-    ([audit.implementation.meta.id, audit]))
-  );
+    ([audit.implementation.meta.id, audit])
+  ));
 
   Object.keys(categories).forEach(categoryId => {
     categories[categoryId].auditRefs.forEach((auditRef, index) => {

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -64,9 +64,9 @@ function validateCategories(categories, audits, groups) {
     return;
   }
 
-  const auditsKeyedById = new Map((audits || []).map(a =>
+  const auditsKeyedById = new Map((audits || []).map(audit =>
     /** @type {[string, LH.Config.AuditDefn]} */
-    ([a.implementation.meta.id, a]))
+    ([audit.implementation.meta.id, audit]))
   );
 
   Object.keys(categories).forEach(categoryId => {


### PR DESCRIPTION
**Summary**
On my machine 90% of the non-requireing time spent in config:init was just validating the categories. Simple conversion of this `.find` to a map eliminated ~60ms.


**Related Issues/PRs**
#6442 
