### PR TITLE
core(font-size): precise text length calculation

### DIFF
--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -182,7 +182,7 @@ function getEffectiveFontRule({inlineStyle, matchedCSSRules, inherited}) {
  * @returns {number}
  */
 function getNodeTextLength(node) {
-  return !node.nodeValue ? 0 : node.nodeValue.trim().length;
+  return !node.nodeValue ? 0 : Array.from(node.nodeValue.trim()).length;
 }
 
 /**

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -10,9 +10,9 @@
 const FontSizeGather = require('../../../../gather/gatherers/seo/font-size');
 let fontSizeGather;
 
-const smallText = ' body small text ';
-const bigText = 'body big text';
-const failingText = 'failing text';
+const smallText = ' body sm𝐀ll text ';
+const bigText = 'body 𝐁ig text';
+const failingText = 'failing text 💩';
 const bodyNode = {nodeId: 3, nodeName: 'BODY', parentId: 1};
 const failingNode = {nodeId: 10, nodeName: 'P', parentId: 3};
 const nodes = [
@@ -93,9 +93,9 @@ describe('Font size gatherer', () => {
     };
 
     const artifact = await fontSizeGather.afterPass({driver});
-    const expectedFailingTextLength = smallText.trim().length;
-    const expectedVisitedTextLength = bigText.trim().length + expectedFailingTextLength;
-    const expectedTotalTextLength = failingText.trim().length + expectedVisitedTextLength;
+    const expectedFailingTextLength = Array.from(smallText.trim()).length;
+    const expectedVisitedTextLength = Array.from(bigText.trim()).length + expectedFailingTextLength;
+    const expectedTotalTextLength = Array.from(failingText.trim()).length + expectedVisitedTextLength;
     const expectedAnalyzedFailingTextLength = expectedFailingTextLength;
 
     expect(artifact).toEqual({

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -95,7 +95,8 @@ describe('Font size gatherer', () => {
     const artifact = await fontSizeGather.afterPass({driver});
     const expectedFailingTextLength = Array.from(smallText.trim()).length;
     const expectedVisitedTextLength = Array.from(bigText.trim()).length + expectedFailingTextLength;
-    const expectedTotalTextLength = Array.from(failingText.trim()).length + expectedVisitedTextLength;
+    const expectedTotalTextLength = Array.from(failingText.trim()).length +
+      expectedVisitedTextLength;
     const expectedAnalyzedFailingTextLength = expectedFailingTextLength;
 
     expect(artifact).toEqual({


### PR DESCRIPTION
**Summary**
**What kind of change does this PR introduce?**
Count JavaScript string symbols not Unicode code points.

**Is this a bugfix, feature, refactoring, build related change, etc?**
Refactoring.

**Describe the need for this change**
To calculate text lengths on the font size gatherer with more precision.

**Link any documentation or information that would help understand this change**
```
> '𝐀'.length
2
> Array.from('𝐀').length
1
> '💩'.length
2
> Array.from('💩').length
1
> '再'.length
2
> Array.from('再').length
1
```