### PR TITLE
tests: add smoketest for slow service worker

### DIFF
--- a/lighthouse-cli/test/fixtures/offline-ready-sw.js
+++ b/lighthouse-cli/test/fixtures/offline-ready-sw.js
@@ -24,7 +24,11 @@ const RUNTIME = 'runtime';
 
 // The install handler takes care of precaching the resources we always need.
 self.addEventListener('install', event => {
-  self.skipWaiting();
+  if (self.location.search.includes('slow')) {
+    event.waitUntil(new Promise(resolve => setTimeout(resolve, 5000)));
+  } else {
+    self.skipWaiting();
+  }
 
   const populateCaches = caches.open(PRECACHE)
       .then(cache => cache.addAll(PRECACHE_URLS));

--- a/lighthouse-cli/test/fixtures/offline-ready.html
+++ b/lighthouse-cli/test/fixtures/offline-ready.html
@@ -24,10 +24,6 @@
 </h4>
 
 <script>
-  function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms))
-  }
-
   async function registerServiceWorker(qs = '') {
     if (!('serviceWorker' in navigator)) return
 
@@ -45,7 +41,7 @@
   }
 
   if (window.location.search.includes('slow')) {
-    setTimeout(() => registerServiceWorker('?delay=5000&slow'), 500);
+    window.addEventListener('load', () => registerServiceWorker('?delay=5000&slow'));
   } else {
     registerServiceWorker();
   }

--- a/lighthouse-cli/test/fixtures/offline-ready.html
+++ b/lighthouse-cli/test/fixtures/offline-ready.html
@@ -24,18 +24,32 @@
 </h4>
 
 <script>
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/offline-ready-sw.js').then(function(registration) {
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
+  }
+
+  async function registerServiceWorker(qs = '') {
+    if (!('serviceWorker' in navigator)) return
+
+    try {
+      const registration = await navigator.serviceWorker.register(`/offline-ready-sw.js${qs}`)
       console.log('service worker registration complete');
 
       registration.addEventListener('statechange',  e => {
         console.log('sw registration is now', e.target.state);
       });
-    }).catch(function(e) {
+    } catch (e) {
       console.error('service worker is not so cool.', e);
       throw e;
-    });
+    }
   }
+
+  if (window.location.search.includes('slow')) {
+    setTimeout(() => registerServiceWorker('?delay=5000&slow'), 500);
+  } else {
+    registerServiceWorker();
+  }
+
 </script>
 
 <!--

--- a/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
@@ -156,4 +156,17 @@ module.exports = [
       },
     },
   },
+
+  {
+    requestedUrl: 'http://localhost:10503/offline-ready.html?slow',
+    finalUrl: 'http://localhost:10503/offline-ready.html?slow',
+    audits: {
+      'service-worker': {
+        score: 1,
+      },
+      'works-offline': {
+        score: 1,
+      },
+    },
+  },
 ];


### PR DESCRIPTION
**Summary**
Curious what types of late service worker we don't catch. I saw @paulirish's comment that it's just calling `.register` but I was skeptical based on the other reports. I should not have been skeptical it lives up, and this just adds a smoketest to prove it. We wait for delays in loading the service worker script itself and delays in the install event too.

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/issues/2924#issuecomment-332989460
#5527 
