### PR TITLE
core: throw fatally on page hang

### DIFF
--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -22,6 +22,7 @@ const opn = require('opn');
 
 const _RUNTIME_ERROR_CODE = 1;
 const _PROTOCOL_TIMEOUT_EXIT_CODE = 67;
+const _PAGE_HUNG_EXIT_CODE = 68;
 
 /**
  * exported for testing
@@ -70,6 +71,12 @@ function showProtocolTimeoutError() {
   process.exit(_PROTOCOL_TIMEOUT_EXIT_CODE);
 }
 
+/** @param {LH.LighthouseError} err */
+function showPageHungError(err) {
+  console.error('Page hung:', err.friendlyMessage);
+  process.exit(_PAGE_HUNG_EXIT_CODE);
+}
+
 /**
  * @param {LH.LighthouseError} err
  */
@@ -89,6 +96,8 @@ function handleError(err) {
     showConnectionError();
   } else if (err.code === 'CRI_TIMEOUT') {
     showProtocolTimeoutError();
+  } else if (err.code === 'PAGE_HUNG') {
+    showPageHungError(err);
   } else {
     showRuntimeError(err);
   }

--- a/lighthouse-cli/test/fixtures/infinite-loop.html
+++ b/lighthouse-cli/test/fixtures/infinite-loop.html
@@ -1,0 +1,16 @@
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<body>
+  This is the function that never ends
+  Yes, it just goes on and on my friends.
+  Some people started computing it, not knowing what it was.
+  And they'll continue computing it forever just because,
+  This is the function that never end.
+
+  <script>
+    while (true) {
+      for (let i = 0; i < 1000000; i++) ;
+    }
+  </script>
+</body>
+</html>

--- a/lighthouse-cli/test/fixtures/infinite-loop.html
+++ b/lighthouse-cli/test/fixtures/infinite-loop.html
@@ -1,3 +1,9 @@
+<!doctype html>
+<!--
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+-->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 <body>
@@ -5,7 +11,7 @@
   Yes, it just goes on and on my friends.
   Some people started computing it, not knowing what it was.
   And they'll continue computing it forever just because,
-  This is the function that never end.
+  This is the function that never ends.
 
   <script>
     while (true) {

--- a/lighthouse-cli/test/smokehouse/error-config.js
+++ b/lighthouse-cli/test/smokehouse/error-config.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */

--- a/lighthouse-cli/test/smokehouse/error-config.js
+++ b/lighthouse-cli/test/smokehouse/error-config.js
@@ -1,0 +1,19 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * Config file for running PWA smokehouse audits.
+ */
+module.exports = {
+  extends: 'lighthouse:default',
+  settings: {
+    maxWaitForLoad: 5000,
+    onlyAudits: [
+      'first-contentful-paint',
+    ],
+  },
+};

--- a/lighthouse-cli/test/smokehouse/error-config.js
+++ b/lighthouse-cli/test/smokehouse/error-config.js
@@ -6,7 +6,7 @@
 'use strict';
 
 /**
- * Config file for running PWA smokehouse audits.
+ * Config file for sites with various errors, just fail out quickly.
  */
 module.exports = {
   extends: 'lighthouse:default',

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -1,0 +1,18 @@
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/**
+ * Expected Lighthouse audit values for sites with various errors.
+ */
+module.exports = [
+  {
+    requestedUrl: 'http://localhost:10200/infinite-loop.html',
+    finalUrl: 'http://localhost:10200/infinite-loop.html',
+    errorCode: 'PAGE_HUNG',
+    audits: {},
+  },
+];

--- a/lighthouse-cli/test/smokehouse/run-smoke.js
+++ b/lighthouse-cli/test/smokehouse/run-smoke.js
@@ -30,6 +30,12 @@ const SMOKETESTS = [{
   expectations: 'a11y/expectations.js',
   batch: 'parallel-first',
 }, {
+  id: 'errors',
+  expectations: smokehouseDir + 'error-expectations.js',
+  config: smokehouseDir + 'error-config.js',
+  batch: 'errors',
+}, {
+}, {
   id: 'pwa',
   expectations: smokehouseDir + 'pwa-expectations.js',
   config: smokehouseDir + 'pwa-config.js',

--- a/lighthouse-cli/test/smokehouse/run-smoke.js
+++ b/lighthouse-cli/test/smokehouse/run-smoke.js
@@ -35,7 +35,6 @@ const SMOKETESTS = [{
   config: smokehouseDir + 'error-config.js',
   batch: 'errors',
 }, {
-}, {
   id: 'pwa',
   expectations: smokehouseDir + 'pwa-expectations.js',
   config: smokehouseDir + 'pwa-config.js',

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -100,7 +100,7 @@ function runLighthouse(url, configPath, isDebug) {
   }
 
   if (runResults.status === PAGE_HUNG_EXIT_CODE) {
-    return {requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}}
+    return {requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}};
   }
 
   const lhr = fs.readFileSync(outputPath, 'utf8');

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -99,9 +99,11 @@ function runLighthouse(url, configPath, isDebug) {
     console.error(`STDERR: ${runResults.stderr}`);
   }
 
-  const lhr = runResults.status === PAGE_HUNG_EXIT_CODE ?
-    JSON.stringify({requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}}) :
-    fs.readFileSync(outputPath, 'utf8');
+  if (runResults.status === PAGE_HUNG_EXIT_CODE) {
+    return {requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}}
+  }
+
+  const lhr = fs.readFileSync(outputPath, 'utf8');
   if (isDebug) {
     console.log('LHR output available at: ', outputPath);
   } else if (fs.existsSync(outputPath)) {

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -151,7 +151,7 @@ const ERRORS = {
   /* Used when the page stopped responding and did not finish loading. */
   PAGE_HUNG: {
     code: 'PAGE_HUNG',
-    message: strings.pageLoadFailed,
+    message: strings.pageLoadFailedHung,
     lhrRuntimeError: true,
   },
 

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -148,6 +148,12 @@ const ERRORS = {
     message: strings.pageLoadFailedInsecure,
     lhrRuntimeError: true,
   },
+  /* Used when the page stopped responding and did not finish loading. */
+  PAGE_HUNG: {
+    code: 'PAGE_HUNG',
+    message: strings.pageLoadFailed,
+    lhrRuntimeError: true,
+  },
 
   // Protocol internal failures
   TRACING_ALREADY_STARTED: {

--- a/lighthouse-core/lib/strings.js
+++ b/lighthouse-core/lib/strings.js
@@ -11,6 +11,7 @@ module.exports = {
   badTraceRecording: `Something went wrong with recording the trace over your page load. Please run Lighthouse again.`,
   pageLoadTookTooLong: `Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse.`,
   pageLoadFailed: `Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests.`,
+  pageLoadFailedHung: `Lighthouse was unable to reliably load the URL you requested because the page stopped responding.`,
   pageLoadFailedInsecure: `The URL you have provided does not have valid security credentials.`,
   internalChromeError: `An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse.`,
   requestContentTimeout: 'Fetching resource content has exceeded the allotted time',

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -47,6 +47,8 @@ enum LighthouseError {
   INSECURE_DOCUMENT_REQUEST = 16;
   // Used when protocol command times out.
   PROTOCOL_TIMEOUT = 17;
+  // Used when the page is not responding after maxWaitForLoad.
+  PAGE_HUNG = 18;
 }
 
 // The overarching Lighthouse Response object (LHR)


### PR DESCRIPTION
**Summary**
I've spent way too much time waffling back and forth on how to handle this, so I thought I'd just put it up for discussion. This PR throws a fatal error if, after our maxWaitForLoad is reached, the page doesn't seem to respond.

Right now this basically gets us earlier exit than trying to do all the gathering and not much else. I agree with @brendankenny that it's a bit dangerous to try to kill JavaScript and continue. If we do anything else I think it might be alternative 1, but still feels risky.

Alternatives:
- Wait for maxWaitForLoad, kill JavaScript, wait and see if page is still hung, then either fatally throw or try to continue
- Wait for maxWaitForLoad, kill JavaScript, and try to continue right away
- Continuously check if page is hung, kill JavaScript as soon as we think it's hung, and do A or B
