### PR TITLE
docs: fix throttling rate comment and tweak comcast bandwidth

### DIFF
--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -48,7 +48,7 @@ Currently, `comcast` will also throttle the websocket port that Lighthouse uses 
 
 ```sh
 # Enable system traffic throttling
-comcast --latency=150 --target-bw=1600
+comcast --latency=150 --target-bw=1638
 
 # Run Lighthouse with its own throttling disabled
 lighthouse --throttling.requestLatencyMs=0 --throttling.downloadThroughputKbps=0 --throttling.uploadThroughputKbps=0 # ...

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -61,14 +61,14 @@ declare global {
     interface ThrottlingSettings {
       /** The round trip time in milliseconds. */
       rttMs?: number;
-      /** The network throughput in kilobytes per second. */
+      /** The network throughput in kilobits per second. */
       throughputKbps?: number;
       // devtools settings
       /** The network request latency in milliseconds. */
       requestLatencyMs?: number;
-      /** The network download throughput in kilobytes per second. */
+      /** The network download throughput in kilobits per second. */
       downloadThroughputKbps?: number;
-      /** The network upload throughput in kilobytes per second. */
+      /** The network upload throughput in kilobits per second. */
       uploadThroughputKbps?: number;
       // used by both
       /** The amount of slowdown applied to the cpu (1/<cpuSlowdownMultiplier>). */


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**

Throttling rate is in kilobits not kilobytes.

LH uses a bandwidth of 1638kbps/1.6mpbs by default, so we should recommend using that with comcast too.