### PR TITLE
core(viewport): create ViewportMeta computed artifact

### DIFF
--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -218,7 +218,7 @@ class FontSize extends Audit {
    */
   static async audit(artifacts, context) {
     const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
-    if (!viewportMeta.hasMobileViewport) {
+    if (!viewportMeta.isMobileOptimized) {
       return {
         rawValue: false,
         explanation: str_(UIStrings.explanationViewport),

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -10,7 +10,7 @@
 const URL = require('../../lib/url-shim');
 const i18n = require('../../lib/i18n/i18n.js');
 const Audit = require('../audit');
-const ComputedViewportMeta = require('../../computed/viewport-meta');
+const ComputedViewportMeta = require('../../computed/viewport-meta.js');
 const MINIMAL_PERCENTAGE_OF_LEGIBLE_TEXT = 60;
 
 const UIStrings = {

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -10,7 +10,7 @@
 const URL = require('../../lib/url-shim');
 const i18n = require('../../lib/i18n/i18n.js');
 const Audit = require('../audit');
-const ViewportAudit = require('../viewport');
+const ComputedViewportMeta = require('../../computed/viewport-meta');
 const MINIMAL_PERCENTAGE_OF_LEGIBLE_TEXT = 60;
 
 const UIStrings = {
@@ -213,11 +213,12 @@ class FontSize extends Audit {
 
   /**
    * @param {LH.Artifacts} artifacts
-   * @return {LH.Audit.Product}
+   * @param {LH.Audit.Context} context
+   * @return {Promise<LH.Audit.Product>}
    */
-  static audit(artifacts) {
-    const hasViewportSet = ViewportAudit.audit(artifacts).rawValue;
-    if (!hasViewportSet) {
+  static async audit(artifacts, context) {
+    const viewportMeta = await ComputedViewportMeta.request(artifacts, context)
+    if (!viewportMeta.hasMobileViewport) {
       return {
         rawValue: false,
         explanation: str_(UIStrings.explanationViewport),

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -217,7 +217,7 @@ class FontSize extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit(artifacts, context) {
-    const viewportMeta = await ComputedViewportMeta.request(artifacts, context)
+    const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
     if (!viewportMeta.hasMobileViewport) {
       return {
         rawValue: false,

--- a/lighthouse-core/audits/seo/tap-targets.js
+++ b/lighthouse-core/audits/seo/tap-targets.js
@@ -275,7 +275,7 @@ class TapTargets extends Audit {
    */
   static async audit(artifacts, context) {
     const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
-    if (!viewportMeta.hasMobileViewport) {
+    if (!viewportMeta.isMobileOptimized) {
       return {
         rawValue: false,
         explanation: str_(UIStrings.explanationViewportMetaNotOptimized),

--- a/lighthouse-core/audits/seo/tap-targets.js
+++ b/lighthouse-core/audits/seo/tap-targets.js
@@ -10,7 +10,7 @@
  * no other tap target that's too close so that the user might accidentally tap on.
  */
 const Audit = require('../audit');
-const ViewportAudit = require('../viewport');
+const ComputedViewportMeta = require('../../computed/viewport-meta');
 const {
   rectsTouchOrOverlap,
   getRectOverlapArea,
@@ -270,11 +270,12 @@ class TapTargets extends Audit {
 
   /**
    * @param {LH.Artifacts} artifacts
-   * @return {LH.Audit.Product}
+   * @param {LH.Audit.Context} context
+   * @return {Promise<LH.Audit.Product>}
    */
-  static audit(artifacts) {
-    const hasViewportSet = ViewportAudit.audit(artifacts).rawValue;
-    if (!hasViewportSet) {
+  static async audit(artifacts, context) {
+    const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
+    if (!viewportMeta.hasMobileViewport) {
       return {
         rawValue: false,
         explanation: str_(UIStrings.explanationViewportMetaNotOptimized),

--- a/lighthouse-core/audits/seo/tap-targets.js
+++ b/lighthouse-core/audits/seo/tap-targets.js
@@ -10,7 +10,7 @@
  * no other tap target that's too close so that the user might accidentally tap on.
  */
 const Audit = require('../audit');
-const ComputedViewportMeta = require('../../computed/viewport-meta');
+const ComputedViewportMeta = require('../../computed/viewport-meta.js');
 const {
   rectsTouchOrOverlap,
   getRectOverlapArea,

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -41,7 +41,7 @@ class Viewport extends Audit {
     }
 
     return {
-      rawValue: !!viewportMeta.hasMobileViewport,
+      rawValue: viewportMeta.hasMobileViewport,
       warnings: viewportMeta.parserWarnings,
     };
   }

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -8,7 +8,6 @@
 const Audit = require('./audit');
 const ComputedViewportMeta = require('../computed/viewport-meta.js');
 
-
 class Viewport extends Audit {
   /**
    * @return {LH.Audit.Meta}

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -6,7 +6,8 @@
 'use strict';
 
 const Audit = require('./audit');
-const Parser = require('metaviewport-parser');
+const ComputedViewportMeta = require('../computed/viewport-meta.js');
+
 
 class Viewport extends Audit {
   /**
@@ -26,33 +27,22 @@ class Viewport extends Audit {
 
   /**
    * @param {LH.Artifacts} artifacts
-   * @return {LH.Audit.Product}
+   * @param {LH.Audit.Context} context
+   * @return {Promise<LH.Audit.Product>}
    */
-  static audit(artifacts) {
-    const viewportMeta = artifacts.MetaElements.find(meta => meta.name === 'viewport');
-    if (!viewportMeta) {
+  static async audit(artifacts, context) {
+    const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
+
+    if (!viewportMeta.hasViewportTag) {
       return {
-        explanation: 'No viewport meta tag found',
         rawValue: false,
+        explanation: 'No viewport meta tag found',
       };
     }
 
-    const warnings = [];
-    const parsedProps = Parser.parseMetaViewPortContent(viewportMeta.content || '');
-
-    if (Object.keys(parsedProps.unknownProperties).length) {
-      warnings.push(`Invalid properties found: ${JSON.stringify(parsedProps.unknownProperties)}`);
-    }
-    if (Object.keys(parsedProps.invalidValues).length) {
-      warnings.push(`Invalid values found: ${JSON.stringify(parsedProps.invalidValues)}`);
-    }
-
-    const viewportProps = parsedProps.validProperties;
-    const hasMobileViewport = viewportProps.width || viewportProps['initial-scale'];
-
     return {
-      rawValue: !!hasMobileViewport,
-      warnings,
+      rawValue: !!viewportMeta.hasMobileViewport,
+      warnings: viewportMeta.parserWarnings,
     };
   }
 }

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -41,7 +41,7 @@ class Viewport extends Audit {
     }
 
     return {
-      rawValue: viewportMeta.hasMobileViewport,
+      rawValue: viewportMeta.isMobileOptimized,
       warnings: viewportMeta.parserWarnings,
     };
   }

--- a/lighthouse-core/computed/viewport-meta.js
+++ b/lighthouse-core/computed/viewport-meta.js
@@ -21,7 +21,7 @@ class ViewportMeta {
     if (!viewportMeta) {
       return {
         hasViewportTag: false,
-        hasMobileViewport: false,
+        isMobileOptimized: false,
         parserWarnings: [],
       };
     }
@@ -37,10 +37,10 @@ class ViewportMeta {
     }
 
     const viewportProps = parsedProps.validProperties;
-    const hasMobileViewport = Boolean(viewportProps.width || viewportProps['initial-scale']);
+    const isMobileOptimized = Boolean(viewportProps.width || viewportProps['initial-scale']);
 
     return {
-      hasMobileViewport,
+      isMobileOptimized,
       hasViewportTag: true,
       parserWarnings: warnings,
     };

--- a/lighthouse-core/computed/viewport-meta.js
+++ b/lighthouse-core/computed/viewport-meta.js
@@ -1,0 +1,50 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Parser = require('metaviewport-parser');
+
+const makeComputedArtifact = require('./computed-artifact.js');
+
+class ViewportMeta {
+  /**
+   * @param {{MetaElements: LH.GathererArtifacts['MetaElements']}} artifacts
+   * @return {Promise<LH.Artifacts.ViewportMeta>}
+  */
+
+  static async compute_({MetaElements}) {
+    const viewportMeta = MetaElements.find(meta => meta.name === 'viewport');
+
+    if (!viewportMeta) {
+      return {
+        hasViewportTag: false,
+        hasMobileViewport: false,
+        parserWarnings: [],
+      };
+    }
+
+    const warnings = [];
+    const parsedProps = Parser.parseMetaViewPortContent(viewportMeta.content || '');
+
+    if (Object.keys(parsedProps.unknownProperties).length) {
+      warnings.push(`Invalid properties found: ${JSON.stringify(parsedProps.unknownProperties)}`);
+    }
+    if (Object.keys(parsedProps.invalidValues).length) {
+      warnings.push(`Invalid values found: ${JSON.stringify(parsedProps.invalidValues)}`);
+    }
+
+    const viewportProps = parsedProps.validProperties;
+    const hasMobileViewport = Boolean(viewportProps.width || viewportProps['initial-scale']);
+
+    return {
+      hasMobileViewport,
+      hasViewportTag: true,
+      parserWarnings: warnings,
+    };
+  }
+}
+
+module.exports = makeComputedArtifact(ViewportMeta);

--- a/lighthouse-core/computed/viewport-meta.js
+++ b/lighthouse-core/computed/viewport-meta.js
@@ -12,9 +12,8 @@ const makeComputedArtifact = require('./computed-artifact.js');
 class ViewportMeta {
   /**
    * @param {{MetaElements: LH.GathererArtifacts['MetaElements']}} artifacts
-   * @return {Promise<LH.Artifacts.ViewportMeta>}
+   * @return {Promise<ViewportMetaResult>}
   */
-
   static async compute_({MetaElements}) {
     const viewportMeta = MetaElements.find(meta => meta.name === 'viewport');
 
@@ -40,11 +39,18 @@ class ViewportMeta {
     const isMobileOptimized = Boolean(viewportProps.width || viewportProps['initial-scale']);
 
     return {
-      isMobileOptimized,
       hasViewportTag: true,
+      isMobileOptimized,
       parserWarnings: warnings,
     };
   }
 }
 
 module.exports = makeComputedArtifact(ViewportMeta);
+
+/**
+ * @typedef {object} ViewportMetaResult
+ * @property {boolean} hasViewportTag Whether the page has any viewport tag.
+ * @property {boolean} isMobileOptimized Whether the viewport tag is optimized for mobile screens.
+ * @property {Array<string>} parserWarnings Warnings if the parser encountered invalid content in the viewport tag.
+ */

--- a/lighthouse-core/test/audits/seo/font-size-test.js
+++ b/lighthouse-core/test/audits/seo/font-size-test.js
@@ -15,7 +15,7 @@ const validViewport = 'width=device-width';
 
 describe('SEO: Font size audit', () => {
   const makeMetaElements = viewport => [{name: 'viewport', content: viewport}];
-  const fakeContext = {computedCache: new Map()};
+  const getFakeContext = () => ({computedCache: new Map()});
 
   it('fails when viewport is not set', async () => {
     const artifacts = {
@@ -24,7 +24,7 @@ describe('SEO: Font size audit', () => {
       FontSize: [],
     };
 
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     assert.equal(auditResult.rawValue, false);
     expect(auditResult.explanation)
       .toBeDisplayString('Text is illegible because there\'s ' +
@@ -47,7 +47,7 @@ describe('SEO: Font size audit', () => {
       },
     };
 
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     assert.equal(auditResult.rawValue, false);
     expect(auditResult.explanation).toBeDisplayString('41% of text is too small.');
     expect(auditResult.displayValue).toBeDisplayString('59% legible text');
@@ -68,7 +68,7 @@ describe('SEO: Font size audit', () => {
       },
     };
 
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     assert.equal(auditResult.rawValue, true);
   });
 
@@ -87,7 +87,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     assert.equal(auditResult.rawValue, true);
     expect(auditResult.displayValue).toBeDisplayString('90% legible text');
   });
@@ -124,7 +124,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
 
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.details.items.length, 2);
@@ -146,7 +146,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.details.items.length, 3);
     assert.equal(auditResult.details.items[1].source, 'Add\'l illegible text');
@@ -168,7 +168,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     assert.equal(auditResult.rawValue, false);
     expect(auditResult.explanation)
       .toBeDisplayString('100% of text is too small (based on 50% sample).');
@@ -190,7 +190,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     expect(auditResult.displayValue).toBeDisplayString('89.78% legible text');
   });
 
@@ -209,7 +209,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
+    const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
     expect(auditResult.displayValue).toBeDisplayString('2.48% legible text');
   });
 });

--- a/lighthouse-core/test/audits/seo/font-size-test.js
+++ b/lighthouse-core/test/audits/seo/font-size-test.js
@@ -15,22 +15,23 @@ const validViewport = 'width=device-width';
 
 describe('SEO: Font size audit', () => {
   const makeMetaElements = viewport => [{name: 'viewport', content: viewport}];
+  const fakeContext = {computedCache: new Map()};
 
-  it('fails when viewport is not set', () => {
+  it('fails when viewport is not set', async () => {
     const artifacts = {
       URL,
       MetaElements: [],
       FontSize: [],
     };
 
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
     assert.equal(auditResult.rawValue, false);
     expect(auditResult.explanation)
       .toBeDisplayString('Text is illegible because there\'s ' +
         'no viewport meta tag optimized for mobile screens.');
   });
 
-  it('fails when less than 60% of text is legible', () => {
+  it('fails when less than 60% of text is legible', async () => {
     const artifacts = {
       URL,
       MetaElements: makeMetaElements(validViewport),
@@ -46,13 +47,13 @@ describe('SEO: Font size audit', () => {
       },
     };
 
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
     assert.equal(auditResult.rawValue, false);
     expect(auditResult.explanation).toBeDisplayString('41% of text is too small.');
     expect(auditResult.displayValue).toBeDisplayString('59% legible text');
   });
 
-  it('passes when there is no text', () => {
+  it('passes when there is no text', async () => {
     const artifacts = {
       URL,
       MetaElements: makeMetaElements(validViewport),
@@ -67,11 +68,11 @@ describe('SEO: Font size audit', () => {
       },
     };
 
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
     assert.equal(auditResult.rawValue, true);
   });
 
-  it('passes when more than 60% of text is legible', () => {
+  it('passes when more than 60% of text is legible', async () => {
     const artifacts = {
       URL,
       MetaElements: makeMetaElements(validViewport),
@@ -86,12 +87,12 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
     assert.equal(auditResult.rawValue, true);
     expect(auditResult.displayValue).toBeDisplayString('90% legible text');
   });
 
-  it('groups entries with same source, sorts them by coverage', () => {
+  it('groups entries with same source, sorts them by coverage', async () => {
     const style1 = {
       styleSheetId: 1,
       type: 'Regular',
@@ -123,7 +124,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
 
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.details.items.length, 2);
@@ -131,7 +132,7 @@ describe('SEO: Font size audit', () => {
     expect(auditResult.displayValue).toBeDisplayString('0% legible text');
   });
 
-  it('adds a category for failing text that wasn\'t analyzed', () => {
+  it('adds a category for failing text that wasn\'t analyzed', async () => {
     const artifacts = {
       URL,
       MetaElements: makeMetaElements(validViewport),
@@ -145,7 +146,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
     assert.equal(auditResult.rawValue, false);
     assert.equal(auditResult.details.items.length, 3);
     assert.equal(auditResult.details.items[1].source, 'Add\'l illegible text');
@@ -153,7 +154,7 @@ describe('SEO: Font size audit', () => {
     expect(auditResult.displayValue).toBeDisplayString('50% legible text');
   });
 
-  it('informs user if audit haven\'t covered all text on the page', () => {
+  it('informs user if audit haven\'t covered all text on the page', async () => {
     const artifacts = {
       URL,
       MetaElements: makeMetaElements(validViewport),
@@ -167,14 +168,14 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
     assert.equal(auditResult.rawValue, false);
     expect(auditResult.explanation)
       .toBeDisplayString('100% of text is too small (based on 50% sample).');
     expect(auditResult.displayValue).toBeDisplayString('0% legible text');
   });
 
-  it('maintains 2 trailing decimal places', () => {
+  it('maintains 2 trailing decimal places', async () => {
     const artifacts = {
       URL,
       MetaElements: makeMetaElements(validViewport),
@@ -189,11 +190,11 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
     expect(auditResult.displayValue).toBeDisplayString('89.78% legible text');
   });
 
-  it('maintains 2 trailing decimal places with only 1 leading digit', () => {
+  it('maintains 2 trailing decimal places with only 1 leading digit', async () => {
     const artifacts = {
       URL,
       MetaElements: makeMetaElements(validViewport),
@@ -208,7 +209,7 @@ describe('SEO: Font size audit', () => {
         ],
       },
     };
-    const auditResult = FontSizeAudit.audit(artifacts);
+    const auditResult = await FontSizeAudit.audit(artifacts, fakeContext);
     expect(auditResult.displayValue).toBeDisplayString('2.48% legible text');
   });
 });

--- a/lighthouse-core/test/audits/seo/tap-targets-test.js
+++ b/lighthouse-core/test/audits/seo/tap-targets-test.js
@@ -12,7 +12,7 @@ const assert = require('assert');
 
 const fakeContext = {computedCache: new Map()};
 
-async function auditTapTargets(tapTargets, metaElements = [{
+function auditTapTargets(tapTargets, metaElements = [{
   name: 'viewport',
   content: 'width=device-width',
 }]) {

--- a/lighthouse-core/test/audits/seo/tap-targets-test.js
+++ b/lighthouse-core/test/audits/seo/tap-targets-test.js
@@ -10,7 +10,9 @@
 const TapTargetsAudit = require('../../../audits/seo/tap-targets.js');
 const assert = require('assert');
 
-function auditTapTargets(tapTargets, metaElements = [{
+const fakeContext = {computedCache: new Map()};
+
+async function auditTapTargets(tapTargets, metaElements = [{
   name: 'viewport',
   content: 'width=device-width',
 }]) {
@@ -19,7 +21,7 @@ function auditTapTargets(tapTargets, metaElements = [{
     MetaElements: metaElements,
   };
 
-  return TapTargetsAudit.audit(artifacts);
+  return TapTargetsAudit.audit(artifacts, fakeContext);
 }
 
 const tapTargetSize = 10;
@@ -113,27 +115,27 @@ function getBorderlineTapTargets(options = {}) {
 }
 
 describe('SEO: Tap targets audit', () => {
-  it('passes when there are no tap targets', () => {
-    const auditResult = auditTapTargets([]);
+  it('passes when there are no tap targets', async () => {
+    const auditResult = await auditTapTargets([]);
     assert.equal(auditResult.rawValue, true);
     expect(auditResult.displayValue).toBeDisplayString('100% appropriately sized tap targets');
     assert.equal(auditResult.score, 1);
   });
 
-  it('passes when tap targets don\'t overlap', () => {
-    const auditResult = auditTapTargets(getBorderlineTapTargets());
+  it('passes when tap targets don\'t overlap', async () => {
+    const auditResult = await auditTapTargets(getBorderlineTapTargets());
     assert.equal(auditResult.rawValue, true);
   });
 
-  it('passes when a target is fully contained in an overlapping target', () => {
-    const auditResult = auditTapTargets(getBorderlineTapTargets({
+  it('passes when a target is fully contained in an overlapping target', async () => {
+    const auditResult = await auditTapTargets(getBorderlineTapTargets({
       addFullyContainedTapTarget: true,
     }));
     assert.equal(auditResult.rawValue, true);
   });
 
-  it('fails if two tap targets overlaps each other horizontally', () => {
-    const auditResult = auditTapTargets(
+  it('fails if two tap targets overlaps each other horizontally', async () => {
+    const auditResult = await auditTapTargets(
       getBorderlineTapTargets({
         overlapRight: true,
       })
@@ -152,8 +154,8 @@ describe('SEO: Tap targets audit', () => {
     assert.equal(failure.height, 10);
   });
 
-  it('fails if a tap target overlaps vertically', () => {
-    const auditResult = auditTapTargets(
+  it('fails if a tap target overlaps vertically', async () => {
+    const auditResult = await auditTapTargets(
       getBorderlineTapTargets({
         overlapBelow: true,
       })
@@ -161,8 +163,8 @@ describe('SEO: Tap targets audit', () => {
     assert.equal(auditResult.rawValue, false);
   });
 
-  it('fails when one of the client rects overlaps', () => {
-    const auditResult = auditTapTargets(
+  it('fails when one of the client rects overlaps', async () => {
+    const auditResult = await auditTapTargets(
       getBorderlineTapTargets({
         overlapSecondClientRect: true,
       })
@@ -170,25 +172,26 @@ describe('SEO: Tap targets audit', () => {
     assert.equal(auditResult.rawValue, false);
   });
 
-  it('reports 2 items if the main target is overlapped both vertically and horizontally', () => {
+  it('reports 2 items if the main target is overlapped both vertically and horizontally',
+    async () => {
     // Main is overlapped by right + below, right and below are each overlapped by main
-    const auditResult = auditTapTargets(
+      const auditResult = await auditTapTargets(
       getBorderlineTapTargets({
         overlapRight: true,
         reduceRightWidth: true,
         overlapBelow: true,
       })
-    );
-    assert.equal(Math.round(auditResult.score * 100), 0); // all tap targets are overlapped by something
-    const failures = auditResult.details.items;
-    assert.equal(failures.length, 2);
-    // Right and Main overlap each other, but Right has a worse score because it's smaller
-    // so it's the failure that appears in the report
-    assert.equal(failures[0].tapTarget.snippet, '<right></right>');
-  });
+      );
+      assert.equal(Math.round(auditResult.score * 100), 0); // all tap targets are overlapped by something
+      const failures = auditResult.details.items;
+      assert.equal(failures.length, 2);
+      // Right and Main overlap each other, but Right has a worse score because it's smaller
+      // so it's the failure that appears in the report
+      assert.equal(failures[0].tapTarget.snippet, '<right></right>');
+    });
 
-  it('reports 1 failure if only one tap target involved in an overlap fails', () => {
-    const auditResult = auditTapTargets(
+  it('reports 1 failure if only one tap target involved in an overlap fails', async () => {
+    const auditResult = await auditTapTargets(
       getBorderlineTapTargets({
         overlapRight: true,
         increaseRightWidth: true,
@@ -200,8 +203,8 @@ describe('SEO: Tap targets audit', () => {
     assert.equal(failures[0].tapTarget.snippet, '<main></main>');
   });
 
-  it('fails if no meta viewport tag is provided', () => {
-    const auditResult = auditTapTargets([], []);
+  it('fails if no meta viewport tag is provided', async () => {
+    const auditResult = await auditTapTargets([], []);
     assert.equal(auditResult.rawValue, false);
 
     expect(auditResult.explanation).toBeDisplayString(

--- a/lighthouse-core/test/audits/seo/tap-targets-test.js
+++ b/lighthouse-core/test/audits/seo/tap-targets-test.js
@@ -172,23 +172,22 @@ describe('SEO: Tap targets audit', () => {
     assert.equal(auditResult.rawValue, false);
   });
 
-  it('reports 2 items if the main target is overlapped both vertically and horizontally',
-    async () => {
+  it('reports 2 items if a target overlapped both vertically and horizontally', async () => {
     // Main is overlapped by right + below, right and below are each overlapped by main
-      const auditResult = await auditTapTargets(
+    const auditResult = await auditTapTargets(
       getBorderlineTapTargets({
         overlapRight: true,
         reduceRightWidth: true,
         overlapBelow: true,
       })
-      );
-      assert.equal(Math.round(auditResult.score * 100), 0); // all tap targets are overlapped by something
-      const failures = auditResult.details.items;
-      assert.equal(failures.length, 2);
-      // Right and Main overlap each other, but Right has a worse score because it's smaller
-      // so it's the failure that appears in the report
-      assert.equal(failures[0].tapTarget.snippet, '<right></right>');
-    });
+    );
+    assert.equal(Math.round(auditResult.score * 100), 0); // all tap targets are overlapped by something
+    const failures = auditResult.details.items;
+    assert.equal(failures.length, 2);
+    // Right and Main overlap each other, but Right has a worse score because it's smaller
+    // so it's the failure that appears in the report
+    assert.equal(failures[0].tapTarget.snippet, '<right></right>');
+  });
 
   it('reports 1 failure if only one tap target involved in an overlap fails', async () => {
     const auditResult = await auditTapTargets(

--- a/lighthouse-core/test/audits/seo/tap-targets-test.js
+++ b/lighthouse-core/test/audits/seo/tap-targets-test.js
@@ -10,7 +10,7 @@
 const TapTargetsAudit = require('../../../audits/seo/tap-targets.js');
 const assert = require('assert');
 
-const fakeContext = {computedCache: new Map()};
+const getFakeContext = () => ({computedCache: new Map()});
 
 function auditTapTargets(tapTargets, metaElements = [{
   name: 'viewport',
@@ -21,7 +21,7 @@ function auditTapTargets(tapTargets, metaElements = [{
     MetaElements: metaElements,
   };
 
-  return TapTargetsAudit.audit(artifacts, fakeContext);
+  return TapTargetsAudit.audit(artifacts, getFakeContext());
 }
 
 const tapTargetSize = 10;

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -18,7 +18,8 @@ describe('Mobile-friendly: viewport audit', () => {
     const auditResult = await Audit.audit({
       MetaElements: [],
     }, fakeContext);
-    return assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.explanation, 'No viewport meta tag found');
   });
 
   it('fails when HTML contains a non-mobile friendly viewport meta tag', async () => {
@@ -28,53 +29,11 @@ describe('Mobile-friendly: viewport audit', () => {
     assert.equal(auditResult.warnings[0], undefined);
   });
 
-  it('fails when HTML contains an invalid viewport meta tag key', async () => {
-    const viewport = 'nonsense=true';
-    const auditResult = await Audit.audit({MetaElements: makeMetaElements(viewport)}, fakeContext);
-    assert.equal(auditResult.rawValue, false);
-    assert.equal(auditResult.warnings[0], 'Invalid properties found: {"nonsense":"true"}');
-  });
-
-  it('fails when HTML contains an invalid viewport meta tag value', async () => {
-    const viewport = 'initial-scale=microscopic';
-    const auditResult = await Audit.audit({MetaElements: makeMetaElements(viewport)}, fakeContext);
-    assert.equal(auditResult.rawValue, false);
-    assert.equal(auditResult.warnings[0], 'Invalid values found: {"initial-scale":"microscopic"}');
-  });
-
-  it('fails when HTML contains an invalid viewport meta tag key and value', async () => {
-    const viewport = 'nonsense=true, initial-scale=microscopic';
-    const {rawValue, warnings} =
-      await Audit.audit({MetaElements: makeMetaElements(viewport)}, fakeContext);
-    assert.equal(rawValue, false);
-    assert.equal(warnings[0], 'Invalid properties found: {"nonsense":"true"}');
-    assert.equal(warnings[1], 'Invalid values found: {"initial-scale":"microscopic"}');
-  });
-
   it('passes when a valid viewport is provided', async () => {
-    const viewports = [
-      'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1',
-      'width = device-width, initial-scale = 1',
-      'initial-scale=1',
-      'width=device-width     ',
-    ];
-    await Promise.all(viewports.map(async viewport => {
-      const auditResult = await Audit.audit({
-        MetaElements: makeMetaElements(viewport),
-      }, fakeContext);
-      assert.equal(auditResult.rawValue, true);
-    }));
-  });
-
-  it('doesn\'t throw when viewport contains "invalid" iOS properties', async () => {
-    const viewports = [
-      'width=device-width, shrink-to-fit=no',
-      'width=device-width, viewport-fit=cover',
-    ];
-    await Promise.all(viewports.map(async viewport => {
-      const result = await Audit.audit({MetaElements: makeMetaElements(viewport)}, fakeContext);
-      assert.equal(result.rawValue, true);
-      assert.equal(result.warnings[0], undefined);
-    }));
+    const viewport = 'initial-scale=1';
+    const auditResult = await Audit.audit({
+      MetaElements: makeMetaElements(viewport),
+    }, fakeContext);
+    assert.equal(auditResult.rawValue, true);
   });
 });

--- a/lighthouse-core/test/computed/viewport-meta-test.js
+++ b/lighthouse-core/test/computed/viewport-meta-test.js
@@ -1,0 +1,85 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-env jest */
+
+const assert = require('assert');
+const ViewportMeta = require('../../computed/viewport-meta');
+
+describe('ViewportMeta computed artifact', () => {
+  const makeMetaElements = viewport => [{name: 'viewport', content: viewport}];
+
+  it('is not mobile optimized when page does not contain a viewport meta tag', async () => {
+    const {hasViewportTag, isMobileOptimized} = await ViewportMeta.compute_({MetaElements: []});
+    assert.equal(hasViewportTag, false);
+    assert.equal(isMobileOptimized, false);
+  });
+
+  /* eslint-disable-next-line max-len */
+  it('is not mobile optimized when HTML contains a non-mobile friendly viewport meta tag', async () => {
+    const viewport = 'maximum-scale=1';
+    const {hasViewportTag, isMobileOptimized} =
+      await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+    assert.equal(hasViewportTag, true);
+    assert.equal(isMobileOptimized, false);
+  });
+
+  it('is not mobile optimized when HTML contains an invalid viewport meta tag key', async () => {
+    const viewport = 'nonsense=true';
+    const {hasViewportTag, isMobileOptimized} =
+      await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+    assert.equal(hasViewportTag, true);
+    assert.equal(isMobileOptimized, false);
+  });
+
+  it('is not mobile optimized when HTML contains an invalid viewport meta tag value', async () => {
+    const viewport = 'initial-scale=microscopic';
+    const {isMobileOptimized, parserWarnings} =
+      await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+    assert.equal(isMobileOptimized, false);
+    assert.equal(parserWarnings[0], 'Invalid values found: {"initial-scale":"microscopic"}');
+  });
+
+  /* eslint-disable-next-line max-len */
+  it('is not mobile optimized when HTML contains an invalid viewport meta tag key and value', async () => {
+    const viewport = 'nonsense=true, initial-scale=microscopic';
+    const {isMobileOptimized, parserWarnings} =
+      await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+    assert.equal(isMobileOptimized, false);
+    assert.equal(parserWarnings[0], 'Invalid properties found: {"nonsense":"true"}');
+    assert.equal(parserWarnings[1], 'Invalid values found: {"initial-scale":"microscopic"}');
+  });
+
+  it('is mobile optimized when a valid viewport is provided', async () => {
+    const viewports = [
+      'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1',
+      'width = device-width, initial-scale = 1',
+      'initial-scale=1',
+      'width=device-width     ',
+    ];
+
+    await Promise.all(viewports.map(async viewport => {
+      const {isMobileOptimized} =
+        await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+      assert.equal(isMobileOptimized, true);
+    }));
+  });
+
+  it('doesn\'t throw when viewport contains "invalid" iOS properties', async () => {
+    const viewports = [
+      'width=device-width, shrink-to-fit=no',
+      'width=device-width, viewport-fit=cover',
+    ];
+    await Promise.all(viewports.map(async viewport => {
+      const {isMobileOptimized, parserWarnings} =
+        await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+      assert.equal(isMobileOptimized, true);
+      assert.equal(parserWarnings[0], undefined);
+    }));
+  });
+});
+

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3944,6 +3944,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:computed:ViewportMeta",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:without-javascript",
         "duration": 100,
         "entryType": "measure"

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -3800,6 +3800,12 @@
             {
                 "duration": 100.0, 
                 "entryType": "measure", 
+                "name": "lh:computed:ViewportMeta", 
+                "startTime": 0.0
+            }, 
+            {
+                "duration": 100.0, 
+                "entryType": "measure", 
                 "name": "lh:audit:without-javascript", 
                 "startTime": 0.0
             }, 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -348,6 +348,15 @@ declare global {
         }[];
       }
 
+      export type ViewportMeta = {
+        /** Whether the page has any viewport tag  */
+        hasViewportTag: boolean;
+        /** Whether the viewport tag is optimized for mobile screens */
+        hasMobileViewport: boolean;
+        /** Warnings if the parser encountered invalid content in the viewport tag */
+        parserWarnings: string[];
+      }
+
       export interface MeasureEntry extends PerformanceEntry {
         /** Whether timing entry was collected during artifact gathering. */
         gather?: boolean;

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -348,15 +348,6 @@ declare global {
         }[];
       }
 
-      export type ViewportMeta = {
-        /** Whether the page has any viewport tag  */
-        hasViewportTag: boolean;
-        /** Whether the viewport tag is optimized for mobile screens */
-        isMobileOptimized: boolean;
-        /** Warnings if the parser encountered invalid content in the viewport tag */
-        parserWarnings: string[];
-      }
-
       export interface MeasureEntry extends PerformanceEntry {
         /** Whether timing entry was collected during artifact gathering. */
         gather?: boolean;

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -352,7 +352,7 @@ declare global {
         /** Whether the page has any viewport tag  */
         hasViewportTag: boolean;
         /** Whether the viewport tag is optimized for mobile screens */
-        hasMobileViewport: boolean;
+        isMobileOptimized: boolean;
         /** Warnings if the parser encountered invalid content in the viewport tag */
         parserWarnings: string[];
       }


### PR DESCRIPTION
**Summary**

Get the viewport info from a ViewportMeta computed artifact, instead of the font size and tap target audits calling the viewport audit.

Involves making the three audits involved async because computed artifacts are async.

@brendankenny also mentioned including a `notApplicable` property in the artifact result, for when Lighthouse is run in desktop mode. I've not done that for now, but will consider it when [adding the `isMobile` artifact](https://github.com/GoogleChrome/lighthouse/issues/7043) or [adding `notApplicable` logic to tap targets](https://github.com/GoogleChrome/lighthouse/issues/6687).

**Related Issues/PRs**

Closes https://github.com/GoogleChrome/lighthouse/issues/7084
