### PR TITLE
misc(tap-targets): remove lines with trailing whitespace

### DIFF
--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -324,6 +324,7 @@ class TapTargets extends Gatherer {
       ${pageFunctions.getNodePathString};
       ${pageFunctions.getNodeSelectorString};
       ${gatherTapTargets.toString()};
+
       return gatherTapTargets();
     })()`;
 

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -324,9 +324,7 @@ class TapTargets extends Gatherer {
       ${pageFunctions.getNodePathString};
       ${pageFunctions.getNodeSelectorString};
       ${gatherTapTargets.toString()};
-      
       return gatherTapTargets();
-    
     })()`;
 
     return passContext.driver.evaluateAsync(expression, {useIsolation: true});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
2 lines in tap-targets were being browserified with trailing white space which fails on the LR bundler.  So just remove those lines.
