### PR TITLE
report: import <detail> polyfill as string, not Buffer

### DIFF
--- a/lighthouse-core/report/html/html-report-assets.js
+++ b/lighthouse-core/report/html/html-report-assets.js
@@ -13,7 +13,7 @@ const REPORT_JAVASCRIPT = [
   fs.readFileSync(__dirname + '/renderer/dom.js', 'utf8'),
   // COMPAT: Remove when Microsoft Edge supports <details>/<summary>
   // https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary/?q=details
-  fs.readFileSync(require.resolve('details-element-polyfill/dist/details-element-polyfill.js')),
+  fs.readFileSync(require.resolve('details-element-polyfill'), 'utf8'),
   fs.readFileSync(__dirname + '/renderer/details-renderer.js', 'utf8'),
   fs.readFileSync(__dirname + '/renderer/crc-details-renderer.js', 'utf8'),
   fs.readFileSync(__dirname + '/../../lib/file-namer.js', 'utf8'),


### PR DESCRIPTION
Fixes viewer bundle size inflation introduced by #6593. The `details-element-polyfill` was accidentally being inlined as a base64-encoded Buffer and then having `toString()` called on it.

The string version is smaller, and we don't also need `Buffer` browserified in :)