### PR TITLE
misc: fix bad auto-merge

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -143,16 +143,16 @@ module.exports = [
             }],
           },
         },
-      },
-      'dom-size': {
-        score: 1,
-        rawValue: 31,
-        details: {
-          items: [
-            {statistic: 'Total DOM Elements', value: '31'},
-            {statistic: 'Maximum DOM Depth', value: '3'},
-            {statistic: 'Maximum Child Elements', value: '29'},
-          ],
+        'dom-size': {
+          score: 1,
+          rawValue: 31,
+          details: {
+            items: [
+              {statistic: 'Total DOM Elements', value: '31'},
+              {statistic: 'Maximum DOM Depth', value: '3'},
+              {statistic: 'Maximum Child Elements', value: '29'},
+            ],
+          },
         },
       },
     },


### PR DESCRIPTION
I broke the build with #8044 :)

One of the rare times that the auto merge was successful and yielded valid javascript but broke the code's logic by taking what was a top-level audit assertion (new since the branch point) and leaving it at the top level after the merge, while #8044 had nested all the other assertions one layer deeper.

(the reason I wasn't able to see the failure locally was because travis was merging with master before testing and I was just checking the branch).