### PR TITLE
core: handle invalid network timing data

### DIFF
--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -269,14 +269,23 @@ class PageDependencyGraph {
     const networkNodeOutput = PageDependencyGraph.getNetworkNodeOutput(networkRecords);
     const cpuNodes = PageDependencyGraph.getCPUNodes(traceOfTab);
 
-    const rootRequest = networkRecords.reduce((min, r) => (min.startTime < r.startTime ? min : r));
+    // The root request is the earliest network request, using position in networkRecords array to break ties.
+    const rootRequest = networkRecords.reduce((min, r) => (r.startTime < min.startTime ? r : min));
     const rootNode = networkNodeOutput.idToNodeMap.get(rootRequest.requestId);
+    // The main document request is the earliest network request *of type document*.
+    // This will be different from the root request when there are server redirects.
     const mainDocumentRequest = NetworkAnalyzer.findMainDocument(networkRecords);
     const mainDocumentNode = networkNodeOutput.idToNodeMap.get(mainDocumentRequest.requestId);
 
     if (!rootNode || !mainDocumentNode) {
       // Should always be found.
       throw new Error(`${rootNode ? 'mainDocument' : 'root'}Node not found.`);
+    }
+
+    if (mainDocumentNode !== rootNode &&
+        (!mainDocumentNode.record.redirects ||
+        !mainDocumentNode.record.redirects.includes(rootNode.record))) {
+      throw new Error('Root node was not in redirect chain of mainDocument');
     }
 
     PageDependencyGraph.linkNetworkNodes(rootNode, networkNodeOutput);

--- a/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/network-analyzer.js
@@ -451,7 +451,8 @@ class NetworkAnalyzer {
     // TODO(phulce): handle more edge cases like client redirects, or plumb through finalUrl
     const documentRequests = records.filter(record => record.resourceType ===
         NetworkRequest.TYPES.Document);
-    return documentRequests.sort((a, b) => a.startTime - b.startTime)[0];
+    // The main document is the earliest document request, using position in networkRecords array to break ties.
+    return documentRequests.reduce((min, r) => (r.startTime < min.startTime ? r : min));
   }
 }
 

--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -272,6 +272,9 @@ module.exports = class NetworkRequest {
    * @param {LH.Crdp.Network.ResourceTiming} timing
    */
   _recomputeTimesWithResourceTiming(timing) {
+    // Don't recompute times if the data is invalid. RequestTime should always be a thread timestamp.
+    // If we don't have receiveHeadersEnd, we really don't have more accurate data.
+    if (timing.requestTime === 0 || timing.receiveHeadersEnd === -1) return
     // Take startTime and responseReceivedTime from timing data for better accuracy.
     // Timing's requestTime is a baseline in seconds, rest of the numbers there are ticks in millis.
     this.startTime = timing.requestTime;

--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -274,7 +274,7 @@ module.exports = class NetworkRequest {
   _recomputeTimesWithResourceTiming(timing) {
     // Don't recompute times if the data is invalid. RequestTime should always be a thread timestamp.
     // If we don't have receiveHeadersEnd, we really don't have more accurate data.
-    if (timing.requestTime === 0 || timing.receiveHeadersEnd === -1) return
+    if (timing.requestTime === 0 || timing.receiveHeadersEnd === -1) return;
     // Take startTime and responseReceivedTime from timing data for better accuracy.
     // Timing's requestTime is a baseline in seconds, rest of the numbers there are ticks in millis.
     this.startTime = timing.requestTime;

--- a/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/network-analyzer-test.js
@@ -374,5 +374,16 @@ describe('DependencyGraph/Simulator/NetworkAnalyzer', () => {
       const mainDocument = NetworkAnalyzer.findMainDocument(records);
       assert.equal(mainDocument.url, 'https://pwa.rocks/');
     });
+
+    it('should break ties using position in array', async () => {
+      const records = [
+        {url: 'http://example.com', resourceType: 'Other'},
+        {url: 'https://example.com', resourceType: 'Other'},
+        {url: 'https://www.example.com', resourceType: 'Document', startTime: 0},
+        {url: 'https://www.iframe.com', resourceType: 'Document', startTime: 0},
+      ];
+      const mainDocument = NetworkAnalyzer.findMainDocument(records);
+      assert.equal(mainDocument.url, 'https://www.example.com');
+    });
   });
 });


### PR DESCRIPTION
**Summary**
In LR, the `timing` object can be defined but have no valid data (`requestTime: 0, receiveHeadersEnd: -1`). This was unexpected and was causing problems later on down the chain for lantern. 

Masking the problem was the fact that the `rootNode` of the lantern graph was trying to pick the earliest network request but was breaking ties by choosing the *last* network record in the array. When the requestTimes were `0`, it just ended up picking the last one and losing the real root node. This PR also adds some sanity checks around that to make sure we'd fail earlier about those unexpected cases.

**Related Issues/PRs**
fixes #6378
