### PR TITLE
deps: update to tsc 3.2.2

### DIFF
--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -113,8 +113,15 @@ async function compileJs() {
   const generatorFilename = `${sourceDir}/../lighthouse-core/report/report-generator.js`;
   const generatorBrowserify = browserify(generatorFilename, {standalone: 'ReportGenerator'})
     .transform('brfs');
-  const generatorBundle = promisify(generatorBrowserify.bundle.bind(generatorBrowserify));
-  const generatorJs = (await generatorBundle()).toString();
+
+  /** @type {Promise<string>} */
+  const generatorJsPromise = new Promise(resolve => {
+    generatorBrowserify.bundle((err, src) => {
+      if (err) throw err;
+      resolve(src.toString());
+    });
+  });
+  const generatorJs = await generatorJsPromise;
 
   // Report renderer scripts.
   const rendererJs = htmlReportAssets.REPORT_JAVASCRIPT;

--- a/build/build-viewer.js
+++ b/build/build-viewer.js
@@ -115,9 +115,9 @@ async function compileJs() {
     .transform('brfs');
 
   /** @type {Promise<string>} */
-  const generatorJsPromise = new Promise(resolve => {
+  const generatorJsPromise = new Promise((resolve, reject) => {
     generatorBrowserify.bundle((err, src) => {
-      if (err) throw err;
+      if (err) return reject(err);
       resolve(src.toString());
     });
   });

--- a/clients/extension/scripts/popup.js
+++ b/clients/extension/scripts/popup.js
@@ -234,12 +234,14 @@ async function initPopup() {
     find('header h2').textContent = siteURL.origin;
   });
 
+  const backgroundPagePromise = new Promise(resolve => chrome.runtime.getBackgroundPage(resolve));
+
   /**
    * Really the Window of the background page, but since we only want what's exposed
    * on window in extension-entry.js, use its module API as the type.
    * @type {BackgroundPage}
    */
-  const background = await new Promise(resolve => chrome.runtime.getBackgroundPage(resolve));
+  const background = await backgroundPagePromise;
 
   // To prevent visual hiccups when opening the popup, we default the subpage
   // to the "running" view and switch to the default view once we're sure

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -45,7 +45,7 @@ class CriticalRequestChains extends Audit {
 
   /**
    * @param {LH.Audit.SimpleCriticalRequestNode} tree
-   * @param {function(CrcNodeInfo)} cb
+   * @param {function(CrcNodeInfo): void} cb
    */
   static _traverse(tree, cb) {
     /**

--- a/lighthouse-core/lib/dependency-graph/base-node.js
+++ b/lighthouse-core/lib/dependency-graph/base-node.js
@@ -216,7 +216,7 @@ class BaseNode {
   /**
    * Traverses all paths in the graph, calling iterator on each node visited. Decides which nodes to
    * visit with the getNext function.
-   * @param {function(Node, Node[])} iterator
+   * @param {function(Node, Node[]): void} iterator
    * @param {function(Node): Node[]} getNext
    */
   _traversePaths(iterator, getNext) {
@@ -238,7 +238,7 @@ class BaseNode {
   /**
    * Traverses all connected nodes exactly once, calling iterator on each. Decides which nodes to
    * visit with the getNext function.
-   * @param {function(Node, Node[])} iterator
+   * @param {function(Node, Node[]): void} iterator
    * @param {function(Node): Node[]} [getNext] Defaults to returning the dependents.
    */
   traverse(iterator, getNext) {

--- a/lighthouse-viewer/app/src/drag-and-drop.js
+++ b/lighthouse-viewer/app/src/drag-and-drop.js
@@ -10,7 +10,7 @@
  */
 class DragAndDrop {
   /**
-   * @param {function(File)} fileHandlerCallback Invoked when the user chooses a new file.
+   * @param {function(File): void} fileHandlerCallback Invoked when the user chooses a new file.
    */
   constructor(fileHandlerCallback) {
     const dropZone = document.querySelector('.drop_zone');

--- a/lighthouse-viewer/app/src/viewer-ui-features.js
+++ b/lighthouse-viewer/app/src/viewer-ui-features.js
@@ -14,7 +14,7 @@
 class ViewerUIFeatures extends ReportUIFeatures {
   /**
    * @param {DOM} dom
-   * @param {?function(LH.ReportResult)} saveGistCallback
+   * @param {?function(LH.ReportResult): void} saveGistCallback
    */
   constructor(dom, saveGistCallback) {
     super(dom);

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "^1.10.0",
     "sinon": "^2.3.5",
-    "typescript": "^3.2.0-rc",
+    "typescript": "3.2.1-insiders.20181127",
     "uglify-es": "3.0.15",
     "url-search-params": "0.6.1",
     "whatwg-fetch": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "^1.10.0",
     "sinon": "^2.3.5",
-    "typescript": "3.1.3",
+    "typescript": "^3.2.0-rc",
     "uglify-es": "3.0.15",
     "url-search-params": "0.6.1",
     "whatwg-fetch": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "^1.10.0",
     "sinon": "^2.3.5",
-    "typescript": "3.2.1-insiders.20181127",
+    "typescript": "3.2.1",
     "uglify-es": "3.0.15",
     "url-search-params": "0.6.1",
     "whatwg-fetch": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "^1.10.0",
     "sinon": "^2.3.5",
-    "typescript": "3.2.1",
+    "typescript": "3.2.2",
     "uglify-es": "3.0.15",
     "url-search-params": "0.6.1",
     "whatwg-fetch": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8770,10 +8770,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.2.0-rc:
-  version "3.2.0-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.0-rc.tgz#7c3816f1c761b096f4f1712382e872f4da8f263e"
-  integrity sha512-RgKDOpEdbU9dAkB4TzxWy46wiyNUKQo0NM0bB7WfvEFw50yu046ldQXpOUYMUTLIAHnToOCtHsu39MYE8o6NCw==
+typescript@3.2.1-insiders.20181127:
+  version "3.2.1-insiders.20181127"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1-insiders.20181127.tgz#92d0fd5491fd67afe1f9ecdf892cabaa7f851f1b"
+  integrity sha512-E+ujgS5E/Z2GdMB7TQO7gwOfeGKvvRxvjif+BgjJhhrSV6iiwfFvYLiD/NRI/rR6/Og1PxQpbx7jxPQOjJ8gVQ==
 
 uglify-es@3.0.15:
   version "3.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8770,10 +8770,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
-  integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
+typescript@^3.2.0-rc:
+  version "3.2.0-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.0-rc.tgz#7c3816f1c761b096f4f1712382e872f4da8f263e"
+  integrity sha512-RgKDOpEdbU9dAkB4TzxWy46wiyNUKQo0NM0bB7WfvEFw50yu046ldQXpOUYMUTLIAHnToOCtHsu39MYE8o6NCw==
 
 uglify-es@3.0.15:
   version "3.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8770,10 +8770,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.2.1-insiders.20181127:
-  version "3.2.1-insiders.20181127"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1-insiders.20181127.tgz#92d0fd5491fd67afe1f9ecdf892cabaa7f851f1b"
-  integrity sha512-E+ujgS5E/Z2GdMB7TQO7gwOfeGKvvRxvjif+BgjJhhrSV6iiwfFvYLiD/NRI/rR6/Og1PxQpbx7jxPQOjJ8gVQ==
+typescript@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
+  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
 
 uglify-es@3.0.15:
   version "3.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8770,10 +8770,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
-  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
+typescript@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 uglify-es@3.0.15:
   version "3.0.15"


### PR DESCRIPTION
typescript 3.2 is out!

https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#typescript-32

Not a whole lot new for us. Main thing is that `Function.prototype.bind()` (and `call()` and `apply()`) are now strictly typed. Fortunately all our uses of `bind()` (mostly event listeners) seem to have been correct, so...good job us :)

There are a few other things that we'll benefit passively from going forward (see release notes). I'm excited that [`null` and `undefined` are now valid union discriminators](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#non-unit-types-as-union-discriminants). I'm fairly certain we have a few places in the code where we awkwardly work around this not working in the past, but I can't remember where they are so we'll just update when we find them :)

Changes in this PR are just fixing a few places the compiler got stricter.