### PR TITLE
report: give passed-opportunities group an icon

### DIFF
--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -188,7 +188,7 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
       groupEl.appendChild(headerEl);
       opportunityAudits.forEach((item, i) =>
           groupEl.appendChild(this._renderOpportunity(item, i, scale)));
-      groupEl.classList.add('lh-audit-group--opportunities');
+      groupEl.classList.add('lh-audit-group--load-opportunities');
       element.appendChild(groupEl);
     }
 

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -617,7 +617,7 @@ details, summary {
   content: '';
   background-image: var(--content-paste-icon-url);
 }
-.lh-audit-group--opportunities .lh-audit-group__header::before {
+.lh-audit-group--load-opportunities .lh-audit-group__header::before {
   content: '';
   background-image: var(--photo-filter-icon-url);
 }
@@ -683,7 +683,7 @@ details, summary {
 
 .lh-clump > .lh-audit-group__description,
 .lh-audit-group--diagnostics .lh-audit-group__description,
-.lh-audit-group--opportunities .lh-audit-group__description,
+.lh-audit-group--load-opportunities .lh-audit-group__description,
 .lh-audit-group--metrics .lh-audit-group__description,
 .lh-audit-group--pwa-fast-reliable .lh-audit-group__description,
 .lh-audit-group--pwa-installable .lh-audit-group__description,


### PR DESCRIPTION
While we figure out #6568, fixes @patrickhulce's https://github.com/GoogleChrome/lighthouse/issues/6568#issuecomment-438911350

The `Opportunities` group icon was being given to the old-style `lh-audit-group--opportunities` css class, but the Opportunities group under `Passed` had the new-style `lh-audit-group--load-opportunities` (`lh-audit-group--` + `groupId`).

This PR just standardizes on the new style of class name.

Before:
<img width="272" alt="screen shot 2018-11-16 at 17 52 51" src="https://user-images.githubusercontent.com/316891/48655152-79250380-e9c8-11e8-9e32-af14140d1b8d.png">

After:
<img width="372" alt="screen shot 2018-11-16 at 17 41 00" src="https://user-images.githubusercontent.com/316891/48655052-580fe300-e9c7-11e8-8667-7ad58b5874a3.png">
