### PR TITLE
misc(lint): break lines after operators

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,6 +68,7 @@ module.exports = {
     'require-jsdoc': 0,
     'valid-jsdoc': 0,
     'arrow-parens': 0,
+    'operator-linebreak': [2, 'after'],
   },
   parserOptions: {
     ecmaVersion: 2018,

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -118,9 +118,9 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
       const firstRuleStart = preview.indexOf('{');
       const firstRuleEnd = preview.indexOf('}');
 
-      if (firstRuleStart === -1 || firstRuleEnd === -1
-          || firstRuleStart > firstRuleEnd
-          || firstRuleStart > PREVIEW_LENGTH) {
+      if (firstRuleStart === -1 || firstRuleEnd === -1 ||
+          firstRuleStart > firstRuleEnd ||
+          firstRuleStart > PREVIEW_LENGTH) {
         // We couldn't determine the first rule-set or it's not within the preview
         preview = preview.slice(0, PREVIEW_LENGTH) + '...';
       } else if (firstRuleEnd < PREVIEW_LENGTH) {

--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -29,10 +29,8 @@ class NoVulnerableLibrariesAudit extends Audit {
   static get meta() {
     return {
       id: 'no-vulnerable-libraries',
-      title: 'Avoids front-end JavaScript libraries'
-        + ' with known security vulnerabilities',
-      failureTitle: 'Includes front-end JavaScript libraries'
-        + ' with known security vulnerabilities',
+      title: 'Avoids front-end JavaScript libraries with known security vulnerabilities',
+      failureTitle: 'Includes front-end JavaScript libraries with known security vulnerabilities',
       description: 'Some third-party scripts may contain known security vulnerabilities ' +
         'that are easily identified and exploited by attackers. ' +
         '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities).',

--- a/lighthouse-core/gather/computed/critical-request-chains.js
+++ b/lighthouse-core/gather/computed/critical-request-chains.js
@@ -29,8 +29,8 @@ class CriticalRequestChains {
     }
 
     // Iframes are considered High Priority but they are not render blocking
-    const isIframe = request.resourceType === NetworkRequest.TYPES.Document
-      && request.frameId !== mainResource.frameId;
+    const isIframe = request.resourceType === NetworkRequest.TYPES.Document &&
+      request.frameId !== mainResource.frameId;
     // XHRs are fetched at High priority, but we exclude them, as they are unlikely to be critical
     // Images are also non-critical.
     // Treat any missed images, primarily favicons, as non-critical resources

--- a/lighthouse-core/gather/computed/metrics/interactive.js
+++ b/lighthouse-core/gather/computed/metrics/interactive.js
@@ -134,9 +134,9 @@ class Interactive extends ComputedMetric {
     }
 
     throw new LHError(
-      cpuCandidate
-        ? LHError.errors.NO_TTI_NETWORK_IDLE_PERIOD
-        : LHError.errors.NO_TTI_CPU_IDLE_PERIOD
+      cpuCandidate ?
+        LHError.errors.NO_TTI_NETWORK_IDLE_PERIOD :
+        LHError.errors.NO_TTI_CPU_IDLE_PERIOD
     );
   }
 

--- a/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-estimated-input-latency.js
@@ -48,9 +48,9 @@ class LanternEstimatedInputLatency extends LanternMetric {
   static getEstimateFromSimulation(simulation, extras) {
     // Intentionally use the opposite FMP estimate, a more pessimistic FMP means that more tasks
     // are excluded from the EIL computation, so a higher FMP means lower EIL for same work.
-    const fmpTimeInMs = extras.optimistic
-      ? extras.fmpResult.pessimisticEstimate.timeInMs
-      : extras.fmpResult.optimisticEstimate.timeInMs;
+    const fmpTimeInMs = extras.optimistic ?
+      extras.fmpResult.pessimisticEstimate.timeInMs :
+      extras.fmpResult.optimisticEstimate.timeInMs;
 
     const events = LanternEstimatedInputLatency.getEventsAfterFMP(
       simulation.nodeTimings,

--- a/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-first-cpu-idle.js
@@ -28,9 +28,9 @@ class LanternFirstCPUIdle extends LanternInteractive {
    * @return {LH.Gatherer.Simulation.Result}
    */
   static getEstimateFromSimulation(simulation, extras) {
-    const fmpTimeInMs = extras.optimistic
-      ? extras.fmpResult.optimisticEstimate.timeInMs
-      : extras.fmpResult.pessimisticEstimate.timeInMs;
+    const fmpTimeInMs = extras.optimistic ?
+      extras.fmpResult.optimisticEstimate.timeInMs :
+      extras.fmpResult.pessimisticEstimate.timeInMs;
 
     return {
       timeInMs: LanternFirstCPUIdle.getFirstCPUIdleWindowStart(simulation.nodeTimings, fmpTimeInMs),

--- a/lighthouse-core/gather/computed/metrics/lantern-interactive.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-interactive.js
@@ -69,9 +69,9 @@ class LanternInteractive extends LanternMetric {
    */
   static getEstimateFromSimulation(simulationResult, extras) {
     const lastTaskAt = LanternInteractive.getLastLongTaskEndTime(simulationResult.nodeTimings);
-    const minimumTime = extras.optimistic
-      ? extras.fmpResult.optimisticEstimate.timeInMs
-      : extras.fmpResult.pessimisticEstimate.timeInMs;
+    const minimumTime = extras.optimistic ?
+      extras.fmpResult.optimisticEstimate.timeInMs :
+      extras.fmpResult.pessimisticEstimate.timeInMs;
     return {
       timeInMs: Math.max(minimumTime, lastTaskAt),
       nodeTimings: simulationResult.nodeTimings,

--- a/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
+++ b/lighthouse-core/gather/computed/metrics/lantern-speed-index.js
@@ -51,9 +51,9 @@ class LanternSpeedIndex extends LanternMetric {
    */
   static getEstimateFromSimulation(simulationResult, extras) {
     const fcpTimeInMs = extras.fcpResult.pessimisticEstimate.timeInMs;
-    const estimate = extras.optimistic
-      ? extras.speedline.speedIndex
-      : LanternSpeedIndex.computeLayoutBasedSpeedIndex(simulationResult.nodeTimings, fcpTimeInMs);
+    const estimate = extras.optimistic ?
+      extras.speedline.speedIndex :
+      LanternSpeedIndex.computeLayoutBasedSpeedIndex(simulationResult.nodeTimings, fcpTimeInMs);
     return {
       timeInMs: estimate,
       nodeTimings: simulationResult.nodeTimings,

--- a/lighthouse-core/gather/gatherers/image-usage.js
+++ b/lighthouse-core/gather/gatherers/image-usage.js
@@ -53,8 +53,8 @@ function collectImageElementInfo() {
       naturalHeight: element.naturalHeight,
       isCss: false,
       isPicture: !!element.parentElement && element.parentElement.tagName === 'PICTURE',
-      usesObjectFit: computedStyle.getPropertyValue('object-fit') === 'cover'
-      || computedStyle.getPropertyValue('object-fit') === 'contain',
+      usesObjectFit: computedStyle.getPropertyValue('object-fit') === 'cover' ||
+      computedStyle.getPropertyValue('object-fit') === 'contain',
     };
   });
 

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -197,9 +197,9 @@ class NetworkAnalyzer {
       if (!Number.isFinite(timing.receiveHeadersEnd) || timing.receiveHeadersEnd < 0) return;
       if (!record.resourceType) return;
 
-      const serverResponseTimePercentage = SERVER_RESPONSE_PERCENTAGE_OF_TTFB[record.resourceType]
-        || DEFAULT_SERVER_RESPONSE_PERCENTAGE;
-      const estimatedServerResponseTime = timing.receiveHeadersEnd * serverResponseTimePercentage;
+      const serverResponseTimePercent = SERVER_RESPONSE_PERCENTAGE_OF_TTFB[record.resourceType] ||
+        DEFAULT_SERVER_RESPONSE_PERCENTAGE;
+      const estimatedServerResponseTime = timing.receiveHeadersEnd * serverResponseTimePercent;
 
       // When connection was reused...
       // TTFB = 1 RT for request + server response time

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -257,9 +257,9 @@ class Simulator {
    */
   _estimateCPUTimeRemaining(cpuNode) {
     const timingData = this._getTimingData(cpuNode);
-    const multiplier = cpuNode.didPerformLayout()
-      ? this._layoutTaskMultiplier
-      : this._cpuSlowdownMultiplier;
+    const multiplier = cpuNode.didPerformLayout() ?
+      this._layoutTaskMultiplier :
+      this._cpuSlowdownMultiplier;
     const totalDuration = Math.min(
       Math.round(cpuNode.event.dur / 1000 * multiplier),
       DEFAULT_MAXIMUM_CPU_TASK_DURATION
@@ -328,9 +328,9 @@ class Simulator {
     const isFinished = timingData.estimatedTimeElapsed === timePeriodLength;
 
     if (node.type === BaseNode.TYPES.CPU || node.fromDiskCache) {
-      return isFinished
-        ? this._markNodeAsComplete(node, totalElapsedTime)
-        : (timingData.timeElapsed += timePeriodLength);
+      return isFinished ?
+        this._markNodeAsComplete(node, totalElapsedTime) :
+        (timingData.timeElapsed += timePeriodLength);
     }
 
     if (node.type !== BaseNode.TYPES.NETWORK) throw new Error('Unsupported');

--- a/lighthouse-core/scripts/lantern/print-correlations.js
+++ b/lighthouse-core/scripts/lantern/print-correlations.js
@@ -266,9 +266,9 @@ function findAndPrintWorst10Sites(metric, lanternMetrics) {
     .slice(0, 10)
     .forEach(entry => {
       console.log(
-        entry.actual < entry.expected
-          ? chalk.cyan('underestimated')
-          : chalk.yellow('overestimated'),
+        entry.actual < entry.expected ?
+          chalk.cyan('underestimated') :
+          chalk.yellow('overestimated'),
         entry.metric,
         chalk.gray('by'),
         Math.round(entry.diff),


### PR DESCRIPTION
inspired by https://github.com/GoogleChrome/lighthouse/pull/6579#discussion_r234372410

Surprised this wasn't on either.
eslint-config-google has the very helpful lines
```
// TODO(philipwalton): add a rule to enforce the operator appearing
// at the end of the line.
```

:P Were we all just following this unconsciously?

I learned from reading about the `operator-linebreak` rule that some people really do prefer to have the ternary (ConditionalExpression) operators at the start of a new line, so we could maybe discuss that for these since there's some preexisting ones.

However, in our code base the `?` and `:` at the end of lines outnumbered them at the beginning of lines by like 5 to 1, so if we go with one of these choices, the changes in this PR seem like the better option.

(`operator-linebreak` is also supported by `--fix`, so should be fine for those using prettier and then fixing)