### PR TITLE
misc: run NetworkService in-process to avoid hanging process kill

### DIFF
--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -57,7 +57,7 @@ function parseChromeFlags(flags = '') {
 function getDebuggableChrome(flags) {
   return ChromeLauncher.launch({
     port: flags.port,
-    chromeFlags: parseChromeFlags(flags.chromeFlags),
+    chromeFlags: parseChromeFlags(flags.chromeFlags + ' --enable-features=NetworkServiceInProcess'),
     logLevel: flags.logLevel,
   });
 }


### PR DESCRIPTION
temporary workaround for the hang on `ChromeLauncher Killing Chrome instance`