### PR TITLE
core(tap targets): make tap targets failures more visible

### DIFF
--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -184,7 +184,7 @@ module.exports = [
     finalUrl: BASE_URL + 'seo-tap-targets.html',
     audits: {
       'tap-targets': {
-        score: 0.81, // 10 passing targets/11 total visible targets, multiplied by 0.9 to get the score
+        score: 0.8, // 10 passing targets/11 total visible targets, multiplied by 0.89 to get the score
         details: {
           items: [
             {

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -184,7 +184,7 @@ module.exports = [
     finalUrl: BASE_URL + 'seo-tap-targets.html',
     audits: {
       'tap-targets': {
-        score: 0.9, // 10 passing targets/11 total visible targets
+        score: 0.81, // 10 passing targets/11 total visible targets, multiplied by 0.9 to get the score
         details: {
           items: [
             {

--- a/lighthouse-core/audits/seo/tap-targets.js
+++ b/lighthouse-core/audits/seo/tap-targets.js
@@ -302,8 +302,15 @@ class TapTargets extends Audit {
     const failingTapTargetCount = new Set(overlapFailures.map(f => f.tapTarget)).size;
     const passingTapTargetCount = tapTargetCount - failingTapTargetCount;
 
-    const score = tapTargetCount > 0 ? passingTapTargetCount / tapTargetCount : 1;
-    const displayValue = str_(UIStrings.displayValue, {decimalProportion: score});
+    let score = 1;
+    let passingTapTargetRatio = 1;
+    if (failingTapTargetCount > 0) {
+      passingTapTargetRatio = (passingTapTargetCount / tapTargetCount);
+      // If there are any failures then we don't want the audit to pass,
+      // so multiply by 0.89 to keep the score below 90.
+      score = passingTapTargetRatio * 0.89;
+    }
+    const displayValue = str_(UIStrings.displayValue, {decimalProportion: passingTapTargetRatio});
 
     return {
       rawValue: tableItems.length === 0,

--- a/lighthouse-core/audits/seo/tap-targets.js
+++ b/lighthouse-core/audits/seo/tap-targets.js
@@ -308,7 +308,7 @@ class TapTargets extends Audit {
       passingTapTargetRatio = (passingTapTargetCount / tapTargetCount);
       // If there are any failures then we don't want the audit to pass,
       // so keep the score below 90.
-      score = Math.min(passingTapTargetRatio * 0.9, 0.89);
+      score = passingTapTargetRatio * 0.89;
     }
     const displayValue = str_(UIStrings.displayValue, {decimalProportion: passingTapTargetRatio});
 

--- a/lighthouse-core/audits/seo/tap-targets.js
+++ b/lighthouse-core/audits/seo/tap-targets.js
@@ -307,8 +307,8 @@ class TapTargets extends Audit {
     if (failingTapTargetCount > 0) {
       passingTapTargetRatio = (passingTapTargetCount / tapTargetCount);
       // If there are any failures then we don't want the audit to pass,
-      // so multiply by 0.89 to keep the score below 90.
-      score = passingTapTargetRatio * 0.89;
+      // so keep the score below 90.
+      score = Math.min(passingTapTargetRatio * 0.9, 0.89);
     }
     const displayValue = str_(UIStrings.displayValue, {decimalProportion: passingTapTargetRatio});
 

--- a/lighthouse-core/test/audits/seo/tap-targets-test.js
+++ b/lighthouse-core/test/audits/seo/tap-targets-test.js
@@ -194,7 +194,7 @@ describe('SEO: Tap targets audit', () => {
         increaseRightWidth: true,
       })
     );
-    assert.equal(Math.round(auditResult.score * 100), 60);
+    assert.equal(Math.round(auditResult.score * 100), 59);
     const failures = auditResult.details.items;
     // <main> fails, but <right> doesn't
     assert.equal(failures[0].tapTarget.snippet, '<main></main>');

--- a/lighthouse-core/test/audits/seo/tap-targets-test.js
+++ b/lighthouse-core/test/audits/seo/tap-targets-test.js
@@ -139,7 +139,7 @@ describe('SEO: Tap targets audit', () => {
       })
     );
     assert.equal(auditResult.rawValue, false);
-    assert.equal(Math.round(auditResult.score * 100), 33);
+    assert.equal(Math.round(auditResult.score * 100), 30);
     const failure = auditResult.details.items[0];
     assert.equal(failure.tapTarget.snippet, '<main></main>');
     assert.equal(failure.overlappingTarget.snippet, '<right></right>');
@@ -194,7 +194,7 @@ describe('SEO: Tap targets audit', () => {
         increaseRightWidth: true,
       })
     );
-    assert.equal(Math.round(auditResult.score * 100), 67);
+    assert.equal(Math.round(auditResult.score * 100), 60);
     const failures = auditResult.details.items;
     // <main> fails, but <right> doesn't
     assert.equal(failures[0].tapTarget.snippet, '<main></main>');


### PR DESCRIPTION
**Summary**

Right now if the audit score is above 90 the tap targets audit doesn't fail even if there are overlap failures. That way it's hard to identify what's dragging the SEO score down. So if there are failures we should cap the score at 89.

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->

Closes https://github.com/GoogleChrome/lighthouse/issues/7338