### PR TITLE
core(starturl): re-use already fetched manifest

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -472,7 +472,7 @@ class GatherRunner {
           /** @param {keyof LH.GathererArtifacts} name */
           async dangerouslyUsePreviousArtifact(name) {
             const gathererPromises = gathererResults[name];
-            if (!gathererPromises) throw new Error(`${name} not yet computed`);
+            if (!gathererPromises) throw new Error(`${name} Gatherer has not yet run`);
 
             const artifacts = {};
             await GatherRunner.convertGathererResultToArtifact(name, gathererPromises, artifacts);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -366,15 +366,15 @@ class GatherRunner {
 
   /**
    * @param {keyof GathererResults} gathererName
-   * @param {GathererResults[keyof GathererResults]} phaseResultPromises
+   * @param {GathererResults[keyof GathererResults]} resultPromises
    * @param {Partial<LH.GathererArtifacts>} gathererArtifacts
    */
-  static async convertGathererResultToArtifact(gathererName, phaseResultPromises, gathererArtifacts) {
+  static async convertGathererResultToArtifact(gathererName, resultPromises, gathererArtifacts) {
     // If the artifact has already been computed, don't do anything, leave it as-is.
     if (gathererArtifacts[gathererName] !== undefined) return;
 
     try {
-      const phaseResults = await Promise.all(phaseResultPromises);
+      const phaseResults = await Promise.all(resultPromises);
       // Take last defined pass result as artifact.
       const definedResults = phaseResults.filter(element => element !== undefined);
       const artifact = definedResults[definedResults.length - 1];
@@ -478,7 +478,7 @@ class GatherRunner {
             await GatherRunner.convertGathererResultToArtifact(name, gathererPromises, artifacts);
             // @ts-ignore - above method will throw if the artifact couldn't be computed
             return artifacts[name];
-          }
+          },
         };
 
         await driver.setThrottling(options.settings, passConfig);

--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -18,7 +18,6 @@ class StartUrl extends Gatherer {
    */
   async afterPass(passContext) {
     const manifest = await passContext.dangerouslyUsePreviousArtifact('Manifest');
-    if (typeof manifest === 'undefined') throw new Error('Cannot');
     const startUrlInfo = this._readManifestStartUrl(manifest);
     if (startUrlInfo.isReadFailure) {
       return {statusCode: -1, explanation: startUrlInfo.reason};

--- a/lighthouse-core/gather/gatherers/start-url.js
+++ b/lighthouse-core/gather/gatherers/start-url.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const Gatherer = require('./gatherer');
-const manifestParser = require('../../lib/manifest-parser');
 
 /** @typedef {import('../driver.js')} Driver */
 

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -20,7 +20,7 @@ declare global {
       options?: object;
       /** Push to this array to add top-level warnings to the LHR. */
       LighthouseRunWarnings: Array<string>;
-      dangerouslyUsePreviousArtifact<K extends keyof GathererArtifacts>(artifactName: K): Promise<Artifacts[K] | undefined>;
+      dangerouslyUsePreviousArtifact<K extends keyof GathererArtifacts>(artifactName: K): Promise<Artifacts[K]>;
     }
 
     export interface LoadData {

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -20,6 +20,7 @@ declare global {
       options?: object;
       /** Push to this array to add top-level warnings to the LHR. */
       LighthouseRunWarnings: Array<string>;
+      dangerouslyUsePreviousArtifact<K extends keyof GathererArtifacts>(artifactName: K): Promise<Artifacts[K] | undefined>;
     }
 
     export interface LoadData {


### PR DESCRIPTION
**Summary**
We've talked about being able to reuse prior artifacts in other future gatherers but were always afraid of the precedence it sets for some horrifying graph of dependencies. This really is great use case though, so I wanted to play with it and see how it feels.

Therefore, I named the method `dangerouslyUsePreviousArtifact` in the hopes it assuages some concerns about this starting to be used everywhere 😆 

Waiting to update start-url test depending on what kind of reaction this gets :)

**Related Issues/PRs**
fixes #6881 
