### PR TITLE
report: add basic messageFormat() for '7 audits'

### DIFF
--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -1259,6 +1259,10 @@
     "message": "The URL you have provided appears to be invalid.",
     "description": "Error message explaining that the provided URL Lighthouse points to is not valid, and cannot be loaded."
   },
+  "lighthouse-core/report/html/renderer/util.js | auditCount": {
+    "message": "{itemCount, number} audits",
+    "description": "Label shown above a list of collapsed to describe how many are in the group. The `{itemCount}` placeholder will be replaced with the number of audits, typically an integer between 1 and 30"
+  },
   "lighthouse-core/report/html/renderer/util.js | auditGroupExpandTooltip": {
     "message": "Show audits",
     "description": "The tooltip text on an expandable chevron icon. Clicking the icon expands a section to reveal a list of audit results that was hidden by default."

--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -285,8 +285,10 @@ class CategoryRenderer {
     }
 
     const itemCountEl = this.dom.find('.lh-audit-group__itemcount', clumpElement);
-    // TODO(i18n): support multiple locales here
-    itemCountEl.textContent = `${auditRefs.length} audits`;
+    itemCountEl.textContent = Util.basicMsgFormat({
+      message: Util.UIStrings.auditCount,
+      values: {itemCount: auditRefs.length},
+    });
 
     // Add all audit results to the clump.
     const auditElements = auditRefs.map(this.renderAudit.bind(this));

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -95,6 +95,22 @@ class Util {
   }
 
   /**
+   * Poor man's implementation of i18n._formatIcuMessage()
+   * @param {{message: string, values: Object|undefined}} audit
+   * @return {string}
+   */
+  static basicMsgFormat({message, values}) {
+    let resolvedMsg = message;
+    for (const [valueName, value] of Object.entries(values)) {
+      // Look for `{valueName}` or `{valueName, number}`
+      // eslint-disable-next-line no-useless-escape
+      const re = new RegExp('\{\\s*?' + valueName + '\\b.*?\}');
+      resolvedMsg = resolvedMsg.replace(re, value);
+    }
+    return resolvedMsg;
+  }
+
+  /**
    * Used to determine if the "passed" for the purposes of showing up in the "failed" or "passed"
    * sections of the report.
    *
@@ -502,6 +518,9 @@ Util.UIStrings = {
   snippetExpandButtonLabel: 'Expand snippet',
   /** Label for button that only shows a few lines of the snippet when clicked */
   snippetCollapseButtonLabel: 'Collapse snippet',
+
+  /** Label shown above a list of collapsed to describe how many are in the group. The `{itemCount}` placeholder will be replaced with the number of audits, typically an integer between 1 and 30 */
+  auditCount: '{itemCount, number} audits',
 
   /** Explanation shown to users below performance results to inform them that the test was done with a 4G network connection and to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. 'Lighthouse' becomes link text to additional documentation. */
   lsPerformanceCategoryDescription: '[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.',

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -138,6 +138,18 @@ describe('util helpers', () => {
     assert.equal(descriptions.cpuThrottling, '2x slowdown (Simulated)');
   });
 
+  it('basicMsgFormat formats boring messageFormat strings with values', () => {
+    assert.equal(Util.basicMsgFormat({message: '{count} audits', values: {count: 5}}), '5 audits');
+    assert.equal(Util.basicMsgFormat({message: 'OK: {count}', values: {count: 3}}), 'OK: 3');
+    assert.equal(Util.basicMsgFormat({message: 'Cool {count}.', values: {count: 2}}), 'Cool 2.');
+    assert.equal(Util.basicMsgFormat({message: '.{count, number}.', values: {count: 1}}), '.1.');
+    assert.equal(Util.basicMsgFormat({message: 'OK: { count }', values: {count: 3}}), 'OK: 3');
+    const prefixOverlap = {cat: 'calico', category: 'Performance'};
+    assert.equal(Util.basicMsgFormat({message: 'Failures {category} {cat}', values: prefixOverlap}),
+      'Failures Performance calico'
+    );
+  });
+
   describe('#prepareReportResult', () => {
     it('corrects underscored `notApplicable` scoreDisplayMode', () => {
       const clonedSampleResult = JSON.parse(JSON.stringify(sampleResult));

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -4822,6 +4822,7 @@
   },
   "i18n": {
     "rendererFormattedStrings": {
+      "auditCount": "{itemCount, number} audits",
       "auditGroupExpandTooltip": "Show audits",
       "crcInitialNavigation": "Initial Navigation",
       "crcLongestDurationLabel": "Maximum critical path latency:",

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -343,6 +343,9 @@ message I18n {
 
     // The label for the button to show only a few lines of a snippet
     string snippet_collapse_button_label = 19;
+
+    // The label describing how many audits are in the collapsed section below
+    string audit_count = 20;
   }
 
   // The message holding all formatted strings

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -3719,6 +3719,7 @@
     "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html", 
     "i18n": {
         "rendererFormattedStrings": {
+            "auditCount": "{itemCount, number} audits", 
             "auditGroupExpandTooltip": "Show audits", 
             "crcInitialNavigation": "Initial Navigation", 
             "crcLongestDurationLabel": "Maximum critical path latency:", 


### PR DESCRIPTION
We've put off this one for a while. But this allows us to translate the last english string that's visible in current PSI.

![image](https://user-images.githubusercontent.com/39191/54886879-3c6f8a00-4e4a-11e9-9bce-e416d39eb363.png)

And opens up our ability to translate other strings that include placeholder values such as:
![image](https://user-images.githubusercontent.com/39191/54886913-92dcc880-4e4a-11e9-978a-d1b0abf3fe35.png)
