### PR TITLE
tests: support artifact assertions in smoke tests

### DIFF
--- a/lighthouse-cli/test/smokehouse/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/a11y/expectations.js
@@ -10,230 +10,232 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/a11y/a11y_tester.html',
-    finalUrl: 'http://localhost:10200/a11y/a11y_tester.html',
-    audits: {
-      'aria-allowed-attr': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+    lhr: {
+      requestedUrl: 'http://localhost:10200/a11y/a11y_tester.html',
+      finalUrl: 'http://localhost:10200/a11y/a11y_tester.html',
+      audits: {
+        'aria-allowed-attr': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'aria-required-children': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'aria-required-children': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'aria-required-parent': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'aria-required-parent': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'aria-roles': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'aria-roles': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'aria-valid-attr-value': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'aria-valid-attr-value': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'aria-valid-attr': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'aria-valid-attr': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'button-name': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'button-name': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'bypass': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'bypass': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'color-contrast': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'color-contrast': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'definition-list': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'definition-list': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'dlitem': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'dlitem': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'document-title': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'document-title': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'duplicate-id': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'duplicate-id': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'frame-title': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'frame-title': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'html-has-lang': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'html-has-lang': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'image-alt': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'image-alt': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'input-image-alt': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'input-image-alt': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'label': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'label': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'layout-table': {
-        score: 1,
-        details: {
-          items: {
-            length: 0,
+        'layout-table': {
+          score: 1,
+          details: {
+            items: {
+              length: 0,
+            },
           },
         },
-      },
-      'link-name': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'link-name': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'list': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'list': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'listitem': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'listitem': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'meta-viewport': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'meta-viewport': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'object-alt': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'object-alt': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'tabindex': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'tabindex': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'td-headers-attr': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'td-headers-attr': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'valid-lang': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'valid-lang': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'accesskeys': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'accesskeys': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/a11y/expectations.js
+++ b/lighthouse-cli/test/smokehouse/a11y/expectations.js
@@ -10,232 +10,230 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/a11y/a11y_tester.html',
-      finalUrl: 'http://localhost:10200/a11y/a11y_tester.html',
-      audits: {
-        'aria-allowed-attr': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+    requestedUrl: 'http://localhost:10200/a11y/a11y_tester.html',
+    finalUrl: 'http://localhost:10200/a11y/a11y_tester.html',
+    audits: {
+      'aria-allowed-attr': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'aria-required-children': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'aria-required-children': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'aria-required-parent': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'aria-required-parent': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'aria-roles': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'aria-roles': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'aria-valid-attr-value': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'aria-valid-attr-value': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'aria-valid-attr': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'aria-valid-attr': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'button-name': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'button-name': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'bypass': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'bypass': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'color-contrast': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'color-contrast': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'definition-list': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'definition-list': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'dlitem': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'dlitem': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'document-title': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'document-title': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'duplicate-id': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'duplicate-id': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'frame-title': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'frame-title': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'html-has-lang': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'html-has-lang': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'image-alt': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'image-alt': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'input-image-alt': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'input-image-alt': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'label': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'label': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'layout-table': {
-          score: 1,
-          details: {
-            items: {
-              length: 0,
-            },
+      },
+      'layout-table': {
+        score: 1,
+        details: {
+          items: {
+            length: 0,
           },
         },
-        'link-name': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'link-name': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'list': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'list': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'listitem': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'listitem': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'meta-viewport': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'meta-viewport': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'object-alt': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'object-alt': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'tabindex': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'tabindex': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'td-headers-attr': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'td-headers-attr': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'valid-lang': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'valid-lang': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'accesskeys': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'accesskeys': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -10,134 +10,138 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/byte-efficiency/tester.html',
-    finalUrl: 'http://localhost:10200/byte-efficiency/tester.html',
-    audits: {
-      'unminified-css': {
-        details: {
-          overallSavingsBytes: '>17000',
-          items: {
-            length: 2,
-          },
-        },
-      },
-      'unminified-javascript': {
-        score: '<1',
-        details: {
-          overallSavingsBytes: '>45000',
-          overallSavingsMs: '>500',
-          items: [
-            {
-              url: 'http://localhost:10200/byte-efficiency/script.js',
-              wastedBytes: '46481 +/- 100',
-              wastedPercent: '87 +/- 5',
+    lhr: {
+      requestedUrl: 'http://localhost:10200/byte-efficiency/tester.html',
+      finalUrl: 'http://localhost:10200/byte-efficiency/tester.html',
+      audits: {
+        'unminified-css': {
+          details: {
+            overallSavingsBytes: '>17000',
+            items: {
+              length: 2,
             },
-            {
-              url: 'inline: \n  function unusedFunction() {\n    // Un...',
-              wastedBytes: '6581 +/- 100',
-              wastedPercent: '99.6 +/- 0.1',
+          },
+        },
+        'unminified-javascript': {
+          score: '<1',
+          details: {
+            overallSavingsBytes: '>45000',
+            overallSavingsMs: '>500',
+            items: [
+              {
+                url: 'http://localhost:10200/byte-efficiency/script.js',
+                wastedBytes: '46481 +/- 100',
+                wastedPercent: '87 +/- 5',
+              },
+              {
+                url: 'inline: \n  function unusedFunction() {\n    // Un...',
+                wastedBytes: '6581 +/- 100',
+                wastedPercent: '99.6 +/- 0.1',
+              },
+              {
+                url: 'inline: \n  // Used block #1\n  // FILLER DATA JUS...',
+                wastedBytes: '6559 +/- 100',
+                wastedPercent: 100,
+              },
+            ],
+          },
+        },
+        'unused-css-rules': {
+          details: {
+            overallSavingsBytes: '>35000',
+            items: {
+              length: 2,
             },
-            {
-              url: 'inline: \n  // Used block #1\n  // FILLER DATA JUS...',
-              wastedBytes: '6559 +/- 100',
-              wastedPercent: 100,
+          },
+        },
+        'unused-javascript': {
+          score: '<1',
+          details: {
+            overallSavingsBytes: '>=25000',
+            overallSavingsMs: '>300',
+            items: {
+              length: 2,
             },
-          ],
-        },
-      },
-      'unused-css-rules': {
-        details: {
-          overallSavingsBytes: '>35000',
-          items: {
-            length: 2,
           },
         },
-      },
-      'unused-javascript': {
-        score: '<1',
-        details: {
-          overallSavingsBytes: '>=25000',
-          overallSavingsMs: '>300',
-          items: {
-            length: 2,
+        'offscreen-images': {
+          details: {
+            items: [
+              {
+                url: /lighthouse-unoptimized.jpg$/,
+              }, {
+                url: /lighthouse-480x320.webp$/,
+              }, {
+                url: /lighthouse-480x320.webp\?invisible$/,
+              }, {
+                url: /large.svg$/,
+              },
+            ],
           },
         },
-      },
-      'offscreen-images': {
-        details: {
-          items: [
-            {
-              url: /lighthouse-unoptimized.jpg$/,
-            }, {
-              url: /lighthouse-480x320.webp$/,
-            }, {
-              url: /lighthouse-480x320.webp\?invisible$/,
-            }, {
-              url: /large.svg$/,
+        'uses-webp-images': {
+          details: {
+            overallSavingsBytes: '>60000',
+            items: {
+              length: 4,
             },
-          ],
-        },
-      },
-      'uses-webp-images': {
-        details: {
-          overallSavingsBytes: '>60000',
-          items: {
-            length: 4,
           },
         },
-      },
-      'uses-text-compression': {
-        score: '<1',
-        details: {
-          overallSavingsMs: '>700',
-          overallSavingsBytes: '>50000',
-          items: {
-            length: 2,
+        'uses-text-compression': {
+          score: '<1',
+          details: {
+            overallSavingsMs: '>700',
+            overallSavingsBytes: '>50000',
+            items: {
+              length: 2,
+            },
           },
         },
-      },
-      'uses-optimized-images': {
-        details: {
-          overallSavingsBytes: '>10000',
-          items: {
-            length: 1,
+        'uses-optimized-images': {
+          details: {
+            overallSavingsBytes: '>10000',
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'uses-responsive-images': {
-        displayValue: 'Potential savings of 75\xa0KB',
-        details: {
-          overallSavingsBytes: '>75000',
-          items: [
-            {wastedPercent: '<60'},
-            {wastedPercent: '<60'},
-            {wastedPercent: '<60'},
-          ],
+        'uses-responsive-images': {
+          displayValue: 'Potential savings of 75\xa0KB',
+          details: {
+            overallSavingsBytes: '>75000',
+            items: [
+              {wastedPercent: '<60'},
+              {wastedPercent: '<60'},
+              {wastedPercent: '<60'},
+            ],
+          },
         },
       },
     },
   },
   {
-    requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
-    finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
-    audits: {
-      'network-requests': {
-        details: {
-          items: [
-            {
-              url: 'http://localhost:10200/byte-efficiency/gzip.html',
-            },
-            {
-              url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
-              transferSize: 1136,
-              resourceSize: 52997,
-            },
-            {
-              url: 'http://localhost:10200/byte-efficiency/script.js',
-              transferSize: 53181,
-              resourceSize: 52997,
-            },
-          ],
+    lhr: {
+      requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+      finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+      audits: {
+        'network-requests': {
+          details: {
+            items: [
+              {
+                url: 'http://localhost:10200/byte-efficiency/gzip.html',
+              },
+              {
+                url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
+                transferSize: 1136,
+                resourceSize: 52997,
+              },
+              {
+                url: 'http://localhost:10200/byte-efficiency/script.js',
+                transferSize: 53181,
+                resourceSize: 52997,
+              },
+            ],
+          },
         },
       },
     },

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -10,138 +10,134 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/byte-efficiency/tester.html',
-      finalUrl: 'http://localhost:10200/byte-efficiency/tester.html',
-      audits: {
-        'unminified-css': {
-          details: {
-            overallSavingsBytes: '>17000',
-            items: {
-              length: 2,
+    requestedUrl: 'http://localhost:10200/byte-efficiency/tester.html',
+    finalUrl: 'http://localhost:10200/byte-efficiency/tester.html',
+    audits: {
+      'unminified-css': {
+        details: {
+          overallSavingsBytes: '>17000',
+          items: {
+            length: 2,
+          },
+        },
+      },
+      'unminified-javascript': {
+        score: '<1',
+        details: {
+          overallSavingsBytes: '>45000',
+          overallSavingsMs: '>500',
+          items: [
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js',
+              wastedBytes: '46481 +/- 100',
+              wastedPercent: '87 +/- 5',
             },
-          },
-        },
-        'unminified-javascript': {
-          score: '<1',
-          details: {
-            overallSavingsBytes: '>45000',
-            overallSavingsMs: '>500',
-            items: [
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js',
-                wastedBytes: '46481 +/- 100',
-                wastedPercent: '87 +/- 5',
-              },
-              {
-                url: 'inline: \n  function unusedFunction() {\n    // Un...',
-                wastedBytes: '6581 +/- 100',
-                wastedPercent: '99.6 +/- 0.1',
-              },
-              {
-                url: 'inline: \n  // Used block #1\n  // FILLER DATA JUS...',
-                wastedBytes: '6559 +/- 100',
-                wastedPercent: 100,
-              },
-            ],
-          },
-        },
-        'unused-css-rules': {
-          details: {
-            overallSavingsBytes: '>35000',
-            items: {
-              length: 2,
+            {
+              url: 'inline: \n  function unusedFunction() {\n    // Un...',
+              wastedBytes: '6581 +/- 100',
+              wastedPercent: '99.6 +/- 0.1',
             },
-          },
-        },
-        'unused-javascript': {
-          score: '<1',
-          details: {
-            overallSavingsBytes: '>=25000',
-            overallSavingsMs: '>300',
-            items: {
-              length: 2,
+            {
+              url: 'inline: \n  // Used block #1\n  // FILLER DATA JUS...',
+              wastedBytes: '6559 +/- 100',
+              wastedPercent: 100,
             },
+          ],
+        },
+      },
+      'unused-css-rules': {
+        details: {
+          overallSavingsBytes: '>35000',
+          items: {
+            length: 2,
           },
         },
-        'offscreen-images': {
-          details: {
-            items: [
-              {
-                url: /lighthouse-unoptimized.jpg$/,
-              }, {
-                url: /lighthouse-480x320.webp$/,
-              }, {
-                url: /lighthouse-480x320.webp\?invisible$/,
-              }, {
-                url: /large.svg$/,
-              },
-            ],
+      },
+      'unused-javascript': {
+        score: '<1',
+        details: {
+          overallSavingsBytes: '>=25000',
+          overallSavingsMs: '>300',
+          items: {
+            length: 2,
           },
         },
-        'uses-webp-images': {
-          details: {
-            overallSavingsBytes: '>60000',
-            items: {
-              length: 4,
+      },
+      'offscreen-images': {
+        details: {
+          items: [
+            {
+              url: /lighthouse-unoptimized.jpg$/,
+            }, {
+              url: /lighthouse-480x320.webp$/,
+            }, {
+              url: /lighthouse-480x320.webp\?invisible$/,
+            }, {
+              url: /large.svg$/,
             },
+          ],
+        },
+      },
+      'uses-webp-images': {
+        details: {
+          overallSavingsBytes: '>60000',
+          items: {
+            length: 4,
           },
         },
-        'uses-text-compression': {
-          score: '<1',
-          details: {
-            overallSavingsMs: '>700',
-            overallSavingsBytes: '>50000',
-            items: {
-              length: 2,
-            },
+      },
+      'uses-text-compression': {
+        score: '<1',
+        details: {
+          overallSavingsMs: '>700',
+          overallSavingsBytes: '>50000',
+          items: {
+            length: 2,
           },
         },
-        'uses-optimized-images': {
-          details: {
-            overallSavingsBytes: '>10000',
-            items: {
-              length: 1,
-            },
+      },
+      'uses-optimized-images': {
+        details: {
+          overallSavingsBytes: '>10000',
+          items: {
+            length: 1,
           },
         },
-        'uses-responsive-images': {
-          displayValue: 'Potential savings of 75\xa0KB',
-          details: {
-            overallSavingsBytes: '>75000',
-            items: [
-              {wastedPercent: '<60'},
-              {wastedPercent: '<60'},
-              {wastedPercent: '<60'},
-            ],
-          },
+      },
+      'uses-responsive-images': {
+        displayValue: 'Potential savings of 75\xa0KB',
+        details: {
+          overallSavingsBytes: '>75000',
+          items: [
+            {wastedPercent: '<60'},
+            {wastedPercent: '<60'},
+            {wastedPercent: '<60'},
+          ],
         },
       },
     },
   },
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
-      finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
-      audits: {
-        'network-requests': {
-          details: {
-            items: [
-              {
-                url: 'http://localhost:10200/byte-efficiency/gzip.html',
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
-                transferSize: 1136,
-                resourceSize: 52997,
-              },
-              {
-                url: 'http://localhost:10200/byte-efficiency/script.js',
-                transferSize: 53181,
-                resourceSize: 52997,
-              },
-            ],
-          },
+    requestedUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+    finalUrl: 'http://localhost:10200/byte-efficiency/gzip.html',
+    audits: {
+      'network-requests': {
+        details: {
+          items: [
+            {
+              url: 'http://localhost:10200/byte-efficiency/gzip.html',
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js?gzip=1',
+              transferSize: 1136,
+              resourceSize: 52997,
+            },
+            {
+              url: 'http://localhost:10200/byte-efficiency/script.js',
+              transferSize: 53181,
+              resourceSize: 52997,
+            },
+          ],
         },
       },
     },

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -10,136 +10,138 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-    finalUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-    audits: {
-      'errors-in-console': {
-        score: 0,
-        details: {
-          items: {
-            length: 6,
+    lhr: {
+      requestedUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+      finalUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+      audits: {
+        'errors-in-console': {
+          score: 0,
+          details: {
+            items: {
+              length: 6,
+            },
           },
         },
-      },
-      'is-on-https': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'is-on-https': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'uses-http2': {
-        score: 0,
-        details: {
-          items: {
-            length: '>15',
+        'uses-http2': {
+          score: 0,
+          details: {
+            items: {
+              length: '>15',
+            },
           },
         },
-      },
-      'external-anchors-use-rel-noopener': {
-        score: 0,
-        warnings: [/Unable to determine.*<a target="_blank">/],
-        details: {
-          items: {
-            length: 3,
+        'external-anchors-use-rel-noopener': {
+          score: 0,
+          warnings: [/Unable to determine.*<a target="_blank">/],
+          details: {
+            items: {
+              length: 3,
+            },
           },
         },
-      },
-      'appcache-manifest': {
-        score: 0,
-        displayValue: 'Found "clock.appcache"',
-      },
-      'geolocation-on-start': {
-        score: 0,
-      },
-      'no-document-write': {
-        score: 0,
-        details: {
-          items: {
-            length: 3,
+        'appcache-manifest': {
+          score: 0,
+          displayValue: 'Found "clock.appcache"',
+        },
+        'geolocation-on-start': {
+          score: 0,
+        },
+        'no-document-write': {
+          score: 0,
+          details: {
+            items: {
+              length: 3,
+            },
           },
         },
-      },
-      'no-vulnerable-libraries': {
-        score: 0,
-        details: {
-          items: {
-            length: 1,
+        'no-vulnerable-libraries': {
+          score: 0,
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
-      },
-      'notification-on-start': {
-        score: 0,
-      },
-      'render-blocking-resources': {
-        score: '<1',
-        rawValue: '>100',
-        details: {
-          items: {
-            length: 7,
+        'notification-on-start': {
+          score: 0,
+        },
+        'render-blocking-resources': {
+          score: '<1',
+          rawValue: '>100',
+          details: {
+            items: {
+              length: 7,
+            },
           },
         },
-      },
-      'uses-passive-event-listeners': {
-        score: 0,
-        details: {
-          items: {
+        'uses-passive-event-listeners': {
+          score: 0,
+          details: {
+            items: {
             // Note: Originally this was 7 but M56 defaults document-level
             // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
             // Note: It was 4, but {passive:false} doesn't get a warning as of M63: https://crbug.com/770208
             // Note: It was 3, but wheel events are now also passive as of field trial in M71 https://crbug.com/626196
-            length: '>=1',
+              length: '>=1',
+            },
           },
         },
-      },
-      'deprecations': {
-        score: 0,
-        details: {
-          items: {
+        'deprecations': {
+          score: 0,
+          details: {
+            items: {
             // Note: HTML Imports added to deprecations in m70, so 3 before, 4 after.
-            length: '>=3',
-          },
-        },
-      },
-      'password-inputs-can-be-pasted-into': {
-        score: 0,
-        details: {
-          items: {
-            length: 2,
-          },
-        },
-      },
-      'image-aspect-ratio': {
-        score: 0,
-        details: {
-          items: {
-            0: {
-              displayedAspectRatio: /^480 x 57/,
+              length: '>=3',
             },
-            length: 1,
           },
         },
-      },
-      'efficient-animated-content': {
-        score: '<0.5',
-        details: {
-          overallSavingsMs: '>2000',
-          items: [
-            {
-              url: 'http://localhost:10200/dobetterweb/lighthouse-rotating.gif',
-              totalBytes: 934285,
-              wastedBytes: 682028,
+        'password-inputs-can-be-pasted-into': {
+          score: 0,
+          details: {
+            items: {
+              length: 2,
             },
-          ],
+          },
         },
-      },
-      'js-libraries': {
-        score: 1,
-        details: {
-          items: [{
-            name: 'jQuery',
-          }],
+        'image-aspect-ratio': {
+          score: 0,
+          details: {
+            items: {
+              0: {
+                displayedAspectRatio: /^480 x 57/,
+              },
+              length: 1,
+            },
+          },
+        },
+        'efficient-animated-content': {
+          score: '<0.5',
+          details: {
+            overallSavingsMs: '>2000',
+            items: [
+              {
+                url: 'http://localhost:10200/dobetterweb/lighthouse-rotating.gif',
+                totalBytes: 934285,
+                wastedBytes: 682028,
+              },
+            ],
+          },
+        },
+        'js-libraries': {
+          score: 1,
+          details: {
+            items: [{
+              name: 'jQuery',
+            }],
+          },
         },
       },
     },

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -10,138 +10,136 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-      finalUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-      audits: {
-        'errors-in-console': {
-          score: 0,
-          details: {
-            items: {
-              length: 6,
-            },
+    requestedUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+    finalUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+    audits: {
+      'errors-in-console': {
+        score: 0,
+        details: {
+          items: {
+            length: 6,
           },
         },
-        'is-on-https': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'is-on-https': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'uses-http2': {
-          score: 0,
-          details: {
-            items: {
-              length: '>15',
-            },
+      },
+      'uses-http2': {
+        score: 0,
+        details: {
+          items: {
+            length: '>15',
           },
         },
-        'external-anchors-use-rel-noopener': {
-          score: 0,
-          warnings: [/Unable to determine.*<a target="_blank">/],
-          details: {
-            items: {
-              length: 3,
-            },
+      },
+      'external-anchors-use-rel-noopener': {
+        score: 0,
+        warnings: [/Unable to determine.*<a target="_blank">/],
+        details: {
+          items: {
+            length: 3,
           },
         },
-        'appcache-manifest': {
-          score: 0,
-          displayValue: 'Found "clock.appcache"',
-        },
-        'geolocation-on-start': {
-          score: 0,
-        },
-        'no-document-write': {
-          score: 0,
-          details: {
-            items: {
-              length: 3,
-            },
+      },
+      'appcache-manifest': {
+        score: 0,
+        displayValue: 'Found "clock.appcache"',
+      },
+      'geolocation-on-start': {
+        score: 0,
+      },
+      'no-document-write': {
+        score: 0,
+        details: {
+          items: {
+            length: 3,
           },
         },
-        'no-vulnerable-libraries': {
-          score: 0,
-          details: {
-            items: {
-              length: 1,
-            },
+      },
+      'no-vulnerable-libraries': {
+        score: 0,
+        details: {
+          items: {
+            length: 1,
           },
         },
-        'notification-on-start': {
-          score: 0,
-        },
-        'render-blocking-resources': {
-          score: '<1',
-          rawValue: '>100',
-          details: {
-            items: {
-              length: 7,
-            },
+      },
+      'notification-on-start': {
+        score: 0,
+      },
+      'render-blocking-resources': {
+        score: '<1',
+        rawValue: '>100',
+        details: {
+          items: {
+            length: 7,
           },
         },
-        'uses-passive-event-listeners': {
-          score: 0,
-          details: {
-            items: {
+      },
+      'uses-passive-event-listeners': {
+        score: 0,
+        details: {
+          items: {
             // Note: Originally this was 7 but M56 defaults document-level
             // listeners to passive. See https://www.chromestatus.com/features/5093566007214080
             // Note: It was 4, but {passive:false} doesn't get a warning as of M63: https://crbug.com/770208
             // Note: It was 3, but wheel events are now also passive as of field trial in M71 https://crbug.com/626196
-              length: '>=1',
-            },
+            length: '>=1',
           },
         },
-        'deprecations': {
-          score: 0,
-          details: {
-            items: {
+      },
+      'deprecations': {
+        score: 0,
+        details: {
+          items: {
             // Note: HTML Imports added to deprecations in m70, so 3 before, 4 after.
-              length: '>=3',
+            length: '>=3',
+          },
+        },
+      },
+      'password-inputs-can-be-pasted-into': {
+        score: 0,
+        details: {
+          items: {
+            length: 2,
+          },
+        },
+      },
+      'image-aspect-ratio': {
+        score: 0,
+        details: {
+          items: {
+            0: {
+              displayedAspectRatio: /^480 x 57/,
             },
+            length: 1,
           },
         },
-        'password-inputs-can-be-pasted-into': {
-          score: 0,
-          details: {
-            items: {
-              length: 2,
+      },
+      'efficient-animated-content': {
+        score: '<0.5',
+        details: {
+          overallSavingsMs: '>2000',
+          items: [
+            {
+              url: 'http://localhost:10200/dobetterweb/lighthouse-rotating.gif',
+              totalBytes: 934285,
+              wastedBytes: 682028,
             },
-          },
+          ],
         },
-        'image-aspect-ratio': {
-          score: 0,
-          details: {
-            items: {
-              0: {
-                displayedAspectRatio: /^480 x 57/,
-              },
-              length: 1,
-            },
-          },
-        },
-        'efficient-animated-content': {
-          score: '<0.5',
-          details: {
-            overallSavingsMs: '>2000',
-            items: [
-              {
-                url: 'http://localhost:10200/dobetterweb/lighthouse-rotating.gif',
-                totalBytes: 934285,
-                wastedBytes: 682028,
-              },
-            ],
-          },
-        },
-        'js-libraries': {
-          score: 1,
-          details: {
-            items: [{
-              name: 'jQuery',
-            }],
-          },
+      },
+      'js-libraries': {
+        score: 1,
+        details: {
+          items: [{
+            name: 'jQuery',
+          }],
         },
       },
     },

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -10,18 +10,18 @@
  */
 module.exports = [
   {
+    errorCode: 'PAGE_HUNG',
     lhr: {
       requestedUrl: 'http://localhost:10200/infinite-loop.html',
       finalUrl: 'http://localhost:10200/infinite-loop.html',
-      errorCode: 'PAGE_HUNG',
       audits: {},
     },
   },
   {
+    errorCode: 'INSECURE_DOCUMENT_REQUEST',
     lhr: {
       requestedUrl: 'https://expired.badssl.com',
       finalUrl: 'https://expired.badssl.com',
-      errorCode: 'INSECURE_DOCUMENT_REQUEST',
       audits: {},
     },
   },

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -10,15 +10,19 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/infinite-loop.html',
-    finalUrl: 'http://localhost:10200/infinite-loop.html',
-    errorCode: 'PAGE_HUNG',
-    audits: {},
+    lhr: {
+      requestedUrl: 'http://localhost:10200/infinite-loop.html',
+      finalUrl: 'http://localhost:10200/infinite-loop.html',
+      errorCode: 'PAGE_HUNG',
+      audits: {},
+    },
   },
   {
-    requestedUrl: 'https://expired.badssl.com',
-    finalUrl: 'https://expired.badssl.com',
-    errorCode: 'INSECURE_DOCUMENT_REQUEST',
-    audits: {},
+    lhr: {
+      requestedUrl: 'https://expired.badssl.com',
+      finalUrl: 'https://expired.badssl.com',
+      errorCode: 'INSECURE_DOCUMENT_REQUEST',
+      audits: {},
+    },
   },
 ];

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -10,19 +10,15 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/infinite-loop.html',
-      finalUrl: 'http://localhost:10200/infinite-loop.html',
-      errorCode: 'PAGE_HUNG',
-      audits: {},
-    },
+    requestedUrl: 'http://localhost:10200/infinite-loop.html',
+    finalUrl: 'http://localhost:10200/infinite-loop.html',
+    errorCode: 'PAGE_HUNG',
+    audits: {},
   },
   {
-    lhr: {
-      requestedUrl: 'https://expired.badssl.com',
-      finalUrl: 'https://expired.badssl.com',
-      errorCode: 'INSECURE_DOCUMENT_REQUEST',
-      audits: {},
-    },
+    requestedUrl: 'https://expired.badssl.com',
+    finalUrl: 'https://expired.badssl.com',
+    errorCode: 'INSECURE_DOCUMENT_REQUEST',
+    audits: {},
   },
 ];

--- a/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
@@ -12,162 +12,167 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/online-only.html',
-    finalUrl: 'http://localhost:10200/online-only.html',
-    audits: {
-      'is-on-https': {
-        score: 1,
+    lhr: {
+      requestedUrl: 'http://localhost:10200/online-only.html',
+      finalUrl: 'http://localhost:10200/online-only.html',
+      audits: {
+        'is-on-https': {
+          score: 1,
+        },
+        'uses-http2': {
+          score: 0,
+        },
+        'external-anchors-use-rel-noopener': {
+          score: 1,
+        },
+        'appcache-manifest': {
+          score: 1,
+        },
+        'geolocation-on-start': {
+          score: 1,
+        },
+        'render-blocking-resources': {
+          score: 1,
+        },
+        'no-document-write': {
+          score: 1,
+        },
+        'uses-passive-event-listeners': {
+          score: 1,
+        },
+        'password-inputs-can-be-pasted-into': {
+          score: 1,
+        },
+        'redirects-http': {
+          score: 0,
+        },
+        'service-worker': {
+          score: 0,
+        },
+        'works-offline': {
+          score: 0,
+        },
+        'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
+          score: 1,
+        },
+        'user-timings': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'critical-request-chains': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'installable-manifest': {
+          score: 0,
+          explanation: 'Failures: No manifest was fetched.',
+          details: {items: [{isParseFailure: true}]},
+        },
+        'splash-screen': {
+          score: 0,
+        },
+        'themed-omnibox': {
+          score: 0,
+        },
+        'aria-valid-attr': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'aria-allowed-attr': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'color-contrast': {
+          score: 1,
+        },
+        'image-alt': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'label': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'tabindex': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'content-width': {
+          score: 1,
+        },
       },
-      'uses-http2': {
-        score: 0,
-      },
-      'external-anchors-use-rel-noopener': {
-        score: 1,
-      },
-      'appcache-manifest': {
-        score: 1,
-      },
-      'geolocation-on-start': {
-        score: 1,
-      },
-      'render-blocking-resources': {
-        score: 1,
-      },
-      'no-document-write': {
-        score: 1,
-      },
-      'uses-passive-event-listeners': {
-        score: 1,
-      },
-      'password-inputs-can-be-pasted-into': {
-        score: 1,
-      },
-      'redirects-http': {
-        score: 0,
-      },
-      'service-worker': {
-        score: 0,
-      },
-      'works-offline': {
-        score: 0,
-      },
-      'viewport': {
-        score: 1,
-      },
-      'without-javascript': {
-        score: 1,
-      },
-      'user-timings': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'critical-request-chains': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'installable-manifest': {
-        score: 0,
-        explanation: 'Failures: No manifest was fetched.',
-        details: {items: [{isParseFailure: true}]},
-      },
-      'splash-screen': {
-        score: 0,
-      },
-      'themed-omnibox': {
-        score: 0,
-      },
-      'aria-valid-attr': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'aria-allowed-attr': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'color-contrast': {
-        score: 1,
-      },
-      'image-alt': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'label': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'tabindex': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'content-width': {
-        score: 1,
+    },
+  },
+  {
+    lhr: {
+      requestedUrl: 'http://localhost:10503/offline-ready.html',
+      finalUrl: 'http://localhost:10503/offline-ready.html',
+      audits: {
+        'is-on-https': {
+          score: 1,
+        },
+        'redirects-http': {
+          score: 0,
+        },
+        'service-worker': {
+          score: 1,
+        },
+        'works-offline': {
+          score: 1,
+        },
+        'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
+          score: 1,
+        },
+        'user-timings': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'critical-request-chains': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'installable-manifest': {
+          score: 1,
+        },
+        'splash-screen': {
+          score: 0,
+        },
+        'themed-omnibox': {
+          score: 0,
+        },
+        'aria-valid-attr': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'aria-allowed-attr': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'color-contrast': {
+          score: 1,
+        },
+        'image-alt': {
+          score: 0,
+        },
+        'label': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'tabindex': {
+          scoreDisplayMode: 'notApplicable',
+        },
+        'content-width': {
+          score: 1,
+        },
       },
     },
   },
 
   {
-    requestedUrl: 'http://localhost:10503/offline-ready.html',
-    finalUrl: 'http://localhost:10503/offline-ready.html',
-    audits: {
-      'is-on-https': {
-        score: 1,
-      },
-      'redirects-http': {
-        score: 0,
-      },
-      'service-worker': {
-        score: 1,
-      },
-      'works-offline': {
-        score: 1,
-      },
-      'viewport': {
-        score: 1,
-      },
-      'without-javascript': {
-        score: 1,
-      },
-      'user-timings': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'critical-request-chains': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'installable-manifest': {
-        score: 1,
-      },
-      'splash-screen': {
-        score: 0,
-      },
-      'themed-omnibox': {
-        score: 0,
-      },
-      'aria-valid-attr': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'aria-allowed-attr': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'color-contrast': {
-        score: 1,
-      },
-      'image-alt': {
-        score: 0,
-      },
-      'label': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'tabindex': {
-        scoreDisplayMode: 'notApplicable',
-      },
-      'content-width': {
-        score: 1,
-      },
-    },
-  },
-
-  {
-    requestedUrl: 'http://localhost:10503/offline-ready.html?slow',
-    finalUrl: 'http://localhost:10503/offline-ready.html?slow',
-    audits: {
-      'service-worker': {
-        score: 1,
-      },
-      'works-offline': {
-        score: 1,
+    lhr: {
+      requestedUrl: 'http://localhost:10503/offline-ready.html?slow',
+      finalUrl: 'http://localhost:10503/offline-ready.html?slow',
+      audits: {
+        'service-worker': {
+          score: 1,
+        },
+        'works-offline': {
+          score: 1,
+        },
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
+++ b/lighthouse-cli/test/smokehouse/offline-local/offline-expectations.js
@@ -12,167 +12,162 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/online-only.html',
-      finalUrl: 'http://localhost:10200/online-only.html',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'uses-http2': {
-          score: 0,
-        },
-        'external-anchors-use-rel-noopener': {
-          score: 1,
-        },
-        'appcache-manifest': {
-          score: 1,
-        },
-        'geolocation-on-start': {
-          score: 1,
-        },
-        'render-blocking-resources': {
-          score: 1,
-        },
-        'no-document-write': {
-          score: 1,
-        },
-        'uses-passive-event-listeners': {
-          score: 1,
-        },
-        'password-inputs-can-be-pasted-into': {
-          score: 1,
-        },
-        'redirects-http': {
-          score: 0,
-        },
-        'service-worker': {
-          score: 0,
-        },
-        'works-offline': {
-          score: 0,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'without-javascript': {
-          score: 1,
-        },
-        'user-timings': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'critical-request-chains': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'installable-manifest': {
-          score: 0,
-          explanation: 'Failures: No manifest was fetched.',
-          details: {items: [{isParseFailure: true}]},
-        },
-        'splash-screen': {
-          score: 0,
-        },
-        'themed-omnibox': {
-          score: 0,
-        },
-        'aria-valid-attr': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'aria-allowed-attr': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'color-contrast': {
-          score: 1,
-        },
-        'image-alt': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'label': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'tabindex': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'content-width': {
-          score: 1,
-        },
+    requestedUrl: 'http://localhost:10200/online-only.html',
+    finalUrl: 'http://localhost:10200/online-only.html',
+    audits: {
+      'is-on-https': {
+        score: 1,
       },
-    },
-  },
-  {
-    lhr: {
-      requestedUrl: 'http://localhost:10503/offline-ready.html',
-      finalUrl: 'http://localhost:10503/offline-ready.html',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'redirects-http': {
-          score: 0,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'works-offline': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'without-javascript': {
-          score: 1,
-        },
-        'user-timings': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'critical-request-chains': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'installable-manifest': {
-          score: 1,
-        },
-        'splash-screen': {
-          score: 0,
-        },
-        'themed-omnibox': {
-          score: 0,
-        },
-        'aria-valid-attr': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'aria-allowed-attr': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'color-contrast': {
-          score: 1,
-        },
-        'image-alt': {
-          score: 0,
-        },
-        'label': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'tabindex': {
-          scoreDisplayMode: 'notApplicable',
-        },
-        'content-width': {
-          score: 1,
-        },
+      'uses-http2': {
+        score: 0,
+      },
+      'external-anchors-use-rel-noopener': {
+        score: 1,
+      },
+      'appcache-manifest': {
+        score: 1,
+      },
+      'geolocation-on-start': {
+        score: 1,
+      },
+      'render-blocking-resources': {
+        score: 1,
+      },
+      'no-document-write': {
+        score: 1,
+      },
+      'uses-passive-event-listeners': {
+        score: 1,
+      },
+      'password-inputs-can-be-pasted-into': {
+        score: 1,
+      },
+      'redirects-http': {
+        score: 0,
+      },
+      'service-worker': {
+        score: 0,
+      },
+      'works-offline': {
+        score: 0,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'without-javascript': {
+        score: 1,
+      },
+      'user-timings': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'critical-request-chains': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'installable-manifest': {
+        score: 0,
+        explanation: 'Failures: No manifest was fetched.',
+        details: {items: [{isParseFailure: true}]},
+      },
+      'splash-screen': {
+        score: 0,
+      },
+      'themed-omnibox': {
+        score: 0,
+      },
+      'aria-valid-attr': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'aria-allowed-attr': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'color-contrast': {
+        score: 1,
+      },
+      'image-alt': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'label': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'tabindex': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'content-width': {
+        score: 1,
       },
     },
   },
 
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10503/offline-ready.html?slow',
-      finalUrl: 'http://localhost:10503/offline-ready.html?slow',
-      audits: {
-        'service-worker': {
-          score: 1,
-        },
-        'works-offline': {
-          score: 1,
-        },
+    requestedUrl: 'http://localhost:10503/offline-ready.html',
+    finalUrl: 'http://localhost:10503/offline-ready.html',
+    audits: {
+      'is-on-https': {
+        score: 1,
+      },
+      'redirects-http': {
+        score: 0,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'works-offline': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'without-javascript': {
+        score: 1,
+      },
+      'user-timings': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'critical-request-chains': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'installable-manifest': {
+        score: 1,
+      },
+      'splash-screen': {
+        score: 0,
+      },
+      'themed-omnibox': {
+        score: 0,
+      },
+      'aria-valid-attr': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'aria-allowed-attr': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'color-contrast': {
+        score: 1,
+      },
+      'image-alt': {
+        score: 0,
+      },
+      'label': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'tabindex': {
+        scoreDisplayMode: 'notApplicable',
+      },
+      'content-width': {
+        score: 1,
+      },
+    },
+  },
+
+  {
+    requestedUrl: 'http://localhost:10503/offline-ready.html?slow',
+    finalUrl: 'http://localhost:10503/offline-ready.html?slow',
+    audits: {
+      'service-worker': {
+        score: 1,
+      },
+      'works-offline': {
+        score: 1,
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/oopif-expectations.js
+++ b/lighthouse-cli/test/smokehouse/oopif-expectations.js
@@ -10,17 +10,19 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/oopif.html',
-    finalUrl: 'http://localhost:10200/oopif.html',
-    audits: {
-      'network-requests': {
-        details: {
-          items: {
+    lhr: {
+      requestedUrl: 'http://localhost:10200/oopif.html',
+      finalUrl: 'http://localhost:10200/oopif.html',
+      audits: {
+        'network-requests': {
+          details: {
+            items: {
             // We want to make sure we are finding the iframe's requests (paulirish.com) *AND*
             // the iframe's iframe's iframe's requests (youtube.com/doubleclick/etc).
             // - paulirish.com ~40-60 requests
             // - paulirish.com + all descendant iframes ~80-90 requests
-            length: '>70',
+              length: '>70',
+            },
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/oopif-expectations.js
+++ b/lighthouse-cli/test/smokehouse/oopif-expectations.js
@@ -10,19 +10,17 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/oopif.html',
-      finalUrl: 'http://localhost:10200/oopif.html',
-      audits: {
-        'network-requests': {
-          details: {
-            items: {
+    requestedUrl: 'http://localhost:10200/oopif.html',
+    finalUrl: 'http://localhost:10200/oopif.html',
+    audits: {
+      'network-requests': {
+        details: {
+          items: {
             // We want to make sure we are finding the iframe's requests (paulirish.com) *AND*
             // the iframe's iframe's iframe's requests (youtube.com/doubleclick/etc).
             // - paulirish.com ~40-60 requests
             // - paulirish.com + all descendant iframes ~80-90 requests
-              length: '>70',
-            },
+            length: '>70',
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -10,68 +10,72 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/preload.html',
-    finalUrl: 'http://localhost:10200/preload.html',
-    audits: {
-      'speed-index': {
-        score: '>=0.80',
-      },
-      'first-meaningful-paint': {
-        score: '>=0.90',
-      },
-      'first-cpu-idle': {
-        score: '>=0.90',
-      },
-      'interactive': {
-        score: '>=0.90',
-      },
-      'time-to-first-byte': {
+    lhr: {
+      requestedUrl: 'http://localhost:10200/preload.html',
+      finalUrl: 'http://localhost:10200/preload.html',
+      audits: {
+        'speed-index': {
+          score: '>=0.80',
+        },
+        'first-meaningful-paint': {
+          score: '>=0.90',
+        },
+        'first-cpu-idle': {
+          score: '>=0.90',
+        },
+        'interactive': {
+          score: '>=0.90',
+        },
+        'time-to-first-byte': {
         // Can be flaky, so test float rawValue instead of boolean score
-        rawValue: '<1000',
-      },
-      'network-requests': {
-        details: {
-          items: {
-            length: '>5',
+          rawValue: '<1000',
+        },
+        'network-requests': {
+          details: {
+            items: {
+              length: '>5',
+            },
           },
         },
-      },
-      'uses-rel-preload': {
-        score: '<1',
-        rawValue: '>500',
-        warnings: {
-          0: /level-2.*warning/,
-          length: 1,
-        },
-        details: {
-          items: {
+        'uses-rel-preload': {
+          score: '<1',
+          rawValue: '>500',
+          warnings: {
+            0: /level-2.*warning/,
             length: 1,
           },
+          details: {
+            items: {
+              length: 1,
+            },
+          },
         },
-      },
-      'uses-rel-preconnect': {
-        score: '<1',
-        warnings: {
-          0: /fonts.googleapis/,
-          length: 1,
-        },
-        details: {
-          items: {
+        'uses-rel-preconnect': {
+          score: '<1',
+          warnings: {
+            0: /fonts.googleapis/,
             length: 1,
+          },
+          details: {
+            items: {
+              length: 1,
+            },
           },
         },
       },
     },
   },
   {
-    requestedUrl: 'http://localhost:10200/perf/fonts.html',
-    finalUrl: 'http://localhost:10200/perf/fonts.html',
-    audits: {
-      'font-display': {
-        score: 0,
-        details: {
-          items: {
-            length: 2,
+    lhr: {
+      requestedUrl: 'http://localhost:10200/perf/fonts.html',
+      finalUrl: 'http://localhost:10200/perf/fonts.html',
+      audits: {
+        'font-display': {
+          score: 0,
+          details: {
+            items: {
+              length: 2,
+            },
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -10,72 +10,68 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/preload.html',
-      finalUrl: 'http://localhost:10200/preload.html',
-      audits: {
-        'speed-index': {
-          score: '>=0.80',
-        },
-        'first-meaningful-paint': {
-          score: '>=0.90',
-        },
-        'first-cpu-idle': {
-          score: '>=0.90',
-        },
-        'interactive': {
-          score: '>=0.90',
-        },
-        'time-to-first-byte': {
+    requestedUrl: 'http://localhost:10200/preload.html',
+    finalUrl: 'http://localhost:10200/preload.html',
+    audits: {
+      'speed-index': {
+        score: '>=0.80',
+      },
+      'first-meaningful-paint': {
+        score: '>=0.90',
+      },
+      'first-cpu-idle': {
+        score: '>=0.90',
+      },
+      'interactive': {
+        score: '>=0.90',
+      },
+      'time-to-first-byte': {
         // Can be flaky, so test float rawValue instead of boolean score
-          rawValue: '<1000',
-        },
-        'network-requests': {
-          details: {
-            items: {
-              length: '>5',
-            },
+        rawValue: '<1000',
+      },
+      'network-requests': {
+        details: {
+          items: {
+            length: '>5',
           },
         },
-        'uses-rel-preload': {
-          score: '<1',
-          rawValue: '>500',
-          warnings: {
-            0: /level-2.*warning/,
+      },
+      'uses-rel-preload': {
+        score: '<1',
+        rawValue: '>500',
+        warnings: {
+          0: /level-2.*warning/,
+          length: 1,
+        },
+        details: {
+          items: {
             length: 1,
           },
-          details: {
-            items: {
-              length: 1,
-            },
-          },
         },
-        'uses-rel-preconnect': {
-          score: '<1',
-          warnings: {
-            0: /fonts.googleapis/,
+      },
+      'uses-rel-preconnect': {
+        score: '<1',
+        warnings: {
+          0: /fonts.googleapis/,
+          length: 1,
+        },
+        details: {
+          items: {
             length: 1,
-          },
-          details: {
-            items: {
-              length: 1,
-            },
           },
         },
       },
     },
   },
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/perf/fonts.html',
-      finalUrl: 'http://localhost:10200/perf/fonts.html',
-      audits: {
-        'font-display': {
-          score: 0,
-          details: {
-            items: {
-              length: 2,
-            },
+    requestedUrl: 'http://localhost:10200/perf/fonts.html',
+    finalUrl: 'http://localhost:10200/perf/fonts.html',
+    audits: {
+      'font-display': {
+        score: 0,
+        details: {
+          items: {
+            length: 2,
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/perf/lantern-expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/lantern-expectations.js
@@ -10,17 +10,19 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/online-only.html',
-    finalUrl: 'http://localhost:10200/online-only.html',
-    audits: {
-      'first-contentful-paint': {
-        rawValue: '>2000',
-      },
-      'first-cpu-idle': {
-        rawValue: '>2000',
-      },
-      'interactive': {
-        rawValue: '>2000',
+    lhr: {
+      requestedUrl: 'http://localhost:10200/online-only.html',
+      finalUrl: 'http://localhost:10200/online-only.html',
+      audits: {
+        'first-contentful-paint': {
+          rawValue: '>2000',
+        },
+        'first-cpu-idle': {
+          rawValue: '>2000',
+        },
+        'interactive': {
+          rawValue: '>2000',
+        },
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/perf/lantern-expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/lantern-expectations.js
@@ -10,19 +10,17 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/online-only.html',
-      finalUrl: 'http://localhost:10200/online-only.html',
-      audits: {
-        'first-contentful-paint': {
-          rawValue: '>2000',
-        },
-        'first-cpu-idle': {
-          rawValue: '>2000',
-        },
-        'interactive': {
-          rawValue: '>2000',
-        },
+    requestedUrl: 'http://localhost:10200/online-only.html',
+    finalUrl: 'http://localhost:10200/online-only.html',
+    audits: {
+      'first-contentful-paint': {
+        rawValue: '>2000',
+      },
+      'first-cpu-idle': {
+        rawValue: '>2000',
+      },
+      'interactive': {
+        rawValue: '>2000',
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -23,121 +23,125 @@ const pwaDetailsExpectations = {
  */
 module.exports = [
   {
-    requestedUrl: 'https://airhorner.com',
-    finalUrl: 'https://airhorner.com/',
-    audits: {
-      'is-on-https': {
-        score: 1,
-      },
-      'redirects-http': {
-        score: 1,
-      },
-      'service-worker': {
-        score: 1,
-      },
-      'works-offline': {
-        score: 1,
-      },
-      'offline-start-url': {
-        score: 1,
-      },
-      'viewport': {
-        score: 1,
-      },
-      'without-javascript': {
-        score: 1,
-      },
-      'load-fast-enough-for-pwa': {
+    lhr: {
+      requestedUrl: 'https://airhorner.com',
+      finalUrl: 'https://airhorner.com/',
+      audits: {
+        'is-on-https': {
+          score: 1,
+        },
+        'redirects-http': {
+          score: 1,
+        },
+        'service-worker': {
+          score: 1,
+        },
+        'works-offline': {
+          score: 1,
+        },
+        'offline-start-url': {
+          score: 1,
+        },
+        'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
+          score: 1,
+        },
+        'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
-      },
-      'installable-manifest': {
-        score: 1,
-        details: {items: [pwaDetailsExpectations]},
-      },
-      'splash-screen': {
-        score: 1,
-        details: {items: [pwaDetailsExpectations]},
-      },
-      'themed-omnibox': {
-        score: 1,
-        details: {items: [{...pwaDetailsExpectations, themeColor: '#2196F3'}]},
-      },
-      'content-width': {
-        score: 1,
-      },
+        },
+        'installable-manifest': {
+          score: 1,
+          details: {items: [pwaDetailsExpectations]},
+        },
+        'splash-screen': {
+          score: 1,
+          details: {items: [pwaDetailsExpectations]},
+        },
+        'themed-omnibox': {
+          score: 1,
+          details: {items: [{...pwaDetailsExpectations, themeColor: '#2196F3'}]},
+        },
+        'content-width': {
+          score: 1,
+        },
 
-      // "manual" audits. Just verify in the results.
-      'pwa-cross-browser': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-page-transitions': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-each-page-has-url': {
-        score: null,
-        scoreDisplayMode: 'manual',
+        // "manual" audits. Just verify in the results.
+        'pwa-cross-browser': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-page-transitions': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-each-page-has-url': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
       },
     },
   },
 
   {
-    requestedUrl: 'https://www.chromestatus.com/',
-    finalUrl: 'https://www.chromestatus.com/features',
-    audits: {
-      'is-on-https': {
-        score: 1,
-      },
-      'redirects-http': {
-        score: 1,
-      },
-      'service-worker': {
-        score: 1,
-      },
-      'works-offline': {
-        score: 0,
-      },
-      'offline-start-url': {
-        score: 1,
-      },
-      'viewport': {
-        score: 1,
-      },
-      'without-javascript': {
-        score: 1,
-      },
-      'load-fast-enough-for-pwa': {
+    lhr: {
+      requestedUrl: 'https://www.chromestatus.com/',
+      finalUrl: 'https://www.chromestatus.com/features',
+      audits: {
+        'is-on-https': {
+          score: 1,
+        },
+        'redirects-http': {
+          score: 1,
+        },
+        'service-worker': {
+          score: 1,
+        },
+        'works-offline': {
+          score: 0,
+        },
+        'offline-start-url': {
+          score: 1,
+        },
+        'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
+          score: 1,
+        },
+        'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
-      },
-      'installable-manifest': {
-        score: 1,
-        details: {items: [pwaDetailsExpectations]},
-      },
-      'splash-screen': {
-        score: 1,
-        details: {items: [pwaDetailsExpectations]},
-      },
-      'themed-omnibox': {
-        score: 1,
-        details: {items: [pwaDetailsExpectations]},
-      },
-      'content-width': {
-        score: 1,
-      },
+        },
+        'installable-manifest': {
+          score: 1,
+          details: {items: [pwaDetailsExpectations]},
+        },
+        'splash-screen': {
+          score: 1,
+          details: {items: [pwaDetailsExpectations]},
+        },
+        'themed-omnibox': {
+          score: 1,
+          details: {items: [pwaDetailsExpectations]},
+        },
+        'content-width': {
+          score: 1,
+        },
 
-      // "manual" audits. Just verify in the results.
-      'pwa-cross-browser': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-page-transitions': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-each-page-has-url': {
-        score: null,
-        scoreDisplayMode: 'manual',
+        // "manual" audits. Just verify in the results.
+        'pwa-cross-browser': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-page-transitions': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-each-page-has-url': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/pwa-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa-expectations.js
@@ -23,125 +23,121 @@ const pwaDetailsExpectations = {
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'https://airhorner.com',
-      finalUrl: 'https://airhorner.com/',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'works-offline': {
-          score: 1,
-        },
-        'offline-start-url': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'without-javascript': {
-          score: 1,
-        },
-        'load-fast-enough-for-pwa': {
+    requestedUrl: 'https://airhorner.com',
+    finalUrl: 'https://airhorner.com/',
+    audits: {
+      'is-on-https': {
+        score: 1,
+      },
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'works-offline': {
+        score: 1,
+      },
+      'offline-start-url': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'without-javascript': {
+        score: 1,
+      },
+      'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
-        },
-        'installable-manifest': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'splash-screen': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'themed-omnibox': {
-          score: 1,
-          details: {items: [{...pwaDetailsExpectations, themeColor: '#2196F3'}]},
-        },
-        'content-width': {
-          score: 1,
-        },
+      },
+      'installable-manifest': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'splash-screen': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'themed-omnibox': {
+        score: 1,
+        details: {items: [{...pwaDetailsExpectations, themeColor: '#2196F3'}]},
+      },
+      'content-width': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },
 
   {
-    lhr: {
-      requestedUrl: 'https://www.chromestatus.com/',
-      finalUrl: 'https://www.chromestatus.com/features',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'works-offline': {
-          score: 0,
-        },
-        'offline-start-url': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'without-javascript': {
-          score: 1,
-        },
-        'load-fast-enough-for-pwa': {
+    requestedUrl: 'https://www.chromestatus.com/',
+    finalUrl: 'https://www.chromestatus.com/features',
+    audits: {
+      'is-on-https': {
+        score: 1,
+      },
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'works-offline': {
+        score: 0,
+      },
+      'offline-start-url': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'without-javascript': {
+        score: 1,
+      },
+      'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
-        },
-        'installable-manifest': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'splash-screen': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'themed-omnibox': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'content-width': {
-          score: 1,
-        },
+      },
+      'installable-manifest': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'splash-screen': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'themed-omnibox': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'content-width': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/pwa2-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa2-expectations.js
@@ -15,124 +15,128 @@ const jakeExpectations = {...pwaDetailsExpectations, hasShortName: false};
  */
 module.exports = [
   {
-    requestedUrl: 'https://jakearchibald.github.io/svgomg/',
-    finalUrl: 'https://jakearchibald.github.io/svgomg/',
-    audits: {
-      'is-on-https': {
-        score: 1,
-      },
-      'redirects-http': {
+    lhr: {
+      requestedUrl: 'https://jakearchibald.github.io/svgomg/',
+      finalUrl: 'https://jakearchibald.github.io/svgomg/',
+      audits: {
+        'is-on-https': {
+          score: 1,
+        },
+        'redirects-http': {
         // Note: relies on JS redirect.
         // see https://github.com/GoogleChrome/lighthouse/issues/2383
-        score: 0,
-      },
-      'service-worker': {
-        score: 1,
-      },
-      'works-offline': {
-        score: 1,
-      },
-      'offline-start-url': {
-        score: 1,
-      },
-      'viewport': {
-        score: 1,
-      },
-      'without-javascript': {
-        score: 1,
-      },
-      'load-fast-enough-for-pwa': {
+          score: 0,
+        },
+        'service-worker': {
+          score: 1,
+        },
+        'works-offline': {
+          score: 1,
+        },
+        'offline-start-url': {
+          score: 1,
+        },
+        'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
+          score: 1,
+        },
+        'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
-      },
-      'installable-manifest': {
-        score: 0,
-        details: {items: [jakeExpectations]},
-        explanation: /^Failures: .*short_name/,
-      },
-      'splash-screen': {
-        score: 1,
-        details: {items: [jakeExpectations]},
-      },
-      'themed-omnibox': {
-        score: 1,
-        details: {items: [jakeExpectations]},
-      },
-      'content-width': {
-        score: 1,
-      },
+        },
+        'installable-manifest': {
+          score: 0,
+          details: {items: [jakeExpectations]},
+          explanation: /^Failures: .*short_name/,
+        },
+        'splash-screen': {
+          score: 1,
+          details: {items: [jakeExpectations]},
+        },
+        'themed-omnibox': {
+          score: 1,
+          details: {items: [jakeExpectations]},
+        },
+        'content-width': {
+          score: 1,
+        },
 
-      // "manual" audits. Just verify in the results.
-      'pwa-cross-browser': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-page-transitions': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-each-page-has-url': {
-        score: null,
-        scoreDisplayMode: 'manual',
+        // "manual" audits. Just verify in the results.
+        'pwa-cross-browser': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-page-transitions': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-each-page-has-url': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
       },
     },
   },
 
   {
-    requestedUrl: 'https://shop.polymer-project.org/',
-    finalUrl: 'https://shop.polymer-project.org/',
-    audits: {
-      'is-on-https': {
-        score: 1,
-      },
-      'redirects-http': {
-        score: 1,
-      },
-      'service-worker': {
-        score: 1,
-      },
-      'works-offline': {
-        score: 1,
-      },
-      'offline-start-url': {
-        score: 1,
-      },
-      'viewport': {
-        score: 1,
-      },
-      'without-javascript': {
-        score: 1,
-      },
-      'load-fast-enough-for-pwa': {
+    lhr: {
+      requestedUrl: 'https://shop.polymer-project.org/',
+      finalUrl: 'https://shop.polymer-project.org/',
+      audits: {
+        'is-on-https': {
+          score: 1,
+        },
+        'redirects-http': {
+          score: 1,
+        },
+        'service-worker': {
+          score: 1,
+        },
+        'works-offline': {
+          score: 1,
+        },
+        'offline-start-url': {
+          score: 1,
+        },
+        'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
+          score: 1,
+        },
+        'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
-      },
-      'installable-manifest': {
-        score: 1,
-        details: {items: [pwaDetailsExpectations]},
-      },
-      'splash-screen': {
-        score: 1,
-        details: {items: [pwaDetailsExpectations]},
-      },
-      'themed-omnibox': {
-        score: 1,
-        details: {items: [pwaDetailsExpectations]},
-      },
-      'content-width': {
-        score: 1,
-      },
+        },
+        'installable-manifest': {
+          score: 1,
+          details: {items: [pwaDetailsExpectations]},
+        },
+        'splash-screen': {
+          score: 1,
+          details: {items: [pwaDetailsExpectations]},
+        },
+        'themed-omnibox': {
+          score: 1,
+          details: {items: [pwaDetailsExpectations]},
+        },
+        'content-width': {
+          score: 1,
+        },
 
-      // "manual" audits. Just verify in the results.
-      'pwa-cross-browser': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-page-transitions': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-each-page-has-url': {
-        score: null,
-        scoreDisplayMode: 'manual',
+        // "manual" audits. Just verify in the results.
+        'pwa-cross-browser': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-page-transitions': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-each-page-has-url': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/pwa2-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa2-expectations.js
@@ -15,128 +15,124 @@ const jakeExpectations = {...pwaDetailsExpectations, hasShortName: false};
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'https://jakearchibald.github.io/svgomg/',
-      finalUrl: 'https://jakearchibald.github.io/svgomg/',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'redirects-http': {
+    requestedUrl: 'https://jakearchibald.github.io/svgomg/',
+    finalUrl: 'https://jakearchibald.github.io/svgomg/',
+    audits: {
+      'is-on-https': {
+        score: 1,
+      },
+      'redirects-http': {
         // Note: relies on JS redirect.
         // see https://github.com/GoogleChrome/lighthouse/issues/2383
-          score: 0,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'works-offline': {
-          score: 1,
-        },
-        'offline-start-url': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'without-javascript': {
-          score: 1,
-        },
-        'load-fast-enough-for-pwa': {
+        score: 0,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'works-offline': {
+        score: 1,
+      },
+      'offline-start-url': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'without-javascript': {
+        score: 1,
+      },
+      'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
-        },
-        'installable-manifest': {
-          score: 0,
-          details: {items: [jakeExpectations]},
-          explanation: /^Failures: .*short_name/,
-        },
-        'splash-screen': {
-          score: 1,
-          details: {items: [jakeExpectations]},
-        },
-        'themed-omnibox': {
-          score: 1,
-          details: {items: [jakeExpectations]},
-        },
-        'content-width': {
-          score: 1,
-        },
+      },
+      'installable-manifest': {
+        score: 0,
+        details: {items: [jakeExpectations]},
+        explanation: /^Failures: .*short_name/,
+      },
+      'splash-screen': {
+        score: 1,
+        details: {items: [jakeExpectations]},
+      },
+      'themed-omnibox': {
+        score: 1,
+        details: {items: [jakeExpectations]},
+      },
+      'content-width': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },
 
   {
-    lhr: {
-      requestedUrl: 'https://shop.polymer-project.org/',
-      finalUrl: 'https://shop.polymer-project.org/',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'works-offline': {
-          score: 1,
-        },
-        'offline-start-url': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'without-javascript': {
-          score: 1,
-        },
-        'load-fast-enough-for-pwa': {
+    requestedUrl: 'https://shop.polymer-project.org/',
+    finalUrl: 'https://shop.polymer-project.org/',
+    audits: {
+      'is-on-https': {
+        score: 1,
+      },
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'works-offline': {
+        score: 1,
+      },
+      'offline-start-url': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'without-javascript': {
+        score: 1,
+      },
+      'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran.
-        },
-        'installable-manifest': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'splash-screen': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'themed-omnibox': {
-          score: 1,
-          details: {items: [pwaDetailsExpectations]},
-        },
-        'content-width': {
-          score: 1,
-        },
+      },
+      'installable-manifest': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'splash-screen': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'themed-omnibox': {
+        score: 1,
+        details: {items: [pwaDetailsExpectations]},
+      },
+      'content-width': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/pwa3-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa3-expectations.js
@@ -15,61 +15,63 @@ const pwaRocksExpectations = {...pwaDetailsExpectations, hasIconsAtLeast512px: f
  */
 module.exports = [
   {
-    requestedUrl: 'https://pwa.rocks',
-    finalUrl: 'https://pwa.rocks/',
-    audits: {
-      'is-on-https': {
-        score: 1,
-      },
-      'redirects-http': {
-        score: 1,
-      },
-      'service-worker': {
-        score: 1,
-      },
-      'works-offline': {
-        score: 1,
-      },
-      'offline-start-url': {
-        score: 1,
-      },
-      'viewport': {
-        score: 1,
-      },
-      'without-javascript': {
-        score: 1,
-      },
-      'load-fast-enough-for-pwa': {
+    lhr: {
+      requestedUrl: 'https://pwa.rocks',
+      finalUrl: 'https://pwa.rocks/',
+      audits: {
+        'is-on-https': {
+          score: 1,
+        },
+        'redirects-http': {
+          score: 1,
+        },
+        'service-worker': {
+          score: 1,
+        },
+        'works-offline': {
+          score: 1,
+        },
+        'offline-start-url': {
+          score: 1,
+        },
+        'viewport': {
+          score: 1,
+        },
+        'without-javascript': {
+          score: 1,
+        },
+        'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran .
-      },
-      'installable-manifest': {
-        score: 1,
-        details: {items: [pwaRocksExpectations]},
-      },
-      'splash-screen': {
-        score: 0,
-        details: {items: [pwaRocksExpectations]},
-      },
-      'themed-omnibox': {
-        score: 0,
-        details: {items: [pwaRocksExpectations]},
-      },
-      'content-width': {
-        score: 1,
-      },
+        },
+        'installable-manifest': {
+          score: 1,
+          details: {items: [pwaRocksExpectations]},
+        },
+        'splash-screen': {
+          score: 0,
+          details: {items: [pwaRocksExpectations]},
+        },
+        'themed-omnibox': {
+          score: 0,
+          details: {items: [pwaRocksExpectations]},
+        },
+        'content-width': {
+          score: 1,
+        },
 
-      // "manual" audits. Just verify in the results.
-      'pwa-cross-browser': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-page-transitions': {
-        score: null,
-        scoreDisplayMode: 'manual',
-      },
-      'pwa-each-page-has-url': {
-        score: null,
-        scoreDisplayMode: 'manual',
+        // "manual" audits. Just verify in the results.
+        'pwa-cross-browser': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-page-transitions': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
+        'pwa-each-page-has-url': {
+          score: null,
+          scoreDisplayMode: 'manual',
+        },
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/pwa3-expectations.js
+++ b/lighthouse-cli/test/smokehouse/pwa3-expectations.js
@@ -15,63 +15,61 @@ const pwaRocksExpectations = {...pwaDetailsExpectations, hasIconsAtLeast512px: f
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'https://pwa.rocks',
-      finalUrl: 'https://pwa.rocks/',
-      audits: {
-        'is-on-https': {
-          score: 1,
-        },
-        'redirects-http': {
-          score: 1,
-        },
-        'service-worker': {
-          score: 1,
-        },
-        'works-offline': {
-          score: 1,
-        },
-        'offline-start-url': {
-          score: 1,
-        },
-        'viewport': {
-          score: 1,
-        },
-        'without-javascript': {
-          score: 1,
-        },
-        'load-fast-enough-for-pwa': {
+    requestedUrl: 'https://pwa.rocks',
+    finalUrl: 'https://pwa.rocks/',
+    audits: {
+      'is-on-https': {
+        score: 1,
+      },
+      'redirects-http': {
+        score: 1,
+      },
+      'service-worker': {
+        score: 1,
+      },
+      'works-offline': {
+        score: 1,
+      },
+      'offline-start-url': {
+        score: 1,
+      },
+      'viewport': {
+        score: 1,
+      },
+      'without-javascript': {
+        score: 1,
+      },
+      'load-fast-enough-for-pwa': {
         // Ignore speed test; just verify that it ran .
-        },
-        'installable-manifest': {
-          score: 1,
-          details: {items: [pwaRocksExpectations]},
-        },
-        'splash-screen': {
-          score: 0,
-          details: {items: [pwaRocksExpectations]},
-        },
-        'themed-omnibox': {
-          score: 0,
-          details: {items: [pwaRocksExpectations]},
-        },
-        'content-width': {
-          score: 1,
-        },
+      },
+      'installable-manifest': {
+        score: 1,
+        details: {items: [pwaRocksExpectations]},
+      },
+      'splash-screen': {
+        score: 0,
+        details: {items: [pwaRocksExpectations]},
+      },
+      'themed-omnibox': {
+        score: 0,
+        details: {items: [pwaRocksExpectations]},
+      },
+      'content-width': {
+        score: 1,
+      },
 
-        // "manual" audits. Just verify in the results.
-        'pwa-cross-browser': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-page-transitions': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
-        'pwa-each-page-has-url': {
-          score: null,
-          scoreDisplayMode: 'manual',
-        },
+      // "manual" audits. Just verify in the results.
+      'pwa-cross-browser': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-page-transitions': {
+        score: null,
+        scoreDisplayMode: 'manual',
+      },
+      'pwa-each-page-has-url': {
+        score: null,
+        scoreDisplayMode: 'manual',
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/redirects/expectations.js
+++ b/lighthouse-cli/test/smokehouse/redirects/expectations.js
@@ -12,30 +12,34 @@ const cacheBuster = Number(new Date());
 
 module.exports = [
   {
-    requestedUrl: `http://localhost:10200/online-only.html?delay=500&redirect=%2Foffline-only.html%3Fcb=${cacheBuster}%26delay=500%26redirect%3D%2Fredirects-final.html`,
-    finalUrl: 'http://localhost:10200/redirects-final.html',
-    audits: {
-      'redirects': {
-        score: '<1',
-        rawValue: '>=500',
-        details: {
-          items: {
-            length: 3,
+    lhr: {
+      requestedUrl: `http://localhost:10200/online-only.html?delay=500&redirect=%2Foffline-only.html%3Fcb=${cacheBuster}%26delay=500%26redirect%3D%2Fredirects-final.html`,
+      finalUrl: 'http://localhost:10200/redirects-final.html',
+      audits: {
+        'redirects': {
+          score: '<1',
+          rawValue: '>=500',
+          details: {
+            items: {
+              length: 3,
+            },
           },
         },
       },
     },
   },
   {
-    requestedUrl: `http://localhost:10200/online-only.html?delay=300&redirect=%2Fredirects-final.html`,
-    finalUrl: 'http://localhost:10200/redirects-final.html',
-    audits: {
-      'redirects': {
-        score: 1,
-        rawValue: '>=250',
-        details: {
-          items: {
-            length: 2,
+    lhr: {
+      requestedUrl: `http://localhost:10200/online-only.html?delay=300&redirect=%2Fredirects-final.html`,
+      finalUrl: 'http://localhost:10200/redirects-final.html',
+      audits: {
+        'redirects': {
+          score: 1,
+          rawValue: '>=250',
+          details: {
+            items: {
+              length: 2,
+            },
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/redirects/expectations.js
+++ b/lighthouse-cli/test/smokehouse/redirects/expectations.js
@@ -12,34 +12,30 @@ const cacheBuster = Number(new Date());
 
 module.exports = [
   {
-    lhr: {
-      requestedUrl: `http://localhost:10200/online-only.html?delay=500&redirect=%2Foffline-only.html%3Fcb=${cacheBuster}%26delay=500%26redirect%3D%2Fredirects-final.html`,
-      finalUrl: 'http://localhost:10200/redirects-final.html',
-      audits: {
-        'redirects': {
-          score: '<1',
-          rawValue: '>=500',
-          details: {
-            items: {
-              length: 3,
-            },
+    requestedUrl: `http://localhost:10200/online-only.html?delay=500&redirect=%2Foffline-only.html%3Fcb=${cacheBuster}%26delay=500%26redirect%3D%2Fredirects-final.html`,
+    finalUrl: 'http://localhost:10200/redirects-final.html',
+    audits: {
+      'redirects': {
+        score: '<1',
+        rawValue: '>=500',
+        details: {
+          items: {
+            length: 3,
           },
         },
       },
     },
   },
   {
-    lhr: {
-      requestedUrl: `http://localhost:10200/online-only.html?delay=300&redirect=%2Fredirects-final.html`,
-      finalUrl: 'http://localhost:10200/redirects-final.html',
-      audits: {
-        'redirects': {
-          score: 1,
-          rawValue: '>=250',
-          details: {
-            items: {
-              length: 2,
-            },
+    requestedUrl: `http://localhost:10200/online-only.html?delay=300&redirect=%2Fredirects-final.html`,
+    finalUrl: 'http://localhost:10200/redirects-final.html',
+    audits: {
+      'redirects': {
+        score: 1,
+        rawValue: '>=250',
+        details: {
+          items: {
+            length: 2,
           },
         },
       },

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -37,187 +37,197 @@ const passHeaders = headersParam([[
  */
 module.exports = [
   {
-    requestedUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
-    finalUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
-    audits: {
-      'viewport': {
-        score: 1,
-      },
-      'document-title': {
-        score: 1,
-      },
-      'meta-description': {
-        score: 1,
-      },
-      'http-status-code': {
-        score: 1,
-      },
-      'font-size': {
-        score: 1,
-        details: {
-          items: {
-            length: 6,
+    lhr: {
+      requestedUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+      finalUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+      audits: {
+        'viewport': {
+          score: 1,
+        },
+        'document-title': {
+          score: 1,
+        },
+        'meta-description': {
+          score: 1,
+        },
+        'http-status-code': {
+          score: 1,
+        },
+        'font-size': {
+          score: 1,
+          details: {
+            items: {
+              length: 6,
+            },
           },
         },
+        'link-text': {
+          score: 1,
+        },
+        'is-crawlable': {
+          score: 1,
+        },
+        'hreflang': {
+          score: 1,
+        },
+        'plugins': {
+          score: 1,
+        },
+        'canonical': {
+          score: 1,
+        },
+        'robots-txt': {
+          score: null,
+          scoreDisplayMode: 'notApplicable',
+        },
       },
-      'link-text': {
-        score: 1,
-      },
-      'is-crawlable': {
-        score: 1,
-      },
-      'hreflang': {
-        score: 1,
-      },
-      'plugins': {
-        score: 1,
-      },
-      'canonical': {
-        score: 1,
-      },
-      'robots-txt': {
-        score: null,
-        scoreDisplayMode: 'notApplicable',
-      },
-    },
-  },
+    }},
   {
-    requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
-    finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
-    audits: {
-      'viewport': {
-        score: 0,
-      },
-      'document-title': {
-        score: 0,
-      },
-      'meta-description': {
-        score: 0,
-      },
-      'http-status-code': {
-        score: 1,
-      },
-      'font-size': {
-        score: 0,
-        explanation:
+    lhr: {
+      requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+      finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+      audits: {
+        'viewport': {
+          score: 0,
+        },
+        'document-title': {
+          score: 0,
+        },
+        'meta-description': {
+          score: 0,
+        },
+        'http-status-code': {
+          score: 1,
+        },
+        'font-size': {
+          score: 0,
+          explanation:
           'Text is illegible because there\'s no viewport meta tag optimized for mobile screens.',
-      },
-      'link-text': {
-        score: 0,
-        displayValue: '4 links found',
-        details: {
-          items: {
-            length: 4,
+        },
+        'link-text': {
+          score: 0,
+          displayValue: '4 links found',
+          details: {
+            items: {
+              length: 4,
+            },
           },
         },
-      },
-      'is-crawlable': {
-        score: 0,
-        details: {
-          items: {
-            length: 2,
+        'is-crawlable': {
+          score: 0,
+          details: {
+            items: {
+              length: 2,
+            },
           },
         },
-      },
-      'hreflang': {
-        score: 0,
-        details: {
-          items: {
-            length: 3,
+        'hreflang': {
+          score: 0,
+          details: {
+            items: {
+              length: 3,
+            },
           },
         },
-      },
-      'plugins': {
-        score: 0,
-        details: {
-          items: {
-            length: 3,
+        'plugins': {
+          score: 0,
+          details: {
+            items: {
+              length: 3,
+            },
           },
         },
-      },
-      'canonical': {
-        score: 0,
-        explanation: 'Multiple conflicting URLs (https://example.com/other, https://example.com/)',
+        'canonical': {
+          score: 0,
+          explanation: 'Multiple conflicting URLs (https://example.com/other, https://example.com/)',
+        },
       },
     },
   },
   {
-    // Note: most scores are null (audit error) because the page 403ed.
-    requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
-    finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
-    audits: {
-      'http-status-code': {
-        score: 0,
-        displayValue: '403',
+    lhr: {// Note: most scores are null (audit error) because the page 403ed.
+      requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+      finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+      audits: {
+        'http-status-code': {
+          score: 0,
+          displayValue: '403',
+        },
+        'viewport': {
+          score: null,
+        },
+        'document-title': {
+          score: null,
+        },
+        'meta-description': {
+          score: null,
+        },
+        'font-size': {
+          score: null,
+        },
+        'link-text': {
+          score: null,
+        },
+        'is-crawlable': {
+          score: null,
+        },
+        'hreflang': {
+          score: null,
+        },
+        'plugins': {
+          score: null,
+        },
+        'canonical': {
+          score: null,
+        },
       },
-      'viewport': {
-        score: null,
-      },
-      'document-title': {
-        score: null,
-      },
-      'meta-description': {
-        score: null,
-      },
-      'font-size': {
-        score: null,
-      },
-      'link-text': {
-        score: null,
-      },
-      'is-crawlable': {
-        score: null,
-      },
-      'hreflang': {
-        score: null,
-      },
-      'plugins': {
-        score: null,
-      },
-      'canonical': {
-        score: null,
-      },
-    },
-  },
+    }},
   {
-    requestedUrl: BASE_URL + 'seo-tap-targets.html',
-    finalUrl: BASE_URL + 'seo-tap-targets.html',
-    audits: {
-      'tap-targets': {
-        score: (() => {
-          const PASSING_TAP_TARGETS = 11;
-          const TOTAL_TAP_TARGETS = 12;
-          const SCORE_FACTOR = 0.89;
-          return Math.floor(PASSING_TAP_TARGETS / TOTAL_TAP_TARGETS * SCORE_FACTOR * 100) / 100;
-        })(),
-        details: {
-          items: [
-            {
-              'tapTarget': {
-                'type': 'node',
-                'snippet': '<a ' +
+    lhr: {
+      finalUrl: BASE_URL + 'seo-tap-targets.html',
+      requestedUrl: BASE_URL + 'seo-tap-targets.html',
+      audits: {
+        'tap-targets': {
+          score: (() => {
+            const PASSING_TAP_TARGETS = 11;
+            const TOTAL_TAP_TARGETS = 12;
+            const SCORE_FACTOR = 0.89;
+            return Math.floor(PASSING_TAP_TARGETS / TOTAL_TAP_TARGETS * SCORE_FACTOR * 100) / 100;
+          })(),
+          details: {
+            items: [
+              {
+                'tapTarget': {
+                  'type': 'node',
+                  'snippet': '<a ' +
                  'style="display: block; width: 100px; height: 30px;background: #ddd;">' +
                  '\n        too small target\n      </a>',
-                'path': '2,HTML,1,BODY,3,DIV,21,DIV,0,A',
-                'selector': 'body > div > div > a',
-              },
-              'overlappingTarget': {
-                'type': 'node',
-                'snippet': '<a ' +
+                  'path': '2,HTML,1,BODY,3,DIV,21,DIV,0,A',
+                  'selector': 'body > div > div > a',
+                },
+                'overlappingTarget': {
+                  'type': 'node',
+                  'snippet': '<a ' +
                   'style="display: block; width: 100px; height: 100px;background: #aaa;">' +
                   '\n        big enough target\n      </a>',
-                'path': '2,HTML,1,BODY,3,DIV,21,DIV,1,A',
-                'selector': 'body > div > div > a',
+                  'path': '2,HTML,1,BODY,3,DIV,21,DIV,1,A',
+                  'selector': 'body > div > div > a',
+                },
+                'size': '100x30',
+                'width': 100,
+                'height': 30,
+                'tapTargetScore': 1440,
+                'overlappingTargetScore': 432,
+                'overlapScoreRatio': 0.3,
               },
-              'size': '100x30',
-              'width': 100,
-              'height': 30,
-              'tapTargetScore': 1440,
-              'overlappingTargetScore': 432,
-              'overlapScoreRatio': 0.3,
-            },
-          ],
+            ],
+          },
         },
+      },
+    },
+    artifacts: {
+      TapTargets: {
+        length: 11,
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -225,5 +225,10 @@ module.exports = [
         },
       },
     },
+    artifacts: {
+      TapTargets: {
+        length: 11,
+      },
+    },
   },
 ];

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -37,186 +37,191 @@ const passHeaders = headersParam([[
  */
 module.exports = [
   {
-    requestedUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
-    finalUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
-    audits: {
-      'viewport': {
-        score: 1,
-      },
-      'document-title': {
-        score: 1,
-      },
-      'meta-description': {
-        score: 1,
-      },
-      'http-status-code': {
-        score: 1,
-      },
-      'font-size': {
-        score: 1,
-        details: {
-          items: {
-            length: 6,
+    lhr: {
+      requestedUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+      finalUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+      audits: {
+        'viewport': {
+          score: 1,
+        },
+        'document-title': {
+          score: 1,
+        },
+        'meta-description': {
+          score: 1,
+        },
+        'http-status-code': {
+          score: 1,
+        },
+        'font-size': {
+          score: 1,
+          details: {
+            items: {
+              length: 6,
+            },
           },
         },
+        'link-text': {
+          score: 1,
+        },
+        'is-crawlable': {
+          score: 1,
+        },
+        'hreflang': {
+          score: 1,
+        },
+        'plugins': {
+          score: 1,
+        },
+        'canonical': {
+          score: 1,
+        },
+        'robots-txt': {
+          score: null,
+          scoreDisplayMode: 'notApplicable',
+        },
       },
-      'link-text': {
-        score: 1,
-      },
-      'is-crawlable': {
-        score: 1,
-      },
-      'hreflang': {
-        score: 1,
-      },
-      'plugins': {
-        score: 1,
-      },
-      'canonical': {
-        score: 1,
-      },
-      'robots-txt': {
-        score: null,
-        scoreDisplayMode: 'notApplicable',
-      },
-    },
-  },
+    }},
   {
-    requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
-    finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
-    audits: {
-      'viewport': {
-        score: 0,
-      },
-      'document-title': {
-        score: 0,
-      },
-      'meta-description': {
-        score: 0,
-      },
-      'http-status-code': {
-        score: 1,
-      },
-      'font-size': {
-        score: 0,
-        explanation:
+    lhr: {
+      requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+      finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+      audits: {
+        'viewport': {
+          score: 0,
+        },
+        'document-title': {
+          score: 0,
+        },
+        'meta-description': {
+          score: 0,
+        },
+        'http-status-code': {
+          score: 1,
+        },
+        'font-size': {
+          score: 0,
+          explanation:
           'Text is illegible because there\'s no viewport meta tag optimized for mobile screens.',
-      },
-      'link-text': {
-        score: 0,
-        displayValue: '4 links found',
-        details: {
-          items: {
-            length: 4,
+        },
+        'link-text': {
+          score: 0,
+          displayValue: '4 links found',
+          details: {
+            items: {
+              length: 4,
+            },
           },
         },
-      },
-      'is-crawlable': {
-        score: 0,
-        details: {
-          items: {
-            length: 2,
+        'is-crawlable': {
+          score: 0,
+          details: {
+            items: {
+              length: 2,
+            },
           },
         },
-      },
-      'hreflang': {
-        score: 0,
-        details: {
-          items: {
-            length: 3,
+        'hreflang': {
+          score: 0,
+          details: {
+            items: {
+              length: 3,
+            },
           },
         },
-      },
-      'plugins': {
-        score: 0,
-        details: {
-          items: {
-            length: 3,
+        'plugins': {
+          score: 0,
+          details: {
+            items: {
+              length: 3,
+            },
           },
         },
-      },
-      'canonical': {
-        score: 0,
-        explanation: 'Multiple conflicting URLs (https://example.com/other, https://example.com/)',
+        'canonical': {
+          score: 0,
+          explanation: 'Multiple conflicting URLs (https://example.com/other, https://example.com/)',
+        },
       },
     },
   },
   {
-    // Note: most scores are null (audit error) because the page 403ed.
-    requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
-    finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
-    audits: {
-      'http-status-code': {
-        score: 0,
-        displayValue: '403',
+    lhr: {// Note: most scores are null (audit error) because the page 403ed.
+      requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+      finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+      audits: {
+        'http-status-code': {
+          score: 0,
+          displayValue: '403',
+        },
+        'viewport': {
+          score: null,
+        },
+        'document-title': {
+          score: null,
+        },
+        'meta-description': {
+          score: null,
+        },
+        'font-size': {
+          score: null,
+        },
+        'link-text': {
+          score: null,
+        },
+        'is-crawlable': {
+          score: null,
+        },
+        'hreflang': {
+          score: null,
+        },
+        'plugins': {
+          score: null,
+        },
+        'canonical': {
+          score: null,
+        },
       },
-      'viewport': {
-        score: null,
-      },
-      'document-title': {
-        score: null,
-      },
-      'meta-description': {
-        score: null,
-      },
-      'font-size': {
-        score: null,
-      },
-      'link-text': {
-        score: null,
-      },
-      'is-crawlable': {
-        score: null,
-      },
-      'hreflang': {
-        score: null,
-      },
-      'plugins': {
-        score: null,
-      },
-      'canonical': {
-        score: null,
-      },
-    },
-  },
+    }},
   {
-    requestedUrl: BASE_URL + 'seo-tap-targets.html',
-    finalUrl: BASE_URL + 'seo-tap-targets.html',
-    audits: {
-      'tap-targets': {
-        score: (() => {
-          const PASSING_TAP_TARGETS = 11;
-          const TOTAL_TAP_TARGETS = 12;
-          const SCORE_FACTOR = 0.89;
-          return Math.floor(PASSING_TAP_TARGETS / TOTAL_TAP_TARGETS * SCORE_FACTOR * 100) / 100;
-        })(),
-        details: {
-          items: [
-            {
-              'tapTarget': {
-                'type': 'node',
-                'snippet': '<a ' +
+    lhr: {
+      finalUrl: BASE_URL + 'seo-tap-targets.html',
+      requestedUrl: BASE_URL + 'seo-tap-targets.html',
+      audits: {
+        'tap-targets': {
+          score: (() => {
+            const PASSING_TAP_TARGETS = 11;
+            const TOTAL_TAP_TARGETS = 12;
+            const SCORE_FACTOR = 0.89;
+            return Math.floor(PASSING_TAP_TARGETS / TOTAL_TAP_TARGETS * SCORE_FACTOR * 100) / 100;
+          })(),
+          details: {
+            items: [
+              {
+                'tapTarget': {
+                  'type': 'node',
+                  'snippet': '<a ' +
                  'style="display: block; width: 100px; height: 30px;background: #ddd;">' +
                  '\n        too small target\n      </a>',
-                'path': '2,HTML,1,BODY,3,DIV,21,DIV,0,A',
-                'selector': 'body > div > div > a',
-              },
-              'overlappingTarget': {
-                'type': 'node',
-                'snippet': '<a ' +
+                  'path': '2,HTML,1,BODY,3,DIV,21,DIV,0,A',
+                  'selector': 'body > div > div > a',
+                },
+                'overlappingTarget': {
+                  'type': 'node',
+                  'snippet': '<a ' +
                   'style="display: block; width: 100px; height: 100px;background: #aaa;">' +
                   '\n        big enough target\n      </a>',
-                'path': '2,HTML,1,BODY,3,DIV,21,DIV,1,A',
-                'selector': 'body > div > div > a',
+                  'path': '2,HTML,1,BODY,3,DIV,21,DIV,1,A',
+                  'selector': 'body > div > div > a',
+                },
+                'size': '100x30',
+                'width': 100,
+                'height': 30,
+                'tapTargetScore': 1440,
+                'overlappingTargetScore': 432,
+                'overlapScoreRatio': 0.3,
               },
-              'size': '100x30',
-              'width': 100,
-              'height': 30,
-              'tapTargetScore': 1440,
-              'overlappingTargetScore': 432,
-              'overlapScoreRatio': 0.3,
-            },
-          ],
+            ],
+          },
         },
       },
     },

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -145,7 +145,8 @@ module.exports = [
     },
   },
   {
-    lhr: {// Note: most scores are null (audit error) because the page 403ed.
+    lhr: {
+      // Note: most scores are null (audit error) because the page 403ed.
       requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
       finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
       audits: {

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -37,197 +37,187 @@ const passHeaders = headersParam([[
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
-      finalUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
-      audits: {
-        'viewport': {
-          score: 1,
-        },
-        'document-title': {
-          score: 1,
-        },
-        'meta-description': {
-          score: 1,
-        },
-        'http-status-code': {
-          score: 1,
-        },
-        'font-size': {
-          score: 1,
-          details: {
-            items: {
-              length: 6,
-            },
+    requestedUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+    finalUrl: BASE_URL + 'seo-tester.html?' + passHeaders,
+    audits: {
+      'viewport': {
+        score: 1,
+      },
+      'document-title': {
+        score: 1,
+      },
+      'meta-description': {
+        score: 1,
+      },
+      'http-status-code': {
+        score: 1,
+      },
+      'font-size': {
+        score: 1,
+        details: {
+          items: {
+            length: 6,
           },
-        },
-        'link-text': {
-          score: 1,
-        },
-        'is-crawlable': {
-          score: 1,
-        },
-        'hreflang': {
-          score: 1,
-        },
-        'plugins': {
-          score: 1,
-        },
-        'canonical': {
-          score: 1,
-        },
-        'robots-txt': {
-          score: null,
-          scoreDisplayMode: 'notApplicable',
         },
       },
-    }},
-  {
-    lhr: {
-      requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
-      finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
-      audits: {
-        'viewport': {
-          score: 0,
-        },
-        'document-title': {
-          score: 0,
-        },
-        'meta-description': {
-          score: 0,
-        },
-        'http-status-code': {
-          score: 1,
-        },
-        'font-size': {
-          score: 0,
-          explanation:
-          'Text is illegible because there\'s no viewport meta tag optimized for mobile screens.',
-        },
-        'link-text': {
-          score: 0,
-          displayValue: '4 links found',
-          details: {
-            items: {
-              length: 4,
-            },
-          },
-        },
-        'is-crawlable': {
-          score: 0,
-          details: {
-            items: {
-              length: 2,
-            },
-          },
-        },
-        'hreflang': {
-          score: 0,
-          details: {
-            items: {
-              length: 3,
-            },
-          },
-        },
-        'plugins': {
-          score: 0,
-          details: {
-            items: {
-              length: 3,
-            },
-          },
-        },
-        'canonical': {
-          score: 0,
-          explanation: 'Multiple conflicting URLs (https://example.com/other, https://example.com/)',
-        },
+      'link-text': {
+        score: 1,
+      },
+      'is-crawlable': {
+        score: 1,
+      },
+      'hreflang': {
+        score: 1,
+      },
+      'plugins': {
+        score: 1,
+      },
+      'canonical': {
+        score: 1,
+      },
+      'robots-txt': {
+        score: null,
+        scoreDisplayMode: 'notApplicable',
       },
     },
   },
   {
-    lhr: {// Note: most scores are null (audit error) because the page 403ed.
-      requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
-      finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
-      audits: {
-        'http-status-code': {
-          score: 0,
-          displayValue: '403',
-        },
-        'viewport': {
-          score: null,
-        },
-        'document-title': {
-          score: null,
-        },
-        'meta-description': {
-          score: null,
-        },
-        'font-size': {
-          score: null,
-        },
-        'link-text': {
-          score: null,
-        },
-        'is-crawlable': {
-          score: null,
-        },
-        'hreflang': {
-          score: null,
-        },
-        'plugins': {
-          score: null,
-        },
-        'canonical': {
-          score: null,
-        },
+    requestedUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+    finalUrl: BASE_URL + 'seo-failure-cases.html?' + failureHeaders,
+    audits: {
+      'viewport': {
+        score: 0,
       },
-    }},
-  {
-    lhr: {
-      finalUrl: BASE_URL + 'seo-tap-targets.html',
-      requestedUrl: BASE_URL + 'seo-tap-targets.html',
-      audits: {
-        'tap-targets': {
-          score: (() => {
-            const PASSING_TAP_TARGETS = 11;
-            const TOTAL_TAP_TARGETS = 12;
-            const SCORE_FACTOR = 0.89;
-            return Math.floor(PASSING_TAP_TARGETS / TOTAL_TAP_TARGETS * SCORE_FACTOR * 100) / 100;
-          })(),
-          details: {
-            items: [
-              {
-                'tapTarget': {
-                  'type': 'node',
-                  'snippet': '<a ' +
-                 'style="display: block; width: 100px; height: 30px;background: #ddd;">' +
-                 '\n        too small target\n      </a>',
-                  'path': '2,HTML,1,BODY,3,DIV,21,DIV,0,A',
-                  'selector': 'body > div > div > a',
-                },
-                'overlappingTarget': {
-                  'type': 'node',
-                  'snippet': '<a ' +
-                  'style="display: block; width: 100px; height: 100px;background: #aaa;">' +
-                  '\n        big enough target\n      </a>',
-                  'path': '2,HTML,1,BODY,3,DIV,21,DIV,1,A',
-                  'selector': 'body > div > div > a',
-                },
-                'size': '100x30',
-                'width': 100,
-                'height': 30,
-                'tapTargetScore': 1440,
-                'overlappingTargetScore': 432,
-                'overlapScoreRatio': 0.3,
-              },
-            ],
+      'document-title': {
+        score: 0,
+      },
+      'meta-description': {
+        score: 0,
+      },
+      'http-status-code': {
+        score: 1,
+      },
+      'font-size': {
+        score: 0,
+        explanation:
+          'Text is illegible because there\'s no viewport meta tag optimized for mobile screens.',
+      },
+      'link-text': {
+        score: 0,
+        displayValue: '4 links found',
+        details: {
+          items: {
+            length: 4,
           },
         },
       },
+      'is-crawlable': {
+        score: 0,
+        details: {
+          items: {
+            length: 2,
+          },
+        },
+      },
+      'hreflang': {
+        score: 0,
+        details: {
+          items: {
+            length: 3,
+          },
+        },
+      },
+      'plugins': {
+        score: 0,
+        details: {
+          items: {
+            length: 3,
+          },
+        },
+      },
+      'canonical': {
+        score: 0,
+        explanation: 'Multiple conflicting URLs (https://example.com/other, https://example.com/)',
+      },
     },
-    artifacts: {
-      TapTargets: {
-        length: 11,
+  },
+  {
+    // Note: most scores are null (audit error) because the page 403ed.
+    requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+    finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+    audits: {
+      'http-status-code': {
+        score: 0,
+        displayValue: '403',
+      },
+      'viewport': {
+        score: null,
+      },
+      'document-title': {
+        score: null,
+      },
+      'meta-description': {
+        score: null,
+      },
+      'font-size': {
+        score: null,
+      },
+      'link-text': {
+        score: null,
+      },
+      'is-crawlable': {
+        score: null,
+      },
+      'hreflang': {
+        score: null,
+      },
+      'plugins': {
+        score: null,
+      },
+      'canonical': {
+        score: null,
+      },
+    },
+  },
+  {
+    requestedUrl: BASE_URL + 'seo-tap-targets.html',
+    finalUrl: BASE_URL + 'seo-tap-targets.html',
+    audits: {
+      'tap-targets': {
+        score: (() => {
+          const PASSING_TAP_TARGETS = 11;
+          const TOTAL_TAP_TARGETS = 12;
+          const SCORE_FACTOR = 0.89;
+          return Math.floor(PASSING_TAP_TARGETS / TOTAL_TAP_TARGETS * SCORE_FACTOR * 100) / 100;
+        })(),
+        details: {
+          items: [
+            {
+              'tapTarget': {
+                'type': 'node',
+                'snippet': '<a ' +
+                 'style="display: block; width: 100px; height: 30px;background: #ddd;">' +
+                 '\n        too small target\n      </a>',
+                'path': '2,HTML,1,BODY,3,DIV,21,DIV,0,A',
+                'selector': 'body > div > div > a',
+              },
+              'overlappingTarget': {
+                'type': 'node',
+                'snippet': '<a ' +
+                  'style="display: block; width: 100px; height: 100px;background: #aaa;">' +
+                  '\n        big enough target\n      </a>',
+                'path': '2,HTML,1,BODY,3,DIV,21,DIV,1,A',
+                'selector': 'body > div > div > a',
+              },
+              'size': '100x30',
+              'width': 100,
+              'height': 30,
+              'tapTargetScore': 1440,
+              'overlappingTargetScore': 432,
+              'overlapScoreRatio': 0.3,
+            },
+          ],
+        },
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/smoke-test-dfns.js
+++ b/lighthouse-cli/test/smokehouse/smoke-test-dfns.js
@@ -110,7 +110,7 @@ function loadConfig(configPath) {
 
 /**
  * @param {string} expectationsPath
- * @return {Smokehouse.ExpectedRunResult[]}
+ * @return {Smokehouse.ExpectedRunnerResult[]}
  */
 function loadExpectations(expectationsPath) {
   return require(expectationsPath);

--- a/lighthouse-cli/test/smokehouse/smoke-test-dfns.js
+++ b/lighthouse-cli/test/smokehouse/smoke-test-dfns.js
@@ -110,7 +110,7 @@ function loadConfig(configPath) {
 
 /**
  * @param {string} expectationsPath
- * @return {Smokehouse.ExpectedRunResult[]}
+ * @return {Smokehouse.ExpectedLHR[]}
  */
 function loadExpectations(expectationsPath) {
   return require(expectationsPath);

--- a/lighthouse-cli/test/smokehouse/smoke-test-dfns.js
+++ b/lighthouse-cli/test/smokehouse/smoke-test-dfns.js
@@ -110,7 +110,7 @@ function loadConfig(configPath) {
 
 /**
  * @param {string} expectationsPath
- * @return {Smokehouse.ExpectedLHR[]}
+ * @return {Smokehouse.ExpectedRunResult[]}
  */
 function loadExpectations(expectationsPath) {
   return require(expectationsPath);

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -103,12 +103,12 @@ function findDifference(path, actual, expected) {
 }
 
 /**
- * @param {string} name
+ * @param {string} name – description of what's being asserted on (e.g. the result of a certain audit)
  * @param {any} actualResult
  * @param {any} expectedResult
- * @returns {Smokehouse.Comparison}
+ * @return {Smokehouse.Comparison}
  */
-function makeAssertion(name, actualResult, expectedResult) {
+function makeComparison(name, actualResult, expectedResult) {
   const diff = findDifference(name, actualResult, expectedResult);
 
   return {
@@ -121,7 +121,7 @@ function makeAssertion(name, actualResult, expectedResult) {
 }
 
 /**
- * Collate results into comparisons of actual and expected scores on each audit.
+ * Collate results into comparisons of actual and expected scores on each audit/artifact.
  * @param {Smokehouse.ExpectedRunResult} actual
  * @param {Smokehouse.ExpectedRunResult} expected
  * @return {Smokehouse.Comparison[]}
@@ -138,23 +138,21 @@ function collateResults(actual, expected) {
       }
 
       const expectedResult = (expected.artifacts || {})[artifactName];
-      return makeAssertion(artifactName + ' artifact', actualResult, expectedResult);
+      return makeComparison(artifactName + ' artifact', actualResult, expectedResult);
     });
   }
 
   /** @type {Smokehouse.Comparison[]} */
   let auditAssertions = [];
-  if (expected.lhr.audits) {
-    auditAssertions = Object.keys(expected.lhr.audits).map(auditName => {
-      const actualResult = actual.lhr.audits[auditName];
-      if (!actualResult) {
-        throw new Error(`Config did not trigger run of expected audit ${auditName}`);
-      }
+  auditAssertions = Object.keys(expected.lhr.audits).map(auditName => {
+    const actualResult = actual.lhr.audits[auditName];
+    if (!actualResult) {
+      throw new Error(`Config did not trigger run of expected audit ${auditName}`);
+    }
 
-      const expectedResult = expected.lhr.audits[auditName];
-      return makeAssertion(auditName + ' audit', actualResult, expectedResult);
-    });
-  }
+    const expectedResult = expected.lhr.audits[auditName];
+    return makeComparison(auditName + ' audit', actualResult, expectedResult);
+  });
 
   return [
     {

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -130,14 +130,15 @@ function collateResults(actual, expected) {
   /** @type {Smokehouse.Comparison[]} */
   let artifactAssertions = [];
   if (expected.artifacts) {
-    const artifactNames = /** @type {(keyof LH.Artifacts)[]} */ (Object.keys(expected.artifacts));
+    const expectedArtifacts = expected.artifacts;
+    const artifactNames = /** @type {(keyof LH.Artifacts)[]} */ (Object.keys(expectedArtifacts));
     artifactAssertions = artifactNames.map(artifactName => {
       const actualResult = (actual.artifacts || {})[artifactName];
       if (!actualResult) {
         throw new Error(`Config run did not generate artifact ${artifactName}`);
       }
 
-      const expectedResult = (expected.artifacts || {})[artifactName];
+      const expectedResult = expectedArtifacts[artifactName];
       return makeComparison(artifactName + ' artifact', actualResult, expectedResult);
     });
   }

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -103,7 +103,7 @@ function findDifference(path, actual, expected) {
 }
 
 /**
- * @param {string} name – description of what's being asserted on (e.g. the result of a certain audit)
+ * @param {string} name – name of the value being asserted on (e.g. the result of a certain audit)
  * @param {any} actualResult
  * @param {any} expectedResult
  * @return {Smokehouse.Comparison}
@@ -112,7 +112,7 @@ function makeComparison(name, actualResult, expectedResult) {
   const diff = findDifference(name, actualResult, expectedResult);
 
   return {
-    category: name,
+    name,
     actual: actualResult,
     expected: expectedResult,
     equal: !diff,
@@ -156,13 +156,13 @@ function collateResults(actual, expected) {
 
   return [
     {
-      category: 'error code',
+      name: 'error code',
       actual: actual.errorCode,
       expected: expected.errorCode,
       equal: actual.errorCode === expected.errorCode,
     },
     {
-      category: 'final url',
+      name: 'final url',
       actual: actual.lhr.finalUrl,
       expected: expected.lhr.finalUrl,
       equal: actual.lhr.finalUrl === expected.lhr.finalUrl,
@@ -192,9 +192,9 @@ function reportAssertion(assertion) {
 
   if (assertion.equal) {
     if (isPlainObject(assertion.actual)) {
-      console.log(`  ${log.greenify(log.tick)} ${assertion.category}`);
+      console.log(`  ${log.greenify(log.tick)} ${assertion.name}`);
     } else {
-      console.log(`  ${log.greenify(log.tick)} ${assertion.category}: ` +
+      console.log(`  ${log.greenify(log.tick)} ${assertion.name}: ` +
           log.greenify(assertion.actual));
     }
   } else {
@@ -211,7 +211,7 @@ function reportAssertion(assertion) {
 `;
       console.log(msg);
     } else {
-      console.log(`  ${log.redify(log.cross)} ${assertion.category}:
+      console.log(`  ${log.redify(log.cross)} ${assertion.name}:
               expected: ${JSON.stringify(assertion.expected)}
                  found: ${JSON.stringify(assertion.actual)}
 `);

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -122,8 +122,8 @@ function makeComparison(name, actualResult, expectedResult) {
 
 /**
  * Collate results into comparisons of actual and expected scores on each audit/artifact.
- * @param {Smokehouse.ExpectedRunResult} actual
- * @param {Smokehouse.ExpectedRunResult} expected
+ * @param {Smokehouse.ExpectedRunnerResult} actual
+ * @param {Smokehouse.ExpectedRunnerResult} expected
  * @return {Smokehouse.Comparison[]}
  */
 function collateResults(actual, expected) {

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -128,23 +128,24 @@ function makeAssertion(name, actualResult, expectedResult) {
  */
 function collateResults(actual, expected) {
   /** @type {Smokehouse.Assertion[]} */
-  const artifactAssertions = [];
+  let artifactAssertions = [];
   if (expected.artifacts) {
-    Object.keys(expected.artifacts).map(artifactName => {
-      const actualResult = /** @type {any} */ (actual.artifacts)[artifactName];
+    const artifactNames = /** @type {(keyof LH.Artifacts)[]} */ (Object.keys(expected.artifacts));
+    artifactAssertions = artifactNames.map(artifactName => {
+      const actualResult = (actual.artifacts || {})[artifactName];
       if (!actualResult) {
         throw new Error(`Config run did not generate artifact ${artifactName}`);
       }
 
-      const expectedResult = /** @type {any} */(expected.artifacts)[artifactName];
+      const expectedResult = (expected.artifacts || {})[artifactName];
       return makeAssertion(artifactName + ' artifact', actualResult, expectedResult);
     });
   }
 
   /** @type {Smokehouse.Assertion[]} */
-  const auditAssertions = [];
+  let auditAssertions = [];
   if (expected.lhr.audits) {
-    Object.keys(expected.lhr.audits).map(auditName => {
+    auditAssertions = Object.keys(expected.lhr.audits).map(auditName => {
       const actualResult = actual.lhr.audits[auditName];
       if (!actualResult) {
         throw new Error(`Config did not trigger run of expected audit ${auditName}`);

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -103,44 +103,73 @@ function findDifference(path, actual, expected) {
 }
 
 /**
- * Collate results into comparisons of actual and expected scores on each audit.
- * @param {Smokehouse.ExpectedLHR} actual
- * @param {Smokehouse.ExpectedLHR} expected
- * @return {Smokehouse.LHRComparison}
+ * @param {string} name
+ * @param {any} actualResult
+ * @param {any} expectedResult
+ * @returns {Smokehouse.Assertion}
  */
-function collateResults(actual, expected) {
-  const auditNames = Object.keys(expected.audits);
-  const collatedAudits = auditNames.map(auditName => {
-    const actualResult = actual.audits[auditName];
-    if (!actualResult) {
-      throw new Error(`Config did not trigger run of expected audit ${auditName}`);
-    }
-
-    const expectedResult = expected.audits[auditName];
-    const diff = findDifference(auditName, actualResult, expectedResult);
-
-    return {
-      category: auditName,
-      actual: actualResult,
-      expected: expectedResult,
-      equal: !diff,
-      diff,
-    };
-  });
+function makeAssertion(name, actualResult, expectedResult) {
+  const diff = findDifference(name, actualResult, expectedResult);
 
   return {
-    audits: collatedAudits,
+    category: name,
+    actual: actualResult,
+    expected: expectedResult,
+    equal: !diff,
+    diff,
+  };
+}
+
+/**
+ * Collate results into comparisons of actual and expected scores on each audit.
+ * @param {Smokehouse.ExpectedRunResult} actual
+ * @param {Smokehouse.ExpectedRunResult} expected
+ * @return {Smokehouse.RunComparison}
+ */
+function collateResults(actual, expected) {
+  /** @type {Smokehouse.Assertion[]} */
+  const artifactAssertions = [];
+  if (expected.artifacts) {
+    Object.keys(expected.artifacts).map(artifactName => {
+      const actualResult = /** @type {any} */ (actual.artifacts)[artifactName];
+      if (!actualResult) {
+        throw new Error(`Config run did not generate artifact ${artifactName}`);
+      }
+
+      const expectedResult = /** @type {any} */(expected.artifacts)[artifactName];
+      return makeAssertion(artifactName + ' artifact', actualResult, expectedResult);
+    });
+  }
+
+  /** @type {Smokehouse.Assertion[]} */
+  const auditAssertions = [];
+  if (expected.lhr.audits) {
+    Object.keys(expected.lhr.audits).map(auditName => {
+      const actualResult = actual.lhr.audits[auditName];
+      if (!actualResult) {
+        throw new Error(`Config did not trigger run of expected audit ${auditName}`);
+      }
+
+      const expectedResult = expected.lhr.audits[auditName];
+      return makeAssertion(auditName + ' audit', actualResult, expectedResult);
+    });
+  }
+
+  const assertions = [...artifactAssertions, ...auditAssertions];
+
+  return {
+    assertions,
     errorCode: {
       category: 'error code',
-      actual: actual.errorCode,
-      expected: expected.errorCode,
-      equal: actual.errorCode === expected.errorCode,
+      actual: actual.lhr.errorCode,
+      expected: expected.lhr.errorCode,
+      equal: actual.lhr.errorCode === expected.lhr.errorCode,
     },
     finalUrl: {
       category: 'final url',
-      actual: actual.finalUrl,
-      expected: expected.finalUrl,
-      equal: actual.finalUrl === expected.finalUrl,
+      actual: actual.lhr.finalUrl,
+      expected: expected.lhr.finalUrl,
+      equal: actual.lhr.finalUrl === expected.lhr.finalUrl,
     },
   };
 }
@@ -199,22 +228,22 @@ function reportAssertion(assertion) {
 /**
  * Log all the comparisons between actual and expected test results, then print
  * summary. Returns count of passed and failed tests.
- * @param {Smokehouse.LHRComparison} results
+ * @param {Smokehouse.RunComparison} results
  * @return {{passed: number, failed: number}}
  */
 function report(results) {
   let correctCount = 0;
   let failedCount = 0;
 
-  [results.finalUrl, results.errorCode, ...results.audits].forEach(auditAssertion => {
-    if (auditAssertion.equal) {
+  [results.finalUrl, results.errorCode, ...results.assertions].forEach(assertion => {
+    if (assertion.equal) {
       correctCount++;
     } else {
       failedCount++;
     }
 
-    if (!auditAssertion.equal || VERBOSE) {
-      reportAssertion(auditAssertion);
+    if (!assertion.equal || VERBOSE) {
+      reportAssertion(assertion);
     }
   });
 

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -161,9 +161,9 @@ function collateResults(actual, expected) {
     assertions,
     errorCode: {
       category: 'error code',
-      actual: actual.lhr.errorCode,
-      expected: expected.lhr.errorCode,
-      equal: actual.lhr.errorCode === expected.lhr.errorCode,
+      actual: actual.errorCode,
+      expected: expected.errorCode,
+      equal: actual.errorCode === expected.errorCode,
     },
     finalUrl: {
       category: 'final url',

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -43,7 +43,7 @@ function resolveLocalOrCwd(payloadPath) {
  * @param {string} url
  * @param {string} configPath
  * @param {boolean=} isDebug
- * @return {Smokehouse.ExpectedRunResult}
+ * @return {Smokehouse.ExpectedRunnerResult}
  */
 function runLighthouse(url, configPath, isDebug) {
   isDebug = isDebug || Boolean(process.env.LH_SMOKE_DEBUG);
@@ -136,7 +136,7 @@ const cli = yargs
   .argv;
 
 const configPath = resolveLocalOrCwd(cli['config-path']);
-/** @type {Smokehouse.ExpectedRunResult[]} */
+/** @type {Smokehouse.ExpectedRunnerResult[]} */
 const expectations = require(resolveLocalOrCwd(cli['expectations-path']));
 
 // Loop sequentially over expectations, comparing against Lighthouse run, and

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -57,12 +57,10 @@ function runLighthouse(url, configPath, isDebug) {
     `--config-path=${configPath}`,
     `--output-path=${outputPath}`,
     '--output=json',
+    `-GA=${artifactsDirectory}`,
     '--quiet',
     '--port=0',
   ];
-
-  // Save artifacts
-  args.push(`-GA=${artifactsDirectory}`);
 
   if (process.env.APPVEYOR) {
     // Appveyor is hella slow already, disable CPU throttling so we're not 16x slowdown

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -117,7 +117,7 @@ function runLighthouse(url, configPath, isDebug) {
   }
 
   const artifacts = JSON.parse(
-    fs.readFileSync(`${artifactsDirectory}/artifacts.json`).toString());
+    fs.readFileSync(`${artifactsDirectory}/artifacts.json`, 'utf8'));
 
   return {
     errorCode,

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -64,7 +64,6 @@ function runLighthouse(url, configPath, isDebug) {
   // Save artifacts
   args.push(`-GA=${artifactsDirectory}`);
 
-
   if (process.env.APPVEYOR) {
     // Appveyor is hella slow already, disable CPU throttling so we're not 16x slowdown
     // see https://github.com/GoogleChrome/lighthouse/issues/4891

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -43,7 +43,7 @@ function resolveLocalOrCwd(payloadPath) {
  * @param {string} url
  * @param {string} configPath
  * @param {boolean=} isDebug
- * @return {Smokehouse.ExpectedRunResult}
+ * @return {Smokehouse.ExpectedLHR}
  */
 function runLighthouse(url, configPath, isDebug) {
   isDebug = isDebug || Boolean(process.env.LH_SMOKE_DEBUG);
@@ -60,9 +60,9 @@ function runLighthouse(url, configPath, isDebug) {
     '--port=0',
   ];
 
-  // Save artifacts
-  args.push('-GA');
-
+  if (isDebug) {
+    args.push('-GA');
+  }
 
   if (process.env.APPVEYOR) {
     // Appveyor is hella slow already, disable CPU throttling so we're not 16x slowdown
@@ -102,15 +102,11 @@ function runLighthouse(url, configPath, isDebug) {
   }
 
   if (runResults.status === PAGE_HUNG_EXIT_CODE) {
-    return {
-      lhr: {requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}},
-    };
+    return {requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}};
   }
 
   if (runResults.status === INSECURE_DOCUMENT_REQUEST_EXIT_CODE) {
-    return {
-      lhr: {requestedUrl: url, finalUrl: url, errorCode: 'INSECURE_DOCUMENT_REQUEST', audits: {}},
-    };
+    return {requestedUrl: url, finalUrl: url, errorCode: 'INSECURE_DOCUMENT_REQUEST', audits: {}};
   }
 
   const lhr = fs.readFileSync(outputPath, 'utf8');
@@ -120,12 +116,7 @@ function runLighthouse(url, configPath, isDebug) {
     fs.unlinkSync(outputPath);
   }
 
-  const artifacts = JSON.parse(fs.readFileSync('./latest-run/artifacts.json').toString());
-
-  return {
-    lhr: JSON.parse(lhr),
-    artifacts,
-  };
+  return JSON.parse(lhr);
 }
 
 const cli = yargs
@@ -140,7 +131,7 @@ const cli = yargs
   .argv;
 
 const configPath = resolveLocalOrCwd(cli['config-path']);
-/** @type {Smokehouse.ExpectedRunResult[]} */
+/** @type {Smokehouse.ExpectedLHR[]} */
 const expectations = require(resolveLocalOrCwd(cli['expectations-path']));
 
 // Loop sequentially over expectations, comparing against Lighthouse run, and
@@ -148,10 +139,10 @@ const expectations = require(resolveLocalOrCwd(cli['expectations-path']));
 let passingCount = 0;
 let failingCount = 0;
 expectations.forEach(expected => {
-  console.log(`Doing a run of '${expected.lhr.requestedUrl}'...`);
-  const results = runLighthouse(expected.lhr.requestedUrl, configPath, cli.debug);
+  console.log(`Doing a run of '${expected.requestedUrl}'...`);
+  const results = runLighthouse(expected.requestedUrl, configPath, cli.debug);
 
-  console.log(`Asserting expected results match those found. (${expected.lhr.requestedUrl})`);
+  console.log(`Asserting expected results match those found. (${expected.requestedUrl})`);
   const collated = collateResults(results, expected);
   const counts = report(collated);
   passingCount += counts.passed;

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -43,7 +43,7 @@ function resolveLocalOrCwd(payloadPath) {
  * @param {string} url
  * @param {string} configPath
  * @param {boolean=} isDebug
- * @return {Smokehouse.ExpectedLHR}
+ * @return {Smokehouse.ExpectedRunResult}
  */
 function runLighthouse(url, configPath, isDebug) {
   isDebug = isDebug || Boolean(process.env.LH_SMOKE_DEBUG);
@@ -60,9 +60,9 @@ function runLighthouse(url, configPath, isDebug) {
     '--port=0',
   ];
 
-  if (isDebug) {
-    args.push('-GA');
-  }
+  // Save artifacts
+  args.push('-GA');
+
 
   if (process.env.APPVEYOR) {
     // Appveyor is hella slow already, disable CPU throttling so we're not 16x slowdown
@@ -102,21 +102,30 @@ function runLighthouse(url, configPath, isDebug) {
   }
 
   if (runResults.status === PAGE_HUNG_EXIT_CODE) {
-    return {requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}};
+    return {
+      lhr: {requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}},
+    };
   }
 
   if (runResults.status === INSECURE_DOCUMENT_REQUEST_EXIT_CODE) {
-    return {requestedUrl: url, finalUrl: url, errorCode: 'INSECURE_DOCUMENT_REQUEST', audits: {}};
+    return {
+      lhr: {requestedUrl: url, finalUrl: url, errorCode: 'INSECURE_DOCUMENT_REQUEST', audits: {}},
+    };
   }
 
-  const lhr = fs.readFileSync(outputPath, 'utf8');
+  const lhr = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
   if (isDebug) {
     console.log('LHR output available at: ', outputPath);
   } else if (fs.existsSync(outputPath)) {
     fs.unlinkSync(outputPath);
   }
 
-  return JSON.parse(lhr);
+  const artifacts = JSON.parse(fs.readFileSync('./latest-run/artifacts.json').toString());
+
+  return {
+    lhr,
+    artifacts,
+  };
 }
 
 const cli = yargs
@@ -131,7 +140,7 @@ const cli = yargs
   .argv;
 
 const configPath = resolveLocalOrCwd(cli['config-path']);
-/** @type {Smokehouse.ExpectedLHR[]} */
+/** @type {Smokehouse.ExpectedRunResult[]} */
 const expectations = require(resolveLocalOrCwd(cli['expectations-path']));
 
 // Loop sequentially over expectations, comparing against Lighthouse run, and
@@ -139,10 +148,10 @@ const expectations = require(resolveLocalOrCwd(cli['expectations-path']));
 let passingCount = 0;
 let failingCount = 0;
 expectations.forEach(expected => {
-  console.log(`Doing a run of '${expected.requestedUrl}'...`);
-  const results = runLighthouse(expected.requestedUrl, configPath, cli.debug);
+  console.log(`Doing a run of '${expected.lhr.requestedUrl}'...`);
+  const results = runLighthouse(expected.lhr.requestedUrl, configPath, cli.debug);
 
-  console.log(`Asserting expected results match those found. (${expected.requestedUrl})`);
+  console.log(`Asserting expected results match those found. (${expected.lhr.requestedUrl})`);
   const collated = collateResults(results, expected);
   const counts = report(collated);
   passingCount += counts.passed;

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -102,29 +102,26 @@ function runLighthouse(url, configPath, isDebug) {
     console.error(`STDERR: ${runResults.stderr}`);
   }
 
+  let errorCode;
+  let lhr = {requestedUrl: url, finalUrl: url, audits: {}};
   if (runResults.status === PAGE_HUNG_EXIT_CODE) {
-    return {
-      lhr: {requestedUrl: url, finalUrl: url, errorCode: 'PAGE_HUNG', audits: {}},
-    };
-  }
-
-  if (runResults.status === INSECURE_DOCUMENT_REQUEST_EXIT_CODE) {
-    return {
-      lhr: {requestedUrl: url, finalUrl: url, errorCode: 'INSECURE_DOCUMENT_REQUEST', audits: {}},
-    };
-  }
-
-  const lhr = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
-  if (isDebug) {
-    console.log('LHR output available at: ', outputPath);
-  } else if (fs.existsSync(outputPath)) {
-    fs.unlinkSync(outputPath);
+    errorCode = 'PAGE_HUNG';
+  } else if (runResults.status === INSECURE_DOCUMENT_REQUEST_EXIT_CODE) {
+    errorCode = 'INSECURE_DOCUMENT_REQUEST';
+  } else {
+    lhr = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    if (isDebug) {
+      console.log('LHR output available at: ', outputPath);
+    } else if (fs.existsSync(outputPath)) {
+      fs.unlinkSync(outputPath);
+    }
   }
 
   const artifacts = JSON.parse(
     fs.readFileSync(`${artifactsDirectory}/artifacts.json`).toString());
 
   return {
+    errorCode,
     lhr,
     artifacts,
   };

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -50,6 +50,7 @@ function runLighthouse(url, configPath, isDebug) {
 
   const command = 'node';
   const outputPath = `smokehouse-${Math.round(Math.random() * 100000)}.report.json`;
+  const artifactsDirectory = './.tmp/smokehouse-artifacts';
   const args = [
     'lighthouse-cli/index.js',
     url,
@@ -61,7 +62,7 @@ function runLighthouse(url, configPath, isDebug) {
   ];
 
   // Save artifacts
-  args.push('-GA');
+  args.push(`-GA=${artifactsDirectory}`);
 
 
   if (process.env.APPVEYOR) {
@@ -120,7 +121,8 @@ function runLighthouse(url, configPath, isDebug) {
     fs.unlinkSync(outputPath);
   }
 
-  const artifacts = JSON.parse(fs.readFileSync('./latest-run/artifacts.json').toString());
+  const artifacts = JSON.parse(
+    fs.readFileSync(`${artifactsDirectory}/artifacts.json`).toString());
 
   return {
     lhr,

--- a/lighthouse-cli/test/smokehouse/tricky-metrics/expectations.js
+++ b/lighthouse-cli/test/smokehouse/tricky-metrics/expectations.js
@@ -10,39 +10,45 @@
  */
 module.exports = [
   {
-    requestedUrl: 'http://localhost:10200/tricky-tti.html',
-    finalUrl: 'http://localhost:10200/tricky-tti.html',
-    audits: {
-      'first-cpu-idle': {
-        score: '<75',
-        rawValue: '>9000',
-      },
-      'interactive': {
-        score: '<75',
-        rawValue: '>9000',
-      },
-    },
-  },
-  {
-    requestedUrl: 'http://localhost:10200/delayed-fcp.html',
-    finalUrl: 'http://localhost:10200/delayed-fcp.html',
-    audits: {
-      'first-contentful-paint': {
-        rawValue: '>1', // We just want to check that it doesn't error
+    lhr: {
+      requestedUrl: 'http://localhost:10200/tricky-tti.html',
+      finalUrl: 'http://localhost:10200/tricky-tti.html',
+      audits: {
+        'first-cpu-idle': {
+          score: '<75',
+          rawValue: '>9000',
+        },
+        'interactive': {
+          score: '<75',
+          rawValue: '>9000',
+        },
       },
     },
   },
   {
-    requestedUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
-    finalUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
-    audits: {
-      'bootup-time': {
-        details: {
-          items: {
-            0: {
+    lhr: {
+      requestedUrl: 'http://localhost:10200/delayed-fcp.html',
+      finalUrl: 'http://localhost:10200/delayed-fcp.html',
+      audits: {
+        'first-contentful-paint': {
+          rawValue: '>1', // We just want to check that it doesn't error
+        },
+      },
+    },
+  },
+  {
+    lhr: {
+      requestedUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
+      finalUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
+      audits: {
+        'bootup-time': {
+          details: {
+            items: {
+              0: {
               // FIXME: Appveyor finds this particular assertion very flaky for some reason :(
-              url: process.env.APPVEYOR ? /main/ : /main-thread-consumer/,
-              scripting: '>1000',
+                url: process.env.APPVEYOR ? /main/ : /main-thread-consumer/,
+                scripting: '>1000',
+              },
             },
           },
         },
@@ -50,16 +56,18 @@ module.exports = [
     },
   },
   {
-    requestedUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
-    finalUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
-    audits: {
-      'bootup-time': {
-        details: {
-          items: {
-            0: {
+    lhr: {
+      requestedUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
+      finalUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
+      audits: {
+        'bootup-time': {
+          details: {
+            items: {
+              0: {
               // TODO: requires async stacks, https://github.com/GoogleChrome/lighthouse/pull/5504
               // url: /main-thread-consumer/,
-              scripting: '>1000',
+                scripting: '>1000',
+              },
             },
           },
         },

--- a/lighthouse-cli/test/smokehouse/tricky-metrics/expectations.js
+++ b/lighthouse-cli/test/smokehouse/tricky-metrics/expectations.js
@@ -10,45 +10,39 @@
  */
 module.exports = [
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/tricky-tti.html',
-      finalUrl: 'http://localhost:10200/tricky-tti.html',
-      audits: {
-        'first-cpu-idle': {
-          score: '<75',
-          rawValue: '>9000',
-        },
-        'interactive': {
-          score: '<75',
-          rawValue: '>9000',
-        },
+    requestedUrl: 'http://localhost:10200/tricky-tti.html',
+    finalUrl: 'http://localhost:10200/tricky-tti.html',
+    audits: {
+      'first-cpu-idle': {
+        score: '<75',
+        rawValue: '>9000',
+      },
+      'interactive': {
+        score: '<75',
+        rawValue: '>9000',
       },
     },
   },
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/delayed-fcp.html',
-      finalUrl: 'http://localhost:10200/delayed-fcp.html',
-      audits: {
-        'first-contentful-paint': {
-          rawValue: '>1', // We just want to check that it doesn't error
-        },
+    requestedUrl: 'http://localhost:10200/delayed-fcp.html',
+    finalUrl: 'http://localhost:10200/delayed-fcp.html',
+    audits: {
+      'first-contentful-paint': {
+        rawValue: '>1', // We just want to check that it doesn't error
       },
     },
   },
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
-      finalUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
-      audits: {
-        'bootup-time': {
-          details: {
-            items: {
-              0: {
+    requestedUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
+    finalUrl: 'http://localhost:10200/tricky-main-thread.html?setTimeout',
+    audits: {
+      'bootup-time': {
+        details: {
+          items: {
+            0: {
               // FIXME: Appveyor finds this particular assertion very flaky for some reason :(
-                url: process.env.APPVEYOR ? /main/ : /main-thread-consumer/,
-                scripting: '>1000',
-              },
+              url: process.env.APPVEYOR ? /main/ : /main-thread-consumer/,
+              scripting: '>1000',
             },
           },
         },
@@ -56,18 +50,16 @@ module.exports = [
     },
   },
   {
-    lhr: {
-      requestedUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
-      finalUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
-      audits: {
-        'bootup-time': {
-          details: {
-            items: {
-              0: {
+    requestedUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
+    finalUrl: 'http://localhost:10200/tricky-main-thread.html?fetch',
+    audits: {
+      'bootup-time': {
+        details: {
+          items: {
+            0: {
               // TODO: requires async stacks, https://github.com/GoogleChrome/lighthouse/pull/5504
               // url: /main-thread-consumer/,
-                scripting: '>1000',
-              },
+              scripting: '>1000',
             },
           },
         },

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -12,7 +12,7 @@
   }
 
   export interface Comparison {
-    category: string;
+    name: string;
     actual: any;
     expected: any;
     equal: boolean;

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -21,7 +21,7 @@
 
   export type ExpectedLHR = Pick<LH.Result, 'audits' | 'finalUrl' | 'requestedUrl'>
 
-  export type ExpectedRunResult = {
+  export type ExpectedRunnerResult = {
     errorCode?: string;
     lhr: ExpectedLHR,
     artifacts?: Partial<LH.Artifacts>

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -33,7 +33,7 @@
     finalUrl: Comparison;
   }
 
-  export interface Assertion{
+  export interface Assertion {
     category: string;
     actual: any;
     expected: any;

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -19,9 +19,10 @@
     diff?: Difference | null;
   }
 
-  export type ExpectedLHR = Pick<LH.Result, 'audits' | 'finalUrl' | 'requestedUrl'> & { errorCode?: string }
+  export type ExpectedLHR = Pick<LH.Result, 'audits' | 'finalUrl' | 'requestedUrl'>
 
   export type ExpectedRunResult = {
+    errorCode?: string;
     lhr: ExpectedLHR,
     artifacts?: Partial<LH.Artifacts>
   }

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -21,10 +21,23 @@
 
   export type ExpectedLHR = Pick<LH.Result, 'audits' | 'finalUrl' | 'requestedUrl'> & { errorCode?: string }
 
-  export interface LHRComparison {
-    audits: Comparison[];
+  export type ExpectedRunResult = {
+    lhr: ExpectedLHR,
+    artifacts?: Partial<LH.Artifacts>
+  }
+
+  export interface RunComparison {
+    assertions: Comparison[];
     errorCode: Comparison;
     finalUrl: Comparison;
+  }
+
+  export interface Assertion{
+    category: string;
+    actual: any;
+    expected: any;
+    equal: boolean;
+    diff: Smokehouse.Difference | null;
   }
 
   export interface TestDfn {

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -21,23 +21,10 @@
 
   export type ExpectedLHR = Pick<LH.Result, 'audits' | 'finalUrl' | 'requestedUrl'> & { errorCode?: string }
 
-  export type ExpectedRunResult = {
-    lhr: ExpectedLHR,
-    artifacts?: Partial<LH.Artifacts>
-  }
-
-  export interface RunComparison {
-    assertions: Comparison[];
+  export interface LHRComparison {
+    audits: Comparison[];
     errorCode: Comparison;
     finalUrl: Comparison;
-  }
-
-  export interface Assertion{
-    category: string;
-    actual: any;
-    expected: any;
-    equal: boolean;
-    diff: Smokehouse.Difference | null;
   }
 
   export interface TestDfn {

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -27,20 +27,6 @@
     artifacts?: Partial<LH.Artifacts>
   }
 
-  export interface RunComparison {
-    assertions: Comparison[];
-    errorCode: Comparison;
-    finalUrl: Comparison;
-  }
-
-  export interface Assertion {
-    category: string;
-    actual: any;
-    expected: any;
-    equal: boolean;
-    diff: Smokehouse.Difference | null;
-  }
-
   export interface TestDfn {
     id: string;
     expectations: string;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**

We'd [like to](https://github.com/GoogleChrome/lighthouse/pull/7778#discussion_r271847241) make assertions against the artifacts in the smoke tests.

- Wrap existing expectations in `lhr` top level object
- Add support for having `artifacts` expectations in addition to `lhr`

