### PR TITLE
core(networkanalysis): set additional RTT to 0 not NaN

### DIFF
--- a/lighthouse-core/computed/network-analysis.js
+++ b/lighthouse-core/computed/network-analysis.js
@@ -35,9 +35,8 @@ class NetworkAnalysis {
     /** @type {Map<string, number>} */
     const serverResponseTimeByOrigin = new Map();
     for (const [origin, summary] of responseTimeSummaries.entries()) {
-      /** @type {number} */
-      // @ts-ignore - satisfy the type checker that entry exists.
-      const rttForOrigin = rttByOrigin.get(origin);
+      // Not all origins have usable timing data, we'll default to using no additional latency.
+      const rttForOrigin = rttByOrigin.get(origin) || minimumRtt;
       additionalRttByOrigin.set(origin, rttForOrigin - minimumRtt);
       serverResponseTimeByOrigin.set(origin, summary.median);
     }

--- a/lighthouse-core/test/computed/network-analysis-test.js
+++ b/lighthouse-core/test/computed/network-analysis-test.js
@@ -1,0 +1,53 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const NetworkAnalysis = require('../../computed/network-analysis.js');
+
+const acceptableDevToolsLog = require('../fixtures/traces/progressive-app-m60.devtools.log.json');
+
+/* eslint-env jest */
+
+describe('Network analysis computed', () => {
+  it('should return network analysis', async () => {
+    const result = await NetworkAnalysis.request(acceptableDevToolsLog, {computedCache: new Map()});
+
+    expect(Math.round(result.rtt)).toEqual(3);
+    expect(Math.round(result.throughput)).toEqual(1628070);
+    expect(result.additionalRttByOrigin).toMatchInlineSnapshot(`
+Map {
+  "https://pwa.rocks" => 0.3960000176447025,
+  "https://www.googletagmanager.com" => 0,
+  "https://www.google-analytics.com" => 1.0450000117997007,
+  "__SUMMARY__" => 0,
+}
+`);
+    expect(result.serverResponseTimeByOrigin).toMatchInlineSnapshot(`
+Map {
+  "https://pwa.rocks" => 159.42199996789026,
+  "https://www.googletagmanager.com" => 153.03200000198592,
+  "https://www.google-analytics.com" => 159.5549999910874,
+  "__SUMMARY__" => 159.42199996789026,
+}
+`);
+  });
+
+  it('should be robust enough to handle missing data', async () => {
+    const mutatedLog = acceptableDevToolsLog.map(entry => {
+      if (entry.method !== 'Network.responseReceived') return entry;
+      if (!entry.params.response.url.includes('google-analytics')) return entry;
+
+      const clonedEntry = JSON.parse(JSON.stringify(entry));
+      const invalidTimings = {sslStart: -1, sslEnd: -1, connectStart: -1, connectEnd: -1};
+      Object.assign(clonedEntry.params.response.timing, invalidTimings);
+
+      return clonedEntry;
+    });
+
+    const result = await NetworkAnalysis.request(mutatedLog, {computedCache: new Map()});
+    expect(result.additionalRttByOrigin.get('https://www.google-analytics.com')).toEqual(0);
+  });
+});


### PR DESCRIPTION
**Summary**
This has no impact on anything other than the new diagnostic audit. In network analysis there could be partial data missing. Before we would set the value as `NaN` and simulator would fallback to using `0`. Instead of letting the consumer fallback, this just explicit falls back so our `maxRtt` doesn't wind up to be `null` in the diagnostic audit.

**Related Issues/PRs**
#7052 
