### PR TITLE
cli: write report in runLighthouse before quitting Chrome

### DIFF
--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -62,53 +62,57 @@ function getDebuggableChrome(flags) {
   });
 }
 
+/** @return {never} */
 function showConnectionError() {
   console.error('Unable to connect to Chrome');
-  process.exit(_RUNTIME_ERROR_CODE);
+  return process.exit(_RUNTIME_ERROR_CODE);
 }
 
+/** @return {never} */
 function showProtocolTimeoutError() {
   console.error('Debugger protocol timed out while connecting to Chrome.');
-  process.exit(_PROTOCOL_TIMEOUT_EXIT_CODE);
+  return process.exit(_PROTOCOL_TIMEOUT_EXIT_CODE);
 }
 
-/** @param {LH.LighthouseError} err */
+/** @param {LH.LighthouseError} err @return {never} */
 function showPageHungError(err) {
   console.error('Page hung:', err.friendlyMessage);
-  process.exit(_PAGE_HUNG_EXIT_CODE);
+  return process.exit(_PAGE_HUNG_EXIT_CODE);
 }
 
-/** @param {LH.LighthouseError} err */
+/** @param {LH.LighthouseError} err @return {never} */
 function showInsecureDocumentRequestError(err) {
   console.error('Insecure document request:', err.friendlyMessage);
-  process.exit(_INSECURE_DOCUMENT_REQUEST_EXIT_CODE);
+  return process.exit(_INSECURE_DOCUMENT_REQUEST_EXIT_CODE);
 }
 
 /**
  * @param {LH.LighthouseError} err
+ * @return {never}
  */
 function showRuntimeError(err) {
   console.error('Runtime error encountered:', err.friendlyMessage || err.message);
   if (err.stack) {
     console.error(err.stack);
   }
-  process.exit(_RUNTIME_ERROR_CODE);
+  return process.exit(_RUNTIME_ERROR_CODE);
 }
 
 /**
  * @param {LH.LighthouseError} err
+ * @return {never}
  */
 function handleError(err) {
   if (err.code === 'ECONNREFUSED') {
-    showConnectionError();
+    return showConnectionError();
   } else if (err.code === 'CRI_TIMEOUT') {
-    showProtocolTimeoutError();
+    return showProtocolTimeoutError();
   } else if (err.code === 'PAGE_HUNG') {
-    showPageHungError(err);
+    return showPageHungError(err);
   } else if (err.code === 'INSECURE_DOCUMENT_REQUEST') {
-    showInsecureDocumentRequestError(err);
+    return showInsecureDocumentRequestError(err);
   } else {
-    showRuntimeError(err);
+    return showRuntimeError(err);
   }
 }
 
@@ -160,65 +164,61 @@ async function saveResults(runnerResult, flags) {
 }
 
 /**
+ * Attempt to kill the launched Chrome, if defined.
+ * @param {ChromeLauncher.LaunchedChrome=} launchedChrome
+ * @return {Promise<void>}
+ */
+async function potentiallyKillChrome(launchedChrome) {
+  if (!launchedChrome) return;
+
+  try {
+    await launchedChrome.kill();
+  } catch (err) {
+    process.stderr.write(`Couldn't quit Chrome process. ${err.toString()}\n`);
+  }
+}
+
+/**
  * @param {string} url
  * @param {LH.CliFlags} flags
  * @param {LH.Config.Json|undefined} config
- * @return {Promise<LH.RunnerResult|void>}
+ * @return {Promise<LH.RunnerResult|undefined>}
  */
-function runLighthouse(url, flags, config) {
-  /** @type {ChromeLauncher.LaunchedChrome|undefined} */
-  let launchedChrome;
-  const shouldGather = flags.gatherMode || flags.gatherMode === flags.auditMode;
-  let chromeP = Promise.resolve();
-
-  process.on('unhandledRejection', async (reason) => {
+async function runLighthouse(url, flags, config) {
+  /** @param {any} reason */
+  async function handleTheUnhandled(reason) {
     process.stderr.write(`Unhandled Rejection. Reason: ${reason}\n`);
-    try {
-      await potentiallyKillChrome();
-    } catch (err) {
-      process.stderr.write(`Couldn't quit Chrome process. ${err.toString()}\n`);
-    }
+    await potentiallyKillChrome(launchedChrome);
     setTimeout(_ => {
       process.exit(1);
     }, 100);
-  });
-
-  if (shouldGather) {
-    chromeP = chromeP.then(_ =>
-      getDebuggableChrome(flags).then(launchedChromeInstance => {
-        launchedChrome = launchedChromeInstance;
-        flags.port = launchedChrome.port;
-      })
-    );
   }
+  process.on('unhandledRejection', handleTheUnhandled);
 
-  const resultsP = chromeP.then(_ => {
-    return lighthouse(url, flags, config).then(runnerResult => {
-      return potentiallyKillChrome().then(_ => runnerResult);
-    }).then(async runnerResult => {
-      // If in gatherMode only, there will be no runnerResult.
-      if (runnerResult) {
-        await saveResults(runnerResult, flags);
-      }
+  /** @type {ChromeLauncher.LaunchedChrome|undefined} */
+  let launchedChrome;
 
-      return runnerResult;
-    });
-  });
-
-  return resultsP.catch(err => {
-    return Promise.resolve()
-      .then(_ => potentiallyKillChrome())
-      .then(_ => handleError(err));
-  });
-
-  /**
-   * @return {Promise<{}>}
-   */
-  function potentiallyKillChrome() {
-    if (launchedChrome !== undefined) {
-      return launchedChrome.kill();
+  try {
+    const shouldGather = flags.gatherMode || flags.gatherMode === flags.auditMode;
+    if (shouldGather) {
+      launchedChrome = await getDebuggableChrome(flags);
+      flags.port = launchedChrome.port;
     }
-    return Promise.resolve({});
+
+    const runnerResult = await lighthouse(url, flags, config);
+
+    // If in gatherMode only, there will be no runnerResult.
+    if (runnerResult) {
+      await saveResults(runnerResult, flags);
+    }
+
+    await potentiallyKillChrome(launchedChrome);
+    process.removeListener('unhandledRejection', handleTheUnhandled);
+
+    return runnerResult;
+  } catch (err) {
+    await potentiallyKillChrome(launchedChrome);
+    handleError(err);
   }
 }
 

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -171,11 +171,12 @@ async function saveResults(runnerResult, flags) {
 async function potentiallyKillChrome(launchedChrome) {
   if (!launchedChrome) return;
 
-  try {
-    await launchedChrome.kill();
-  } catch (err) {
+  return Promise.race([
+    launchedChrome.kill(),
+    new Promise((_, reject) => setTimeout(reject, 5000, 'Timed out.')),
+  ]).catch(err => {
     process.stderr.write(`Couldn't quit Chrome process. ${err.toString()}\n`);
-  }
+  });
 }
 
 /**

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -175,7 +175,7 @@ async function potentiallyKillChrome(launchedChrome) {
     launchedChrome.kill(),
     new Promise((_, reject) => setTimeout(reject, 5000, 'Timed out.')),
   ]).catch(err => {
-    process.stderr.write(`Couldn't quit Chrome process. ${err.toString()}\n`);
+    throw new Error(`Couldn't quit Chrome process. ${err}`);
   });
 }
 
@@ -189,7 +189,7 @@ async function runLighthouse(url, flags, config) {
   /** @param {any} reason */
   async function handleTheUnhandled(reason) {
     process.stderr.write(`Unhandled Rejection. Reason: ${reason}\n`);
-    await potentiallyKillChrome(launchedChrome);
+    await potentiallyKillChrome(launchedChrome).catch(() => {});
     setTimeout(_ => {
       process.exit(1);
     }, 100);
@@ -218,7 +218,7 @@ async function runLighthouse(url, flags, config) {
 
     return runnerResult;
   } catch (err) {
-    await potentiallyKillChrome(launchedChrome);
+    await potentiallyKillChrome(launchedChrome).catch(() => {});
     handleError(err);
   }
 }


### PR DESCRIPTION
while we wait for the fix for https://crbug.com/936272 and/or in chrome-launcher, this change at least writes the report to disk before waiting for Chrome to close.

Also removes the `unhandledRejection` listener when done (fixing the `MaxListenersExceededWarning` for @Hoten) and converts`runLighthouse` to use async/await, as the ancient promise business in there was inscrutable. I think there's still more to improve here, both bikeshedding and file organization (e.g. `handleError` should maybe be in `bin.js`, not in here); happy for more ideas or leaving all that for yet another day.