### PR TITLE
tsc: add types for trace events

### DIFF
--- a/lighthouse-core/computed/screenshots.js
+++ b/lighthouse-core/computed/screenshots.js
@@ -16,7 +16,8 @@ class Screenshots {
   */
   static async compute_(trace) {
     return trace.traceEvents
-      .filter(evt => evt.name === SCREENSHOT_TRACE_NAME)
+      .filter(/** @return {e is LH.TraceEvent.Screenshot} */
+        e => e.name === SCREENSHOT_TRACE_NAME)
       .map(evt => {
         return {
           timestamp: evt.ts / 1000,

--- a/lighthouse-core/computed/speedline.js
+++ b/lighthouse-core/computed/speedline.js
@@ -26,6 +26,7 @@ class Speedline {
       // Force use of nav start as reference point for speedline
       // See https://github.com/GoogleChrome/lighthouse/issues/2095
       const navStart = traceOfTab.timestamps.navigationStart;
+      // @ts-ignore - Type incompatability with Speedline.TraceEvent.
       return speedline(traceEvents, {
         timeOrigin: navStart,
         fastMode: true,

--- a/lighthouse-core/computed/user-timings.js
+++ b/lighthouse-core/computed/user-timings.js
@@ -38,7 +38,7 @@ class UserTimings {
       return evt.name !== 'requestStart' &&
           evt.name !== 'navigationStart' &&
           evt.name !== 'paintNonDefaultBackgroundColor' &&
-          evt.args.frame === undefined;
+          !('frame' in evt.args);
     })
     .forEach(ut => {
       // Mark events fall under phases R and I (or i)

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -18,8 +18,8 @@ function convertNodeTimingsToTrace(nodeTimings) {
   /** @param {number} ms */
   const toMicroseconds = ms => baseTs + ms * 1000;
 
-  traceEvents.push(createFakeTracingStartedEvent());
-  traceEvents.push({...createFakeTracingStartedEvent(), name: 'TracingStartedInBrowser'});
+  traceEvents.push(createFakeTracingStartedInPageEvent());
+  traceEvents.push(createFakeTracingStartedInBrowserEvent());
 
   // Create a fake requestId counter
   let requestId = 1;
@@ -53,13 +53,35 @@ function convertNodeTimingsToTrace(nodeTimings) {
   return {traceEvents};
 
   /**
-   * @return {LH.TraceEvent}
+   * @return {LH.TraceEvent.TracingStartedInPage}
    */
-  function createFakeTracingStartedEvent() {
+  function createFakeTracingStartedInPageEvent() {
     const argsData = {
       frameTreeNodeId: 1,
       sessionId: '1.1',
+      persistentIds: true,
       page: frame,
+    };
+
+    return {
+      ...baseEvent,
+      ts: baseTs - 1e5,
+      ph: 'I',
+      s: 't',
+      cat: 'disabled-by-default-devtools.timeline',
+      name: 'TracingStartedInPage',
+      args: {data: argsData},
+      dur: 0,
+    };
+  }
+
+  /**
+   * @return {LH.TraceEvent.TracingStartedInBrowser}
+   */
+  function createFakeTracingStartedInBrowserEvent() {
+    const argsData = {
+      frameTreeNodeId: 1,
+      sessionId: '1.1',
       persistentIds: true,
       frames: [{frame, url: 'about:blank', name: '', processId: 1}],
     };
@@ -70,7 +92,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
       ph: 'I',
       s: 't',
       cat: 'disabled-by-default-devtools.timeline',
-      name: 'TracingStartedInPage',
+      name: 'TracingStartedInBrowser',
       args: {data: argsData},
       dur: 0,
     };
@@ -141,6 +163,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
       requestMethod: record.requestMethod,
       url: record.url,
       priority: record.priority,
+      stackTrace: [],
     };
 
     const receiveResponseData = {

--- a/lighthouse-core/lib/timing-trace-saver.js
+++ b/lighthouse-core/lib/timing-trace-saver.js
@@ -25,6 +25,7 @@ function generateTraceEvents(entries, threadId = 0) {
       // 1) Remove 'lh:' for readability
       // 2) Colons in user_timing names get special handling in traceviewer we don't want. https://goo.gl/m23Vz7
       //    Replace with a 'Modifier letter colon' ;)
+      // @ts-ignore - allow string.
       name: entry.name.replace('lh:', '').replace(/:/g, '\ua789'),
       cat: 'blink.user_timing',
       ts: entry.startTime * 1000,

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -202,7 +202,9 @@ class TraceProcessor {
    */
   static findMainFrameIds(events) {
     // Prefer the newer TracingStartedInBrowser event first, if it exists
-    const startedInBrowserEvt = events.find(e => e.name === 'TracingStartedInBrowser');
+    const startedInBrowserEvt = events.find(
+      /** @return {e is LH.TraceEvent.TracingStartedInBrowser} */
+      e => e.name === 'TracingStartedInBrowser');
     if (startedInBrowserEvt && startedInBrowserEvt.args.data &&
         startedInBrowserEvt.args.data.frames) {
       const mainFrame = startedInBrowserEvt.args.data.frames.find(frame => !frame.parent);
@@ -225,7 +227,9 @@ class TraceProcessor {
     // Support legacy browser versions that do not emit TracingStartedInBrowser event.
     // The first TracingStartedInPage in the trace is definitely our renderer thread of interest
     // Beware: the tracingStartedInPage event can appear slightly after a navigationStart
-    const startedInPageEvt = events.find(e => e.name === 'TracingStartedInPage');
+    const startedInPageEvt = events.find(
+      /** @return {e is LH.TraceEvent.TracingStartedInPage} */
+      e => e.name === 'TracingStartedInPage');
     if (startedInPageEvt && startedInPageEvt.args && startedInPageEvt.args.data) {
       const frameId = startedInPageEvt.args.data.page;
       if (frameId) {

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -6,6 +6,7 @@
 
 import _Crdp from 'devtools-protocol/types/protocol';
 import _CrdpMappings from 'devtools-protocol/types/protocol-mapping'
+import _TraceEvent from './trace-events'
 
 declare global {
   // Augment global Error type to include node's optional `code` property
@@ -219,44 +220,8 @@ declare global {
       [futureProps: string]: any;
     }
 
-    /**
-     * @see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
-     */
-    export interface TraceEvent {
-      name: string;
-      cat: string;
-      args: {
-        fileName?: string;
-        snapshot?: string;
-        data?: {
-          documentLoaderURL?: string;
-          frames?: {
-            frame: string;
-            parent?: string;
-            processId?: number;
-          }[];
-          page?: string;
-          readyState?: number;
-          requestId?: string;
-          stackTrace?: {
-            url: string
-          }[];
-          styleSheetUrl?: string;
-          timerId?: string;
-          url?: string;
-        };
-        frame?: string;
-        name?: string;
-        labels?: string;
-      };
-      pid: number;
-      tid: number;
-      ts: number;
-      dur: number;
-      ph: 'B'|'b'|'D'|'E'|'e'|'F'|'I'|'M'|'N'|'n'|'O'|'R'|'S'|'T'|'X';
-      s?: 't';
-      id?: string;
-    }
+    export import TraceEvent = _TraceEvent;
+    export type TraceEvent = _TraceEvent.TraceEvent;
 
     export interface DevToolsJsonTarget {
       description: string;

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -1,0 +1,235 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+ // Keep interfaces sorted.
+
+export namespace _TraceEvent {
+  export type TraceEvent =
+    EvaluateScript |
+    FunctionCall |
+    InvalidateLayout |
+    NavigationStart |
+    ParseAuthorStyleSheet |
+    ResourceSendRequest |
+    ScheduleStyleRecalculation |
+    Screenshot |
+    TimerFire |
+    TimerInstall |
+    TracingStartedInBrowser |
+    TracingStartedInPage |
+    V8.Compile |
+    V8.CompileModule |
+    XHRReadyStateChange |
+    Other;
+
+  /**
+   * @see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+   */
+  export interface TraceEventImpl {
+    cat: string;
+    pid: number;
+    tid: number;
+    ts: number;
+    dur: number;
+    ph: 'B'|'b'|'D'|'E'|'e'|'F'|'I'|'M'|'N'|'n'|'O'|'R'|'S'|'T'|'X';
+    s?: 't';
+    id?: string;
+  }
+
+  interface EvaluateScript extends TraceEventImpl {
+    name: 'EvaluateScript';
+    args: {
+      data?: {
+        url: string;
+        stackTrace?: {
+          url: string
+        }[];
+      };
+    };
+  }
+
+  interface FunctionCall extends TraceEventImpl {
+    name: 'FunctionCall';
+    args: {
+      data: {
+        url: string;
+      };
+    };
+  }
+
+  interface InvalidateLayout extends TraceEventImpl {
+    name: 'InvalidateLayout';
+    args: {
+      data: {
+        stackTrace: {
+          url: string
+        }[];
+      };
+    };
+  }
+
+  interface NavigationStart extends TraceEventImpl {
+    name: 'navigationStart';
+    args: {
+      data: {
+        documentLoaderURL: string;
+      };
+    };
+  }
+
+  interface ParseAuthorStyleSheet extends TraceEventImpl {
+    name: 'ParseAuthorStyleSheet';
+    args: {
+      data: {
+        styleSheetUrl: string;
+      };
+    };
+  }
+
+  interface ResourceSendRequest extends TraceEventImpl {
+    name: 'ResourceSendRequest';
+    args: {
+      data: {
+        requestId: string;
+        stackTrace?: {
+          url: string
+        }[];
+      };
+    }
+  }
+
+  interface ScheduleStyleRecalculation extends TraceEventImpl {
+    name: 'ScheduleStyleRecalculation';
+    args: {
+      data: {
+        stackTrace: {
+          url: string
+        }[];
+      };
+    }
+  }
+
+  interface Screenshot extends TraceEventImpl {
+    name: 'Screenshot';
+    args: {
+      snapshot: string;
+      data: never;
+    };
+  }
+
+  interface TimerFire extends TraceEventImpl {
+    name: 'TimerFire';
+    args: {
+      data: {
+        timerId: string;
+      };
+    };
+  }
+
+  interface TimerInstall extends TraceEventImpl {
+    name: 'TimerInstall';
+    args: {
+      data: {
+        timerId: string;
+        stackTrace: {
+          url: string;
+        }[];
+      };
+    };
+  }
+
+  interface TracingStartedInBrowser extends TraceEventImpl {
+    name: 'TracingStartedInBrowser';
+    args: {
+      data: {
+        frames: {
+          frame: string;
+          parent?: string;
+          processId?: number;
+        }[];
+      };
+    };
+  }
+  interface TracingStartedInPage extends TraceEventImpl {
+    name: 'TracingStartedInPage';
+    args: {
+      data: {
+        page: string;
+      };
+    }
+  }
+
+  module V8 {
+    interface Compile extends TraceEventImpl {
+      name: 'v8.compile';
+      args: {
+        data?: {
+          url: string;
+          stackTrace: {
+            url: string;
+          }[];
+        };
+      }
+    }
+
+    interface CompileModule extends TraceEventImpl {
+      name: 'v8.compileModule';
+      args: {
+        fileName: string;
+        data?: {
+          stackTrace: {
+            url: string;
+          }[];
+        };
+      }
+    }
+  }
+
+  interface XHRReadyStateChange extends TraceEventImpl {
+    name: 'XHRReadyStateChange';
+    args: {
+      data: {
+        readyState: number;
+        url: string;
+        stackTrace: {
+          url: string;
+        }[];
+      };
+    };
+  }
+
+  // Catch-all for everything else. If anything in "args" is used, extract to an interface.
+  interface Other extends TraceEventImpl {
+    name:
+      'domContentLoadedEventEnd' |
+      'firstContentfulPaint' |
+      'firstMeaningfulPaint' |
+      'firstMeaningfulPaintCandidate' |
+      'firstPaint' |
+      'Layout' |
+      'loadEventEnd' |
+      'paintNonDefaultBackgroundColor' |
+      'process_labels' |
+      'requestStart' |
+      'ResourceFinish' |
+      'ResourceReceiveResponse' |
+      'RunTask' |
+      'Task' |
+      'TaskQueueManager::ProcessTaskFromWorkQueue' |
+      'thread_name' |
+      'ThreadControllerImpl::DoWork' |
+      'ThreadControllerImpl::RunTask' |
+      never;
+    args: {
+      data?: {};
+      frame?: string;
+      name?: string;
+      labels?: string;
+    };
+  }
+}
+
+export default _TraceEvent;


### PR DESCRIPTION
I took a thousand tiny little stabs at this.

@brendankenny do you still think this is an improvement?

Future work might look into generating _some_ of this from Chromium source, and doing further type discrimination on `ph` (some types here were given optional `args`/`data` due to only existing on one of `B` / `E`).