### PR TITLE
report: expand groups within collapsed clumps

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -182,7 +182,7 @@ class CategoryRenderer {
    * Renders the group container for a group of audits. Individual audit elements can be added
    * directly to the returned element.
    * @param {LH.Result.ReportGroup} group
-   * @param {{expandable: boolean, itemCount?: number}} opts
+   * @param {{expandable: boolean, open?: boolean, itemCount?: number}} opts
    * @return {Element}
    */
   renderAuditGroup(group, opts) {
@@ -195,6 +195,8 @@ class CategoryRenderer {
     if (expandable) {
       const chevronEl = summaryInnerEl.appendChild(this._createChevron());
       chevronEl.title = Util.UIStrings.auditGroupExpandTooltip;
+
+      /** @type {HTMLDetailsElement} */ (groupEl).open = !!opts.open;
     }
 
     if (group.description) {
@@ -216,7 +218,7 @@ class CategoryRenderer {
    * array of audit and audit-group elements.
    * @param {Array<LH.ReportResult.AuditRef>} auditRefs
    * @param {Object<string, LH.Result.ReportGroup>} groupDefinitions
-   * @param {{expandable: boolean}} opts
+   * @param {{expandable: boolean, open?: boolean}} opts
    * @return {Array<Element>}
    */
   _renderGroupedAudits(auditRefs, groupDefinitions, opts) {
@@ -304,14 +306,14 @@ class CategoryRenderer {
       return failedElem;
     }
 
-    const expandable = true;
-    const elements = this._renderGroupedAudits(auditRefs, groupDefinitions, {expandable});
+    const opts = {expandable: true, open: true};
+    const elements = this._renderGroupedAudits(auditRefs, groupDefinitions, opts);
 
     const clumpInfo = this._clumpDisplayInfo[clumpId];
     // TODO: renderAuditGroup shouldn't be used to render a clump (since it *contains* audit groups).
     const groupDef = {title: clumpInfo.title, description};
-    const opts = {expandable, itemCount: auditRefs.length};
-    const clumpElem = this.renderAuditGroup(groupDef, opts);
+    const clumpOpts = {expandable: true, itemCount: auditRefs.length};
+    const clumpElem = this.renderAuditGroup(groupDef, clumpOpts);
     clumpElem.classList.add('lh-clump', clumpInfo.className);
 
     elements.forEach(elem => clumpElem.appendChild(elem));


### PR DESCRIPTION
This is still under discussion, but ready to go if we decide to go this way.

When groups are nested under a closed clump (e.g. the a11y groups under the `Passed audits` section of the a11y category) the groups are also collapsed themselves. This isn't great, as when you open the collapsed section, the whole point is that you're indicating that you want to see the audits contained within.

This PR adds another audit group option when the group is set to be `expandable` that indicates whether it should be expanded or collapsed by default. I went with `open` for this option, but `expanded` might be better (it just seemed too similar to the other option and `open` matches the `<details>` attribute).

Humorously, all groups that are expandable are also set to be `open` *except* the abuse of using `renderAuditGroup` to render clumps, which are expandable but sometimes not open (e.g. `Passed audits`). If we fix the clump TODO on `renderAuditGroup` then we can just drop the `open` option and have them always open.

![expanded-groups](https://user-images.githubusercontent.com/316891/48655668-d7ed7b80-e9ce-11e8-8551-45ada2f01879.gif)
