### PR TITLE
clients(lr): apply Lightrider timings to NetworkRequests

### DIFF
--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -428,8 +428,41 @@ class NetworkRequest {
       return;
     }
 
+    // Init blank timing if needed.
+    if (this.timing === undefined) {
+      this.timing = {
+        requestTime: this.startTime,
+        proxyStart: -1,
+        proxyEnd: -1,
+        dnsStart: -1,
+        dnsEnd: -1,
+        connectStart: -1,
+        connectEnd: -1,
+        sslStart: -1,
+        sslEnd: -1,
+        workerStart: -1,
+        workerReady: -1,
+        sendStart: -1,
+        sendEnd: -1,
+        pushStart: -1,
+        pushEnd: -1,
+        receiveHeadersEnd: -1,
+      };
+    }
+
+    const origEnd = this.endTime;
+    // EndTime and responseReceivedTime are in seconds, so conversion is necessary.
+    this.endTime = this.startTime + (totalMs / 1000);
+    this.responseReceivedTime = this.startTime + ((TCPMs + requestMs) / 1000);
+    this.timing.connectStart = 0;
+    this.timing.connectEnd = TCPMs;
+    this.timing.sslStart = TCPMs - SSLMs;
+    this.timing.sslEnd = TCPMs;
+    this.timing.sendStart = TCPMs;
+    this.timing.sendEnd = TCPMs;
+    this.timing.receiveHeadersEnd = TCPMs + requestMs;
     this.lrStatistics = {
-      endTimeDeltaMs: (this.endTime - (this.startTime + (totalMs / 1000))) * 1000,
+      endTimeDeltaMs: (origEnd - this.endTime) * 1000,
       TCPMs: TCPMs,
       requestMs: requestMs,
       responseMs: responseMs,

--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -451,9 +451,10 @@ class NetworkRequest {
     }
 
     const origEnd = this.endTime;
-    // EndTime and responseReceivedTime are in seconds, so conversion is necessary.
+    // `this.endTime` and `this.responseReceivedTime` are in seconds, so convert from milliseconds.
     this.endTime = this.startTime + (totalMs / 1000);
     this.responseReceivedTime = this.startTime + ((TCPMs + requestMs) / 1000);
+
     this.timing.connectStart = 0;
     this.timing.connectEnd = TCPMs;
     this.timing.sslStart = TCPMs - SSLMs;
@@ -461,6 +462,7 @@ class NetworkRequest {
     this.timing.sendStart = TCPMs;
     this.timing.sendEnd = TCPMs;
     this.timing.receiveHeadersEnd = TCPMs + requestMs;
+
     this.lrStatistics = {
       endTimeDeltaMs: (origEnd - this.endTime) * 1000,
       TCPMs: TCPMs,

--- a/lighthouse-core/lib/network-request.js
+++ b/lighthouse-core/lib/network-request.js
@@ -428,27 +428,25 @@ class NetworkRequest {
       return;
     }
 
-    // Init blank timing if needed.
-    if (this.timing === undefined) {
-      this.timing = {
-        requestTime: this.startTime,
-        proxyStart: -1,
-        proxyEnd: -1,
-        dnsStart: -1,
-        dnsEnd: -1,
-        connectStart: -1,
-        connectEnd: -1,
-        sslStart: -1,
-        sslEnd: -1,
-        workerStart: -1,
-        workerReady: -1,
-        sendStart: -1,
-        sendEnd: -1,
-        pushStart: -1,
-        pushEnd: -1,
-        receiveHeadersEnd: -1,
-      };
-    }
+    // Init timing.
+    this.timing = {
+      requestTime: this.startTime,
+      proxyStart: -1,
+      proxyEnd: -1,
+      dnsStart: -1,
+      dnsEnd: -1,
+      connectStart: -1,
+      connectEnd: -1,
+      sslStart: -1,
+      sslEnd: -1,
+      workerStart: -1,
+      workerReady: -1,
+      sendStart: -1,
+      sendEnd: -1,
+      pushStart: -1,
+      pushEnd: -1,
+      receiveHeadersEnd: -1,
+    };
 
     const origEnd = this.endTime;
     // `this.endTime` and `this.responseReceivedTime` are in seconds, so convert from milliseconds.

--- a/lighthouse-core/test/lib/network-request-test.js
+++ b/lighthouse-core/test/lib/network-request-test.js
@@ -281,7 +281,7 @@ describe('NetworkRequest', () => {
       });
     });
 
-    it('merges with existing timing properties', function() {
+    it('overrides existing timing properties', function() {
       const req = getRequest();
       req.timing = {proxyStart: 17, sslStart: 35};
       const devtoolsLog = networkRecordsToDevtoolsLog([req]);
@@ -297,7 +297,7 @@ describe('NetworkRequest', () => {
       expect(lrRecord.endTime).toStrictEqual(10);
       expect(lrRecord.responseReceivedTime).toStrictEqual(7.5);
       expect(lrRecord.timing).toMatchObject({
-        proxyStart: 17,
+        proxyStart: -1,
         connectStart: 0,
         connectEnd: 5000,
         sslStart: 4000,

--- a/lighthouse-core/test/lib/network-request-test.js
+++ b/lighthouse-core/test/lib/network-request-test.js
@@ -100,13 +100,15 @@ describe('NetworkRequest', () => {
       expect(record.startTime).toStrictEqual(0);
       expect(record.endTime).toStrictEqual(10);
       expect(record.responseReceivedTime).toStrictEqual(7.5);
-      expect(record.timing.connectStart).toStrictEqual(0);
-      expect(record.timing.connectEnd).toStrictEqual(5000);
-      expect(record.timing.sslStart).toStrictEqual(4000);
-      expect(record.timing.sslEnd).toStrictEqual(5000);
-      expect(record.timing.sendStart).toStrictEqual(5000);
-      expect(record.timing.sendEnd).toStrictEqual(5000);
-      expect(record.timing.receiveHeadersEnd).toStrictEqual(7500);
+      expect(record.timing).toMatchObject({
+        connectStart: 0,
+        connectEnd: 5000,
+        sslStart: 4000,
+        sslEnd: 5000,
+        sendStart: 5000,
+        sendEnd: 5000,
+        receiveHeadersEnd: 7500,
+      });
       expect(record.lrStatistics).toStrictEqual({
         endTimeDeltaMs: -8000,
         TCPMs: 5000,
@@ -199,13 +201,15 @@ describe('NetworkRequest', () => {
       expect(record.startTime).toStrictEqual(0);
       expect(record.endTime).toStrictEqual(10);
       expect(record.responseReceivedTime).toStrictEqual(0);
-      expect(record.timing.connectStart).toStrictEqual(0);
-      expect(record.timing.connectEnd).toStrictEqual(0);
-      expect(record.timing.sslStart).toStrictEqual(0);
-      expect(record.timing.sslEnd).toStrictEqual(0);
-      expect(record.timing.sendStart).toStrictEqual(0);
-      expect(record.timing.sendEnd).toStrictEqual(0);
-      expect(record.timing.receiveHeadersEnd).toStrictEqual(0);
+      expect(record.timing).toMatchObject({
+        connectStart: 0,
+        connectEnd: 0,
+        sslStart: 0,
+        sslEnd: 0,
+        sendStart: 0,
+        sendEnd: 0,
+        receiveHeadersEnd: 0,
+      });
       expect(record.lrStatistics).toStrictEqual({
         endTimeDeltaMs: -8000,
         TCPMs: 0,
@@ -227,13 +231,15 @@ describe('NetworkRequest', () => {
       expect(record.startTime).toStrictEqual(0);
       expect(record.endTime).toStrictEqual(10);
       expect(record.responseReceivedTime).toStrictEqual(1);
-      expect(record.timing.connectStart).toStrictEqual(0);
-      expect(record.timing.connectEnd).toStrictEqual(1000);
-      expect(record.timing.sslStart).toStrictEqual(1000);
-      expect(record.timing.sslEnd).toStrictEqual(1000);
-      expect(record.timing.sendStart).toStrictEqual(1000);
-      expect(record.timing.sendEnd).toStrictEqual(1000);
-      expect(record.timing.receiveHeadersEnd).toStrictEqual(1000);
+      expect(record.timing).toMatchObject({
+        connectStart: 0,
+        connectEnd: 1000,
+        sslStart: 1000,
+        sslEnd: 1000,
+        sendStart: 1000,
+        sendEnd: 1000,
+        receiveHeadersEnd: 1000,
+      });
       expect(record.lrStatistics).toStrictEqual({
         endTimeDeltaMs: -8000,
         TCPMs: 1000,
@@ -257,14 +263,16 @@ describe('NetworkRequest', () => {
       expect(lrRecord.startTime).toStrictEqual(0);
       expect(lrRecord.endTime).toStrictEqual(10);
       expect(lrRecord.responseReceivedTime).toStrictEqual(7.5);
-      expect(lrRecord.timing.proxyStart).toStrictEqual(-1);
-      expect(lrRecord.timing.connectStart).toStrictEqual(0);
-      expect(lrRecord.timing.connectEnd).toStrictEqual(5000);
-      expect(lrRecord.timing.sslStart).toStrictEqual(4000);
-      expect(lrRecord.timing.sslEnd).toStrictEqual(5000);
-      expect(lrRecord.timing.sendStart).toStrictEqual(5000);
-      expect(lrRecord.timing.sendEnd).toStrictEqual(5000);
-      expect(lrRecord.timing.receiveHeadersEnd).toStrictEqual(7500);
+      expect(lrRecord.timing).toMatchObject({
+        proxyStart: -1,
+        connectStart: 0,
+        connectEnd: 5000,
+        sslStart: 4000,
+        sslEnd: 5000,
+        sendStart: 5000,
+        sendEnd: 5000,
+        receiveHeadersEnd: 7500,
+      });
       expect(lrRecord.lrStatistics).toStrictEqual({
         endTimeDeltaMs: -8000,
         TCPMs: 5000,
@@ -288,14 +296,16 @@ describe('NetworkRequest', () => {
       expect(lrRecord.startTime).toStrictEqual(0);
       expect(lrRecord.endTime).toStrictEqual(10);
       expect(lrRecord.responseReceivedTime).toStrictEqual(7.5);
-      expect(lrRecord.timing.proxyStart).toStrictEqual(17);
-      expect(lrRecord.timing.connectStart).toStrictEqual(0);
-      expect(lrRecord.timing.connectEnd).toStrictEqual(5000);
-      expect(lrRecord.timing.sslStart).toStrictEqual(4000);
-      expect(lrRecord.timing.sslEnd).toStrictEqual(5000);
-      expect(lrRecord.timing.sendStart).toStrictEqual(5000);
-      expect(lrRecord.timing.sendEnd).toStrictEqual(5000);
-      expect(lrRecord.timing.receiveHeadersEnd).toStrictEqual(7500);
+      expect(lrRecord.timing).toMatchObject({
+        proxyStart: 17,
+        connectStart: 0,
+        connectEnd: 5000,
+        sslStart: 4000,
+        sslEnd: 5000,
+        sendStart: 5000,
+        sendEnd: 5000,
+        receiveHeadersEnd: 7500,
+      });
       expect(lrRecord.lrStatistics).toStrictEqual({
         endTimeDeltaMs: -8000,
         TCPMs: 5000,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Follow up to #7888 which now actually applies those LR timings.

Call out if I forgot to re-add anything.
