### PR TITLE
core(oopif): attach to all descendants

### DIFF
--- a/lighthouse-cli/test/fixtures/oopif.html
+++ b/lighthouse-cli/test/fixtures/oopif.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <h1>Hello frames</h1>
-    <iframe name="oopif" src="https://airhorner.com"></iframe>
+    <iframe name="oopif" src="https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/" style="width: 100vw; height: 100vh;"></iframe>
   </body>
 </html>

--- a/lighthouse-cli/test/smokehouse/oopif-expectations.js
+++ b/lighthouse-cli/test/smokehouse/oopif-expectations.js
@@ -16,10 +16,11 @@ module.exports = [
       'network-requests': {
         details: {
           items: {
-            // The page itself only makes a few requests.
-            // We want to make sure we are finding the iframe's requests (airhorner) while being flexible enough
-            // to allow changes to the live site.
-            length: '>10',
+            // We want to make sure we are finding the iframe's requests (paulirish.com) *AND*
+            // the iframe's iframe's iframe's requests (youtube.com/doubleclick/etc).
+            // - paulirish.com ~40-60 requests
+            // - paulirish.com + all descendant iframes ~80-90 requests
+            length: '>70',
           },
         },
       },

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -304,7 +304,7 @@ class Driver {
 
     // We receive messages from the outermost subtarget which wraps the messages from the inner subtargets.
     // We are recursively processing them from outside in, so build the list of parentSessionIds accordingly.
-    const sessionIdPath = [event.sessionId, ...parentSessionIds];
+    const sessionIdPath = [sessionId, ...parentSessionIds];
 
     if (protocolMessage.method === 'Target.receivedMessageFromTarget') {
       // Unravel any messages from subtargets by recursively processing

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -315,10 +315,14 @@ class Driver {
    * @param {string[]} parentSessionIds The list of session ids of the parents from oldest to youngest.
    */
   _handleTargetAttached(event, parentSessionIds) {
-    // We're only interested in network requests from iframes for now as those are "part of the page".
-    if (event.targetInfo.type !== 'iframe') return;
-
     const sessionIds = parentSessionIds.concat([event.sessionId]);
+
+    // We're only interested in network requests from iframes for now as those are "part of the page".
+    if (event.targetInfo.type !== 'iframe') {
+      this.sendMessageToTarget(sessionIds, 'Runtime.runIfWaitingForDebugger');
+      return;
+    }
+
     // Events from subtargets will be stringified and sent back on `Target.receivedMessageFromTarget`.
     // We want to receive information about network requests from iframes, so enable the Network domain.
     this.sendMessageToTarget(sessionIds, 'Network.enable');

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -1069,16 +1069,22 @@ describe('Multi-target management', () => {
     });
   });
 
-  it('ignores other target types', async () => {
+  it('ignores other target types, but still resumes them', async () => {
     connectionStub.sendCommand = createMockSendCommandFn()
       .mockResponse('Target.sendMessageToTarget', {});
 
     driver._eventEmitter.emit('Target.attachedToTarget', {
-      sessionId: 123,
+      sessionId: 'SW1',
       targetInfo: {type: 'service_worker'},
     });
     await flushAllTimersAndMicrotasks();
 
-    expect(connectionStub.sendCommand).not.toHaveBeenCalled();
+
+    const sendMessageArgs = connectionStub.sendCommand
+      .findInvocation('Target.sendMessageToTarget');
+    expect(sendMessageArgs).toEqual({
+      message: JSON.stringify({id: 1, method: 'Runtime.runIfWaitingForDebugger'}),
+      sessionId: 'SW1',
+    });
   });
 });

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -1000,6 +1000,8 @@ describe('.goOnline', () => {
 describe('Multi-target management', () => {
   it('enables the Network domain for iframes', async () => {
     connectionStub.sendCommand = createMockSendCommandFn()
+      .mockResponse('Target.sendMessageToTarget', {})
+      .mockResponse('Target.sendMessageToTarget', {})
       .mockResponse('Target.sendMessageToTarget', {});
 
     driver._eventEmitter.emit('Target.attachedToTarget', {
@@ -1016,9 +1018,60 @@ describe('Multi-target management', () => {
     });
   });
 
+  it('enables the Network domain for iframes of iframes of iframes', async () => {
+    connectionStub.sendCommand = createMockSendCommandFn()
+      .mockResponse('Target.sendMessageToTarget', {})
+      .mockResponse('Target.sendMessageToTarget', {})
+      .mockResponse('Target.sendMessageToTarget', {});
+
+    driver._eventEmitter.emit('Target.receivedMessageFromTarget', {
+      sessionId: 'Outer',
+      message: JSON.stringify({
+        method: 'Target.receivedMessageFromTarget',
+        params: {
+          sessionId: 'Middle',
+          message: JSON.stringify({
+            method: 'Target.attachedToTarget',
+            params: {
+              sessionId: 'Inner',
+              targetInfo: {type: 'iframe'},
+            },
+          }),
+        },
+      }),
+    });
+
+    await flushAllTimersAndMicrotasks();
+
+    const sendMessageArgs = connectionStub.sendCommand
+      .findInvocation('Target.sendMessageToTarget');
+    const stringified = `{
+      "id": 3,
+      "method": "Target.sendMessageToTarget",
+      "params": {
+        "sessionId": "Middle",
+        "message": "{
+          \\"id\\": 2,
+          \\"method\\": \\"Target.sendMessageToTarget\\",
+          \\"params\\": {
+            \\"sessionId\\": \\"Inner\\",
+            \\"message\\":\\ "{
+              \\\\\\"id\\\\\\":1,
+              \\\\\\"method\\\\\\":\\\\\\"Network.enable\\\\\\"
+            }\\"
+          }}"
+        }
+      }`.replace(/\s+/g, '');
+
+    expect(sendMessageArgs).toEqual({
+      message: stringified,
+      sessionId: 'Outer',
+    });
+  });
+
   it('ignores other target types', async () => {
     connectionStub.sendCommand = createMockSendCommandFn()
-    .mockResponse('Target.sendMessageToTarget', {});
+      .mockResponse('Target.sendMessageToTarget', {});
 
     driver._eventEmitter.emit('Target.attachedToTarget', {
       sessionId: 123,

--- a/lighthouse-core/test/lib/network-recorder-test.js
+++ b/lighthouse-core/test/lib/network-recorder-test.js
@@ -249,9 +249,7 @@ describe('network recorder', function() {
       ];
 
       const periods = NetworkRecorder.findNetworkQuietPeriods(records, 0);
-      assert.deepStrictEqual(periods, [
-        {start: 1200, end: Infinity},
-      ]);
+      assert.deepStrictEqual(periods, []);
     });
 
     it('should handle QUIC requests', () => {


### PR DESCRIPTION
**Summary**
OK, OOPIF fixes attempt 479 :)

The good news: this is now 100% contained in driver.js and should work in all our environments 🎉 

The bad news: it's kinda ugly to look at and reason about (we have to do nested Target.sendMessageToTarget calls and unpack nested receiveMessageFromTarget messages)

**Related Issues/PRs**
#7517 #7566 also #6922 #6337 #6078
