### PR TITLE
report: fix pwa-optimized badge gauge

### DIFF
--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -601,6 +601,10 @@ limitations under the License.
     .lh-gauge--pwa__wrapper:not([class*='lh-badged--']) .lh-gauge--pwa__na-line {
       display: inline;
     }
+    /* Just optimized. Same n/a line as no passing groups. */
+    .lh-gauge--pwa__wrapper.lh-badged--pwa-optimized .lh-gauge--pwa__na-line {
+      display: inline;
+    }
 
     /* Just fast and reliable. */
     .lh-gauge--pwa__wrapper.lh-badged--pwa-fast-reliable:not(.lh-badged--pwa-installable) .lh-gauge--pwa__fast-reliable-badge {


### PR DESCRIPTION
part of #6395

@exterkamp noticed that a report completing just the PWA `Optimized` group was getting a blank gray badge gauge.

<img width="153" alt="screen shot 2018-11-27 at 17 14 46" src="https://user-images.githubusercontent.com/316891/49122147-13f2cd00-f268-11e8-84dd-d63d9489e4fe.png">

This fixes it to get the proper N/A gauge as specced.

<img width="161" alt="screen shot 2018-11-27 at 17 11 38" src="https://user-images.githubusercontent.com/316891/49122015-86af7880-f267-11e8-8fca-01a84a65886c.png">
