### PR TITLE
core(driver): handle promise rejections from sendCommand

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -630,11 +630,11 @@ class Driver {
      * @param {() => void} resolve
      */
     function checkForQuiet(driver, resolve) {
-      if (cancelled) resolve();
+      if (cancelled) return Promise.resolve();
 
       return driver.evaluateAsync(checkForQuietExpression)
         .then(timeSinceLongTask => {
-          if (cancelled) resolve();
+          if (cancelled) return Promise.resolve();
 
           if (typeof timeSinceLongTask === 'number') {
             if (timeSinceLongTask >= waitForCPUQuiet) {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -651,7 +651,7 @@ class Driver {
     let cancel = () => {
       throw new Error('_waitForCPUIdle.cancel() called before it was defined');
     };
-    const promise = new Promise(async (resolve, reject) => {
+    const promise = new Promise((resolve, reject) => {
       checkForQuiet(this, resolve).catch(reject);
       cancel = () => {
         cancelled = true;
@@ -911,7 +911,7 @@ class Driver {
           maxWaitMs);
     }
 
-    // Awaiting so that errors can be properly processed.
+    // Bring `Page.navigate` errors back into the promise chain. See #6739.
     await waitforPageNavigateCmd;
 
     return this._endNetworkStatusMonitoring();

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -891,13 +891,11 @@ class Driver {
     await this.sendCommand('Page.enable');
     await this.sendCommand('Emulation.setScriptExecutionDisabled', {value: disableJS});
     // No timeout needed for Page.navigate. See #6413.
-    this._innerSendCommand('Page.navigate', {url});
+    const waitforPageNavigateCmd = this._innerSendCommand('Page.navigate', {url});
 
     if (waitForNavigated) {
       await this._waitForFrameNavigated();
-    }
-
-    if (waitForLoad) {
+    } else if (waitForLoad) {
       const passConfig = /** @type {Partial<LH.Config.Pass>} */ (passContext.passConfig || {});
       let {pauseAfterLoadMs, networkQuietThresholdMs, cpuQuietThresholdMs} = passConfig;
       let maxWaitMs = passContext.settings && passContext.settings.maxWaitForLoad;
@@ -912,6 +910,9 @@ class Driver {
       await this._waitForFullyLoaded(pauseAfterLoadMs, networkQuietThresholdMs, cpuQuietThresholdMs,
           maxWaitMs);
     }
+
+    // Awaiting so that errors can be properly processed.
+    await waitforPageNavigateCmd;
 
     return this._endNetworkStatusMonitoring();
   }

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -652,11 +652,7 @@ class Driver {
       throw new Error('_waitForCPUIdle.cancel() called before it was defined');
     };
     const promise = new Promise(async (resolve, reject) => {
-      try {
-        await checkForQuiet(this, resolve);
-      } catch (e) {
-        reject(e);
-      }
+      checkForQuiet(this, resolve).catch(reject);
       cancel = () => {
         cancelled = true;
         if (lastTimeout) clearTimeout(lastTimeout);

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -892,9 +892,6 @@ class Driver {
     await this._beginNetworkStatusMonitoring(url);
     await this._clearIsolatedContextId();
 
-    // These can 'race' and that's OK.
-    // We don't want to wait for Page.navigate's resolution, as it can now
-    // happen _after_ onload: https://crbug.com/768961
     await this.sendCommand('Page.enable');
     await this.sendCommand('Emulation.setScriptExecutionDisabled', {value: disableJS});
     // No timeout needed for Page.navigate. See #6413.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
As of #6347 driver's `sendCommand` can reject its Promise if the underlying protocol command times out.  This new rejection path isn't handled in some invocations of sendCommand leading to unhandled promise rejections.  This would present as us "missing" a PROTOCOL_TIMEOUT in LR, leading to the graceful resolve fix push; however, upon investigation, the cause of missing those timeouts was the timeouts causing an unhandled promise rejection which freaks out LR!  
This should catch all unhandled promise rejections as of right now.  I did a lot of testing to try to track down unhandled promise rejection, but I might have missed some, so if you find any lmk.

**Related Issues/PRs**
- makes #6671 irrelevant
- #6336 doesn't fix this, but it does help LR's story and removes the need for more error handling, because the errors are handled now!
