### PR TITLE
 core(driver): assert page not hung after each gatherer

### DIFF
--- a/lighthouse-cli/test/fixtures/infinite-loop.html
+++ b/lighthouse-cli/test/fixtures/infinite-loop.html
@@ -14,8 +14,17 @@
   This is the function that never ends.
 
   <script>
-    while (true) {
-      for (let i = 0; i < 1000000; i++) ;
+    function hang() {
+      while (true) {
+        for (let i = 0; i < 1000000; i++) ;
+      }
+    }
+
+    if (location.search.includes('afterPass')) {
+      // Force the JSLibraries gatherer to hang when it calls Object.entries
+      Object.entries = hang;
+    } else {
+      hang()
     }
   </script>
 </body>

--- a/lighthouse-cli/test/smokehouse/error-config.js
+++ b/lighthouse-cli/test/smokehouse/error-config.js
@@ -14,6 +14,7 @@ module.exports = {
     maxWaitForLoad: 5000,
     onlyAudits: [
       'first-contentful-paint',
+      'js-libraries', // Invoke JSLibraries gatherer so we can force it to hang if necessary
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -15,4 +15,10 @@ module.exports = [
     errorCode: 'PAGE_HUNG',
     audits: {},
   },
+  {
+    requestedUrl: 'http://localhost:10200/infinite-loop.html?afterPass',
+    finalUrl: 'http://localhost:10200/infinite-loop.html?afterPass',
+    errorCode: 'PAGE_HUNG',
+    audits: {},
+  },
 ];

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -707,6 +707,15 @@ class Driver {
     }
   }
 
+  async assertPageNotHung() {
+    if (await this.isPageHung()) {
+      log.warn('Driver', 'Page appears to be hung, killing JavaScript...');
+      await this.sendCommand('Emulation.setScriptExecutionDisabled', {value: true});
+      await this.sendCommand('Runtime.terminateExecution');
+      throw new LHError(LHError.errors.PAGE_HUNG);
+    }
+  }
+
   /**
    * Returns a promise that resolves when:
    * - All of the following conditions have been met:
@@ -761,13 +770,7 @@ class Driver {
         waitForLoadEvent.cancel();
         waitForNetworkIdle.cancel();
         waitForCPUIdle && waitForCPUIdle.cancel();
-
-        if (await this.isPageHung()) {
-          log.warn('Driver', 'Page appears to be hung, killing JavaScript...');
-          await this.sendCommand('Emulation.setScriptExecutionDisabled', {value: true});
-          await this.sendCommand('Runtime.terminateExecution');
-          throw new LHError(LHError.errors.PAGE_HUNG);
-        }
+        await this.assertPageNotHung();
       };
     });
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -345,6 +345,7 @@ class GatherRunner {
       gathererResult.push(artifactPromise);
       gathererResults[gatherer.name] = gathererResult;
       await artifactPromise.catch(() => {});
+      await driver.assertPageNotHung();
       log.timeEnd(status);
     }
     log.timeEnd(apStatus);

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -43,6 +43,9 @@ const fakeDriver = {
   assertNoSameOriginServiceWorkerClients() {
     return Promise.resolve();
   },
+  assertPageNotHung() {
+    return Promise.resolve();
+  },
   reloadForCleanStateIfNeeded() {
     return Promise.resolve();
   },

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -45,6 +45,9 @@ function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn,
     assertNoSameOriginServiceWorkerClients() {
       return Promise.resolve();
     }
+    assertPageNotHung() {
+      return Promise.resolve();
+    }
     cacheNatives() {
       return Promise.resolve();
     }
@@ -501,6 +504,30 @@ describe('GatherRunner', function() {
       assert.equal(calledTrace, true);
       assert.equal(passData.trace, fakeTraceData);
     });
+  });
+
+  it('checks if the page is hung', async () => {
+    const url = 'https://example.com';
+
+    const driver = Object.assign({}, fakeDriver, {
+      assertPageNotHung() {
+        return Promise.reject(new Error('Hung'));
+      },
+    });
+
+    const passConfig = {
+      recordTrace: true,
+      gatherers: [
+        {instance: new TestGatherer()},
+      ],
+    };
+
+    try {
+      await GatherRunner.afterPass({url, driver, passConfig}, {TestGatherer: []});
+      throw new Error('Not hung');
+    } catch (err) {
+      expect(err.message).toEqual('Hung');
+    }
   });
 
   it('tells the driver to begin devtoolsLog collection', () => {


### PR DESCRIPTION
**Summary**
per @paulirish 's request this checks if the page is hung after each gatherer's afterPass. The smoketest takes a full minute since our timeout for evaluate is a full 60s :/ If other's are cool with it, I'll add an option for controlling this? Could be a `process.env.SMOKETEST_PROTOCOL_TIMEOUT` or a real option like `maxWaitForLoad`

**Related Issues/PRs**
#6497 
