### PR TITLE
core(image-aspect-ratio): ignore css background images

### DIFF
--- a/lighthouse-core/audits/image-aspect-ratio.js
+++ b/lighthouse-core/audits/image-aspect-ratio.js
@@ -72,10 +72,13 @@ class ImageAspectRatio extends Audit {
     /** @type {Array<{url: string, displayedAspectRatio: string, actualAspectRatio: string, doRatiosMatch: boolean}>} */
     const results = [];
     images.filter(image => {
+      // - filter out css background images since we don't have a reliable way to tell if it's a
+      //   sprite sheet, repeated for effect, etc
       // - filter out images that don't have following properties:
       //   networkRecord, width, height, images that use `object-fit`: `cover` or `contain`
       // - filter all svgs as they have no natural dimensions to audit
-      return image.mimeType &&
+      return !image.isCss &&
+        image.mimeType &&
         image.mimeType !== 'image/svg+xml' &&
         image.naturalHeight > 5 &&
         image.naturalWidth > 5 &&

--- a/lighthouse-core/test/audits/image-aspect-ratio-test.js
+++ b/lighthouse-core/test/audits/image-aspect-ratio-test.js
@@ -37,7 +37,16 @@ describe('Images: aspect-ratio audit', () => {
         assert.ok(!result.warnings || result.warnings.length === 0, 'should not have warnings');
       }
     });
-  }
+  };
+
+  testImage('is a css image', {
+    rawValue: true,
+    clientSize: [1000, 20],
+    naturalSize: [5, 5],
+    props: {
+      isCss: true,
+    },
+  });
 
   testImage('is much larger than natural aspect ratio', {
     rawValue: false,

--- a/lighthouse-core/test/audits/image-aspect-ratio-test.js
+++ b/lighthouse-core/test/audits/image-aspect-ratio-test.js
@@ -37,7 +37,7 @@ describe('Images: aspect-ratio audit', () => {
         assert.ok(!result.warnings || result.warnings.length === 0, 'should not have warnings');
       }
     });
-  };
+  }
 
   testImage('is a css image', {
     rawValue: true,


### PR DESCRIPTION
**Summary**
We just don't have reliable ways of doing this for CSS background images, it's not worth the distrust this brings. See #7487 and https://twitter.com/_Caleb_R/status/1106204173048139776

**Related Issues/PRs**
closes #7487
