### PR TITLE
misc: remove unused typedef

### DIFF
--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -99,18 +99,6 @@ declare global {
         /** A brief description of the purpose of the display group. */
         description?: string;
       }
-
-      /**
-       * A description of configuration used for gathering.
-       */
-      export interface RuntimeConfig {
-        environment: {
-          name: 'Device Emulation'|'Network Throttling'|'CPU Throttling';
-          description: string;
-        }[];
-        blockedUrlPatterns: string[];
-        extraHeaders: Crdp.Network.Headers;
-      }
     }
   }
 }


### PR DESCRIPTION
was starting work on a public `d.ts` file and come across this unused type. The public `d.ts` file is a lot more work than I'm prepared to take on for it at the moment, but wanted to flush this before I forgot :)