### PR TITLE
core(pwa): audit and report group renames

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -844,32 +844,32 @@ Object {
           "weight": 2,
         },
         Object {
-          "group": "pwa-engaging",
+          "group": "pwa-optimized",
           "id": "redirects-http",
           "weight": 2,
         },
         Object {
-          "group": "pwa-engaging",
+          "group": "pwa-optimized",
           "id": "splash-screen",
           "weight": 1,
         },
         Object {
-          "group": "pwa-engaging",
+          "group": "pwa-optimized",
           "id": "themed-omnibox",
           "weight": 1,
         },
         Object {
-          "group": "pwa-engaging",
+          "group": "pwa-optimized",
           "id": "content-width",
           "weight": 1,
         },
         Object {
-          "group": "pwa-engaging",
+          "group": "pwa-optimized",
           "id": "viewport",
           "weight": 2,
         },
         Object {
-          "group": "pwa-engaging",
+          "group": "pwa-optimized",
           "id": "without-javascript",
           "weight": 1,
         },
@@ -1005,14 +1005,14 @@ Object {
     "metrics": Object {
       "title": "Metrics",
     },
-    "pwa-engaging": Object {
-      "title": "Engaging",
-    },
     "pwa-fast-reliable": Object {
       "title": "Fast and reliable",
     },
     "pwa-installable": Object {
       "title": "Installable",
+    },
+    "pwa-optimized": Object {
+      "title": "PWA Optimized",
     },
     "seo-content": Object {
       "description": "Format your HTML in a way that enables crawlers to better understand your app’s content.",
@@ -1263,14 +1263,14 @@ Object {
     "metrics": Object {
       "title": "Metrics",
     },
-    "pwa-engaging": Object {
-      "title": "Engaging",
-    },
     "pwa-fast-reliable": Object {
       "title": "Fast and reliable",
     },
     "pwa-installable": Object {
       "title": "Installable",
+    },
+    "pwa-optimized": Object {
+      "title": "PWA Optimized",
     },
     "seo-content": Object {
       "description": "Format your HTML in a way that enables crawlers to better understand your app’s content.",

--- a/lighthouse-core/audits/themed-omnibox.js
+++ b/lighthouse-core/audits/themed-omnibox.js
@@ -26,8 +26,8 @@ class ThemedOmnibox extends MultiCheckAudit {
   static get meta() {
     return {
       id: 'themed-omnibox',
-      title: 'Address bar matches brand colors',
-      failureTitle: 'Address bar does not match brand colors',
+      title: 'Sets an address-bar theme color',
+      failureTitle: 'Does not set an address-bar theme color',
       description: 'The browser address bar can be themed to match your site. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/address-bar).',
       requiredArtifacts: ['Manifest', 'ThemeColor'],

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -15,8 +15,8 @@ class WorksOffline extends Audit {
   static get meta() {
     return {
       id: 'works-offline',
-      title: 'Responds with a 200 when offline',
-      failureTitle: 'Does not respond with a 200 when offline',
+      title: 'Current page responds with a 200 when offline',
+      failureTitle: 'Current page does not respond with a 200 when offline',
       description: 'If you\'re building a Progressive Web App, consider using a service worker ' +
           'so that your app can work offline. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).',

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -67,8 +67,8 @@ const UIStrings = {
   pwaFastReliableGroupTitle: 'Fast and reliable',
   /** Title of the Installable section of the web app category. Within this section are audits that check if Chrome supports installing the web site as an app on their device. */
   pwaInstallableGroupTitle: 'Installable',
-  /** Title of the Engaging section of the web app category. Within this section are audits that check if the developer has taken advantage of features to make their web page more enjoyable and engaging for the user. */
-  pwaEngagingGroupTitle: 'Engaging',
+  /** Title of the "PWA Optimized" section of the web app category. Within this section are audits that check if the developer has taken advantage of features to make their web page more enjoyable and engaging for the user. */
+  pwaOptimizedGroupTitle: 'PWA Optimized',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -269,8 +269,8 @@ const defaultConfig = {
     'pwa-installable': {
       title: str_(UIStrings.pwaInstallableGroupTitle),
     },
-    'pwa-engaging': {
-      title: str_(UIStrings.pwaEngagingGroupTitle),
+    'pwa-optimized': {
+      title: str_(UIStrings.pwaOptimizedGroupTitle),
     },
     'a11y-color-contrast': {
       title: str_(UIStrings.a11yColorContrastGroupTitle),
@@ -373,12 +373,12 @@ const defaultConfig = {
         {id: 'service-worker', weight: 1, group: 'pwa-installable'},
         {id: 'webapp-install-banner', weight: 2, group: 'pwa-installable'},
         // Engaging
-        {id: 'redirects-http', weight: 2, group: 'pwa-engaging'},
-        {id: 'splash-screen', weight: 1, group: 'pwa-engaging'},
-        {id: 'themed-omnibox', weight: 1, group: 'pwa-engaging'},
-        {id: 'content-width', weight: 1, group: 'pwa-engaging'},
-        {id: 'viewport', weight: 2, group: 'pwa-engaging'},
-        {id: 'without-javascript', weight: 1, group: 'pwa-engaging'},
+        {id: 'redirects-http', weight: 2, group: 'pwa-optimized'},
+        {id: 'splash-screen', weight: 1, group: 'pwa-optimized'},
+        {id: 'themed-omnibox', weight: 1, group: 'pwa-optimized'},
+        {id: 'content-width', weight: 1, group: 'pwa-optimized'},
+        {id: 'viewport', weight: 2, group: 'pwa-optimized'},
+        {id: 'without-javascript', weight: 1, group: 'pwa-optimized'},
         // Manual audits
         {id: 'pwa-cross-browser', weight: 0},
         {id: 'pwa-page-transitions', weight: 0},

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -871,10 +871,6 @@
     "message": "Performance",
     "description": "Title of the Performance category of audits. Equivalent to 'Web performance', this term is inclusive of all web page speed and loading optimization topics. Also used as a label of a score gauge; try to limit to 20 characters."
   },
-  "lighthouse-core/config/default-config.js | pwaEngagingGroupTitle": {
-    "message": "Engaging",
-    "description": "Title of the Engaging section of the web app category. Within this section are audits that check if the developer has taken advantage of features to make their web page more enjoyable and engaging for the user."
-  },
   "lighthouse-core/config/default-config.js | pwaFastReliableGroupTitle": {
     "message": "Fast and reliable",
     "description": "Title of the Fast and Reliable section of the web app category. Within this section are audits that check if the web site loaded quickly and can reliably load even if the internet connection is very slow or goes offline."
@@ -882,6 +878,10 @@
   "lighthouse-core/config/default-config.js | pwaInstallableGroupTitle": {
     "message": "Installable",
     "description": "Title of the Installable section of the web app category. Within this section are audits that check if Chrome supports installing the web site as an app on their device."
+  },
+  "lighthouse-core/config/default-config.js | pwaOptimizedGroupTitle": {
+    "message": "PWA Optimized",
+    "description": "Title of the \"PWA Optimized\" section of the web app category. Within this section are audits that check if the developer has taken advantage of features to make their web page more enjoyable and engaging for the user."
   },
   "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": {
     "message": "Cache TTL",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -57,7 +57,7 @@
     },
     "works-offline": {
       "id": "works-offline",
-      "title": "Does not respond with a 200 when offline",
+      "title": "Current page does not respond with a 200 when offline",
       "description": "If you're building a Progressive Web App, consider using a service worker so that your app can work offline. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).",
       "score": 0,
       "scoreDisplayMode": "binary",
@@ -503,7 +503,7 @@
     },
     "themed-omnibox": {
       "id": "themed-omnibox",
-      "title": "Address bar does not match brand colors",
+      "title": "Does not set an address-bar theme color",
       "description": "The browser address bar can be themed to match your site. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/address-bar).",
       "score": 0,
       "scoreDisplayMode": "binary",
@@ -2959,32 +2959,32 @@
         {
           "id": "redirects-http",
           "weight": 2,
-          "group": "pwa-engaging"
+          "group": "pwa-optimized"
         },
         {
           "id": "splash-screen",
           "weight": 1,
-          "group": "pwa-engaging"
+          "group": "pwa-optimized"
         },
         {
           "id": "themed-omnibox",
           "weight": 1,
-          "group": "pwa-engaging"
+          "group": "pwa-optimized"
         },
         {
           "id": "content-width",
           "weight": 1,
-          "group": "pwa-engaging"
+          "group": "pwa-optimized"
         },
         {
           "id": "viewport",
           "weight": 2,
-          "group": "pwa-engaging"
+          "group": "pwa-optimized"
         },
         {
           "id": "without-javascript",
           "weight": 1,
-          "group": "pwa-engaging"
+          "group": "pwa-optimized"
         },
         {
           "id": "pwa-cross-browser",
@@ -3388,8 +3388,8 @@
     "pwa-installable": {
       "title": "Installable"
     },
-    "pwa-engaging": {
-      "title": "Engaging"
+    "pwa-optimized": {
+      "title": "PWA Optimized"
     },
     "a11y-color-contrast": {
       "title": "Color Contrast Is Satisfactory",
@@ -4795,8 +4795,8 @@
       "lighthouse-core/config/default-config.js | pwaInstallableGroupTitle": [
         "categoryGroups[pwa-installable].title"
       ],
-      "lighthouse-core/config/default-config.js | pwaEngagingGroupTitle": [
-        "categoryGroups[pwa-engaging].title"
+      "lighthouse-core/config/default-config.js | pwaOptimizedGroupTitle": [
+        "categoryGroups[pwa-optimized].title"
       ],
       "lighthouse-core/config/default-config.js | a11yColorContrastGroupTitle": [
         "categoryGroups[a11y-color-contrast].title"

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -1952,7 +1952,7 @@
             "id": "themed-omnibox", 
             "score": 0.0, 
             "scoreDisplayMode": "binary", 
-            "title": "Address bar does not match brand colors"
+            "title": "Does not set an address-bar theme color"
         }, 
         "time-to-first-byte": {
             "description": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).", 
@@ -2574,7 +2574,7 @@
             "id": "works-offline", 
             "score": 0.0, 
             "scoreDisplayMode": "binary", 
-            "title": "Does not respond with a 200 when offline", 
+            "title": "Current page does not respond with a 200 when offline", 
             "warnings": []
         }
     }, 
@@ -3070,32 +3070,32 @@
                     "weight": 2.0
                 }, 
                 {
-                    "group": "pwa-engaging", 
+                    "group": "pwa-optimized", 
                     "id": "redirects-http", 
                     "weight": 2.0
                 }, 
                 {
-                    "group": "pwa-engaging", 
+                    "group": "pwa-optimized", 
                     "id": "splash-screen", 
                     "weight": 1.0
                 }, 
                 {
-                    "group": "pwa-engaging", 
+                    "group": "pwa-optimized", 
                     "id": "themed-omnibox", 
                     "weight": 1.0
                 }, 
                 {
-                    "group": "pwa-engaging", 
+                    "group": "pwa-optimized", 
                     "id": "content-width", 
                     "weight": 1.0
                 }, 
                 {
-                    "group": "pwa-engaging", 
+                    "group": "pwa-optimized", 
                     "id": "viewport", 
                     "weight": 2.0
                 }, 
                 {
-                    "group": "pwa-engaging", 
+                    "group": "pwa-optimized", 
                     "id": "without-javascript", 
                     "weight": 1.0
                 }, 
@@ -3235,14 +3235,14 @@
         "metrics": {
             "title": "Metrics"
         }, 
-        "pwa-engaging": {
-            "title": "Engaging"
-        }, 
         "pwa-fast-reliable": {
             "title": "Fast and reliable"
         }, 
         "pwa-installable": {
             "title": "Installable"
+        }, 
+        "pwa-optimized": {
+            "title": "PWA Optimized"
         }, 
         "seo-content": {
             "description": "Format your HTML in a way that enables crawlers to better understand your app\u2019s content.", 


### PR DESCRIPTION
Requested renames from #6395

- Going with "PWA Optimized" for the third group for now (see ongoing discussion in https://github.com/GoogleChrome/lighthouse/issues/6395#issuecomment-436420337)
- Updated "Address bar matches brand colors" to "Sets an address-bar theme color"
- Updated "Responds with a 200 when offline" to "Current page does not respond with a 200 when offline"

These are the replacements previously discussed. Note that we can keep tweaking after this, this just gets us to the state of the doc.