### PR TITLE
core(cache-headers): fix typo in must-revalidate

### DIFF
--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -175,7 +175,7 @@ class CacheHeaders extends Audit {
     // Ignore assets where policy implies they should not be cached long periods
     if (cacheControl &&
       (
-        cacheControl['must-validate'] ||
+        cacheControl['must-revalidate'] ||
         cacheControl['no-cache'] ||
         cacheControl['no-store'] ||
         cacheControl['private'])) {

--- a/lighthouse-core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js
@@ -190,7 +190,7 @@ describe('Cache headers audit', () => {
 
   it('ignores assets where policy implies they should not be cached long periods', () => {
     const networkRecords = [
-      networkRecord({headers: {'cache-control': 'must-validate'}}),
+      networkRecord({headers: {'cache-control': 'must-revalidate'}}),
       networkRecord({headers: {'cache-control': 'no-cache'}}),
       networkRecord({headers: {'cache-control': 'private'}}),
     ];

--- a/types/parse-cache-control/index.d.ts
+++ b/types/parse-cache-control/index.d.ts
@@ -8,7 +8,7 @@ declare module 'parse-cache-control' {
   // Follows the potential settings of cache-control, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
   interface CacheHeaders {
     'max-age'?: number;
-    'must-validate'?: boolean;
+    'must-revalidate'?: boolean;
     'no-cache'?: boolean;
     'no-store'?: boolean;
     'private'?: boolean;


### PR DESCRIPTION
**Summary**
Fixes the typo in our cache audit that was looking for `must-validate` instead of `must-revalidate`
