### PR TITLE
misc(gather): update comment re: ClientRect copying

### DIFF
--- a/lighthouse-core/gather/gatherers/image-elements.js
+++ b/lighthouse-core/gather/gatherers/image-elements.js
@@ -22,7 +22,7 @@ function collectImageElementInfo() {
   function getClientRect(element) {
     const clientRect = element.getBoundingClientRect();
     return {
-      // manually copy the properties because ClientRect does not JSONify
+      // Just grab the DOMRect properties we want, excluding x/y/width/height
       top: clientRect.top,
       bottom: clientRect.bottom,
       left: clientRect.left,


### PR DESCRIPTION
the comment is out of date.

getBoundingClientRect  used to return a ClientRect which stringified to {}
but [as of july 2017](https://bugs.chromium.org/p/chromium/issues/detail?id=719246#c20), it returns a DOMRect, which stringifies fine.

Still, we dont want all the props, so we'll keep the basic functionality here.


this change is so minor. sorry for the noise.
credit to @brendankenny who brought this up