### PR TITLE
core(oopif): autoattach to all descendants

### DIFF
--- a/lighthouse-cli/test/fixtures/oopif.html
+++ b/lighthouse-cli/test/fixtures/oopif.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <h1>Hello frames</h1>
-    <iframe name="oopif" src="https://airhorner.com"></iframe>
+    <iframe name="oopif" src="https://paulirish.com/page/2"></iframe>
   </body>
 </html>

--- a/lighthouse-cli/test/smokehouse/oopif-expectations.js
+++ b/lighthouse-cli/test/smokehouse/oopif-expectations.js
@@ -16,10 +16,11 @@ module.exports = [
       'network-requests': {
         details: {
           items: {
-            // The page itself only makes a few requests.
-            // We want to make sure we are finding the iframe's requests (airhorner) while being flexible enough
-            // to allow changes to the live site.
-            length: '>10',
+            // We want to make sure we are finding the iframe's requests (paulirish.com) *AND*
+            // the iframe's iframe's iframe's requests (youtube.com/doubleclick/etc).
+            // - paulirish.com ~50-60 requests
+            // - paulirish.com + all descendant iframes ~80-90 requests
+            length: '>70',
           },
         },
       },

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -52,18 +52,18 @@ class Connection {
    * Call protocol methods
    * @template {keyof LH.CrdpCommands} C
    * @param {C} method
+   * @param {string|undefined} sessionId
    * @param {LH.CrdpCommands[C]['paramsType']} paramArgs,
    * @return {Promise<LH.CrdpCommands[C]['returnType']>}
    */
-  sendCommand(method, ...paramArgs) {
+  sendCommand(method, sessionId, ...paramArgs) {
     // Reify params since we need it as a property so can't just spread again.
     const params = paramArgs.length ? paramArgs[0] : undefined;
 
-    log.formatProtocol('method => browser', {method, params}, 'verbose');
+    log.formatProtocol('method => browser', {method, params, sessionId}, 'verbose');
     const id = ++this._lastCommandId;
-    const message = JSON.stringify({id, method, params});
+    const message = JSON.stringify({id, method, params, sessionId});
     this.sendRawMessage(message);
-
     return new Promise(resolve => {
       this._callbacks.set(id, {method, resolve});
     });

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -70,16 +70,21 @@ class Driver {
     this._monitoredUrl = null;
 
     let targetProxyMessageId = 0;
-    this.on('Target.attachedToTarget', event => {
+    this.on('Target.targetCreated', async event => {
       targetProxyMessageId++;
       // We're only interested in network requests from iframes for now as those are "part of the page".
       if (event.targetInfo.type !== 'iframe') return;
+
+      // Attach to the target, so we can get a sessionId and send messages to it.
+      const {sessionId} = await this.sendCommand('Target.attachToTarget', {
+        targetId: event.targetInfo.targetId,
+      });
 
       // We want to receive information about network requests from iframes, so enable the Network domain.
       // Network events from subtargets will be stringified and sent back on `Target.receivedMessageFromTarget`.
       this.sendCommand('Target.sendMessageToTarget', {
         message: JSON.stringify({id: targetProxyMessageId, method: 'Network.enable'}),
-        sessionId: event.sessionId,
+        sessionId,
       });
     });
 
@@ -1041,11 +1046,9 @@ class Driver {
     await this._beginNetworkStatusMonitoring(url);
     await this._clearIsolatedContextId();
 
-    // Enable auto-attaching to subtargets so we receive iframe information
-    await this.sendCommand('Target.setAutoAttach', {
-      autoAttach: true,
-      waitForDebuggerOnStart: false,
-    });
+    // Enable auto-discovering of subtargets, so we can find iframes.
+    // Prefer this over `setAutoAttach` because it doesn't really attach to all targets.
+    await this.sendCommand('Target.setDiscoverTargets', {discover: true});
 
     await this.sendCommand('Page.enable');
     await this.sendCommand('Page.setLifecycleEventsEnabled', {enabled: true});

--- a/lighthouse-core/lib/network-recorder.js
+++ b/lighthouse-core/lib/network-recorder.js
@@ -102,25 +102,11 @@ class NetworkRecorder extends EventEmitter {
   }
 
   /**
-   * frame root network requests don't always "finish" even when they're done loading data, use responseReceived instead
-   * @see https://github.com/GoogleChrome/lighthouse/issues/6067#issuecomment-423211201
-   * @param {LH.Artifacts.NetworkRequest} record
-   * @return {boolean}
-   */
-  static _isFrameRootRequestAndFinished(record) {
-    const isFrameRootRequest = record.url === record.documentURL;
-    const responseReceived = record.responseReceivedTime > 0;
-    return !!(isFrameRootRequest && responseReceived && record.endTime);
-  }
-
-  /**
    * @param {LH.Artifacts.NetworkRequest} record
    * @return {boolean}
    */
   static isNetworkRecordFinished(record) {
-    return record.finished ||
-      NetworkRecorder._isQUICAndFinished(record) ||
-      NetworkRecorder._isFrameRootRequestAndFinished(record);
+    return record.finished || NetworkRecorder._isQUICAndFinished(record);
   }
 
   /**

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -56,7 +56,7 @@ function getMockedEmulationDriver(emulationFn, netThrottleFn, cpuThrottleFn,
     clearDataForOrigin() {}
   };
   const EmulationMock = class extends Connection {
-    sendCommand(command, params) {
+    sendCommand(command, sessionId, params) {
       let fn = null;
       switch (command) {
         case 'Network.emulateNetworkConditions':

--- a/lighthouse-core/test/lib/network-recorder-test.js
+++ b/lighthouse-core/test/lib/network-recorder-test.js
@@ -249,9 +249,7 @@ describe('network recorder', function() {
       ];
 
       const periods = NetworkRecorder.findNetworkQuietPeriods(records, 0);
-      assert.deepStrictEqual(periods, [
-        {start: 1200, end: Infinity},
-      ]);
+      assert.deepStrictEqual(periods, []);
     });
 
     it('should handle QUIC requests', () => {


### PR DESCRIPTION
**Summary**
While trying to revert #6078 discovered a few iframes that don't get autoattached for some reason. ~~It's unclear to me why `setAutoAttach` doesn't find them. At first I thought it was a grandchild iframe problem, but that didn't really explain the pattern and recursively sending `setAutoAttach` didn't solve it either.~~ It's cross-origin grandchild frames that get put into new processes distinct from all other previous frames. AFAICT, in many cases the grandchild issue wasn't a problem before because the site also had a direct child that got grouped into that same process (i.e. the verge has a doubleclick iframe so when a different ad iframe adds a doubleclick grandchild frame we were still good, or at least that's why I believe my test cases were all my passing). The reproducible case I've got now is our localhost iframing paulirish.com which iframes youtube, 3 distinct origins that always get separated.

~~Switching over to autodiscover solved it though, so I've switched to that here. I feel a tad out of my depth here maybe someone from devtools would want to comment on what my issue is. Perhaps `flatten: true` solves this and isn't just about the `sessionId` bookkeeping change?~~ Per Pavel we should avoid autodiscover and go with autoattach. This means we must start keeping track of session ids on our connection, so here comes the plumbing! 😭 

~~I'm also not 100% how to add a test for this since I don't fully understand why devtools doesn't attach to all targets and I have trouble reproducing it anyhow, but suggestions welcome :)~~

**Related Issues/PRs**
#6337  #6078
