### PR TITLE
core(preload): warn when duplicate requests issued

### DIFF
--- a/lighthouse-cli/test/fixtures/perf/level-2.js
+++ b/lighthouse-cli/test/fixtures/perf/level-2.js
@@ -6,4 +6,4 @@
 
 /* eslint-disable */
 
-document.write('<script src="level-3.js"></script>');
+document.write('<script src="/perf/level-3.js"></script>');

--- a/lighthouse-cli/test/fixtures/perf/preload_tester.js
+++ b/lighthouse-cli/test/fixtures/perf/preload_tester.js
@@ -6,7 +6,8 @@
 
 /* eslint-disable */
 
-document.write('<script src="level-2.js?delay=500"></script>');
+document.write('<script src="/perf/level-2.js?delay=500"></script>');
+document.write('<script src="/perf/level-2.js?warning&delay=500"></script>');
 
 // delay our preconnect-candidates so that they're not assumed to be working already
 setTimeout(() => {

--- a/lighthouse-cli/test/fixtures/preload.html
+++ b/lighthouse-cli/test/fixtures/preload.html
@@ -1,6 +1,8 @@
 <html>
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
   <link rel="stylesheet" href="/perf/preload_style.css" />
+  <!-- WARN(preload): This should be no crossorigin -->
+  <link rel="preload" href="/perf/level-2.js?warning&delay=500" as="script" crossorigin="use-credentials"/>
   <!-- WARN(preconnect): This should be no crossorigin -->
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous" />
   <!-- PASS(preconnect): This uses crossorigin correctly -->

--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -39,6 +39,10 @@ module.exports = [
       'uses-rel-preload': {
         score: '<1',
         rawValue: '>500',
+        warnings: {
+          0: /level-2.*warning/,
+          length: 1,
+        },
         details: {
           items: {
             length: 1,

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -763,6 +763,10 @@
     "message": "Preconnect to required origins",
     "description": "Imperative title of a Lighthouse audit that tells the user to connect early to internet domains that will be used to load page resources. Origin is the correct term, however 'domain name' could be used if neccsesary. This is displayed in a list of audit titles that Lighthouse generates."
   },
+  "lighthouse-core/audits/uses-rel-preload.js | crossoriginWarning": {
+    "message": "A preload <link> was found for \"{preloadURL}\" but was not used by the browser. Check that you are using the `crossorigin` attribute properly.",
+    "description": "A warning message that is shown when the user tried to follow the advice of the audit, but it's not working as expected. Forgetting to set the `crossorigin` HTML attribute, or setting it to an incorrect value, on the link is a common mistake when adding preload links."
+  },
   "lighthouse-core/audits/uses-rel-preload.js | description": {
     "message": "Consider using <link rel=preload> to prioritize fetching resources that are currently requested later in page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/preload).",
     "description": "Description of a Lighthouse audit that tells the user *why* they should preload important network requests. The associated network requests are started halfway through pageload (or later) but should be started at the beginning. This is displayed after a user expands the section to see more. No character length limits. '<link rel=preload>' is the html code the user would include in their page and shouldn't be translated. 'Learn More' becomes link text to additional documentation."


### PR DESCRIPTION
**Summary**
We are ignoring URLs to suggest based on what URLs were ever preloaded. This can lead to silent failures where there was a preload request but it wasn't used so the request was reissued. This adds a warning a-la #6694 

**Related Issues/PRs**
ref #6417
