### PR TITLE
tests(smokehouse): use native node URLSearchParams

### DIFF
--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -13,7 +13,7 @@ const path = require('path');
 const fs = require('fs');
 const parseQueryString = require('querystring').parse;
 const parseURL = require('url').parse;
-const URLSearchParams = require('../../../lighthouse-core/lib/url-shim').URLSearchParams;
+const URLSearchParams = require('url').URLSearchParams;
 const HEADER_SAFELIST = new Set(['x-robots-tag', 'link']);
 
 const lhRootDirPath = path.join(__dirname, '../../../');

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 const BASE_URL = 'http://localhost:10200/seo/';
-const URLSearchParams = require('../../../../lighthouse-core/lib/url-shim').URLSearchParams;
+const URLSearchParams = require('url').URLSearchParams;
 
 function headersParam(headers) {
   const headerString = new URLSearchParams(headers).toString();

--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -206,8 +206,6 @@ class URLShim extends URL {
 }
 
 URLShim.URL = URL;
-URLShim.URLSearchParams = (typeof self !== 'undefined' && self.URLSearchParams) ||
-    require('url').URLSearchParams;
 
 URLShim.NON_NETWORK_PROTOCOLS = ['blob', 'data', 'intent'];
 


### PR DESCRIPTION
Originally added to `url-shim` back in #3941 (pre Node 8 minimum) when we needed the `whatwg-url` lib for it.

Noticed this while reviewing #6874, which had a fix for the type of `URLSearchParams` to unconfuse tsc about our browser/node union. However, #4712 dropped the `whatwg-url` require, and we only ever use `URLSearchParams` on the Node side anyways, so might as well require it locally instead of adding complexity to fix the complexity we don't use :)