### PR TITLE
report: rename clump classes; give classes to all audit groups

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -46,19 +46,19 @@ class CategoryRenderer {
   get _clumpDisplayInfo() {
     return {
       'failed': {
-        className: 'lh-failed-audits',
+        className: 'lh-clump--failed',
       },
       'manual': {
         title: Util.UIStrings.manualAuditsGroupTitle,
-        className: 'lh-audit-group--manual',
+        className: 'lh-clump--manual',
       },
       'passed': {
         title: Util.UIStrings.passedAuditsGroupTitle,
-        className: 'lh-passed-audits',
+        className: 'lh-clump--passed',
       },
       'not-applicable': {
         title: Util.UIStrings.notApplicableAuditsGroupTitle,
-        className: 'lh-audit-group--not-applicable',
+        className: 'lh-clump--not-applicable',
       },
     };
   }
@@ -255,7 +255,7 @@ class CategoryRenderer {
       for (const auditRef of groupAuditRefs) {
         auditGroupElem.appendChild(this.renderAudit(auditRef, index++));
       }
-      auditGroupElem.classList.add('lh-audit-group--unadorned');
+      auditGroupElem.classList.add(`lh-audit-group--${groupId}`);
       auditElements.push(auditGroupElem);
     }
 
@@ -300,7 +300,7 @@ class CategoryRenderer {
     if (clumpId === 'failed') {
       // Failed audit clump is always expanded and not nested in an lh-audit-group.
       const failedElem = this.renderUnexpandableClump(auditRefs, groupDefinitions);
-      failedElem.classList.add(this._clumpDisplayInfo.failed.className);
+      failedElem.classList.add('lh-clump', this._clumpDisplayInfo.failed.className);
       return failedElem;
     }
 
@@ -312,7 +312,7 @@ class CategoryRenderer {
     const groupDef = {title: clumpInfo.title, description};
     const opts = {expandable, itemCount: auditRefs.length};
     const clumpElem = this.renderAuditGroup(groupDef, opts);
-    clumpElem.classList.add(clumpInfo.className);
+    clumpElem.classList.add('lh-clump', clumpInfo.className);
 
     elements.forEach(elem => clumpElem.appendChild(elem));
 

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -569,7 +569,8 @@
 }
 
 .lh-audit-group__header::before {
-  content: '';
+  /* By default, groups don't get an icon */
+  content: none;
   width: calc(var(--subheader-font-size) / 14 * 24);
   height: calc(var(--subheader-font-size) / 14 * 24);
   margin-right: calc(var(--subheader-font-size) / 2);
@@ -579,29 +580,30 @@
   vertical-align: middle;
 }
 
-/* A11y/Seo groups within Passed don't get an icon */
-.lh-audit-group--unadorned .lh-audit-group__header::before {
-  content: none;
-}
-
-
-.lh-audit-group--manual .lh-audit-group__header::before {
+.lh-clump--manual > summary .lh-audit-group__header::before {
+  content: '';
   background-image: var(--search-icon-url);
 }
-.lh-passed-audits .lh-audit-group__header::before {
+.lh-clump--passed > summary .lh-audit-group__header::before {
+  content: '';
   background-image: var(--check-icon-url);
 }
+.lh-clump--not-applicable > summary .lh-audit-group__header::before {
+  content: '';
+  background-image: var(--remove-circle-icon-url);
+}
+
 .lh-audit-group--diagnostics .lh-audit-group__header::before {
+  content: '';
   background-image: var(--content-paste-icon-url);
 }
 .lh-audit-group--opportunities .lh-audit-group__header::before {
+  content: '';
   background-image: var(--photo-filter-icon-url);
 }
 .lh-audit-group--metrics .lh-audit-group__header::before {
+  content: '';
   background-image: var(--av-timer-icon-url);
-}
-.lh-audit-group--not-applicable .lh-audit-group__header::before {
-  background-image: var(--remove-circle-icon-url);
 }
 
 /* Removing too much whitespace */
@@ -627,11 +629,14 @@
 .lh-audit-group__description {
   font-size: var(--body-font-size);
   color: var(--medium-75-gray);
-  margin: var(--lh-audit-group-vpadding) 0;
+  margin: 0 0 var(--lh-audit-group-vpadding);
 }
 
-.lh-audit-group--unadorned .lh-audit-group__description {
-  margin-top: 0;
+.lh-clump > .lh-audit-group__description,
+.lh-audit-group--diagnostics .lh-audit-group__description,
+.lh-audit-group--opportunities .lh-audit-group__description,
+.lh-audit-group--metrics .lh-audit-group__description {
+  margin-top: var(--lh-audit-group-vpadding);
 }
 
 .lh-audit-explanation {

--- a/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
@@ -147,7 +147,7 @@ describe('PerfCategoryRenderer', () => {
 
   it('renders the passed audits', () => {
     const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
-    const passedSection = categoryDOM.querySelector('.lh-category > .lh-passed-audits');
+    const passedSection = categoryDOM.querySelector('.lh-category > .lh-clump--passed');
 
     const passedAudits = category.auditRefs.filter(audit =>
         audit.group && audit.group !== 'metrics' && Util.showAsPassed(audit.result));


### PR DESCRIPTION
working on #6395

The PWA category renderer needs to add custom icons to its groups (like the performance renderer does), but to do so without creating each group itself or grossly reaching into things, this PR sets it up by adding a class name to each group based on the group's id in the config (`.lh-audit-group--${groupId}`, modelled after the existing `lh-audit-group--metrics`, `lh-audit-group--opportunities`, etc).

To not collide with anything, the clump names need to move off a mishmash of class names (`lh-failed-audits`, `lh-audit-group--manual`, etc). So we'll just double down on "clump" for those :)

This PR also removes `lh-audit-group--unadorned` since "unadorned" is not a group name and it's somewhat ambiguous what should fall into that class, but that leaves a bit of a mess with `::before` content and margins. I believe I have that all straightened out now. Previously the "unadorned" case took things away from the styling of clumps and important groups, now it's more the default style and clumps and important groups add to it.