### PR TITLE
refactor: Only require html report templates when generating html report

### DIFF
--- a/lighthouse-core/report/report-generator.js
+++ b/lighthouse-core/report/report-generator.js
@@ -5,8 +5,6 @@
  */
 'use strict';
 
-const htmlReportAssets = require('./html/html-report-assets');
-
 class ReportGenerator {
   /**
    * Replaces all the specified strings in source without serial replacements.
@@ -33,6 +31,8 @@ class ReportGenerator {
    * @return {string}
    */
   static generateReportHtml(lhr) {
+    const htmlReportAssets = require('./html/html-report-assets');
+
     const sanitizedJson = JSON.stringify(lhr)
       .replace(/</g, '\\u003c') // replaces opening script tags
       .replace(/\u2028/g, '\\u2028') // replaces line separators ()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

Moved importing of html report templates to happen lazily at the time when a html report is being generated.

<!-- Describe the need for this change -->
Reading html template files from disk when not generating html-reports is wasteful. It's also a lot easier to configure a bundler for a serverless deployment if the runtime isn't reading files on disk that are not in the module dendendency graph.

<!-- Link any documentation or information that would help understand this change -->
Case in point: I'm bundling up my lighthouse with webpack to minimize my lambda deployment package, but am running into errors because these template files are not included in the dependency graph. I'm only generating a json report, so I really don't need them