### PR TITLE
core(logging): Don't log when closing already closed page

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -128,7 +128,7 @@ class GatherRunner {
     } catch (err) {
       // Ignore disconnecting error if browser was already closed.
       // See https://github.com/GoogleChrome/lighthouse/issues/1583
-      if (!(/close\/.*status: 500$/.test(err.message))) {
+      if (!(/close\/.*status: (500|404)$/.test(err.message))) {
         log.error('GatherRunner disconnect', err.message);
       }
     }


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! -->

**Summary**
![Screenshot 2019-03-19 at 15 29 54](https://user-images.githubusercontent.com/2109932/54613937-df479300-4a5b-11e9-9ad6-cc6062d5cf92.png)

Happens when running lighthouse on insecure pages:
```
lighthouse https://wrong.host.badssl.com/
```
<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**

I also sometimes get this error (like one in 10 times or so).

![Screenshot 2019-03-19 at 15 56 40](https://user-images.githubusercontent.com/2109932/54616220-a4475e80-4a5f-11e9-9c00-263868954b0f.png)
