### PR TITLE
core(tap-targets): exclude sticky elements from tap targets audit

### DIFF
--- a/lighthouse-cli/test/fixtures/seo/seo-tap-targets.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tap-targets.html
@@ -119,7 +119,7 @@
       This is <a>a link in a text block.</a>
     </p>
 
-    <a style="background: #afa; top: 0; left: 0; display: block; width: 100vw; height: 800px;">
+    <a style="background: #afa; display: block; width: 100%; height: 800px;">
       This link is intentionally placed at the bottom of the page, so that when we've scrolled
       to the bottom of the page it overlaps with the sticky header. (Should not fail though
       because the overlap depends on the current scroll position.)

--- a/lighthouse-cli/test/fixtures/seo/seo-tap-targets.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tap-targets.html
@@ -26,6 +26,9 @@
 <body>
   <!-- Big tap target, but it's invisible because it's behind the main content div -->
   <a style="background: red; position: absolute; top: 0; bottom: 0; left: 0; right: 0; z-index: -1;"></a>
+
+  <a style="background: red; position: sticky; top: 0; left: 0; display: block; width: 100vw; height: 40px; z-index: 1;">sticky</a>
+
   <div style="background: white; padding: 20px;">
     <h1>SEO Tap targets</h1>
 
@@ -108,13 +111,19 @@
     </div>
 
     <!-- Links in text blocks are exempted from size/overlap requirements and should not fail -->
-    <p style="width: 100px">
+    <p style="width: 100px;margin-bottom: 30px;">
       This is <a>a link in a text block.</a>
       This is <a>a link in a text block.</a>
       This is <a>a link in a text block.</a>
       This is <a>a link in a text block.</a>
       This is <a>a link in a text block.</a>
     </p>
+
+    <a style="background: #afa; top: 0; left: 0; display: block; width: 100vw; height: 800px;">
+      This link is intentionally placed at the bottom of the page, so that when we've scrolled
+      to the bottom of the page it overlaps with the sticky header. (Should not fail though
+      because the overlap depends on the current scroll position.)
+    </a>
   </div>
 </body>
 </html>

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -184,7 +184,12 @@ module.exports = [
     finalUrl: BASE_URL + 'seo-tap-targets.html',
     audits: {
       'tap-targets': {
-        score: 0.8, // 10 passing targets/11 total visible targets, multiplied by 0.89 to get the score
+        score: (() => {
+          const PASSING_TAP_TARGETS = 11;
+          const TOTAL_TAP_TARGETS = 12;
+          const SCORE_FACTOR = 0.89;
+          return Math.floor(PASSING_TAP_TARGETS / TOTAL_TAP_TARGETS * SCORE_FACTOR * 100) / 100;
+        })(),
         details: {
           items: [
             {
@@ -193,7 +198,7 @@ module.exports = [
                 'snippet': '<a ' +
                  'style="display: block; width: 100px; height: 30px;background: #ddd;">' +
                  '\n        too small target\n      </a>',
-                'path': '2,HTML,1,BODY,2,DIV,21,DIV,0,A',
+                'path': '2,HTML,1,BODY,3,DIV,21,DIV,0,A',
                 'selector': 'body > div > div > a',
               },
               'overlappingTarget': {
@@ -201,7 +206,7 @@ module.exports = [
                 'snippet': '<a ' +
                   'style="display: block; width: 100px; height: 100px;background: #aaa;">' +
                   '\n        big enough target\n      </a>',
-                'path': '2,HTML,1,BODY,2,DIV,21,DIV,1,A',
+                'path': '2,HTML,1,BODY,3,DIV,21,DIV,1,A',
                 'selector': 'body > div > div > a',
               },
               'size': '100x30',

--- a/lighthouse-core/gather/gatherers/seo/tap-targets.js
+++ b/lighthouse-core/gather/gatherers/seo/tap-targets.js
@@ -225,13 +225,13 @@ function elementIsInTextBlock(element) {
  * @returns {boolean}
  */
 /* istanbul ignore next */
-function elementIsPositionFixedOrAbsolute(element) {
+function elementIsPositionFixedStickyOrAbsolute(element) {
   const {position} = getComputedStyle(element);
-  if (position === 'fixed' || position === 'absolute') {
+  if (position === 'fixed' || position === 'absolute' || position === 'sticky') {
     return true;
   }
   if (element.parentElement) {
-    return elementIsPositionFixedOrAbsolute(element.parentElement);
+    return elementIsPositionFixedStickyOrAbsolute(element.parentElement);
   }
   return false;
 }
@@ -273,7 +273,7 @@ function gatherTapTargets() {
       // in the Web Content Accessibility Guidelines https://www.w3.org/TR/WCAG21/#target-size
       return;
     }
-    if (elementIsPositionFixedOrAbsolute(tapTargetElement)) {
+    if (elementIsPositionFixedStickyOrAbsolute(tapTargetElement)) {
       // Absolutely positioned elements might not be visible if they have a lower z-index
       // than other tap targets, but if we don't ignore them we can get false failures.
       //
@@ -311,7 +311,7 @@ class TapTargets extends Gatherer {
       const tapTargetsSelector = "${tapTargetsSelector}";
       ${pageFunctions.getElementsInDocumentString};
       ${filterClientRectsWithinAncestorsVisibleScrollArea.toString()};
-      ${elementIsPositionFixedOrAbsolute.toString()};
+      ${elementIsPositionFixedStickyOrAbsolute.toString()};
       ${elementIsVisible.toString()};
       ${elementHasAncestorTapTarget.toString()};
       ${getVisibleClientRects.toString()};


### PR DESCRIPTION
**Summary**

Whether sticky elements overlap depends on the current scroll position, so we should exclude them like we do with position absolute and fixed.

**Related Issues/PRs**

Pointed out here: https://github.com/GoogleChrome/lighthouse/issues/7365#issuecomment-474095920