### PR TITLE
core: stricter LR desktop metric thresholds

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -137,7 +137,6 @@ function getFlags(manualArgv) {
       // default values
       .default('chrome-flags', '')
       .default('output', ['html'])
-      .default('emulated-form-factor', 'mobile')
       .default('port', 0)
       .default('hostname', 'localhost')
       .default('enable-error-reporting', undefined) // Undefined so prompted by default

--- a/lighthouse-core/config/lr-desktop-config.js
+++ b/lighthouse-core/config/lr-desktop-config.js
@@ -33,7 +33,7 @@ const config = {
     // SELECT QUANTILES(fullyLoaded, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
     {path: 'metrics/interactive', options: {scorePODR: 2000, scoreMedian: 4500}},
     {path: 'metrics/first-cpu-idle', options: {scorePODR: 2000, scoreMedian: 4500}},
-  ]
+  ],
 };
 
 module.exports = config;

--- a/lighthouse-core/config/lr-desktop-config.js
+++ b/lighthouse-core/config/lr-desktop-config.js
@@ -21,6 +21,19 @@ const config = {
     // Skip the h2 audit so it doesn't lie to us. See #6539
     skipAudits: ['uses-http2'],
   },
+  audits: [
+    // 75th and 95th percentiles -> median and PODR
+    // SELECT QUANTILES(renderStart, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
+    {path: 'metrics/first-contentful-paint', options: {scorePODR: 800, scoreMedian: 1600}},
+    {path: 'metrics/first-meaningful-paint', options: {scorePODR: 800, scoreMedian: 1600}},
+    // 75th and 95th percentiles -> median and PODR
+    // SELECT QUANTILES(SpeedIndex, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
+    {path: 'metrics/speed-index', options: {scorePODR: 1100, scoreMedian: 2300}},
+    // 75th and 95th percentiles -> median and PODR
+    // SELECT QUANTILES(fullyLoaded, 21) FROM [httparchive:summary_pages.2018_12_15_desktop] LIMIT 1000
+    {path: 'metrics/interactive', options: {scorePODR: 2000, scoreMedian: 4500}},
+    {path: 'metrics/first-cpu-idle', options: {scorePODR: 2000, scoreMedian: 4500}},
+  ]
 };
 
 module.exports = config;


### PR DESCRIPTION
**Summary**
Uses data from HTTPArchive desktop runs to get new score thresholds

## CNN Before
 ![image](https://user-images.githubusercontent.com/2301202/50926109-d910b700-1419-11e9-95bb-4fef400bbc5f.png)

## CNN After
![image](https://user-images.githubusercontent.com/2301202/50926053-b1215380-1419-11e9-9cfc-1feaf08c7483.png) | 

**Related Issues/PRs**
fixes #6836 
