### PR TITLE
misc(github): ask people to test a11y issues upstream first

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -6,7 +6,7 @@ about: Report something working incorrectly
 
 <!-- Before creating an issue please make sure you are using the latest version and have checked for duplicate issues. -->
 
-<!-- Before creating an Accessibility issue please test that it is reproducible upstream with axe deque.com/axe/ first. -->
+<!-- Before creating an Accessibility issue please test that it is reproducible upstream with axe (https://www.deque.com/axe/) first and file the issue there if necessary. -->
 
 #### Provide the steps to reproduce
 1. Run LH on <affected url>

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -6,6 +6,8 @@ about: Report something working incorrectly
 
 <!-- Before creating an issue please make sure you are using the latest version and have checked for duplicate issues. -->
 
+<!-- Before creating an Accessibility issue please test that it is reproducible upstream with axe deque.com/axe/ first. -->
+
 #### Provide the steps to reproduce
 1. Run LH on <affected url>
 


### PR DESCRIPTION
**Summary**
Add text requesting issue filers to test Accessibility issues upstream with axe first 

It will reduce people submitting Lighthouse Accessibility issues that are actually belong upstream with axe. 

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/issues/6737
