### PR TITLE
tests(smokehouse): gzip test to assert transfer and resource sizes

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/gzip.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/gzip.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<!--
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+-->
+<html>
+<head>
+<title>Gzip</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+<script src="script.js?gzip=1"></script>
+<script src="script.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -72,7 +72,7 @@ function requestHandler(request, response) {
     }
 
     let delay = 0;
-    let gzip = false;
+    let useGzip = false;
     if (queryString) {
       const params = new URLSearchParams(queryString);
       // set document status-code
@@ -96,7 +96,7 @@ function requestHandler(request, response) {
       }
 
       if (params.has('gzip')) {
-        gzip = Boolean(params.get('gzip'));
+        useGzip = Boolean(params.get('gzip'));
       }
 
       // redirect url to new url if present
@@ -105,7 +105,7 @@ function requestHandler(request, response) {
       }
     }
 
-    if (gzip) {
+    if (useGzip) {
       headers['Content-Encoding'] = 'gzip';
     }
 
@@ -116,7 +116,7 @@ function requestHandler(request, response) {
       return setTimeout(finishResponse, delay, data);
     }
 
-    finishResponse(data, gzip);
+    finishResponse(data, useGzip);
   }
 
   function sendRedirect(url) {
@@ -127,8 +127,8 @@ function requestHandler(request, response) {
     response.end();
   }
 
-  function finishResponse(data, gzip) {
-    if (gzip) {
+  function finishResponse(data, useGzip) {
+    if (useGzip) {
       response.write(zlib.gzipSync(data), 'binary');
     } else {
       response.write(data, 'binary');

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -106,6 +106,7 @@ function requestHandler(request, response) {
     }
 
     if (useGzip) {
+      data = zlib.gzipSync(data);
       headers['Content-Encoding'] = 'gzip';
     }
 
@@ -113,10 +114,10 @@ function requestHandler(request, response) {
 
     // Delay the response
     if (delay > 0) {
-      return setTimeout(finishResponse, delay, data, useGzip);
+      return setTimeout(finishResponse, delay, data);
     }
 
-    finishResponse(data, useGzip);
+    finishResponse(data);
   }
 
   function sendRedirect(url) {
@@ -127,12 +128,8 @@ function requestHandler(request, response) {
     response.end();
   }
 
-  function finishResponse(data, useGzip) {
-    if (useGzip) {
-      response.write(zlib.gzipSync(data), 'binary');
-    } else {
-      response.write(data, 'binary');
-    }
+  function finishResponse(data) {
+    response.write(data, 'binary');
     response.end();
   }
 }

--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -113,7 +113,7 @@ function requestHandler(request, response) {
 
     // Delay the response
     if (delay > 0) {
-      return setTimeout(finishResponse, delay, data);
+      return setTimeout(finishResponse, delay, data, useGzip);
     }
 
     finishResponse(data, useGzip);

--- a/lighthouse-cli/test/smokehouse/byte-config.js
+++ b/lighthouse-cli/test/smokehouse/byte-config.js
@@ -12,6 +12,7 @@ module.exports = {
   extends: 'lighthouse:full',
   settings: {
     onlyAudits: [
+      'network-requests',
       'offscreen-images',
       'uses-webp-images',
       'uses-optimized-images',

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -103,4 +103,29 @@ module.exports = [
       },
     },
   },
+  {
+    requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+    finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+    audits: {
+      'network-requests': {
+        details: {
+          items: [
+            {
+              url: 'http://localhost:10200/byte-efficiency/gzip.html',
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
+              transferSize: 1136,
+              resourceSize: 52997,
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js',
+              transferSize: 53181,
+              resourceSize: 52997,
+            },
+          ],
+        },
+      },
+    },
+  },
 ];


### PR DESCRIPTION
Assert that gzip savings are correctly being provided by the browser for LH to use.

Regression test for when a version of headless Chrome was giving weird `dataReceivedEvent` values in the face of gzipped resources (see [this doc](https://docs.google.com/document/d/1FcvF1kKtWuKh2OLXXkTsBuh7qq9f6PxmA-JWcre1wFo/edit) (private to Googlers) for more).

Related: #7284