### PR TITLE
core(font-display): handle carriage returns

### DIFF
--- a/lighthouse-core/audits/font-display.js
+++ b/lighthouse-core/audits/font-display.js
@@ -52,7 +52,7 @@ class FontDisplay extends Audit {
     // Go through all the stylesheets to find all @font-face declarations
     for (const stylesheet of artifacts.CSSUsage.stylesheets) {
       // Eliminate newlines so we can more easily scan through with a regex
-      const newlinesStripped = stylesheet.content.replace(/\n/g, ' ');
+      const newlinesStripped = stylesheet.content.replace(/(\r|\n)+/g, ' ');
       // Find the @font-faces
       const fontFaceDeclarations = newlinesStripped.match(/@font-face\s*{(.*?)}/g) || [];
       // Go through all the @font-face declarations to find a declared `font-display: ` property

--- a/lighthouse-core/test/audits/font-display-test.js
+++ b/lighthouse-core/test/audits/font-display-test.js
@@ -136,18 +136,20 @@ describe('Performance: Font Display audit', () => {
   it('passes when all fonts have a correct font-display rule', async () => {
     stylesheet.content = `
       @font-face {
+        /* make sure we can handle carriage returns */
+        \r\n
         font-display: block;
         /* try with " */
         src: url("./font-a.woff");
       }
 
-      @font-face {
+      @font-face {\r
         font-display: fallback;
         /* try up a directory with ' */
         src: url('../font-b.woff');
       }
 
-      @font-face {
+      @font-face {\n
         font-display: optional;
         /* try no path with no quotes ' */
         src: url(font.woff);


### PR DESCRIPTION
**Summary**
Apparently leftover `\r` characters destroy our match statement later on so we should remove them before trying to find our `@font-face` declarations.

**Related Issues/PRs**
#7708