### PR TITLE
i18n: localize audit error strings

### DIFF
--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -927,8 +927,12 @@
     "message": "{timeInMs, number, seconds} s",
     "description": "Used to show the duration in seconds that something lasted. The {timeInMs} placeholder will be replaced with the time duration, shown in seconds (e.g. 5.2 s)"
   },
+  "lighthouse-core/lib/lh-error.js | badTraceRecording": {
+    "message": "Something went wrong with recording the trace over your page load. Please run Lighthouse again. ({errorCode})",
+    "description": "Error message explaining that the network trace was not able to be recorded for the Lighthouse run."
+  },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
-    "message": "Chrome didn't collect any screenshots during the page load. Please make sure there is content visible on the page, and then try re-running Lighthouse.",
+    "message": "Chrome didn't collect any screenshots during the page load. Please make sure there is content visible on the page, and then try re-running Lighthouse. ({errorCode})",
     "description": "Error message explaining that the Lighthouse run was not able to collect screenshots through Chrome."
   },
   "lighthouse-core/lib/lh-error.js | dnsFailure": {
@@ -938,26 +942,6 @@
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse.",
     "description": "Error message explaining that Chrome has encountered an error during the Lighthouse run, and that Chrome should be restarted."
-  },
-  "lighthouse-core/lib/lh-error.js | noDomContentLoaded": {
-    "message": "The DOM content could not be loaded for this page. Please run Lighthouse again. (NO_DCL)",
-    "description": "Error message explaining that the DOM content for the page could not be loaded."
-  },
-  "lighthouse-core/lib/lh-error.js | noFirstContentfulPaint": {
-    "message": "A first contentful paint could not be derived for this page. Please run Lighthouse again. (NO_FCP)",
-    "description": "Error message explaining that a First Contentful Paint was not able to be constructed from the page's tracing events."
-  },
-  "lighthouse-core/lib/lh-error.js | noFirstMeaningfulPaint": {
-    "message": "A first meaningful paint could not be derived for this page. Please run Lighthouse again. (NO_FMP)",
-    "description": "Error message explaining that a First Meaningful Paint was not able to be constructed from the page's tracing events."
-  },
-  "lighthouse-core/lib/lh-error.js | noNavigationStarted": {
-    "message": "Navigation could not be started for this page. Please run Lighthouse again. (NO_NAVSTART)",
-    "description": "Error message explaining that page navigation couldn't be started for the requested page."
-  },
-  "lighthouse-core/lib/lh-error.js | noTracingStarted": {
-    "message": "Network tracing for this page was unable to start. Please run Lighthouse again. (NO_TRACING_STARTED)",
-    "description": "Error message explaining that tracing was unable to start for the given page."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests.",
@@ -980,7 +964,7 @@
     "description": "Error message explaining that Lighthouse could not load the requested URL and the steps that might be taken to fix the unreliability."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadTookTooLong": {
-    "message": "Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse.",
+    "message": "Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse. ({errorCode})",
     "description": "Error message explaining that the page loaded too slowly to perform a Lighthouse run."
   },
   "lighthouse-core/lib/lh-error.js | protocolTimeout": {

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -927,10 +927,6 @@
     "message": "{timeInMs, number, seconds} s",
     "description": "Used to show the duration in seconds that something lasted. The {timeInMs} placeholder will be replaced with the time duration, shown in seconds (e.g. 5.2 s)"
   },
-  "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Something went wrong with recording the trace over your page load. Please run Lighthouse again. ({traceCode})",
-    "description": "Error message explaining that the network trace was not able to be recorded for the Lighthouse run."
-  },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {
     "message": "Chrome didn't collect any screenshots during the page load. Please make sure there is content visible on the page, and then try re-running Lighthouse.",
     "description": "Error message explaining that the Lighthouse run was not able to collect screenshots through Chrome."
@@ -942,6 +938,26 @@
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse.",
     "description": "Error message explaining that Chrome has encountered an error during the Lighthouse run, and that Chrome should be restarted."
+  },
+  "lighthouse-core/lib/lh-error.js | noDomContentLoaded": {
+    "message": "The DOM content could not be loaded for this page. Please run Lighthouse again. (NO_DCL)",
+    "description": "Error message explaining that the DOM content for the page could not be loaded."
+  },
+  "lighthouse-core/lib/lh-error.js | noFirstContentfulPaint": {
+    "message": "A first contentful paint could not be derived for this page. Please run Lighthouse again. (NO_FCP)",
+    "description": "Error message explaining that a First Contentful Paint was not able to be constructed from the page's tracing events."
+  },
+  "lighthouse-core/lib/lh-error.js | noFirstMeaningfulPaint": {
+    "message": "A first meaningful paint could not be derived for this page. Please run Lighthouse again. (NO_FMP)",
+    "description": "Error message explaining that a First Meaningful Paint was not able to be constructed from the page's tracing events."
+  },
+  "lighthouse-core/lib/lh-error.js | noNavigationStarted": {
+    "message": "Navigation could not be started for this page. Please run Lighthouse again. (NO_NAVSTART)",
+    "description": "Error message explaining that page navigation couldn't be started for the requested page."
+  },
+  "lighthouse-core/lib/lh-error.js | noTracingStarted": {
+    "message": "Network tracing for this page was unable to start. Please run Lighthouse again. (NO_TRACING_STARTED)",
+    "description": "Error message explaining that tracing was unable to start for the given page."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests.",

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -928,7 +928,7 @@
     "description": "Used to show the duration in seconds that something lasted. The {timeInMs} placeholder will be replaced with the time duration, shown in seconds (e.g. 5.2 s)"
   },
   "lighthouse-core/lib/lh-error.js | badTraceRecording": {
-    "message": "Something went wrong with recording the trace over your page load. Please run Lighthouse again.",
+    "message": "Something went wrong with recording the trace over your page load. Please run Lighthouse again. ({traceCode})",
     "description": "Error message explaining that the network trace was not able to be recorded for the Lighthouse run."
   },
   "lighthouse-core/lib/lh-error.js | didntCollectScreenshots": {

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -12,7 +12,7 @@ const UIStrings = {
   /** Error message explaining that the Lighthouse run was not able to collect screenshots through Chrome.*/
   didntCollectScreenshots: `Chrome didn't collect any screenshots during the page load. Please make sure there is content visible on the page, and then try re-running Lighthouse.`,
   /** Error message explaining that the network trace was not able to be recorded for the Lighthouse run. */
-  badTraceRecording: 'Something went wrong with recording the trace over your page load. Please run Lighthouse again.',
+  badTraceRecording: 'Something went wrong with recording the trace over your page load. Please run Lighthouse again. ({traceCode})',
   /** Error message explaining that the page loaded too slowly to perform a Lighthouse run.  */
   pageLoadTookTooLong: 'Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse.',
   /** Error message explaining that Lighthouse could not load the requested URL and the steps that might be taken to fix the unreliability. */
@@ -46,6 +46,7 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
  * @property {string} message
  * @property {RegExp} [pattern]
  * @property {boolean} [lhrRuntimeError] True if it should appear in the top-level LHR.runtimeError property.
+ * @property {object} [defaultProperties] Optional default properties to use for i18n.
  */
 
 class LighthouseError extends Error {
@@ -57,21 +58,12 @@ class LighthouseError extends Error {
     super(errorDefinition.code);
     this.name = 'LHError';
     this.code = errorDefinition.code;
-    this.friendlyMessage = str_(errorDefinition.message, properties);
+    const mergedProperties = {...errorDefinition.defaultProperties, ...properties};
+    this.friendlyMessage = str_(errorDefinition.message, mergedProperties);
     this.lhrRuntimeError = !!errorDefinition.lhrRuntimeError;
     if (properties) Object.assign(this, properties);
 
     Error.captureStackTrace(this, LighthouseError);
-  }
-
-  /**
-   * @param {LighthouseError} err
-   * @return {LighthouseError}
-   */
-  static fromLighthouseError(err) {
-    const {code, friendlyMessage: message, ...rest} = err;
-    // Note: {...rest} convinces tsc 3.1 that it's assignable to a Record.
-    return new LighthouseError({code, message}, {...rest});
   }
 
   /**
@@ -127,25 +119,40 @@ const ERRORS = {
     code: 'NO_TRACING_STARTED',
     message: UIStrings.badTraceRecording,
     lhrRuntimeError: true,
+    defaultProperties: {
+      traceCode: 'NO_TRACING_STARTED',
+    },
   },
   NO_NAVSTART: {
     code: 'NO_NAVSTART',
     message: UIStrings.badTraceRecording,
     lhrRuntimeError: true,
+    defaultProperties: {
+      traceCode: 'NO_NAVSTART',
+    },
   },
   NO_FCP: {
     code: 'NO_FCP',
     message: UIStrings.badTraceRecording,
     lhrRuntimeError: true,
+    defaultProperties: {
+      traceCode: 'NO_FCP',
+    },
   },
   NO_DCL: {
     code: 'NO_DCL',
     message: UIStrings.badTraceRecording,
     lhrRuntimeError: true,
+    defaultProperties: {
+      traceCode: 'NO_DCL',
+    },
   },
   NO_FMP: {
     code: 'NO_FMP',
     message: UIStrings.badTraceRecording,
+    defaultProperties: {
+      traceCode: 'NO_FMP',
+    },
   },
 
   // TTI calculation failures

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -11,8 +11,16 @@ const i18n = require('./i18n/i18n.js');
 const UIStrings = {
   /** Error message explaining that the Lighthouse run was not able to collect screenshots through Chrome.*/
   didntCollectScreenshots: `Chrome didn't collect any screenshots during the page load. Please make sure there is content visible on the page, and then try re-running Lighthouse.`,
-  /** Error message explaining that the network trace was not able to be recorded for the Lighthouse run. */
-  badTraceRecording: 'Something went wrong with recording the trace over your page load. Please run Lighthouse again. ({traceCode})',
+  /** Error message explaining that tracing was unable to start for the given page. */
+  noTracingStarted: 'Network tracing for this page was unable to start. Please run Lighthouse again. (NO_TRACING_STARTED)',
+  /** Error message explaining that a First Contentful Paint was not able to be constructed from the page's tracing events. */
+  noFirstContentfulPaint: 'A first contentful paint could not be derived for this page. Please run Lighthouse again. (NO_FCP)',
+  /** Error message explaining that a First Meaningful Paint was not able to be constructed from the page's tracing events. */
+  noFirstMeaningfulPaint: 'A first meaningful paint could not be derived for this page. Please run Lighthouse again. (NO_FMP)',
+  /** Error message explaining that the DOM content for the page could not be loaded. */
+  noDomContentLoaded: 'The DOM content could not be loaded for this page. Please run Lighthouse again. (NO_DCL)',
+  /** Error message explaining that page navigation couldn't be started for the requested page. */
+  noNavigationStarted: 'Navigation could not be started for this page. Please run Lighthouse again. (NO_NAVSTART)',
   /** Error message explaining that the page loaded too slowly to perform a Lighthouse run.  */
   pageLoadTookTooLong: 'Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse.',
   /** Error message explaining that Lighthouse could not load the requested URL and the steps that might be taken to fix the unreliability. */
@@ -46,7 +54,6 @@ const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
  * @property {string} message
  * @property {RegExp} [pattern]
  * @property {boolean} [lhrRuntimeError] True if it should appear in the top-level LHR.runtimeError property.
- * @property {object} [defaultProperties] Optional default properties to use for i18n.
  */
 
 class LighthouseError extends Error {
@@ -58,8 +65,7 @@ class LighthouseError extends Error {
     super(errorDefinition.code);
     this.name = 'LHError';
     this.code = errorDefinition.code;
-    const mergedProperties = {...errorDefinition.defaultProperties, ...properties};
-    this.friendlyMessage = str_(errorDefinition.message, mergedProperties);
+    this.friendlyMessage = str_(errorDefinition.message, properties);
     this.lhrRuntimeError = !!errorDefinition.lhrRuntimeError;
     if (properties) Object.assign(this, properties);
 
@@ -117,42 +123,27 @@ const ERRORS = {
   // Trace parsing errors
   NO_TRACING_STARTED: {
     code: 'NO_TRACING_STARTED',
-    message: UIStrings.badTraceRecording,
+    message: UIStrings.noTracingStarted,
     lhrRuntimeError: true,
-    defaultProperties: {
-      traceCode: 'NO_TRACING_STARTED',
-    },
   },
   NO_NAVSTART: {
     code: 'NO_NAVSTART',
-    message: UIStrings.badTraceRecording,
+    message: UIStrings.noNavigationStarted,
     lhrRuntimeError: true,
-    defaultProperties: {
-      traceCode: 'NO_NAVSTART',
-    },
   },
   NO_FCP: {
     code: 'NO_FCP',
-    message: UIStrings.badTraceRecording,
+    message: UIStrings.noFirstContentfulPaint,
     lhrRuntimeError: true,
-    defaultProperties: {
-      traceCode: 'NO_FCP',
-    },
   },
   NO_DCL: {
     code: 'NO_DCL',
-    message: UIStrings.badTraceRecording,
+    message: UIStrings.noDomContentLoaded,
     lhrRuntimeError: true,
-    defaultProperties: {
-      traceCode: 'NO_DCL',
-    },
   },
   NO_FMP: {
     code: 'NO_FMP',
-    message: UIStrings.badTraceRecording,
-    defaultProperties: {
-      traceCode: 'NO_FMP',
-    },
+    message: UIStrings.noFirstMeaningfulPaint,
   },
 
   // TTI calculation failures

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -57,6 +57,7 @@ class LighthouseError extends Error {
     super(errorDefinition.code);
     this.name = 'LHError';
     this.code = errorDefinition.code;
+    // Insert the i18n reference with errorCode and all additional ICU replacement properties.
     this.friendlyMessage = str_(errorDefinition.message, {errorCode: this.code, ...properties});
     this.lhrRuntimeError = !!errorDefinition.lhrRuntimeError;
     if (properties) Object.assign(this, properties);

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -10,19 +10,11 @@ const i18n = require('./i18n/i18n.js');
 /* eslint-disable max-len */
 const UIStrings = {
   /** Error message explaining that the Lighthouse run was not able to collect screenshots through Chrome.*/
-  didntCollectScreenshots: `Chrome didn't collect any screenshots during the page load. Please make sure there is content visible on the page, and then try re-running Lighthouse.`,
-  /** Error message explaining that tracing was unable to start for the given page. */
-  noTracingStarted: 'Network tracing for this page was unable to start. Please run Lighthouse again. (NO_TRACING_STARTED)',
-  /** Error message explaining that a First Contentful Paint was not able to be constructed from the page's tracing events. */
-  noFirstContentfulPaint: 'A first contentful paint could not be derived for this page. Please run Lighthouse again. (NO_FCP)',
-  /** Error message explaining that a First Meaningful Paint was not able to be constructed from the page's tracing events. */
-  noFirstMeaningfulPaint: 'A first meaningful paint could not be derived for this page. Please run Lighthouse again. (NO_FMP)',
-  /** Error message explaining that the DOM content for the page could not be loaded. */
-  noDomContentLoaded: 'The DOM content could not be loaded for this page. Please run Lighthouse again. (NO_DCL)',
-  /** Error message explaining that page navigation couldn't be started for the requested page. */
-  noNavigationStarted: 'Navigation could not be started for this page. Please run Lighthouse again. (NO_NAVSTART)',
+  didntCollectScreenshots: `Chrome didn't collect any screenshots during the page load. Please make sure there is content visible on the page, and then try re-running Lighthouse. ({errorCode})`,
+  /** Error message explaining that the network trace was not able to be recorded for the Lighthouse run. */
+  badTraceRecording: 'Something went wrong with recording the trace over your page load. Please run Lighthouse again. ({errorCode})',
   /** Error message explaining that the page loaded too slowly to perform a Lighthouse run.  */
-  pageLoadTookTooLong: 'Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse.',
+  pageLoadTookTooLong: 'Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse. ({errorCode})',
   /** Error message explaining that Lighthouse could not load the requested URL and the steps that might be taken to fix the unreliability. */
   pageLoadFailed: 'Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests.',
   /** Error message explaining that Lighthouse could not load the requested URL and the steps that might be taken to fix the unreliability. */
@@ -65,7 +57,7 @@ class LighthouseError extends Error {
     super(errorDefinition.code);
     this.name = 'LHError';
     this.code = errorDefinition.code;
-    this.friendlyMessage = str_(errorDefinition.message, properties);
+    this.friendlyMessage = str_(errorDefinition.message, {errorCode: this.code, ...properties});
     this.lhrRuntimeError = !!errorDefinition.lhrRuntimeError;
     if (properties) Object.assign(this, properties);
 
@@ -123,27 +115,27 @@ const ERRORS = {
   // Trace parsing errors
   NO_TRACING_STARTED: {
     code: 'NO_TRACING_STARTED',
-    message: UIStrings.noTracingStarted,
+    message: UIStrings.badTraceRecording,
     lhrRuntimeError: true,
   },
   NO_NAVSTART: {
     code: 'NO_NAVSTART',
-    message: UIStrings.noNavigationStarted,
+    message: UIStrings.badTraceRecording,
     lhrRuntimeError: true,
   },
   NO_FCP: {
     code: 'NO_FCP',
-    message: UIStrings.noFirstContentfulPaint,
+    message: UIStrings.badTraceRecording,
     lhrRuntimeError: true,
   },
   NO_DCL: {
     code: 'NO_DCL',
-    message: UIStrings.noDomContentLoaded,
+    message: UIStrings.badTraceRecording,
     lhrRuntimeError: true,
   },
   NO_FMP: {
     code: 'NO_FMP',
-    message: UIStrings.noFirstMeaningfulPaint,
+    message: UIStrings.badTraceRecording,
   },
 
   // TTI calculation failures

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -321,9 +321,7 @@ class Runner {
 
       Sentry.captureException(err, {tags: {audit: audit.meta.id}, level: 'error'});
       // Errors become error audit result.
-      const errorMessage = err.friendlyMessage ?
-        `${err.friendlyMessage} (${err.message})` :
-        `Audit error: ${err.message}`;
+      const errorMessage = err.friendlyMessage ? err.friendlyMessage : err.message;
       auditResult = Audit.generateErrorAuditResult(audit, errorMessage);
     }
 

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -2669,7 +2669,7 @@
       "score": null,
       "scoreDisplayMode": "error",
       "rawValue": null,
-      "errorMessage": "Audit error: Required RobotsTxt gatherer did not run."
+      "errorMessage": "Required RobotsTxt gatherer did not run."
     },
     "robots-txt": {
       "id": "robots-txt",
@@ -2678,7 +2678,7 @@
       "score": null,
       "scoreDisplayMode": "error",
       "rawValue": null,
-      "errorMessage": "Audit error: Required RobotsTxt gatherer did not run."
+      "errorMessage": "Required RobotsTxt gatherer did not run."
     },
     "hreflang": {
       "id": "hreflang",

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -607,7 +607,7 @@ describe('Runner', () => {
     // And it bubbled up to the runtimeError.
     assert.strictEqual(lhr.runtimeError.code, NO_FCP.code);
     expect(lhr.runtimeError.message)
-      .toBeDisplayString(/A first contentful .*(NO_FCP)/);
+      .toBeDisplayString(/Something .*(NO_FCP)/);
   });
 
   it('localized errors thrown from driver', async () => {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -606,7 +606,8 @@ describe('Runner', () => {
     assert.ok(lhr.audits['test-audit'].errorMessage.includes(NO_FCP.code));
     // And it bubbled up to the runtimeError.
     assert.strictEqual(lhr.runtimeError.code, NO_FCP.code);
-    assert.ok(lhr.runtimeError.message.includes(NO_FCP.message));
+    expect(lhr.runtimeError.message)
+      .toBeDisplayString(/Something went wrong .*(NO_FCP)/);
   });
 
   it('localized errors thrown from driver', async () => {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -607,7 +607,7 @@ describe('Runner', () => {
     // And it bubbled up to the runtimeError.
     assert.strictEqual(lhr.runtimeError.code, NO_FCP.code);
     expect(lhr.runtimeError.message)
-      .toBeDisplayString(/Something .*(NO_FCP)/);
+      .toBeDisplayString(/Something .*\(NO_FCP\)/);
   });
 
   it('localized errors thrown from driver', async () => {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -607,7 +607,7 @@ describe('Runner', () => {
     // And it bubbled up to the runtimeError.
     assert.strictEqual(lhr.runtimeError.code, NO_FCP.code);
     expect(lhr.runtimeError.message)
-      .toBeDisplayString(/Something went wrong .*(NO_FCP)/);
+      .toBeDisplayString(/A first contentful .*(NO_FCP)/);
   });
 
   it('localized errors thrown from driver', async () => {

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -969,7 +969,7 @@
         }, 
         "is-crawlable": {
             "description": "Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/indexing).", 
-            "errorMessage": "Audit error: Required RobotsTxt gatherer did not run.", 
+            "errorMessage": "Required RobotsTxt gatherer did not run.", 
             "id": "is-crawlable", 
             "score": null, 
             "scoreDisplayMode": "error", 
@@ -1821,7 +1821,7 @@
         }, 
         "robots-txt": {
             "description": "If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed.", 
-            "errorMessage": "Audit error: Required RobotsTxt gatherer did not run.", 
+            "errorMessage": "Required RobotsTxt gatherer did not run.", 
             "id": "robots-txt", 
             "score": null, 
             "scoreDisplayMode": "error", 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Audit errors were adding the message code to the end of the errorMessage with parens which was destroying the ICU replacement.  This adds `defaultProperties` to easier facilitate mutliple LHErrors using the same UIString to replace and use their own defaults that are constant per error.

**Related Issues/PRs**
fixes: #6804 
