### PR TITLE
test(smoke): remove trivial uses of rawValue from expectations

### DIFF
--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -69,7 +69,6 @@ module.exports = [
     audits: {
       'font-display': {
         score: 0,
-        rawValue: false,
         details: {
           items: {
             length: 2,

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -53,7 +53,7 @@ module.exports = [
         score: 1,
       },
       'font-size': {
-        rawValue: true,
+        score: 1,
         details: {
           items: {
             length: 6,
@@ -76,7 +76,7 @@ module.exports = [
         score: 1,
       },
       'robots-txt': {
-        rawValue: true,
+        score: null,
         scoreDisplayMode: 'notApplicable',
       },
     },
@@ -98,7 +98,7 @@ module.exports = [
         score: 1,
       },
       'font-size': {
-        rawValue: false,
+        score: 0,
         explanation:
           'Text is illegible because there\'s no viewport meta tag optimized for mobile screens.',
       },


### PR DESCRIPTION
These were the simple ones - the ones that an equivalent assertion on `score` was possible. One that seemed to not assert anything really.

**Related Issues/PRs**

#6199
