### PR TITLE
core(base-artifacts): add FormFactorIsMobile base artifact

### DIFF
--- a/lighthouse-core/audits/content-width.js
+++ b/lighthouse-core/audits/content-width.js
@@ -19,26 +19,21 @@ class ContentWidth extends Audit {
       description: 'If the width of your app\'s content doesn\'t match the width ' +
           'of the viewport, your app might not be optimized for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport).',
-      requiredArtifacts: ['ViewportDimensions', 'HostUserAgent'],
+      requiredArtifacts: ['ViewportDimensions', 'IsMobile'],
     };
   }
 
   /**
    * @param {LH.Artifacts} artifacts
-   * @param {LH.Audit.Context} context
    * @return {LH.Audit.Product}
    */
-  static audit(artifacts, context) {
-    const userAgent = artifacts.HostUserAgent;
+  static audit(artifacts) {
+    const IsMobile = artifacts.IsMobile;
     const viewportWidth = artifacts.ViewportDimensions.innerWidth;
     const windowWidth = artifacts.ViewportDimensions.outerWidth;
     const widthsMatch = viewportWidth === windowWidth;
 
-    const isMobileHost = userAgent.includes('Android') || userAgent.includes('Mobile');
-    const isMobile = context.settings.emulatedFormFactor === 'mobile' ||
-      (context.settings.emulatedFormFactor !== 'desktop' && isMobileHost);
-
-    if (isMobile) {
+    if (IsMobile) {
       return {
         rawValue: widthsMatch,
         explanation: this.createExplanation(widthsMatch, artifacts.ViewportDimensions),

--- a/lighthouse-core/audits/content-width.js
+++ b/lighthouse-core/audits/content-width.js
@@ -19,7 +19,7 @@ class ContentWidth extends Audit {
       description: 'If the width of your app\'s content doesn\'t match the width ' +
           'of the viewport, your app might not be optimized for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport).',
-      requiredArtifacts: ['ViewportDimensions', 'FormFactorIsMobile'],
+      requiredArtifacts: ['ViewportDimensions', 'TestedAsMobileDevice'],
     };
   }
 
@@ -28,7 +28,7 @@ class ContentWidth extends Audit {
    * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
-    const IsMobile = artifacts.FormFactorIsMobile;
+    const IsMobile = artifacts.TestedAsMobileDevice;
     const viewportWidth = artifacts.ViewportDimensions.innerWidth;
     const windowWidth = artifacts.ViewportDimensions.outerWidth;
     const widthsMatch = viewportWidth === windowWidth;

--- a/lighthouse-core/audits/content-width.js
+++ b/lighthouse-core/audits/content-width.js
@@ -19,7 +19,7 @@ class ContentWidth extends Audit {
       description: 'If the width of your app\'s content doesn\'t match the width ' +
           'of the viewport, your app might not be optimized for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport).',
-      requiredArtifacts: ['ViewportDimensions', 'IsMobile'],
+      requiredArtifacts: ['ViewportDimensions', 'IsMobileFormFactor'],
     };
   }
 
@@ -28,7 +28,7 @@ class ContentWidth extends Audit {
    * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
-    const IsMobile = artifacts.IsMobile;
+    const IsMobile = artifacts.IsMobileFormFactor;
     const viewportWidth = artifacts.ViewportDimensions.innerWidth;
     const windowWidth = artifacts.ViewportDimensions.outerWidth;
     const widthsMatch = viewportWidth === windowWidth;

--- a/lighthouse-core/audits/content-width.js
+++ b/lighthouse-core/audits/content-width.js
@@ -19,7 +19,7 @@ class ContentWidth extends Audit {
       description: 'If the width of your app\'s content doesn\'t match the width ' +
           'of the viewport, your app might not be optimized for mobile screens. ' +
           '[Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport).',
-      requiredArtifacts: ['ViewportDimensions', 'IsMobileFormFactor'],
+      requiredArtifacts: ['ViewportDimensions', 'FormFactorIsMobile'],
     };
   }
 
@@ -28,7 +28,7 @@ class ContentWidth extends Audit {
    * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
-    const IsMobile = artifacts.IsMobileFormFactor;
+    const IsMobile = artifacts.FormFactorIsMobile;
     const viewportWidth = artifacts.ViewportDimensions.innerWidth;
     const windowWidth = artifacts.ViewportDimensions.outerWidth;
     const widthsMatch = viewportWidth === windowWidth;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -395,10 +395,19 @@ class GatherRunner {
    * @return {Promise<LH.BaseArtifacts>}
    */
   static async getBaseArtifacts(options) {
+    const hostUserAgent = (await options.driver.getBrowserVersion()).userAgent;
+
+    const {emulatedFormFactor} = options.settings;
+    const IsMobileHost = hostUserAgent.includes('Android') || hostUserAgent.includes('Mobile');
+    const IsMobile = emulatedFormFactor === 'mobile' ||
+      (emulatedFormFactor !== 'desktop' && IsMobileHost);
+
     return {
       fetchTime: (new Date()).toJSON(),
       LighthouseRunWarnings: [],
-      HostUserAgent: (await options.driver.getBrowserVersion()).userAgent,
+      IsMobile,
+      IsMobileHost,
+      HostUserAgent: hostUserAgent,
       NetworkUserAgent: '', // updated later
       BenchmarkIndex: 0, // updated later
       WebAppManifest: null, // updated later

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -400,13 +400,13 @@ class GatherRunner {
     const {emulatedFormFactor} = options.settings;
     // Whether Lighthouse was run on a mobile device (i.e. not on a desktop machine).
     const IsMobileHost = hostUserAgent.includes('Android') || hostUserAgent.includes('Mobile');
-    const FormFactorIsMobile = emulatedFormFactor === 'mobile' ||
+    const TestedAsMobileDevice = emulatedFormFactor === 'mobile' ||
       (emulatedFormFactor !== 'desktop' && IsMobileHost);
 
     return {
       fetchTime: (new Date()).toJSON(),
       LighthouseRunWarnings: [],
-      FormFactorIsMobile,
+      TestedAsMobileDevice,
       HostUserAgent: hostUserAgent,
       NetworkUserAgent: '', // updated later
       BenchmarkIndex: 0, // updated later

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -399,13 +399,13 @@ class GatherRunner {
 
     const {emulatedFormFactor} = options.settings;
     const IsMobileHost = hostUserAgent.includes('Android') || hostUserAgent.includes('Mobile');
-    const IsMobile = emulatedFormFactor === 'mobile' ||
+    const IsMobileFormFactor = emulatedFormFactor === 'mobile' ||
       (emulatedFormFactor !== 'desktop' && IsMobileHost);
 
     return {
       fetchTime: (new Date()).toJSON(),
       LighthouseRunWarnings: [],
-      IsMobile,
+      IsMobileFormFactor,
       IsMobileHost,
       HostUserAgent: hostUserAgent,
       NetworkUserAgent: '', // updated later

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -398,15 +398,15 @@ class GatherRunner {
     const hostUserAgent = (await options.driver.getBrowserVersion()).userAgent;
 
     const {emulatedFormFactor} = options.settings;
+    // Whether Lighthouse was run on a mobile device (i.e. not on a desktop machine).
     const IsMobileHost = hostUserAgent.includes('Android') || hostUserAgent.includes('Mobile');
-    const IsMobileFormFactor = emulatedFormFactor === 'mobile' ||
+    const FormFactorIsMobile = emulatedFormFactor === 'mobile' ||
       (emulatedFormFactor !== 'desktop' && IsMobileHost);
 
     return {
       fetchTime: (new Date()).toJSON(),
       LighthouseRunWarnings: [],
-      IsMobileFormFactor,
-      IsMobileHost,
+      FormFactorIsMobile,
       HostUserAgent: hostUserAgent,
       NetworkUserAgent: '', // updated later
       BenchmarkIndex: 0, // updated later

--- a/lighthouse-core/test/audits/content-width-test.js
+++ b/lighthouse-core/test/audits/content-width-test.js
@@ -13,12 +13,12 @@ const assert = require('assert');
 describe('Mobile-friendly: content-width audit', () => {
   it('fails when scroll width differs from viewport width', () => {
     const result = Audit.audit({
-      HostUserAgent: 'Desktop',
+      IsMobile: true,
       ViewportDimensions: {
         innerWidth: 100,
         outerWidth: 300,
       },
-    }, {settings: {emulatedFormFactor: 'mobile'}});
+    });
 
     assert.equal(result.rawValue, false);
     assert.ok(result.explanation);
@@ -26,12 +26,12 @@ describe('Mobile-friendly: content-width audit', () => {
 
   it('fails when host user agent is a phone', () => {
     const result = Audit.audit({
-      HostUserAgent: 'Mobile Android',
+      IsMobile: true,
       ViewportDimensions: {
         innerWidth: 100,
         outerWidth: 300,
       },
-    }, {settings: {emulatedFormFactor: 'none'}});
+    });
 
     assert.equal(result.rawValue, false);
     assert.ok(result.explanation);
@@ -47,13 +47,13 @@ describe('Mobile-friendly: content-width audit', () => {
     }, {settings: {emulatedFormFactor: 'mobile'}}).rawValue, true);
   });
 
-  it('not applicable when device emulation is turned off', () => {
+  it('not applicable when run on desktop', () => {
     return assert.equal(Audit.audit({
-      HostUserAgent: 'Mobile Android Chrome',
+      IsMobile: false,
       ViewportDimensions: {
         innerWidth: 300,
         outerWidth: 450,
       },
-    }, {settings: {emulatedFormFactor: 'desktop'}}).notApplicable, true);
+    }).notApplicable, true);
   });
 });

--- a/lighthouse-core/test/audits/content-width-test.js
+++ b/lighthouse-core/test/audits/content-width-test.js
@@ -24,19 +24,6 @@ describe('Mobile-friendly: content-width audit', () => {
     assert.ok(result.explanation);
   });
 
-  it('fails when host user agent is a phone', () => {
-    const result = Audit.audit({
-      IsMobile: true,
-      ViewportDimensions: {
-        innerWidth: 100,
-        outerWidth: 300,
-      },
-    });
-
-    assert.equal(result.rawValue, false);
-    assert.ok(result.explanation);
-  });
-
   it('passes when widths match', () => {
     return assert.equal(Audit.audit({
       HostUserAgent: '',

--- a/lighthouse-core/test/audits/content-width-test.js
+++ b/lighthouse-core/test/audits/content-width-test.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 describe('Mobile-friendly: content-width audit', () => {
   it('fails when scroll width differs from viewport width', () => {
     const result = Audit.audit({
-      FormFactorIsMobile: true,
+      TestedAsMobileDevice: true,
       ViewportDimensions: {
         innerWidth: 100,
         outerWidth: 300,
@@ -36,7 +36,7 @@ describe('Mobile-friendly: content-width audit', () => {
 
   it('not applicable when run on desktop', () => {
     return assert.equal(Audit.audit({
-      FormFactorIsMobile: false,
+      TestedAsMobileDevice: false,
       ViewportDimensions: {
         innerWidth: 300,
         outerWidth: 450,

--- a/lighthouse-core/test/audits/content-width-test.js
+++ b/lighthouse-core/test/audits/content-width-test.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 describe('Mobile-friendly: content-width audit', () => {
   it('fails when scroll width differs from viewport width', () => {
     const result = Audit.audit({
-      IsMobileFormFactor: true,
+      FormFactorIsMobile: true,
       ViewportDimensions: {
         innerWidth: 100,
         outerWidth: 300,
@@ -36,7 +36,7 @@ describe('Mobile-friendly: content-width audit', () => {
 
   it('not applicable when run on desktop', () => {
     return assert.equal(Audit.audit({
-      IsMobileFormFactor: false,
+      FormFactorIsMobile: false,
       ViewportDimensions: {
         innerWidth: 300,
         outerWidth: 450,

--- a/lighthouse-core/test/audits/content-width-test.js
+++ b/lighthouse-core/test/audits/content-width-test.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 describe('Mobile-friendly: content-width audit', () => {
   it('fails when scroll width differs from viewport width', () => {
     const result = Audit.audit({
-      IsMobile: true,
+      IsMobileFormFactor: true,
       ViewportDimensions: {
         innerWidth: 100,
         outerWidth: 300,
@@ -36,7 +36,7 @@ describe('Mobile-friendly: content-width audit', () => {
 
   it('not applicable when run on desktop', () => {
     return assert.equal(Audit.audit({
-      IsMobile: false,
+      IsMobileFormFactor: false,
       ViewportDimensions: {
         innerWidth: 300,
         outerWidth: 450,

--- a/lighthouse-core/test/gather/fake-driver.js
+++ b/lighthouse-core/test/gather/fake-driver.js
@@ -5,6 +5,79 @@
  */
 'use strict';
 
+function makeFakeDriver({protocolGetVersionResponse}) {
+  return {
+    getBrowserVersion() {
+      return Promise.resolve(Object.assign({}, protocolGetVersionResponse, {milestone: 71}));
+    },
+    getBenchmarkIndex() {
+      return Promise.resolve(125.2);
+    },
+    getAppManifest() {
+      return Promise.resolve(null);
+    },
+    connect() {
+      return Promise.resolve();
+    },
+    disconnect() {
+      return Promise.resolve();
+    },
+    gotoURL() {
+      return Promise.resolve('https://www.reddit.com/r/nba');
+    },
+    beginEmulation() {
+      return Promise.resolve();
+    },
+    setThrottling() {
+      return Promise.resolve();
+    },
+    dismissJavaScriptDialogs() {
+      return Promise.resolve();
+    },
+    assertNoSameOriginServiceWorkerClients() {
+      return Promise.resolve();
+    },
+    reloadForCleanStateIfNeeded() {
+      return Promise.resolve();
+    },
+    enableRuntimeEvents() {
+      return Promise.resolve();
+    },
+    evaluateScriptOnLoad() {
+      return Promise.resolve();
+    },
+    cleanBrowserCaches() {},
+    clearDataForOrigin() {},
+    cacheNatives() {
+      return Promise.resolve();
+    },
+    evaluateAsync() {
+      return Promise.resolve({});
+    },
+    registerPerformanceObserver() {
+      return Promise.resolve();
+    },
+    beginTrace() {
+      return Promise.resolve();
+    },
+    endTrace() {
+      return Promise.resolve(
+      require('../fixtures/traces/progressive-app.json')
+      );
+    },
+    beginDevtoolsLog() {},
+    endDevtoolsLog() {
+      return require('../fixtures/artifacts/perflog/defaultPass.devtoolslog.json');
+    },
+    blockUrlPatterns() {
+      return Promise.resolve();
+    },
+    setExtraHTTPHeaders() {
+      return Promise.resolve();
+    },
+  };
+}
+
 // https://chromedevtools.github.io/devtools-protocol/tot/Browser#method-getVersion
 const protocolGetVersionResponse = {
   protocolVersion: '1.3',
@@ -14,77 +87,16 @@ const protocolGetVersionResponse = {
   userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3577.0 Safari/537.36',
   jsVersion: '7.1.314',
 };
+const fakeDriver = makeFakeDriver({protocolGetVersionResponse});
 
-const fakeDriver = {
-  getBrowserVersion() {
-    return Promise.resolve(Object.assign({}, protocolGetVersionResponse, {milestone: 71}));
+const fakeDriverUsingRealMobileDevice = makeFakeDriver({
+  protocolGetVersionResponse: {
+    ...protocolGetVersionResponse,
+    // eslint-disable-next-line max-len
+    userAgent: 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/69.0.3464.0 Mobile Safari/537.36',
   },
-  getBenchmarkIndex() {
-    return Promise.resolve(125.2);
-  },
-  getAppManifest() {
-    return Promise.resolve(null);
-  },
-  connect() {
-    return Promise.resolve();
-  },
-  disconnect() {
-    return Promise.resolve();
-  },
-  gotoURL() {
-    return Promise.resolve('https://www.reddit.com/r/nba');
-  },
-  beginEmulation() {
-    return Promise.resolve();
-  },
-  setThrottling() {
-    return Promise.resolve();
-  },
-  dismissJavaScriptDialogs() {
-    return Promise.resolve();
-  },
-  assertNoSameOriginServiceWorkerClients() {
-    return Promise.resolve();
-  },
-  reloadForCleanStateIfNeeded() {
-    return Promise.resolve();
-  },
-  enableRuntimeEvents() {
-    return Promise.resolve();
-  },
-  evaluateScriptOnLoad() {
-    return Promise.resolve();
-  },
-  cleanBrowserCaches() {},
-  clearDataForOrigin() {},
-  cacheNatives() {
-    return Promise.resolve();
-  },
-  evaluateAsync() {
-    return Promise.resolve({});
-  },
-  registerPerformanceObserver() {
-    return Promise.resolve();
-  },
-  beginTrace() {
-    return Promise.resolve();
-  },
-  endTrace() {
-    return Promise.resolve(
-      require('../fixtures/traces/progressive-app.json')
-    );
-  },
-  beginDevtoolsLog() {},
-  endDevtoolsLog() {
-    return require('../fixtures/artifacts/perflog/defaultPass.devtoolslog.json');
-  },
-  blockUrlPatterns() {
-    return Promise.resolve();
-  },
-  setExtraHTTPHeaders() {
-    return Promise.resolve();
-  },
-};
+});
 
 module.exports = fakeDriver;
+module.exports.fakeDriverUsingRealMobileDevice = fakeDriverUsingRealMobileDevice;
 module.exports.protocolGetVersionResponse = protocolGetVersionResponse;

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -33,6 +33,7 @@ class TestGathererNoArtifact extends Gatherer {
 }
 
 const fakeDriver = require('./fake-driver');
+const fakeDriverUsingRealMobileDevice = fakeDriver.fakeDriverUsingRealMobileDevice;
 
 function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn,
   blockUrlFn, extraHeadersFn) {
@@ -153,6 +154,50 @@ describe('GatherRunner', function() {
     return GatherRunner.run(config.passes, options).then(artifacts => {
       assert.deepStrictEqual(artifacts.URL, {requestedUrl, finalUrl},
         'did not find expected URL artifact');
+    });
+  });
+
+  describe('collects IsMobile and IsMobileHost as artifacts', () => {
+    const url = 'https://example.com';
+    it('works when running on desktop device without emulation', async () => {
+      const driver = fakeDriver;
+      const config = new Config({passes: [{}]});
+      const settings = {};
+      const options = {url, driver, config, settings};
+
+      const results = await GatherRunner.run(config.passes, options);
+      expect(results.IsMobile).toBe(false);
+      expect(results.IsMobileHost).toBe(false);
+    });
+    it('works when running on desktop device with mobile emulation', async () => {
+      const driver = fakeDriver;
+      const config = new Config({passes: [{}]});
+      const settings = {emulatedFormFactor: 'mobile'};
+      const options = {url, driver, config, settings};
+
+      const results = await GatherRunner.run(config.passes, options);
+      expect(results.IsMobile).toBe(true);
+      expect(results.IsMobileHost).toBe(false);
+    });
+    it('works when running on mobile device without emulation', async () => {
+      const driver = fakeDriverUsingRealMobileDevice;
+      const config = new Config({passes: [{}]});
+      const settings = {};
+      const options = {url, driver, config, settings};
+
+      const results = await GatherRunner.run(config.passes, options);
+      expect(results.IsMobile).toBe(true);
+      expect(results.IsMobileHost).toBe(true);
+    });
+    it('works when running on mobile device with desktop emulation', async () => {
+      const driver = fakeDriverUsingRealMobileDevice;
+      const config = new Config({passes: [{}]});
+      const settings = {emulatedFormFactor: 'desktop'};
+      const options = {url, driver, config, settings};
+
+      const results = await GatherRunner.run(config.passes, options);
+      expect(results.IsMobile).toBe(false);
+      expect(results.IsMobileHost).toBe(true);
     });
   });
 

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -159,6 +159,7 @@ describe('GatherRunner', function() {
 
   describe('collects IsMobile and IsMobileHost as artifacts', () => {
     const url = 'https://example.com';
+
     it('works when running on desktop device without emulation', async () => {
       const driver = fakeDriver;
       const config = new Config({passes: [{}]});
@@ -169,6 +170,7 @@ describe('GatherRunner', function() {
       expect(results.IsMobile).toBe(false);
       expect(results.IsMobileHost).toBe(false);
     });
+
     it('works when running on desktop device with mobile emulation', async () => {
       const driver = fakeDriver;
       const config = new Config({passes: [{}]});
@@ -179,6 +181,7 @@ describe('GatherRunner', function() {
       expect(results.IsMobile).toBe(true);
       expect(results.IsMobileHost).toBe(false);
     });
+
     it('works when running on mobile device without emulation', async () => {
       const driver = fakeDriverUsingRealMobileDevice;
       const config = new Config({passes: [{}]});
@@ -189,6 +192,7 @@ describe('GatherRunner', function() {
       expect(results.IsMobile).toBe(true);
       expect(results.IsMobileHost).toBe(true);
     });
+
     it('works when running on mobile device with desktop emulation', async () => {
       const driver = fakeDriverUsingRealMobileDevice;
       const config = new Config({passes: [{}]});

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -157,7 +157,7 @@ describe('GatherRunner', function() {
     });
   });
 
-  describe('collects FormFactorIsMobile as an artifact', () => {
+  describe('collects TestedAsMobileDevice as an artifact', () => {
     const url = 'https://example.com';
 
     it('works when running on desktop device without emulation', async () => {
@@ -167,7 +167,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.FormFactorIsMobile).toBe(false);
+      expect(results.TestedAsMobileDevice).toBe(false);
     });
 
     it('works when running on desktop device with mobile emulation', async () => {
@@ -177,7 +177,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.FormFactorIsMobile).toBe(true);
+      expect(results.TestedAsMobileDevice).toBe(true);
     });
 
     it('works when running on mobile device without emulation', async () => {
@@ -187,7 +187,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.FormFactorIsMobile).toBe(true);
+      expect(results.TestedAsMobileDevice).toBe(true);
     });
 
     it('works when running on mobile device with desktop emulation', async () => {
@@ -197,7 +197,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.FormFactorIsMobile).toBe(false);
+      expect(results.TestedAsMobileDevice).toBe(false);
     });
   });
 

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -157,7 +157,7 @@ describe('GatherRunner', function() {
     });
   });
 
-  describe('collects IsMobileFormFactor and IsMobileHost as artifacts', () => {
+  describe('collects FormFactorIsMobile as an artifact', () => {
     const url = 'https://example.com';
 
     it('works when running on desktop device without emulation', async () => {
@@ -167,8 +167,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.IsMobileFormFactor).toBe(false);
-      expect(results.IsMobileHost).toBe(false);
+      expect(results.FormFactorIsMobile).toBe(false);
     });
 
     it('works when running on desktop device with mobile emulation', async () => {
@@ -178,8 +177,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.IsMobileFormFactor).toBe(true);
-      expect(results.IsMobileHost).toBe(false);
+      expect(results.FormFactorIsMobile).toBe(true);
     });
 
     it('works when running on mobile device without emulation', async () => {
@@ -189,8 +187,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.IsMobileFormFactor).toBe(true);
-      expect(results.IsMobileHost).toBe(true);
+      expect(results.FormFactorIsMobile).toBe(true);
     });
 
     it('works when running on mobile device with desktop emulation', async () => {
@@ -200,8 +197,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.IsMobileFormFactor).toBe(false);
-      expect(results.IsMobileHost).toBe(true);
+      expect(results.FormFactorIsMobile).toBe(false);
     });
   });
 

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -157,7 +157,7 @@ describe('GatherRunner', function() {
     });
   });
 
-  describe('collects IsMobile and IsMobileHost as artifacts', () => {
+  describe('collects IsMobileFormFactor and IsMobileHost as artifacts', () => {
     const url = 'https://example.com';
 
     it('works when running on desktop device without emulation', async () => {
@@ -167,7 +167,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.IsMobile).toBe(false);
+      expect(results.IsMobileFormFactor).toBe(false);
       expect(results.IsMobileHost).toBe(false);
     });
 
@@ -178,7 +178,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.IsMobile).toBe(true);
+      expect(results.IsMobileFormFactor).toBe(true);
       expect(results.IsMobileHost).toBe(false);
     });
 
@@ -189,7 +189,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.IsMobile).toBe(true);
+      expect(results.IsMobileFormFactor).toBe(true);
       expect(results.IsMobileHost).toBe(true);
     });
 
@@ -200,7 +200,7 @@ describe('GatherRunner', function() {
       const options = {url, driver, config, settings};
 
       const results = await GatherRunner.run(config.passes, options);
-      expect(results.IsMobile).toBe(false);
+      expect(results.IsMobileFormFactor).toBe(false);
       expect(results.IsMobileHost).toBe(true);
     });
   });

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -1,6 +1,8 @@
 {
   "LighthouseRunWarnings": [],
   "BenchmarkIndex": 1000,
+  "IsMobile": true,
+  "IsMobileHost": false,
   "HostUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
   "NetworkUserAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/66.0.3359.30 Mobile Safari/537.36",
   "fetchTime": "2018-03-13T00:55:45.840Z",

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -1,7 +1,7 @@
 {
   "LighthouseRunWarnings": [],
   "BenchmarkIndex": 1000,
-  "FormFactorIsMobile": true,
+  "TestedAsMobileDevice": true,
   "HostUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
   "NetworkUserAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/66.0.3359.30 Mobile Safari/537.36",
   "fetchTime": "2018-03-13T00:55:45.840Z",

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -1,7 +1,7 @@
 {
   "LighthouseRunWarnings": [],
   "BenchmarkIndex": 1000,
-  "IsMobile": true,
+  "IsMobileFormFactor": true,
   "IsMobileHost": false,
   "HostUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
   "NetworkUserAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/66.0.3359.30 Mobile Safari/537.36",

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -1,8 +1,7 @@
 {
   "LighthouseRunWarnings": [],
   "BenchmarkIndex": 1000,
-  "IsMobileFormFactor": true,
-  "IsMobileHost": false,
+  "FormFactorIsMobile": true,
   "HostUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
   "NetworkUserAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/66.0.3359.30 Mobile Safari/537.36",
   "fetchTime": "2018-03-13T00:55:45.840Z",

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -23,6 +23,10 @@ declare global {
       fetchTime: string;
       /** A set of warnings about unexpected things encountered while loading and testing the page. */
       LighthouseRunWarnings: string[];
+      /** Whether the page was loaded on either a real or emulated mobile device */
+      IsMobile: boolean;
+      /** Whether Lighthouse was run on a mobile device (i.e. not on a desktop machine) */
+      IsMobileHost: boolean;
       /** The user agent string of the version of Chrome used. */
       HostUserAgent: string;
       /** The user agent string that Lighthouse used to load the page. */

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -23,7 +23,7 @@ declare global {
       fetchTime: string;
       /** A set of warnings about unexpected things encountered while loading and testing the page. */
       LighthouseRunWarnings: string[];
-      /** Whether the page was loaded on either a real or emulated mobile device */
+      /** Whether the page was loaded on either a real or emulated mobile device. */
       IsMobile: boolean;
       /** Whether Lighthouse was run on a mobile device (i.e. not on a desktop machine) */
       IsMobileHost: boolean;

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -25,7 +25,7 @@ declare global {
       LighthouseRunWarnings: string[];
       /** Whether the page was loaded on either a real or emulated mobile device. */
       IsMobile: boolean;
-      /** Whether Lighthouse was run on a mobile device (i.e. not on a desktop machine) */
+      /** Whether Lighthouse was run on a mobile device (i.e. not on a desktop machine). */
       IsMobileHost: boolean;
       /** The user agent string of the version of Chrome used. */
       HostUserAgent: string;

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -24,7 +24,7 @@ declare global {
       /** A set of warnings about unexpected things encountered while loading and testing the page. */
       LighthouseRunWarnings: string[];
       /** Whether the page was loaded on either a real or emulated mobile device. */
-      FormFactorIsMobile: boolean;
+      TestedAsMobileDevice: boolean;
       /** The user agent string of the version of Chrome used. */
       HostUserAgent: string;
       /** The user agent string that Lighthouse used to load the page. */

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -24,9 +24,7 @@ declare global {
       /** A set of warnings about unexpected things encountered while loading and testing the page. */
       LighthouseRunWarnings: string[];
       /** Whether the page was loaded on either a real or emulated mobile device. */
-      IsMobileFormFactor: boolean;
-      /** Whether Lighthouse was run on a mobile device (i.e. not on a desktop machine). */
-      IsMobileHost: boolean;
+      FormFactorIsMobile: boolean;
       /** The user agent string of the version of Chrome used. */
       HostUserAgent: string;
       /** The user agent string that Lighthouse used to load the page. */

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -24,7 +24,7 @@ declare global {
       /** A set of warnings about unexpected things encountered while loading and testing the page. */
       LighthouseRunWarnings: string[];
       /** Whether the page was loaded on either a real or emulated mobile device. */
-      IsMobile: boolean;
+      IsMobileFormFactor: boolean;
       /** Whether Lighthouse was run on a mobile device (i.e. not on a desktop machine). */
       IsMobileHost: boolean;
       /** The user agent string of the version of Chrome used. */


### PR DESCRIPTION
**Summary**

Extract the logic for this from the `content-width` audit so we can use it for other audits.

@patrickhulce I know we were talking about an `Environment` artifact to wrap these two properties, but since there are already other environment-related properties directly on `baseArtifacts` I just added them there.

**Related Issues/PRs**

Closes https://github.com/GoogleChrome/lighthouse/issues/7043
