### PR TITLE
core: add group support for plugins

### DIFF
--- a/lighthouse-core/config/config-plugin.js
+++ b/lighthouse-core/config/config-plugin.js
@@ -159,18 +159,16 @@ class ConfigPlugin {
     }
 
     if (!isObjectOfUnknownProperties(groupsJson)) {
-      throw new Error(`${pluginName} groups json is not valid.`);
+      throw new Error(`${pluginName} groups json is not defined as an object.`);
     }
 
     const groups = Object.entries(groupsJson);
-    if (!groups.length) {
-      throw new Error(`${pluginName} has an empty groups object.`);
-    }
-    /** @type {Record<string, LH.Config.GroupJson>} **/
+
+    /** @type {Record<string, LH.Config.GroupJson>} */
     const parsedGroupsJson = {};
     groups.forEach(([groupId, groupJson]) => {
       if (!isObjectOfUnknownProperties(groupJson)) {
-        throw new Error(`${pluginName} has an invalid group.`);
+        throw new Error(`${pluginName} has a group not defined as an object.`);
       }
       const {title, description, ...invalidRest} = groupJson;
       assertNoExcessProperties(invalidRest, pluginName, 'group');
@@ -204,20 +202,20 @@ class ConfigPlugin {
     }
 
     const {
-      groups: pluginGroupsJson,
       audits: pluginAuditsJson,
       category: pluginCategoryJson,
+      groups: pluginGroupsJson,
       ...invalidRest
     } = pluginJson;
 
     assertNoExcessProperties(invalidRest, pluginName);
 
     return {
-      groups: ConfigPlugin._parseGroups(pluginGroupsJson, pluginName),
       audits: ConfigPlugin._parseAuditsList(pluginAuditsJson, pluginName),
       categories: {
         [pluginName]: ConfigPlugin._parseCategory(pluginCategoryJson, pluginName),
       },
+      groups: ConfigPlugin._parseGroups(pluginGroupsJson, pluginName),
     };
   }
 }

--- a/lighthouse-core/config/config-plugin.js
+++ b/lighthouse-core/config/config-plugin.js
@@ -159,15 +159,12 @@ class ConfigPlugin {
     }
 
     if (!isObjectOfUnknownProperties(groupsJson)) {
-      throw new Error(`${pluginName} group json is not valid.`);
+      throw new Error(`${pluginName} groups json is not valid.`);
     }
 
-    if (typeof groupsJson !== 'object') {
-      throw new Error(`${pluginName} has an invalid group type.`);
-    }
     const groups = Object.entries(groupsJson);
     if (!groups.length) {
-      throw new Error(`${pluginName} has an an empty groups object.`);
+      throw new Error(`${pluginName} has an empty groups object.`);
     }
     /** @type {Record<string, LH.Config.GroupJson>} **/
     const parsedGroupsJson = {};
@@ -216,7 +213,7 @@ class ConfigPlugin {
     assertNoExcessProperties(invalidRest, pluginName);
 
     return {
-      ...pluginGroupsJson && {groups: ConfigPlugin._parseGroups(pluginGroupsJson, pluginName)},
+      groups: ConfigPlugin._parseGroups(pluginGroupsJson, pluginName),
       audits: ConfigPlugin._parseAuditsList(pluginAuditsJson, pluginName),
       categories: {
         [pluginName]: ConfigPlugin._parseCategory(pluginCategoryJson, pluginName),

--- a/lighthouse-core/test/config/__snapshots__/config-plugin-test.js.snap
+++ b/lighthouse-core/test/config/__snapshots__/config-plugin-test.js.snap
@@ -11,11 +11,12 @@ Object {
     "lighthouse-plugin-nice-plugin": Object {
       "auditRefs": Array [
         Object {
-          "group": "group-a",
+          "group": "lighthouse-plugin-nice-plugin-group-a",
           "id": "nice-audit",
           "weight": 1,
         },
         Object {
+          "group": undefined,
           "id": "installable-manifest",
           "weight": 220,
         },
@@ -26,10 +27,11 @@ Object {
     },
   },
   "groups": Object {
-    "group-a": Object {
+    "lighthouse-plugin-nice-plugin-group-a": Object {
+      "description": undefined,
       "title": "Group A",
     },
-    "group-b": Object {
+    "lighthouse-plugin-nice-plugin-group-b": Object {
       "description": "This description is optional",
       "title": "Group B",
     },

--- a/lighthouse-core/test/config/__snapshots__/config-plugin-test.js.snap
+++ b/lighthouse-core/test/config/__snapshots__/config-plugin-test.js.snap
@@ -11,6 +11,7 @@ Object {
     "lighthouse-plugin-nice-plugin": Object {
       "auditRefs": Array [
         Object {
+          "group": "group-a",
           "id": "nice-audit",
           "weight": 1,
         },
@@ -22,6 +23,15 @@ Object {
       "description": "A nice plugin for nice testing",
       "manualDescription": undefined,
       "title": "Nice Plugin",
+    },
+  },
+  "groups": Object {
+    "group-a": Object {
+      "title": "Group A",
+    },
+    "group-b": Object {
+      "description": "This description is optional",
+      "title": "Group B",
     },
   },
 }

--- a/lighthouse-core/test/config/config-plugin-test.js
+++ b/lighthouse-core/test/config/config-plugin-test.js
@@ -71,7 +71,7 @@ describe('ConfigPlugin', () => {
       description: 'A plugin that\'s trying to undermine you.',
       manualDescription: 'Still here.',
       auditRefs: [
-        {id: 'evil-audit', weight: 0},
+        {id: 'evil-audit', weight: 0, group: undefined},
       ],
     };
 
@@ -211,8 +211,10 @@ describe('ConfigPlugin', () => {
         const pluginJson = ConfigPlugin.parsePlugin(nicePlugin, nicePluginName);
 
         const auditRefs = pluginJson.categories[nicePluginName].auditRefs;
-        assert.deepStrictEqual(auditRefs[0], {id: 'nice-audit', weight: 1, group: 'group-a'});
-        assert.deepStrictEqual(auditRefs[1], {id: 'installable-manifest', weight: 220});
+        assert.deepStrictEqual(auditRefs[0],
+          {id: 'nice-audit', weight: 1, group: 'lighthouse-plugin-nice-plugin-group-a'});
+        assert.deepStrictEqual(auditRefs[1],
+          {id: 'installable-manifest', weight: 220, group: undefined});
       });
 
       it('throws if auditRefs is missing', () => {

--- a/lighthouse-core/test/config/config-plugin-test.js
+++ b/lighthouse-core/test/config/config-plugin-test.js
@@ -93,6 +93,7 @@ describe('ConfigPlugin', () => {
       categories: {
         'lighthouse-plugin-evil': evilCategory,
       },
+      groups: undefined,
     });
     assert.strictEqual(Object.getOwnPropertyDescriptor(pluginJson, 'audits').get, undefined);
   });
@@ -262,6 +263,57 @@ describe('ConfigPlugin', () => {
         assert.throws(() => ConfigPlugin.parsePlugin(pluginClone2, nicePluginName),
           /^Error: lighthouse-plugin-nice-plugin has an invalid auditRef weight/);
       });
+    });
+  });
+
+  describe('`groups`', () => {
+    it('throws if auditRef has an invalid group id', () => {
+      const pluginClone = deepClone(nicePlugin);
+      pluginClone.category.auditRefs[0].group = 55;
+      assert.throws(() => ConfigPlugin.parsePlugin(pluginClone, nicePluginName),
+        /^Error: lighthouse-plugin-nice-plugin has an invalid auditRef group/);
+    });
+
+    it('accepts a plugin with no groups', () => {
+      const pluginClone = deepClone(nicePlugin);
+      delete pluginClone.groups;
+      const pluginJson = ConfigPlugin.parsePlugin(pluginClone, nicePluginName);
+      assert.ok(pluginJson);
+    });
+
+    it('throws if groups is not an object', () => {
+      const pluginClone = deepClone(nicePlugin);
+      pluginClone.groups = [0, 1, 2, 3];
+      assert.throws(() => ConfigPlugin.parsePlugin(pluginClone, nicePluginName),
+        /^Error: lighthouse-plugin-nice-plugin groups json is not valid/);
+    });
+
+    it('throws if groups contains non-objects', () => {
+      const pluginClone = deepClone(nicePlugin);
+      pluginClone.groups['group-b'] = [0, 1, 2, 3];
+      assert.throws(() => ConfigPlugin.parsePlugin(pluginClone, nicePluginName),
+        /^Error: lighthouse-plugin-nice-plugin has an invalid group/);
+    });
+
+    it('throws if groups is empty', () => {
+      const pluginClone = deepClone(nicePlugin);
+      pluginClone.groups = {};
+      assert.throws(() => ConfigPlugin.parsePlugin(pluginClone, nicePluginName),
+        /^Error: lighthouse-plugin-nice-plugin has an empty groups object/);
+    });
+
+    it('throws if group title is invalid', () => {
+      const pluginClone = deepClone(nicePlugin);
+      pluginClone.groups['group-a'].title = 55;
+      assert.throws(() => ConfigPlugin.parsePlugin(pluginClone, nicePluginName),
+        /^Error: lighthouse-plugin-nice-plugin has an invalid group title/);
+    });
+
+    it('throws if group description is invalid', () => {
+      const pluginClone = deepClone(nicePlugin);
+      pluginClone.groups['group-a'].description = 55;
+      assert.throws(() => ConfigPlugin.parsePlugin(pluginClone, nicePluginName),
+        /^Error: lighthouse-plugin-nice-plugin has an invalid group description/);
     });
   });
 });

--- a/lighthouse-core/test/config/config-plugin-test.js
+++ b/lighthouse-core/test/config/config-plugin-test.js
@@ -21,11 +21,20 @@ function deepClone(val) {
 const nicePluginName = 'lighthouse-plugin-nice-plugin';
 const nicePlugin = {
   audits: [{path: 'not/a/path/audit.js'}],
+  groups: {
+    'group-a': {
+      title: 'Group A',
+    },
+    'group-b': {
+      title: 'Group B',
+      description: 'This description is optional',
+    },
+  },
   category: {
     title: 'Nice Plugin',
     description: 'A nice plugin for nice testing',
     auditRefs: [
-      {id: 'nice-audit', weight: 1},
+      {id: 'nice-audit', weight: 1, group: 'group-a'},
       {id: 'installable-manifest', weight: 220},
     ],
   },
@@ -202,7 +211,7 @@ describe('ConfigPlugin', () => {
         const pluginJson = ConfigPlugin.parsePlugin(nicePlugin, nicePluginName);
 
         const auditRefs = pluginJson.categories[nicePluginName].auditRefs;
-        assert.deepStrictEqual(auditRefs[0], {id: 'nice-audit', weight: 1});
+        assert.deepStrictEqual(auditRefs[0], {id: 'nice-audit', weight: 1, group: 'group-a'});
         assert.deepStrictEqual(auditRefs[1], {id: 'installable-manifest', weight: 220});
       });
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -721,6 +721,19 @@ describe('Config', () => {
       assert.strictEqual(config.categories['lighthouse-plugin-simple'].title, 'Simple');
     });
 
+    it('should append a group', () => {
+      const configJson = {
+        extends: 'lighthouse:default',
+        plugins: ['lighthouse-plugin-simple'],
+      };
+      const config = new Config(configJson, {configPath: configFixturePath});
+      const groupIds = Object.keys(config.groups);
+      assert.ok(groupIds.length > 1);
+      assert.strictEqual(groupIds[groupIds.length - 1], 'new-group');
+      assert.strictEqual(config.groups['new-group'].title, 'New Group');
+    });
+
+
     it('should throw if the plugin is invalid', () => {
       const configJson = {
         extends: 'lighthouse:default',

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -729,8 +729,8 @@ describe('Config', () => {
       const config = new Config(configJson, {configPath: configFixturePath});
       const groupIds = Object.keys(config.groups);
       assert.ok(groupIds.length > 1);
-      assert.strictEqual(groupIds[groupIds.length - 1], 'new-group');
-      assert.strictEqual(config.groups['new-group'].title, 'New Group');
+      assert.strictEqual(groupIds[groupIds.length - 1], 'lighthouse-plugin-simple-new-group');
+      assert.strictEqual(config.groups['lighthouse-plugin-simple-new-group'].title, 'New Group');
     });
 
 

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -699,14 +699,20 @@ describe('Config', () => {
   describe('mergePlugins', () => {
     const configFixturePath = __dirname + '/../fixtures/config-plugins/';
 
-    it('should append audits', () => {
+    it('should append audits and a group', () => {
       const configJson = {
         audits: ['installable-manifest', 'metrics'],
         plugins: ['lighthouse-plugin-simple'],
       };
       const config = new Config(configJson, {configPath: configFixturePath});
+      const groupIds = Object.keys(config.groups);
       assert.deepStrictEqual(config.audits.map(a => a.path),
         ['installable-manifest', 'metrics', 'redirects', 'user-timings']);
+      assert.ok(groupIds.length === 1);
+      assert.strictEqual(groupIds[groupIds.length - 1], 'lighthouse-plugin-simple-new-group');
+      assert.strictEqual(config.groups['lighthouse-plugin-simple-new-group'].title, 'New Group');
+      assert.strictEqual(config.categories['lighthouse-plugin-simple'].auditRefs[0].group,
+        'lighthouse-plugin-simple-new-group');
     });
 
     it('should append a category', () => {
@@ -720,19 +726,6 @@ describe('Config', () => {
       assert.strictEqual(categoryNames[categoryNames.length - 1], 'lighthouse-plugin-simple');
       assert.strictEqual(config.categories['lighthouse-plugin-simple'].title, 'Simple');
     });
-
-    it('should append a group', () => {
-      const configJson = {
-        extends: 'lighthouse:default',
-        plugins: ['lighthouse-plugin-simple'],
-      };
-      const config = new Config(configJson, {configPath: configFixturePath});
-      const groupIds = Object.keys(config.groups);
-      assert.ok(groupIds.length > 1);
-      assert.strictEqual(groupIds[groupIds.length - 1], 'lighthouse-plugin-simple-new-group');
-      assert.strictEqual(config.groups['lighthouse-plugin-simple-new-group'].title, 'New Group');
-    });
-
 
     it('should throw if the plugin is invalid', () => {
       const configJson = {

--- a/lighthouse-core/test/fixtures/config-plugins/lighthouse-plugin-simple/plugin-simple.js
+++ b/lighthouse-core/test/fixtures/config-plugins/lighthouse-plugin-simple/plugin-simple.js
@@ -7,6 +7,11 @@
 
 /** @type {LH.Config.Plugin} */
 module.exports = {
+  groups: {
+    'new-group': {
+      title: 'New Group',
+    },
+  },
   audits: [
     {path: 'redirects'},
     {path: 'user-timings'},

--- a/lighthouse-core/test/fixtures/config-plugins/lighthouse-plugin-simple/plugin-simple.js
+++ b/lighthouse-core/test/fixtures/config-plugins/lighthouse-plugin-simple/plugin-simple.js
@@ -18,6 +18,8 @@ module.exports = {
   ],
   category: {
     title: 'Simple',
-    auditRefs: [],
+    auditRefs: [
+      {id: 'redirects', weight: 1, group: 'new-group'},
+    ],
   },
 };

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -113,7 +113,8 @@ declare global {
         audits?: Array<{path: string}>;
         /** Provide a category to display the plugin results in the report. */
         category: LH.Config.Category;
-        // TODO(bckenny): groups
+        /** Optionally provide more groups in addition to those specified by the base config. */
+        groups?: Record<string, LH.Config.GroupJson>;
       }
 
       export type MergeOptionsOfItems = <T extends {path?: string, options: Record<string, any>}>(items: T[]) => T[];


### PR DESCRIPTION
**Summary**
Allow for plugin to add custom groups and assign custom to plugin auditRefs. 
Modify tests to verify groups added and assigned properly.

**Related Issues/PRs**
#6959
#6070
