### PR TITLE
misc: simplifications in simulator/connection-pool

### DIFF
--- a/lighthouse-core/computed/network-analysis.js
+++ b/lighthouse-core/computed/network-analysis.js
@@ -57,7 +57,7 @@ class NetworkAnalysis {
     const records = await NetworkRecords.request(devtoolsLog, context);
     const throughput = NetworkAnalyzer.estimateThroughput(records);
     const rttAndServerResponseTime = NetworkAnalysis.computeRTTAndServerResponseTime(records);
-    return {records, throughput, ...rttAndServerResponseTime};
+    return {throughput, ...rttAndServerResponseTime};
   }
 }
 

--- a/lighthouse-core/computed/page-dependency-graph.js
+++ b/lighthouse-core/computed/page-dependency-graph.js
@@ -133,9 +133,9 @@ class PageDependencyGraph {
         rootNode.addDependent(node);
       }
 
-      const redirects = Array.from(node.record.redirects || []);
-      redirects.push(node.record);
+      if (!node.record.redirects) return;
 
+      const redirects = [...node.record.redirects, node.record];
       for (let i = 1; i < redirects.length; i++) {
         const redirectNode = networkNodeOutput.idToNodeMap.get(redirects[i - 1].requestId);
         const actualNode = networkNodeOutput.idToNodeMap.get(redirects[i].requestId);

--- a/lighthouse-core/lib/dependency-graph/simulator/simulator.js
+++ b/lighthouse-core/lib/dependency-graph/simulator/simulator.js
@@ -141,8 +141,9 @@ class Simulator {
 
   /**
    * @param {Node} node
+   * @param {number} queuedTime
    */
-  _markNodeAsReadyToStart(node) {
+  _markNodeAsReadyToStart(node, queuedTime) {
     const firstNodeIndexWithGreaterStartTime = this._cachedNodeListByStartTime
       .findIndex(candidate => candidate.startTime > node.startTime);
     const insertionIndex = firstNodeIndexWithGreaterStartTime === -1 ?
@@ -151,6 +152,7 @@ class Simulator {
 
     this._nodes[NodeState.ReadyToStart].add(node);
     this._nodes[NodeState.NotReadyToStart].delete(node);
+    this._setTimingData(node, {queuedTime});
   }
 
   /**
@@ -184,7 +186,7 @@ class Simulator {
       if (dependencies.some(dep => !this._nodes[NodeState.Complete].has(dep))) continue;
 
       // Otherwise add it to the queue
-      this._markNodeAsReadyToStart(dependent);
+      this._markNodeAsReadyToStart(dependent, endTime);
     }
   }
 
@@ -442,7 +444,7 @@ class Simulator {
     let iteration = 0;
 
     // root node is always ready to start
-    this._markNodeAsReadyToStart(rootNode);
+    this._markNodeAsReadyToStart(rootNode, totalElapsedTime);
 
     // loop as long as we have nodes in the queue or currently in progress
     while (nodesReadyToStart.size || nodesInProgress.size) {
@@ -499,6 +501,7 @@ module.exports = Simulator;
  * @typedef NodeTimingIntermediate
  * @property {number} [startTime]
  * @property {number} [endTime]
+ * @property {number} [queuedTime] Helpful for debugging.
  * @property {number} [estimatedTimeElapsed]
  * @property {number} [timeElapsed]
  * @property {number} [timeElapsedOvershoot]

--- a/lighthouse-core/test/lib/dependency-graph/simulator/connection-pool-test.js
+++ b/lighthouse-core/test/lib/dependency-graph/simulator/connection-pool-test.js
@@ -85,8 +85,8 @@ describe('DependencyGraph/Simulator/ConnectionPool', () => {
       const connectionForA = pool.acquire(recordA);
       const connectionForB = pool.acquire(recordB);
       for (let i = 0; i < 10; i++) {
-        assert.equal(pool.acquire(recordA), connectionForA);
-        assert.equal(pool.acquire(recordB), connectionForB);
+        assert.equal(pool.acquireActiveConnectionFromRecord(recordA), connectionForA);
+        assert.equal(pool.acquireActiveConnectionFromRecord(recordB), connectionForB);
       }
 
       assert.deepStrictEqual(pool.connectionsInUse(), [connectionForA, connectionForB]);
@@ -152,7 +152,8 @@ describe('DependencyGraph/Simulator/ConnectionPool', () => {
       }
 
       assert.ok(pool.acquire(coldRecord, opts), 'should have acquired connection');
-      assert.ok(pool.acquire(warmRecord, opts), 'should have acquired connection');
+      assert.ok(pool.acquireActiveConnectionFromRecord(warmRecord, opts),
+        'should have acquired connection');
     });
 
     it('should acquire in order of warmness', () => {

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -376,7 +376,6 @@ declare global {
       }
 
       export interface NetworkAnalysis {
-        records: Array<NetworkRequest>;
         rtt: number;
         additionalRttByOrigin: Map<string, number>;
         serverResponseTimeByOrigin: Map<string, number>;


### PR DESCRIPTION
another one I accumulated while stepping through the simulator. Feel free to reject anything @patrickhulce :)

1) remove `records` from `LH.Artifacts.NetworkAnalysis`. The caller of the computed artifact has to already have them to get the `NetworkAnalysis`, and we never use them on any instance of the type anyways.
2) early return in `PageDependencyGraph.linkNetworkNodes()` for the common case where there were no redirects of a particular record
3) split `ConnectionPool.acquire()` into the case where a connection is needed to fetch a record and the case where a connection is already fetching a record.

   This seems ok as a place where the generality hasn't proven necessary...we only call `acquire()` in three places, and the two done that return assigned connections already explicitly call out with a comment and a type cast that it knows a connection already exists for this record.
4) removed `NodeTimingIntermediate.queuedTime` as it isn't used for anything. I can add back if this was useful for debugging or something.