### PR TITLE
misc(ci): build report and deploy to now.sh on every commit

### DIFF
--- a/.build-for-now.sh
+++ b/.build-for-now.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
+
+##
+# @license Copyright 2019 Google Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+##
+
 set -x
 
 # Manually install this one report dependency. Avoid installing all deps (for speed)
 rm package.json
-npm install details-element-polyfill@2.2.0
+yarn add details-element-polyfill@2.2.0
 
 # Create dist if it's not already there
 mkdir -p dist
 
 # Generate the report and place as dist/index.html
-node lighthouse-core/scripts/build-report-to-dist.js
+node lighthouse-core/scripts/build-report-for-autodeployment.js

--- a/.build-for-now.sh
+++ b/.build-for-now.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -x
 
-# manually install this one report dependency. Avoid installing all deps.
+# Manually install this one report dependency. Avoid installing all deps (for speed)
 rm package.json
 npm install details-element-polyfill@2.2.0
 
-# create dist if it's not already there
+# Create dist if it's not already there
 mkdir -p dist
 
-# generate the report and place as dist/index.html
+# Generate the report and place as dist/index.html
 node lighthouse-core/scripts/build-report-to-dist.js

--- a/.build-for-now.sh
+++ b/.build-for-now.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -x
+
+# manually install this one report dependency. Avoid installing all deps.
+rm package.json
+npm install details-element-polyfill@2.2.0
+
+# create dist if it's not already there
+mkdir -p dist
+
+# generate the report and place as dist/index.html
+node lighthouse-core/scripts/build-report-to-dist.js

--- a/lighthouse-core/scripts/build-report-for-autodeployment.js
+++ b/lighthouse-core/scripts/build-report-for-autodeployment.js
@@ -11,12 +11,12 @@
 const fs = require('fs');
 const path = require('path');
 
-const ReportGenerator = require('../../lighthouse-core/report/report-generator');
+const ReportGenerator = require('../../lighthouse-core/report/report-generator.js');
 const lhr = require('../../lighthouse-core/test/results/sample_v2.json');
 
 console.log('🕒 Generating report for sample_v2.json...');
 // @ts-ignore
 const html = ReportGenerator.generateReport(lhr, 'html');
-const filename = path.resolve(__dirname + '/../../dist/index.html');
+const filename = path.join(__dirname, '../../dist/index.html');
 fs.writeFileSync(filename, html, {encoding: 'utf-8'});
 console.log('✅', filename, 'written.');

--- a/lighthouse-core/scripts/build-report-to-dist.js
+++ b/lighthouse-core/scripts/build-report-to-dist.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+
+const ReportGenerator = require('../../lighthouse-core/report/report-generator');
+const lhr = require('../../lighthouse-core/test/results/sample_v2.json');
+
+console.log('🕒 Generating report for sample_v2.json...');
+// @ts-ignore
+const html = ReportGenerator.generateReport(lhr, 'html');
+const filename = path.resolve(__dirname + '/../../dist/index.html');
+fs.writeFileSync(filename, html, {encoding: 'utf-8'});
+console.log('✅', filename, 'written.');

--- a/lighthouse-core/scripts/build-report-to-dist.js
+++ b/lighthouse-core/scripts/build-report-to-dist.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @license Copyright 2018 Google Inc. All Rights Reserved.
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */

--- a/now.json
+++ b/now.json
@@ -1,0 +1,12 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": ".build-for-now.sh",
+      "use": "@now/static-build"
+    }
+  ],
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
As described in #8159. :)

Jeffy enabled Now for us in this org. Thx!

Each deployment URL is unique. But there are also living URL aliases that represent each branch (including master):

* This PR (branch `nowjson`) is `lighthouse-git-nowjson.googlechrome.now.sh`
   * The pattern ([documented here](https://zeit.co/docs/v2/domains-and-aliases/aliasing-a-deployment/#git-staging-aliases)) is `lighthouse-git-<branch name>.googlechrome.now.sh`. I don't believe we can change this.
* Master is `lighthouse.googlechrome.now.sh`



The .sh has to be in the project root for the now builder to be reasonable. Ideally I would have liked it to be in lighthouse-core/scripts, but so it goes.


ref #8159