### PR TITLE
report: add missing </div>

### DIFF
--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -497,6 +497,7 @@ limitations under the License.
         <a href="#" class="report-icon report-icon--open lh-export--gist" data-action="save-gist">Save as Gist</a>
       </div>
     </div>
+  </div>
 </template>
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**

This PR fixes #8110 where a div was missing.

This change was needed in favour of beautified exported reports where e.g. prettier printed an error because of that missing closing tag.

**Related Issues/PRs**

Related PR: https://github.com/GoogleChrome/lighthouse/pull/8128
Related Issue: #8110 
