### PR TITLE
core(renderer): do not attempt fireworks for devtools

### DIFF
--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -207,14 +207,12 @@ class ReportRenderer {
     }
 
     // Fireworks
-    if (!this._dom.isDevTools()) {
-      const scoresAll100 = report.reportCategories.every(cat => cat.score === 1);
-      if (scoresAll100) {
-        headerContainer.classList.add('score100');
-        this._dom.find('.lh-header', headerContainer).addEventListener('click', _ => {
-          headerContainer.classList.toggle('fireworks-paused');
-        });
-      }
+    const scoresAll100 = report.reportCategories.every(cat => cat.score === 1);
+    if (!this._dom.isDevTools() && scoresAll100) {
+      headerContainer.classList.add('score100');
+      this._dom.find('.lh-header', headerContainer).addEventListener('click', _ => {
+        headerContainer.classList.toggle('fireworks-paused');
+      });
     }
 
     if (scoreHeader) {

--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -207,12 +207,14 @@ class ReportRenderer {
     }
 
     // Fireworks
-    const scoresAll100 = report.reportCategories.every(cat => cat.score === 1);
-    if (scoresAll100) {
-      headerContainer.classList.add('score100');
-      this._dom.find('.lh-header', headerContainer).addEventListener('click', _ => {
-        headerContainer.classList.toggle('fireworks-paused');
-      });
+    if (!this._dom.isDevTools()) {
+      const scoresAll100 = report.reportCategories.every(cat => cat.score === 1);
+      if (scoresAll100) {
+        headerContainer.classList.add('score100');
+        this._dom.find('.lh-header', headerContainer).addEventListener('click', _ => {
+          headerContainer.classList.toggle('fireworks-paused');
+        });
+      }
     }
 
     if (scoreHeader) {


### PR DESCRIPTION
This was a hotfix applied to the 4.0.0 devtools roll. Now adding here.