### PR TITLE
core(url-shim): add intent protocol to NON_NETWORK_PROTOCOLS

### DIFF
--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -209,7 +209,7 @@ URLShim.URL = URL;
 URLShim.URLSearchParams = (typeof self !== 'undefined' && self.URLSearchParams) ||
     require('url').URLSearchParams;
 
-URLShim.NON_NETWORK_PROTOCOLS = ['blob', 'data'];
+URLShim.NON_NETWORK_PROTOCOLS = ['blob', 'data', 'intent'];
 
 URLShim.INVALID_URL_DEBUG_STRING =
     'Lighthouse was unable to determine the URL of some script executions. ' +

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -209,6 +209,18 @@ describe('Performance: uses-rel-preload audit', () => {
       assert.equal(output.details.items.length, 0);
     });
   });
+  
+  it(`shouldn't suggest preload for protocol scheme`, () => {
+    const networkRecords = getMockNetworkRecords();
+    networkRecords[2].protocol = 'scheme';
+
+    const artifacts = mockArtifacts(networkRecords, defaultMainResourceUrl);
+    const context = {settings: {}, computedCache: new Map()};
+    return UsesRelPreload.audit(artifacts, context).then(output => {
+      assert.equal(output.rawValue, 0);
+      assert.equal(output.details.items.length, 0);
+    });
+  });
 
   it('does not throw on a real trace/devtools log', async () => {
     const artifacts = {

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -210,9 +210,9 @@ describe('Performance: uses-rel-preload audit', () => {
     });
   });
   
-  it(`shouldn't suggest preload for protocol scheme`, () => {
+  it(`shouldn't suggest preload for protocol intent`, () => {
     const networkRecords = getMockNetworkRecords();
-    networkRecords[2].protocol = 'scheme';
+    networkRecords[2].protocol = 'intent';
 
     const artifacts = mockArtifacts(networkRecords, defaultMainResourceUrl);
     const context = {settings: {}, computedCache: new Map()};

--- a/lighthouse-core/test/audits/uses-rel-preload-test.js
+++ b/lighthouse-core/test/audits/uses-rel-preload-test.js
@@ -209,7 +209,7 @@ describe('Performance: uses-rel-preload audit', () => {
       assert.equal(output.details.items.length, 0);
     });
   });
-  
+
   it(`shouldn't suggest preload for protocol intent`, () => {
     const networkRecords = getMockNetworkRecords();
     networkRecords[2].protocol = 'intent';


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
**Summary**
What kind of change does this PR introduce?
Don't regard an `intent:` request as key request

Is this a bugfix, feature, refactoring, build related change, etc?
Issue been tagged as bug. So bugfix :)

Link any documentation or information that would help understand this change
I'm unsure whether my change/addition goes in the right direction, as I cannot find more detailed information about `intent` protocol/requests

**Related Issues/PRs**
closes https://github.com/GoogleChrome/lighthouse/issues/6660

Cheers
midzer