### PR TITLE
core(lantern): remove unnecessary sort calls

### DIFF
--- a/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/connection-pool.js
@@ -97,8 +97,9 @@ module.exports = class ConnectionPool {
    * @param {Array<TcpConnection>} connections
    */
   _findConnectionWithLargestCongestionWindow(connections) {
-    /** @type {TcpConnection|null} */
-    let maxConnection = connections[0] || null;
+    if (!connections.length) return null;
+
+    let maxConnection = connections[0];
     for (let i = 1; i < connections.length; i++) {
       const connection = connections[i];
       const currentMax = maxConnection.congestionWindow;

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -444,7 +444,7 @@ class Simulator {
     // loop as long as we have nodes in the queue or currently in progress
     while (nodesReadyToStart.size || nodesInProgress.size) {
       // move all possible queued nodes to in progress
-      for (const node of this._getNodesSortedByStartTime(nodesReadyToStart)) {
+      for (const node of this._getNodesSortedByStartTime()) {
         this._startNodeIfPossible(node, totalElapsedTime);
       }
 

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -140,7 +140,7 @@ class Simulator {
     const firstNodeIndexWithGreaterStartTime = this._cachedNodeListByStartTime
       .findIndex(candidate => candidate.startTime > node.startTime);
     const insertionIndex = firstNodeIndexWithGreaterStartTime === -1 ?
-      0 : firstNodeIndexWithGreaterStartTime + 1;
+      this._cachedNodeListByStartTime.length : firstNodeIndexWithGreaterStartTime;
     this._cachedNodeListByStartTime.splice(insertionIndex, 0, node);
 
     this._nodes[NodeState.ReadyToStart].add(node);
@@ -194,11 +194,11 @@ class Simulator {
   }
 
   /**
-   * @param {Set<Node>} nodes
    * @return {Node[]}
    */
-  _getNodesSortedByStartTime(nodes) {
-    return this._cachedNodeListByStartTime;
+  _getNodesSortedByStartTime() {
+    // Make a copy so we don't skip nodes due to concurrent modification
+    return Array.from(this._cachedNodeListByStartTime);
   }
 
   /**

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -101,6 +101,7 @@ class Simulator {
     this._cachedNodeListByStartTime = [];
     // NOTE: We don't actually need *all* of these sets, but the clarity that each node progresses
     // through the system is quite nice.
+    // TODO(phulce): consider refactoring this so that it's easier to follow
     for (const state of Object.values(NodeState)) {
       this._nodes[state] = new Set();
     }

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -91,7 +91,7 @@ class Simulator {
   }
 
   /**
-   * Initializes the various state data structures such as _nodesReadyToStart and _nodesCompleted.
+   * Initializes the various state data structures such _nodeTimings and the _node Sets by state.
    */
   _initializeAuxiliaryData() {
     this._nodeTimings = new Map();
@@ -99,6 +99,8 @@ class Simulator {
 
     this._nodes = {};
     this._cachedNodeListByStartTime = [];
+    // NOTE: We don't actually need *all* of these sets, but the clarity that each node progresses
+    // through the system is quite nice.
     for (const state of Object.values(NodeState)) {
       this._nodes[state] = new Set();
     }


### PR DESCRIPTION
**Summary**
while investigating #6893 I noticed there was a crazy amount of time spent in graph simulation due to the 1200+ network requests they fire. Turns out most of this was just spent on just 2 `.sort` calls. One of which we don't even need sort, it's just a `max` and the other can be easily solved by maintaining an extra copy of the nodes that's sorted.

It shouldn't impact accuracy either.

**This reduced total auditing time from 17.2 s to 7.8 s**

**Related Issues/PRs**
 #6893
