### PR TITLE
core: always run axe last

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -1082,9 +1082,6 @@ Object {
           "path": "chrome-console-messages",
         },
         Object {
-          "path": "accessibility",
-        },
-        Object {
           "path": "anchor-elements",
         },
         Object {
@@ -1134,6 +1131,9 @@ Object {
         },
         Object {
           "path": "seo/tap-targets",
+        },
+        Object {
+          "path": "accessibility",
         },
       ],
       "networkQuietThresholdMs": 1000,

--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -144,6 +144,7 @@ setTimeout(() => {
   <div class="onscreen" style="width: 30px; height: 30px; background: 25% 50% url(lighthouse-480x320.jpg?sprite);"></div>
   <div class="onscreen" style="width: 30px; height: 30px; background: 50% 50% url(lighthouse-480x320.jpg?sprite);"></div>
   <div class="onscreen" style="width: 30px; height: 30px; background: 75% 50% url(lighthouse-480x320.jpg?sprite);"></div>
+  <p style="background: blue;">Add some text here so axe will scroll to the bottom</p>
 </div>
 
 <template id="lazily-loaded-image">

--- a/lighthouse-cli/test/smokehouse/byte-config.js
+++ b/lighthouse-cli/test/smokehouse/byte-config.js
@@ -12,6 +12,7 @@ module.exports = {
   extends: 'lighthouse:full',
   settings: {
     onlyAudits: [
+      'accesskeys', // run axe on the page since we've had problems with interactions
       'network-requests',
       'offscreen-images',
       'uses-webp-images',

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -102,7 +102,6 @@ const defaultConfig = {
       'viewport-dimensions',
       'runtime-exceptions',
       'chrome-console-messages',
-      'accessibility',
       'anchor-elements',
       'image-elements',
       'link-elements',
@@ -120,6 +119,8 @@ const defaultConfig = {
       'seo/embedded-content',
       'seo/robots-txt',
       'seo/tap-targets',
+      // Always run axe last because it scrolls the page down to the bottom
+      'accessibility',
     ],
   },
   {


### PR DESCRIPTION
**Summary**
I broke offscreen images when I moved the image-elements gatherer down below accessibility in https://github.com/GoogleChrome/lighthouse/pull/7030.

This PR adds a smoketest to capture this and moves axe to the bottom with a comment.

**Related Issues/PRs**
broken in #7030
fixes #8211 
