### PR TITLE
core: truncate measure timings to hundredths

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -179,13 +179,16 @@ class Runner {
       ...timingEntriesFromRunner,
       // As entries can share a name, dedupe based on the startTime timestamp
     ].map(entry => /** @type {[number, PerformanceEntry]} */ ([entry.startTime, entry]));
-    const timingEntries = Array.from(new Map(timingEntriesKeyValues).values());
-    for (const timing of timingEntries) {
-      // @ts-ignore - ignore readonly
-      timing.startTime = parseFloat(timing.startTime.toFixed(2));
-      // @ts-ignore - ignore readonly
-      timing.duration = parseFloat(timing.duration.toFixed(2));
-    }
+    const timingEntries = Array.from(new Map(timingEntriesKeyValues).values())
+    // Truncate timestamps to hundredths of a millisecond saves ~4KB. No need for microsecond
+    // resolution.
+    .map(entry => {
+      return /** @type {PerformanceEntry} */ ({
+        ...entry,
+        duration: parseFloat(entry.duration.toFixed(2)),
+        startTime: parseFloat(entry.startTime.toFixed(2)),
+      });
+    });
     const runnerEntry = timingEntries.find(e => e.name === 'lh:runner:run');
     return {entries: timingEntries, total: runnerEntry && runnerEntry.duration || 0};
   }

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -180,6 +180,12 @@ class Runner {
       // As entries can share a name, dedupe based on the startTime timestamp
     ].map(entry => /** @type {[number, PerformanceEntry]} */ ([entry.startTime, entry]));
     const timingEntries = Array.from(new Map(timingEntriesKeyValues).values());
+    for (const timing of timingEntries) {
+      // @ts-ignore - ignore readonly
+      timing.startTime = parseFloat(timing.startTime.toFixed(2));
+      // @ts-ignore - ignore readonly
+      timing.duration = parseFloat(timing.duration.toFixed(2));
+    }
     const runnerEntry = timingEntries.find(e => e.name === 'lh:runner:run');
     return {entries: timingEntries, total: runnerEntry && runnerEntry.duration || 0};
   }


### PR DESCRIPTION
Reduces LHR size by ~4KB. That was ~1% of the LHR I tested it with.

**Related Issues/PRs**

#7160