### PR TITLE
OOPIF full support in extension

### DIFF
--- a/clients/test/extension/extension-test.js
+++ b/clients/test/extension/extension-test.js
@@ -70,7 +70,7 @@ describe('Lighthouse chrome extension', function() {
     });
 
     const page = await browser.newPage();
-    await page.goto('https://www.paulirish.com', {waitUntil: 'networkidle2'});
+    await page.goto('https://www.paulirish.com/page/2', {waitUntil: 'networkidle2'});
     const targets = await browser.targets();
     const extensionTarget = targets.find(({_targetInfo}) => {
       return _targetInfo.title === 'Lighthouse' && _targetInfo.type === 'background_page';
@@ -179,5 +179,9 @@ describe('Lighthouse chrome extension', function() {
 
   it('should specify the channel as extension', async () => {
     assert.equal(lhr.configSettings.channel, 'extension');
+  });
+
+  it('should find OOPIF network requests', async () => {
+    expect(lhr.audits['network-requests'].details.items.length).toBeGreaterThan(60);
   });
 });

--- a/lighthouse-core/gather/connections/connection.js
+++ b/lighthouse-core/gather/connections/connection.js
@@ -52,14 +52,14 @@ class Connection {
    * Call protocol methods
    * @template {keyof LH.CrdpCommands} C
    * @param {C} method
-   * @param {string|undefined} sessionId
+   * @param {{sessionId: string, targetId: string}|undefined} target
    * @param {LH.CrdpCommands[C]['paramsType']} paramArgs,
    * @return {Promise<LH.CrdpCommands[C]['returnType']>}
    */
-  sendCommand(method, sessionId, ...paramArgs) {
+  sendCommand(method, target, ...paramArgs) {
     // Reify params since we need it as a property so can't just spread again.
     const params = paramArgs.length ? paramArgs[0] : undefined;
-
+    const sessionId = target && target.sessionId;
     log.formatProtocol('method => browser', {method, params, sessionId}, 'verbose');
     const id = ++this._lastCommandId;
     const message = JSON.stringify({id, method, params, sessionId});


### PR DESCRIPTION
broken out from #7517 for easier diffing

**tl;dr** I don't see an immediate way to make extensions work with `setAutoAttach`

**Summary**
The problem: [extension debugger API](https://developers.chrome.com/extensions/debugger#method-sendCommand) does not have a parameter for `sessionId`. It's method of talking to targets uses `targetId` and a different `sendCommand` just to them. This PR implements that approach, *however*, we run into a problem.

1. You cannot `chrome.debugger.sendCommand` to a target you have not yet attached to.
2. You cannot `chrome.debugger.attach` to a target that has already been attached to by another debugger (which `Target.setAutoAttach` seems to do).

The options as I see it:

1. Get `chrome.debugger.sendCommand` to support `sessionId` as a `Debuggee` target (maybe there's hidden support I haven't found?? I tried sending it as part of params too with no luck)
2. Switch back to `discover` all the targets and filter the frame tree instead of `setAutoAttach`
3. Something I'm missing?


**Related Issues/PRs**
#7517 
