### PR TITLE
misc: clean node_modules/.cache before travis builds its cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ before_cache:
   # the `yarn compile-devtools` task adds these to node_modules, which slows down caching
   - rm -rf ./node_modules/temp-devtoolsfrontend/
   - rm -rf ./node_modules/temp-devtoolsprotocol/
+  # nyc, jest and other projects store files in here. They mess up the travis build cache.
+  - rm -rf ./node_modules/.cache/
 after_success:
   - yarn coveralls
   - yarn codecov


### PR DESCRIPTION
I noticed this in the travis logs:

![image](https://user-images.githubusercontent.com/39191/53833244-eb503280-3f3c-11e9-81e6-015d76469ac1.png)

Fixing this might speed up travis by ~55s..