### PR TITLE
core(gather): fix usesObjectFit property for ImageElement

### DIFF
--- a/lighthouse-core/gather/gatherers/image-usage.js
+++ b/lighthouse-core/gather/gatherers/image-usage.js
@@ -53,8 +53,9 @@ function collectImageElementInfo() {
       naturalHeight: element.naturalHeight,
       isCss: false,
       isPicture: !!element.parentElement && element.parentElement.tagName === 'PICTURE',
-      usesObjectFit: computedStyle.getPropertyValue('object-fit') === 'cover'
-      || computedStyle.getPropertyValue('object-fit') === 'contain',
+      usesObjectFit: ['cover', 'contain', 'scale-down', 'none'].includes(
+        computedStyle.getPropertyValue('object-fit')
+      ),
     };
   });
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
It is bugfix.

<!-- Describe the need for this change -->
There is good check [Displays Images With Incorrect Aspect Ratio](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio). However, this check is not needed when  image has css property [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) different than `fill`. Values `cover` and `contain` already prevent this check. This PR makes values `scale-down` and `none` also prevent this check.

<!-- Link any documentation or information that would help understand this change -->
Appropriate links:
https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio
https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
#6760