### PR TITLE
core(oopifs): surface oopifs in audits

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/optimized-images.js
@@ -45,8 +45,8 @@ class OptimizedImages extends Gatherer {
     /** @type {Set<string>} */
     const seenUrls = new Set();
     return networkRecords.reduce((prev, record) => {
-      // Skip records that we've seen before, never finished, or came from OOPIFs.
-      if (seenUrls.has(record.url) || !record.finished || record.sessionId) {
+      // Skip records that we've seen before or never finished
+      if (seenUrls.has(record.url) || !record.finished) {
         return prev;
       }
 

--- a/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/response-compression.js
@@ -40,9 +40,6 @@ class ResponseCompression extends Gatherer {
     const unoptimizedResponses = [];
 
     networkRecords.forEach(record => {
-      // Ignore records from OOPIFs
-      if (record.sessionId) return;
-
       const mimeType = record.mimeType;
       const resourceType = record.resourceType || NetworkRequest.TYPES.Other;
       const resourceSize = record.resourceSize;

--- a/lighthouse-core/gather/gatherers/scripts.js
+++ b/lighthouse-core/gather/gatherers/scripts.js
@@ -58,8 +58,6 @@ class Scripts extends Gatherer {
     }
 
     const scriptRecords = loadData.networkRecords
-      // Ignore records from OOPIFs
-      .filter(record => !record.sessionId)
       // Only get the content of script requests
       .filter(record => record.resourceType === NetworkRequest.TYPES.Script);
 


### PR DESCRIPTION
continuing conversation from https://github.com/GoogleChrome/lighthouse/pull/7640#pullrequestreview-220363683  -- i figure we'll just use this issue to host our discussion.

i said: 

> So the changes to the 3 gatherers I don't really agree with.

and @patrickhulce 	replied

>  unconvinced myself we should surface them in the regular audit results. The things flagged in OOPIFs will tend to be on another level actionability-wise. While you might have some control over the third parties you include, you almost definitely have no control over the third parties that your third parties include. Without being able to pinpoint that this ad iframe X was added by script Y and so the script is the thing you need to fix, I feel like surfacing the OOPIF data will just be noise. You could probably make this argument with a lot of things in the report, but the things discovered in OOPIFs will just overwhelmingly be in this bucket compared to unknown CDN assets and whatnot.

> Add to this the complexity that we need to start talking to other targets to get this information and it just feels extra not worth it. I'm not totally against it for 5.0 if others feel differently, but IMO, it's not the best use of our efforts.

-------------

Here's the PR that would actually surface OOPIF differences in audit results.


#### questions

1. @patrickhulce as of current state of master, does oopif network activity impact network quietness for _waitForFullyLoaded and tti?
1. do we surface oopif results in audits? Personally I think their visibility should be dictated by #6351 (third party report filter) and not their OOPIF status. Open to other opinions though.