### PR TITLE
core(seo): support spanish in link-text audit

### DIFF
--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -43,7 +43,7 @@ const BLOCKLIST = new Set([
   'este',
   'enlace',
   'este enlace',
-  'empezar', 
+  'empezar',
 ]);
 const i18n = require('../../lib/i18n/i18n.js');
 

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -25,6 +25,25 @@ const BLOCKLIST = new Set([
   '続きを読む',
   '続く',
   '全文表示',
+  // Spanish
+  'click aquí',
+  'click aqui',
+  'clicka aquí',
+  'clicka aqui',
+  'pincha aquí',
+  'pincha aqui',
+  'aquí',
+  'aqui',
+  'más',
+  'mas',
+  'más información',
+  'más informacion',
+  'mas información',
+  'mas informacion',
+  'este',
+  'enlace',
+  'este enlace',
+  'empezar', 
 ]);
 const i18n = require('../../lib/i18n/i18n.js');
 


### PR DESCRIPTION
I have added a couple of translations for the [Links Do Not Have Descriptive Text](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text) audit in Spanish.

Note that in Spanish there is this symbol: `´`. People forget to write it so we may take into account these errors, let me know your opinion.

**Related Issues/PRs**
#5322 but in Spanish
