### PR TITLE
core: adjustments to stack-pack comments and types

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -53,7 +53,7 @@ async function browserifyFile(entryPath, distPath) {
 
   bundle
     // Transform the fs.readFile etc into inline strings.
-    .transform('brfs', {global: true, parserOpts: {ecmaVersion: 9}})
+    .transform('brfs', {global: true, parserOpts: {ecmaVersion: 10}})
     // Strip everything out of package.json includes except for the version.
     .transform('package-json-versionify');
 
@@ -121,6 +121,7 @@ function minifyScript(filePath) {
     shouldPrintComment: () => false, // Don't include @license or @preserve comments either
     plugins: [
       'syntax-object-rest-spread',
+      'syntax-async-generators',
     ],
     // sourceMaps: 'both'
   };

--- a/lighthouse-core/audits/dobetterweb/js-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/js-libraries.js
@@ -30,12 +30,12 @@ class JsLibrariesAudit extends Audit {
    * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
-    const libDetails = (artifacts.Stacks || [])
+    const libDetails = artifacts.Stacks
       .filter(stack => stack.detector === 'js')
       .map(stack => ({
         name: stack.name,
-        version: stack.version || undefined, // null if not detected
-        npm: stack.npm || undefined, // ~70% of libs come with this field
+        version: stack.version,
+        npm: stack.npm,
       }));
 
     /** @type {LH.Audit.Details.Table['headings']} */

--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -60,8 +60,8 @@ class NoVulnerableLibrariesAudit extends Audit {
 
   /**
    * Attempts to normalize the version.
-   * @param {?string} version
-   * @return {?string}
+   * @param {string|undefined} version
+   * @return {string|undefined}
    */
   static normalizeVersion(version) {
     if (!version) return version;
@@ -78,7 +78,7 @@ class NoVulnerableLibrariesAudit extends Audit {
 
   /**
    * @param {string} normalizedVersion
-   * @param {{name: string, version: string, npm?: string}} lib
+   * @param {LH.Artifacts.DetectedStack} lib
    * @param {SnykDB} snykDB
    * @return {Array<Vulnerability>}
    */
@@ -135,7 +135,7 @@ class NoVulnerableLibrariesAudit extends Audit {
    * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
-    const foundLibraries = (artifacts.Stacks || []).filter(stack => stack.detector === 'js');
+    const foundLibraries = artifacts.Stacks.filter(stack => stack.detector === 'js');
     const snykDB = NoVulnerableLibrariesAudit.snykDB;
 
     if (!foundLibraries.length) {

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -7,7 +7,7 @@
 
 const log = require('lighthouse-logger');
 const manifestParser = require('../lib/manifest-parser.js');
-const stacksGatherer = require('../lib/gatherer-stacks.js');
+const stacksGatherer = require('../lib/stack-collector.js');
 const LHError = require('../lib/lh-error.js');
 const URL = require('../lib/url-shim.js');
 const NetworkRecorder = require('../lib/network-recorder.js');
@@ -412,7 +412,7 @@ class GatherRunner {
       NetworkUserAgent: '', // updated later
       BenchmarkIndex: 0, // updated later
       WebAppManifest: null, // updated later
-      Stacks: null, // updated later
+      Stacks: [], // updated later
       traces: {},
       devtoolsLogs: {},
       settings: options.settings,
@@ -480,11 +480,17 @@ class GatherRunner {
         }
         await GatherRunner.beforePass(passContext, gathererResults);
         await GatherRunner.pass(passContext, gathererResults);
+
         if (isFirstPass) {
+          // Fetch the manifest, if it exists. Currently must be fetched before gatherers' `afterPass`.
           baseArtifacts.WebAppManifest = await GatherRunner.getWebAppManifest(passContext);
+        }
+
+        const passData = await GatherRunner.afterPass(passContext, gathererResults);
+
+        if (isFirstPass) {
           baseArtifacts.Stacks = await stacksGatherer(passContext);
         }
-        const passData = await GatherRunner.afterPass(passContext, gathererResults);
 
         // Save devtoolsLog, but networkRecords are discarded and not added onto artifacts.
         baseArtifacts.devtoolsLogs[passConfig.passName] = passData.devtoolsLog;

--- a/lighthouse-core/lib/stack-collector.js
+++ b/lighthouse-core/lib/stack-collector.js
@@ -15,45 +15,51 @@
 
 const fs = require('fs');
 const libDetectorSource = fs.readFileSync(
-  require.resolve('js-library-detector/library/libraries.js'),
-  'utf8'
-);
+  require.resolve('js-library-detector/library/libraries.js'), 'utf8');
+
+/**
+ * @typedef JSLibraryDetectorTest
+ * @property {string} icon Essentially an id, useful if no npm name is detected.
+ * @property {string} url
+ * @property {string|null} npm npm module name, if applicable to library.
+ * @property {function(Window): false|{version: string|null} | Promise<false|{version: string|null}>} test Returns false if library is not present, otherwise returns an object that contains the library version (set to null if the version is not detected).
+ */
 
 /**
  * @typedef JSLibrary
  * @property {string} name
- * @property {string} version
- * @property {string} npm
- * @property {string} iconName
+ * @property {string} icon
+ * @property {string|null} version
+ * @property {string|null} npm
  */
 
 /**
  * Obtains a list of detected JS libraries and their versions.
  */
 /* istanbul ignore next */
-function detectLibraries() {
+async function detectLibraries() {
   /** @type {JSLibrary[]} */
   const libraries = [];
 
   // d41d8cd98f00b204e9800998ecf8427e_ is a consistent prefix used by the detect libraries
   // see https://github.com/HTTPArchive/httparchive/issues/77#issuecomment-291320900
+  /** @type {Record<string, JSLibraryDetectorTest>} */
   // @ts-ignore - injected libDetectorSource var
-  Object.entries(d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests).forEach(
-    async ([name, lib]) => {
-      // eslint-disable-line max-len
-      try {
-        const result = await lib.test(window);
-        if (result) {
-          libraries.push({
-            name: name,
-            version: result.version,
-            npm: lib.npm,
-            iconName: lib.icon,
-          });
-        }
-      } catch (e) {}
-    }
-  );
+  const libraryDetectorTests = d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests; // eslint-disable-line 
+
+  for await (const [name, lib] of Object.entries(libraryDetectorTests)) {
+    try {
+      const result = await lib.test(window);
+      if (result) {
+        libraries.push({
+          name: name,
+          icon: lib.icon,
+          version: result.version,
+          npm: lib.npm,
+        });
+      }
+    } catch (e) {}
+  }
 
   return libraries;
 }
@@ -62,23 +68,22 @@ function detectLibraries() {
  * @param {LH.Gatherer.PassContext} passContext
  * @return {Promise<LH.Artifacts['Stacks']>}
  */
-async function getStacks(passContext) {
+async function collectStacks(passContext) {
   const expression = `(function () {
     ${libDetectorSource};
     return (${detectLibraries.toString()}());
   })()`;
 
-  const jsLibraries = /** @type {JSLibrary[]} */ (await passContext.driver.evaluateAsync(
-    expression
-  ));
+  /** @type {JSLibrary[]} */
+  const jsLibraries = await passContext.driver.evaluateAsync(expression);
 
   return jsLibraries.map(lib => ({
     detector: /** @type {'js'} */ ('js'),
-    id: lib.npm || lib.iconName,
+    id: lib.npm || lib.icon,
     name: lib.name,
-    version: lib.version,
-    npm: lib.npm,
+    version: lib.version || undefined,
+    npm: lib.npm || undefined,
   }));
 }
 
-module.exports = getStacks;
+module.exports = collectStacks;

--- a/lighthouse-core/lib/stack-collector.js
+++ b/lighthouse-core/lib/stack-collector.js
@@ -17,12 +17,13 @@ const fs = require('fs');
 const libDetectorSource = fs.readFileSync(
   require.resolve('js-library-detector/library/libraries.js'), 'utf8');
 
+/** @typedef {false | {version: string|null}} JSLibraryDetectorTestResult */
 /**
  * @typedef JSLibraryDetectorTest
  * @property {string} icon Essentially an id, useful if no npm name is detected.
  * @property {string} url
  * @property {string|null} npm npm module name, if applicable to library.
- * @property {function(Window): false|{version: string|null} | Promise<false|{version: string|null}>} test Returns false if library is not present, otherwise returns an object that contains the library version (set to null if the version is not detected).
+ * @property {function(Window): JSLibraryDetectorTestResult | Promise<JSLibraryDetectorTestResult>} test Returns false if library is not present, otherwise returns an object that contains the library version (set to null if the version is not detected).
  */
 
 /**
@@ -47,7 +48,7 @@ async function detectLibraries() {
   // @ts-ignore - injected libDetectorSource var
   const libraryDetectorTests = d41d8cd98f00b204e9800998ecf8427e_LibraryDetectorTests; // eslint-disable-line 
 
-  for await (const [name, lib] of Object.entries(libraryDetectorTests)) {
+  for (const [name, lib] of Object.entries(libraryDetectorTests)) {
     try {
       const result = await lib.test(window);
       if (result) {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -148,7 +148,7 @@ class Runner {
           rendererFormattedStrings: i18n.getRendererFormattedStrings(settings.locale),
           icuMessagePaths: {},
         },
-        stackPacks: stackPacks.getStackPacks(artifacts),
+        stackPacks: stackPacks.getStackPacks(artifacts.Stacks),
       };
 
       // Replace ICU message references with localized strings; save replaced paths in lhr.

--- a/lighthouse-core/test/audits/dobetterweb/js-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/js-libraries-test.js
@@ -21,7 +21,7 @@ describe('Returns detected front-end JavaScript libraries', () => {
     const auditResult2 = JsLibrariesAudit.audit({
       Stacks: [
         {detector: 'js', name: 'lib1', version: '3.10.1', npm: 'lib1'},
-        {detector: 'js', name: 'lib2', version: null, npm: 'lib2'},
+        {detector: 'js', name: 'lib2', version: undefined, npm: 'lib2'},
       ],
     });
     assert.equal(auditResult2.rawValue, true);
@@ -29,11 +29,11 @@ describe('Returns detected front-end JavaScript libraries', () => {
     // LOTS of frontend libs
     const auditResult3 = JsLibrariesAudit.audit({
       Stacks: [
-        {detector: 'js', name: 'React', version: null, npm: 'react'},
-        {detector: 'js', name: 'Polymer', version: null, npm: 'polymer-core'},
-        {detector: 'js', name: 'Preact', version: null, npm: 'preact'},
-        {detector: 'js', name: 'Angular', version: null, npm: 'angular'},
-        {detector: 'js', name: 'jQuery', version: null, npm: 'jquery'},
+        {detector: 'js', name: 'React', version: undefined, npm: 'react'},
+        {detector: 'js', name: 'Polymer', version: undefined, npm: 'polymer-core'},
+        {detector: 'js', name: 'Preact', version: undefined, npm: 'preact'},
+        {detector: 'js', name: 'Angular', version: undefined, npm: 'angular'},
+        {detector: 'js', name: 'jQuery', version: undefined, npm: 'jquery'},
       ],
     });
     assert.equal(auditResult3.rawValue, true);
@@ -43,7 +43,7 @@ describe('Returns detected front-end JavaScript libraries', () => {
     const auditResult = JsLibrariesAudit.audit({
       Stacks: [
         {detector: 'js', name: 'lib1', version: '3.10.1', npm: 'lib1'},
-        {detector: 'js', name: 'lib2', version: null, npm: 'lib2'},
+        {detector: 'js', name: 'lib2', version: undefined, npm: 'lib2'},
       ],
     });
     const expected = [

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 describe('Avoids front-end JavaScript libraries with known vulnerabilities', () => {
   describe('#normalizeVersion', () => {
     it('should leave valid and unsavable versions untouched', () => {
-      assert.equal(NoVulnerableLibrariesAudit.normalizeVersion(null), null);
+      assert.equal(NoVulnerableLibrariesAudit.normalizeVersion(undefined), undefined);
       assert.equal(NoVulnerableLibrariesAudit.normalizeVersion('52.1.13'), '52.1.13');
       assert.equal(NoVulnerableLibrariesAudit.normalizeVersion('52.1.13-rc.1'), '52.1.13-rc.1');
       assert.equal(NoVulnerableLibrariesAudit.normalizeVersion('c0ab71056b936'), 'c0ab71056b936');
@@ -31,7 +31,7 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
       Stacks: [
         {detector: 'js', name: 'lib1', version: '1.0.0', npm: 'lib1'},
         {detector: 'js', name: 'angular', version: '1.1.4', npm: 'angular'},
-        {detector: 'js', name: 'lib3', version: null, npm: 'lib3'},
+        {detector: 'js', name: 'lib3', version: undefined, npm: 'lib3'},
       ],
     });
     assert.equal(auditResult.rawValue, false);
@@ -89,7 +89,7 @@ Array [
     const auditResult = NoVulnerableLibrariesAudit.audit({
       Stacks: [
         {detector: 'js', name: 'lib1', version: '3.10.1', npm: 'lib1'},
-        {detector: 'js', name: 'lib2', version: null, npm: 'lib2'},
+        {detector: 'js', name: 'lib2', version: undefined, npm: 'lib2'},
       ],
     });
     assert.equal(auditResult.rawValue, true);

--- a/lighthouse-core/test/fixtures/artifacts/empty-artifacts/artifacts.json
+++ b/lighthouse-core/test/fixtures/artifacts/empty-artifacts/artifacts.json
@@ -2,5 +2,6 @@
   "URL": {
     "requestedUrl": "https://example.com/",
     "finalUrl": "https://example.com/"
-  }
+  },
+  "Stacks": []
 }

--- a/lighthouse-core/test/fixtures/artifacts/perflog/artifacts.json
+++ b/lighthouse-core/test/fixtures/artifacts/perflog/artifacts.json
@@ -9,6 +9,7 @@
     "requestedUrl": "https://www.reddit.com/r/nba",
     "finalUrl": "https://www.reddit.com/r/nba"
   },
+  "Stacks": [],
   "MetaElements": [],
   "ViewportDimensions": {
     "innerWidth": 412,

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -14,7 +14,7 @@ const Config = require('../../config/config');
 const unresolvedPerfLog = require('./../fixtures/unresolved-perflog.json');
 const NetworkRequest = require('../../lib/network-request.js');
 
-jest.mock('../../lib/gatherer-stacks.js', () => () => Promise.resolve([]));
+jest.mock('../../lib/stack-collector.js', () => () => Promise.resolve([]));
 
 class TestGatherer extends Gatherer {
   constructor() {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -20,7 +20,7 @@ const LHError = require('../lib/lh-error.js');
 
 /* eslint-env jest */
 
-jest.mock('../lib/gatherer-stacks.js', () => () => Promise.resolve([]));
+jest.mock('../lib/stack-collector.js', () => () => Promise.resolve([]));
 
 describe('Runner', () => {
   /** @type {jest.Mock} */

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "angular": "^1.7.4",
     "archiver": "^3.0.0",
     "babel-core": "^6.26.0",
+    "babel-plugin-syntax-async-generators": "^6.13.0",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "brfs": "^1.6.1",
     "browserify": "^16.2.3",
@@ -130,6 +131,7 @@
     "zone.js": "^0.7.3"
   },
   "dependencies": {
+    "@lighthouse/stack-packs": "file:./stack-packs",
     "axe-core": "3.1.2",
     "chrome-launcher": "^0.10.5",
     "configstore": "^3.1.1",
@@ -158,8 +160,7 @@
     "update-notifier": "^2.5.0",
     "ws": "3.3.2",
     "yargs": "3.32.0",
-    "yargs-parser": "7.0.0",
-    "@lighthouse/stack-packs": "file:./stack-packs"
+    "yargs-parser": "7.0.0"
   },
   "resolutions": {
     "chrome-launcher/@types/node": "*"

--- a/stack-packs/index.js
+++ b/stack-packs/index.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-/** @type {import('./stack-packs').Pack[]} */
+/** @type {typeof import('./stack-packs')} */
 const stackPacks = [
   require('./packs/wordpress.js'),
 ];

--- a/stack-packs/package.json
+++ b/stack-packs/package.json
@@ -7,7 +7,8 @@
   "keywords": [
     "google",
     "chrome",
-    "devtools"
+    "devtools",
+    "lighthouse"
   ],
   "author": "The Chromium Authors",
   "license": "Apache-2.0",

--- a/stack-packs/stack-packs.d.ts
+++ b/stack-packs/stack-packs.d.ts
@@ -1,3 +1,9 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
 interface Pack {
   id: string;
   iconDataURL: string;

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -34,7 +34,7 @@ declare global {
       /** Parsed version of the page's Web App Manifest, or null if none found. */
       WebAppManifest: Artifacts.Manifest | null;
       /** Information on detected tech stacks (e.g. JS libraries) used by the page. */
-      Stacks: Artifacts.DetectedStack[] | null;
+      Stacks: Artifacts.DetectedStack[];
       /** A set of page-load traces, keyed by passName. */
       traces: {[passName: string]: Trace};
       /** A set of DevTools debugger protocol records, keyed by passName. */
@@ -447,16 +447,17 @@ declare global {
         fmpFellBack: boolean;
       }
 
+      /** Information on a tech stack (e.g. a JS library) used by the page. */
       export interface DetectedStack {
-        /** The identifier on how this stack got detected */
+        /** The identifier for how this stack was detected. */
         detector: 'js';
-        /** The unique name of the stack stripped of special characters */
+        /** The unique string ID for the stack. */
         id: string;
-        /** The name of the stack */
+        /** The name of the stack. */
         name: string;
-        /** The version of the stack we found */
-        version: string;
-        /** The package name on NPM if it exists */
+        /** The version of the stack, if it could be detected. */
+        version?: string;
+        /** The package name on NPM, if it exists. */
         npm?: string;
       }
     }

--- a/types/html-renderer.d.ts
+++ b/types/html-renderer.d.ts
@@ -45,15 +45,6 @@ declare global {
     prepareLabData: typeof _prepareLabData;
   }
 
-  interface StackPackRef {
-    /** Title of the stackpack, used as an alt text */
-    title: string;
-    /** Base64 url of the current stackpack */
-    iconDataURL: string;
-    /** Description of the current audit of the stackpack */
-    description: string;
-  }
-
   module LH {
     // During report generation, the LHR object is transformed a bit for convenience
     // Primarily, the auditResult is added as .result onto the auditRef.
@@ -66,8 +57,18 @@ declare global {
       export interface Category extends Result.Category {
         auditRefs: Array<AuditRef>
       }
+
       export interface AuditRef extends Result.AuditRef {
-        result: Audit.Result & { stackPacks?: StackPackRef[] }
+        result: Audit.Result & { stackPacks?: StackPackDescription[] }
+      }
+
+      export interface StackPackDescription {
+         /** The title of the stack pack. */
+        title: string;
+        /** A base64 data url to be used as the stack pack's icon. */
+        iconDataURL: string;
+        /** The stack-specific description for this audit. */
+        description: string;
       }
     }
   }

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -60,7 +60,7 @@ declare global {
       timing: Result.Timing;
       /** The record of all formatted string locations in the LHR and their corresponding source values. */
       i18n: {rendererFormattedStrings: I18NRendererStrings, icuMessagePaths: I18NMessages};
-      /** An array containing the result of all stackpacks */
+      /** An array containing the result of all stack packs. */
       stackPacks: Result.StackPack[];
     }
 
@@ -103,16 +103,18 @@ declare global {
       }
 
       /**
-       * A description of a stack pack
+       * A pack of secondary audit descriptions to be used when a page uses a
+       * specific technology stack, giving stack-specific advice for some of
+       * Lighthouse's audits.
        */
       export interface StackPack {
-        /** The unique stackpack's name stripped from special characters */
+        /** The unique string ID for this stack pack. */
         id: string;
-        /** The name of the stack pack which we display on our report */
+        /** The title of the stack pack, to be displayed in the report. */
         title: string;
-        /** The base64 url of the icon  */
+        /** A base64 data url to be used as the stack pack's icon. */
         iconDataURL: string;
-        /** An object containing the descriptions of the audits, keyed by the audits' `id` identifier. */
+        /** A set of descriptions for some of Lighthouse's audits, keyed by the audits' `id`. */
         descriptions: Record<string, string>;
       }
     }

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -114,7 +114,7 @@ declare global {
         title: string;
         /** A base64 data url to be used as the stack pack's icon. */
         iconDataURL: string;
-        /** A set of descriptions for some of Lighthouse's audits, keyed by the audits' `id`. */
+        /** A set of descriptions for some of Lighthouse's audits, keyed by audit `id`. */
         descriptions: Record<string, string>;
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,6 +1292,11 @@ babel-plugin-jest-hoist@^24.3.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-syntax-async-generators@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+  integrity sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=
+
 babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"


### PR DESCRIPTION
changes:
- clean up of some of the jsdocs for stack pack types and properties in various `d.ts` files
- made `artifacts.Stacks` always defined (just init with a `[]`, get to remove the null checks). makes sense cause it's an array (so no results can just be an empty array) and it's a base artifact, so really should always be defined
- moved `lib/gatherer-stacks.js` to `lib/stack-collector.js` after discussing names with @paulirish. Happy to bikeshed more tho :)
- added types to `js-library-detector` output (in `stack-collector.js`), and settled on normalizing its various combinations of `undefined` and `null` for missing output to just using `undefined` once it becomes an artifact.
- while fixing `js-library-detector` noticed our incorrect async `Object.entries().forEach()`, which gives us our first `for await...of` in honor of moving to node 10 :)

TODO (tomorrow):
- stack pack tests :|