### PR TITLE
core(tsc): begin clean up of audit details types

### DIFF
--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -126,11 +126,11 @@ class Audit {
   }
 
   /**
-   * @param {Array<LH.ResultLite.Audit.ColumnHeading>} headings
-   * @param {Array<LH.ResultLite.Audit.WastedBytesDetailsItem>|Array<LH.ResultLite.Audit.WastedTimeDetailsItem>} items
+   * @param {Array<LH.Audit.Details.TableColumnHeading>} headings
+   * @param {Array<LH.Audit.Details.OpportunityItem>} items
    * @param {number} overallSavingsMs
    * @param {number=} overallSavingsBytes
-   * @return {LH.Result.Audit.OpportunityDetails}
+   * @return {LH.Audit.Details.Opportunity}
    */
   static makeOpportunityDetails(headings, items, overallSavingsMs, overallSavingsBytes) {
     return {

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -126,7 +126,7 @@ class Audit {
   }
 
   /**
-   * @param {Array<LH.Audit.Details.TableColumnHeading>} headings
+   * @param {Array<LH.Audit.Details.OpportunityColumnHeading>} headings
    * @param {Array<LH.Audit.Details.OpportunityItem>} items
    * @param {number} overallSavingsMs
    * @param {number=} overallSavingsBytes

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -27,7 +27,7 @@ const WASTED_MS_FOR_SCORE_OF_ZERO = 5000;
 /**
  * @typedef {object} ByteEfficiencyProduct
  * @property {Array<LH.Audit.ByteEfficiencyItem>} items
- * @property {LH.Result.Audit.OpportunityDetails['headings']} headings
+ * @property {LH.Audit.Details.Opportunity['headings']} headings
  * @property {string} [displayValue]
  * @property {string} [explanation]
  * @property {Array<string>} [warnings]

--- a/lighthouse-core/audits/byte-efficiency/efficient-animated-content.js
+++ b/lighthouse-core/audits/byte-efficiency/efficient-animated-content.js
@@ -74,7 +74,7 @@ class EfficientAnimatedContent extends ByteEfficiencyAudit {
       };
     });
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},

--- a/lighthouse-core/audits/byte-efficiency/offscreen-images.js
+++ b/lighthouse-core/audits/byte-efficiency/offscreen-images.js
@@ -223,7 +223,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
         await TraceOfTab.request(trace, context).then(tot => tot.timestamps.traceEnd));
     }
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'thumbnail', label: ''},
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -211,7 +211,7 @@ class RenderBlockingResources extends Audit {
       displayValue = str_(i18n.UIStrings.displayValueMsSavings, {wastedMs});
     }
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},

--- a/lighthouse-core/audits/byte-efficiency/unminified-css.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-css.js
@@ -102,7 +102,7 @@ class UnminifiedCSS extends ByteEfficiencyAudit {
       items.push(result);
     }
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},

--- a/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-javascript.js
@@ -95,7 +95,7 @@ class UnminifiedJavaScript extends ByteEfficiencyAudit {
       }
     }
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -173,7 +173,7 @@ class UnusedCSSRules extends ByteEfficiencyAudit {
           .map(sheetId => UnusedCSSRules.mapSheetToResult(indexedSheets[sheetId], pageUrl))
           .filter(sheet => sheet && sheet.wastedBytes > IGNORE_THRESHOLD_IN_BYTES);
 
-      /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+      /** @type {LH.Audit.Details.Opportunity['headings']} */
       const headings = [
         {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
         {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -80,7 +80,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
       });
     }
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'thumbnail', label: ''},
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},

--- a/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-responsive-images.js
@@ -119,7 +119,7 @@ class UsesResponsiveImages extends ByteEfficiencyAudit {
     const items = Array.from(resultsMap.values())
         .filter(item => item.wastedBytes > IGNORE_THRESHOLD_IN_BYTES);
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'thumbnail', label: ''},
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},

--- a/lighthouse-core/audits/byte-efficiency/uses-text-compression.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-text-compression.js
@@ -82,7 +82,7 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
       });
     });
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnSize)},

--- a/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
@@ -79,7 +79,7 @@ class UsesWebPImages extends ByteEfficiencyAudit {
       });
     }
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'thumbnail', label: ''},
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},

--- a/lighthouse-core/audits/redirects.js
+++ b/lighthouse-core/audits/redirects.js
@@ -98,7 +98,7 @@ class Redirects extends Audit {
       });
     }
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'wastedMs', valueType: 'timespanMs', label: str_(i18n.UIStrings.columnTimeSpent)},

--- a/lighthouse-core/audits/time-to-first-byte.js
+++ b/lighthouse-core/audits/time-to-first-byte.js
@@ -60,7 +60,7 @@ class TTFBMetric extends Audit {
     const passed = ttfb < TTFB_THRESHOLD;
     const displayValue = str_(UIStrings.displayValue, {timeInMs: ttfb});
 
-    /** @type {LH.Result.Audit.OpportunityDetails} */
+    /** @type {LH.Audit.Details.Opportunity} */
     const details = {
       type: 'opportunity',
       overallSavingsMs: ttfb - TTFB_THRESHOLD,

--- a/lighthouse-core/audits/uses-rel-preconnect.js
+++ b/lighthouse-core/audits/uses-rel-preconnect.js
@@ -178,7 +178,7 @@ class UsesRelPreconnectAudit extends Audit {
     results = results
       .sort((a, b) => b.wastedMs - a.wastedMs);
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'wastedMs', valueType: 'timespanMs', label: str_(i18n.UIStrings.columnWastedMs)},

--- a/lighthouse-core/audits/uses-rel-preload.js
+++ b/lighthouse-core/audits/uses-rel-preload.js
@@ -213,7 +213,7 @@ class UsesRelPreloadAudit extends Audit {
         .map(preloadURL => str_(UIStrings.crossoriginWarning, {preloadURL}));
     }
 
-    /** @type {LH.Result.Audit.OpportunityDetails['headings']} */
+    /** @type {LH.Audit.Details.Opportunity['headings']} */
     const headings = [
       {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
       {key: 'wastedMs', valueType: 'timespanMs', label: str_(i18n.UIStrings.columnWastedMs)},

--- a/lighthouse-core/report/html/renderer/crc-details-renderer.js
+++ b/lighthouse-core/report/html/renderer/crc-details-renderer.js
@@ -145,7 +145,7 @@ class CriticalRequestChainRenderer {
    * @param {DocumentFragment} tmpl
    * @param {CRCSegment} segment
    * @param {Element} elem Parent element.
-   * @param {CRCDetailsJSON} details
+   * @param {LH.Audit.Details.CriticalRequestChain} details
    */
   static buildTree(dom, tmpl, segment, elem, details) {
     elem.appendChild(CriticalRequestChainRenderer.createChainNode(dom, tmpl, segment));
@@ -161,7 +161,7 @@ class CriticalRequestChainRenderer {
   /**
    * @param {DOM} dom
    * @param {ParentNode} templateContext
-   * @param {CRCDetailsJSON} details
+   * @param {LH.Audit.Details.CriticalRequestChain} details
    * @return {Element}
    */
   static render(dom, templateContext, details) {
@@ -193,14 +193,6 @@ if (typeof module !== 'undefined' && module.exports) {
 } else {
   self.CriticalRequestChainRenderer = CriticalRequestChainRenderer;
 }
-
-/** @typedef {{
-      type: string,
-      header: {text: string},
-      longestChain: {duration: number, length: number, transferSize: number},
-      chains: LH.Audit.SimpleCriticalRequestNode
-  }} CRCDetailsJSON
- */
 
 /** @typedef {{
       node: LH.Audit.SimpleCriticalRequestNode[string],

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -19,8 +19,7 @@
 /* globals self CriticalRequestChainRenderer Util URL */
 
 /** @typedef {import('./dom.js')} DOM */
-/** @typedef {import('./crc-details-renderer.js')} CRCDetailsJSON */
-/** @typedef {LH.Result.Audit.OpportunityDetails} OpportunityDetails */
+/** @typedef {LH.Audit.Details.Opportunity} OpportunityDetails */
 
 /** @type {Array<string>} */
 const URL_PREFIXES = ['http://', 'https://', 'data:'];
@@ -76,7 +75,7 @@ class DetailsRenderer {
       case 'criticalrequestchain':
         return CriticalRequestChainRenderer.render(this._dom, this._templateContext,
           // @ts-ignore - TODO(bckenny): Fix type hierarchy
-          /** @type {CRCDetailsJSON} */ (details));
+          /** @type {LH.Audit.Details.CriticalRequestChain} */ (details));
       case 'opportunity':
         // @ts-ignore - TODO(bckenny): Fix type hierarchy
         return this._renderOpportunityTable(details);
@@ -289,7 +288,7 @@ class DetailsRenderer {
     for (const row of details.items) {
       const rowElem = this._dom.createChildOf(tbodyElem, 'tr');
       for (const heading of details.headings) {
-        const key = /** @type {keyof LH.Result.Audit.OpportunityDetailsItem} */ (heading.key);
+        const key = /** @type {keyof LH.Audit.Details.OpportunityItem} */ (heading.key);
         const value = row[key];
 
         if (typeof value === 'undefined' || value === null) {
@@ -360,7 +359,7 @@ class DetailsRenderer {
   }
 
   /**
-   * @param {FilmstripDetails} details
+   * @param {LH.Audit.Details.Filmstrip} details
    * @return {Element}
    */
   _renderFilmstrip(details) {
@@ -460,9 +459,3 @@ if (typeof module !== 'undefined' && module.exports) {
   }} LinkDetailsJSON
  */
 
-/** @typedef {{
-      type: string,
-      scale: number,
-      items: Array<{timing: number, timestamp: number, data: string}>,
-  }} FilmstripDetails
- */

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -19,8 +19,7 @@
 /* globals self, Util, CategoryRenderer */
 
 /** @typedef {import('./dom.js')} DOM */
-/** @typedef {import('./details-renderer.js').FilmstripDetails} FilmstripDetails */
-/** @typedef {LH.Result.Audit.OpportunityDetails} OpportunityDetails */
+/** @typedef {LH.Audit.Details.Opportunity} OpportunityDetails */
 
 class PerformanceCategoryRenderer extends CategoryRenderer {
   /**

--- a/lighthouse-core/test/report/html/renderer/crc-details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/crc-details-renderer-test.js
@@ -23,7 +23,6 @@ const superLongURL =
     'https://example.com/thisIsASuperLongURLThatWillTriggerFilenameTruncationWhichWeWantToTest.js';
 const DETAILS = {
   type: 'criticalrequestchain',
-  header: {type: 'text', text: 'CRC Header'},
   chains: {
     0: {
       request: {

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -1,0 +1,71 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+declare global {
+  module LH.Audit.Details {
+    export interface Filmstrip {
+      type: 'filmstrip';
+      scale: number;
+      items: {
+        timing: number;
+        timestamp: number;
+        data: string;
+      }[];
+    }
+
+    export interface Screenshot {
+      type: 'screenshot';
+      timestamp: number;
+      data: string;
+    }
+
+    export interface Opportunity {
+      type: 'opportunity';
+      overallSavingsMs: number;
+      overallSavingsBytes?: number;
+      headings: TableColumnHeading[];
+      items: OpportunityItem[];
+    }
+
+    export interface CriticalRequestChain {
+      type: 'criticalrequestchain';
+      longestChain: {
+        duration: number;
+        length: number;
+        transferSize: number;
+      };
+      chains: Audit.SimpleCriticalRequestNode;
+    }
+
+    // TODO(bckenny)
+    // export interface MultiCheck {}
+    // export interface Table {}
+    // export interface SomeKindOfHiddenThing
+
+    // Contents of details below here
+
+    export interface TableColumnHeading {
+      /** The name of the property within items being described. */
+      key: string;
+      /** Readable text label of the field. */
+      label: string;
+      // TODO(bckenny): should be just string and let lhr be more specific?
+      valueType: string; // 'url' | 'timespanMs' | 'bytes' | 'thumbnail';
+    }
+    
+    export interface OpportunityItem {
+      url: string;
+      wastedBytes?: number;
+      totalBytes?: number;
+      wastedMs?: number;
+      [p: string]: number | boolean | string | undefined;
+    }
+
+  }
+}
+
+// empty export to keep file a module
+export {}

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -10,8 +10,11 @@ declare global {
       type: 'filmstrip';
       scale: number;
       items: {
+        /** The relative time from navigationStart to this frame, in milliseconds. */
         timing: number;
+        /** The raw timestamp of this frame, in microseconds. */
         timestamp: number;
+        /** The data URL encoding of this frame. */
         data: string;
       }[];
     }
@@ -26,7 +29,7 @@ declare global {
       type: 'opportunity';
       overallSavingsMs: number;
       overallSavingsBytes?: number;
-      headings: TableColumnHeading[];
+      headings: OpportunityColumnHeading[];
       items: OpportunityItem[];
     }
 
@@ -40,20 +43,15 @@ declare global {
       chains: Audit.SimpleCriticalRequestNode;
     }
 
-    // TODO(bckenny)
-    // export interface MultiCheck {}
-    // export interface Table {}
-    // export interface SomeKindOfHiddenThing
-
     // Contents of details below here
 
-    export interface TableColumnHeading {
+    export interface OpportunityColumnHeading {
       /** The name of the property within items being described. */
       key: string;
       /** Readable text label of the field. */
       label: string;
-      // TODO(bckenny): should be just string and let lhr be more specific?
-      valueType: string; // 'url' | 'timespanMs' | 'bytes' | 'thumbnail';
+      /** The data format of the column of values being described. */
+      valueType: string;
     }
     
     export interface OpportunityItem {

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -63,7 +63,7 @@ declare global {
       granularity?: number;
     }
 
-    export interface ByteEfficiencyItem extends Result.Audit.OpportunityDetailsItem {
+    export interface ByteEfficiencyItem extends Audit.Details.OpportunityItem {
       url: string;
       wastedBytes: number;
       totalBytes: number;

--- a/types/lhr-lite.d.ts
+++ b/types/lhr-lite.d.ts
@@ -70,48 +70,9 @@ declare global {
         /** An explanation of audit-related issues encountered on the test page. */
         explanation?: string;
         /** Extra information provided by some types of audits. */
-        details?: Audit.MetricDetails | Audit.OpportunityDetails;
+        details?: never;
         /** Error message from any exception thrown while running this audit. */
         errorMessage?: string;
-      }
-
-      export module Audit {
-        export interface MetricDetails {
-          type: 'metric';
-          /** The value of the metric expressed in milliseconds. */
-          timespanMs?: number;
-        }
-
-        export interface OpportunityDetails {
-          type: 'opportunity';
-          overallSavingsMs: number
-          overallSavingsBytes?: number
-          headings: ColumnHeading[];
-          items: (WastedBytesDetailsItem | WastedTimeDetailsItem)[];
-        }
-
-        export interface ColumnHeading {
-          /** The property key name within DetailsItem being described. */
-          key: string;
-          /** Readable text label of the field. */
-          label: string;
-          // TODO(bckenny): should be just string and let lhr be more specific?
-          valueType: 'url' | 'timespanMs' | 'bytes' | 'thumbnail';
-        }
-
-        export interface WastedBytesDetailsItem {
-          url: string;
-          wastedBytes?: number;
-          totalBytes?: number;
-          [p: string]: number | boolean | string | undefined;
-        }
-
-        export interface WastedTimeDetailsItem {
-          url: string;
-          wastedMs: number;
-          totalBytes?: number;
-          [p: string]: number | boolean | string | undefined;
-        }
       }
     }
   }

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -113,20 +113,6 @@ declare global {
         blockedUrlPatterns: string[];
         extraHeaders: Crdp.Network.Headers;
       }
-
-      export module Audit {
-        export interface OpportunityDetailsItem {
-          url: string;
-          wastedBytes?: number;
-          totalBytes?: number;
-          wastedMs?: number;
-          [p: string]: number | boolean | string | undefined;
-        }
-
-        export interface OpportunityDetails extends ResultLite.Audit.OpportunityDetails {
-          items: OpportunityDetailsItem[];
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
wading through #6999 makes it clear that our `details` type situation is approaching untenable :)

This starts us off, unifying several top-level details types under `LH.Audit.Details`. There are no functional changes, just types, so this is just describing what we're already doing in a slightly different way (hopefully better).

This is the cleanest set of things I could find to do before starting to need code changes, so we'll build from here :)

Happy to bikeshed on names