### PR TITLE
report: larger vertical margins for audit-group summaries

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -652,6 +652,7 @@
   border-bottom: none;
 }
 .lh-audit-group--metrics .lh-audit-group__summary {
+  margin-top: 0;
   margin-bottom: 0;
 }
 
@@ -659,7 +660,8 @@
   display: flex;
   justify-content: space-between;
   padding-right: var(--text-indent);
-  margin-bottom: var(--lh-audit-vpadding);
+  margin-top: calc(var(--section-padding) * 1.5);
+  margin-bottom: var(--section-padding);
 }
 
 .lh-audit-group__itemcount {


### PR DESCRIPTION
part of #6395

Widens the vertical margins around group header summaries to match the specced design (see discussion starting with https://github.com/GoogleChrome/lighthouse/issues/6395#issuecomment-439259634).

Before:

<img width="827" alt="screen shot 2018-11-29 at 15 19 05" src="https://user-images.githubusercontent.com/316891/49258415-3c0a3980-f3ea-11e8-8d46-08c1361ce5cf.png">

After:

<img width="832" alt="screen shot 2018-11-29 at 15 21 25" src="https://user-images.githubusercontent.com/316891/49258489-77a50380-f3ea-11e8-99b5-60c700414f67.png">

Things are a little spread out for e.g. the a11y groups:

<img width="826" alt="screen shot 2018-11-29 at 15 22 46" src="https://user-images.githubusercontent.com/316891/49258545-a9b66580-f3ea-11e8-926e-71527af66946.png">

but it's not egregious