### PR TITLE
cli(logging): Use lighthouse logger to display runtime errors

### DIFF
--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -64,25 +64,25 @@ function getDebuggableChrome(flags) {
 
 /** @return {never} */
 function showConnectionError() {
-  log.error('CLI runtime', 'Unable to connect to Chrome');
+  log.error('CLI', 'Unable to connect to Chrome');
   return process.exit(_RUNTIME_ERROR_CODE);
 }
 
 /** @return {never} */
 function showProtocolTimeoutError() {
-  log.error('CLI runtime', 'Debugger protocol timed out while connecting to Chrome.');
+  log.error('CLI', 'Debugger protocol timed out while connecting to Chrome.');
   return process.exit(_PROTOCOL_TIMEOUT_EXIT_CODE);
 }
 
 /** @param {LH.LighthouseError} err @return {never} */
 function showPageHungError(err) {
-  log.error('CLI runtime', 'Page hung:', err.friendlyMessage);
+  log.error('CLI', 'Page hung:', err.friendlyMessage);
   return process.exit(_PAGE_HUNG_EXIT_CODE);
 }
 
 /** @param {LH.LighthouseError} err @return {never} */
 function showInsecureDocumentRequestError(err) {
-  log.error('CLI runtime', 'Insecure document request:', err.friendlyMessage);
+  log.error('CLI', 'Insecure document request:', err.friendlyMessage);
   return process.exit(_INSECURE_DOCUMENT_REQUEST_EXIT_CODE);
 }
 
@@ -91,9 +91,9 @@ function showInsecureDocumentRequestError(err) {
  * @return {never}
  */
 function showRuntimeError(err) {
-  log.error('CLI runtime', 'Runtime error encountered:', err.friendlyMessage || err.message);
+  log.error('CLI', 'Runtime error encountered:', err.friendlyMessage || err.message);
   if (err.stack) {
-    log.error('CLI runtime', err.stack);
+    log.error('CLI', err.stack);
   }
   return process.exit(_RUNTIME_ERROR_CODE);
 }

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -64,25 +64,25 @@ function getDebuggableChrome(flags) {
 
 /** @return {never} */
 function showConnectionError() {
-  console.error('Unable to connect to Chrome');
+  log.error('CLI runtime', 'Unable to connect to Chrome');
   return process.exit(_RUNTIME_ERROR_CODE);
 }
 
 /** @return {never} */
 function showProtocolTimeoutError() {
-  console.error('Debugger protocol timed out while connecting to Chrome.');
+  log.error('CLI runtime', 'Debugger protocol timed out while connecting to Chrome.');
   return process.exit(_PROTOCOL_TIMEOUT_EXIT_CODE);
 }
 
 /** @param {LH.LighthouseError} err @return {never} */
 function showPageHungError(err) {
-  console.error('Page hung:', err.friendlyMessage);
+  log.error('CLI runtime', 'Page hung:', err.friendlyMessage);
   return process.exit(_PAGE_HUNG_EXIT_CODE);
 }
 
 /** @param {LH.LighthouseError} err @return {never} */
 function showInsecureDocumentRequestError(err) {
-  console.error('Insecure document request:', err.friendlyMessage);
+  log.error('CLI runtime', 'Insecure document request:', err.friendlyMessage);
   return process.exit(_INSECURE_DOCUMENT_REQUEST_EXIT_CODE);
 }
 
@@ -91,9 +91,9 @@ function showInsecureDocumentRequestError(err) {
  * @return {never}
  */
 function showRuntimeError(err) {
-  console.error('Runtime error encountered:', err.friendlyMessage || err.message);
+  log.error('CLI runtime', 'Runtime error encountered:', err.friendlyMessage || err.message);
   if (err.stack) {
-    console.error(err.stack);
+    log.error('CLI runtime', err.stack);
   }
   return process.exit(_RUNTIME_ERROR_CODE);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**

Turns these logs:
![Screenshot 2019-03-19 at 16 09 38](https://user-images.githubusercontent.com/2109932/54617378-706d3880-4a61-11e9-8fc0-03e400c33d21.png)
into these logs:
![Screenshot 2019-03-19 at 16 08 38](https://user-images.githubusercontent.com/2109932/54617384-77944680-4a61-11e9-9be6-5081ea2cd9a3.png)

<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

**Describe the need for this change**

Just to clean up the output and make it more uniform.

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
