### PR TITLE
core(fcp-3g): remove unused i18n for LR compatibility

### DIFF
--- a/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
@@ -56,7 +56,7 @@ class FirstContentfulPaint3G extends Audit {
         context.options.scoreMedian
       ),
       rawValue: metricResult.timing,
-      displayValue: `${metricResult.timing}ms`,
+      displayValue: `${metricResult.timing}\xa0ms`,
     };
   }
 }

--- a/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
@@ -56,7 +56,7 @@ class FirstContentfulPaint3G extends Audit {
         context.options.scoreMedian
       ),
       rawValue: metricResult.timing,
-      displayValue: `${metricResult.timing}s`,
+      displayValue: `${metricResult.timing}ms`,
     };
   }
 }

--- a/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
@@ -7,18 +7,7 @@
 
 const Audit = require('../audit.js');
 const regular3G = require('../../config/constants.js').throttling.mobileRegluar3G;
-const i18n = require('../../lib/i18n/i18n.js');
 const ComputedFcp = require('../../computed/metrics/first-contentful-paint.js');
-
-const UIStrings = {
-  /** The name of the metric that marks the time at which the first text or image is painted by the browser, on a 3G network. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit. */
-  title: 'First Contentful Paint (3G)',
-  /** Description of the First Contentful Paint (FCP) metric, which marks the time at which the first text or image is painted by the browser. This is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
-  description: 'First Contentful Paint 3G marks the time at which the first text or image is ' +
-      `painted while on a 3G network. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).`,
-};
-
-const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
 class FirstContentfulPaint3G extends Audit {
   /**
@@ -27,8 +16,9 @@ class FirstContentfulPaint3G extends Audit {
   static get meta() {
     return {
       id: 'first-contentful-paint-3g',
-      title: str_(UIStrings.title),
-      description: str_(UIStrings.description),
+      title: 'First Contentful Paint (3G)',
+      description: 'First Contentful Paint 3G marks the time at which the first text or image is ' +
+        `painted while on a 3G network. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).`,
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
@@ -66,10 +56,9 @@ class FirstContentfulPaint3G extends Audit {
         context.options.scoreMedian
       ),
       rawValue: metricResult.timing,
-      displayValue: str_(i18n.UIStrings.seconds, {timeInMs: metricResult.timing}),
+      displayValue: `${metricResult.timing}s`,
     };
   }
 }
 
 module.exports = FirstContentfulPaint3G;
-module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
+++ b/lighthouse-core/audits/metrics/first-contentful-paint-3g.js
@@ -8,11 +8,17 @@
 const Audit = require('../audit.js');
 const regular3G = require('../../config/constants.js').throttling.mobileRegluar3G;
 const i18n = require('../../lib/i18n/i18n.js');
-const FCP = require('./first-contentful-paint.js');
 const ComputedFcp = require('../../computed/metrics/first-contentful-paint.js');
 
-const i18nFilename = require.resolve('./first-contentful-paint.js');
-const str_ = i18n.createMessageInstanceIdFn(i18nFilename, FCP.UIStrings);
+const UIStrings = {
+  /** The name of the metric that marks the time at which the first text or image is painted by the browser, on a 3G network. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit. */
+  title: 'First Contentful Paint (3G)',
+  /** Description of the First Contentful Paint (FCP) metric, which marks the time at which the first text or image is painted by the browser. This is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  description: 'First Contentful Paint 3G marks the time at which the first text or image is ' +
+      `painted while on a 3G network. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).`,
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
 class FirstContentfulPaint3G extends Audit {
   /**
@@ -21,8 +27,8 @@ class FirstContentfulPaint3G extends Audit {
   static get meta() {
     return {
       id: 'first-contentful-paint-3g',
-      title: str_(FCP.UIStrings.title),
-      description: str_(FCP.UIStrings.description),
+      title: str_(UIStrings.title),
+      description: str_(UIStrings.description),
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
@@ -66,3 +72,4 @@ class FirstContentfulPaint3G extends Audit {
 }
 
 module.exports = FirstContentfulPaint3G;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -675,6 +675,14 @@
     "message": "Estimated Input Latency",
     "description": "The name of the metric that marks the estimated time between the page receiving input (a user clicking, tapping, or typing) and the page responding. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit."
   },
+  "lighthouse-core/audits/metrics/first-contentful-paint-3g.js | description": {
+    "message": "First Contentful Paint 3G marks the time at which the first text or image is painted while on a 3G network. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).",
+    "description": "Description of the First Contentful Paint (FCP) metric, which marks the time at which the first text or image is painted by the browser. This is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
+  },
+  "lighthouse-core/audits/metrics/first-contentful-paint-3g.js | title": {
+    "message": "First Contentful Paint (3G)",
+    "description": "The name of the metric that marks the time at which the first text or image is painted by the browser, on a 3G network. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit."
+  },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
     "message": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).",
     "description": "Description of the First Contentful Paint (FCP) metric, which marks the time at which the first text or image is painted by the browser. This is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation."

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -675,14 +675,6 @@
     "message": "Estimated Input Latency",
     "description": "The name of the metric that marks the estimated time between the page receiving input (a user clicking, tapping, or typing) and the page responding. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit."
   },
-  "lighthouse-core/audits/metrics/first-contentful-paint-3g.js | description": {
-    "message": "First Contentful Paint 3G marks the time at which the first text or image is painted while on a 3G network. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).",
-    "description": "Description of the First Contentful Paint (FCP) metric, which marks the time at which the first text or image is painted by the browser. This is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
-  },
-  "lighthouse-core/audits/metrics/first-contentful-paint-3g.js | title": {
-    "message": "First Contentful Paint (3G)",
-    "description": "The name of the metric that marks the time at which the first text or image is painted by the browser, on a 3G network. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit."
-  },
   "lighthouse-core/audits/metrics/first-contentful-paint.js | description": {
     "message": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).",
     "description": "Description of the First Contentful Paint (FCP) metric, which marks the time at which the first text or image is painted by the browser. This is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation."


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Drop the `require.resolve`to find the i18n strings in exchange for an inlined `UIStrings` so that browserify can find them and the audit can be run in Lightrider.