### PR TITLE
tsc: add generated types for trace events

### DIFF
--- a/lighthouse-core/computed/main-thread-tasks.js
+++ b/lighthouse-core/computed/main-thread-tasks.js
@@ -184,7 +184,6 @@ class MainThreadTasks {
       case 'v8.compile':
       case 'EvaluateScript':
       case 'FunctionCall':
-        // @ts-ignore - TODO(cjamcl) #7790
         taskURLs = [argsData.url].concat(stackFrameURLs);
         break;
       // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.

--- a/lighthouse-core/computed/main-thread-tasks.js
+++ b/lighthouse-core/computed/main-thread-tasks.js
@@ -164,8 +164,14 @@ class MainThreadTasks {
    * @param {PriorTaskData} priorTaskData
    */
   static _computeRecursiveAttributableURLs(task, parentURLs, priorTaskData) {
+    // @ts-ignore - TODO(cjamcl) #7790 Types in transition. New types for trace events w/ no other
+    // changes need a little guidance.
     const argsData = task.event.args.data || {};
-    const stackFrameURLs = (argsData.stackTrace || []).map(entry => entry.url);
+
+    /** @type {string[]} */
+    const stackFrameURLs = (argsData.stackTrace || [])
+      // @ts-ignore - TODO(cjamcl) #7790
+      .map(entry => entry.url);
 
     /** @type {Array<string|undefined>} */
     let taskURLs = [];
@@ -178,9 +184,12 @@ class MainThreadTasks {
       case 'v8.compile':
       case 'EvaluateScript':
       case 'FunctionCall':
+        // @ts-ignore - TODO(cjamcl) #7790
         taskURLs = [argsData.url].concat(stackFrameURLs);
         break;
+      // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.
       case 'v8.compileModule':
+        // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.
         taskURLs = [task.event.args.fileName].concat(stackFrameURLs);
         break;
       case 'TimerFire': {

--- a/lighthouse-core/computed/metrics/lantern-interactive.js
+++ b/lighthouse-core/computed/metrics/lantern-interactive.js
@@ -39,6 +39,7 @@ class LanternInteractive extends LanternMetric {
     return dependencyGraph.cloneWithRelationships(node => {
       // Include everything that might be a long task
       if (node.type === BaseNode.TYPES.CPU) {
+        // @ts-ignore - TODO(cjamcl) #7790
         return node.event.dur > minimumCpuTaskDuration;
       }
 

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -193,7 +193,7 @@ class PageDependencyGraph {
       cpuNode.addDependency(minCandidate);
     }
 
-    /** @type {Map<string, CPUNode>} */
+    /** @type {Map<number, CPUNode>} */
     const timers = new Map();
     for (const node of cpuNodes) {
       for (const evt of node.childEvents) {
@@ -212,12 +212,10 @@ class PageDependencyGraph {
 
         switch (evt.name) {
           case 'TimerInstall':
-            // @ts-ignore - 'TimerInstall' event means timerId exists.
             timers.set(evt.args.data.timerId, node);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
           case 'TimerFire': {
-            // @ts-ignore - 'TimerFire' event means timerId exists.
             const installer = timers.get(evt.args.data.timerId);
             if (!installer) break;
             installer.addDependent(node);
@@ -237,27 +235,22 @@ class PageDependencyGraph {
 
           case 'XHRReadyStateChange':
             // Only create the dependency if the request was completed
-            // @ts-ignore - 'XHRReadyStateChange' event means readyState is defined.
             if (evt.args.data.readyState !== 4) break;
 
-            // @ts-ignore - 'XHRReadyStateChange' event means argsUrl is defined.
             addDependencyOnUrl(node, argsUrl);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;
 
           case 'FunctionCall':
           case 'v8.compile':
-            // @ts-ignore - events mean argsUrl is defined.
             addDependencyOnUrl(node, argsUrl);
             break;
 
           case 'ParseAuthorStyleSheet':
-            // @ts-ignore - 'ParseAuthorStyleSheet' event means styleSheetUrl is defined.
             addDependencyOnUrl(node, evt.args.data.styleSheetUrl);
             break;
 
           case 'ResourceSendRequest':
-            // @ts-ignore - 'ResourceSendRequest' event means requestId is defined.
             addDependentNetworkRequest(node, evt.args.data.requestId);
             stackTraceUrls.forEach(url => addDependencyOnUrl(node, url));
             break;

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -90,9 +90,8 @@ class PageDependencyGraph {
       // Skip all trace events that aren't schedulable tasks with sizable duration
       if (
         !TracingProcessor.isScheduleableTask(evt) ||
-        // @ts-ignore - TODO(cjamcl) #7790
+        !TracingProcessor.isTaskWithDuration(evt) ||
         !evt.dur ||
-        // @ts-ignore - TODO(cjamcl) #7790
         evt.dur < minimumEvtDur
       ) {
         i++;

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -90,7 +90,9 @@ class PageDependencyGraph {
       // Skip all trace events that aren't schedulable tasks with sizable duration
       if (
         !TracingProcessor.isScheduleableTask(evt) ||
+        // @ts-ignore - TODO(cjamcl) #7790
         !evt.dur ||
+        // @ts-ignore - TODO(cjamcl) #7790
         evt.dur < minimumEvtDur
       ) {
         i++;
@@ -102,6 +104,7 @@ class PageDependencyGraph {
       const children = [];
       i++; // Start examining events after this one
       for (
+        // @ts-ignore - TODO(cjamcl) #7790
         const endTime = evt.ts + evt.dur;
         i < traceOfTab.mainThreadEvents.length && traceOfTab.mainThreadEvents[i].ts < endTime;
         i++
@@ -195,10 +198,18 @@ class PageDependencyGraph {
     const timers = new Map();
     for (const node of cpuNodes) {
       for (const evt of node.childEvents) {
+        // @ts-ignore - TODO(cjamcl) #7790 Types in transition. New types for trace events w/ no
+        // other changes need a little guidance.
         if (!evt.args.data) continue;
 
+        // @ts-ignore - TODO(cjamcl) #7790
         const argsUrl = evt.args.data.url;
-        const stackTraceUrls = (evt.args.data.stackTrace || []).map(l => l.url).filter(Boolean);
+
+        /** @type {string[]} */
+        // @ts-ignore - TODO(cjamcl) #7790
+        const stackTraceUrls = (evt.args.data.stackTrace || [])
+          // @ts-ignore - TODO(cjamcl) #7790
+          .map(l => l.url).filter(Boolean);
 
         switch (evt.name) {
           case 'TimerInstall':

--- a/lighthouse-core/computed/screenshots.js
+++ b/lighthouse-core/computed/screenshots.js
@@ -16,7 +16,9 @@ class Screenshots {
   */
   static async compute_(trace) {
     return trace.traceEvents
-      .filter(evt => evt.name === SCREENSHOT_TRACE_NAME)
+      // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.
+      // .filter(/** @return {e is LH.TraceEvent.Screenshot} */
+      .filter(/** @return {e is any} */ e => e.name === SCREENSHOT_TRACE_NAME)
       .map(evt => {
         return {
           timestamp: evt.ts / 1000,

--- a/lighthouse-core/computed/screenshots.js
+++ b/lighthouse-core/computed/screenshots.js
@@ -16,9 +16,7 @@ class Screenshots {
   */
   static async compute_(trace) {
     return trace.traceEvents
-      // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.
-      // .filter(/** @return {e is LH.TraceEvent.Screenshot} */
-      .filter(/** @return {e is any} */ e => e.name === SCREENSHOT_TRACE_NAME)
+      .filter(/** @return {e is LH.TraceEvent.Screenshot.O} */ e => e.name === SCREENSHOT_TRACE_NAME)
       .map(evt => {
         return {
           timestamp: evt.ts / 1000,

--- a/lighthouse-core/computed/screenshots.js
+++ b/lighthouse-core/computed/screenshots.js
@@ -16,8 +16,7 @@ class Screenshots {
   */
   static async compute_(trace) {
     return trace.traceEvents
-      .filter(/** @return {e is LH.TraceEvent.Screenshot.O} */
-        e => e.name === SCREENSHOT_TRACE_NAME)
+      .filter(/** @return {e is LH.TraceEvent.Screenshot} */ e => e.name === SCREENSHOT_TRACE_NAME)
       .map(evt => {
         return {
           timestamp: evt.ts / 1000,

--- a/lighthouse-core/computed/screenshots.js
+++ b/lighthouse-core/computed/screenshots.js
@@ -16,7 +16,8 @@ class Screenshots {
   */
   static async compute_(trace) {
     return trace.traceEvents
-      .filter(/** @return {e is LH.TraceEvent.Screenshot.O} */ e => e.name === SCREENSHOT_TRACE_NAME)
+      .filter(/** @return {e is LH.TraceEvent.Screenshot.O} */
+        e => e.name === SCREENSHOT_TRACE_NAME)
       .map(evt => {
         return {
           timestamp: evt.ts / 1000,

--- a/lighthouse-core/computed/speedline.js
+++ b/lighthouse-core/computed/speedline.js
@@ -26,6 +26,7 @@ class Speedline {
       // Force use of nav start as reference point for speedline
       // See https://github.com/GoogleChrome/lighthouse/issues/2095
       const navStart = traceOfTab.timestamps.navigationStart;
+      // @ts-ignore - Type incompatability with Speedline.TraceEvent.
       return speedline(traceEvents, {
         timeOrigin: navStart,
         fastMode: true,

--- a/lighthouse-core/computed/trace-of-tab.js
+++ b/lighthouse-core/computed/trace-of-tab.js
@@ -85,6 +85,7 @@ class TraceOfTab {
     const mainFrameIds = TracingProcessor.findMainFrameIds(keyEvents);
 
     // Filter to just events matching the frame ID for sanity
+    // @ts-ignore - Can't narrow types based on categories.
     const frameEvents = keyEvents.filter(e => e.args.frame === mainFrameIds.frameId);
 
     // Our navStart will be the last frame navigation in the trace
@@ -141,6 +142,7 @@ class TraceOfTab {
     const traceEnd = trace.traceEvents.reduce((max, evt) => {
       return max.ts > evt.ts ? max : evt;
     });
+    // @ts-ignore - TODO(cjamcl) #7790
     const fakeEndOfTraceEvt = {ts: traceEnd.ts + (traceEnd.dur || 0)};
 
     /** @param {{ts: number}=} event */

--- a/lighthouse-core/computed/user-timings.js
+++ b/lighthouse-core/computed/user-timings.js
@@ -37,7 +37,6 @@ class UserTimings {
       // https://cs.chromium.org/search/?q=trace_event.*?user_timing&sq=package:chromium&type=cs
       return evt.name !== 'requestStart' &&
           evt.name !== 'navigationStart' &&
-          // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.
           evt.name !== 'paintNonDefaultBackgroundColor' &&
           !('frame' in evt.args);
     })

--- a/lighthouse-core/computed/user-timings.js
+++ b/lighthouse-core/computed/user-timings.js
@@ -37,8 +37,9 @@ class UserTimings {
       // https://cs.chromium.org/search/?q=trace_event.*?user_timing&sq=package:chromium&type=cs
       return evt.name !== 'requestStart' &&
           evt.name !== 'navigationStart' &&
+          // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.
           evt.name !== 'paintNonDefaultBackgroundColor' &&
-          evt.args.frame === undefined;
+          !('frame' in evt.args);
     })
     .forEach(ut => {
       // Mark events fall under phases R and I (or i)

--- a/lighthouse-core/lib/dependency-graph/cpu-node.js
+++ b/lighthouse-core/lib/dependency-graph/cpu-node.js
@@ -35,6 +35,7 @@ class CPUNode extends BaseNode {
    * @return {number}
    */
   get endTime() {
+    // @ts-ignore - TODO(cjamcl) #7790
     return this._event.ts + this._event.dur;
   }
 

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -277,6 +277,7 @@ class Simulator {
       ? this._layoutTaskMultiplier
       : this._cpuSlowdownMultiplier;
     const totalDuration = Math.min(
+      // @ts-ignore - TODO(cjamcl) #7790
       Math.round(cpuNode.event.dur / 1000 * multiplier),
       DEFAULT_MAXIMUM_CPU_TASK_DURATION
     );

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -71,10 +71,11 @@ function convertNodeTimingsToTrace(nodeTimings) {
       ph: 'I',
       s: 't',
       cat: 'disabled-by-default-devtools.timeline',
-      // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.
       name: 'TracingStartedInPage',
       args: {data: argsData},
       dur: 0,
+      tdur: 0,
+      tts: 0,
     };
   }
 

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -18,8 +18,9 @@ function convertNodeTimingsToTrace(nodeTimings) {
   /** @param {number} ms */
   const toMicroseconds = ms => baseTs + ms * 1000;
 
-  traceEvents.push(createFakeTracingStartedInPageEvent());
-  traceEvents.push(createFakeTracingStartedInBrowserEvent());
+  traceEvents.push(createFakeTracingStartedEvent());
+  // @ts-ignore - TODO(cjamcl) #7790
+  traceEvents.push({...createFakeTracingStartedEvent(), name: 'TracingStartedInBrowser'});
 
   // Create a fake requestId counter
   let requestId = 1;
@@ -53,38 +54,13 @@ function convertNodeTimingsToTrace(nodeTimings) {
   return {traceEvents};
 
   /**
-   * TODO(cjamcl) - TODO(cjamcl) #7790 This type has not been generated yet.
-   * LH.TraceEvent.TracingStartedInPage
    * @return {LH.TraceEvent}
    */
-  function createFakeTracingStartedInPageEvent() {
+  function createFakeTracingStartedEvent() {
     const argsData = {
       frameTreeNodeId: 1,
       sessionId: '1.1',
-      persistentIds: true,
       page: frame,
-    };
-
-    return {
-      ...baseEvent,
-      ts: baseTs - 1e5,
-      ph: 'I',
-      s: 't',
-      cat: 'disabled-by-default-devtools.timeline',
-      // @ts-ignore - TODO(cjamcl) #7790
-      name: 'TracingStartedInPage',
-      args: {data: argsData},
-      dur: 0,
-    };
-  }
-
-  /**
-   * @return {LH.TraceEvent.TracingStartedInBrowser.I}
-   */
-  function createFakeTracingStartedInBrowserEvent() {
-    const argsData = {
-      frameTreeNodeId: 1,
-      sessionId: '1.1',
       persistentIds: true,
       frames: [{frame, url: 'about:blank', name: '', processId: 1}],
     };
@@ -92,12 +68,13 @@ function convertNodeTimingsToTrace(nodeTimings) {
     return {
       ...baseEvent,
       ts: baseTs - 1e5,
-      tts: baseTs - 1e5,
       ph: 'I',
       s: 't',
       cat: 'disabled-by-default-devtools.timeline',
-      name: 'TracingStartedInBrowser',
+      // @ts-ignore - TODO(cjamcl) #7790 This type has not been generated yet.
+      name: 'TracingStartedInPage',
       args: {data: argsData},
+      dur: 0,
     };
   }
 

--- a/lighthouse-core/lib/timing-trace-saver.js
+++ b/lighthouse-core/lib/timing-trace-saver.js
@@ -33,6 +33,7 @@ function generateTraceEvents(entries, threadId = 0) {
       dur: 0,
       pid: 0,
       tid: threadId,
+      // @ts-ignore - None of the generated types happen to have a 'b' phase yet.
       ph: 'b',
       id: '0x' + (i++).toString(16),
     };

--- a/lighthouse-core/lib/timing-trace-saver.js
+++ b/lighthouse-core/lib/timing-trace-saver.js
@@ -25,6 +25,7 @@ function generateTraceEvents(entries, threadId = 0) {
       // 1) Remove 'lh:' for readability
       // 2) Colons in user_timing names get special handling in traceviewer we don't want. https://goo.gl/m23Vz7
       //    Replace with a 'Modifier letter colon' ;)
+      // @ts-ignore - Allow string.
       name: entry.name.replace('lh:', '').replace(/:/g, '\ua789'),
       cat: 'blink.user_timing',
       ts: entry.startTime * 1000,

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -206,7 +206,7 @@ class TraceProcessor {
   static findMainFrameIds(events) {
     // Prefer the newer TracingStartedInBrowser event first, if it exists
     const startedInBrowserEvt = events.find(
-      /** @return {e is LH.TraceEvent.TracingStartedInBrowser.I} */
+      /** @return {e is LH.TraceEvent.TracingStartedInBrowser} */
       e => e.name === 'TracingStartedInBrowser');
     if (startedInBrowserEvt && startedInBrowserEvt.args.data &&
         startedInBrowserEvt.args.data.frames) {

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -180,8 +180,8 @@ class TraceProcessor {
     const topLevelEvents = [];
     // note: mainThreadEvents is already sorted by event start
     for (const event of tabTrace.mainThreadEvents) {
-      // @ts-ignore - TODO(cjamcl) #7790
-      if (!TraceProcessor.isScheduleableTask(event) || !event.dur) continue;
+      if (!TraceProcessor.isScheduleableTask(event)) continue;
+      if (!TraceProcessor.isTaskWithDuration(event)) continue;
 
       const start = (event.ts - tabTrace.navigationStartEvt.ts) / 1000;
       // @ts-ignore - TODO(cjamcl) #7790

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -261,6 +261,14 @@ class TraceProcessor {
     // @ts-ignore
     evt.name === SCHEDULABLE_TASK_TITLE_ALT3;
   }
+
+  /**
+   * @param {LH.TraceEvent} evt
+   * @return {evt is LH.TraceEvent & {dur?: number}}
+   */
+  static isTaskWithDuration(evt) {
+    return 'dur' in evt && typeof evt !== 'undefined';
+  }
 }
 
 /**

--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -180,15 +180,18 @@ class TraceProcessor {
     const topLevelEvents = [];
     // note: mainThreadEvents is already sorted by event start
     for (const event of tabTrace.mainThreadEvents) {
+      // @ts-ignore - TODO(cjamcl) #7790
       if (!TraceProcessor.isScheduleableTask(event) || !event.dur) continue;
 
       const start = (event.ts - tabTrace.navigationStartEvt.ts) / 1000;
+      // @ts-ignore - TODO(cjamcl) #7790
       const end = (event.ts + event.dur - tabTrace.navigationStartEvt.ts) / 1000;
       if (start > endTime || end < startTime) continue;
 
       topLevelEvents.push({
         start,
         end,
+        // @ts-ignore - TODO(cjamcl) #7790
         duration: event.dur / 1000,
       });
     }
@@ -202,9 +205,12 @@ class TraceProcessor {
    */
   static findMainFrameIds(events) {
     // Prefer the newer TracingStartedInBrowser event first, if it exists
-    const startedInBrowserEvt = events.find(e => e.name === 'TracingStartedInBrowser');
+    const startedInBrowserEvt = events.find(
+      /** @return {e is LH.TraceEvent.TracingStartedInBrowser.I} */
+      e => e.name === 'TracingStartedInBrowser');
     if (startedInBrowserEvt && startedInBrowserEvt.args.data &&
         startedInBrowserEvt.args.data.frames) {
+      // @ts-ignore - TODO(cjamcl) #7790
       const mainFrame = startedInBrowserEvt.args.data.frames.find(frame => !frame.parent);
       const frameId = mainFrame && mainFrame.frame;
       const pid = mainFrame && mainFrame.processId;
@@ -225,6 +231,8 @@ class TraceProcessor {
     // Support legacy browser versions that do not emit TracingStartedInBrowser event.
     // The first TracingStartedInPage in the trace is definitely our renderer thread of interest
     // Beware: the tracingStartedInPage event can appear slightly after a navigationStart
+    /** @type {{args: {data: {page: string}} } & LH.TraceEvent.Base} */
+    // @ts-ignore - Type generation does not currently attempt retired tasks types.
     const startedInPageEvt = events.find(e => e.name === 'TracingStartedInPage');
     if (startedInPageEvt && startedInPageEvt.args && startedInPageEvt.args.data) {
       const frameId = startedInPageEvt.args.data.page;
@@ -246,8 +254,11 @@ class TraceProcessor {
    */
   static isScheduleableTask(evt) {
     return evt.name === SCHEDULABLE_TASK_TITLE_LH ||
+    // @ts-ignore - Type generation does not currently attempt retired tasks types.
     evt.name === SCHEDULABLE_TASK_TITLE_ALT1 ||
+    // @ts-ignore
     evt.name === SCHEDULABLE_TASK_TITLE_ALT2 ||
+    // @ts-ignore
     evt.name === SCHEDULABLE_TASK_TITLE_ALT3;
   }
 }

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -37,6 +37,16 @@ const toplevelTaskNames = new Set([
   'ThreadControllerImpl::RunTask',
 ]);
 
+/**
+ * @param {LH.TraceEvent} evt
+ * @return {evt is (LH.TraceEvent.ThreadControllerImpl.DoWork.X  |
+ *                  LH.TraceEvent.ThreadControllerImpl.RunTask.X |
+ *                  LH.TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue.X)}
+ */
+function isToplevelTask(evt) {
+  return toplevelTaskNames.has(evt.name);
+}
+
 const traceEventsToAlwaysKeep = new Set([
   'Screenshot',
   'TracingStartedInBrowser',
@@ -94,9 +104,8 @@ function filterOutUnnecessaryTasksByNameAndDuration(events) {
  */
 function filterOutOrphanedTasks(events) {
   const toplevelRanges = events
-    .filter(evt => toplevelTaskNames.has(evt.name))
-    // @ts-ignore - TODO(cjamcl) #7790
-    .map(evt => [evt.ts, evt.ts + evt.dur]);
+    .filter(isToplevelTask)
+    .map(evt => [evt.ts, evt.ts + (evt.dur || 0)]);
 
   /** @param {LH.TraceEvent} e */
   const isInToplevelTask = e => toplevelRanges.some(([start, end]) => e.ts >= start && e.ts <= end);

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -91,8 +91,7 @@ function filterOutUnnecessaryTasksByNameAndDuration(events) {
   const {pid} = TracingProcessor.findMainFrameIds(events);
 
   return events.filter(evt => {
-    // @ts-ignore - TODO(cjamcl) #7790
-    if (toplevelTaskNames.has(evt.name) && evt.dur < 1000) return false;
+    if (isToplevelTask(evt) && (evt.dur || 0) < 1000) return false;
     if (evt.pid === pid && traceEventsToKeepInProcess.has(evt.name)) return true;
     return traceEventsToAlwaysKeep.has(evt.name);
   });

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -81,6 +81,7 @@ function filterOutUnnecessaryTasksByNameAndDuration(events) {
   const {pid} = TracingProcessor.findMainFrameIds(events);
 
   return events.filter(evt => {
+    // @ts-ignore - TODO(cjamcl) #7790
     if (toplevelTaskNames.has(evt.name) && evt.dur < 1000) return false;
     if (evt.pid === pid && traceEventsToKeepInProcess.has(evt.name)) return true;
     return traceEventsToAlwaysKeep.has(evt.name);
@@ -94,6 +95,7 @@ function filterOutUnnecessaryTasksByNameAndDuration(events) {
 function filterOutOrphanedTasks(events) {
   const toplevelRanges = events
     .filter(evt => toplevelTaskNames.has(evt.name))
+    // @ts-ignore - TODO(cjamcl) #7790
     .map(evt => [evt.ts, evt.ts + evt.dur]);
 
   /** @param {LH.TraceEvent} e */

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -39,9 +39,9 @@ const toplevelTaskNames = new Set([
 
 /**
  * @param {LH.TraceEvent} evt
- * @return {evt is (LH.TraceEvent.ThreadControllerImpl.DoWork.X  |
- *                  LH.TraceEvent.ThreadControllerImpl.RunTask.X |
- *                  LH.TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue.X)}
+ * @return {evt is (LH.TraceEvent.ThreadControllerImpl.DoWork  |
+ *                  LH.TraceEvent.ThreadControllerImpl.RunTask |
+ *                  LH.TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue)}
  */
 function isToplevelTask(evt) {
   return toplevelTaskNames.has(evt.name);

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -6,6 +6,7 @@
 
 import _Crdp from 'devtools-protocol/types/protocol';
 import _CrdpMappings from 'devtools-protocol/types/protocol-mapping'
+import _TraceEvent from './trace-events'
 
 declare global {
   // Augment global Error type to include node's optional `code` property
@@ -219,44 +220,8 @@ declare global {
       [futureProps: string]: any;
     }
 
-    /**
-     * @see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
-     */
-    export interface TraceEvent {
-      name: string;
-      cat: string;
-      args: {
-        fileName?: string;
-        snapshot?: string;
-        data?: {
-          documentLoaderURL?: string;
-          frames?: {
-            frame: string;
-            parent?: string;
-            processId?: number;
-          }[];
-          page?: string;
-          readyState?: number;
-          requestId?: string;
-          stackTrace?: {
-            url: string
-          }[];
-          styleSheetUrl?: string;
-          timerId?: string;
-          url?: string;
-        };
-        frame?: string;
-        name?: string;
-        labels?: string;
-      };
-      pid: number;
-      tid: number;
-      ts: number;
-      dur: number;
-      ph: 'B'|'b'|'D'|'E'|'e'|'F'|'I'|'M'|'N'|'n'|'O'|'R'|'S'|'T'|'X';
-      s?: 't';
-      id?: string;
-    }
+    export import TraceEvent = _TraceEvent;
+    export type TraceEvent = _TraceEvent.TraceEvent;
 
     export interface DevToolsJsonTarget {
       description: string;

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -6,7 +6,7 @@
 
 import _Crdp from 'devtools-protocol/types/protocol';
 import _CrdpMappings from 'devtools-protocol/types/protocol-mapping'
-import _TraceEvent from './trace-events'
+import {TraceEvent as _TraceEvent} from './trace-events'
 
 declare global {
   // Augment global Error type to include node's optional `code` property
@@ -221,7 +221,7 @@ declare global {
     }
 
     export import TraceEvent = _TraceEvent;
-    export type TraceEvent = _TraceEvent.TraceEvent;
+    export type TraceEvent = TraceEvent.TraceEvent;
 
     export interface DevToolsJsonTarget {
       description: string;

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -17,9 +17,11 @@ export namespace _TraceEvent {
   type TraceEvent = 
     DomContentLoadedEventEnd.R |
     EvaluateScript.X |
+    FirstContentfulPaint.I |
     FirstContentfulPaint.R |
     FirstMeaningfulPaint.R |
     FirstMeaningfulPaintCandidate.R |
+    FirstPaint.I |
     FirstPaint.R |
     FunctionCall.B |
     FunctionCall.E |
@@ -38,6 +40,7 @@ export namespace _TraceEvent {
     RunTask.X |
     ScheduleStyleRecalculation.I |
     Screenshot.O |
+    TaskQueueManager.ProcessTaskFromWorkQueue.X |
     Thread_name.M |
     ThreadControllerImpl.DoWork.X |
     ThreadControllerImpl.RunTask.X |
@@ -87,6 +90,16 @@ export namespace _TraceEvent {
   }
 
   namespace FirstContentfulPaint {
+    interface I extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'firstContentfulPaint';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  
     interface R extends Base {
       args: {
         data?: {
@@ -130,6 +143,16 @@ export namespace _TraceEvent {
   }
 
   namespace FirstPaint {
+    interface I extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'firstPaint';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  
     interface R extends Base {
       args: {
         data?: {
@@ -147,7 +170,7 @@ export namespace _TraceEvent {
     interface B extends Base {
       args: {
         data: {
-          columnNumber: number;
+          columnNumber?: number;
           frame: string;
           functionName: string;
           lineNumber: number;
@@ -306,10 +329,11 @@ export namespace _TraceEvent {
     interface I extends Base {
       args: {
         data: {
-          decodedBodyLength: number;
+          decodedBodyLength?: number;
           didFail: boolean;
-          encodedDataLength: number;
+          encodedDataLength?: number;
           finishTime?: number;
+          networkTime?: number;
           requestId: string;
         };
       };
@@ -324,10 +348,10 @@ export namespace _TraceEvent {
     interface I extends Base {
       args: {
         data: {
-          encodedDataLength: number;
+          encodedDataLength?: number;
           frame: string;
-          fromCache: boolean;
-          fromServiceWorker: boolean;
+          fromCache?: boolean;
+          fromServiceWorker?: boolean;
           mimeType: string;
           requestId: string;
           statusCode: number;
@@ -426,6 +450,22 @@ export namespace _TraceEvent {
       name: 'Screenshot';
       ph: 'O';
       tts: number;
+    }
+  }
+
+  namespace TaskQueueManager {
+    namespace ProcessTaskFromWorkQueue {
+      interface X extends Base {
+        args: {
+          src_file: string;
+          src_func: string;
+        };
+        dur?: number;
+        name: 'TaskQueueManager::ProcessTaskFromWorkQueue';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
     }
   }
 
@@ -580,7 +620,12 @@ export namespace _TraceEvent {
     
       interface X extends Base {
         args: {
-        
+          data?: {
+            columnNumber: number;
+            lineNumber: number;
+            url: string;
+          };
+          fileName?: string;
         };
         dur?: number;
         name: 'v8.compile';

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -1,0 +1,2075 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+// https://github.com/Hoten/chrome-trace-events-tsc/blob/master/trace-events.d.ts
+
+export namespace _TraceEvent {
+  interface Base {
+    cat: string;
+    pid: number;
+    tid: number;
+    ts: number;
+  }
+
+  type TraceEvent = 
+    Animation.B |
+    Animation.E |
+    Animation.N |
+    CommitLoad.X |
+    CompositeLayers.B |
+    CompositeLayers.E |
+    ContextCreatedNotification.X |
+    DecodeImage.X |
+    DecodeLazyPixelRef.X |
+    DomComplete.R |
+    DOMContentLoaded.B |
+    DOMContentLoaded.E |
+    DomContentLoadedEventEnd.R |
+    DomContentLoadedEventStart.R |
+    DomInteractive.R |
+    DomLoading.R |
+    DrawLazyPixelRef.I |
+    EndofTrace.B |
+    EndofTrace.E |
+    EvaluateScript.X |
+    EventDispatch.X |
+    FetchStart.R |
+    FireAnimationFrame.X |
+    FirstContentfulPaint.B |
+    FirstContentfulPaint.E |
+    FirstContentfulPaint.R |
+    FirstImagePaint.R |
+    FirstLayout.R |
+    FirstMeaningfulPaint.B |
+    FirstMeaningfulPaint.E |
+    FirstMeaningfulPaint.R |
+    FirstMeaningfulPaintCandidate.R |
+    FirstPaint.R |
+    FirstVisualChange.B |
+    FirstVisualChange.E |
+    FrameCommittedInBrowser.I |
+    FrameDeletedInBrowser.I |
+    FrameStartedLoading.I |
+    FunctionCall.B |
+    FunctionCall.E |
+    GPUTask.X |
+    HitTest.B |
+    HitTest.E |
+    ImageDecodeTask.B |
+    ImageDecodeTask.E |
+    InstallConditionalFeatures.X |
+    InvalidateLayout.I |
+    LayerId.D |
+    LayerId.N |
+    Layout.B |
+    Layout.E |
+    LoadEventEnd.R |
+    LoadEventStart.R |
+    LocalWindowProxy.CreateContext.X |
+    LocalWindowProxy.Initialize.X |
+    LocalWindowProxy.SetupWindowPrototypeChain.X |
+    LocalWindowProxy.UpdateDocumentProperty.X |
+    MajorGC.B |
+    MajorGC.E |
+    MarkDOMContent.I |
+    MarkLoad.I |
+    MinorGC.B |
+    MinorGC.E |
+    NavigationStart.R |
+    Num_cpus.M |
+    OnLoad.B |
+    OnLoad.E |
+    Paint.X |
+    PaintImage.X |
+    ParseAuthorStyleSheet.X |
+    ParseHTML.B |
+    ParseHTML.E |
+    PlatformResourceSendRequest.B |
+    PlatformResourceSendRequest.E |
+    Process_labels.M |
+    Process_name.M |
+    Process_sort_index.M |
+    Process_uptime_seconds.M |
+    RasterTask.B |
+    RasterTask.E |
+    RequestAnimationFrame.I |
+    RequestStart.R |
+    ResourceChangePriority.X |
+    ResourceFinish.I |
+    ResourceReceivedData.I |
+    ResourceReceiveResponse.I |
+    ResourceSendRequest.I |
+    ResponseEnd.R |
+    RunMicrotasks.B |
+    RunMicrotasks.E |
+    RunTask.X |
+    ScheduledAction.Execute.X |
+    ScheduleStyleRecalculation.I |
+    Screenshot.O |
+    SetLayerTreeId.I |
+    SpeedIndex.B |
+    SpeedIndex.E |
+    Thread_name.M |
+    Thread_sort_index.M |
+    TimerFire.X |
+    TimerInstall.I |
+    TimerRemove.I |
+    TracingSessionIdForWorker.I |
+    TracingStartedInBrowser.I |
+    UnloadEventEnd.R |
+    UnloadEventStart.R |
+    UpdateCounters.I |
+    UpdateLayer.B |
+    UpdateLayer.E |
+    UpdateLayerTree.X |
+    UpdateLayoutTree.B |
+    UpdateLayoutTree.E |
+    V8.CallFunction.X |
+    V8.Compile.B |
+    V8.Compile.E |
+    V8.Compile.X |
+    V8.DeoptimizeCode.X |
+    V8.Execute.B |
+    V8.Execute.E |
+    V8.GCCompactor.X |
+    V8.GCIdleNotification.X |
+    V8.GCPhantomHandleProcessingCallback.X |
+    V8.GCScavenger.X |
+    V8.HandleInterrupts.X |
+    V8.InvokeApiInterruptCallbacks.X |
+    V8.NewContext.B |
+    V8.NewContext.E |
+    V8.NewInstance.X |
+    V8.ParseOnBackground.X |
+    V8.Run.X |
+    V8.RunMicrotasks.B |
+    V8.RunMicrotasks.E |
+    V8.ScriptCompiler.B |
+    V8.ScriptCompiler.E |
+    V8.StackGuard.X |
+    V8.Task.B |
+    V8.Task.E |
+    VisuallyComplete100.B |
+    VisuallyComplete100.E |
+    XHRLoad.X |
+    XHRReadyStateChange.X;
+
+  namespace Animation {
+    interface B extends Base {
+      args: {
+        data: {
+          id: string;
+          name: string;
+          nodeId: number;
+          nodeName: string;
+          state: string;
+        };
+      };
+      id: string;
+      name: 'Animation';
+      ph: 'b';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+        endData: {
+          state: string;
+        };
+      };
+      id: string;
+      name: 'Animation';
+      ph: 'e';
+      tts: number;
+    }
+  
+    interface N extends Base {
+      args: {
+        data: {
+          state: string;
+        };
+      };
+      id: string;
+      name: 'Animation';
+      ph: 'n';
+      tts: number;
+    }
+  }
+
+  namespace CommitLoad {
+    interface X extends Base {
+      args: {
+        data: {
+          frame: string;
+          isMainFrame: boolean;
+          name: string;
+          nodeId?: number;
+          page: string;
+          parent?: string;
+          url: string;
+        };
+      };
+      dur: number;
+      name: 'CommitLoad';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace CompositeLayers {
+    interface B extends Base {
+      args: {
+        layerTreeId: number;
+      };
+      name: 'CompositeLayers';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      name: 'CompositeLayers';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace ContextCreatedNotification {
+    interface X extends Base {
+      args: {
+        IsMainFrame: boolean;
+      };
+      dur: number;
+      name: 'ContextCreatedNotification';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace DecodeImage {
+    interface X extends Base {
+      args: {
+        imageType: string;
+      };
+      dur: number;
+      name: 'Decode Image';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace DecodeLazyPixelRef {
+    interface X extends Base {
+      args: {
+        LazyPixelRef: number;
+      };
+      dur: number;
+      name: 'Decode LazyPixelRef';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace DomComplete {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'domComplete';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace DOMContentLoaded {
+    interface B extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'DOM Content Loaded';
+      ph: 'b';
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'DOM Content Loaded';
+      ph: 'e';
+    }
+  }
+
+  namespace DomContentLoadedEventEnd {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'domContentLoadedEventEnd';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace DomContentLoadedEventStart {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'domContentLoadedEventStart';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace DomInteractive {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'domInteractive';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace DomLoading {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'domLoading';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace DrawLazyPixelRef {
+    interface I extends Base {
+      args: {
+        LazyPixelRef: number;
+      };
+      name: 'Draw LazyPixelRef';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace EndofTrace {
+    interface B extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'End of Trace';
+      ph: 'b';
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'End of Trace';
+      ph: 'e';
+    }
+  }
+
+  namespace EvaluateScript {
+    interface X extends Base {
+      args: {
+        data?: {
+          columnNumber: number;
+          frame: string;
+          lineNumber: number;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          url: string;
+        };
+      };
+      dur: number;
+      name: 'EvaluateScript';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace EventDispatch {
+    interface X extends Base {
+      args: {
+        data: {
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          type: string;
+        };
+      };
+      dur: number;
+      name: 'EventDispatch';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace FetchStart {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'fetchStart';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace FireAnimationFrame {
+    interface X extends Base {
+      args: {
+        data: {
+          frame: string;
+          id: number;
+        };
+      };
+      dur: number;
+      name: 'FireAnimationFrame';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace FirstContentfulPaint {
+    interface B extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'First Contentful Paint';
+      ph: 'b';
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'First Contentful Paint';
+      ph: 'e';
+    }
+  
+    interface R extends Base {
+      args: {
+        data: {
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'firstContentfulPaint';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace FirstImagePaint {
+    interface R extends Base {
+      args: {
+        data: {
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'firstImagePaint';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace FirstLayout {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'firstLayout';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace FirstMeaningfulPaint {
+    interface B extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'First Meaningful Paint';
+      ph: 'b';
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'First Meaningful Paint';
+      ph: 'e';
+    }
+  
+    interface R extends Base {
+      args: {
+        afterUserInput?: number;
+        data?: {
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'firstMeaningfulPaint';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace FirstMeaningfulPaintCandidate {
+    interface R extends Base {
+      args: {
+        data: {
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'firstMeaningfulPaintCandidate';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace FirstPaint {
+    interface R extends Base {
+      args: {
+        data: {
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'firstPaint';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace FirstVisualChange {
+    interface B extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'First Visual Change';
+      ph: 'b';
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'First Visual Change';
+      ph: 'e';
+    }
+  }
+
+  namespace FrameCommittedInBrowser {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          name: string;
+          parent?: string;
+          processId: number;
+          url: string;
+        };
+      };
+      name: 'FrameCommittedInBrowser';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace FrameDeletedInBrowser {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+        };
+      };
+      name: 'FrameDeletedInBrowser';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace FrameStartedLoading {
+    interface I extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'FrameStartedLoading';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace FunctionCall {
+    interface B extends Base {
+      args: {
+        data: {
+          columnNumber: number;
+          frame: string;
+          functionName: string;
+          lineNumber: number;
+          scriptId: string;
+          url: string;
+        };
+      };
+      name: 'FunctionCall';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      name: 'FunctionCall';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace GPUTask {
+    interface X extends Base {
+      args: {
+        data: {
+          renderer_pid: number;
+          used_bytes: number;
+        };
+      };
+      dur: number;
+      name: 'GPUTask';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace HitTest {
+    interface B extends Base {
+      args: {
+      
+      };
+      name: 'HitTest';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+        endData: {
+          nodeId: number;
+          nodeName: string;
+          rectilinear: boolean;
+          x: number;
+          y: number;
+        };
+      };
+      name: 'HitTest';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace ImageDecodeTask {
+    interface B extends Base {
+      args: {
+        pixelRefId: number;
+      };
+      name: 'ImageDecodeTask';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      name: 'ImageDecodeTask';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace InstallConditionalFeatures {
+    interface X extends Base {
+      args: {
+        IsMainFrame: boolean;
+      };
+      dur: number;
+      name: 'InstallConditionalFeatures';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace InvalidateLayout {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+        };
+      };
+      name: 'InvalidateLayout';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace LayerId {
+    interface D extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'layerId';
+      ph: 'D';
+      tts: number;
+    }
+  
+    interface N extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'layerId';
+      ph: 'N';
+      tts: number;
+    }
+  }
+
+  namespace Layout {
+    interface B extends Base {
+      args: {
+        beginData: {
+          dirtyObjects: number;
+          frame: string;
+          partialLayout: boolean;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          totalObjects: number;
+        };
+      };
+      name: 'Layout';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+        endData: {
+          root: {
+          
+          }[];
+          rootNode: number;
+        };
+      };
+      name: 'Layout';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace LoadEventEnd {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'loadEventEnd';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace LoadEventStart {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'loadEventStart';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace LocalWindowProxy {
+    namespace CreateContext {
+      interface X extends Base {
+        args: {
+          IsMainFrame: boolean;
+        };
+        dur: number;
+        name: 'LocalWindowProxy::CreateContext';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace Initialize {
+      interface X extends Base {
+        args: {
+          IsMainFrame: boolean;
+        };
+        dur: number;
+        name: 'LocalWindowProxy::Initialize';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace SetupWindowPrototypeChain {
+      interface X extends Base {
+        args: {
+          IsMainFrame: boolean;
+        };
+        dur: number;
+        name: 'LocalWindowProxy::SetupWindowPrototypeChain';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace UpdateDocumentProperty {
+      interface X extends Base {
+        args: {
+          IsMainFrame: boolean;
+        };
+        dur: number;
+        name: 'LocalWindowProxy::UpdateDocumentProperty';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  }
+
+  namespace MajorGC {
+    interface B extends Base {
+      args: {
+        type: string;
+        usedHeapSizeBefore: number;
+      };
+      name: 'MajorGC';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+        usedHeapSizeAfter: number;
+      };
+      name: 'MajorGC';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace MarkDOMContent {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          isMainFrame: boolean;
+          page: string;
+        };
+      };
+      name: 'MarkDOMContent';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace MarkLoad {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          isMainFrame: boolean;
+          page: string;
+        };
+      };
+      name: 'MarkLoad';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace MinorGC {
+    interface B extends Base {
+      args: {
+        usedHeapSizeBefore: number;
+      };
+      name: 'MinorGC';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+        usedHeapSizeAfter: number;
+      };
+      name: 'MinorGC';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace NavigationStart {
+    interface R extends Base {
+      args: {
+        data: {
+          documentLoaderURL: string;
+          isLoadingMainFrame: boolean;
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'navigationStart';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace Num_cpus {
+    interface M extends Base {
+      args: {
+        number: number;
+      };
+      name: 'num_cpus';
+      ph: 'M';
+    }
+  }
+
+  namespace OnLoad {
+    interface B extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'On Load';
+      ph: 'b';
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'On Load';
+      ph: 'e';
+    }
+  }
+
+  namespace Paint {
+    interface X extends Base {
+      args: {
+        data: {
+          clip: {
+          
+          }[];
+          frame: string;
+          layerId: number;
+          nodeId: number;
+        };
+      };
+      dur: number;
+      name: 'Paint';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace PaintImage {
+    interface X extends Base {
+      args: {
+        data: {
+          height: number;
+          nodeId: number;
+          srcHeight: number;
+          srcWidth: number;
+          url?: string;
+          width: number;
+          x: number;
+          y: number;
+        };
+      };
+      dur: number;
+      name: 'PaintImage';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace ParseAuthorStyleSheet {
+    interface X extends Base {
+      args: {
+        data: {
+          styleSheetUrl: string;
+        };
+      };
+      dur: number;
+      name: 'ParseAuthorStyleSheet';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace ParseHTML {
+    interface B extends Base {
+      args: {
+        beginData: {
+          frame: string;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          startLine: number;
+          url: string;
+        };
+      };
+      name: 'ParseHTML';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+        endData: {
+          endLine: number;
+        };
+      };
+      name: 'ParseHTML';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace PlatformResourceSendRequest {
+    interface B extends Base {
+      args: {
+        data: {
+          id: string;
+        };
+      };
+      name: 'PlatformResourceSendRequest';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      name: 'PlatformResourceSendRequest';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace Process_labels {
+    interface M extends Base {
+      args: {
+        labels: string;
+      };
+      name: 'process_labels';
+      ph: 'M';
+    }
+  }
+
+  namespace Process_name {
+    interface M extends Base {
+      args: {
+        name: string;
+      };
+      name: 'process_name';
+      ph: 'M';
+    }
+  }
+
+  namespace Process_sort_index {
+    interface M extends Base {
+      args: {
+        sort_index: number;
+      };
+      name: 'process_sort_index';
+      ph: 'M';
+    }
+  }
+
+  namespace Process_uptime_seconds {
+    interface M extends Base {
+      args: {
+        uptime: number;
+      };
+      name: 'process_uptime_seconds';
+      ph: 'M';
+    }
+  }
+
+  namespace RasterTask {
+    interface B extends Base {
+      args: {
+        tileData: {
+          layerId: number;
+          sourceFrameNumber: number;
+          tileId: {
+            id_ref: string;
+          };
+          tileResolution: string;
+        };
+      };
+      name: 'RasterTask';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      name: 'RasterTask';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace RequestAnimationFrame {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          id: number;
+          stackTrace: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+        };
+      };
+      name: 'RequestAnimationFrame';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace RequestStart {
+    interface R extends Base {
+      args: {
+      
+      };
+      name: 'requestStart';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace ResourceChangePriority {
+    interface X extends Base {
+      args: {
+        data: {
+          priority: string;
+          requestId: string;
+        };
+      };
+      dur: number;
+      name: 'ResourceChangePriority';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace ResourceFinish {
+    interface I extends Base {
+      args: {
+        data: {
+          decodedBodyLength: number;
+          didFail: boolean;
+          encodedDataLength: number;
+          finishTime?: number;
+          requestId: string;
+        };
+      };
+      name: 'ResourceFinish';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace ResourceReceivedData {
+    interface I extends Base {
+      args: {
+        data: {
+          encodedDataLength: number;
+          frame: string;
+          requestId: string;
+        };
+      };
+      name: 'ResourceReceivedData';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace ResourceReceiveResponse {
+    interface I extends Base {
+      args: {
+        data: {
+          encodedDataLength: number;
+          frame: string;
+          fromCache: boolean;
+          fromServiceWorker: boolean;
+          mimeType: string;
+          requestId: string;
+          statusCode: number;
+          timing?: {
+            connectEnd: number;
+            connectStart: number;
+            dnsEnd: number;
+            dnsStart: number;
+            proxyEnd: number;
+            proxyStart: number;
+            pushEnd: number;
+            pushStart: number;
+            receiveHeadersEnd: number;
+            requestTime: number;
+            sendEnd: number;
+            sendStart: number;
+            sslEnd: number;
+            sslStart: number;
+            workerReady: number;
+            workerStart: number;
+          };
+        };
+      };
+      name: 'ResourceReceiveResponse';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace ResourceSendRequest {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          priority: string;
+          requestId: string;
+          requestMethod: string;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          url: string;
+        };
+      };
+      name: 'ResourceSendRequest';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace ResponseEnd {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'responseEnd';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace RunMicrotasks {
+    interface B extends Base {
+      args: {
+      
+      };
+      name: 'RunMicrotasks';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+        microtask_count: number;
+      };
+      name: 'RunMicrotasks';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace RunTask {
+    interface X extends Base {
+      args: {
+      
+      };
+      dur: number;
+      name: 'RunTask';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace ScheduledAction {
+    namespace Execute {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'ScheduledAction::execute';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  }
+
+  namespace ScheduleStyleRecalculation {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+        };
+      };
+      name: 'ScheduleStyleRecalculation';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace Screenshot {
+    interface O extends Base {
+      args: {
+        snapshot: string;
+      };
+      id: string;
+      name: 'Screenshot';
+      ph: 'O';
+      tts: number;
+    }
+  }
+
+  namespace SetLayerTreeId {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          layerTreeId: number;
+        };
+      };
+      name: 'SetLayerTreeId';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace SpeedIndex {
+    interface B extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'Speed Index';
+      ph: 'b';
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'Speed Index';
+      ph: 'e';
+    }
+  }
+
+  namespace Thread_name {
+    interface M extends Base {
+      args: {
+        name: string;
+      };
+      name: 'thread_name';
+      ph: 'M';
+    }
+  }
+
+  namespace Thread_sort_index {
+    interface M extends Base {
+      args: {
+        sort_index: number;
+      };
+      name: 'thread_sort_index';
+      ph: 'M';
+    }
+  }
+
+  namespace TimerFire {
+    interface X extends Base {
+      args: {
+        data: {
+          frame: string;
+          timerId: number;
+        };
+      };
+      dur: number;
+      name: 'TimerFire';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace TimerInstall {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          singleShot: boolean;
+          stackTrace: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          timeout: number;
+          timerId: number;
+        };
+      };
+      name: 'TimerInstall';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace TimerRemove {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          stackTrace: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          timerId: number;
+        };
+      };
+      name: 'TimerRemove';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace TracingSessionIdForWorker {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          url: string;
+          workerId: string;
+          workerThreadId: number;
+        };
+      };
+      name: 'TracingSessionIdForWorker';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace TracingStartedInBrowser {
+    interface I extends Base {
+      args: {
+        data: {
+          frameTreeNodeId: number;
+          frames: {
+            frame: string;
+            name: string;
+            processId: number;
+            url: string;
+          }[];
+          persistentIds: boolean;
+        };
+      };
+      name: 'TracingStartedInBrowser';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace UnloadEventEnd {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'unloadEventEnd';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace UnloadEventStart {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'unloadEventStart';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace UpdateCounters {
+    interface I extends Base {
+      args: {
+        data: {
+          documents: number;
+          jsEventListeners: number;
+          jsHeapSizeUsed: number;
+          nodes: number;
+        };
+      };
+      name: 'UpdateCounters';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
+  namespace UpdateLayer {
+    interface B extends Base {
+      args: {
+        layerId: number;
+        layerTreeId: number;
+      };
+      name: 'UpdateLayer';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      name: 'UpdateLayer';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace UpdateLayerTree {
+    interface X extends Base {
+      args: {
+        data: {
+          frame: string;
+        };
+      };
+      dur: number;
+      name: 'UpdateLayerTree';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace UpdateLayoutTree {
+    interface B extends Base {
+      args: {
+        beginData: {
+          frame: string;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+        };
+      };
+      name: 'UpdateLayoutTree';
+      ph: 'B';
+      tts: number;
+    }
+  
+    interface E extends Base {
+      args: {
+        elementCount: number;
+      };
+      name: 'UpdateLayoutTree';
+      ph: 'E';
+      tts: number;
+    }
+  }
+
+  namespace V8 {
+    namespace CallFunction {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'v8.callFunction';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace Compile {
+      interface B extends Base {
+        args: {
+          fileName: string;
+        };
+        name: 'v8.compile';
+        ph: 'B';
+        tts: number;
+      }
+    
+      interface E extends Base {
+        args: {
+          data: {
+            cacheConsumeOptions?: string;
+            cacheRejected?: boolean;
+            columnNumber: number;
+            consumedCacheSize?: number;
+            lineNumber: number;
+            notStreamedReason?: string;
+            producedCacheSize?: number;
+            streamed: boolean;
+            url: string;
+          };
+        };
+        name: 'v8.compile';
+        ph: 'E';
+        tts: number;
+      }
+    
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'v8.compile';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace DeoptimizeCode {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'V8.DeoptimizeCode';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace Execute {
+      interface B extends Base {
+        args: {
+        
+        };
+        name: 'V8.Execute';
+        ph: 'B';
+        tts: number;
+      }
+    
+      interface E extends Base {
+        args: {
+          'runtime-call-stats': {
+          
+          };
+        };
+        name: 'V8.Execute';
+        ph: 'E';
+        tts: number;
+      }
+    }
+  
+    namespace GCCompactor {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'V8.GCCompactor';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace GCIdleNotification {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'V8.GCIdleNotification';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace GCPhantomHandleProcessingCallback {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'V8.GCPhantomHandleProcessingCallback';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace GCScavenger {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'V8.GCScavenger';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace HandleInterrupts {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'V8.HandleInterrupts';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace InvokeApiInterruptCallbacks {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'V8.InvokeApiInterruptCallbacks';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace NewContext {
+      interface B extends Base {
+        args: {
+        
+        };
+        name: 'V8.NewContext';
+        ph: 'B';
+        tts: number;
+      }
+    
+      interface E extends Base {
+        args: {
+          'runtime-call-stats': {
+          
+          };
+        };
+        name: 'V8.NewContext';
+        ph: 'E';
+        tts: number;
+      }
+    }
+  
+    namespace NewInstance {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'v8.newInstance';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace ParseOnBackground {
+      interface X extends Base {
+        args: {
+          data: {
+            requestId: string;
+            url: string;
+          };
+        };
+        bind_id: string;
+        dur: number;
+        flow_in: boolean;
+        flow_out: boolean;
+        id: string;
+        name: 'v8.parseOnBackground';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace Run {
+      interface X extends Base {
+        args: {
+          fileName?: string;
+        };
+        dur: number;
+        name: 'v8.run';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace RunMicrotasks {
+      interface B extends Base {
+        args: {
+        
+        };
+        name: 'V8.RunMicrotasks';
+        ph: 'B';
+        tts: number;
+      }
+    
+      interface E extends Base {
+        args: {
+          'runtime-call-stats': {
+          
+          };
+        };
+        name: 'V8.RunMicrotasks';
+        ph: 'E';
+        tts: number;
+      }
+    }
+  
+    namespace ScriptCompiler {
+      interface B extends Base {
+        args: {
+        
+        };
+        name: 'V8.ScriptCompiler';
+        ph: 'B';
+        tts: number;
+      }
+    
+      interface E extends Base {
+        args: {
+          'runtime-call-stats': {
+          
+          };
+        };
+        name: 'V8.ScriptCompiler';
+        ph: 'E';
+        tts: number;
+      }
+    }
+  
+    namespace StackGuard {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'V8.StackGuard';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace Task {
+      interface B extends Base {
+        args: {
+        
+        };
+        name: 'V8.Task';
+        ph: 'B';
+        tts: number;
+      }
+    
+      interface E extends Base {
+        args: {
+          'runtime-call-stats': {
+          
+          };
+        };
+        name: 'V8.Task';
+        ph: 'E';
+        tts: number;
+      }
+    }
+  }
+
+  namespace VisuallyComplete100 {
+    interface B extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'Visually Complete 100%';
+      ph: 'b';
+    }
+  
+    interface E extends Base {
+      args: {
+      
+      };
+      id: string;
+      name: 'Visually Complete 100%';
+      ph: 'e';
+    }
+  }
+
+  namespace XHRLoad {
+    interface X extends Base {
+      args: {
+        data: {
+          frame: string;
+          url: string;
+        };
+      };
+      dur: number;
+      name: 'XHRLoad';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+
+  namespace XHRReadyStateChange {
+    interface X extends Base {
+      args: {
+        data: {
+          frame: string;
+          readyState: number;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          url: string;
+        };
+      };
+      dur: number;
+      name: 'XHRReadyStateChange';
+      ph: 'X';
+      tdur: number;
+      tts: number;
+    }
+  }
+}
+
+export default _TraceEvent;

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -137,7 +137,7 @@ export namespace TraceEvent {
     TraceEvent.XHRReadyStateChange.X;
 
   namespace DomContentLoadedEventEnd {
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
         frame: string;
       };
@@ -150,7 +150,7 @@ export namespace TraceEvent {
   }
 
   namespace EvaluateScript {
-    interface X extends Base {
+    interface X extends TraceEvent.Base {
       args: {
         data?: {
           columnNumber: number;
@@ -178,7 +178,7 @@ export namespace TraceEvent {
   }
 
   namespace FirstContentfulPaint {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         frame: string;
       };
@@ -190,7 +190,7 @@ export namespace TraceEvent {
       tts: number;
     }
   
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
         data?: {
           navigationId: string;
@@ -206,7 +206,7 @@ export namespace TraceEvent {
   }
 
   namespace FirstMeaningfulPaint {
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
         afterUserInput?: number;
         data?: {
@@ -223,7 +223,7 @@ export namespace TraceEvent {
   }
 
   namespace FirstMeaningfulPaintCandidate {
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
         data: {
           navigationId: string;
@@ -239,7 +239,7 @@ export namespace TraceEvent {
   }
 
   namespace FirstPaint {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         frame: string;
       };
@@ -251,7 +251,7 @@ export namespace TraceEvent {
       tts: number;
     }
   
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
         data?: {
           navigationId: string;
@@ -267,7 +267,7 @@ export namespace TraceEvent {
   }
 
   namespace FunctionCall {
-    interface B extends Base {
+    interface B extends TraceEvent.Base {
       args: {
         data: {
           columnNumber?: number;
@@ -285,7 +285,7 @@ export namespace TraceEvent {
       tts: number;
     }
   
-    interface E extends Base {
+    interface E extends TraceEvent.Base {
       args: {
       
       };
@@ -298,7 +298,7 @@ export namespace TraceEvent {
   }
 
   namespace InvalidateLayout {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         data: {
           frame: string;
@@ -321,7 +321,7 @@ export namespace TraceEvent {
   }
 
   namespace Layout {
-    interface B extends Base {
+    interface B extends TraceEvent.Base {
       args: {
         beginData: {
           dirtyObjects: number;
@@ -344,7 +344,7 @@ export namespace TraceEvent {
       tts: number;
     }
   
-    interface E extends Base {
+    interface E extends TraceEvent.Base {
       args: {
         endData: {
           root: {
@@ -362,7 +362,7 @@ export namespace TraceEvent {
   }
 
   namespace LoadEventEnd {
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
         frame: string;
       };
@@ -375,7 +375,7 @@ export namespace TraceEvent {
   }
 
   namespace NavigationStart {
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
         data?: {
           documentLoaderURL: string;
@@ -393,7 +393,7 @@ export namespace TraceEvent {
   }
 
   namespace PaintNonDefaultBackgroundColor {
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
       
       };
@@ -406,7 +406,7 @@ export namespace TraceEvent {
   }
 
   namespace ParseAuthorStyleSheet {
-    interface X extends Base {
+    interface X extends TraceEvent.Base {
       args: {
         data: {
           styleSheetUrl: string;
@@ -424,7 +424,7 @@ export namespace TraceEvent {
   }
 
   namespace Process_labels {
-    interface M extends Base {
+    interface M extends TraceEvent.Base {
       args: {
         labels: string;
       };
@@ -435,7 +435,7 @@ export namespace TraceEvent {
   }
 
   namespace RequestStart {
-    interface R extends Base {
+    interface R extends TraceEvent.Base {
       args: {
       
       };
@@ -448,7 +448,7 @@ export namespace TraceEvent {
   }
 
   namespace ResourceFinish {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         data: {
           decodedBodyLength?: number;
@@ -469,7 +469,7 @@ export namespace TraceEvent {
   }
 
   namespace ResourceReceiveResponse {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         data: {
           encodedDataLength?: number;
@@ -509,7 +509,7 @@ export namespace TraceEvent {
   }
 
   namespace ResourceSendRequest {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         data: {
           frame: string;
@@ -536,7 +536,7 @@ export namespace TraceEvent {
   }
 
   namespace RunTask {
-    interface X extends Base {
+    interface X extends TraceEvent.Base {
       args: {
       
       };
@@ -552,7 +552,7 @@ export namespace TraceEvent {
   }
 
   namespace ScheduleStyleRecalculation {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         data: {
           frame: string;
@@ -575,7 +575,7 @@ export namespace TraceEvent {
   }
 
   namespace Screenshot {
-    interface O extends Base {
+    interface O extends TraceEvent.Base {
       args: {
         snapshot: string;
       };
@@ -593,7 +593,7 @@ export namespace TraceEvent {
       TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue.X;
   
     namespace ProcessTaskFromWorkQueue {
-      interface X extends Base {
+      interface X extends TraceEvent.Base {
         args: {
           src_file: string;
           src_func: string;
@@ -611,7 +611,7 @@ export namespace TraceEvent {
   }
 
   namespace Thread_name {
-    interface M extends Base {
+    interface M extends TraceEvent.Base {
       args: {
         name: string;
       };
@@ -629,7 +629,7 @@ export namespace TraceEvent {
       TraceEvent.ThreadControllerImpl.RunTask.X;
   
     namespace DoWork {
-      interface X extends Base {
+      interface X extends TraceEvent.Base {
         args: {
         
         };
@@ -645,7 +645,7 @@ export namespace TraceEvent {
     }
   
     namespace RunTask {
-      interface X extends Base {
+      interface X extends TraceEvent.Base {
         args: {
           src_file?: string;
           src_func?: string;
@@ -666,7 +666,7 @@ export namespace TraceEvent {
   }
 
   namespace TimerFire {
-    interface X extends Base {
+    interface X extends TraceEvent.Base {
       args: {
         data: {
           frame: string;
@@ -685,7 +685,7 @@ export namespace TraceEvent {
   }
 
   namespace TimerInstall {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         data: {
           frame: string;
@@ -711,7 +711,7 @@ export namespace TraceEvent {
   }
 
   namespace TracingStartedInBrowser {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         data: {
           frameTreeNodeId: number;
@@ -734,7 +734,7 @@ export namespace TraceEvent {
   }
 
   namespace TracingStartedInPage {
-    interface I extends Base {
+    interface I extends TraceEvent.Base {
       args: {
         data: {
           page: string;
@@ -757,7 +757,7 @@ export namespace TraceEvent {
       TraceEvent.V8.Compile.X;
   
     namespace Compile {
-      interface B extends Base {
+      interface B extends TraceEvent.Base {
         args: {
           fileName: string;
         };
@@ -768,7 +768,7 @@ export namespace TraceEvent {
         tts: number;
       }
     
-      interface E extends Base {
+      interface E extends TraceEvent.Base {
         args: {
           data: {
             cacheConsumeOptions?: string;
@@ -790,7 +790,7 @@ export namespace TraceEvent {
         tts: number;
       }
     
-      interface X extends Base {
+      interface X extends TraceEvent.Base {
         args: {
           data?: {
             columnNumber: number;
@@ -812,7 +812,7 @@ export namespace TraceEvent {
   }
 
   namespace XHRReadyStateChange {
-    interface X extends Base {
+    interface X extends TraceEvent.Base {
       args: {
         data: {
           frame: string;

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -8,9 +8,13 @@
 
 export namespace TraceEvent {
   interface Base {
+    // Comma-separated list of category names.
     cat: string;
+    // Process id of the process that generated the event.
     pid: number;
+    // Thread id of the thread that generated the event.
     tid: number;
+    // Timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
     ts: number;
   }
 
@@ -139,7 +143,9 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'domContentLoadedEventEnd';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -161,10 +167,13 @@ export namespace TraceEvent {
             url: string;
           };
         };
+        // Duration.
         dur: number;
         name: 'EvaluateScript';
+        // Phase.
         ph: 'X';
         tdur: number;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -175,8 +184,10 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstContentfulPaint';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     
@@ -188,7 +199,9 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstContentfulPaint';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -203,7 +216,9 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstMeaningfulPaint';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -217,7 +232,9 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstMeaningfulPaintCandidate';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -228,8 +245,10 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstPaint';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     
@@ -241,7 +260,9 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstPaint';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -259,7 +280,9 @@ export namespace TraceEvent {
           };
         };
         name: 'FunctionCall';
+        // Phase.
         ph: 'B';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     
@@ -268,7 +291,9 @@ export namespace TraceEvent {
         
         };
         name: 'FunctionCall';
+        // Phase.
         ph: 'E';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -288,8 +313,10 @@ export namespace TraceEvent {
           };
         };
         name: 'InvalidateLayout';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -312,7 +339,9 @@ export namespace TraceEvent {
           };
         };
         name: 'Layout';
+        // Phase.
         ph: 'B';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     
@@ -326,7 +355,9 @@ export namespace TraceEvent {
           };
         };
         name: 'Layout';
+        // Phase.
         ph: 'E';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -337,7 +368,9 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'loadEventEnd';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -353,7 +386,9 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'navigationStart';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -364,7 +399,9 @@ export namespace TraceEvent {
         
         };
         name: 'paintNonDefaultBackgroundColor';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -376,10 +413,13 @@ export namespace TraceEvent {
             styleSheetUrl: string;
           };
         };
+        // Duration.
         dur: number;
         name: 'ParseAuthorStyleSheet';
+        // Phase.
         ph: 'X';
         tdur: number;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -390,6 +430,7 @@ export namespace TraceEvent {
           labels: string;
         };
         name: 'process_labels';
+        // Phase.
         ph: 'M';
       }
     }
@@ -400,7 +441,9 @@ export namespace TraceEvent {
         
         };
         name: 'requestStart';
+        // Phase.
         ph: 'R';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -418,8 +461,10 @@ export namespace TraceEvent {
           };
         };
         name: 'ResourceFinish';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -456,8 +501,10 @@ export namespace TraceEvent {
           };
         };
         name: 'ResourceReceiveResponse';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -481,8 +528,10 @@ export namespace TraceEvent {
           };
         };
         name: 'ResourceSendRequest';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -492,10 +541,13 @@ export namespace TraceEvent {
         args: {
         
         };
+        // Duration.
         dur?: number;
         name: 'RunTask';
+        // Phase.
         ph: 'X';
         tdur?: number;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -515,8 +567,10 @@ export namespace TraceEvent {
           };
         };
         name: 'ScheduleStyleRecalculation';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -528,7 +582,9 @@ export namespace TraceEvent {
         };
         id: string;
         name: 'Screenshot';
+        // Phase.
         ph: 'O';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -543,10 +599,13 @@ export namespace TraceEvent {
             src_file: string;
             src_func: string;
           };
+          // Duration.
           dur?: number;
           name: 'TaskQueueManager::ProcessTaskFromWorkQueue';
+          // Phase.
           ph: 'X';
           tdur: number;
+          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
           tts: number;
         }
       }
@@ -558,6 +617,7 @@ export namespace TraceEvent {
           name: string;
         };
         name: 'thread_name';
+        // Phase.
         ph: 'M';
       }
     }
@@ -574,10 +634,13 @@ export namespace TraceEvent {
           args: {
           
           };
+          // Duration.
           dur?: number;
           name: 'ThreadControllerImpl::DoWork';
+          // Phase.
           ph: 'X';
           tdur: number;
+          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
           tts: number;
         }
       }
@@ -589,12 +652,15 @@ export namespace TraceEvent {
             src_func?: string;
           };
           bind_id?: string;
+          // Duration.
           dur?: number;
           flow_in?: boolean;
           id?: string;
           name: 'ThreadControllerImpl::RunTask';
+          // Phase.
           ph: 'X';
           tdur: number;
+          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
           tts: number;
         }
       }
@@ -608,10 +674,13 @@ export namespace TraceEvent {
             timerId: number;
           };
         };
+        // Duration.
         dur: number;
         name: 'TimerFire';
+        // Phase.
         ph: 'X';
         tdur: number;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -634,8 +703,10 @@ export namespace TraceEvent {
           };
         };
         name: 'TimerInstall';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -655,8 +726,10 @@ export namespace TraceEvent {
           };
         };
         name: 'TracingStartedInBrowser';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -670,8 +743,10 @@ export namespace TraceEvent {
           };
         };
         name: 'TracingStartedInPage';
+        // Phase.
         ph: 'I';
         s: string;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
@@ -688,7 +763,9 @@ export namespace TraceEvent {
             fileName: string;
           };
           name: 'v8.compile';
+          // Phase.
           ph: 'B';
+          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
           tts: number;
         }
       
@@ -708,7 +785,9 @@ export namespace TraceEvent {
             };
           };
           name: 'v8.compile';
+          // Phase.
           ph: 'E';
+          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
           tts: number;
         }
       
@@ -721,10 +800,13 @@ export namespace TraceEvent {
             };
             fileName?: string;
           };
+          // Duration.
           dur?: number;
           name: 'v8.compile';
+          // Phase.
           ph: 'X';
           tdur?: number;
+          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
           tts: number;
         }
       }
@@ -746,10 +828,13 @@ export namespace TraceEvent {
             url: string;
           };
         };
+        // Duration.
         dur: number;
         name: 'XHRReadyStateChange';
+        // Phase.
         ph: 'X';
         tdur: number;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -36,547 +36,453 @@ export namespace TraceEvent {
     TraceEvent.RunTask |
     TraceEvent.ScheduleStyleRecalculation |
     TraceEvent.Screenshot |
-    TaskQueueManager.ProcessTaskFromWorkQueue |
+    TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue |
     TraceEvent.Thread_name |
-    ThreadControllerImpl.DoWork |
-    ThreadControllerImpl.RunTask |
+    TraceEvent.ThreadControllerImpl.DoWork |
+    TraceEvent.ThreadControllerImpl.RunTask |
     TraceEvent.TimerFire |
     TraceEvent.TimerInstall |
     TraceEvent.TracingStartedInBrowser |
     TraceEvent.TracingStartedInPage |
-    V8.Compile |
+    TraceEvent.V8.Compile |
     TraceEvent.XHRReadyStateChange;
 
-  type DomContentLoadedEventEnd = 
-    DomContentLoadedEventEnd.R;
-
-  type EvaluateScript = 
-    EvaluateScript.X;
-
-  type FirstContentfulPaint = 
-    FirstContentfulPaint.I |
-    FirstContentfulPaint.R;
-
-  type FirstMeaningfulPaint = 
-    FirstMeaningfulPaint.R;
-
-  type FirstMeaningfulPaintCandidate = 
-    FirstMeaningfulPaintCandidate.R;
-
-  type FirstPaint = 
-    FirstPaint.I |
-    FirstPaint.R;
-
-  type FunctionCall = 
-    FunctionCall.B |
-    FunctionCall.E;
-
-  type InvalidateLayout = 
-    InvalidateLayout.I;
-
-  type Layout = 
-    Layout.B |
-    Layout.E;
-
-  type LoadEventEnd = 
-    LoadEventEnd.R;
-
-  type NavigationStart = 
-    NavigationStart.R;
-
-  type PaintNonDefaultBackgroundColor = 
-    PaintNonDefaultBackgroundColor.R;
-
-  type ParseAuthorStyleSheet = 
-    ParseAuthorStyleSheet.X;
-
-  type Process_labels = 
-    Process_labels.M;
-
-  type RequestStart = 
-    RequestStart.R;
-
-  type ResourceFinish = 
-    ResourceFinish.I;
-
-  type ResourceReceiveResponse = 
-    ResourceReceiveResponse.I;
-
-  type ResourceSendRequest = 
-    ResourceSendRequest.I;
-
-  type RunTask = 
-    RunTask.X;
-
-  type ScheduleStyleRecalculation = 
-    ScheduleStyleRecalculation.I;
-
-  type Screenshot = 
-    Screenshot.O;
-
-  type Thread_name = 
-    Thread_name.M;
-
-  type TimerFire = 
-    TimerFire.X;
-
-  type TimerInstall = 
-    TimerInstall.I;
-
-  type TracingStartedInBrowser = 
-    TracingStartedInBrowser.I;
-
-  type TracingStartedInPage = 
-    TracingStartedInPage.I;
-
-  type XHRReadyStateChange = 
-    XHRReadyStateChange.X;
-
-  namespace DomContentLoadedEventEnd {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'domContentLoadedEventEnd';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace EvaluateScript {
-    interface X extends Base {
-      args: {
-        data?: {
-          columnNumber: number;
+  namespace TraceEvent {
+    type DomContentLoadedEventEnd = 
+      TraceEvent.DomContentLoadedEventEnd.R;
+  
+    type EvaluateScript = 
+      TraceEvent.EvaluateScript.X;
+  
+    type FirstContentfulPaint = 
+      TraceEvent.FirstContentfulPaint.I |
+      TraceEvent.FirstContentfulPaint.R;
+  
+    type FirstMeaningfulPaint = 
+      TraceEvent.FirstMeaningfulPaint.R;
+  
+    type FirstMeaningfulPaintCandidate = 
+      TraceEvent.FirstMeaningfulPaintCandidate.R;
+  
+    type FirstPaint = 
+      TraceEvent.FirstPaint.I |
+      TraceEvent.FirstPaint.R;
+  
+    type FunctionCall = 
+      TraceEvent.FunctionCall.B |
+      TraceEvent.FunctionCall.E;
+  
+    type InvalidateLayout = 
+      TraceEvent.InvalidateLayout.I;
+  
+    type Layout = 
+      TraceEvent.Layout.B |
+      TraceEvent.Layout.E;
+  
+    type LoadEventEnd = 
+      TraceEvent.LoadEventEnd.R;
+  
+    type NavigationStart = 
+      TraceEvent.NavigationStart.R;
+  
+    type PaintNonDefaultBackgroundColor = 
+      TraceEvent.PaintNonDefaultBackgroundColor.R;
+  
+    type ParseAuthorStyleSheet = 
+      TraceEvent.ParseAuthorStyleSheet.X;
+  
+    type Process_labels = 
+      TraceEvent.Process_labels.M;
+  
+    type RequestStart = 
+      TraceEvent.RequestStart.R;
+  
+    type ResourceFinish = 
+      TraceEvent.ResourceFinish.I;
+  
+    type ResourceReceiveResponse = 
+      TraceEvent.ResourceReceiveResponse.I;
+  
+    type ResourceSendRequest = 
+      TraceEvent.ResourceSendRequest.I;
+  
+    type RunTask = 
+      TraceEvent.RunTask.X;
+  
+    type ScheduleStyleRecalculation = 
+      TraceEvent.ScheduleStyleRecalculation.I;
+  
+    type Screenshot = 
+      TraceEvent.Screenshot.O;
+  
+    type Thread_name = 
+      TraceEvent.Thread_name.M;
+  
+    type TimerFire = 
+      TraceEvent.TimerFire.X;
+  
+    type TimerInstall = 
+      TraceEvent.TimerInstall.I;
+  
+    type TracingStartedInBrowser = 
+      TraceEvent.TracingStartedInBrowser.I;
+  
+    type TracingStartedInPage = 
+      TraceEvent.TracingStartedInPage.I;
+  
+    type XHRReadyStateChange = 
+      TraceEvent.XHRReadyStateChange.X;
+  
+    namespace DomContentLoadedEventEnd {
+      interface R extends Base {
+        args: {
           frame: string;
-          lineNumber: number;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-          url: string;
         };
-      };
-      dur: number;
-      name: 'EvaluateScript';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace FirstContentfulPaint {
-    interface I extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'firstContentfulPaint';
-      ph: 'I';
-      s: string;
-      tts: number;
+        name: 'domContentLoadedEventEnd';
+        ph: 'R';
+        tts: number;
+      }
     }
   
-    interface R extends Base {
-      args: {
-        data?: {
-          navigationId: string;
-        };
-        frame: string;
-      };
-      name: 'firstContentfulPaint';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace FirstMeaningfulPaint {
-    interface R extends Base {
-      args: {
-        afterUserInput?: number;
-        data?: {
-          navigationId: string;
-        };
-        frame: string;
-      };
-      name: 'firstMeaningfulPaint';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace FirstMeaningfulPaintCandidate {
-    interface R extends Base {
-      args: {
-        data: {
-          navigationId: string;
-        };
-        frame: string;
-      };
-      name: 'firstMeaningfulPaintCandidate';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace FirstPaint {
-    interface I extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'firstPaint';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  
-    interface R extends Base {
-      args: {
-        data?: {
-          navigationId: string;
-        };
-        frame: string;
-      };
-      name: 'firstPaint';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace FunctionCall {
-    interface B extends Base {
-      args: {
-        data: {
-          columnNumber?: number;
-          frame: string;
-          functionName: string;
-          lineNumber: number;
-          scriptId: string;
-          url: string;
-        };
-      };
-      name: 'FunctionCall';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      name: 'FunctionCall';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace InvalidateLayout {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-        };
-      };
-      name: 'InvalidateLayout';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace Layout {
-    interface B extends Base {
-      args: {
-        beginData: {
-          dirtyObjects: number;
-          frame: string;
-          partialLayout: boolean;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-          totalObjects: number;
-        };
-      };
-      name: 'Layout';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-        endData: {
-          root: {
-          
-          }[];
-          rootNode: number;
-        };
-      };
-      name: 'Layout';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace LoadEventEnd {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'loadEventEnd';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace NavigationStart {
-    interface R extends Base {
-      args: {
-        data?: {
-          documentLoaderURL: string;
-          isLoadingMainFrame: boolean;
-          navigationId: string;
-        };
-        frame: string;
-      };
-      name: 'navigationStart';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace PaintNonDefaultBackgroundColor {
-    interface R extends Base {
-      args: {
-      
-      };
-      name: 'paintNonDefaultBackgroundColor';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace ParseAuthorStyleSheet {
-    interface X extends Base {
-      args: {
-        data: {
-          styleSheetUrl: string;
-        };
-      };
-      dur: number;
-      name: 'ParseAuthorStyleSheet';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace Process_labels {
-    interface M extends Base {
-      args: {
-        labels: string;
-      };
-      name: 'process_labels';
-      ph: 'M';
-    }
-  }
-
-  namespace RequestStart {
-    interface R extends Base {
-      args: {
-      
-      };
-      name: 'requestStart';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace ResourceFinish {
-    interface I extends Base {
-      args: {
-        data: {
-          decodedBodyLength?: number;
-          didFail: boolean;
-          encodedDataLength?: number;
-          finishTime?: number;
-          networkTime?: number;
-          requestId: string;
-        };
-      };
-      name: 'ResourceFinish';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace ResourceReceiveResponse {
-    interface I extends Base {
-      args: {
-        data: {
-          encodedDataLength?: number;
-          frame: string;
-          fromCache?: boolean;
-          fromServiceWorker?: boolean;
-          mimeType: string;
-          requestId: string;
-          statusCode: number;
-          timing?: {
-            connectEnd: number;
-            connectStart: number;
-            dnsEnd: number;
-            dnsStart: number;
-            proxyEnd: number;
-            proxyStart: number;
-            pushEnd: number;
-            pushStart: number;
-            receiveHeadersEnd: number;
-            requestTime: number;
-            sendEnd: number;
-            sendStart: number;
-            sslEnd: number;
-            sslStart: number;
-            workerReady: number;
-            workerStart: number;
-          };
-        };
-      };
-      name: 'ResourceReceiveResponse';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace ResourceSendRequest {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          priority: string;
-          requestId: string;
-          requestMethod: string;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-          url: string;
-        };
-      };
-      name: 'ResourceSendRequest';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace RunTask {
-    interface X extends Base {
-      args: {
-      
-      };
-      dur?: number;
-      name: 'RunTask';
-      ph: 'X';
-      tdur?: number;
-      tts: number;
-    }
-  }
-
-  namespace ScheduleStyleRecalculation {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-        };
-      };
-      name: 'ScheduleStyleRecalculation';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace Screenshot {
-    interface O extends Base {
-      args: {
-        snapshot: string;
-      };
-      id: string;
-      name: 'Screenshot';
-      ph: 'O';
-      tts: number;
-    }
-  }
-
-  namespace TaskQueueManager {
-    type ProcessTaskFromWorkQueue = 
-      TaskQueueManager.ProcessTaskFromWorkQueue.X;
-  
-    namespace ProcessTaskFromWorkQueue {
+    namespace EvaluateScript {
       interface X extends Base {
         args: {
-          src_file: string;
-          src_func: string;
+          data?: {
+            columnNumber: number;
+            frame: string;
+            lineNumber: number;
+            stackTrace?: {
+              columnNumber: number;
+              functionName: string;
+              lineNumber: number;
+              scriptId: string;
+              url: string;
+            }[];
+            url: string;
+          };
         };
-        dur?: number;
-        name: 'TaskQueueManager::ProcessTaskFromWorkQueue';
+        dur: number;
+        name: 'EvaluateScript';
         ph: 'X';
         tdur: number;
         tts: number;
       }
     }
-  }
-
-  namespace Thread_name {
-    interface M extends Base {
-      args: {
-        name: string;
-      };
-      name: 'thread_name';
-      ph: 'M';
+  
+    namespace FirstContentfulPaint {
+      interface I extends Base {
+        args: {
+          frame: string;
+        };
+        name: 'firstContentfulPaint';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    
+      interface R extends Base {
+        args: {
+          data?: {
+            navigationId: string;
+          };
+          frame: string;
+        };
+        name: 'firstContentfulPaint';
+        ph: 'R';
+        tts: number;
+      }
     }
-  }
-
-  namespace ThreadControllerImpl {
-    type DoWork = 
-      ThreadControllerImpl.DoWork.X;
   
-    type RunTask = 
-      ThreadControllerImpl.RunTask.X;
+    namespace FirstMeaningfulPaint {
+      interface R extends Base {
+        args: {
+          afterUserInput?: number;
+          data?: {
+            navigationId: string;
+          };
+          frame: string;
+        };
+        name: 'firstMeaningfulPaint';
+        ph: 'R';
+        tts: number;
+      }
+    }
   
-    namespace DoWork {
-      interface X extends Base {
+    namespace FirstMeaningfulPaintCandidate {
+      interface R extends Base {
+        args: {
+          data: {
+            navigationId: string;
+          };
+          frame: string;
+        };
+        name: 'firstMeaningfulPaintCandidate';
+        ph: 'R';
+        tts: number;
+      }
+    }
+  
+    namespace FirstPaint {
+      interface I extends Base {
+        args: {
+          frame: string;
+        };
+        name: 'firstPaint';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    
+      interface R extends Base {
+        args: {
+          data?: {
+            navigationId: string;
+          };
+          frame: string;
+        };
+        name: 'firstPaint';
+        ph: 'R';
+        tts: number;
+      }
+    }
+  
+    namespace FunctionCall {
+      interface B extends Base {
+        args: {
+          data: {
+            columnNumber?: number;
+            frame: string;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          };
+        };
+        name: 'FunctionCall';
+        ph: 'B';
+        tts: number;
+      }
+    
+      interface E extends Base {
         args: {
         
         };
-        dur?: number;
-        name: 'ThreadControllerImpl::DoWork';
+        name: 'FunctionCall';
+        ph: 'E';
+        tts: number;
+      }
+    }
+  
+    namespace InvalidateLayout {
+      interface I extends Base {
+        args: {
+          data: {
+            frame: string;
+            stackTrace?: {
+              columnNumber: number;
+              functionName: string;
+              lineNumber: number;
+              scriptId: string;
+              url: string;
+            }[];
+          };
+        };
+        name: 'InvalidateLayout';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    }
+  
+    namespace Layout {
+      interface B extends Base {
+        args: {
+          beginData: {
+            dirtyObjects: number;
+            frame: string;
+            partialLayout: boolean;
+            stackTrace?: {
+              columnNumber: number;
+              functionName: string;
+              lineNumber: number;
+              scriptId: string;
+              url: string;
+            }[];
+            totalObjects: number;
+          };
+        };
+        name: 'Layout';
+        ph: 'B';
+        tts: number;
+      }
+    
+      interface E extends Base {
+        args: {
+          endData: {
+            root: {
+            
+            }[];
+            rootNode: number;
+          };
+        };
+        name: 'Layout';
+        ph: 'E';
+        tts: number;
+      }
+    }
+  
+    namespace LoadEventEnd {
+      interface R extends Base {
+        args: {
+          frame: string;
+        };
+        name: 'loadEventEnd';
+        ph: 'R';
+        tts: number;
+      }
+    }
+  
+    namespace NavigationStart {
+      interface R extends Base {
+        args: {
+          data?: {
+            documentLoaderURL: string;
+            isLoadingMainFrame: boolean;
+            navigationId: string;
+          };
+          frame: string;
+        };
+        name: 'navigationStart';
+        ph: 'R';
+        tts: number;
+      }
+    }
+  
+    namespace PaintNonDefaultBackgroundColor {
+      interface R extends Base {
+        args: {
+        
+        };
+        name: 'paintNonDefaultBackgroundColor';
+        ph: 'R';
+        tts: number;
+      }
+    }
+  
+    namespace ParseAuthorStyleSheet {
+      interface X extends Base {
+        args: {
+          data: {
+            styleSheetUrl: string;
+          };
+        };
+        dur: number;
+        name: 'ParseAuthorStyleSheet';
         ph: 'X';
         tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace Process_labels {
+      interface M extends Base {
+        args: {
+          labels: string;
+        };
+        name: 'process_labels';
+        ph: 'M';
+      }
+    }
+  
+    namespace RequestStart {
+      interface R extends Base {
+        args: {
+        
+        };
+        name: 'requestStart';
+        ph: 'R';
+        tts: number;
+      }
+    }
+  
+    namespace ResourceFinish {
+      interface I extends Base {
+        args: {
+          data: {
+            decodedBodyLength?: number;
+            didFail: boolean;
+            encodedDataLength?: number;
+            finishTime?: number;
+            networkTime?: number;
+            requestId: string;
+          };
+        };
+        name: 'ResourceFinish';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    }
+  
+    namespace ResourceReceiveResponse {
+      interface I extends Base {
+        args: {
+          data: {
+            encodedDataLength?: number;
+            frame: string;
+            fromCache?: boolean;
+            fromServiceWorker?: boolean;
+            mimeType: string;
+            requestId: string;
+            statusCode: number;
+            timing?: {
+              connectEnd: number;
+              connectStart: number;
+              dnsEnd: number;
+              dnsStart: number;
+              proxyEnd: number;
+              proxyStart: number;
+              pushEnd: number;
+              pushStart: number;
+              receiveHeadersEnd: number;
+              requestTime: number;
+              sendEnd: number;
+              sendStart: number;
+              sslEnd: number;
+              sslStart: number;
+              workerReady: number;
+              workerStart: number;
+            };
+          };
+        };
+        name: 'ResourceReceiveResponse';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    }
+  
+    namespace ResourceSendRequest {
+      interface I extends Base {
+        args: {
+          data: {
+            frame: string;
+            priority: string;
+            requestId: string;
+            requestMethod: string;
+            stackTrace?: {
+              columnNumber: number;
+              functionName: string;
+              lineNumber: number;
+              scriptId: string;
+              url: string;
+            }[];
+            url: string;
+          };
+        };
+        name: 'ResourceSendRequest';
+        ph: 'I';
+        s: string;
         tts: number;
       }
     }
@@ -584,172 +490,268 @@ export namespace TraceEvent {
     namespace RunTask {
       interface X extends Base {
         args: {
-          src_file?: string;
-          src_func?: string;
-        };
-        bind_id?: string;
-        dur?: number;
-        flow_in?: boolean;
-        id?: string;
-        name: 'ThreadControllerImpl::RunTask';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  }
-
-  namespace TimerFire {
-    interface X extends Base {
-      args: {
-        data: {
-          frame: string;
-          timerId: number;
-        };
-      };
-      dur: number;
-      name: 'TimerFire';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace TimerInstall {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          singleShot: boolean;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-          timeout: number;
-          timerId: number;
-        };
-      };
-      name: 'TimerInstall';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace TracingStartedInBrowser {
-    interface I extends Base {
-      args: {
-        data: {
-          frameTreeNodeId: number;
-          frames: {
-            frame: string;
-            name: string;
-            processId: number;
-            url: string;
-          }[];
-          persistentIds: boolean;
-        };
-      };
-      name: 'TracingStartedInBrowser';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace TracingStartedInPage {
-    interface I extends Base {
-      args: {
-        data: {
-          page: string;
-          sessionId: string;
-        };
-      };
-      name: 'TracingStartedInPage';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace V8 {
-    type Compile = 
-      V8.Compile.B |
-      V8.Compile.E |
-      V8.Compile.X;
-  
-    namespace Compile {
-      interface B extends Base {
-        args: {
-          fileName: string;
-        };
-        name: 'v8.compile';
-        ph: 'B';
-        tts: number;
-      }
-    
-      interface E extends Base {
-        args: {
-          data: {
-            cacheConsumeOptions?: string;
-            cacheProduceOptions?: string;
-            cacheRejected?: boolean;
-            columnNumber: number;
-            consumedCacheSize?: number;
-            lineNumber: number;
-            notStreamedReason?: string;
-            producedCacheSize?: number;
-            streamed: boolean;
-            url: string;
-          };
-        };
-        name: 'v8.compile';
-        ph: 'E';
-        tts: number;
-      }
-    
-      interface X extends Base {
-        args: {
-          data?: {
-            columnNumber: number;
-            lineNumber: number;
-            url: string;
-          };
-          fileName?: string;
+        
         };
         dur?: number;
-        name: 'v8.compile';
+        name: 'RunTask';
         ph: 'X';
         tdur?: number;
         tts: number;
       }
     }
-  }
-
-  namespace XHRReadyStateChange {
-    interface X extends Base {
-      args: {
-        data: {
-          frame: string;
-          readyState: number;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-          url: string;
+  
+    namespace ScheduleStyleRecalculation {
+      interface I extends Base {
+        args: {
+          data: {
+            frame: string;
+            stackTrace?: {
+              columnNumber: number;
+              functionName: string;
+              lineNumber: number;
+              scriptId: string;
+              url: string;
+            }[];
+          };
         };
-      };
-      dur: number;
-      name: 'XHRReadyStateChange';
-      ph: 'X';
-      tdur: number;
-      tts: number;
+        name: 'ScheduleStyleRecalculation';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    }
+  
+    namespace Screenshot {
+      interface O extends Base {
+        args: {
+          snapshot: string;
+        };
+        id: string;
+        name: 'Screenshot';
+        ph: 'O';
+        tts: number;
+      }
+    }
+  
+    namespace TaskQueueManager {
+      type ProcessTaskFromWorkQueue = 
+        TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue.X;
+    
+      namespace ProcessTaskFromWorkQueue {
+        interface X extends Base {
+          args: {
+            src_file: string;
+            src_func: string;
+          };
+          dur?: number;
+          name: 'TaskQueueManager::ProcessTaskFromWorkQueue';
+          ph: 'X';
+          tdur: number;
+          tts: number;
+        }
+      }
+    }
+  
+    namespace Thread_name {
+      interface M extends Base {
+        args: {
+          name: string;
+        };
+        name: 'thread_name';
+        ph: 'M';
+      }
+    }
+  
+    namespace ThreadControllerImpl {
+      type DoWork = 
+        TraceEvent.ThreadControllerImpl.DoWork.X;
+    
+      type RunTask = 
+        TraceEvent.ThreadControllerImpl.RunTask.X;
+    
+      namespace DoWork {
+        interface X extends Base {
+          args: {
+          
+          };
+          dur?: number;
+          name: 'ThreadControllerImpl::DoWork';
+          ph: 'X';
+          tdur: number;
+          tts: number;
+        }
+      }
+    
+      namespace RunTask {
+        interface X extends Base {
+          args: {
+            src_file?: string;
+            src_func?: string;
+          };
+          bind_id?: string;
+          dur?: number;
+          flow_in?: boolean;
+          id?: string;
+          name: 'ThreadControllerImpl::RunTask';
+          ph: 'X';
+          tdur: number;
+          tts: number;
+        }
+      }
+    }
+  
+    namespace TimerFire {
+      interface X extends Base {
+        args: {
+          data: {
+            frame: string;
+            timerId: number;
+          };
+        };
+        dur: number;
+        name: 'TimerFire';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace TimerInstall {
+      interface I extends Base {
+        args: {
+          data: {
+            frame: string;
+            singleShot: boolean;
+            stackTrace?: {
+              columnNumber: number;
+              functionName: string;
+              lineNumber: number;
+              scriptId: string;
+              url: string;
+            }[];
+            timeout: number;
+            timerId: number;
+          };
+        };
+        name: 'TimerInstall';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    }
+  
+    namespace TracingStartedInBrowser {
+      interface I extends Base {
+        args: {
+          data: {
+            frameTreeNodeId: number;
+            frames: {
+              frame: string;
+              name: string;
+              processId: number;
+              url: string;
+            }[];
+            persistentIds: boolean;
+          };
+        };
+        name: 'TracingStartedInBrowser';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    }
+  
+    namespace TracingStartedInPage {
+      interface I extends Base {
+        args: {
+          data: {
+            page: string;
+            sessionId: string;
+          };
+        };
+        name: 'TracingStartedInPage';
+        ph: 'I';
+        s: string;
+        tts: number;
+      }
+    }
+  
+    namespace V8 {
+      type Compile = 
+        TraceEvent.V8.Compile.B |
+        TraceEvent.V8.Compile.E |
+        TraceEvent.V8.Compile.X;
+    
+      namespace Compile {
+        interface B extends Base {
+          args: {
+            fileName: string;
+          };
+          name: 'v8.compile';
+          ph: 'B';
+          tts: number;
+        }
+      
+        interface E extends Base {
+          args: {
+            data: {
+              cacheConsumeOptions?: string;
+              cacheProduceOptions?: string;
+              cacheRejected?: boolean;
+              columnNumber: number;
+              consumedCacheSize?: number;
+              lineNumber: number;
+              notStreamedReason?: string;
+              producedCacheSize?: number;
+              streamed: boolean;
+              url: string;
+            };
+          };
+          name: 'v8.compile';
+          ph: 'E';
+          tts: number;
+        }
+      
+        interface X extends Base {
+          args: {
+            data?: {
+              columnNumber: number;
+              lineNumber: number;
+              url: string;
+            };
+            fileName?: string;
+          };
+          dur?: number;
+          name: 'v8.compile';
+          ph: 'X';
+          tdur?: number;
+          tts: number;
+        }
+      }
+    }
+  
+    namespace XHRReadyStateChange {
+      interface X extends Base {
+        args: {
+          data: {
+            frame: string;
+            readyState: number;
+            stackTrace?: {
+              columnNumber: number;
+              functionName: string;
+              lineNumber: number;
+              scriptId: string;
+              url: string;
+            }[];
+            url: string;
+          };
+        };
+        dur: number;
+        name: 'XHRReadyStateChange';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
     }
   }
 }

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -40,497 +40,605 @@ export namespace TraceEvent {
     TraceEvent.RunTask |
     TraceEvent.ScheduleStyleRecalculation |
     TraceEvent.Screenshot |
-    TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue |
+    TaskQueueManager.ProcessTaskFromWorkQueue |
     TraceEvent.Thread_name |
-    TraceEvent.ThreadControllerImpl.DoWork |
-    TraceEvent.ThreadControllerImpl.RunTask |
+    ThreadControllerImpl.DoWork |
+    ThreadControllerImpl.RunTask |
     TraceEvent.TimerFire |
     TraceEvent.TimerInstall |
     TraceEvent.TracingStartedInBrowser |
     TraceEvent.TracingStartedInPage |
-    TraceEvent.V8.Compile |
+    V8.Compile |
     TraceEvent.XHRReadyStateChange;
 
-  namespace TraceEvent {
-    type DomContentLoadedEventEnd = 
-      TraceEvent.DomContentLoadedEventEnd.R;
-  
-    type EvaluateScript = 
-      TraceEvent.EvaluateScript.X;
-  
-    type FirstContentfulPaint = 
-      TraceEvent.FirstContentfulPaint.I |
-      TraceEvent.FirstContentfulPaint.R;
-  
-    type FirstMeaningfulPaint = 
-      TraceEvent.FirstMeaningfulPaint.R;
-  
-    type FirstMeaningfulPaintCandidate = 
-      TraceEvent.FirstMeaningfulPaintCandidate.R;
-  
-    type FirstPaint = 
-      TraceEvent.FirstPaint.I |
-      TraceEvent.FirstPaint.R;
-  
-    type FunctionCall = 
-      TraceEvent.FunctionCall.B |
-      TraceEvent.FunctionCall.E;
-  
-    type InvalidateLayout = 
-      TraceEvent.InvalidateLayout.I;
-  
-    type Layout = 
-      TraceEvent.Layout.B |
-      TraceEvent.Layout.E;
-  
-    type LoadEventEnd = 
-      TraceEvent.LoadEventEnd.R;
-  
-    type NavigationStart = 
-      TraceEvent.NavigationStart.R;
-  
-    type PaintNonDefaultBackgroundColor = 
-      TraceEvent.PaintNonDefaultBackgroundColor.R;
-  
-    type ParseAuthorStyleSheet = 
-      TraceEvent.ParseAuthorStyleSheet.X;
-  
-    type Process_labels = 
-      TraceEvent.Process_labels.M;
-  
-    type RequestStart = 
-      TraceEvent.RequestStart.R;
-  
-    type ResourceFinish = 
-      TraceEvent.ResourceFinish.I;
-  
-    type ResourceReceiveResponse = 
-      TraceEvent.ResourceReceiveResponse.I;
-  
-    type ResourceSendRequest = 
-      TraceEvent.ResourceSendRequest.I;
-  
-    type RunTask = 
-      TraceEvent.RunTask.X;
-  
-    type ScheduleStyleRecalculation = 
-      TraceEvent.ScheduleStyleRecalculation.I;
-  
-    type Screenshot = 
-      TraceEvent.Screenshot.O;
-  
-    type Thread_name = 
-      TraceEvent.Thread_name.M;
-  
-    type TimerFire = 
-      TraceEvent.TimerFire.X;
-  
-    type TimerInstall = 
-      TraceEvent.TimerInstall.I;
-  
-    type TracingStartedInBrowser = 
-      TraceEvent.TracingStartedInBrowser.I;
-  
-    type TracingStartedInPage = 
-      TraceEvent.TracingStartedInPage.I;
-  
-    type XHRReadyStateChange = 
-      TraceEvent.XHRReadyStateChange.X;
-  
-    namespace DomContentLoadedEventEnd {
-      interface R extends Base {
-        args: {
-          frame: string;
-        };
-        name: 'domContentLoadedEventEnd';
-        // Denotes a mark of the event DomContentLoadedEventEnd.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
+  type DomContentLoadedEventEnd = 
+    TraceEvent.DomContentLoadedEventEnd.R;
+
+  type EvaluateScript = 
+    TraceEvent.EvaluateScript.X;
+
+  type FirstContentfulPaint = 
+    TraceEvent.FirstContentfulPaint.I |
+    TraceEvent.FirstContentfulPaint.R;
+
+  type FirstMeaningfulPaint = 
+    TraceEvent.FirstMeaningfulPaint.R;
+
+  type FirstMeaningfulPaintCandidate = 
+    TraceEvent.FirstMeaningfulPaintCandidate.R;
+
+  type FirstPaint = 
+    TraceEvent.FirstPaint.I |
+    TraceEvent.FirstPaint.R;
+
+  type FunctionCall = 
+    TraceEvent.FunctionCall.B |
+    TraceEvent.FunctionCall.E;
+
+  type InvalidateLayout = 
+    TraceEvent.InvalidateLayout.I;
+
+  type Layout = 
+    TraceEvent.Layout.B |
+    TraceEvent.Layout.E;
+
+  type LoadEventEnd = 
+    TraceEvent.LoadEventEnd.R;
+
+  type NavigationStart = 
+    TraceEvent.NavigationStart.R;
+
+  type PaintNonDefaultBackgroundColor = 
+    TraceEvent.PaintNonDefaultBackgroundColor.R;
+
+  type ParseAuthorStyleSheet = 
+    TraceEvent.ParseAuthorStyleSheet.X;
+
+  type Process_labels = 
+    TraceEvent.Process_labels.M;
+
+  type RequestStart = 
+    TraceEvent.RequestStart.R;
+
+  type ResourceFinish = 
+    TraceEvent.ResourceFinish.I;
+
+  type ResourceReceiveResponse = 
+    TraceEvent.ResourceReceiveResponse.I;
+
+  type ResourceSendRequest = 
+    TraceEvent.ResourceSendRequest.I;
+
+  type RunTask = 
+    TraceEvent.RunTask.X;
+
+  type ScheduleStyleRecalculation = 
+    TraceEvent.ScheduleStyleRecalculation.I;
+
+  type Screenshot = 
+    TraceEvent.Screenshot.O;
+
+  type Thread_name = 
+    TraceEvent.Thread_name.M;
+
+  type TimerFire = 
+    TraceEvent.TimerFire.X;
+
+  type TimerInstall = 
+    TraceEvent.TimerInstall.I;
+
+  type TracingStartedInBrowser = 
+    TraceEvent.TracingStartedInBrowser.I;
+
+  type TracingStartedInPage = 
+    TraceEvent.TracingStartedInPage.I;
+
+  type XHRReadyStateChange = 
+    TraceEvent.XHRReadyStateChange.X;
+
+  namespace DomContentLoadedEventEnd {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'domContentLoadedEventEnd';
+      // Denotes a mark of the event DomContentLoadedEventEnd.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
     }
-  
-    namespace EvaluateScript {
-      interface X extends Base {
-        args: {
-          data?: {
+  }
+
+  namespace EvaluateScript {
+    interface X extends Base {
+      args: {
+        data?: {
+          columnNumber: number;
+          frame: string;
+          lineNumber: number;
+          stackTrace?: {
             columnNumber: number;
-            frame: string;
-            lineNumber: number;
-            stackTrace?: {
-              columnNumber: number;
-              functionName: string;
-              lineNumber: number;
-              scriptId: string;
-              url: string;
-            }[];
-            url: string;
-          };
-        };
-        // Duration.
-        dur: number;
-        name: 'EvaluateScript';
-        // Denotes the end of the event EvaluateScript.
-        ph: 'X';
-        tdur: number;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace FirstContentfulPaint {
-      interface I extends Base {
-        args: {
-          frame: string;
-        };
-        name: 'firstContentfulPaint';
-        // Denotes an event FirstContentfulPaint. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    
-      interface R extends Base {
-        args: {
-          data?: {
-            navigationId: string;
-          };
-          frame: string;
-        };
-        name: 'firstContentfulPaint';
-        // Denotes a mark of the event FirstContentfulPaint.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace FirstMeaningfulPaint {
-      interface R extends Base {
-        args: {
-          afterUserInput?: number;
-          data?: {
-            navigationId: string;
-          };
-          frame: string;
-        };
-        name: 'firstMeaningfulPaint';
-        // Denotes a mark of the event FirstMeaningfulPaint.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace FirstMeaningfulPaintCandidate {
-      interface R extends Base {
-        args: {
-          data: {
-            navigationId: string;
-          };
-          frame: string;
-        };
-        name: 'firstMeaningfulPaintCandidate';
-        // Denotes a mark of the event FirstMeaningfulPaintCandidate.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace FirstPaint {
-      interface I extends Base {
-        args: {
-          frame: string;
-        };
-        name: 'firstPaint';
-        // Denotes an event FirstPaint. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    
-      interface R extends Base {
-        args: {
-          data?: {
-            navigationId: string;
-          };
-          frame: string;
-        };
-        name: 'firstPaint';
-        // Denotes a mark of the event FirstPaint.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace FunctionCall {
-      interface B extends Base {
-        args: {
-          data: {
-            columnNumber?: number;
-            frame: string;
             functionName: string;
             lineNumber: number;
             scriptId: string;
             url: string;
-          };
+          }[];
+          url: string;
         };
-        name: 'FunctionCall';
-        // Denotes the beginning of the event FunctionCall.
-        ph: 'B';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    
-      interface E extends Base {
-        args: {
-        
-        };
-        name: 'FunctionCall';
-        // Denotes the ending of the event FunctionCall.
-        ph: 'E';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
+      };
+      // Duration.
+      dur: number;
+      name: 'EvaluateScript';
+      // Denotes the end of the event EvaluateScript.
+      ph: 'X';
+      tdur: number;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace FirstContentfulPaint {
+    interface I extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'firstContentfulPaint';
+      // Denotes an event FirstContentfulPaint. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
     }
   
-    namespace InvalidateLayout {
-      interface I extends Base {
-        args: {
-          data: {
-            frame: string;
-            stackTrace?: {
-              columnNumber: number;
-              functionName: string;
-              lineNumber: number;
-              scriptId: string;
-              url: string;
-            }[];
-          };
+    interface R extends Base {
+      args: {
+        data?: {
+          navigationId: string;
         };
-        name: 'InvalidateLayout';
-        // Denotes an event InvalidateLayout. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
+        frame: string;
+      };
+      name: 'firstContentfulPaint';
+      // Denotes a mark of the event FirstContentfulPaint.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace FirstMeaningfulPaint {
+    interface R extends Base {
+      args: {
+        afterUserInput?: number;
+        data?: {
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'firstMeaningfulPaint';
+      // Denotes a mark of the event FirstMeaningfulPaint.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace FirstMeaningfulPaintCandidate {
+    interface R extends Base {
+      args: {
+        data: {
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'firstMeaningfulPaintCandidate';
+      // Denotes a mark of the event FirstMeaningfulPaintCandidate.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace FirstPaint {
+    interface I extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'firstPaint';
+      // Denotes an event FirstPaint. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
     }
   
-    namespace Layout {
-      interface B extends Base {
-        args: {
-          beginData: {
-            dirtyObjects: number;
-            frame: string;
-            partialLayout: boolean;
-            stackTrace?: {
-              columnNumber: number;
-              functionName: string;
-              lineNumber: number;
-              scriptId: string;
-              url: string;
-            }[];
-            totalObjects: number;
-          };
+    interface R extends Base {
+      args: {
+        data?: {
+          navigationId: string;
         };
-        name: 'Layout';
-        // Denotes the beginning of the event Layout.
-        ph: 'B';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    
-      interface E extends Base {
-        args: {
-          endData: {
-            root: {
-            
-            }[];
-            rootNode: number;
-          };
-        };
-        name: 'Layout';
-        // Denotes the ending of the event Layout.
-        ph: 'E';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
+        frame: string;
+      };
+      name: 'firstPaint';
+      // Denotes a mark of the event FirstPaint.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
     }
-  
-    namespace LoadEventEnd {
-      interface R extends Base {
-        args: {
+  }
+
+  namespace FunctionCall {
+    interface B extends Base {
+      args: {
+        data: {
+          columnNumber?: number;
           frame: string;
+          functionName: string;
+          lineNumber: number;
+          scriptId: string;
+          url: string;
         };
-        name: 'loadEventEnd';
-        // Denotes a mark of the event LoadEventEnd.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
+      };
+      name: 'FunctionCall';
+      // Denotes the beginning of the event FunctionCall.
+      ph: 'B';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
     }
   
-    namespace NavigationStart {
-      interface R extends Base {
-        args: {
-          data?: {
-            documentLoaderURL: string;
-            isLoadingMainFrame: boolean;
-            navigationId: string;
-          };
+    interface E extends Base {
+      args: {
+      
+      };
+      name: 'FunctionCall';
+      // Denotes the ending of the event FunctionCall.
+      ph: 'E';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace InvalidateLayout {
+    interface I extends Base {
+      args: {
+        data: {
           frame: string;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
         };
-        name: 'navigationStart';
-        // Denotes a mark of the event NavigationStart.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
+      };
+      name: 'InvalidateLayout';
+      // Denotes an event InvalidateLayout. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace Layout {
+    interface B extends Base {
+      args: {
+        beginData: {
+          dirtyObjects: number;
+          frame: string;
+          partialLayout: boolean;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          totalObjects: number;
+        };
+      };
+      name: 'Layout';
+      // Denotes the beginning of the event Layout.
+      ph: 'B';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
     }
   
-    namespace PaintNonDefaultBackgroundColor {
-      interface R extends Base {
-        args: {
-        
+    interface E extends Base {
+      args: {
+        endData: {
+          root: {
+          
+          }[];
+          rootNode: number;
         };
-        name: 'paintNonDefaultBackgroundColor';
-        // Denotes a mark of the event PaintNonDefaultBackgroundColor.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
+      };
+      name: 'Layout';
+      // Denotes the ending of the event Layout.
+      ph: 'E';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
     }
+  }
+
+  namespace LoadEventEnd {
+    interface R extends Base {
+      args: {
+        frame: string;
+      };
+      name: 'loadEventEnd';
+      // Denotes a mark of the event LoadEventEnd.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace NavigationStart {
+    interface R extends Base {
+      args: {
+        data?: {
+          documentLoaderURL: string;
+          isLoadingMainFrame: boolean;
+          navigationId: string;
+        };
+        frame: string;
+      };
+      name: 'navigationStart';
+      // Denotes a mark of the event NavigationStart.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace PaintNonDefaultBackgroundColor {
+    interface R extends Base {
+      args: {
+      
+      };
+      name: 'paintNonDefaultBackgroundColor';
+      // Denotes a mark of the event PaintNonDefaultBackgroundColor.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace ParseAuthorStyleSheet {
+    interface X extends Base {
+      args: {
+        data: {
+          styleSheetUrl: string;
+        };
+      };
+      // Duration.
+      dur: number;
+      name: 'ParseAuthorStyleSheet';
+      // Denotes the end of the event ParseAuthorStyleSheet.
+      ph: 'X';
+      tdur: number;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace Process_labels {
+    interface M extends Base {
+      args: {
+        labels: string;
+      };
+      name: 'process_labels';
+      // Denotes metadata for the event Process_labels.
+      ph: 'M';
+    }
+  }
+
+  namespace RequestStart {
+    interface R extends Base {
+      args: {
+      
+      };
+      name: 'requestStart';
+      // Denotes a mark of the event RequestStart.
+      ph: 'R';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace ResourceFinish {
+    interface I extends Base {
+      args: {
+        data: {
+          decodedBodyLength?: number;
+          didFail: boolean;
+          encodedDataLength?: number;
+          finishTime?: number;
+          networkTime?: number;
+          requestId: string;
+        };
+      };
+      name: 'ResourceFinish';
+      // Denotes an event ResourceFinish. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace ResourceReceiveResponse {
+    interface I extends Base {
+      args: {
+        data: {
+          encodedDataLength?: number;
+          frame: string;
+          fromCache?: boolean;
+          fromServiceWorker?: boolean;
+          mimeType: string;
+          requestId: string;
+          statusCode: number;
+          timing?: {
+            connectEnd: number;
+            connectStart: number;
+            dnsEnd: number;
+            dnsStart: number;
+            proxyEnd: number;
+            proxyStart: number;
+            pushEnd: number;
+            pushStart: number;
+            receiveHeadersEnd: number;
+            requestTime: number;
+            sendEnd: number;
+            sendStart: number;
+            sslEnd: number;
+            sslStart: number;
+            workerReady: number;
+            workerStart: number;
+          };
+        };
+      };
+      name: 'ResourceReceiveResponse';
+      // Denotes an event ResourceReceiveResponse. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace ResourceSendRequest {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          priority: string;
+          requestId: string;
+          requestMethod: string;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          url: string;
+        };
+      };
+      name: 'ResourceSendRequest';
+      // Denotes an event ResourceSendRequest. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace RunTask {
+    interface X extends Base {
+      args: {
+      
+      };
+      // Duration.
+      dur?: number;
+      name: 'RunTask';
+      // Denotes the end of the event RunTask.
+      ph: 'X';
+      tdur?: number;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace ScheduleStyleRecalculation {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+        };
+      };
+      name: 'ScheduleStyleRecalculation';
+      // Denotes an event ScheduleStyleRecalculation. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace Screenshot {
+    interface O extends Base {
+      args: {
+        snapshot: string;
+      };
+      id: string;
+      name: 'Screenshot';
+      // Denotes a snapshot object of the event Screenshot.
+      ph: 'O';
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace TaskQueueManager {
+    type ProcessTaskFromWorkQueue = 
+      TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue.X;
   
-    namespace ParseAuthorStyleSheet {
+    namespace ProcessTaskFromWorkQueue {
       interface X extends Base {
         args: {
-          data: {
-            styleSheetUrl: string;
-          };
+          src_file: string;
+          src_func: string;
         };
         // Duration.
-        dur: number;
-        name: 'ParseAuthorStyleSheet';
-        // Denotes the end of the event ParseAuthorStyleSheet.
+        dur?: number;
+        name: 'TaskQueueManager::ProcessTaskFromWorkQueue';
+        // Denotes the end of the event ProcessTaskFromWorkQueue.
         ph: 'X';
         tdur: number;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
-  
-    namespace Process_labels {
-      interface M extends Base {
-        args: {
-          labels: string;
-        };
-        name: 'process_labels';
-        // Denotes metadata for the event Process_labels.
-        ph: 'M';
-      }
+  }
+
+  namespace Thread_name {
+    interface M extends Base {
+      args: {
+        name: string;
+      };
+      name: 'thread_name';
+      // Denotes metadata for the event Thread_name.
+      ph: 'M';
     }
+  }
+
+  namespace ThreadControllerImpl {
+    type DoWork = 
+      TraceEvent.ThreadControllerImpl.DoWork.X;
   
-    namespace RequestStart {
-      interface R extends Base {
+    type RunTask = 
+      TraceEvent.ThreadControllerImpl.RunTask.X;
+  
+    namespace DoWork {
+      interface X extends Base {
         args: {
         
         };
-        name: 'requestStart';
-        // Denotes a mark of the event RequestStart.
-        ph: 'R';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace ResourceFinish {
-      interface I extends Base {
-        args: {
-          data: {
-            decodedBodyLength?: number;
-            didFail: boolean;
-            encodedDataLength?: number;
-            finishTime?: number;
-            networkTime?: number;
-            requestId: string;
-          };
-        };
-        name: 'ResourceFinish';
-        // Denotes an event ResourceFinish. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace ResourceReceiveResponse {
-      interface I extends Base {
-        args: {
-          data: {
-            encodedDataLength?: number;
-            frame: string;
-            fromCache?: boolean;
-            fromServiceWorker?: boolean;
-            mimeType: string;
-            requestId: string;
-            statusCode: number;
-            timing?: {
-              connectEnd: number;
-              connectStart: number;
-              dnsEnd: number;
-              dnsStart: number;
-              proxyEnd: number;
-              proxyStart: number;
-              pushEnd: number;
-              pushStart: number;
-              receiveHeadersEnd: number;
-              requestTime: number;
-              sendEnd: number;
-              sendStart: number;
-              sslEnd: number;
-              sslStart: number;
-              workerReady: number;
-              workerStart: number;
-            };
-          };
-        };
-        name: 'ResourceReceiveResponse';
-        // Denotes an event ResourceReceiveResponse. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace ResourceSendRequest {
-      interface I extends Base {
-        args: {
-          data: {
-            frame: string;
-            priority: string;
-            requestId: string;
-            requestMethod: string;
-            stackTrace?: {
-              columnNumber: number;
-              functionName: string;
-              lineNumber: number;
-              scriptId: string;
-              url: string;
-            }[];
-            url: string;
-          };
-        };
-        name: 'ResourceSendRequest';
-        // Denotes an event ResourceSendRequest. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
+        // Duration.
+        dur?: number;
+        name: 'ThreadControllerImpl::DoWork';
+        // Denotes the end of the event DoWork.
+        ph: 'X';
+        tdur: number;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
@@ -539,304 +647,194 @@ export namespace TraceEvent {
     namespace RunTask {
       interface X extends Base {
         args: {
-        
+          src_file?: string;
+          src_func?: string;
+        };
+        bind_id?: string;
+        // Duration.
+        dur?: number;
+        flow_in?: boolean;
+        id?: string;
+        name: 'ThreadControllerImpl::RunTask';
+        // Denotes the end of the event RunTask.
+        ph: 'X';
+        tdur: number;
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+        tts: number;
+      }
+    }
+  }
+
+  namespace TimerFire {
+    interface X extends Base {
+      args: {
+        data: {
+          frame: string;
+          timerId: number;
+        };
+      };
+      // Duration.
+      dur: number;
+      name: 'TimerFire';
+      // Denotes the end of the event TimerFire.
+      ph: 'X';
+      tdur: number;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace TimerInstall {
+    interface I extends Base {
+      args: {
+        data: {
+          frame: string;
+          singleShot: boolean;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
+            url: string;
+          }[];
+          timeout: number;
+          timerId: number;
+        };
+      };
+      name: 'TimerInstall';
+      // Denotes an event TimerInstall. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace TracingStartedInBrowser {
+    interface I extends Base {
+      args: {
+        data: {
+          frameTreeNodeId: number;
+          frames: {
+            frame: string;
+            name: string;
+            processId: number;
+            url: string;
+          }[];
+          persistentIds: boolean;
+        };
+      };
+      name: 'TracingStartedInBrowser';
+      // Denotes an event TracingStartedInBrowser. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace TracingStartedInPage {
+    interface I extends Base {
+      args: {
+        data: {
+          page: string;
+          sessionId: string;
+        };
+      };
+      name: 'TracingStartedInPage';
+      // Denotes an event TracingStartedInPage. There are no begining/ending phases.
+      ph: 'I';
+      s: string;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
+    }
+  }
+
+  namespace V8 {
+    type Compile = 
+      TraceEvent.V8.Compile.B |
+      TraceEvent.V8.Compile.E |
+      TraceEvent.V8.Compile.X;
+  
+    namespace Compile {
+      interface B extends Base {
+        args: {
+          fileName: string;
+        };
+        name: 'v8.compile';
+        // Denotes the beginning of the event Compile.
+        ph: 'B';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+        tts: number;
+      }
+    
+      interface E extends Base {
+        args: {
+          data: {
+            cacheConsumeOptions?: string;
+            cacheProduceOptions?: string;
+            cacheRejected?: boolean;
+            columnNumber: number;
+            consumedCacheSize?: number;
+            lineNumber: number;
+            notStreamedReason?: string;
+            producedCacheSize?: number;
+            streamed: boolean;
+            url: string;
+          };
+        };
+        name: 'v8.compile';
+        // Denotes the ending of the event Compile.
+        ph: 'E';
+        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+        tts: number;
+      }
+    
+      interface X extends Base {
+        args: {
+          data?: {
+            columnNumber: number;
+            lineNumber: number;
+            url: string;
+          };
+          fileName?: string;
         };
         // Duration.
         dur?: number;
-        name: 'RunTask';
-        // Denotes the end of the event RunTask.
+        name: 'v8.compile';
+        // Denotes the end of the event Compile.
         ph: 'X';
         tdur?: number;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
       }
     }
-  
-    namespace ScheduleStyleRecalculation {
-      interface I extends Base {
-        args: {
-          data: {
-            frame: string;
-            stackTrace?: {
-              columnNumber: number;
-              functionName: string;
-              lineNumber: number;
-              scriptId: string;
-              url: string;
-            }[];
-          };
-        };
-        name: 'ScheduleStyleRecalculation';
-        // Denotes an event ScheduleStyleRecalculation. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace Screenshot {
-      interface O extends Base {
-        args: {
-          snapshot: string;
-        };
-        id: string;
-        name: 'Screenshot';
-        // Denotes a snapshot object of the event Screenshot.
-        ph: 'O';
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace TaskQueueManager {
-      type ProcessTaskFromWorkQueue = 
-        TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue.X;
-    
-      namespace ProcessTaskFromWorkQueue {
-        interface X extends Base {
-          args: {
-            src_file: string;
-            src_func: string;
-          };
-          // Duration.
-          dur?: number;
-          name: 'TaskQueueManager::ProcessTaskFromWorkQueue';
-          // Denotes the end of the event ProcessTaskFromWorkQueue.
-          ph: 'X';
-          tdur: number;
-          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-          tts: number;
-        }
-      }
-    }
-  
-    namespace Thread_name {
-      interface M extends Base {
-        args: {
-          name: string;
-        };
-        name: 'thread_name';
-        // Denotes metadata for the event Thread_name.
-        ph: 'M';
-      }
-    }
-  
-    namespace ThreadControllerImpl {
-      type DoWork = 
-        TraceEvent.ThreadControllerImpl.DoWork.X;
-    
-      type RunTask = 
-        TraceEvent.ThreadControllerImpl.RunTask.X;
-    
-      namespace DoWork {
-        interface X extends Base {
-          args: {
-          
-          };
-          // Duration.
-          dur?: number;
-          name: 'ThreadControllerImpl::DoWork';
-          // Denotes the end of the event DoWork.
-          ph: 'X';
-          tdur: number;
-          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-          tts: number;
-        }
-      }
-    
-      namespace RunTask {
-        interface X extends Base {
-          args: {
-            src_file?: string;
-            src_func?: string;
-          };
-          bind_id?: string;
-          // Duration.
-          dur?: number;
-          flow_in?: boolean;
-          id?: string;
-          name: 'ThreadControllerImpl::RunTask';
-          // Denotes the end of the event RunTask.
-          ph: 'X';
-          tdur: number;
-          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-          tts: number;
-        }
-      }
-    }
-  
-    namespace TimerFire {
-      interface X extends Base {
-        args: {
-          data: {
-            frame: string;
-            timerId: number;
-          };
-        };
-        // Duration.
-        dur: number;
-        name: 'TimerFire';
-        // Denotes the end of the event TimerFire.
-        ph: 'X';
-        tdur: number;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace TimerInstall {
-      interface I extends Base {
-        args: {
-          data: {
-            frame: string;
-            singleShot: boolean;
-            stackTrace?: {
-              columnNumber: number;
-              functionName: string;
-              lineNumber: number;
-              scriptId: string;
-              url: string;
-            }[];
-            timeout: number;
-            timerId: number;
-          };
-        };
-        name: 'TimerInstall';
-        // Denotes an event TimerInstall. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace TracingStartedInBrowser {
-      interface I extends Base {
-        args: {
-          data: {
-            frameTreeNodeId: number;
-            frames: {
-              frame: string;
-              name: string;
-              processId: number;
-              url: string;
-            }[];
-            persistentIds: boolean;
-          };
-        };
-        name: 'TracingStartedInBrowser';
-        // Denotes an event TracingStartedInBrowser. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace TracingStartedInPage {
-      interface I extends Base {
-        args: {
-          data: {
-            page: string;
-            sessionId: string;
-          };
-        };
-        name: 'TracingStartedInPage';
-        // Denotes an event TracingStartedInPage. There are no begining/ending phases.
-        ph: 'I';
-        s: string;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
-    }
-  
-    namespace V8 {
-      type Compile = 
-        TraceEvent.V8.Compile.B |
-        TraceEvent.V8.Compile.E |
-        TraceEvent.V8.Compile.X;
-    
-      namespace Compile {
-        interface B extends Base {
-          args: {
-            fileName: string;
-          };
-          name: 'v8.compile';
-          // Denotes the beginning of the event Compile.
-          ph: 'B';
-          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-          tts: number;
-        }
-      
-        interface E extends Base {
-          args: {
-            data: {
-              cacheConsumeOptions?: string;
-              cacheProduceOptions?: string;
-              cacheRejected?: boolean;
-              columnNumber: number;
-              consumedCacheSize?: number;
-              lineNumber: number;
-              notStreamedReason?: string;
-              producedCacheSize?: number;
-              streamed: boolean;
-              url: string;
-            };
-          };
-          name: 'v8.compile';
-          // Denotes the ending of the event Compile.
-          ph: 'E';
-          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-          tts: number;
-        }
-      
-        interface X extends Base {
-          args: {
-            data?: {
-              columnNumber: number;
-              lineNumber: number;
-              url: string;
-            };
-            fileName?: string;
-          };
-          // Duration.
-          dur?: number;
-          name: 'v8.compile';
-          // Denotes the end of the event Compile.
-          ph: 'X';
-          tdur?: number;
-          // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-          tts: number;
-        }
-      }
-    }
-  
-    namespace XHRReadyStateChange {
-      interface X extends Base {
-        args: {
-          data: {
-            frame: string;
-            readyState: number;
-            stackTrace?: {
-              columnNumber: number;
-              functionName: string;
-              lineNumber: number;
-              scriptId: string;
-              url: string;
-            }[];
+  }
+
+  namespace XHRReadyStateChange {
+    interface X extends Base {
+      args: {
+        data: {
+          frame: string;
+          readyState: number;
+          stackTrace?: {
+            columnNumber: number;
+            functionName: string;
+            lineNumber: number;
+            scriptId: string;
             url: string;
-          };
+          }[];
+          url: string;
         };
-        // Duration.
-        dur: number;
-        name: 'XHRReadyStateChange';
-        // Denotes the end of the event XHRReadyStateChange.
-        ph: 'X';
-        tdur: number;
-        // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
-        tts: number;
-      }
+      };
+      // Duration.
+      dur: number;
+      name: 'XHRReadyStateChange';
+      // Denotes the end of the event XHRReadyStateChange.
+      ph: 'X';
+      tdur: number;
+      // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
+      tts: number;
     }
   }
 }

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -6,7 +6,7 @@
 
 // https://github.com/Hoten/chrome-trace-events-tsc/blob/master/dist/lh-trace-events.d.ts
 
-export namespace _TraceEvent {
+export namespace TraceEvent {
   interface Base {
     cat: string;
     pid: number;
@@ -15,42 +15,121 @@ export namespace _TraceEvent {
   }
 
   type TraceEvent = 
-    DomContentLoadedEventEnd.R |
-    EvaluateScript.X |
+    TraceEvent.DomContentLoadedEventEnd |
+    TraceEvent.EvaluateScript |
+    TraceEvent.FirstContentfulPaint |
+    TraceEvent.FirstMeaningfulPaint |
+    TraceEvent.FirstMeaningfulPaintCandidate |
+    TraceEvent.FirstPaint |
+    TraceEvent.FunctionCall |
+    TraceEvent.InvalidateLayout |
+    TraceEvent.Layout |
+    TraceEvent.LoadEventEnd |
+    TraceEvent.NavigationStart |
+    TraceEvent.PaintNonDefaultBackgroundColor |
+    TraceEvent.ParseAuthorStyleSheet |
+    TraceEvent.Process_labels |
+    TraceEvent.RequestStart |
+    TraceEvent.ResourceFinish |
+    TraceEvent.ResourceReceiveResponse |
+    TraceEvent.ResourceSendRequest |
+    TraceEvent.RunTask |
+    TraceEvent.ScheduleStyleRecalculation |
+    TraceEvent.Screenshot |
+    TaskQueueManager.ProcessTaskFromWorkQueue |
+    TraceEvent.Thread_name |
+    ThreadControllerImpl.DoWork |
+    ThreadControllerImpl.RunTask |
+    TraceEvent.TimerFire |
+    TraceEvent.TimerInstall |
+    TraceEvent.TracingStartedInBrowser |
+    TraceEvent.TracingStartedInPage |
+    V8.Compile |
+    TraceEvent.XHRReadyStateChange;
+
+  type DomContentLoadedEventEnd = 
+    DomContentLoadedEventEnd.R;
+
+  type EvaluateScript = 
+    EvaluateScript.X;
+
+  type FirstContentfulPaint = 
     FirstContentfulPaint.I |
-    FirstContentfulPaint.R |
-    FirstMeaningfulPaint.R |
-    FirstMeaningfulPaintCandidate.R |
+    FirstContentfulPaint.R;
+
+  type FirstMeaningfulPaint = 
+    FirstMeaningfulPaint.R;
+
+  type FirstMeaningfulPaintCandidate = 
+    FirstMeaningfulPaintCandidate.R;
+
+  type FirstPaint = 
     FirstPaint.I |
-    FirstPaint.R |
+    FirstPaint.R;
+
+  type FunctionCall = 
     FunctionCall.B |
-    FunctionCall.E |
-    InvalidateLayout.I |
+    FunctionCall.E;
+
+  type InvalidateLayout = 
+    InvalidateLayout.I;
+
+  type Layout = 
     Layout.B |
-    Layout.E |
-    LoadEventEnd.R |
-    NavigationStart.R |
-    PaintNonDefaultBackgroundColor.R |
-    ParseAuthorStyleSheet.X |
-    Process_labels.M |
-    RequestStart.R |
-    ResourceFinish.I |
-    ResourceReceiveResponse.I |
-    ResourceSendRequest.I |
-    RunTask.X |
-    ScheduleStyleRecalculation.I |
-    Screenshot.O |
-    TaskQueueManager.ProcessTaskFromWorkQueue.X |
-    Thread_name.M |
-    ThreadControllerImpl.DoWork.X |
-    ThreadControllerImpl.RunTask.X |
-    TimerFire.X |
-    TimerInstall.I |
-    TracingStartedInBrowser.I |
-    TracingStartedInPage.I |
-    V8.Compile.B |
-    V8.Compile.E |
-    V8.Compile.X |
+    Layout.E;
+
+  type LoadEventEnd = 
+    LoadEventEnd.R;
+
+  type NavigationStart = 
+    NavigationStart.R;
+
+  type PaintNonDefaultBackgroundColor = 
+    PaintNonDefaultBackgroundColor.R;
+
+  type ParseAuthorStyleSheet = 
+    ParseAuthorStyleSheet.X;
+
+  type Process_labels = 
+    Process_labels.M;
+
+  type RequestStart = 
+    RequestStart.R;
+
+  type ResourceFinish = 
+    ResourceFinish.I;
+
+  type ResourceReceiveResponse = 
+    ResourceReceiveResponse.I;
+
+  type ResourceSendRequest = 
+    ResourceSendRequest.I;
+
+  type RunTask = 
+    RunTask.X;
+
+  type ScheduleStyleRecalculation = 
+    ScheduleStyleRecalculation.I;
+
+  type Screenshot = 
+    Screenshot.O;
+
+  type Thread_name = 
+    Thread_name.M;
+
+  type TimerFire = 
+    TimerFire.X;
+
+  type TimerInstall = 
+    TimerInstall.I;
+
+  type TracingStartedInBrowser = 
+    TracingStartedInBrowser.I;
+
+  type TracingStartedInPage = 
+    TracingStartedInPage.I;
+
+  type XHRReadyStateChange = 
     XHRReadyStateChange.X;
 
   namespace DomContentLoadedEventEnd {
@@ -454,6 +533,9 @@ export namespace _TraceEvent {
   }
 
   namespace TaskQueueManager {
+    type ProcessTaskFromWorkQueue = 
+      TaskQueueManager.ProcessTaskFromWorkQueue.X;
+  
     namespace ProcessTaskFromWorkQueue {
       interface X extends Base {
         args: {
@@ -480,6 +562,12 @@ export namespace _TraceEvent {
   }
 
   namespace ThreadControllerImpl {
+    type DoWork = 
+      ThreadControllerImpl.DoWork.X;
+  
+    type RunTask = 
+      ThreadControllerImpl.RunTask.X;
+  
     namespace DoWork {
       interface X extends Base {
         args: {
@@ -588,6 +676,11 @@ export namespace _TraceEvent {
   }
 
   namespace V8 {
+    type Compile = 
+      V8.Compile.B |
+      V8.Compile.E |
+      V8.Compile.X;
+  
     namespace Compile {
       interface B extends Base {
         args: {
@@ -661,4 +754,4 @@ export namespace _TraceEvent {
   }
 }
 
-export default _TraceEvent;
+export default TraceEvent;

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -40,15 +40,15 @@ export namespace TraceEvent {
     TraceEvent.RunTask |
     TraceEvent.ScheduleStyleRecalculation |
     TraceEvent.Screenshot |
-    TaskQueueManager.ProcessTaskFromWorkQueue |
+    TraceEvent.TaskQueueManager.ProcessTaskFromWorkQueue |
     TraceEvent.Thread_name |
-    ThreadControllerImpl.DoWork |
-    ThreadControllerImpl.RunTask |
+    TraceEvent.ThreadControllerImpl.DoWork |
+    TraceEvent.ThreadControllerImpl.RunTask |
     TraceEvent.TimerFire |
     TraceEvent.TimerInstall |
     TraceEvent.TracingStartedInBrowser |
     TraceEvent.TracingStartedInPage |
-    V8.Compile |
+    TraceEvent.V8.Compile |
     TraceEvent.XHRReadyStateChange;
 
   type DomContentLoadedEventEnd = 

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -375,10 +375,10 @@ export namespace _TraceEvent {
       args: {
       
       };
-      dur: number;
+      dur?: number;
       name: 'RunTask';
       ph: 'X';
-      tdur: number;
+      tdur?: number;
       tts: number;
     }
   }
@@ -432,7 +432,7 @@ export namespace _TraceEvent {
         args: {
         
         };
-        dur: number;
+        dur?: number;
         name: 'ThreadControllerImpl::DoWork';
         ph: 'X';
         tdur: number;
@@ -446,10 +446,10 @@ export namespace _TraceEvent {
           src_file?: string;
           src_func?: string;
         };
-        bind_id: string;
-        dur: number;
-        flow_in: boolean;
-        id: string;
+        bind_id?: string;
+        dur?: number;
+        flow_in?: boolean;
+        id?: string;
         name: 'ThreadControllerImpl::RunTask';
         ph: 'X';
         tdur: number;
@@ -553,10 +553,10 @@ export namespace _TraceEvent {
         args: {
         
         };
-        dur: number;
+        dur?: number;
         name: 'v8.compile';
         ph: 'X';
-        tdur: number;
+        tdur?: number;
         tts: number;
       }
     }

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -143,7 +143,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'domContentLoadedEventEnd';
-        // Phase.
+        // Denotes a mark of the event DomContentLoadedEventEnd.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -170,7 +170,7 @@ export namespace TraceEvent {
         // Duration.
         dur: number;
         name: 'EvaluateScript';
-        // Phase.
+        // Denotes the end of the event EvaluateScript.
         ph: 'X';
         tdur: number;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -184,7 +184,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstContentfulPaint';
-        // Phase.
+        // Denotes an event FirstContentfulPaint. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -199,7 +199,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstContentfulPaint';
-        // Phase.
+        // Denotes a mark of the event FirstContentfulPaint.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -216,7 +216,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstMeaningfulPaint';
-        // Phase.
+        // Denotes a mark of the event FirstMeaningfulPaint.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -232,7 +232,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstMeaningfulPaintCandidate';
-        // Phase.
+        // Denotes a mark of the event FirstMeaningfulPaintCandidate.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -245,7 +245,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstPaint';
-        // Phase.
+        // Denotes an event FirstPaint. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -260,7 +260,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'firstPaint';
-        // Phase.
+        // Denotes a mark of the event FirstPaint.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -280,7 +280,7 @@ export namespace TraceEvent {
           };
         };
         name: 'FunctionCall';
-        // Phase.
+        // Denotes the beginning of the event FunctionCall.
         ph: 'B';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -291,7 +291,7 @@ export namespace TraceEvent {
         
         };
         name: 'FunctionCall';
-        // Phase.
+        // Denotes the ending of the event FunctionCall.
         ph: 'E';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -313,7 +313,7 @@ export namespace TraceEvent {
           };
         };
         name: 'InvalidateLayout';
-        // Phase.
+        // Denotes an event InvalidateLayout. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -339,7 +339,7 @@ export namespace TraceEvent {
           };
         };
         name: 'Layout';
-        // Phase.
+        // Denotes the beginning of the event Layout.
         ph: 'B';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -355,7 +355,7 @@ export namespace TraceEvent {
           };
         };
         name: 'Layout';
-        // Phase.
+        // Denotes the ending of the event Layout.
         ph: 'E';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -368,7 +368,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'loadEventEnd';
-        // Phase.
+        // Denotes a mark of the event LoadEventEnd.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -386,7 +386,7 @@ export namespace TraceEvent {
           frame: string;
         };
         name: 'navigationStart';
-        // Phase.
+        // Denotes a mark of the event NavigationStart.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -399,7 +399,7 @@ export namespace TraceEvent {
         
         };
         name: 'paintNonDefaultBackgroundColor';
-        // Phase.
+        // Denotes a mark of the event PaintNonDefaultBackgroundColor.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -416,7 +416,7 @@ export namespace TraceEvent {
         // Duration.
         dur: number;
         name: 'ParseAuthorStyleSheet';
-        // Phase.
+        // Denotes the end of the event ParseAuthorStyleSheet.
         ph: 'X';
         tdur: number;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -430,7 +430,7 @@ export namespace TraceEvent {
           labels: string;
         };
         name: 'process_labels';
-        // Phase.
+        // Denotes metadata for the event Process_labels.
         ph: 'M';
       }
     }
@@ -441,7 +441,7 @@ export namespace TraceEvent {
         
         };
         name: 'requestStart';
-        // Phase.
+        // Denotes a mark of the event RequestStart.
         ph: 'R';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -461,7 +461,7 @@ export namespace TraceEvent {
           };
         };
         name: 'ResourceFinish';
-        // Phase.
+        // Denotes an event ResourceFinish. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -501,7 +501,7 @@ export namespace TraceEvent {
           };
         };
         name: 'ResourceReceiveResponse';
-        // Phase.
+        // Denotes an event ResourceReceiveResponse. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -528,7 +528,7 @@ export namespace TraceEvent {
           };
         };
         name: 'ResourceSendRequest';
-        // Phase.
+        // Denotes an event ResourceSendRequest. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -544,7 +544,7 @@ export namespace TraceEvent {
         // Duration.
         dur?: number;
         name: 'RunTask';
-        // Phase.
+        // Denotes the end of the event RunTask.
         ph: 'X';
         tdur?: number;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -567,7 +567,7 @@ export namespace TraceEvent {
           };
         };
         name: 'ScheduleStyleRecalculation';
-        // Phase.
+        // Denotes an event ScheduleStyleRecalculation. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -582,7 +582,7 @@ export namespace TraceEvent {
         };
         id: string;
         name: 'Screenshot';
-        // Phase.
+        // Denotes a snapshot object of the event Screenshot.
         ph: 'O';
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
         tts: number;
@@ -602,7 +602,7 @@ export namespace TraceEvent {
           // Duration.
           dur?: number;
           name: 'TaskQueueManager::ProcessTaskFromWorkQueue';
-          // Phase.
+          // Denotes the end of the event ProcessTaskFromWorkQueue.
           ph: 'X';
           tdur: number;
           // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -617,7 +617,7 @@ export namespace TraceEvent {
           name: string;
         };
         name: 'thread_name';
-        // Phase.
+        // Denotes metadata for the event Thread_name.
         ph: 'M';
       }
     }
@@ -637,7 +637,7 @@ export namespace TraceEvent {
           // Duration.
           dur?: number;
           name: 'ThreadControllerImpl::DoWork';
-          // Phase.
+          // Denotes the end of the event DoWork.
           ph: 'X';
           tdur: number;
           // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -657,7 +657,7 @@ export namespace TraceEvent {
           flow_in?: boolean;
           id?: string;
           name: 'ThreadControllerImpl::RunTask';
-          // Phase.
+          // Denotes the end of the event RunTask.
           ph: 'X';
           tdur: number;
           // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -677,7 +677,7 @@ export namespace TraceEvent {
         // Duration.
         dur: number;
         name: 'TimerFire';
-        // Phase.
+        // Denotes the end of the event TimerFire.
         ph: 'X';
         tdur: number;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -703,7 +703,7 @@ export namespace TraceEvent {
           };
         };
         name: 'TimerInstall';
-        // Phase.
+        // Denotes an event TimerInstall. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -726,7 +726,7 @@ export namespace TraceEvent {
           };
         };
         name: 'TracingStartedInBrowser';
-        // Phase.
+        // Denotes an event TracingStartedInBrowser. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -743,7 +743,7 @@ export namespace TraceEvent {
           };
         };
         name: 'TracingStartedInPage';
-        // Phase.
+        // Denotes an event TracingStartedInPage. There are no begining/ending phases.
         ph: 'I';
         s: string;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -763,7 +763,7 @@ export namespace TraceEvent {
             fileName: string;
           };
           name: 'v8.compile';
-          // Phase.
+          // Denotes the beginning of the event Compile.
           ph: 'B';
           // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
           tts: number;
@@ -785,7 +785,7 @@ export namespace TraceEvent {
             };
           };
           name: 'v8.compile';
-          // Phase.
+          // Denotes the ending of the event Compile.
           ph: 'E';
           // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
           tts: number;
@@ -803,7 +803,7 @@ export namespace TraceEvent {
           // Duration.
           dur?: number;
           name: 'v8.compile';
-          // Phase.
+          // Denotes the end of the event Compile.
           ph: 'X';
           tdur?: number;
           // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.
@@ -831,7 +831,7 @@ export namespace TraceEvent {
         // Duration.
         dur: number;
         name: 'XHRReadyStateChange';
-        // Phase.
+        // Denotes the end of the event XHRReadyStateChange.
         ph: 'X';
         tdur: number;
         // Thread timestamp of the event. This value is monotonically increasing among all events generated in the same thread.

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-// https://github.com/Hoten/chrome-trace-events-tsc/blob/master/trace-events.d.ts
+// https://github.com/Hoten/chrome-trace-events-tsc/blob/master/dist/lh-trace-events.d.ts
 
 export namespace _TraceEvent {
   interface Base {
@@ -15,300 +15,38 @@ export namespace _TraceEvent {
   }
 
   type TraceEvent = 
-    Animation.B |
-    Animation.E |
-    Animation.N |
-    CommitLoad.X |
-    CompositeLayers.B |
-    CompositeLayers.E |
-    ContextCreatedNotification.X |
-    DecodeImage.X |
-    DecodeLazyPixelRef.X |
-    DomComplete.R |
-    DOMContentLoaded.B |
-    DOMContentLoaded.E |
     DomContentLoadedEventEnd.R |
-    DomContentLoadedEventStart.R |
-    DomInteractive.R |
-    DomLoading.R |
-    DrawLazyPixelRef.I |
-    EndofTrace.B |
-    EndofTrace.E |
     EvaluateScript.X |
-    EventDispatch.X |
-    FetchStart.R |
-    FireAnimationFrame.X |
-    FirstContentfulPaint.B |
-    FirstContentfulPaint.E |
     FirstContentfulPaint.R |
-    FirstImagePaint.R |
-    FirstLayout.R |
-    FirstMeaningfulPaint.B |
-    FirstMeaningfulPaint.E |
     FirstMeaningfulPaint.R |
     FirstMeaningfulPaintCandidate.R |
     FirstPaint.R |
-    FirstVisualChange.B |
-    FirstVisualChange.E |
-    FrameCommittedInBrowser.I |
-    FrameDeletedInBrowser.I |
-    FrameStartedLoading.I |
     FunctionCall.B |
     FunctionCall.E |
-    GPUTask.X |
-    HitTest.B |
-    HitTest.E |
-    ImageDecodeTask.B |
-    ImageDecodeTask.E |
-    InstallConditionalFeatures.X |
     InvalidateLayout.I |
-    LayerId.D |
-    LayerId.N |
     Layout.B |
     Layout.E |
     LoadEventEnd.R |
-    LoadEventStart.R |
-    LocalWindowProxy.CreateContext.X |
-    LocalWindowProxy.Initialize.X |
-    LocalWindowProxy.SetupWindowPrototypeChain.X |
-    LocalWindowProxy.UpdateDocumentProperty.X |
-    MajorGC.B |
-    MajorGC.E |
-    MarkDOMContent.I |
-    MarkLoad.I |
-    MinorGC.B |
-    MinorGC.E |
     NavigationStart.R |
-    Num_cpus.M |
-    OnLoad.B |
-    OnLoad.E |
-    Paint.X |
-    PaintImage.X |
     ParseAuthorStyleSheet.X |
-    ParseHTML.B |
-    ParseHTML.E |
-    PlatformResourceSendRequest.B |
-    PlatformResourceSendRequest.E |
     Process_labels.M |
-    Process_name.M |
-    Process_sort_index.M |
-    Process_uptime_seconds.M |
-    RasterTask.B |
-    RasterTask.E |
-    RequestAnimationFrame.I |
     RequestStart.R |
-    ResourceChangePriority.X |
     ResourceFinish.I |
-    ResourceReceivedData.I |
     ResourceReceiveResponse.I |
     ResourceSendRequest.I |
-    ResponseEnd.R |
-    RunMicrotasks.B |
-    RunMicrotasks.E |
     RunTask.X |
-    ScheduledAction.Execute.X |
     ScheduleStyleRecalculation.I |
     Screenshot.O |
-    SetLayerTreeId.I |
-    SpeedIndex.B |
-    SpeedIndex.E |
     Thread_name.M |
-    Thread_sort_index.M |
+    ThreadControllerImpl.DoWork.X |
+    ThreadControllerImpl.RunTask.X |
     TimerFire.X |
     TimerInstall.I |
-    TimerRemove.I |
-    TracingSessionIdForWorker.I |
     TracingStartedInBrowser.I |
-    UnloadEventEnd.R |
-    UnloadEventStart.R |
-    UpdateCounters.I |
-    UpdateLayer.B |
-    UpdateLayer.E |
-    UpdateLayerTree.X |
-    UpdateLayoutTree.B |
-    UpdateLayoutTree.E |
-    V8.CallFunction.X |
     V8.Compile.B |
     V8.Compile.E |
     V8.Compile.X |
-    V8.DeoptimizeCode.X |
-    V8.Execute.B |
-    V8.Execute.E |
-    V8.GCCompactor.X |
-    V8.GCIdleNotification.X |
-    V8.GCPhantomHandleProcessingCallback.X |
-    V8.GCScavenger.X |
-    V8.HandleInterrupts.X |
-    V8.InvokeApiInterruptCallbacks.X |
-    V8.NewContext.B |
-    V8.NewContext.E |
-    V8.NewInstance.X |
-    V8.ParseOnBackground.X |
-    V8.Run.X |
-    V8.RunMicrotasks.B |
-    V8.RunMicrotasks.E |
-    V8.ScriptCompiler.B |
-    V8.ScriptCompiler.E |
-    V8.StackGuard.X |
-    V8.Task.B |
-    V8.Task.E |
-    VisuallyComplete100.B |
-    VisuallyComplete100.E |
-    XHRLoad.X |
     XHRReadyStateChange.X;
-
-  namespace Animation {
-    interface B extends Base {
-      args: {
-        data: {
-          id: string;
-          name: string;
-          nodeId: number;
-          nodeName: string;
-          state: string;
-        };
-      };
-      id: string;
-      name: 'Animation';
-      ph: 'b';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-        endData: {
-          state: string;
-        };
-      };
-      id: string;
-      name: 'Animation';
-      ph: 'e';
-      tts: number;
-    }
-  
-    interface N extends Base {
-      args: {
-        data: {
-          state: string;
-        };
-      };
-      id: string;
-      name: 'Animation';
-      ph: 'n';
-      tts: number;
-    }
-  }
-
-  namespace CommitLoad {
-    interface X extends Base {
-      args: {
-        data: {
-          frame: string;
-          isMainFrame: boolean;
-          name: string;
-          nodeId?: number;
-          page: string;
-          parent?: string;
-          url: string;
-        };
-      };
-      dur: number;
-      name: 'CommitLoad';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace CompositeLayers {
-    interface B extends Base {
-      args: {
-        layerTreeId: number;
-      };
-      name: 'CompositeLayers';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      name: 'CompositeLayers';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace ContextCreatedNotification {
-    interface X extends Base {
-      args: {
-        IsMainFrame: boolean;
-      };
-      dur: number;
-      name: 'ContextCreatedNotification';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace DecodeImage {
-    interface X extends Base {
-      args: {
-        imageType: string;
-      };
-      dur: number;
-      name: 'Decode Image';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace DecodeLazyPixelRef {
-    interface X extends Base {
-      args: {
-        LazyPixelRef: number;
-      };
-      dur: number;
-      name: 'Decode LazyPixelRef';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace DomComplete {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'domComplete';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace DOMContentLoaded {
-    interface B extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'DOM Content Loaded';
-      ph: 'b';
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'DOM Content Loaded';
-      ph: 'e';
-    }
-  }
 
   namespace DomContentLoadedEventEnd {
     interface R extends Base {
@@ -318,71 +56,6 @@ export namespace _TraceEvent {
       name: 'domContentLoadedEventEnd';
       ph: 'R';
       tts: number;
-    }
-  }
-
-  namespace DomContentLoadedEventStart {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'domContentLoadedEventStart';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace DomInteractive {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'domInteractive';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace DomLoading {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'domLoading';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace DrawLazyPixelRef {
-    interface I extends Base {
-      args: {
-        LazyPixelRef: number;
-      };
-      name: 'Draw LazyPixelRef';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace EndofTrace {
-    interface B extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'End of Trace';
-      ph: 'b';
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'End of Trace';
-      ph: 'e';
     }
   }
 
@@ -411,74 +84,7 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace EventDispatch {
-    interface X extends Base {
-      args: {
-        data: {
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-          type: string;
-        };
-      };
-      dur: number;
-      name: 'EventDispatch';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace FetchStart {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'fetchStart';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace FireAnimationFrame {
-    interface X extends Base {
-      args: {
-        data: {
-          frame: string;
-          id: number;
-        };
-      };
-      dur: number;
-      name: 'FireAnimationFrame';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
   namespace FirstContentfulPaint {
-    interface B extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'First Contentful Paint';
-      ph: 'b';
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'First Contentful Paint';
-      ph: 'e';
-    }
-  
     interface R extends Base {
       args: {
         data: {
@@ -492,50 +98,7 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace FirstImagePaint {
-    interface R extends Base {
-      args: {
-        data: {
-          navigationId: string;
-        };
-        frame: string;
-      };
-      name: 'firstImagePaint';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace FirstLayout {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'firstLayout';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
   namespace FirstMeaningfulPaint {
-    interface B extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'First Meaningful Paint';
-      ph: 'b';
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'First Meaningful Paint';
-      ph: 'e';
-    }
-  
     interface R extends Base {
       args: {
         afterUserInput?: number;
@@ -578,70 +141,6 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace FirstVisualChange {
-    interface B extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'First Visual Change';
-      ph: 'b';
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'First Visual Change';
-      ph: 'e';
-    }
-  }
-
-  namespace FrameCommittedInBrowser {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          name: string;
-          parent?: string;
-          processId: number;
-          url: string;
-        };
-      };
-      name: 'FrameCommittedInBrowser';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace FrameDeletedInBrowser {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-        };
-      };
-      name: 'FrameDeletedInBrowser';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace FrameStartedLoading {
-    interface I extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'FrameStartedLoading';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
   namespace FunctionCall {
     interface B extends Base {
       args: {
@@ -669,81 +168,6 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace GPUTask {
-    interface X extends Base {
-      args: {
-        data: {
-          renderer_pid: number;
-          used_bytes: number;
-        };
-      };
-      dur: number;
-      name: 'GPUTask';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace HitTest {
-    interface B extends Base {
-      args: {
-      
-      };
-      name: 'HitTest';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-        endData: {
-          nodeId: number;
-          nodeName: string;
-          rectilinear: boolean;
-          x: number;
-          y: number;
-        };
-      };
-      name: 'HitTest';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace ImageDecodeTask {
-    interface B extends Base {
-      args: {
-        pixelRefId: number;
-      };
-      name: 'ImageDecodeTask';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      name: 'ImageDecodeTask';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace InstallConditionalFeatures {
-    interface X extends Base {
-      args: {
-        IsMainFrame: boolean;
-      };
-      dur: number;
-      name: 'InstallConditionalFeatures';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
   namespace InvalidateLayout {
     interface I extends Base {
       args: {
@@ -761,28 +185,6 @@ export namespace _TraceEvent {
       name: 'InvalidateLayout';
       ph: 'I';
       s: string;
-      tts: number;
-    }
-  }
-
-  namespace LayerId {
-    interface D extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'layerId';
-      ph: 'D';
-      tts: number;
-    }
-  
-    interface N extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'layerId';
-      ph: 'N';
       tts: number;
     }
   }
@@ -835,144 +237,6 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace LoadEventStart {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'loadEventStart';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace LocalWindowProxy {
-    namespace CreateContext {
-      interface X extends Base {
-        args: {
-          IsMainFrame: boolean;
-        };
-        dur: number;
-        name: 'LocalWindowProxy::CreateContext';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace Initialize {
-      interface X extends Base {
-        args: {
-          IsMainFrame: boolean;
-        };
-        dur: number;
-        name: 'LocalWindowProxy::Initialize';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace SetupWindowPrototypeChain {
-      interface X extends Base {
-        args: {
-          IsMainFrame: boolean;
-        };
-        dur: number;
-        name: 'LocalWindowProxy::SetupWindowPrototypeChain';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace UpdateDocumentProperty {
-      interface X extends Base {
-        args: {
-          IsMainFrame: boolean;
-        };
-        dur: number;
-        name: 'LocalWindowProxy::UpdateDocumentProperty';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  }
-
-  namespace MajorGC {
-    interface B extends Base {
-      args: {
-        type: string;
-        usedHeapSizeBefore: number;
-      };
-      name: 'MajorGC';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-        usedHeapSizeAfter: number;
-      };
-      name: 'MajorGC';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace MarkDOMContent {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          isMainFrame: boolean;
-          page: string;
-        };
-      };
-      name: 'MarkDOMContent';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace MarkLoad {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          isMainFrame: boolean;
-          page: string;
-        };
-      };
-      name: 'MarkLoad';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace MinorGC {
-    interface B extends Base {
-      args: {
-        usedHeapSizeBefore: number;
-      };
-      name: 'MinorGC';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-        usedHeapSizeAfter: number;
-      };
-      name: 'MinorGC';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
   namespace NavigationStart {
     interface R extends Base {
       args: {
@@ -985,78 +249,6 @@ export namespace _TraceEvent {
       };
       name: 'navigationStart';
       ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace Num_cpus {
-    interface M extends Base {
-      args: {
-        number: number;
-      };
-      name: 'num_cpus';
-      ph: 'M';
-    }
-  }
-
-  namespace OnLoad {
-    interface B extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'On Load';
-      ph: 'b';
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'On Load';
-      ph: 'e';
-    }
-  }
-
-  namespace Paint {
-    interface X extends Base {
-      args: {
-        data: {
-          clip: {
-          
-          }[];
-          frame: string;
-          layerId: number;
-          nodeId: number;
-        };
-      };
-      dur: number;
-      name: 'Paint';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace PaintImage {
-    interface X extends Base {
-      args: {
-        data: {
-          height: number;
-          nodeId: number;
-          srcHeight: number;
-          srcWidth: number;
-          url?: string;
-          width: number;
-          x: number;
-          y: number;
-        };
-      };
-      dur: number;
-      name: 'PaintImage';
-      ph: 'X';
-      tdur: number;
       tts: number;
     }
   }
@@ -1076,61 +268,6 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace ParseHTML {
-    interface B extends Base {
-      args: {
-        beginData: {
-          frame: string;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-          startLine: number;
-          url: string;
-        };
-      };
-      name: 'ParseHTML';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-        endData: {
-          endLine: number;
-        };
-      };
-      name: 'ParseHTML';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace PlatformResourceSendRequest {
-    interface B extends Base {
-      args: {
-        data: {
-          id: string;
-        };
-      };
-      name: 'PlatformResourceSendRequest';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      name: 'PlatformResourceSendRequest';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
   namespace Process_labels {
     interface M extends Base {
       args: {
@@ -1141,85 +278,6 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace Process_name {
-    interface M extends Base {
-      args: {
-        name: string;
-      };
-      name: 'process_name';
-      ph: 'M';
-    }
-  }
-
-  namespace Process_sort_index {
-    interface M extends Base {
-      args: {
-        sort_index: number;
-      };
-      name: 'process_sort_index';
-      ph: 'M';
-    }
-  }
-
-  namespace Process_uptime_seconds {
-    interface M extends Base {
-      args: {
-        uptime: number;
-      };
-      name: 'process_uptime_seconds';
-      ph: 'M';
-    }
-  }
-
-  namespace RasterTask {
-    interface B extends Base {
-      args: {
-        tileData: {
-          layerId: number;
-          sourceFrameNumber: number;
-          tileId: {
-            id_ref: string;
-          };
-          tileResolution: string;
-        };
-      };
-      name: 'RasterTask';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      name: 'RasterTask';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace RequestAnimationFrame {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          id: number;
-          stackTrace: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-        };
-      };
-      name: 'RequestAnimationFrame';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
   namespace RequestStart {
     interface R extends Base {
       args: {
@@ -1227,22 +285,6 @@ export namespace _TraceEvent {
       };
       name: 'requestStart';
       ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace ResourceChangePriority {
-    interface X extends Base {
-      args: {
-        data: {
-          priority: string;
-          requestId: string;
-        };
-      };
-      dur: number;
-      name: 'ResourceChangePriority';
-      ph: 'X';
-      tdur: number;
       tts: number;
     }
   }
@@ -1259,22 +301,6 @@ export namespace _TraceEvent {
         };
       };
       name: 'ResourceFinish';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace ResourceReceivedData {
-    interface I extends Base {
-      args: {
-        data: {
-          encodedDataLength: number;
-          frame: string;
-          requestId: string;
-        };
-      };
-      name: 'ResourceReceivedData';
       ph: 'I';
       s: string;
       tts: number;
@@ -1344,37 +370,6 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace ResponseEnd {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'responseEnd';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace RunMicrotasks {
-    interface B extends Base {
-      args: {
-      
-      };
-      name: 'RunMicrotasks';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-        microtask_count: number;
-      };
-      name: 'RunMicrotasks';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
   namespace RunTask {
     interface X extends Base {
       args: {
@@ -1385,21 +380,6 @@ export namespace _TraceEvent {
       ph: 'X';
       tdur: number;
       tts: number;
-    }
-  }
-
-  namespace ScheduledAction {
-    namespace Execute {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'ScheduledAction::execute';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
     }
   }
 
@@ -1436,41 +416,6 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace SetLayerTreeId {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          layerTreeId: number;
-        };
-      };
-      name: 'SetLayerTreeId';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace SpeedIndex {
-    interface B extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'Speed Index';
-      ph: 'b';
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'Speed Index';
-      ph: 'e';
-    }
-  }
-
   namespace Thread_name {
     interface M extends Base {
       args: {
@@ -1481,13 +426,35 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace Thread_sort_index {
-    interface M extends Base {
-      args: {
-        sort_index: number;
-      };
-      name: 'thread_sort_index';
-      ph: 'M';
+  namespace ThreadControllerImpl {
+    namespace DoWork {
+      interface X extends Base {
+        args: {
+        
+        };
+        dur: number;
+        name: 'ThreadControllerImpl::DoWork';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
+    }
+  
+    namespace RunTask {
+      interface X extends Base {
+        args: {
+          src_file?: string;
+          src_func?: string;
+        };
+        bind_id: string;
+        dur: number;
+        flow_in: boolean;
+        id: string;
+        name: 'ThreadControllerImpl::RunTask';
+        ph: 'X';
+        tdur: number;
+        tts: number;
+      }
     }
   }
 
@@ -1513,7 +480,7 @@ export namespace _TraceEvent {
         data: {
           frame: string;
           singleShot: boolean;
-          stackTrace: {
+          stackTrace?: {
             columnNumber: number;
             functionName: string;
             lineNumber: number;
@@ -1525,45 +492,6 @@ export namespace _TraceEvent {
         };
       };
       name: 'TimerInstall';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace TimerRemove {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          stackTrace: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-          timerId: number;
-        };
-      };
-      name: 'TimerRemove';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace TracingSessionIdForWorker {
-    interface I extends Base {
-      args: {
-        data: {
-          frame: string;
-          url: string;
-          workerId: string;
-          workerThreadId: number;
-        };
-      };
-      name: 'TracingSessionIdForWorker';
       ph: 'I';
       s: string;
       tts: number;
@@ -1591,124 +519,7 @@ export namespace _TraceEvent {
     }
   }
 
-  namespace UnloadEventEnd {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'unloadEventEnd';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace UnloadEventStart {
-    interface R extends Base {
-      args: {
-        frame: string;
-      };
-      name: 'unloadEventStart';
-      ph: 'R';
-      tts: number;
-    }
-  }
-
-  namespace UpdateCounters {
-    interface I extends Base {
-      args: {
-        data: {
-          documents: number;
-          jsEventListeners: number;
-          jsHeapSizeUsed: number;
-          nodes: number;
-        };
-      };
-      name: 'UpdateCounters';
-      ph: 'I';
-      s: string;
-      tts: number;
-    }
-  }
-
-  namespace UpdateLayer {
-    interface B extends Base {
-      args: {
-        layerId: number;
-        layerTreeId: number;
-      };
-      name: 'UpdateLayer';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      name: 'UpdateLayer';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
-  namespace UpdateLayerTree {
-    interface X extends Base {
-      args: {
-        data: {
-          frame: string;
-        };
-      };
-      dur: number;
-      name: 'UpdateLayerTree';
-      ph: 'X';
-      tdur: number;
-      tts: number;
-    }
-  }
-
-  namespace UpdateLayoutTree {
-    interface B extends Base {
-      args: {
-        beginData: {
-          frame: string;
-          stackTrace?: {
-            columnNumber: number;
-            functionName: string;
-            lineNumber: number;
-            scriptId: string;
-            url: string;
-          }[];
-        };
-      };
-      name: 'UpdateLayoutTree';
-      ph: 'B';
-      tts: number;
-    }
-  
-    interface E extends Base {
-      args: {
-        elementCount: number;
-      };
-      name: 'UpdateLayoutTree';
-      ph: 'E';
-      tts: number;
-    }
-  }
-
   namespace V8 {
-    namespace CallFunction {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'v8.callFunction';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
     namespace Compile {
       interface B extends Base {
         args: {
@@ -1748,302 +559,6 @@ export namespace _TraceEvent {
         tdur: number;
         tts: number;
       }
-    }
-  
-    namespace DeoptimizeCode {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'V8.DeoptimizeCode';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace Execute {
-      interface B extends Base {
-        args: {
-        
-        };
-        name: 'V8.Execute';
-        ph: 'B';
-        tts: number;
-      }
-    
-      interface E extends Base {
-        args: {
-          'runtime-call-stats': {
-          
-          };
-        };
-        name: 'V8.Execute';
-        ph: 'E';
-        tts: number;
-      }
-    }
-  
-    namespace GCCompactor {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'V8.GCCompactor';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace GCIdleNotification {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'V8.GCIdleNotification';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace GCPhantomHandleProcessingCallback {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'V8.GCPhantomHandleProcessingCallback';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace GCScavenger {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'V8.GCScavenger';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace HandleInterrupts {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'V8.HandleInterrupts';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace InvokeApiInterruptCallbacks {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'V8.InvokeApiInterruptCallbacks';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace NewContext {
-      interface B extends Base {
-        args: {
-        
-        };
-        name: 'V8.NewContext';
-        ph: 'B';
-        tts: number;
-      }
-    
-      interface E extends Base {
-        args: {
-          'runtime-call-stats': {
-          
-          };
-        };
-        name: 'V8.NewContext';
-        ph: 'E';
-        tts: number;
-      }
-    }
-  
-    namespace NewInstance {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'v8.newInstance';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace ParseOnBackground {
-      interface X extends Base {
-        args: {
-          data: {
-            requestId: string;
-            url: string;
-          };
-        };
-        bind_id: string;
-        dur: number;
-        flow_in: boolean;
-        flow_out: boolean;
-        id: string;
-        name: 'v8.parseOnBackground';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace Run {
-      interface X extends Base {
-        args: {
-          fileName?: string;
-        };
-        dur: number;
-        name: 'v8.run';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace RunMicrotasks {
-      interface B extends Base {
-        args: {
-        
-        };
-        name: 'V8.RunMicrotasks';
-        ph: 'B';
-        tts: number;
-      }
-    
-      interface E extends Base {
-        args: {
-          'runtime-call-stats': {
-          
-          };
-        };
-        name: 'V8.RunMicrotasks';
-        ph: 'E';
-        tts: number;
-      }
-    }
-  
-    namespace ScriptCompiler {
-      interface B extends Base {
-        args: {
-        
-        };
-        name: 'V8.ScriptCompiler';
-        ph: 'B';
-        tts: number;
-      }
-    
-      interface E extends Base {
-        args: {
-          'runtime-call-stats': {
-          
-          };
-        };
-        name: 'V8.ScriptCompiler';
-        ph: 'E';
-        tts: number;
-      }
-    }
-  
-    namespace StackGuard {
-      interface X extends Base {
-        args: {
-        
-        };
-        dur: number;
-        name: 'V8.StackGuard';
-        ph: 'X';
-        tdur: number;
-        tts: number;
-      }
-    }
-  
-    namespace Task {
-      interface B extends Base {
-        args: {
-        
-        };
-        name: 'V8.Task';
-        ph: 'B';
-        tts: number;
-      }
-    
-      interface E extends Base {
-        args: {
-          'runtime-call-stats': {
-          
-          };
-        };
-        name: 'V8.Task';
-        ph: 'E';
-        tts: number;
-      }
-    }
-  }
-
-  namespace VisuallyComplete100 {
-    interface B extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'Visually Complete 100%';
-      ph: 'b';
-    }
-  
-    interface E extends Base {
-      args: {
-      
-      };
-      id: string;
-      name: 'Visually Complete 100%';
-      ph: 'e';
-    }
-  }
-
-  namespace XHRLoad {
-    interface X extends Base {
-      args: {
-        data: {
-          frame: string;
-          url: string;
-        };
-      };
-      dur: number;
-      name: 'XHRLoad';
-      ph: 'X';
-      tdur: number;
-      tts: number;
     }
   }
 

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -28,6 +28,7 @@ export namespace _TraceEvent {
     Layout.E |
     LoadEventEnd.R |
     NavigationStart.R |
+    PaintNonDefaultBackgroundColor.R |
     ParseAuthorStyleSheet.X |
     Process_labels.M |
     RequestStart.R |
@@ -43,6 +44,7 @@ export namespace _TraceEvent {
     TimerFire.X |
     TimerInstall.I |
     TracingStartedInBrowser.I |
+    TracingStartedInPage.I |
     V8.Compile.B |
     V8.Compile.E |
     V8.Compile.X |
@@ -87,7 +89,7 @@ export namespace _TraceEvent {
   namespace FirstContentfulPaint {
     interface R extends Base {
       args: {
-        data: {
+        data?: {
           navigationId: string;
         };
         frame: string;
@@ -130,7 +132,7 @@ export namespace _TraceEvent {
   namespace FirstPaint {
     interface R extends Base {
       args: {
-        data: {
+        data?: {
           navigationId: string;
         };
         frame: string;
@@ -240,7 +242,7 @@ export namespace _TraceEvent {
   namespace NavigationStart {
     interface R extends Base {
       args: {
-        data: {
+        data?: {
           documentLoaderURL: string;
           isLoadingMainFrame: boolean;
           navigationId: string;
@@ -248,6 +250,17 @@ export namespace _TraceEvent {
         frame: string;
       };
       name: 'navigationStart';
+      ph: 'R';
+      tts: number;
+    }
+  }
+
+  namespace PaintNonDefaultBackgroundColor {
+    interface R extends Base {
+      args: {
+      
+      };
+      name: 'paintNonDefaultBackgroundColor';
       ph: 'R';
       tts: number;
     }
@@ -519,6 +532,21 @@ export namespace _TraceEvent {
     }
   }
 
+  namespace TracingStartedInPage {
+    interface I extends Base {
+      args: {
+        data: {
+          page: string;
+          sessionId: string;
+        };
+      };
+      name: 'TracingStartedInPage';
+      ph: 'I';
+      s: string;
+      tts: number;
+    }
+  }
+
   namespace V8 {
     namespace Compile {
       interface B extends Base {
@@ -534,6 +562,7 @@ export namespace _TraceEvent {
         args: {
           data: {
             cacheConsumeOptions?: string;
+            cacheProduceOptions?: string;
             cacheRejected?: boolean;
             columnNumber: number;
             consumedCacheSize?: number;

--- a/types/trace-events.d.ts
+++ b/types/trace-events.d.ts
@@ -4,7 +4,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-// https://github.com/Hoten/chrome-trace-events-tsc/blob/master/dist/lh-trace-events.d.ts
+/**
+ * Generated from https://github.com/Hoten/chrome-trace-events-tsc/blob/master/dist/lh-trace-events.d.ts
+ * @see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+ */
 
 export namespace TraceEvent {
   interface Base {


### PR DESCRIPTION
No functional changes.

Will follow up with removing the easy `@ts-ignores`, starting with the ones around switch statements (places where type narrowing will actually happen).

One last thing I need to do before merging this: generate types from more than just one single trace. Will do that Monday.

**Related Issues/PRs**

#7790
