### PR TITLE
core(computed-artifacts): fix cache and add perf timing

### DIFF
--- a/lighthouse-core/computed/computed-artifact.js
+++ b/lighthouse-core/computed/computed-artifact.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const ArbitraryEqualityMap = require('../lib/arbitrary-equality-map.js');
+const log = require('lighthouse-logger');
 
 /**
  * Decorate computableArtifact with a caching `request()` method which will
@@ -25,17 +26,24 @@ function makeComputedArtifact(computableArtifact) {
    */
   const request = (artifacts, context) => {
     const computedCache = context.computedCache;
-    const cache = computedCache.get(computableArtifact.name) || new ArbitraryEqualityMap();
-    computedCache.set(computableArtifact.name, cache);
+    const computedName = computableArtifact.name;
+
+    const cache = computedCache.get(computedName) || new ArbitraryEqualityMap();
+    computedCache.set(computedName, cache);
 
     const computed = /** @type {ReturnType<C['compute_']>|undefined} */ (cache.get(artifacts));
     if (computed) {
       return computed;
     }
 
+    const status = {msg: `Computing artifact: ${computedName}`, id: `lh:computed:${computedName}`};
+    log.time(status, 'verbose');
+
     const artifactPromise = /** @type {ReturnType<C['compute_']>} */
         (computableArtifact.compute_(artifacts, context));
     cache.set(artifacts, artifactPromise);
+
+    artifactPromise.then(() => log.timeEnd(status)).catch(() => log.timeEnd(status));
 
     return artifactPromise;
   };

--- a/lighthouse-core/lib/arbitrary-equality-map.js
+++ b/lighthouse-core/lib/arbitrary-equality-map.js
@@ -14,7 +14,7 @@ const isEqual = require('lodash.isequal');
  */
 class ArbitraryEqualityMap {
   constructor() {
-    this._equalsFn = /** @type {function(*,*):boolean} */ ((a, b) => a === b);
+    this._equalsFn = ArbitraryEqualityMap.deepEquals;
     /** @type {Array<{key: *, value: *}>} */
     this._entries = [];
   }

--- a/lighthouse-core/test/computed/computed-artifact-test.js
+++ b/lighthouse-core/test/computed/computed-artifact-test.js
@@ -12,7 +12,7 @@ const assert = require('assert');
 const makeComputedArtifact = require('../../computed/computed-artifact.js');
 
 describe('ComputedArtifact base class', () => {
-  it.skip('caches computed artifacts by strict equality', async () => {
+  it('caches computed artifacts by strict equality', async () => {
     let computeCounter = 0;
 
     const TestComputedArtifact = makeComputedArtifact(class TestComputedArtifact {

--- a/lighthouse-core/test/computed/computed-artifact-test.js
+++ b/lighthouse-core/test/computed/computed-artifact-test.js
@@ -14,17 +14,17 @@ const makeComputedArtifact = require('../../computed/computed-artifact.js');
 describe('ComputedArtifact base class', () => {
   it('caches computed artifacts by strict equality', async () => {
     let computeCounter = 0;
-
-    const TestComputedArtifact = makeComputedArtifact(class TestComputedArtifact {
+    class RawTestComputedArtifact {
       static async compute_() {
         return computeCounter++;
       }
-    });
+    }
 
     const context = {
       computedCache: new Map(),
     };
 
+    const TestComputedArtifact = makeComputedArtifact(RawTestComputedArtifact);
     let result = await TestComputedArtifact.request({x: 1}, context);
     assert.equal(result, 0);
 

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3476,6 +3476,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:computed:NetworkRecords",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:redirects-http",
         "duration": 100,
         "entryType": "measure"
@@ -3512,7 +3518,25 @@
       },
       {
         "startTime": 0,
+        "name": "lh:computed:FirstContentfulPaint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:TraceOfTab",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:first-meaningful-paint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:FirstMeaningfulPaint",
         "duration": 100,
         "entryType": "measure"
       },
@@ -3524,7 +3548,25 @@
       },
       {
         "startTime": 0,
+        "name": "lh:computed:Interactive",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:speed-index",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:SpeedIndex",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:Speedline",
         "duration": 100,
         "entryType": "measure"
       },
@@ -3542,7 +3584,19 @@
       },
       {
         "startTime": 0,
+        "name": "lh:computed:Screenshots",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:estimated-input-latency",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:EstimatedInputLatency",
         "duration": 100,
         "entryType": "measure"
       },
@@ -3560,7 +3614,19 @@
       },
       {
         "startTime": 0,
+        "name": "lh:computed:MainResource",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:first-cpu-idle",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:FirstCPUIdle",
         "duration": 100,
         "entryType": "measure"
       },
@@ -3584,13 +3650,61 @@
       },
       {
         "startTime": 0,
+        "name": "lh:computed:CriticalRequestChains",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:redirects",
         "duration": 100,
         "entryType": "measure"
       },
       {
         "startTime": 0,
+        "name": "lh:computed:LanternInteractive",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:LanternFirstMeaningfulPaint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:LanternFirstContentfulPaint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:PageDependencyGraph",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:LoadSimulator",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:NetworkAnalysis",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:webapp-install-banner",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:ManifestValues",
         "duration": 100,
         "entryType": "measure"
       },
@@ -3632,6 +3746,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:computed:MainThreadTasks",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:bootup-time",
         "duration": 100,
         "entryType": "measure"
@@ -3639,6 +3759,12 @@
       {
         "startTime": 0,
         "name": "lh:audit:uses-rel-preload",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:LoadSimulator",
         "duration": 100,
         "entryType": "measure"
       },
@@ -3987,6 +4113,18 @@
       {
         "startTime": 0,
         "name": "lh:audit:render-blocking-resources",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:FirstContentfulPaint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:LanternFirstContentfulPaint",
         "duration": 100,
         "entryType": "measure"
       },

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -3333,6 +3333,12 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:NetworkRecords", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:redirects-http", 
                 "startTime": 0.0
             }, 
@@ -3369,7 +3375,25 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:FirstContentfulPaint", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:TraceOfTab", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:first-meaningful-paint", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:FirstMeaningfulPaint", 
                 "startTime": 0.0
             }, 
             {
@@ -3381,7 +3405,25 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:Interactive", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:speed-index", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:SpeedIndex", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:Speedline", 
                 "startTime": 0.0
             }, 
             {
@@ -3399,7 +3441,19 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:Screenshots", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:estimated-input-latency", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:EstimatedInputLatency", 
                 "startTime": 0.0
             }, 
             {
@@ -3417,7 +3471,19 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:MainResource", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:first-cpu-idle", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:FirstCPUIdle", 
                 "startTime": 0.0
             }, 
             {
@@ -3441,13 +3507,61 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:CriticalRequestChains", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:redirects", 
                 "startTime": 0.0
             }, 
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:LanternInteractive", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:LanternFirstMeaningfulPaint", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:LanternFirstContentfulPaint", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:PageDependencyGraph", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:LoadSimulator", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:NetworkAnalysis", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:webapp-install-banner", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:ManifestValues", 
                 "startTime": 0.0
             }, 
             {
@@ -3489,6 +3603,12 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:MainThreadTasks", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:bootup-time", 
                 "startTime": 0.0
             }, 
@@ -3496,6 +3616,12 @@
                 "duration": 100.0, 
                 "entryType": "measure", 
                 "name": "lh:audit:uses-rel-preload", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:LoadSimulator", 
                 "startTime": 0.0
             }, 
             {
@@ -3844,6 +3970,18 @@
                 "duration": 100.0, 
                 "entryType": "measure", 
                 "name": "lh:audit:render-blocking-resources", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:FirstContentfulPaint", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
+                "name": "lh:computed:LanternFirstContentfulPaint", 
                 "startTime": 0.0
             }, 
             {


### PR DESCRIPTION
split off from #6618

- log timing was added at the same time that #6204 updated computed artifacts, so timing info hasn't actually been collected for computed artifacts (timing was still accounted for in the audits that called them, though). This PR adds timing to the new version.
- #6204 messed up and was using strict equality testing for the computed artifact cache, not deep equality. Computed artifacts that take a bare artifact (e.g. `trace-of-tab`) had no issue with this and cached correctly. Any computed artifact that take a more complicated input (e.g. all the metrics) always found keys to be unequal, and so reran their computations every time they were called. This was especially bad in the lantern metrics, which tend to call each other a lot and benefit a good deal from caching.

  This PR defaults `ArbitraryEqualityMap` to using deep equality now (since that's the only way we use it), and the kind of goofball test updated in `computed-artifact-test.js` proved it's worth and will prevent this from regressing again.

Good news: runs should speed up :)