### PR TITLE
Testing travis build time [do not commit]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: required
 language: node_js
-branches:
-  only:
-  - master
 matrix:
   include:
     - node_js: "8"


### PR DESCRIPTION
Back in Nov 2018 our travis builds were very consistently taking 9-10 min. Lately they have been taking much longer.. 14-15min. 

![image](https://user-images.githubusercontent.com/39191/53835746-12a9fe00-3f43-11e9-811a-320059db2da0.png)

This branch is off a commit in november, so we'd expect it to take 9-10 minutes for travis to build it...



