### PR TITLE
tests(smokehouse): set Content-Type for webp images served by static-server.js

### DIFF
--- a/lighthouse-cli/test/fixtures/static-server.js
+++ b/lighthouse-cli/test/fixtures/static-server.js
@@ -75,6 +75,8 @@ function requestHandler(request, response) {
       headers['Content-Type'] = 'image/gif';
     } else if (filePath.endsWith('.jpg') || filePath.endsWith('.jpeg')) {
       headers['Content-Type'] = 'image/jpeg';
+    } else if (filePath.endsWith('.webp')) {
+      headers['Content-Type'] = 'image/webp';
     }
 
     let delay = 0;


### PR DESCRIPTION
For Smokerider.