### PR TITLE
extension: return runnerResult

### DIFF
--- a/clients/extension/scripts/extension-entry.js
+++ b/clients/extension/scripts/extension-entry.js
@@ -104,7 +104,7 @@ async function runLighthouseInExtension(flags, categoryIDs) {
   const reportHtml = /** @type {string} */ (runnerResult.report);
   const blobURL = createReportPageAsBlob(reportHtml);
   await new Promise(resolve => chrome.windows.create({url: blobURL}, resolve));
-  
+
   return runnerResult;
 }
 

--- a/clients/extension/scripts/extension-entry.js
+++ b/clients/extension/scripts/extension-entry.js
@@ -76,7 +76,7 @@ function updateBadgeUI(optUrl) {
 /**
  * @param {LH.Flags} flags Lighthouse flags.
  * @param {Array<string>} categoryIDs Name values of categories to include.
- * @return {Promise<LH.RunnerResult|void>}
+ * @return {Promise<LH.RunnerResult>}
  */
 async function runLighthouseInExtension(flags, categoryIDs) {
   // Default to 'info' logging level.

--- a/clients/extension/scripts/extension-entry.js
+++ b/clients/extension/scripts/extension-entry.js
@@ -104,6 +104,8 @@ async function runLighthouseInExtension(flags, categoryIDs) {
   const reportHtml = /** @type {string} */ (runnerResult.report);
   const blobURL = createReportPageAsBlob(reportHtml);
   await new Promise(resolve => chrome.windows.create({url: blobURL}, resolve));
+  
+  return runnerResult;
 }
 
 /**


### PR DESCRIPTION
No change in behavior.

I noticed that this function was typed to return a runner result, but it never does. It would be useful for #6831 if it actually did.