### PR TITLE
report: reorganize a11y audit groups

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -130,6 +130,9 @@ Object {
       "path": "manual/pwa-each-page-has-url",
     },
     Object {
+      "path": "accessibility/accesskeys",
+    },
+    Object {
       "path": "accessibility/aria-allowed-attr",
     },
     Object {
@@ -230,9 +233,6 @@ Object {
     },
     Object {
       "path": "accessibility/video-description",
-    },
-    Object {
-      "path": "accessibility/manual/accesskeys",
     },
     Object {
       "path": "accessibility/manual/custom-controls-labels",
@@ -377,6 +377,11 @@ Object {
     "accessibility": Object {
       "auditRefs": Array [
         Object {
+          "group": "a11y-navigation",
+          "id": "accesskeys",
+          "weight": 3,
+        },
+        Object {
           "group": "a11y-aria",
           "id": "aria-allowed-attr",
           "weight": 3,
@@ -412,17 +417,17 @@ Object {
           "weight": 5,
         },
         Object {
-          "group": "a11y-correct-attributes",
+          "group": "a11y-audio-video",
           "id": "audio-caption",
           "weight": 4,
         },
         Object {
-          "group": "a11y-element-names",
+          "group": "a11y-names-labels",
           "id": "button-name",
           "weight": 10,
         },
         Object {
-          "group": "a11y-describe-contents",
+          "group": "a11y-navigation",
           "id": "bypass",
           "weight": 10,
         },
@@ -432,27 +437,27 @@ Object {
           "weight": 6,
         },
         Object {
-          "group": "a11y-well-structured",
+          "group": "a11y-tables-lists",
           "id": "definition-list",
           "weight": 1,
         },
         Object {
-          "group": "a11y-well-structured",
+          "group": "a11y-tables-lists",
           "id": "dlitem",
           "weight": 1,
         },
         Object {
-          "group": "a11y-describe-contents",
+          "group": "a11y-names-labels",
           "id": "document-title",
           "weight": 2,
         },
         Object {
-          "group": "a11y-well-structured",
+          "group": "a11y-best-practices",
           "id": "duplicate-id",
           "weight": 5,
         },
         Object {
-          "group": "a11y-describe-contents",
+          "group": "a11y-names-labels",
           "id": "frame-title",
           "weight": 5,
         },
@@ -467,67 +472,67 @@ Object {
           "weight": 1,
         },
         Object {
-          "group": "a11y-correct-attributes",
+          "group": "a11y-names-labels",
           "id": "image-alt",
           "weight": 8,
         },
         Object {
-          "group": "a11y-correct-attributes",
+          "group": "a11y-names-labels",
           "id": "input-image-alt",
           "weight": 1,
         },
         Object {
-          "group": "a11y-describe-contents",
+          "group": "a11y-names-labels",
           "id": "label",
           "weight": 10,
         },
         Object {
-          "group": "a11y-describe-contents",
+          "group": "a11y-tables-lists",
           "id": "layout-table",
           "weight": 1,
         },
         Object {
-          "group": "a11y-element-names",
+          "group": "a11y-names-labels",
           "id": "link-name",
           "weight": 9,
         },
         Object {
-          "group": "a11y-well-structured",
+          "group": "a11y-tables-lists",
           "id": "list",
           "weight": 5,
         },
         Object {
-          "group": "a11y-well-structured",
+          "group": "a11y-tables-lists",
           "id": "listitem",
           "weight": 4,
         },
         Object {
-          "group": "a11y-meta",
+          "group": "a11y-best-practices",
           "id": "meta-refresh",
           "weight": 1,
         },
         Object {
-          "group": "a11y-meta",
+          "group": "a11y-best-practices",
           "id": "meta-viewport",
           "weight": 3,
         },
         Object {
-          "group": "a11y-describe-contents",
+          "group": "a11y-names-labels",
           "id": "object-alt",
           "weight": 4,
         },
         Object {
-          "group": "a11y-correct-attributes",
+          "group": "a11y-navigation",
           "id": "tabindex",
           "weight": 4,
         },
         Object {
-          "group": "a11y-correct-attributes",
+          "group": "a11y-tables-lists",
           "id": "td-headers-attr",
           "weight": 1,
         },
         Object {
-          "group": "a11y-correct-attributes",
+          "group": "a11y-tables-lists",
           "id": "th-has-data-cells",
           "weight": 1,
         },
@@ -537,18 +542,14 @@ Object {
           "weight": 1,
         },
         Object {
-          "group": "a11y-describe-contents",
+          "group": "a11y-audio-video",
           "id": "video-caption",
           "weight": 4,
         },
         Object {
-          "group": "a11y-describe-contents",
+          "group": "a11y-audio-video",
           "id": "video-description",
           "weight": 3,
-        },
-        Object {
-          "id": "accesskeys",
-          "weight": 0,
         },
         Object {
           "id": "logical-tab-order",
@@ -999,35 +1000,35 @@ Object {
   "groups": Object {
     "a11y-aria": Object {
       "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader.",
-      "title": "ARIA Attributes Follow Best Practices",
+      "title": "ARIA",
+    },
+    "a11y-audio-video": Object {
+      "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments.",
+      "title": "Audio and video",
+    },
+    "a11y-best-practices": Object {
+      "description": "These are opportunities to improve the interpretation of your content by users in different locales.",
+      "title": "Best practices",
     },
     "a11y-color-contrast": Object {
       "description": "These are opportunities to improve the legibility of your content.",
-      "title": "Color Contrast Is Satisfactory",
-    },
-    "a11y-correct-attributes": Object {
-      "description": "These are opportunities to improve the configuration of your HTML elements.",
-      "title": "Elements Use Attributes Correctly",
-    },
-    "a11y-describe-contents": Object {
-      "description": "These are opportunities to make your content easier to understand for a user of assistive technology, like a screen reader.",
-      "title": "Elements Describe Contents Well",
-    },
-    "a11y-element-names": Object {
-      "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.",
-      "title": "Elements Have Discernible Names",
+      "title": "Contrast",
     },
     "a11y-language": Object {
       "description": "These are opportunities to improve the interpretation of your content by users in different locales.",
-      "title": "Page Specifies Valid Language",
+      "title": "Internationalization and localization",
     },
-    "a11y-meta": Object {
-      "description": "These are opportunities to improve the user experience of your site.",
-      "title": "Meta Tags Used Properly",
+    "a11y-names-labels": Object {
+      "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.",
+      "title": "Names and labels",
     },
-    "a11y-well-structured": Object {
-      "description": "These are opportunities to make sure your HTML is appropriately structured.",
-      "title": "Elements Are Well Structured",
+    "a11y-navigation": Object {
+      "description": "These are opportunities to improve keyboard navigation in your application.",
+      "title": "Navigation",
+    },
+    "a11y-tables-lists": Object {
+      "description": "These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader.",
+      "title": "Tables and lists",
     },
     "diagnostics": Object {
       "description": "More information about the performance of your application.",
@@ -1248,35 +1249,35 @@ Object {
   "groups": Object {
     "a11y-aria": Object {
       "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader.",
-      "title": "ARIA Attributes Follow Best Practices",
+      "title": "ARIA",
+    },
+    "a11y-audio-video": Object {
+      "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments.",
+      "title": "Audio and video",
+    },
+    "a11y-best-practices": Object {
+      "description": "These are opportunities to improve the interpretation of your content by users in different locales.",
+      "title": "Best practices",
     },
     "a11y-color-contrast": Object {
       "description": "These are opportunities to improve the legibility of your content.",
-      "title": "Color Contrast Is Satisfactory",
-    },
-    "a11y-correct-attributes": Object {
-      "description": "These are opportunities to improve the configuration of your HTML elements.",
-      "title": "Elements Use Attributes Correctly",
-    },
-    "a11y-describe-contents": Object {
-      "description": "These are opportunities to make your content easier to understand for a user of assistive technology, like a screen reader.",
-      "title": "Elements Describe Contents Well",
-    },
-    "a11y-element-names": Object {
-      "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.",
-      "title": "Elements Have Discernible Names",
+      "title": "Contrast",
     },
     "a11y-language": Object {
       "description": "These are opportunities to improve the interpretation of your content by users in different locales.",
-      "title": "Page Specifies Valid Language",
+      "title": "Internationalization and localization",
     },
-    "a11y-meta": Object {
-      "description": "These are opportunities to improve the user experience of your site.",
-      "title": "Meta Tags Used Properly",
+    "a11y-names-labels": Object {
+      "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.",
+      "title": "Names and labels",
     },
-    "a11y-well-structured": Object {
-      "description": "These are opportunities to make sure your HTML is appropriately structured.",
-      "title": "Elements Are Well Structured",
+    "a11y-navigation": Object {
+      "description": "These are opportunities to improve keyboard navigation in your application.",
+      "title": "Navigation",
+    },
+    "a11y-tables-lists": Object {
+      "description": "These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader.",
+      "title": "Tables and lists",
     },
     "diagnostics": Object {
       "description": "More information about the performance of your application.",

--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -1007,7 +1007,7 @@ Object {
       "title": "Audio and video",
     },
     "a11y-best-practices": Object {
-      "description": "These are opportunities to improve the interpretation of your content by users in different locales.",
+      "description": "These items highlight common accessibility best practices.",
       "title": "Best practices",
     },
     "a11y-color-contrast": Object {
@@ -1256,7 +1256,7 @@ Object {
       "title": "Audio and video",
     },
     "a11y-best-practices": Object {
-      "description": "These are opportunities to improve the interpretation of your content by users in different locales.",
+      "description": "These items highlight common accessibility best practices.",
       "title": "Best practices",
     },
     "a11y-color-contrast": Object {

--- a/lighthouse-cli/test/fixtures/a11y/a11y_tester.html
+++ b/lighthouse-cli/test/fixtures/a11y/a11y_tester.html
@@ -11,6 +11,11 @@
     <meta name="viewport" content="user-scalable=no, maximum-scale=1.0">
   </head>
   <body>
+    <p>accesskeys</p>
+    <section>
+      <button id="accesskeys1" accesskey="s">Foo</button>
+      <button id="accesskeys2" accesskey="s">Bar</button>
+    </section>
     <p>aria-allowed-attr</p>
     <section>
       <div

--- a/lighthouse-cli/test/smokehouse/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/a11y/expectations.js
@@ -230,8 +230,12 @@ module.exports = [
         },
       },
       'accesskeys': {
-        score: null,
-        scoreDisplayMode: 'manual',
+        score: 0,
+        details: {
+          items: {
+            length: 1,
+          },
+        },
       },
     },
   },

--- a/lighthouse-core/audits/accessibility/accesskeys.js
+++ b/lighthouse-core/audits/accessibility/accesskeys.js
@@ -6,15 +6,18 @@
 'use strict';
 
 /**
- * @fileoverview Manual a11y audit to remind to check every accesskey attribute value is unique.
+ * @fileoverview Ensures accesskey values are unique.
+ * See base class in axe-audit.js for audit() implementation.
  */
 
-const Audit = require('../../audit.js');
-const i18n = require('../../../lib/i18n/i18n.js');
+const AxeAudit = require('./axe-audit.js');
+const i18n = require('../../lib/i18n/i18n.js');
 
 const UIStrings = {
   /** Title of an accesibility audit that evaluates if the accesskey HTML attribute values are unique across all elements. This title is descriptive of the successful state and is shown to users when no user action is required. */
   title: '`[accesskey]` values are unique',
+  /** Title of an accesibility audit that evaluates if the ARIA HTML attributes are misaligned with the aria-role HTML attribute specificed on the element, such mismatches are invalid. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  failureTitle: '`[accesskey]` values are not unique',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Access keys let users quickly focus a part of the page. For proper ' +
       'navigation, each access key must be unique. ' +
@@ -23,7 +26,7 @@ const UIStrings = {
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
-class Accesskeys extends Audit {
+class Accesskeys extends AxeAudit {
   /**
    * @return {LH.Audit.Meta}
    */
@@ -31,17 +34,10 @@ class Accesskeys extends Audit {
     return {
       id: 'accesskeys',
       title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      scoreDisplayMode: Audit.SCORING_MODES.MANUAL,
-      requiredArtifacts: [],
+      requiredArtifacts: ['Accessibility'],
     };
-  }
-
-  /**
-   * @return {LH.Audit.Product}
-   */
-  static audit() {
-    return {rawValue: false};
   }
 }
 

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -40,7 +40,7 @@ const UIStrings = {
   /** Title of the best practices section of the Accessibility category. Within this section are audits with descriptive titles that highlight common accessibility best practices. */
   a11yBestPracticesGroupTitle: 'Best practices',
   /* Description of the best practices section within the Accessibility category. Within this section are audits with descriptive titles that highlight common accessibility best practices. */
-  a11yBestPracticesGroupDescription: 'These are opportunities to improve the interpretation of your content by users in different locales.',
+  a11yBestPracticesGroupDescription: 'These items highlight common accessibility best practices.',
   /* Title of the color contrast section within the Accessibility category. Within this section are audits with descriptive titles that highlight the color and vision aspects of the page's accessibility that are passing or failing. */
   a11yColorContrastGroupTitle: 'Contrast',
   /* Description of the color contrast section within the Accessibility category. Within this section are audits with descriptive titles that highlight the color and vision aspects of the page's accessibility that are passing or failing. */

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -31,44 +31,44 @@ const UIStrings = {
   diagnosticsGroupTitle: 'Diagnostics',
   /** Description of the diagnostics section of the Performance category. Within this section are audits with non-imperative titles that provide more detail on the page's page load performance characteristics. Whereas the 'Opportunities' suggest an action along with expected time savings, diagnostics do not. Within this section, the user may read the details and deduce additional actions they could take. */
   diagnosticsGroupDescription: 'More information about the performance of your application.',
-  /** Title of the Accessibility category of audits. This section contains audits focused on making web content accessible to users with disabilities. Also used as a label of a score gauge; try to limit to 20 characters. */
+  /** Title of the Accessibility category of audits. This section contains audits focused on making web content accessible to all users. Also used as a label of a score gauge; try to limit to 20 characters. */
   a11yCategoryTitle: 'Accessibility',
-  /** Description of the Accessibility category. This is displayed at the top of a list of audits focused on making web content accessible to users with disabilities. No character length limits. 'improve the accessibility of your web app' becomes link text to additional documentation. */
+  /** Description of the Accessibility category. This is displayed at the top of a list of audits focused on making web content accessible to all users. No character length limits. 'improve the accessibility of your web app' becomes link text to additional documentation. */
   a11yCategoryDescription: 'These checks highlight opportunities to [improve the accessibility of your web app](https://developers.google.com/web/fundamentals/accessibility). Only a subset of accessibility issues can be automatically detected so manual testing is also encouraged.',
   /** Description of the Accessibility manual checks category. This description is displayed above a list of accessibility audits that currently have no automated test and so must be verified manually by the user. No character length limits. 'conducting an accessibility review' becomes link text to additional documentation. */
   a11yCategoryManualDescription: 'These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).',
+  /** Title of the best practices section of the Accessibility category. Within this section are audits with descriptive titles that highlight common accessibility best practices. */
+  a11yBestPracticesGroupTitle: 'Best practices',
+  /* Description of the best practices section within the Accessibility category. Within this section are audits with descriptive titles that highlight common accessibility best practices. */
+  a11yBestPracticesGroupDescription: 'These are opportunities to improve the interpretation of your content by users in different locales.',
   /* Title of the color contrast section within the Accessibility category. Within this section are audits with descriptive titles that highlight the color and vision aspects of the page's accessibility that are passing or failing. */
-  a11yColorContrastGroupTitle: 'Color Contrast Is Satisfactory',
+  a11yColorContrastGroupTitle: 'Contrast',
   /* Description of the color contrast section within the Accessibility category. Within this section are audits with descriptive titles that highlight the color and vision aspects of the page's accessibility that are passing or failing. */
   a11yColorContrastGroupDescription: 'These are opportunities to improve the legibility of your content.',
-  /* Title of the screen reader annotation section within the Accessibility category. Within this section are audits with descriptive titles that highlight the screen reader readability aspects of the page's accessibility that are passing or failing. 'Elements' refers to HTML elements. */
-  a11yDescribeContentsGroupTitle: 'Elements Describe Contents Well',
-  /* Description of the screen reader annotation section within the Accessibility category. Within this section are audits with descriptive titles that highlight the screen reader readability aspects of the page's accessibility that are passing or failing. */
-  a11yDescribeContentsGroupDescription: 'These are opportunities to make your content easier to understand for a user of assistive technology, like a screen reader.',
-  /* Title of the HTML validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight structural HTML aspects of the page's accessibility that are passing or failing (i.e. that list items are contained within list parents, etc). 'Elements' refers to HTML elements. */
-  a11yWellStructuredGroupTitle: 'Elements Are Well Structured',
-  /* Description of the HTML validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight structural HTML aspects of the page's accessibility that are passing or failing. */
-  a11yWellStructuredGroupDescription: 'These are opportunities to make sure your HTML is appropriately structured.',
+  /* Title of the HTML element naming section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the non-textual HTML elements on the page have names discernible by a screen reader. */
+  a11yNamesLabelsGroupTitle: 'Names and labels',
+  /* Description of the HTML element naming section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the non-textual HTML elements on the page have names discernible by a screen reader. */
+  a11yNamesLabelsGroupDescription: 'These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.',
+  /* Title of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve keyboard navigation. */
+  a11yNavigationGroupTitle: 'Navigation',
+  /* Description of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve keyboard navigation. */
+  a11yNavigationGroupDescription: 'These are opportunities to improve keyboard navigation in your application.',
   /* Title of the ARIA validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight if whether all the aria-* HTML attributes have been used properly. */
-  a11yAriaGroupTitle: 'ARIA Attributes Follow Best Practices',
+  a11yAriaGroupTitle: 'ARIA',
   /* Description of the ARIA validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight if whether all the aria-* HTML attributes have been used properly. */
   a11yAriaGroupDescription: 'These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader.',
-  /* Title of the HTML attribute validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the HTML attribute values on the page are used correctly. 'Elements' refers to HTML elements. */
-  a11yCorrectAttributesGroupTitle: 'Elements Use Attributes Correctly',
-  /* Description of the HTML attribute validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the HTML attribute values on the page are used correctly. */
-  a11yCorrectAttributesGroupDescription: 'These are opportunities to improve the configuration of your HTML elements.',
-  /* Title of the HTML element naming section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the non-textual HTML elements on the page have names discernible by a screen reader. */
-  a11yElementNamesGroupTitle: 'Elements Have Discernible Names',
-  /* Description of the HTML element naming section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the non-textual HTML elements on the page have names discernible by a screen reader. */
-  a11yElementNamesGroupDescription: 'These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.',
   /* Title of the language section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the language has been annotated in the correct HTML attributes on the page. */
-  a11yLanguageGroupTitle: 'Page Specifies Valid Language',
+  a11yLanguageGroupTitle: 'Internationalization and localization',
   /* Description of the language section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the language has been annotated in the correct HTML attributes on the page. */
   a11yLanguageGroupDescription: 'These are opportunities to improve the interpretation of your content by users in different locales.',
-  /* Title of the meta tag section within the Accessibility category. Within this section are audits with descriptive titles that highlight if meta tags on the page have been used properly and if any important ones are missing. */
-  a11yMetaGroupTitle: 'Meta Tags Used Properly',
-  /* Description of the meta tag section within the Accessibility category. Within this section are audits with descriptive titles that highlight if meta tags on the page have been used properly and if any important ones are missing. */
-  a11yMetaGroupDescription: 'These are opportunities to improve the user experience of your site.',
+  /* Title of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to provide alternative content for audio and video. */
+  a11yAudioVideoGroupTitle: 'Audio and video',
+  /* Description of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to provide alternative content for audio and video. */
+  a11yAudioVideoGroupDescription: 'These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments.',
+  /* Title of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve the experience of reading tabular or list data using assistive technology. */
+  a11yTablesListsVideoGroupTitle: 'Tables and lists',
+  /* Description of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve the experience of reading tabular or list data using assistive technology. */
+  a11yTablesListsVideoGroupDescription: 'These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader.',
   /** Title of the Search Engine Optimization (SEO) category of audits. This is displayed at the top of a list of audits focused on topics related to optimizing a website for indexing by search engines. Also used as a label of a score gauge; try to limit to 20 characters. */
   seoCategoryTitle: 'SEO',
   /** Description of the Search Engine Optimization (SEO) category. This is displayed at the top of a list of audits focused on optimizing a website for indexing by search engines. No character length limits. 'Learn More' becomes link text to additional documentation. */
@@ -184,6 +184,7 @@ const defaultConfig = {
     'manual/pwa-cross-browser',
     'manual/pwa-page-transitions',
     'manual/pwa-each-page-has-url',
+    'accessibility/accesskeys',
     'accessibility/aria-allowed-attr',
     'accessibility/aria-required-attr',
     'accessibility/aria-required-children',
@@ -218,7 +219,6 @@ const defaultConfig = {
     'accessibility/valid-lang',
     'accessibility/video-caption',
     'accessibility/video-description',
-    'accessibility/manual/accesskeys',
     'accessibility/manual/custom-controls-labels',
     'accessibility/manual/custom-controls-roles',
     'accessibility/manual/focus-traps',
@@ -288,37 +288,37 @@ const defaultConfig = {
     'pwa-optimized': {
       title: str_(UIStrings.pwaOptimizedGroupTitle),
     },
+    'a11y-best-practices': {
+      title: str_(UIStrings.a11yBestPracticesGroupTitle),
+      description: str_(UIStrings.a11yBestPracticesGroupDescription),
+    },
     'a11y-color-contrast': {
       title: str_(UIStrings.a11yColorContrastGroupTitle),
       description: str_(UIStrings.a11yColorContrastGroupDescription),
     },
-    'a11y-describe-contents': {
-      title: str_(UIStrings.a11yDescribeContentsGroupTitle),
-      description: str_(UIStrings.a11yDescribeContentsGroupDescription),
+    'a11y-names-labels': {
+      title: str_(UIStrings.a11yNamesLabelsGroupTitle),
+      description: str_(UIStrings.a11yNamesLabelsGroupDescription),
     },
-    'a11y-well-structured': {
-      title: str_(UIStrings.a11yWellStructuredGroupTitle),
-      description: str_(UIStrings.a11yWellStructuredGroupDescription),
+    'a11y-navigation': {
+      title: str_(UIStrings.a11yNavigationGroupTitle),
+      description: str_(UIStrings.a11yNavigationGroupDescription),
     },
     'a11y-aria': {
       title: str_(UIStrings.a11yAriaGroupTitle),
       description: str_(UIStrings.a11yAriaGroupDescription),
     },
-    'a11y-correct-attributes': {
-      title: str_(UIStrings.a11yCorrectAttributesGroupTitle),
-      description: str_(UIStrings.a11yCorrectAttributesGroupDescription),
-    },
-    'a11y-element-names': {
-      title: str_(UIStrings.a11yElementNamesGroupTitle),
-      description: str_(UIStrings.a11yElementNamesGroupDescription),
-    },
     'a11y-language': {
       title: str_(UIStrings.a11yLanguageGroupTitle),
       description: str_(UIStrings.a11yLanguageGroupDescription),
     },
-    'a11y-meta': {
-      title: str_(UIStrings.a11yMetaGroupTitle),
-      description: str_(UIStrings.a11yMetaGroupDescription),
+    'a11y-audio-video': {
+      title: str_(UIStrings.a11yAudioVideoGroupTitle),
+      description: str_(UIStrings.a11yAudioVideoGroupDescription),
+    },
+    'a11y-tables-lists': {
+      title: str_(UIStrings.a11yTablesListsVideoGroupTitle),
+      description: str_(UIStrings.a11yTablesListsVideoGroupDescription),
     },
     'seo-mobile': {
       title: 'Mobile Friendly',
@@ -384,6 +384,7 @@ const defaultConfig = {
       description: str_(UIStrings.a11yCategoryDescription),
       manualDescription: str_(UIStrings.a11yCategoryManualDescription),
       auditRefs: [
+        {id: 'accesskeys', weight: 3, group: 'a11y-navigation'},
         {id: 'aria-allowed-attr', weight: 3, group: 'a11y-aria'},
         {id: 'aria-required-attr', weight: 2, group: 'a11y-aria'},
         {id: 'aria-required-children', weight: 5, group: 'a11y-aria'},
@@ -391,35 +392,34 @@ const defaultConfig = {
         {id: 'aria-roles', weight: 3, group: 'a11y-aria'},
         {id: 'aria-valid-attr-value', weight: 2, group: 'a11y-aria'},
         {id: 'aria-valid-attr', weight: 5, group: 'a11y-aria'},
-        {id: 'audio-caption', weight: 4, group: 'a11y-correct-attributes'},
-        {id: 'button-name', weight: 10, group: 'a11y-element-names'},
-        {id: 'bypass', weight: 10, group: 'a11y-describe-contents'},
+        {id: 'button-name', weight: 10, group: 'a11y-names-labels'},
+        {id: 'bypass', weight: 10, group: 'a11y-navigation'},
         {id: 'color-contrast', weight: 6, group: 'a11y-color-contrast'},
-        {id: 'definition-list', weight: 1, group: 'a11y-well-structured'},
-        {id: 'dlitem', weight: 1, group: 'a11y-well-structured'},
-        {id: 'document-title', weight: 2, group: 'a11y-describe-contents'},
-        {id: 'duplicate-id', weight: 5, group: 'a11y-well-structured'},
-        {id: 'frame-title', weight: 5, group: 'a11y-describe-contents'},
+        {id: 'definition-list', weight: 1, group: 'a11y-tables-lists'},
+        {id: 'dlitem', weight: 1, group: 'a11y-tables-lists'},
+        {id: 'document-title', weight: 2, group: 'a11y-names-labels'},
+        {id: 'duplicate-id', weight: 5, group: 'a11y-best-practices'},
+        {id: 'frame-title', weight: 5, group: 'a11y-names-labels'},
         {id: 'html-has-lang', weight: 4, group: 'a11y-language'},
         {id: 'html-lang-valid', weight: 1, group: 'a11y-language'},
-        {id: 'image-alt', weight: 8, group: 'a11y-correct-attributes'},
-        {id: 'input-image-alt', weight: 1, group: 'a11y-correct-attributes'},
-        {id: 'label', weight: 10, group: 'a11y-describe-contents'},
-        {id: 'layout-table', weight: 1, group: 'a11y-describe-contents'},
-        {id: 'link-name', weight: 9, group: 'a11y-element-names'},
-        {id: 'list', weight: 5, group: 'a11y-well-structured'},
-        {id: 'listitem', weight: 4, group: 'a11y-well-structured'},
-        {id: 'meta-refresh', weight: 1, group: 'a11y-meta'},
-        {id: 'meta-viewport', weight: 3, group: 'a11y-meta'},
-        {id: 'object-alt', weight: 4, group: 'a11y-describe-contents'},
-        {id: 'tabindex', weight: 4, group: 'a11y-correct-attributes'},
-        {id: 'td-headers-attr', weight: 1, group: 'a11y-correct-attributes'},
-        {id: 'th-has-data-cells', weight: 1, group: 'a11y-correct-attributes'},
+        {id: 'image-alt', weight: 8, group: 'a11y-names-labels'},
+        {id: 'input-image-alt', weight: 1, group: 'a11y-names-labels'},
+        {id: 'label', weight: 10, group: 'a11y-names-labels'},
+        {id: 'layout-table', weight: 1, group: 'a11y-tables-lists'},
+        {id: 'link-name', weight: 9, group: 'a11y-names-labels'},
+        {id: 'list', weight: 5, group: 'a11y-tables-lists'},
+        {id: 'listitem', weight: 4, group: 'a11y-tables-lists'},
+        {id: 'meta-refresh', weight: 1, group: 'a11y-best-practices'},
+        {id: 'meta-viewport', weight: 3, group: 'a11y-best-practices'},
+        {id: 'object-alt', weight: 4, group: 'a11y-names-labels'},
+        {id: 'tabindex', weight: 4, group: 'a11y-navigation'},
+        {id: 'td-headers-attr', weight: 1, group: 'a11y-tables-lists'},
+        {id: 'th-has-data-cells', weight: 1, group: 'a11y-tables-lists'},
         {id: 'valid-lang', weight: 1, group: 'a11y-language'},
-        {id: 'video-caption', weight: 4, group: 'a11y-describe-contents'},
-        {id: 'video-description', weight: 3, group: 'a11y-describe-contents'},
+        {id: 'audio-caption', weight: 4, group: 'a11y-audio-video'},
+        {id: 'video-caption', weight: 4, group: 'a11y-audio-video'},
+        {id: 'video-description', weight: 3, group: 'a11y-audio-video'},
         // Manual audits
-        {id: 'accesskeys', weight: 0},
         {id: 'logical-tab-order', weight: 0},
         {id: 'focusable-controls', weight: 0},
         {id: 'interactive-element-affordance', weight: 0},

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -392,6 +392,7 @@ const defaultConfig = {
         {id: 'aria-roles', weight: 3, group: 'a11y-aria'},
         {id: 'aria-valid-attr-value', weight: 2, group: 'a11y-aria'},
         {id: 'aria-valid-attr', weight: 5, group: 'a11y-aria'},
+        {id: 'audio-caption', weight: 4, group: 'a11y-audio-video'},
         {id: 'button-name', weight: 10, group: 'a11y-names-labels'},
         {id: 'bypass', weight: 10, group: 'a11y-navigation'},
         {id: 'color-contrast', weight: 6, group: 'a11y-color-contrast'},
@@ -416,7 +417,6 @@ const defaultConfig = {
         {id: 'td-headers-attr', weight: 1, group: 'a11y-tables-lists'},
         {id: 'th-has-data-cells', weight: 1, group: 'a11y-tables-lists'},
         {id: 'valid-lang', weight: 1, group: 'a11y-language'},
-        {id: 'audio-caption', weight: 4, group: 'a11y-audio-video'},
         {id: 'video-caption', weight: 4, group: 'a11y-audio-video'},
         {id: 'video-description', weight: 3, group: 'a11y-audio-video'},
         // Manual audits

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -33,6 +33,7 @@ function runA11yChecks() {
     resultTypes: ['violations', 'inapplicable'],
     rules: {
       'tabindex': {enabled: true},
+      'accesskeys': {enabled: true},
       'table-fake-caption': {enabled: false},
       'td-has-header': {enabled: false},
       'marquee': {enabled: false},

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -1044,7 +1044,7 @@
     "description": "Title of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to provide alternative content for audio and video."
   },
   "lighthouse-core/config/default-config.js | a11yBestPracticesGroupDescription": {
-    "message": "These are opportunities to improve the interpretation of your content by users in different locales.",
+    "message": "These items highlight common accessibility best practices.",
     "description": "Description of the best practices section within the Accessibility category. Within this section are audits with descriptive titles that highlight common accessibility best practices."
   },
   "lighthouse-core/config/default-config.js | a11yBestPracticesGroupTitle": {

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -1,4 +1,16 @@
 {
+  "lighthouse-core/audits/accessibility/accesskeys.js | description": {
+    "message": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).",
+    "description": "Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
+  },
+  "lighthouse-core/audits/accessibility/accesskeys.js | failureTitle": {
+    "message": "`[accesskey]` values are not unique",
+    "description": "Title of an accesibility audit that evaluates if the ARIA HTML attributes are misaligned with the aria-role HTML attribute specificed on the element, such mismatches are invalid. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed."
+  },
+  "lighthouse-core/audits/accessibility/accesskeys.js | title": {
+    "message": "`[accesskey]` values are unique",
+    "description": "Title of an accesibility audit that evaluates if the accesskey HTML attribute values are unique across all elements. This title is descriptive of the successful state and is shown to users when no user action is required."
+  },
   "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": {
     "message": "Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse).",
     "description": "Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
@@ -302,14 +314,6 @@
   "lighthouse-core/audits/accessibility/listitem.js | title": {
     "message": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements",
     "description": "Title of an accesibility audit that evaluates if any list item elements do not have list parent elements. This title is descriptive of the successful state and is shown to users when no user action is required."
-  },
-  "lighthouse-core/audits/accessibility/manual/accesskeys.js | description": {
-    "message": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).",
-    "description": "Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
-  },
-  "lighthouse-core/audits/accessibility/manual/accesskeys.js | title": {
-    "message": "`[accesskey]` values are unique",
-    "description": "Title of an accesibility audit that evaluates if the accesskey HTML attribute values are unique across all elements. This title is descriptive of the successful state and is shown to users when no user action is required."
   },
   "lighthouse-core/audits/accessibility/meta-refresh.js | description": {
     "message": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse).",
@@ -1028,12 +1032,28 @@
     "description": "Description of the ARIA validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight if whether all the aria- HTML attributes have been used properly."
   },
   "lighthouse-core/config/default-config.js | a11yAriaGroupTitle": {
-    "message": "ARIA Attributes Follow Best Practices",
+    "message": "ARIA",
     "description": "Title of the ARIA validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight if whether all the aria- HTML attributes have been used properly."
+  },
+  "lighthouse-core/config/default-config.js | a11yAudioVideoGroupDescription": {
+    "message": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments.",
+    "description": "Description of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to provide alternative content for audio and video."
+  },
+  "lighthouse-core/config/default-config.js | a11yAudioVideoGroupTitle": {
+    "message": "Audio and video",
+    "description": "Title of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to provide alternative content for audio and video."
+  },
+  "lighthouse-core/config/default-config.js | a11yBestPracticesGroupDescription": {
+    "message": "These are opportunities to improve the interpretation of your content by users in different locales.",
+    "description": "Description of the best practices section within the Accessibility category. Within this section are audits with descriptive titles that highlight common accessibility best practices."
+  },
+  "lighthouse-core/config/default-config.js | a11yBestPracticesGroupTitle": {
+    "message": "Best practices",
+    "description": "Title of the best practices section of the Accessibility category. Within this section are audits with descriptive titles that highlight common accessibility best practices."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryDescription": {
     "message": "These checks highlight opportunities to [improve the accessibility of your web app](https://developers.google.com/web/fundamentals/accessibility). Only a subset of accessibility issues can be automatically detected so manual testing is also encouraged.",
-    "description": "Description of the Accessibility category. This is displayed at the top of a list of audits focused on making web content accessible to users with disabilities. No character length limits. 'improve the accessibility of your web app' becomes link text to additional documentation."
+    "description": "Description of the Accessibility category. This is displayed at the top of a list of audits focused on making web content accessible to all users. No character length limits. 'improve the accessibility of your web app' becomes link text to additional documentation."
   },
   "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": {
     "message": "These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).",
@@ -1041,63 +1061,47 @@
   },
   "lighthouse-core/config/default-config.js | a11yCategoryTitle": {
     "message": "Accessibility",
-    "description": "Title of the Accessibility category of audits. This section contains audits focused on making web content accessible to users with disabilities. Also used as a label of a score gauge; try to limit to 20 characters."
+    "description": "Title of the Accessibility category of audits. This section contains audits focused on making web content accessible to all users. Also used as a label of a score gauge; try to limit to 20 characters."
   },
   "lighthouse-core/config/default-config.js | a11yColorContrastGroupDescription": {
     "message": "These are opportunities to improve the legibility of your content.",
     "description": "Description of the color contrast section within the Accessibility category. Within this section are audits with descriptive titles that highlight the color and vision aspects of the page's accessibility that are passing or failing."
   },
   "lighthouse-core/config/default-config.js | a11yColorContrastGroupTitle": {
-    "message": "Color Contrast Is Satisfactory",
+    "message": "Contrast",
     "description": "Title of the color contrast section within the Accessibility category. Within this section are audits with descriptive titles that highlight the color and vision aspects of the page's accessibility that are passing or failing."
-  },
-  "lighthouse-core/config/default-config.js | a11yCorrectAttributesGroupDescription": {
-    "message": "These are opportunities to improve the configuration of your HTML elements.",
-    "description": "Description of the HTML attribute validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the HTML attribute values on the page are used correctly."
-  },
-  "lighthouse-core/config/default-config.js | a11yCorrectAttributesGroupTitle": {
-    "message": "Elements Use Attributes Correctly",
-    "description": "Title of the HTML attribute validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the HTML attribute values on the page are used correctly. 'Elements' refers to HTML elements."
-  },
-  "lighthouse-core/config/default-config.js | a11yDescribeContentsGroupDescription": {
-    "message": "These are opportunities to make your content easier to understand for a user of assistive technology, like a screen reader.",
-    "description": "Description of the screen reader annotation section within the Accessibility category. Within this section are audits with descriptive titles that highlight the screen reader readability aspects of the page's accessibility that are passing or failing."
-  },
-  "lighthouse-core/config/default-config.js | a11yDescribeContentsGroupTitle": {
-    "message": "Elements Describe Contents Well",
-    "description": "Title of the screen reader annotation section within the Accessibility category. Within this section are audits with descriptive titles that highlight the screen reader readability aspects of the page's accessibility that are passing or failing. 'Elements' refers to HTML elements."
-  },
-  "lighthouse-core/config/default-config.js | a11yElementNamesGroupDescription": {
-    "message": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.",
-    "description": "Description of the HTML element naming section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the non-textual HTML elements on the page have names discernible by a screen reader."
-  },
-  "lighthouse-core/config/default-config.js | a11yElementNamesGroupTitle": {
-    "message": "Elements Have Discernible Names",
-    "description": "Title of the HTML element naming section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the non-textual HTML elements on the page have names discernible by a screen reader."
   },
   "lighthouse-core/config/default-config.js | a11yLanguageGroupDescription": {
     "message": "These are opportunities to improve the interpretation of your content by users in different locales.",
     "description": "Description of the language section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the language has been annotated in the correct HTML attributes on the page."
   },
   "lighthouse-core/config/default-config.js | a11yLanguageGroupTitle": {
-    "message": "Page Specifies Valid Language",
+    "message": "Internationalization and localization",
     "description": "Title of the language section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the language has been annotated in the correct HTML attributes on the page."
   },
-  "lighthouse-core/config/default-config.js | a11yMetaGroupDescription": {
-    "message": "These are opportunities to improve the user experience of your site.",
-    "description": "Description of the meta tag section within the Accessibility category. Within this section are audits with descriptive titles that highlight if meta tags on the page have been used properly and if any important ones are missing."
+  "lighthouse-core/config/default-config.js | a11yNamesLabelsGroupDescription": {
+    "message": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.",
+    "description": "Description of the HTML element naming section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the non-textual HTML elements on the page have names discernible by a screen reader."
   },
-  "lighthouse-core/config/default-config.js | a11yMetaGroupTitle": {
-    "message": "Meta Tags Used Properly",
-    "description": "Title of the meta tag section within the Accessibility category. Within this section are audits with descriptive titles that highlight if meta tags on the page have been used properly and if any important ones are missing."
+  "lighthouse-core/config/default-config.js | a11yNamesLabelsGroupTitle": {
+    "message": "Names and labels",
+    "description": "Title of the HTML element naming section within the Accessibility category. Within this section are audits with descriptive titles that highlight if the non-textual HTML elements on the page have names discernible by a screen reader."
   },
-  "lighthouse-core/config/default-config.js | a11yWellStructuredGroupDescription": {
-    "message": "These are opportunities to make sure your HTML is appropriately structured.",
-    "description": "Description of the HTML validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight structural HTML aspects of the page's accessibility that are passing or failing."
+  "lighthouse-core/config/default-config.js | a11yNavigationGroupDescription": {
+    "message": "These are opportunities to improve keyboard navigation in your application.",
+    "description": "Description of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve keyboard navigation."
   },
-  "lighthouse-core/config/default-config.js | a11yWellStructuredGroupTitle": {
-    "message": "Elements Are Well Structured",
-    "description": "Title of the HTML validity section within the Accessibility category. Within this section are audits with descriptive titles that highlight structural HTML aspects of the page's accessibility that are passing or failing (i.e. that list items are contained within list parents, etc). 'Elements' refers to HTML elements."
+  "lighthouse-core/config/default-config.js | a11yNavigationGroupTitle": {
+    "message": "Navigation",
+    "description": "Title of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve keyboard navigation."
+  },
+  "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupDescription": {
+    "message": "These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader.",
+    "description": "Description of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve the experience of reading tabular or list data using assistive technology."
+  },
+  "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
+    "message": "Tables and lists",
+    "description": "Title of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve the experience of reading tabular or list data using assistive technology."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
     "message": "More information about the performance of your application.",

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -201,7 +201,7 @@ describe('CategoryRenderer', () => {
       const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
 
       const gauge = categoryDOM.querySelector('.lh-gauge__percentage');
-      assert.equal(gauge.textContent.trim(), '33', 'score is 0-100');
+      assert.equal(gauge.textContent.trim(), '36', 'score is 0-100');
 
       const score = categoryDOM.querySelector('.lh-category-header');
       const value = categoryDOM.querySelector('.lh-gauge__percentage');

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3837,7 +3837,7 @@
     },
     "a11y-best-practices": {
       "title": "Best practices",
-      "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+      "description": "These items highlight common accessibility best practices."
     },
     "a11y-color-contrast": {
       "title": "Contrast",
@@ -5566,8 +5566,7 @@
         "categoryGroups[a11y-best-practices].title"
       ],
       "lighthouse-core/config/default-config.js | a11yBestPracticesGroupDescription": [
-        "categoryGroups[a11y-best-practices].description",
-        "categoryGroups[a11y-language].description"
+        "categoryGroups[a11y-best-practices].description"
       ],
       "lighthouse-core/config/default-config.js | a11yColorContrastGroupTitle": [
         "categoryGroups[a11y-color-contrast].title"
@@ -5595,6 +5594,9 @@
       ],
       "lighthouse-core/config/default-config.js | a11yLanguageGroupTitle": [
         "categoryGroups[a11y-language].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yLanguageGroupDescription": [
+        "categoryGroups[a11y-language].description"
       ],
       "lighthouse-core/config/default-config.js | a11yAudioVideoGroupTitle": [
         "categoryGroups[a11y-audio-video].title"

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1448,6 +1448,19 @@
       "scoreDisplayMode": "manual",
       "rawValue": false
     },
+    "accesskeys": {
+      "id": "accesskeys",
+      "title": "`[accesskey]` values are unique",
+      "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).",
+      "score": 1,
+      "scoreDisplayMode": "binary",
+      "rawValue": true,
+      "details": {
+        "type": "table",
+        "headings": [],
+        "items": []
+      }
+    },
     "aria-allowed-attr": {
       "id": "aria-allowed-attr",
       "title": "`[aria-*]` attributes match their roles",
@@ -2001,14 +2014,6 @@
       "score": null,
       "scoreDisplayMode": "notApplicable",
       "rawValue": true
-    },
-    "accesskeys": {
-      "id": "accesskeys",
-      "title": "`[accesskey]` values are unique",
-      "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).",
-      "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
     },
     "custom-controls-labels": {
       "id": "custom-controls-labels",
@@ -3365,6 +3370,11 @@
       "manualDescription": "These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).",
       "auditRefs": [
         {
+          "id": "accesskeys",
+          "weight": 3,
+          "group": "a11y-navigation"
+        },
+        {
           "id": "aria-allowed-attr",
           "weight": 0,
           "group": "a11y-aria"
@@ -3400,19 +3410,14 @@
           "group": "a11y-aria"
         },
         {
-          "id": "audio-caption",
-          "weight": 0,
-          "group": "a11y-correct-attributes"
-        },
-        {
           "id": "button-name",
           "weight": 0,
-          "group": "a11y-element-names"
+          "group": "a11y-names-labels"
         },
         {
           "id": "bypass",
           "weight": 10,
-          "group": "a11y-describe-contents"
+          "group": "a11y-navigation"
         },
         {
           "id": "color-contrast",
@@ -3422,27 +3427,27 @@
         {
           "id": "definition-list",
           "weight": 0,
-          "group": "a11y-well-structured"
+          "group": "a11y-tables-lists"
         },
         {
           "id": "dlitem",
           "weight": 0,
-          "group": "a11y-well-structured"
+          "group": "a11y-tables-lists"
         },
         {
           "id": "document-title",
           "weight": 2,
-          "group": "a11y-describe-contents"
+          "group": "a11y-names-labels"
         },
         {
           "id": "duplicate-id",
           "weight": 5,
-          "group": "a11y-well-structured"
+          "group": "a11y-best-practices"
         },
         {
           "id": "frame-title",
           "weight": 0,
-          "group": "a11y-describe-contents"
+          "group": "a11y-names-labels"
         },
         {
           "id": "html-has-lang",
@@ -3457,67 +3462,67 @@
         {
           "id": "image-alt",
           "weight": 8,
-          "group": "a11y-correct-attributes"
+          "group": "a11y-names-labels"
         },
         {
           "id": "input-image-alt",
           "weight": 0,
-          "group": "a11y-correct-attributes"
+          "group": "a11y-names-labels"
         },
         {
           "id": "label",
           "weight": 10,
-          "group": "a11y-describe-contents"
+          "group": "a11y-names-labels"
         },
         {
           "id": "layout-table",
           "weight": 0,
-          "group": "a11y-describe-contents"
+          "group": "a11y-tables-lists"
         },
         {
           "id": "link-name",
           "weight": 9,
-          "group": "a11y-element-names"
+          "group": "a11y-names-labels"
         },
         {
           "id": "list",
           "weight": 0,
-          "group": "a11y-well-structured"
+          "group": "a11y-tables-lists"
         },
         {
           "id": "listitem",
           "weight": 0,
-          "group": "a11y-well-structured"
+          "group": "a11y-tables-lists"
         },
         {
           "id": "meta-refresh",
           "weight": 0,
-          "group": "a11y-meta"
+          "group": "a11y-best-practices"
         },
         {
           "id": "meta-viewport",
           "weight": 3,
-          "group": "a11y-meta"
+          "group": "a11y-best-practices"
         },
         {
           "id": "object-alt",
           "weight": 4,
-          "group": "a11y-describe-contents"
+          "group": "a11y-names-labels"
         },
         {
           "id": "tabindex",
           "weight": 0,
-          "group": "a11y-correct-attributes"
+          "group": "a11y-navigation"
         },
         {
           "id": "td-headers-attr",
           "weight": 0,
-          "group": "a11y-correct-attributes"
+          "group": "a11y-tables-lists"
         },
         {
           "id": "th-has-data-cells",
           "weight": 0,
-          "group": "a11y-correct-attributes"
+          "group": "a11y-tables-lists"
         },
         {
           "id": "valid-lang",
@@ -3525,18 +3530,19 @@
           "group": "a11y-language"
         },
         {
+          "id": "audio-caption",
+          "weight": 0,
+          "group": "a11y-audio-video"
+        },
+        {
           "id": "video-caption",
           "weight": 0,
-          "group": "a11y-describe-contents"
+          "group": "a11y-audio-video"
         },
         {
           "id": "video-description",
           "weight": 0,
-          "group": "a11y-describe-contents"
-        },
-        {
-          "id": "accesskeys",
-          "weight": 0
+          "group": "a11y-audio-video"
         },
         {
           "id": "logical-tab-order",
@@ -3584,7 +3590,7 @@
         }
       ],
       "id": "accessibility",
-      "score": 0.33
+      "score": 0.36
     },
     "best-practices": {
       "title": "Best Practices",
@@ -3829,37 +3835,37 @@
     "pwa-optimized": {
       "title": "PWA Optimized"
     },
-    "a11y-color-contrast": {
-      "title": "Color Contrast Is Satisfactory",
-      "description": "These are opportunities to improve the legibility of your content."
-    },
-    "a11y-describe-contents": {
-      "title": "Elements Describe Contents Well",
-      "description": "These are opportunities to make your content easier to understand for a user of assistive technology, like a screen reader."
-    },
-    "a11y-well-structured": {
-      "title": "Elements Are Well Structured",
-      "description": "These are opportunities to make sure your HTML is appropriately structured."
-    },
-    "a11y-aria": {
-      "title": "ARIA Attributes Follow Best Practices",
-      "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
-    },
-    "a11y-correct-attributes": {
-      "title": "Elements Use Attributes Correctly",
-      "description": "These are opportunities to improve the configuration of your HTML elements."
-    },
-    "a11y-element-names": {
-      "title": "Elements Have Discernible Names",
-      "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
-    },
-    "a11y-language": {
-      "title": "Page Specifies Valid Language",
+    "a11y-best-practices": {
+      "title": "Best practices",
       "description": "These are opportunities to improve the interpretation of your content by users in different locales."
     },
-    "a11y-meta": {
-      "title": "Meta Tags Used Properly",
-      "description": "These are opportunities to improve the user experience of your site."
+    "a11y-color-contrast": {
+      "title": "Contrast",
+      "description": "These are opportunities to improve the legibility of your content."
+    },
+    "a11y-names-labels": {
+      "title": "Names and labels",
+      "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+    },
+    "a11y-navigation": {
+      "title": "Navigation",
+      "description": "These are opportunities to improve keyboard navigation in your application."
+    },
+    "a11y-aria": {
+      "title": "ARIA",
+      "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+    },
+    "a11y-language": {
+      "title": "Internationalization and localization",
+      "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+    },
+    "a11y-audio-video": {
+      "title": "Audio and video",
+      "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+    },
+    "a11y-tables-lists": {
+      "title": "Tables and lists",
+      "description": "These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
     },
     "seo-mobile": {
       "title": "Mobile Friendly",
@@ -4298,6 +4304,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:audit:accesskeys",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:aria-allowed-attr",
         "duration": 100,
         "entryType": "measure"
@@ -4497,12 +4509,6 @@
       {
         "startTime": 0,
         "name": "lh:audit:video-description",
-        "duration": 100,
-        "entryType": "measure"
-      },
-      {
-        "startTime": 0,
-        "name": "lh:audit:accesskeys",
         "duration": 100,
         "entryType": "measure"
       },
@@ -5264,12 +5270,6 @@
       "lighthouse-core/audits/accessibility/video-description.js | description": [
         "audits[video-description].description"
       ],
-      "lighthouse-core/audits/accessibility/manual/accesskeys.js | title": [
-        "audits.accesskeys.title"
-      ],
-      "lighthouse-core/audits/accessibility/manual/accesskeys.js | description": [
-        "audits.accesskeys.description"
-      ],
       "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | failureTitle": [
         "audits[uses-long-cache-ttl].title"
       ],
@@ -5556,23 +5556,30 @@
       "lighthouse-core/config/default-config.js | pwaOptimizedGroupTitle": [
         "categoryGroups[pwa-optimized].title"
       ],
+      "lighthouse-core/config/default-config.js | a11yBestPracticesGroupTitle": [
+        "categoryGroups[a11y-best-practices].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yBestPracticesGroupDescription": [
+        "categoryGroups[a11y-best-practices].description",
+        "categoryGroups[a11y-language].description"
+      ],
       "lighthouse-core/config/default-config.js | a11yColorContrastGroupTitle": [
         "categoryGroups[a11y-color-contrast].title"
       ],
       "lighthouse-core/config/default-config.js | a11yColorContrastGroupDescription": [
         "categoryGroups[a11y-color-contrast].description"
       ],
-      "lighthouse-core/config/default-config.js | a11yDescribeContentsGroupTitle": [
-        "categoryGroups[a11y-describe-contents].title"
+      "lighthouse-core/config/default-config.js | a11yNamesLabelsGroupTitle": [
+        "categoryGroups[a11y-names-labels].title"
       ],
-      "lighthouse-core/config/default-config.js | a11yDescribeContentsGroupDescription": [
-        "categoryGroups[a11y-describe-contents].description"
+      "lighthouse-core/config/default-config.js | a11yNamesLabelsGroupDescription": [
+        "categoryGroups[a11y-names-labels].description"
       ],
-      "lighthouse-core/config/default-config.js | a11yWellStructuredGroupTitle": [
-        "categoryGroups[a11y-well-structured].title"
+      "lighthouse-core/config/default-config.js | a11yNavigationGroupTitle": [
+        "categoryGroups[a11y-navigation].title"
       ],
-      "lighthouse-core/config/default-config.js | a11yWellStructuredGroupDescription": [
-        "categoryGroups[a11y-well-structured].description"
+      "lighthouse-core/config/default-config.js | a11yNavigationGroupDescription": [
+        "categoryGroups[a11y-navigation].description"
       ],
       "lighthouse-core/config/default-config.js | a11yAriaGroupTitle": [
         "categoryGroups[a11y-aria].title"
@@ -5580,29 +5587,20 @@
       "lighthouse-core/config/default-config.js | a11yAriaGroupDescription": [
         "categoryGroups[a11y-aria].description"
       ],
-      "lighthouse-core/config/default-config.js | a11yCorrectAttributesGroupTitle": [
-        "categoryGroups[a11y-correct-attributes].title"
-      ],
-      "lighthouse-core/config/default-config.js | a11yCorrectAttributesGroupDescription": [
-        "categoryGroups[a11y-correct-attributes].description"
-      ],
-      "lighthouse-core/config/default-config.js | a11yElementNamesGroupTitle": [
-        "categoryGroups[a11y-element-names].title"
-      ],
-      "lighthouse-core/config/default-config.js | a11yElementNamesGroupDescription": [
-        "categoryGroups[a11y-element-names].description"
-      ],
       "lighthouse-core/config/default-config.js | a11yLanguageGroupTitle": [
         "categoryGroups[a11y-language].title"
       ],
-      "lighthouse-core/config/default-config.js | a11yLanguageGroupDescription": [
-        "categoryGroups[a11y-language].description"
+      "lighthouse-core/config/default-config.js | a11yAudioVideoGroupTitle": [
+        "categoryGroups[a11y-audio-video].title"
       ],
-      "lighthouse-core/config/default-config.js | a11yMetaGroupTitle": [
-        "categoryGroups[a11y-meta].title"
+      "lighthouse-core/config/default-config.js | a11yAudioVideoGroupDescription": [
+        "categoryGroups[a11y-audio-video].description"
       ],
-      "lighthouse-core/config/default-config.js | a11yMetaGroupDescription": [
-        "categoryGroups[a11y-meta].description"
+      "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": [
+        "categoryGroups[a11y-tables-lists].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupDescription": [
+        "categoryGroups[a11y-tables-lists].description"
       ]
     }
   }

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3410,6 +3410,11 @@
           "group": "a11y-aria"
         },
         {
+          "id": "audio-caption",
+          "weight": 0,
+          "group": "a11y-audio-video"
+        },
+        {
           "id": "button-name",
           "weight": 0,
           "group": "a11y-names-labels"
@@ -3528,11 +3533,6 @@
           "id": "valid-lang",
           "weight": 0,
           "group": "a11y-language"
-        },
-        {
-          "id": "audio-caption",
-          "weight": 0,
-          "group": "a11y-audio-video"
         },
         {
           "id": "video-caption",
@@ -5057,6 +5057,12 @@
       ],
       "lighthouse-core/audits/network-server-latency.js | description": [
         "audits[network-server-latency].description"
+      ],
+      "lighthouse-core/audits/accessibility/accesskeys.js | title": [
+        "audits.accesskeys.title"
+      ],
+      "lighthouse-core/audits/accessibility/accesskeys.js | description": [
+        "audits.accesskeys.description"
       ],
       "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": [
         "audits[aria-allowed-attr].title"

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -2,9 +2,14 @@
     "audits": {
         "accesskeys": {
             "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).", 
+            "details": {
+                "headings": [], 
+                "items": [], 
+                "type": "table"
+            }, 
             "id": "accesskeys", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "score": 1.0, 
+            "scoreDisplayMode": "binary", 
             "title": "`[accesskey]` values are unique"
         }, 
         "appcache-manifest": {
@@ -2998,6 +3003,11 @@
         "accessibility": {
             "auditRefs": [
                 {
+                    "group": "a11y-navigation", 
+                    "id": "accesskeys", 
+                    "weight": 3.0
+                }, 
+                {
                     "group": "a11y-aria", 
                     "id": "aria-allowed-attr", 
                     "weight": 0.0
@@ -3033,17 +3043,12 @@
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-correct-attributes", 
-                    "id": "audio-caption", 
-                    "weight": 0.0
-                }, 
-                {
-                    "group": "a11y-element-names", 
+                    "group": "a11y-names-labels", 
                     "id": "button-name", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-describe-contents", 
+                    "group": "a11y-navigation", 
                     "id": "bypass", 
                     "weight": 10.0
                 }, 
@@ -3053,27 +3058,27 @@
                     "weight": 6.0
                 }, 
                 {
-                    "group": "a11y-well-structured", 
+                    "group": "a11y-tables-lists", 
                     "id": "definition-list", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-well-structured", 
+                    "group": "a11y-tables-lists", 
                     "id": "dlitem", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-describe-contents", 
+                    "group": "a11y-names-labels", 
                     "id": "document-title", 
                     "weight": 2.0
                 }, 
                 {
-                    "group": "a11y-well-structured", 
+                    "group": "a11y-best-practices", 
                     "id": "duplicate-id", 
                     "weight": 5.0
                 }, 
                 {
-                    "group": "a11y-describe-contents", 
+                    "group": "a11y-names-labels", 
                     "id": "frame-title", 
                     "weight": 0.0
                 }, 
@@ -3088,67 +3093,67 @@
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-correct-attributes", 
+                    "group": "a11y-names-labels", 
                     "id": "image-alt", 
                     "weight": 8.0
                 }, 
                 {
-                    "group": "a11y-correct-attributes", 
+                    "group": "a11y-names-labels", 
                     "id": "input-image-alt", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-describe-contents", 
+                    "group": "a11y-names-labels", 
                     "id": "label", 
                     "weight": 10.0
                 }, 
                 {
-                    "group": "a11y-describe-contents", 
+                    "group": "a11y-tables-lists", 
                     "id": "layout-table", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-element-names", 
+                    "group": "a11y-names-labels", 
                     "id": "link-name", 
                     "weight": 9.0
                 }, 
                 {
-                    "group": "a11y-well-structured", 
+                    "group": "a11y-tables-lists", 
                     "id": "list", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-well-structured", 
+                    "group": "a11y-tables-lists", 
                     "id": "listitem", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-meta", 
+                    "group": "a11y-best-practices", 
                     "id": "meta-refresh", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-meta", 
+                    "group": "a11y-best-practices", 
                     "id": "meta-viewport", 
                     "weight": 3.0
                 }, 
                 {
-                    "group": "a11y-describe-contents", 
+                    "group": "a11y-names-labels", 
                     "id": "object-alt", 
                     "weight": 4.0
                 }, 
                 {
-                    "group": "a11y-correct-attributes", 
+                    "group": "a11y-navigation", 
                     "id": "tabindex", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-correct-attributes", 
+                    "group": "a11y-tables-lists", 
                     "id": "td-headers-attr", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-correct-attributes", 
+                    "group": "a11y-tables-lists", 
                     "id": "th-has-data-cells", 
                     "weight": 0.0
                 }, 
@@ -3158,17 +3163,18 @@
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-describe-contents", 
+                    "group": "a11y-audio-video", 
+                    "id": "audio-caption", 
+                    "weight": 0.0
+                }, 
+                {
+                    "group": "a11y-audio-video", 
                     "id": "video-caption", 
                     "weight": 0.0
                 }, 
                 {
-                    "group": "a11y-describe-contents", 
+                    "group": "a11y-audio-video", 
                     "id": "video-description", 
-                    "weight": 0.0
-                }, 
-                {
-                    "id": "accesskeys", 
                     "weight": 0.0
                 }, 
                 {
@@ -3219,7 +3225,7 @@
             "description": "These checks highlight opportunities to [improve the accessibility of your web app](https://developers.google.com/web/fundamentals/accessibility). Only a subset of accessibility issues can be automatically detected so manual testing is also encouraged.", 
             "id": "accessibility", 
             "manualDescription": "These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).", 
-            "score": 0.33, 
+            "score": 0.36, 
             "title": "Accessibility"
         }, 
         "best-practices": {
@@ -3630,35 +3636,35 @@
     "categoryGroups": {
         "a11y-aria": {
             "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader.", 
-            "title": "ARIA Attributes Follow Best Practices"
+            "title": "ARIA"
+        }, 
+        "a11y-audio-video": {
+            "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments.", 
+            "title": "Audio and video"
+        }, 
+        "a11y-best-practices": {
+            "description": "These are opportunities to improve the interpretation of your content by users in different locales.", 
+            "title": "Best practices"
         }, 
         "a11y-color-contrast": {
             "description": "These are opportunities to improve the legibility of your content.", 
-            "title": "Color Contrast Is Satisfactory"
-        }, 
-        "a11y-correct-attributes": {
-            "description": "These are opportunities to improve the configuration of your HTML elements.", 
-            "title": "Elements Use Attributes Correctly"
-        }, 
-        "a11y-describe-contents": {
-            "description": "These are opportunities to make your content easier to understand for a user of assistive technology, like a screen reader.", 
-            "title": "Elements Describe Contents Well"
-        }, 
-        "a11y-element-names": {
-            "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.", 
-            "title": "Elements Have Discernible Names"
+            "title": "Contrast"
         }, 
         "a11y-language": {
             "description": "These are opportunities to improve the interpretation of your content by users in different locales.", 
-            "title": "Page Specifies Valid Language"
+            "title": "Internationalization and localization"
         }, 
-        "a11y-meta": {
-            "description": "These are opportunities to improve the user experience of your site.", 
-            "title": "Meta Tags Used Properly"
+        "a11y-names-labels": {
+            "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.", 
+            "title": "Names and labels"
         }, 
-        "a11y-well-structured": {
-            "description": "These are opportunities to make sure your HTML is appropriately structured.", 
-            "title": "Elements Are Well Structured"
+        "a11y-navigation": {
+            "description": "These are opportunities to improve keyboard navigation in your application.", 
+            "title": "Navigation"
+        }, 
+        "a11y-tables-lists": {
+            "description": "These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader.", 
+            "title": "Tables and lists"
         }, 
         "diagnostics": {
             "description": "More information about the performance of your application.", 
@@ -4154,6 +4160,12 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:audit:accesskeys", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:aria-allowed-attr", 
                 "startTime": 0.0
             }, 
@@ -4353,12 +4365,6 @@
                 "duration": 100.0, 
                 "entryType": "measure", 
                 "name": "lh:audit:video-description", 
-                "startTime": 0.0
-            }, 
-            {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:accesskeys", 
                 "startTime": 0.0
             }, 
             {

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -3043,6 +3043,11 @@
                     "weight": 0.0
                 }, 
                 {
+                    "group": "a11y-audio-video", 
+                    "id": "audio-caption", 
+                    "weight": 0.0
+                }, 
+                {
                     "group": "a11y-names-labels", 
                     "id": "button-name", 
                     "weight": 0.0
@@ -3160,11 +3165,6 @@
                 {
                     "group": "a11y-language", 
                     "id": "valid-lang", 
-                    "weight": 0.0
-                }, 
-                {
-                    "group": "a11y-audio-video", 
-                    "id": "audio-caption", 
                     "weight": 0.0
                 }, 
                 {

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -3643,7 +3643,7 @@
             "title": "Audio and video"
         }, 
         "a11y-best-practices": {
-            "description": "These are opportunities to improve the interpretation of your content by users in different locales.", 
+            "description": "These items highlight common accessibility best practices.", 
             "title": "Best practices"
         }, 
         "a11y-color-contrast": {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**

Improve the categorization of accessibility audits.

- Note: Also enables the `accesskeys` audit which was accidentally turned off in [a previous PR](https://github.com/GoogleChrome/lighthouse/pull/7020/files#diff-427cb962a42ed8d3463f1a773c2f4cc8L9).

**Related Issues/PRs**
fixes #7019