### PR TITLE
tests: better fatal trace logic error coverage

### DIFF
--- a/lighthouse-core/computed/main-thread-tasks.js
+++ b/lighthouse-core/computed/main-thread-tasks.js
@@ -153,10 +153,12 @@ class MainThreadTasks {
    */
   static _computeRecursiveSelfTime(task, parent) {
     if (parent) {
-      if (task.startTime < parent.startTime)
-        throw new Error('Fatal trace logic error - child cannot start before parent')
-      if (task.endTime > parent.endTime)
-        throw new Error('Fatal trace logic error - child cannot end after parent')
+      if (task.startTime < parent.startTime) {
+        throw new Error('Fatal trace logic error - child cannot start before parent');
+      }
+      if (task.endTime > parent.endTime) {
+        throw new Error('Fatal trace logic error - child cannot end after parent');
+      }
     }
 
     const childTime = task.children

--- a/lighthouse-core/computed/main-thread-tasks.js
+++ b/lighthouse-core/computed/main-thread-tasks.js
@@ -148,11 +148,19 @@ class MainThreadTasks {
 
   /**
    * @param {TaskNode} task
+   * @param {TaskNode|undefined} parent
    * @return {number}
    */
-  static _computeRecursiveSelfTime(task) {
+  static _computeRecursiveSelfTime(task, parent) {
+    if (parent) {
+      if (task.startTime < parent.startTime)
+        throw new Error('Fatal trace logic error - child cannot start before parent')
+      if (task.endTime > parent.endTime)
+        throw new Error('Fatal trace logic error - child cannot end after parent')
+    }
+
     const childTime = task.children
-      .map(MainThreadTasks._computeRecursiveSelfTime)
+      .map(child => MainThreadTasks._computeRecursiveSelfTime(child, task))
       .reduce((sum, child) => sum + child, 0);
     task.duration = task.endTime - task.startTime;
     task.selfTime = task.duration - childTime;
@@ -237,7 +245,7 @@ class MainThreadTasks {
     for (const task of tasks) {
       if (task.parent) continue;
 
-      MainThreadTasks._computeRecursiveSelfTime(task);
+      MainThreadTasks._computeRecursiveSelfTime(task, undefined);
       MainThreadTasks._computeRecursiveAttributableURLs(task, [], priorTaskData);
       MainThreadTasks._computeRecursiveTaskGroup(task);
     }

--- a/lighthouse-core/computed/main-thread-tasks.js
+++ b/lighthouse-core/computed/main-thread-tasks.js
@@ -152,13 +152,8 @@ class MainThreadTasks {
    * @return {number}
    */
   static _computeRecursiveSelfTime(task, parent) {
-    if (parent) {
-      if (task.startTime < parent.startTime) {
-        throw new Error('Fatal trace logic error - child cannot start before parent');
-      }
-      if (task.endTime > parent.endTime) {
-        throw new Error('Fatal trace logic error - child cannot end after parent');
-      }
+    if (parent && task.endTime > parent.endTime) {
+      throw new Error('Fatal trace logic error - child cannot end after parent');
     }
 
     const childTime = task.children

--- a/lighthouse-core/test/computed/main-thread-tasks-test.js
+++ b/lighthouse-core/test/computed/main-thread-tasks-test.js
@@ -195,4 +195,40 @@ describe('MainResource computed artifact', () => {
       group: taskGroups.other,
     });
   });
+
+  const invalidEventSets = [
+    [
+      // TaskA overlaps with TaskB
+      {ph: 'X', name: 'TaskA', pid, tid, ts: baseTs, dur: 100e3, args},
+      {ph: 'B', name: 'TaskB', pid, tid, ts: baseTs + 5e3, args},
+      {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 115e3, args},
+    ],
+    [
+      // TaskA is missing a B event
+      {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs, args},
+      {ph: 'B', name: 'TaskB', pid, tid, ts: baseTs + 5e3, args},
+      {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 115e3, args},
+    ],
+    [
+      // TaskB is missing a B event after an X
+      {ph: 'X', name: 'TaskA', pid, tid, ts: baseTs, dur: 100e3, args},
+      {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 10e3, args},
+    ],
+  ];
+
+  for (const invalidEvents of invalidEventSets) {
+    it('should throw on invalid task input', async () => {
+      const traceEvents = [
+        ...boilerplateTrace,
+        ...invalidEvents,
+      ];
+
+      traceEvents.forEach(evt => Object.assign(evt, {cat: 'devtools.timeline'}));
+
+      const context = {computedCache: new Map()};
+      const promise = MainThreadTasks.request({traceEvents}, context);
+      console.log(await promise.catch(err => err.stack))
+      await expect(promise).rejects.toBeTruthy();
+    });
+  }
 });

--- a/lighthouse-core/test/computed/main-thread-tasks-test.js
+++ b/lighthouse-core/test/computed/main-thread-tasks-test.js
@@ -198,10 +198,16 @@ describe('MainResource computed artifact', () => {
 
   const invalidEventSets = [
     [
-      // TaskA overlaps with TaskB
+      // TaskA overlaps with TaskB, X first
       {ph: 'X', name: 'TaskA', pid, tid, ts: baseTs, dur: 100e3, args},
       {ph: 'B', name: 'TaskB', pid, tid, ts: baseTs + 5e3, args},
       {ph: 'E', name: 'TaskB', pid, tid, ts: baseTs + 115e3, args},
+    ],
+    [
+      // TaskA overlaps with TaskB, B first
+      {ph: 'B', name: 'TaskA', pid, tid, ts: baseTs, args},
+      {ph: 'X', name: 'TaskB', pid, tid, ts: baseTs + 5e3, dur: 100e3, args},
+      {ph: 'E', name: 'TaskA', pid, tid, ts: baseTs + 90e3, args},
     ],
     [
       // TaskA is missing a B event

--- a/lighthouse-core/test/computed/main-thread-tasks-test.js
+++ b/lighthouse-core/test/computed/main-thread-tasks-test.js
@@ -227,7 +227,6 @@ describe('MainResource computed artifact', () => {
 
       const context = {computedCache: new Map()};
       const promise = MainThreadTasks.request({traceEvents}, context);
-      console.log(await promise.catch(err => err.stack))
       await expect(promise).rejects.toBeTruthy();
     });
   }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
There were some extra cases where we weren't throwing on nonsensical trace event structures. This PR adds some coverage for those cases.

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/issues/7764#issuecomment-479325992
