### PR TITLE
report: refactor rendering of top-level failed/passing/etc sections

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -43,7 +43,7 @@ class CategoryRenderer {
   /**
    * Display info per top-level clump. Define on class to avoid race with Util init.
    */
-  get _clumpInfo() {
+  get _clumpDisplayInfo() {
     return {
       'failed': {
         className: 'lh-failed-audits',
@@ -293,23 +293,21 @@ class CategoryRenderer {
    *   ├── …
    *   ⋮
    * @param {TopLevelClumpId} clumpId
-   * @param {Array<LH.ReportResult.AuditRef>} auditRefs
-   * @param {Object<string, LH.Result.ReportGroup>} groupDefinitions
-   * @param {string} [description] Optional description for clump (e.g. manualDescription)
+   * @param {{auditRefs: Array<LH.ReportResult.AuditRef>, groupDefinitions: Object<string, LH.Result.ReportGroup>, description?: string}} clumpOpts
    * @return {Element}
    */
-  renderClump(clumpId, auditRefs, groupDefinitions, description) {
+  renderClump(clumpId, {auditRefs, groupDefinitions, description}) {
     if (clumpId === 'failed') {
       // Failed audit clump is always expanded and not nested in an lh-audit-group.
       const failedElem = this.renderUnexpandableClump(auditRefs, groupDefinitions);
-      failedElem.classList.add(this._clumpInfo['failed'].className);
+      failedElem.classList.add(this._clumpDisplayInfo.failed.className);
       return failedElem;
     }
 
     const expandable = true;
     const elements = this._renderGroupedAudits(auditRefs, groupDefinitions, {expandable});
 
-    const clumpInfo = this._clumpInfo[clumpId];
+    const clumpInfo = this._clumpDisplayInfo[clumpId];
     // TODO: renderAuditGroup shouldn't be used to render a clump (since it *contains* audit groups).
     const groupDef = {title: clumpInfo.title, description};
     const opts = {expandable, itemCount: auditRefs.length};
@@ -412,8 +410,8 @@ class CategoryRenderer {
       if (clumpRefs.length === 0) continue;
 
       const description = clumpId === 'manual' ? category.manualDescription : undefined;
-      const clumpElem = this.renderClump(clumpId, clumpRefs, groupDefinitions,
-          description);
+      const clumpElem = this.renderClump(clumpId, {auditRefs: clumpRefs, groupDefinitions,
+        description});
       element.appendChild(clumpElem);
     }
 

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -215,7 +215,11 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
 
     if (!passedAudits.length) return element;
 
-    const passedElem = this.renderClump('passed', passedAudits, groups);
+    const clumpOpts = {
+      auditRefs: passedAudits,
+      groupDefinitions: groups,
+    };
+    const passedElem = this.renderClump('passed', clumpOpts);
     element.appendChild(passedElem);
     return element;
   }

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -209,14 +209,13 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
     }
 
     // Passed audits
-    const passedElements = category.auditRefs
+    const passedAudits = category.auditRefs
         .filter(audit => (audit.group === 'load-opportunities' || audit.group === 'diagnostics') &&
-            Util.showAsPassed(audit.result))
-        .map((audit, i) => this.renderAudit(audit, i));
+            Util.showAsPassed(audit.result));
 
-    if (!passedElements.length) return element;
+    if (!passedAudits.length) return element;
 
-    const passedElem = this.renderPassedAuditsSection(passedElements);
+    const passedElem = this.renderTopLevelSection('passed', passedAudits, groups);
     element.appendChild(passedElem);
     return element;
   }

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -215,7 +215,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
 
     if (!passedAudits.length) return element;
 
-    const passedElem = this.renderTopLevelSection('passed', passedAudits, groups);
+    const passedElem = this.renderClump('passed', passedAudits, groups);
     element.appendChild(passedElem);
     return element;
   }


### PR DESCRIPTION
This makes the process of grouping under failed/passing/manual/notApplicable and then again under audit groups a lot easier to understand. It also sets the stage for making a new `pwa-category-renderer.js` (where they aren't split into failed/passing/etc) much easier.

Before the renderer was mixing up levels of failed/passing/notApplicable and audit groups, putting those states inside groups, then ending up rendering the opposite way (groups inside failed/passing/notApplicable). Manual audits were handled separately, even though it's just another of these states.

Instead, this new code sorts by state, then renders groups in each of them. The code is just a little shorter (longer with new tests), but it's hopefully easier to follow.

Importantly, this makes for an easy interface for `renderTopLevelSection` (which `performance-category-renderer` now uses) and `renderUnexpandableTopLevelSection` (which the pwa one will use).

It also lets us get rid of `_getTotalAuditsLength` and allows easy numbering across groups now.

The numbering is the only thing that has changed from master (so no changed tests, only new ones). *edit: also (collapsed) passed audits in the performance section are now grouped like they are in other categories*