### PR TITLE
core(vuln-libs): match against all semver ranges provided by snyk

### DIFF
--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -108,13 +108,13 @@ class NoVulnerableLibrariesAudit extends Audit {
     });
 
     const vulns = matchingVulns.map(vuln => {
-        return {
-          severity: vuln.severity,
-          numericSeverity: this.severityMap[vuln.severity],
-          library: `${lib.name}@${normalizedVersion}`,
-          url: 'https://snyk.io/vuln/' + vuln.id,
-        };
-      });
+      return {
+        severity: vuln.severity,
+        numericSeverity: this.severityMap[vuln.severity],
+        library: `${lib.name}@${normalizedVersion}`,
+        url: 'https://snyk.io/vuln/' + vuln.id,
+      };
+    });
 
     return vulns;
   }

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -5,8 +5,7 @@
  */
 'use strict';
 
-const NoVulnerableLibrariesAudit =
-  require('../../../audits/dobetterweb/no-vulnerable-libraries.js');
+const NoVulnerableLibrariesAudit = require('../../../audits/dobetterweb/no-vulnerable-libraries.js');
 const assert = require('assert');
 
 /* eslint-env jest */
@@ -41,6 +40,26 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
     assert.equal(auditResult.details.items[0].detectedLib.type, 'link');
     assert.equal(auditResult.details.items[0].detectedLib.text, 'angular@1.1.4');
     assert.equal(auditResult.details.items[0].detectedLib.url, 'https://snyk.io/vuln/npm:angular?lh=1.1.4&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit');
+  });
+
+  it('fails when JS libraries w/ vulnerabilities are detected (in the semver range array)', () => {
+    const auditResult = NoVulnerableLibrariesAudit.audit({
+      JSLibraries: [{name: 'jquery', version: '2.1.1', npmPkgName: 'jquery'}],
+    });
+    expect(auditResult.details.items).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "detectedLib": Object {
+      "text": "jquery@2.1.1",
+      "type": "link",
+      "url": "https://snyk.io/vuln/npm:jquery?lh=2.1.1&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit",
+    },
+    "highestSeverity": "Medium",
+    "vulnCount": 1,
+  },
+]
+`);
+    assert.equal(auditResult.rawValue, false);
   });
 
   it('handles ill-specified versions', () => {

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -39,20 +39,23 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
     assert.equal(auditResult.details.items[0].highestSeverity, 'High');
     assert.equal(auditResult.details.items[0].detectedLib.type, 'link');
     assert.equal(auditResult.details.items[0].detectedLib.text, 'angular@1.1.4');
-    assert.equal(auditResult.details.items[0].detectedLib.url, 'https://snyk.io/vuln/npm:angular?lh=1.1.4&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit');
+    assert.equal(
+      auditResult.details.items[0].detectedLib.url,
+      'https://snyk.io/vuln/npm:angular?lh=1.1.4&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit'
+    );
   });
 
   it('fails when JS libraries w/ vulnerabilities are detected (in the semver range array)', () => {
     const auditResult = NoVulnerableLibrariesAudit.audit({
-      JSLibraries: [{name: 'jquery', version: '2.1.1', npmPkgName: 'jquery'}],
+      JSLibraries: [{name: 'Bootstrap', version: '4.0.0-alpha', npmPkgName: 'bootstrap'}],
     });
     expect(auditResult.details.items).toMatchInlineSnapshot(`
 Array [
   Object {
     "detectedLib": Object {
-      "text": "jquery@2.1.1",
+      "text": "Bootstrap@4.0.0-alpha",
       "type": "link",
-      "url": "https://snyk.io/vuln/npm:jquery?lh=2.1.1&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit",
+      "url": "https://snyk.io/vuln/npm:bootstrap?lh=4.0.0-alpha&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit",
     },
     "highestSeverity": "Medium",
     "vulnCount": 1,

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -43,7 +43,7 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
     assert.equal(auditResult.details.items[0].detectedLib.url, 'https://snyk.io/vuln/npm:angular?lh=1.1.4&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit');
   });
 
-  describe('handles vuln details correctly', () => {
+  it('fails when libraries w/ vulnerabilities are detected (anywhere in the semver array)', () => {
     // Vulnerability with an array of semver ranges
     const mockSnykDb = {
       npm: {
@@ -52,33 +52,22 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
         ],
       },
     };
-    beforeEach(() => {
-      origSnykDb = NoVulnerableLibrariesAudit.snykDB;
-      NoVulnerableLibrariesAudit.setSnykDBForTest(mockSnykDb);
-    });
-    afterEach(() => {
-      NoVulnerableLibrariesAudit.setSnykDBForTest(undefined);
-    });
-
-    it('fails when libraries w/ vulnerabilities are detected (in the semver range array)', () => {
-      const auditResult = NoVulnerableLibrariesAudit.audit({
-        JSLibraries: [{name: 'Badlib', version: '3.0.0', npmPkgName: 'badlib'}],
-      });
-      expect(auditResult.details.items).toMatchInlineSnapshot(`
+    const JSLibraries = [{name: 'Badlib', version: '3.0.0', npmPkgName: 'badlib'}];
+    const vulns = NoVulnerableLibrariesAudit.getVulnerabilities(
+      '3.0.0',
+      JSLibraries[0],
+      mockSnykDb
+    );
+    expect(vulns).toMatchInlineSnapshot(`
 Array [
   Object {
-    "detectedLib": Object {
-      "text": "Badlib@3.0.0",
-      "type": "link",
-      "url": "https://snyk.io/vuln/npm:badlib?lh=3.0.0&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit",
-    },
-    "highestSeverity": "Medium",
-    "vulnCount": 1,
+    "library": "Badlib@3.0.0",
+    "numericSeverity": 2,
+    "severity": "medium",
+    "url": "https://snyk.io/vuln/badlibvuln:12345",
   },
 ]
 `);
-      assert.equal(auditResult.rawValue, false);
-    });
   });
 
   it('handles ill-specified versions', () => {


### PR DESCRIPTION
Fixes issue identified in https://github.com/GoogleChrome/lighthouse/pull/7392/files#r262967099


Up until now we've been missing 3 vulns for bootstrap that had more than one semver range.
![image](https://user-images.githubusercontent.com/39191/53903418-8528e580-3ff8-11e9-8507-db00fb0de52a.png)

But aside from 4.0.0-alpha, these versions [had been flagged](https://github.com/GoogleChrome/lighthouse/blob/d93bdf35f467957a11a31aa48456d63373e08ad7/third-party/snyk/snapshot.json#L31) with another vuln, so we really hadn't been missing out on any coverage..  :)

