### PR TITLE
misc: fix extension package path and viewer comments

### DIFF
--- a/build/build-extension.js
+++ b/build/build-extension.js
@@ -78,7 +78,7 @@ async function packageExtension() {
     writeStream.on('error', reject);
 
     archive.pipe(writeStream);
-    archive.glob(`${distDir}/**`);
+    archive.directory(distDir, false);
     archive.finalize();
   });
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,11 @@
  <a name="4.0.0"></a>
 # 4.0.0 (2019-01-16)
 
-## New Contributors!
+## New contributors!
 
 @mattzeunert, @dima74, @jeffbcross, @knoxmic, and @shogunsea. Thanks!
 
-## Major Changes
+## Major changes
 
 * A bevy of bug fixes and performance improvements.
 
@@ -14,6 +14,23 @@
 * A new layout for the PWA category, emphasizing speed, installability, and polish.
 
 <a href="https://user-images.githubusercontent.com/316891/51218948-6e60ef00-18e3-11e9-8a48-535b59a41301.png"><img height="300" alt="Lighthouse 4.0 PWA category" src="https://user-images.githubusercontent.com/316891/51218948-6e60ef00-18e3-11e9-8a48-535b59a41301.png"></a>
+
+## Breaking changes
+
+* New PWA category, organization, and scoring ([#6395](https://github.com/GoogleChrome/lighthouse/issues/6395))
+  - the PWA section of the report has a set of badges instead of a numeric score gauge ([#6526](https://github.com/googlechrome/lighthouse/pull/6526), [#6670](https://github.com/googlechrome/lighthouse/pull/6670))
+  - the `webapp-install-banner` audit is now `installable-manifest` ([#6630](https://github.com/googlechrome/lighthouse/pull/6630))
+  - the offline check formerly in `webapp-install-banner` is the new audit `offline-start-url` ([#6397](https://github.com/googlechrome/lighthouse/pull/6397))
+* audits' `scoreDisplayMode` `'not-applicable'` is now `'notApplicable'` ([#6783](https://github.com/googlechrome/lighthouse/pull/6783))
+* `no-websql` audit removed due to performance cost ([#6293](https://github.com/googlechrome/lighthouse/pull/6293))
+* `speed-index` scoring now scales based on throttling ([#7007](https://github.com/googlechrome/lighthouse/pull/7007))
+* empty children arrays are now removed from `critical-request-chain` audit result ([#6211](https://github.com/googlechrome/lighthouse/pull/6211))
+* the correct Nexus 5X screen height of 660 now used instead of 732 ([#6932](https://github.com/googlechrome/lighthouse/pull/6932))
+* throttling constants under `mobile3G` renamed to the more accurate `mobileSlow4G` with no change in values ([#6163](https://github.com/googlechrome/lighthouse/pull/6163))
+* typescript definition files are now located under `types/` ([#6617](https://github.com/googlechrome/lighthouse/pull/6617))
+* computed artifact files are now located under `lighthouse-core/computed/` ([#6618](https://github.com/googlechrome/lighthouse/pull/6618))
+
+<hr>
 
 [Full Changelog](https://github.com/googlechrome/lighthouse/compare/v4.0.0-beta...v4.0.0) (in addition to the changes in [4.0.0-beta](https://github.com/GoogleChrome/lighthouse/releases/tag/v4.0.0-beta), [4.0.0-alpha.1](https://github.com/GoogleChrome/lighthouse/releases/tag/v4.0.0-alpha.1), and [4.0.0-alpha.0](https://github.com/GoogleChrome/lighthouse/releases/tag/4.0.0-alpha.0))
 

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -209,8 +209,8 @@ class LighthouseReportViewer {
     const warnMsg = `Version mismatch between viewer and JSON. Opening compatible viewer...`;
     logger.log(warnMsg, false);
 
+    // TODO: Handle 4x reports if we break viewer compat moving to v5.
     // Place report in IDB, then navigate current tab to the legacy viewer
-    // TODO: viewer4x :)
     const viewerPath = new URL('../viewer2x/', location.href);
     idbKeyval.set('2xreport', reportJson).then(_ => {
       window.location.href = viewerPath.href;

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -138,12 +138,11 @@ class LighthouseReportViewer {
   _replaceReportHtml(json) {
     this._validateReportJson(json);
 
+    // Redirect to old viewer if a v2 report. v3 and v4 both handled by v4 viewer.
     if (json.lighthouseVersion.startsWith('2')) {
       this._loadInLegacyViewerVersion(json);
       return;
     }
-
-    // TODO: viewer3x :)
 
     const dom = new DOM(document);
     const renderer = new ReportRenderer(dom);
@@ -202,7 +201,7 @@ class LighthouseReportViewer {
   }
 
   /**
-   * Stores v2.x report in IDB, then navigates to legacy viewer in current tab
+   * Stores v2.x report in IDB, then navigates to legacy viewer in current tab.
    * @param {LH.ReportResult} reportJson
    * @private
    */
@@ -211,6 +210,7 @@ class LighthouseReportViewer {
     logger.log(warnMsg, false);
 
     // Place report in IDB, then navigate current tab to the legacy viewer
+    // TODO: viewer4x :)
     const viewerPath = new URL('../viewer2x/', location.href);
     idbKeyval.set('2xreport', reportJson).then(_ => {
       window.location.href = viewerPath.href;


### PR DESCRIPTION
These came up in the process of pushing 4.0.

For the extension, using `archiver.glob` with an absolute path nests the extension directory within a recreation of the absolute path of directories leading up to it within the zip file. Kind of amazing that that still works as an extension, but weird to ship it that way. Switching to `archiver.directory()` allows `dist/extension/` to be the root of the zip file.

The viewer comment changes are just to assure the next release that both 3x and 4x results are handled by the current viewer.

I also updated the changelog with the "Breaking changes" section I added to the 4.0 release notes.