### PR TITLE
report(safari): fix dropdown overlap translateZ

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -247,7 +247,7 @@ class ReportUIFeatures {
     this.toolbar.style.transform = `translateY(${heightDiff * scrollPct}px)`;
     const exportParent = this.exportButton.parentElement;
     if (exportParent) {
-      exportParent.style.transform = `translateY(${heightDiff * scrollPct}px)`;
+      exportParent.style.transform = `translateY(${heightDiff * scrollPct}px) translateZ(1px)`;
     }
     this.exportButton.style.transform = `scale(${1 - 0.2 * scrollPct})`;
     // Start showing the productinfo when we are at the 50% mark of our animation

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -247,7 +247,7 @@ class ReportUIFeatures {
     this.toolbar.style.transform = `translateY(${heightDiff * scrollPct}px)`;
     const exportParent = this.exportButton.parentElement;
     if (exportParent) {
-      exportParent.style.transform = `translateY(${heightDiff * scrollPct}px) translateZ(1px)`;
+      exportParent.style.transform = `translateY(${heightDiff * scrollPct}px)`;
     }
     this.exportButton.style.transform = `scale(${1 - 0.2 * scrollPct})`;
     // Start showing the productinfo when we are at the 50% mark of our animation

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -247,7 +247,7 @@ limitations under the License.
     .lh-export {
       position: absolute;
       right: var(--section-indent);
-      transform: translateY(0);
+      transform: translateY(0) translateZ(1px);
       top: calc(var(--section-padding) / 2);
       will-change: transform;
       z-index: 2;

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -197,7 +197,6 @@ limitations under the License.
     }
     .lh-scores-wrapper {
       margin-top: -30px;
-      transform: translateZ(1px);
     }
     .lh-scores-wrapper__shadow {
       opacity: 0;
@@ -247,7 +246,7 @@ limitations under the License.
     .lh-export {
       position: absolute;
       right: var(--section-indent);
-      transform: translateY(0) translateZ(1px);
+      transform: translateY(0);
       top: calc(var(--section-padding) / 2);
       will-change: transform;
       z-index: 2;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
fixes the dropdown overlap between score container in safari.

demo:
http://wardpeet-filestorage.surge.sh/lh-store/pr-6546/report.html

<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
#6510
<!-- Provide any additional information we might need to understand the pull request -->
