### PR TITLE
docs(readme): add Speedrank to the list of integrations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -271,6 +271,8 @@ This section details services that have integrated Lighthouse data. If you're wo
 
 * **[SpeedCurve](https://speedcurve.com)** — SpeedCurve is a tool for continuously monitoring web performance across different browsers, devices, and regions. It can aggregate any metric including Lighthouse scores across multiple pages and sites, and allows you to set performance budgets with Slack or email alerts. SpeedCurve is a paid product with a free 30-day trial.
 
+* **[Speedrank](https://speedrank.app)** - Speedrank monitors the performance of your website in the background. It displays Lighthouse reports in time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.
+
 * **[Treo](https://treo.sh)** - Treo is Lighthouse as a Service. It provides regression testing, geographical regions, custom networks, and integrations with GitHub & Slack. Treo is a paid product with plans for solo-developers and teams.
 
 * **[Web Page Test](https://www.webpagetest.org)** — An [open source](https://github.com/WPO-Foundation/webpagetest) tool for measuring and analyzing the performance of web pages on real devices. Users can choose to produce a Lighthouse report alongside the analysis of WebPageTest results.

--- a/readme.md
+++ b/readme.md
@@ -271,7 +271,7 @@ This section details services that have integrated Lighthouse data. If you're wo
 
 * **[SpeedCurve](https://speedcurve.com)** — SpeedCurve is a tool for continuously monitoring web performance across different browsers, devices, and regions. It can aggregate any metric including Lighthouse scores across multiple pages and sites, and allows you to set performance budgets with Slack or email alerts. SpeedCurve is a paid product with a free 30-day trial.
 
-* **[Speedrank](https://speedrank.app)** - Speedrank monitors the performance of your website in the background. It displays Lighthouse reports in time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.
+* **[Speedrank](https://speedrank.app)** - Speedrank monitors the performance of your website in the background. It displays Lighthouse reports over time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.
 
 * **[Treo](https://treo.sh)** - Treo is Lighthouse as a Service. It provides regression testing, geographical regions, custom networks, and integrations with GitHub & Slack. Treo is a paid product with plans for solo-developers and teams.
 


### PR DESCRIPTION
**Summary**
Add [Speedrank](https://speedrank.app) to the list of integrations in alphabetical order.

Speedrank monitors the performance of your website in the background. It displays Lighthouse reports in time and delivers recommendations for improvement. Speedrank is a paid product with 14-day-trial.