### PR TITLE
core(driver): wait for Page.frameNavigated for about:blank

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -1029,7 +1029,6 @@ Object {
   },
   "passes": Array [
     Object {
-      "blankDuration": 300,
       "blankPage": "about:blank",
       "blockedUrlPatterns": Array [],
       "cpuQuietThresholdMs": 1000,
@@ -1123,7 +1122,6 @@ Object {
       "useThrottling": true,
     },
     Object {
-      "blankDuration": 300,
       "blankPage": "about:blank",
       "blockedUrlPatterns": Array [],
       "cpuQuietThresholdMs": 0,
@@ -1145,7 +1143,6 @@ Object {
       "useThrottling": false,
     },
     Object {
-      "blankDuration": 300,
       "blankPage": "about:blank",
       "blockedUrlPatterns": Array [
         "*.css",
@@ -1290,7 +1287,6 @@ Object {
   },
   "passes": Array [
     Object {
-      "blankDuration": 300,
       "blankPage": "about:blank",
       "blockedUrlPatterns": Array [],
       "cpuQuietThresholdMs": 1000,

--- a/lighthouse-core/config/constants.js
+++ b/lighthouse-core/config/constants.js
@@ -59,7 +59,6 @@ const defaultPassConfig = {
   cpuQuietThresholdMs: 0,
   blockedUrlPatterns: [],
   blankPage: 'about:blank',
-  blankDuration: 300,
   gatherers: [],
 };
 

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -497,6 +497,16 @@ class Driver {
   }
 
   /**
+   * Returns a promise that resolve when a frame has been navigated.
+   * Used for detecting that our about:blank reset has been completed.
+   */
+  _waitForFrameNavigated() {
+    return new Promise(resolve => {
+      this.once('Page.frameNavigated', resolve);
+    });
+  }
+
+  /**
    * Returns a promise that resolves when the network has been idle (after DCL) for
    * `networkQuietThresholdMs` ms and a method to cancel internal network listeners/timeout.
    * @param {number} networkQuietThresholdMs
@@ -824,10 +834,11 @@ class Driver {
    * possible workaround.
    * Resolves on the url of the loaded page, taking into account any redirects.
    * @param {string} url
-   * @param {{waitForLoad?: boolean, passContext?: LH.Gatherer.PassContext}} options
+   * @param {{waitForLoad?: boolean, waitForNavigated?: boolean, passContext?: LH.Gatherer.PassContext}} options
    * @return {Promise<string>}
    */
   async gotoURL(url, options = {}) {
+    const waitForNavigated = options.waitForNavigated || false;
     const waitForLoad = options.waitForLoad || false;
     const passContext = /** @type {Partial<LH.Gatherer.PassContext>} */ (options.passContext || {});
     const disableJS = passContext.disableJavaScript || false;
@@ -842,6 +853,10 @@ class Driver {
     this.sendCommand('Emulation.setScriptExecutionDisabled', {value: disableJS});
     this.setNextProtocolTimeout(30 * 1000);
     this.sendCommand('Page.navigate', {url});
+
+    if (waitForNavigated) {
+      await this._waitForFrameNavigated();
+    }
 
     if (waitForLoad) {
       const passConfig = /** @type {Partial<LH.Config.Pass>} */ (passContext.passConfig || {});

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -843,6 +843,10 @@ class Driver {
     const passContext = /** @type {Partial<LH.Gatherer.PassContext>} */ (options.passContext || {});
     const disableJS = passContext.disableJavaScript || false;
 
+    if (waitForNavigated && waitForLoad) {
+      throw new Error('Cannot use both waitForNavigated and waitForLoad, pick just one');
+    }
+
     await this._beginNetworkStatusMonitoring(url);
     await this._clearIsolatedContextId();
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -70,10 +70,7 @@ class GatherRunner {
    * @param {string=} url
    * @return {Promise<void>}
    */
-  static async loadBlank(
-      driver,
-      url = constants.defaultPassConfig.blankPage
-  ) {
+  static async loadBlank(driver, url = constants.defaultPassConfig.blankPage) {
     const status = {msg: 'Resetting state with about:blank', id: 'lh:gather:loadBlank'};
     log.time(status);
     await driver.gotoURL(url, {waitForNavigated: true});

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -72,7 +72,7 @@ class GatherRunner {
    */
   static async loadBlank(
       driver,
-      url = constants.defaultPassConfig.blankPage,
+      url = constants.defaultPassConfig.blankPage
   ) {
     const status = {msg: 'Resetting state with about:blank', id: 'lh:gather:loadBlank'};
     log.time(status);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -68,18 +68,15 @@ class GatherRunner {
    * never fired on it.
    * @param {Driver} driver
    * @param {string=} url
-   * @param {number=} duration
    * @return {Promise<void>}
    */
   static async loadBlank(
       driver,
       url = constants.defaultPassConfig.blankPage,
-      duration = constants.defaultPassConfig.blankDuration
   ) {
     const status = {msg: 'Resetting state with about:blank', id: 'lh:gather:loadBlank'};
     log.time(status);
-    await driver.gotoURL(url);
-    await new Promise(resolve => setTimeout(resolve, duration));
+    await driver.gotoURL(url, {waitForNavigated: true});
     log.timeEnd(status);
   }
 
@@ -458,7 +455,7 @@ class GatherRunner {
         await driver.setThrottling(options.settings, passConfig);
         if (!isFirstPass) {
           // Already on blank page if driver was just set up.
-          await GatherRunner.loadBlank(driver, passConfig.blankPage, passConfig.blankDuration);
+          await GatherRunner.loadBlank(driver, passConfig.blankPage);
         }
         await GatherRunner.beforePass(passContext, gathererResults);
         await GatherRunner.pass(passContext, gathererResults);

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -560,14 +560,12 @@ describe('GatherRunner', function() {
     const settings = {};
 
     const passes = [{
-      blankDuration: 0,
       recordTrace: true,
       passName: 'firstPass',
       gatherers: [
         {instance: t1},
       ],
     }, {
-      blankDuration: 0,
       passName: 'secondPass',
       gatherers: [
         {instance: t2},
@@ -587,12 +585,10 @@ describe('GatherRunner', function() {
 
   it('respects trace names', () => {
     const passes = [{
-      blankDuration: 0,
       recordTrace: true,
       passName: 'firstPass',
       gatherers: [{instance: new TestGatherer()}],
     }, {
-      blankDuration: 0,
       recordTrace: true,
       passName: 'secondPass',
       gatherers: [{instance: new TestGatherer()}],
@@ -610,12 +606,10 @@ describe('GatherRunner', function() {
 
   it('doesn\'t leave networkRecords as an artifact', () => {
     const passes = [{
-      blankDuration: 0,
       recordTrace: true,
       passName: 'firstPass',
       gatherers: [{instance: new TestGatherer()}],
     }, {
-      blankDuration: 0,
       recordTrace: true,
       passName: 'secondPass',
       gatherers: [{instance: new TestGatherer()}],
@@ -790,7 +784,7 @@ describe('GatherRunner', function() {
         },
       ];
       const passes = [{
-        blankDuration: 0,
+
         gatherers: gatherers.map(G => ({instance: new G()})),
       }];
 
@@ -844,7 +838,7 @@ describe('GatherRunner', function() {
       ].map(instance => ({instance}));
       const gathererNames = gatherers.map(gatherer => gatherer.instance.name);
       const passes = [{
-        blankDuration: 0,
+
         gatherers,
       }];
 
@@ -881,7 +875,7 @@ describe('GatherRunner', function() {
         {instance: new class EavesdropGatherer3 extends EavesdropGatherer {}()},
       ];
 
-      const passes = [{blankDuration: 0, gatherers}];
+      const passes = [{gatherers}];
       return GatherRunner.run(passes, {
         driver: fakeDriver,
         requestedUrl: 'https://example.com',
@@ -1002,7 +996,7 @@ describe('GatherRunner', function() {
       ].map(instance => ({instance}));
       const gathererNames = gatherers.map(gatherer => gatherer.instance.name);
       const passes = [{
-        blankDuration: 0,
+
         gatherers,
       }];
 
@@ -1022,7 +1016,7 @@ describe('GatherRunner', function() {
 
     it('rejects if a gatherer does not provide an artifact', () => {
       const passes = [{
-        blankDuration: 0,
+
         recordTrace: true,
         passName: 'firstPass',
         gatherers: [
@@ -1040,7 +1034,7 @@ describe('GatherRunner', function() {
 
     it('rejects when domain name can\'t be resolved', () => {
       const passes = [{
-        blankDuration: 0,
+
         recordTrace: true,
         passName: 'firstPass',
         gatherers: [],
@@ -1071,7 +1065,7 @@ describe('GatherRunner', function() {
 
     it('resolves when domain name can\'t be resolved but is offline', () => {
       const passes = [{
-        blankDuration: 0,
+
         recordTrace: true,
         passName: 'firstPass',
         gatherers: [],

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -35,7 +35,6 @@ declare global {
         cpuQuietThresholdMs?: number;
         blockedUrlPatterns?: string[];
         blankPage?: string;
-        blankDuration?: number;
         gatherers?: GathererJson[];
       }
 


### PR DESCRIPTION
**Summary**
I'll want to put this through the DZL wringer and maybe someone sanity check this with the DevTools folks, but it seems like we should be able to just wait for the frameNavigated event instead of 300ms all the time.

On my machine it drives down about:blank times from...

300ms -> 200ms
300ms -> 16ms
300ms -> 14ms

If this gets cursory 👍 I'll remove references to blankDuration elsewhere, or we can keep it but just update the minimum to be 0

**Related Issues/PRs**
#6442 
