### PR TITLE
report: audits metadata results style

### DIFF
--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -191,6 +191,7 @@ limitations under the License.
     .lh-metadata__results {
       text-overflow: ellipsis;
       white-space: nowrap;
+      overflow: hidden;
     }
     .lh-metadata__url {
       color: currentColor;


### PR DESCRIPTION
- `.lh-metadata__results` with text ellipsis needs "overflow:hidden"

## Summary

### Before
![image](https://user-images.githubusercontent.com/2628239/50320727-0a7c1e00-0511-11e9-8a4b-7bb25c271d9b.png)

### After

![image](https://user-images.githubusercontent.com/2628239/50320751-25e72900-0511-11e9-9494-1a004e5da0c7.png)



**Related Issues/PRs**

This is related the comment.:) thanks: @exterkamp
https://github.com/GoogleChrome/lighthouse/pull/6833#pullrequestreview-186692186