### PR TITLE
core(lantern): drop node id from error message

### DIFF
--- a/lighthouse-core/lib/dependency-graph/base-node.js
+++ b/lighthouse-core/lib/dependency-graph/base-node.js
@@ -209,7 +209,7 @@ class BaseNode {
       }
     });
 
-    if (!idToNodeMap.has(this.id)) throw new Error(`Cloned graph missing node ${this.id}`);
+    if (!idToNodeMap.has(this.id)) throw new Error(`Cloned graph missing node`);
     return idToNodeMap.get(this.id);
   }
 

--- a/lighthouse-core/lib/dependency-graph/base-node.js
+++ b/lighthouse-core/lib/dependency-graph/base-node.js
@@ -209,7 +209,7 @@ class BaseNode {
       }
     });
 
-    if (!idToNodeMap.has(this.id)) throw new Error(`Cloned graph missing node`);
+    if (!idToNodeMap.has(this.id)) throw new Error('Cloned graph missing node');
     return idToNodeMap.get(this.id);
   }
 


### PR DESCRIPTION
In LR we collect and report all our errors. This one causes our metrics to get a little funky since it changes every time.
Does this work for you, @patrickhulce.

Also i imagine you want a few URLs that can reproduce this?

b/120845363