### PR TITLE
fix(report): edge Invalid argument error

### DIFF
--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -127,7 +127,8 @@ class DetailsRenderer {
       displayedHost = parsed.file === '/' ? '' : `(${parsed.hostname})`;
       title = url;
     } catch (/** @type {!Error} */ e) {
-      if (!e.name.startsWith('TypeError')) {
+      // All browsers throw a TypeError except Edge they throw a regular Error with Invalid argument as a message
+      if (!e.name.startsWith('TypeError') && !e.message.startsWith('Invalid argument')) {
         throw e;
       }
       displayedPath = url;

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -126,11 +126,7 @@ class DetailsRenderer {
       displayedPath = parsed.file === '/' ? parsed.origin : parsed.file;
       displayedHost = parsed.file === '/' ? '' : `(${parsed.hostname})`;
       title = url;
-    } catch (/** @type {!Error} */ e) {
-      // All browsers throw a TypeError except Edge they throw a regular Error with Invalid argument as a message
-      if (!e.name.startsWith('TypeError') && !e.message.startsWith('Invalid argument')) {
-        throw e;
-      }
+    } catch (e) {
       displayedPath = url;
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Seo font-size audit has a 'Legible Text' value in an url column. Inside the report we run `new URL('Legible Text');` which throws an error in all browsers. We catch it by checking e.name is typeError. Edge just throws an Error with Invalid Argument as a message. We now support both.

**Related Issues/PRs**
#6444 
