### PR TITLE
tests(smokehouse): set Content-Type for images served by static-server.js

### DIFF
--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -69,6 +69,12 @@ function requestHandler(request, response) {
       headers['Content-Type'] = 'text/css';
     } else if (filePath.endsWith('.svg')) {
       headers['Content-Type'] = 'image/svg+xml';
+    } else if (filePath.endsWith('.png')) {
+      headers['Content-Type'] = 'image/png';
+    } else if (filePath.endsWith('.gif')) {
+      headers['Content-Type'] = 'image/gif';
+    } else if (filePath.endsWith('.jpg') || filePath.endsWith('.jpeg')) {
+      headers['Content-Type'] = 'image/jpeg';
     }
 
     let delay = 0;


### PR DESCRIPTION
Files served through GAE with no Content-Type get assigned `text/html`. This caused some image resources to not get checked in the `image-aspect-ratio` and `efficient-animated-content` audits in Smokerider.