### PR TITLE
core(byte-efficiency): use more optimistic GZIP ratios

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -23,7 +23,7 @@ function generateInlineStyleWithSize(sizeInBytes, firstContent = '', used = fals
       div.classList.add(className);
       document.body.appendChild(div);
     }
-    sizeInBytes -= rule.length / 3; // 1 byte per character, GZip estimate is 3x
+    sizeInBytes -= rule.length * 0.2; // 1 byte per character, GZip estimate is 20% for Stylesheets
   }
 
   const style = document.createElement('style');
@@ -157,11 +157,11 @@ setTimeout(() => {
 // PASS: unused but too small savings
 generateInlineStyleWithSize(512, '.too-small { background: none; }\n');
 // PASS: used
-generateInlineStyleWithSize(4000, '.mostly-used { background: none; }\n', true);
-// PASSWARN: unused and a bit of savings
-generateInlineStyleWithSize(2000, '.kinda-unused { background: none; }\n');
+generateInlineStyleWithSize(5000, '.mostly-used { background: none; }\n', true);
+// FAIL: unused and a bit of savings
+generateInlineStyleWithSize(5000, '.kinda-unused { background: none; }\n');
 // FAIL: unused and lots of savings
-generateInlineStyleWithSize(24000, '.definitely-unused { background: none; }\n');
+generateInlineStyleWithSize(30000, '.definitely-unused { background: none; }\n');
 </script>
 
 <!-- Ensure the page takes at least 7 seconds and we don't exit before the lazily loaded image -->

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -17,7 +17,7 @@ module.exports = [
         details: {
           overallSavingsBytes: '>17000',
           items: {
-            length: 1,
+            length: 2,
           },
         },
       },
@@ -33,7 +33,7 @@ module.exports = [
       },
       'unused-css-rules': {
         details: {
-          overallSavingsBytes: '>39000',
+          overallSavingsBytes: '>35000',
           items: {
             length: 2,
           },

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -80,7 +80,7 @@ class UnusedBytes extends Audit {
           return Math.round(totalBytes * 0.2);
         case 'Script':
         case 'Document':
-          // Scripts and HTMl compress fairly well too.
+          // Scripts and HTML compress fairly well too.
           return Math.round(totalBytes * 0.33);
         default:
           // Otherwise we'll just fallback to the average savings in HTTPArchive

--- a/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/lighthouse-core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -66,15 +66,26 @@ class UnusedBytes extends Audit {
    * @param {LH.Artifacts.NetworkRequest=} networkRecord
    * @param {number} totalBytes Uncompressed size of the resource
    * @param {LH.Crdp.Page.ResourceType=} resourceType
-   * @param {number=} compressionRatio
    * @return {number}
    */
-  static estimateTransferSize(networkRecord, totalBytes, resourceType, compressionRatio = 0.5) {
+  static estimateTransferSize(networkRecord, totalBytes, resourceType) {
     if (!networkRecord) {
       // We don't know how many bytes this asset used on the network, but we can guess it was
       // roughly the size of the content gzipped.
-      // See https://discuss.httparchive.org/t/file-size-and-compression-savings/145 for multipliers
-      return Math.round(totalBytes * compressionRatio);
+      // See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer for specific CSS/Script examples
+      // See https://discuss.httparchive.org/t/file-size-and-compression-savings/145 for fallback multipliers
+      switch (resourceType) {
+        case 'Stylesheet':
+          // Stylesheets tend to compress extremely well.
+          return Math.round(totalBytes * 0.2);
+        case 'Script':
+        case 'Document':
+          // Scripts and HTMl compress fairly well too.
+          return Math.round(totalBytes * 0.33);
+        default:
+          // Otherwise we'll just fallback to the average savings in HTTPArchive
+          return Math.round(totalBytes * 0.5);
+      }
     } else if (networkRecord.resourceType === resourceType) {
       // This was a regular standalone asset, just use the transfer size.
       return networkRecord.transferSize || 0;

--- a/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/byte-efficiency-audit-test.js
@@ -53,9 +53,11 @@ describe('Byte efficiency base audit', () => {
   describe('#estimateTransferSize', () => {
     const estimate = ByteEfficiencyAudit.estimateTransferSize;
 
-    it('should estimate by compression ratio when no network record available', () => {
-      const result = estimate(undefined, 1000, '', 0.345);
-      assert.equal(result, 345);
+    it('should estimate by resource type compression ratio when no network info available', () => {
+      assert.equal(estimate(undefined, 1000, 'Stylesheet'), 200);
+      assert.equal(estimate(undefined, 1000, 'Script'), 330);
+      assert.equal(estimate(undefined, 1000, 'Document'), 330);
+      assert.equal(estimate(undefined, 1000, ''), 500);
     });
 
     it('should return transferSize when asset matches', () => {

--- a/lighthouse-core/test/audits/byte-efficiency/unused-css-rules-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/unused-css-rules-test.js
@@ -166,8 +166,8 @@ describe('Best Practices: unused css rules audit', () => {
     it('fails when lots of rules are unused', () => {
       return UnusedCSSAudit.audit_(getArtifacts({
         CSSUsage: {rules: [
-          {styleSheetId: 'a', used: true, startOffset: 0, endOffset: 11}, // 44 * 1 / 4
-          {styleSheetId: 'b', used: true, startOffset: 0, endOffset: 6000}, // 4000 * 3 / 2
+          {styleSheetId: 'a', used: true, startOffset: 0, endOffset: 11}, // 44 * 25% = 11
+          {styleSheetId: 'b', used: true, startOffset: 0, endOffset: 60000}, // 40000 * 3 * 50% = 60000
         ], stylesheets: [
           {
             header: {styleSheetId: 'a', sourceURL: 'file://a.css'},
@@ -175,7 +175,7 @@ describe('Best Practices: unused css rules audit', () => {
           },
           {
             header: {styleSheetId: 'b', sourceURL: 'file://b.css'},
-            content: `${generate('123', 4000)}`,
+            content: `${generate('123', 40000)}`,
           },
           {
             header: {styleSheetId: 'c', sourceURL: ''},
@@ -185,7 +185,7 @@ describe('Best Practices: unused css rules audit', () => {
       }), networkRecords).then(result => {
         assert.equal(result.items.length, 2);
         assert.equal(result.items[0].totalBytes, 10 * 1024);
-        assert.equal(result.items[1].totalBytes, 6000);
+        assert.equal(result.items[1].totalBytes, 40000 * 3 * 0.2);
         assert.equal(result.items[0].wastedPercent, 75);
         assert.equal(result.items[1].wastedPercent, 50);
       });


### PR DESCRIPTION
**Summary**
Our assumed compression ratio for GZIP was pretty far off for CSS. This updates our compression ratios to be more realistic.

**Related Issues/PRs**
closes #7180 
