### PR TITLE
misc: update sample_v2 artifacts

### DIFF
--- a/lighthouse-core/scripts/build-report-for-autodeployment.js
+++ b/lighthouse-core/scripts/build-report-for-autodeployment.js
@@ -12,10 +12,9 @@ const fs = require('fs');
 const path = require('path');
 
 const ReportGenerator = require('../../lighthouse-core/report/report-generator.js');
-const lhr = require('../../lighthouse-core/test/results/sample_v2.json');
+const lhr = /** @type {LH.Result} */ (require('../../lighthouse-core/test/results/sample_v2.json'));
 
 console.log('🕒 Generating report for sample_v2.json...');
-// @ts-ignore
 const html = ReportGenerator.generateReport(lhr, 'html');
 const filename = path.join(__dirname, '../../dist/index.html');
 fs.writeFileSync(filename, html, {encoding: 'utf-8'});

--- a/lighthouse-core/scripts/cleanup-LHR-for-diff.js
+++ b/lighthouse-core/scripts/cleanup-LHR-for-diff.js
@@ -26,10 +26,10 @@ function cleanAndFormatLHR(lhrString) {
   /** @type {LH.Result} */
   const lhr = JSON.parse(lhrString);
 
-  // TODO: Resolve the below so we don't need to delete it:
+  // TODO: Resolve the below so we don't need to force it to a boolean value:
   // 1) The string|boolean story for proto
   // 2) Travis gets a absolute path during yarn diff:sample-json
-  delete lhr.configSettings.auditMode;
+  lhr.configSettings.auditMode = true;
 
   // Set timing values, which change from run to run, to predictable values
   lhr.timing.total = 12345.6789;

--- a/lighthouse-core/test/config/default-config-test.js
+++ b/lighthouse-core/test/config/default-config-test.js
@@ -15,6 +15,10 @@ describe('Default Config', () => {
   it('only has opportunity audits that return opportunities details', async () => {
     const flags = {
       auditMode: __dirname + '/../results/artifacts/',
+
+      // sample_v2 was run with these settings, so need to match them.
+      throttlingMethod: 'devtools',
+      channel: 'cli',
     };
     const {lhr} = await lighthouse('', flags);
 

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -9,8 +9,129 @@
     "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
     "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html"
   },
+  "settings": {
+    "output": [
+      "html"
+    ],
+    "maxWaitForFcp": 15000,
+    "maxWaitForLoad": 45000,
+    "throttlingMethod": "devtools",
+    "throttling": {
+      "rttMs": 150,
+      "throughputKbps": 1638.4,
+      "requestLatencyMs": 562.5,
+      "downloadThroughputKbps": 1474.5600000000002,
+      "uploadThroughputKbps": 675,
+      "cpuSlowdownMultiplier": 4
+    },
+    "auditMode": false,
+    "gatherMode": "lighthouse-core/test/results/artifacts",
+    "disableStorageReset": false,
+    "disableDeviceEmulation": false,
+    "emulatedFormFactor": "mobile",
+    "channel": "cli",
+    "locale": "en-US",
+    "blockedUrlPatterns": null,
+    "additionalTraceCategories": null,
+    "extraHeaders": null,
+    "precomputedLanternData": null,
+    "onlyAudits": null,
+    "onlyCategories": null,
+    "skipAudits": null
+  },
   "Timing": [],
-  "LinkElements": [],
+  "LinkElements": [
+    {
+      "rel": "stylesheet",
+      "href": "http://localhost:54819/dobetterweb/dobetterweb/dbw_tester.css?delay=100",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dobetterweb/dbw_tester.css?delay=100",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "stylesheet",
+      "href": "http://localhost:54819/dobetterweb/unknown404.css?delay=200",
+      "hrefRaw": "http://localhost:54819/dobetterweb/unknown404.css?delay=200",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "stylesheet",
+      "href": "http://localhost:54819/dobetterweb/dbw_tester.css?delay=2200",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dbw_tester.css?delay=2200",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "stylesheet",
+      "href": "http://localhost:54819/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "import",
+      "href": "http://localhost:54819/dobetterweb/dbw_partial_a.html?delay=200",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dbw_partial_a.html?delay=200",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "import",
+      "href": "http://localhost:54819/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dbw_partial_b.html?delay=200&isasync",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "stylesheet",
+      "href": "http://localhost:54819/dobetterweb/dbw_tester.css?delay=3000&capped",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dbw_tester.css?delay=3000&capped",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "stylesheet",
+      "href": "http://localhost:54819/dobetterweb/dbw_tester.css?delay=2000&async=true",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dbw_tester.css?delay=2000&async=true",
+      "hreflang": "",
+      "as": "style",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "stylesheet",
+      "href": "http://localhost:54819/dobetterweb/dbw_tester.css?delay=3000&async=true",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dbw_tester.css?delay=3000&async=true",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    },
+    {
+      "rel": "stylesheet",
+      "href": "http://localhost:54819/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+      "hrefRaw": "http://localhost:54819/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+      "hreflang": "",
+      "as": "",
+      "crossOrigin": null,
+      "source": "head"
+    }
+  ],
   "ScriptElements": [
     {
       "type": "text/javascript",
@@ -228,7 +349,14 @@
   },
   "WebAppManifest": null,
   "MetaElements": [
-    {"name": "viewport", "content": "width=device-width, initial-scale=1, minimum-scale=1"}
+    {
+      "name": "",
+      "content": ""
+    },
+    {
+      "name": "viewport",
+      "content": "width=device-width, initial-scale=1, minimum-scale=1"
+    }
   ],
   "RuntimeExceptions": [
     {
@@ -1553,780 +1681,6 @@
       }
     ]
   },
-  "EventListeners": [
-    {
-      "type": "load",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "24",
-      "lineNumber": 30,
-      "columnNumber": 110,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function onload(event) {\nthis.rel = 'stylesheet'\n}",
-        "objectId": "{\"injectedScriptId\":3,\"id\":60}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function onload(event) {\nthis.rel = 'stylesheet'\n}",
-        "objectId": "{\"injectedScriptId\":3,\"id\":61}"
-      },
-      "backendNodeId": 14,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 30,
-      "startColumn": 110,
-      "endLine": 30,
-      "endColumn": 133,
-      "executionContextId": 3,
-      "hash": "03B7BA432E3ACDD1BD41A5A63A45B174068EC257",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 23,
-      "objectName": "link",
-      "line": 31,
-      "col": 111
-    },
-    {
-      "type": "DOMNodeInserted",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 205,
-      "columnNumber": 49,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted on element');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":64}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted on element');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":65}"
-      },
-      "backendNodeId": 65,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "section#touchmove-section",
-      "line": 206,
-      "col": 50
-    },
-    {
-      "type": "touchmove",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 248,
-      "columnNumber": 43,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchmove');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":66}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchmove');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":67}"
-      },
-      "backendNodeId": 65,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "section#touchmove-section",
-      "line": 249,
-      "col": 44
-    },
-    {
-      "type": "DOMNodeInserted",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 199,
-      "columnNumber": 60,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":72}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":73}"
-      },
-      "backendNodeId": 23,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "body",
-      "line": 200,
-      "col": 61
-    },
-    {
-      "type": "touchmove",
-      "useCapture": false,
-      "passive": true,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 242,
-      "columnNumber": 54,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchmove');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":74}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchmove');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":75}"
-      },
-      "backendNodeId": 23,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "body",
-      "line": 243,
-      "col": 55
-    },
-    {
-      "type": "touchstart",
-      "useCapture": false,
-      "passive": true,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 261,
-      "columnNumber": 55,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchstart');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":76}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchstart');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":77}"
-      },
-      "backendNodeId": 23,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "body",
-      "line": 262,
-      "col": 56
-    },
-    {
-      "type": "DOMNodeInserted",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "25",
-      "lineNumber": 19,
-      "columnNumber": 55,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":78}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":79}"
-      },
-      "backendNodeId": 4,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-      "startLine": 0,
-      "startColumn": 0,
-      "endLine": 40,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "33DA02F13192F7E6B2A847607F18B65509E84951",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 1552,
-      "objectName": "#document",
-      "line": 20,
-      "col": 56
-    },
-    {
-      "type": "DOMNodeInserted",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 189,
-      "columnNumber": 55,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":80}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":81}"
-      },
-      "backendNodeId": 4,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "#document",
-      "line": 190,
-      "col": 56
-    },
-    {
-      "type": "wheel",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "25",
-      "lineNumber": 26,
-      "columnNumber": 37,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "e => {\n    console.log('wheel: arrow function');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":82}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "e => {\n    console.log('wheel: arrow function');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":83}"
-      },
-      "backendNodeId": 4,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
-      "startLine": 0,
-      "startColumn": 0,
-      "endLine": 40,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "33DA02F13192F7E6B2A847607F18B65509E84951",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 1552,
-      "objectName": "#document",
-      "line": 27,
-      "col": 38
-    },
-    {
-      "type": "DOMNodeRemoved",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 194,
-      "columnNumber": 54,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeRemoved');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":84}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeRemoved');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":85}"
-      },
-      "backendNodeId": 4,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "#document",
-      "line": 195,
-      "col": 55
-    },
-    {
-      "type": "touchstart",
-      "useCapture": false,
-      "passive": true,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 237,
-      "columnNumber": 50,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchstart document');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":86}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchstart document');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":87}"
-      },
-      "backendNodeId": 4,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "#document",
-      "line": 238,
-      "col": 51
-    },
-    {
-      "type": "touchstart",
-      "useCapture": false,
-      "passive": true,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 253,
-      "columnNumber": 50,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n\n    e.preventDefault(); // intentionally surrounded by whitespace.\n\n    console.log('touchstart - preventDefault called');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":88}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n\n    e.preventDefault(); // intentionally surrounded by whitespace.\n\n    console.log('touchstart - preventDefault called');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":89}"
-      },
-      "backendNodeId": 4,
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "#document",
-      "line": 254,
-      "col": 51
-    },
-    {
-      "type": "DOMNodeInserted",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 210,
-      "columnNumber": 53,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":90}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMNodeInserted');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":91}"
-      },
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "Window",
-      "line": 211,
-      "col": 54
-    },
-    {
-      "type": "DOMContentLoaded",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 215,
-      "columnNumber": 54,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMContentLoaded');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":92}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('DOMContentLoaded');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":93}"
-      },
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "Window",
-      "line": 216,
-      "col": 55
-    },
-    {
-      "type": "wheel",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 222,
-      "columnNumber": 43,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('wheel');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":94}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('wheel');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":95}"
-      },
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "Window",
-      "line": 223,
-      "col": 44
-    },
-    {
-      "type": "touchstart",
-      "useCapture": false,
-      "passive": true,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 227,
-      "columnNumber": 48,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchstart');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":96}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchstart');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":97}"
-      },
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "Window",
-      "line": 228,
-      "col": 49
-    },
-    {
-      "type": "touchstart",
-      "useCapture": false,
-      "passive": true,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 266,
-      "columnNumber": 48,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchstart passive');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":98}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('touchstart passive');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":99}"
-      },
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "Window",
-      "line": 267,
-      "col": 49
-    },
-    {
-      "type": "mousewheel",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 232,
-      "columnNumber": 48,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('mousewheel');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":100}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('mousewheel');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":101}"
-      },
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "Window",
-      "line": 233,
-      "col": 49
-    },
-    {
-      "type": "scroll",
-      "useCapture": false,
-      "passive": false,
-      "once": false,
-      "scriptId": "29",
-      "lineNumber": 271,
-      "columnNumber": 44,
-      "handler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('scroll');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":102}"
-      },
-      "originalHandler": {
-        "type": "function",
-        "className": "Function",
-        "description": "function(e) {\n    console.log('scroll');\n  }",
-        "objectId": "{\"injectedScriptId\":3,\"id\":103}"
-      },
-      "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
-      "startLine": 147,
-      "startColumn": 8,
-      "endLine": 397,
-      "endColumn": 0,
-      "executionContextId": 3,
-      "hash": "8F4D1710C2EE2C10C5EB4AF2E44F02A488222D15",
-      "executionContextAuxData": {
-        "isDefault": true,
-        "frameId": "A36E31E517F452A18C51AA32F4163A8C"
-      },
-      "isLiveEdit": false,
-      "sourceMapURL": "",
-      "hasSourceURL": false,
-      "isModule": false,
-      "length": 5963,
-      "objectName": "Window",
-      "line": 272,
-      "col": 45
-    }
-  ],
   "AnchorElements": [
     {
       "href": "https://www.google.com/",
@@ -2378,20 +1732,22 @@
   "AppCacheManifest": "clock.appcache",
   "DOMStats": {
     "depth": {
-      "max": 4,
+      "max": 3,
       "pathToElement": [
         "html",
         "body",
         "div",
         "h2"
-      ]
+      ],
+      "snippet": "<h2>"
     },
     "width": {
-      "max": 22,
+      "max": 29,
       "pathToElement": [
         "html",
         "body"
-      ]
+      ],
+      "snippet": "<body>"
     },
     "totalBodyElements": 31
   },
@@ -2406,14 +1762,12 @@
   ],
   "OptimizedImages": [
     {
-      "fromProtocol": true,
+      "failed": false,
       "originalSize": 24620,
-      "jpegSize": 22129,
-      "webpSize": 16094,
-      "isSameOrigin": true,
-      "isBase64DataUri": false,
-      "requestId": "75994.19",
-      "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
+      "jpegSize": 21575,
+      "webpSize": 15592,
+      "requestId": "1000083267.14",
+      "url": "http://localhost:54819/dobetterweb/lighthouse-480x318.jpg",
       "mimeType": "image/jpeg",
       "resourceSize": 24620
     }
@@ -2588,12 +1942,6 @@
       "endTime": 185605.113307
     }
   ],
-  "WebSQL": {
-    "id": "1",
-    "domain": "localhost",
-    "name": "mydb",
-    "version": "1.0"
-  },
   "FontSize": {
     "analyzedFailingNodesData": [],
     "analyzedFailingTextLength": 0,
@@ -2601,17 +1949,37 @@
     "visitedTextLength": 228,
     "totalTextLength": 228
   },
-  "Hreflang": [],
-  "EmbeddedContent": [],
-  "Canonical": [],
-  "Fonts": [],
+  "EmbeddedContent": [
+    {
+      "tagName": "OBJECT",
+      "type": null,
+      "src": null,
+      "data": null,
+      "code": null,
+      "params": []
+    },
+    {
+      "tagName": "OBJECT",
+      "type": null,
+      "src": null,
+      "data": null,
+      "code": null,
+      "params": []
+    }
+  ],
+  "RobotsTxt": {
+    "status": 404,
+    "content": null
+  },
+  "TapTargets": [],
   "ServiceWorker": {
-    "versions": []
+    "versions": [],
+    "registrations": []
   },
   "Offline": -1,
   "StartUrl": {
     "statusCode": -1,
-    "debugString": "No start URL to fetch: No usable web app manifest found on page http://localhost:10200/dobetterweb/dbw_tester.html"
+    "explanation": "No usable web app manifest found on page."
   },
   "HTTPRedirect": {
     "value": false

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1288,6 +1288,7 @@
       "score": 0,
       "scoreDisplayMode": "binary",
       "rawValue": false,
+      "explanation": "No usable web app manifest found on page.",
       "warnings": []
     },
     "pwa-cross-browser": {
@@ -2302,7 +2303,7 @@
       "score": 1,
       "scoreDisplayMode": "numeric",
       "rawValue": 0,
-      "displayValue": "Potential savings of 8 KB",
+      "displayValue": "Potential savings of 9 KB",
       "warnings": [],
       "details": {
         "type": "opportunity",
@@ -2330,15 +2331,15 @@
         ],
         "items": [
           {
-            "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
+            "url": "http://localhost:54819/dobetterweb/lighthouse-480x318.jpg",
             "fromProtocol": true,
-            "isCrossOrigin": false,
+            "isCrossOrigin": true,
             "totalBytes": 24620,
-            "wastedBytes": 8526
+            "wastedBytes": 9028
           }
         ],
         "overallSavingsMs": 0,
-        "overallSavingsBytes": 8526
+        "overallSavingsBytes": 9028
       }
     },
     "uses-optimized-images": {
@@ -2487,16 +2488,18 @@
           {
             "statistic": "Maximum DOM Depth",
             "element": {
-              "type": "code"
+              "type": "code",
+              "value": "<h2>"
             },
-            "value": "4"
+            "value": "3"
           },
           {
             "statistic": "Maximum Child Elements",
             "element": {
-              "type": "code"
+              "type": "code",
+              "value": "<body>"
             },
-            "value": "22"
+            "value": "29"
           }
         ]
       }
@@ -2952,30 +2955,38 @@
     },
     "is-crawlable": {
       "id": "is-crawlable",
-      "title": "Page is blocked from indexing",
+      "title": "Page isn’t blocked from indexing",
       "description": "Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/indexing).",
-      "score": null,
-      "scoreDisplayMode": "error",
-      "rawValue": null,
-      "errorMessage": "Required RobotsTxt gatherer did not run."
+      "score": 1,
+      "scoreDisplayMode": "binary",
+      "rawValue": true,
+      "details": {
+        "type": "table",
+        "headings": [],
+        "items": []
+      }
     },
     "robots-txt": {
       "id": "robots-txt",
-      "title": "robots.txt is not valid",
+      "title": "robots.txt is valid",
       "description": "If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed.",
       "score": null,
-      "scoreDisplayMode": "error",
-      "rawValue": null,
-      "errorMessage": "Required RobotsTxt gatherer did not run."
+      "scoreDisplayMode": "notApplicable",
+      "rawValue": true
     },
     "tap-targets": {
       "id": "tap-targets",
-      "title": "Tap targets are not sized appropriately",
+      "title": "Tap targets are sized appropriately",
       "description": "Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design).",
-      "score": null,
-      "scoreDisplayMode": "error",
-      "rawValue": null,
-      "errorMessage": "Required TapTargets gatherer did not run."
+      "score": 1,
+      "scoreDisplayMode": "binary",
+      "rawValue": true,
+      "displayValue": "100% appropriately sized tap targets",
+      "details": {
+        "type": "table",
+        "headings": [],
+        "items": []
+      }
     },
     "hreflang": {
       "id": "hreflang",
@@ -3035,6 +3046,7 @@
       "uploadThroughputKbps": 675,
       "cpuSlowdownMultiplier": 4
     },
+    "auditMode": true,
     "gatherMode": false,
     "disableStorageReset": false,
     "disableDeviceEmulation": false,
@@ -3565,7 +3577,7 @@
         },
         {
           "id": "robots-txt",
-          "weight": 1,
+          "weight": 0,
           "group": "seo-crawl"
         },
         {
@@ -3599,7 +3611,7 @@
         }
       ],
       "id": "seo",
-      "score": null
+      "score": 0.9
     },
     "pwa": {
       "title": "Progressive Web App",
@@ -5235,7 +5247,7 @@
         },
         {
           "values": {
-            "wastedBytes": 8526
+            "wastedBytes": 9028
           },
           "path": "audits[uses-webp-images].displayValue"
         },
@@ -5351,23 +5363,31 @@
       "lighthouse-core/audits/seo/link-text.js | description": [
         "audits[link-text].description"
       ],
-      "lighthouse-core/audits/seo/is-crawlable.js | failureTitle": [
+      "lighthouse-core/audits/seo/is-crawlable.js | title": [
         "audits[is-crawlable].title"
       ],
       "lighthouse-core/audits/seo/is-crawlable.js | description": [
         "audits[is-crawlable].description"
       ],
-      "lighthouse-core/audits/seo/robots-txt.js | failureTitle": [
+      "lighthouse-core/audits/seo/robots-txt.js | title": [
         "audits[robots-txt].title"
       ],
       "lighthouse-core/audits/seo/robots-txt.js | description": [
         "audits[robots-txt].description"
       ],
-      "lighthouse-core/audits/seo/tap-targets.js | failureTitle": [
+      "lighthouse-core/audits/seo/tap-targets.js | title": [
         "audits[tap-targets].title"
       ],
       "lighthouse-core/audits/seo/tap-targets.js | description": [
         "audits[tap-targets].description"
+      ],
+      "lighthouse-core/audits/seo/tap-targets.js | displayValue": [
+        {
+          "values": {
+            "decimalProportion": 1
+          },
+          "path": "audits[tap-targets].displayValue"
+        }
       ],
       "lighthouse-core/audits/seo/hreflang.js | title": [
         "audits.hreflang.title"

--- a/lighthouse-viewer/test/viewer-test-pptr.js
+++ b/lighthouse-viewer/test/viewer-test-pptr.js
@@ -133,10 +133,6 @@ describe('Lighthouse Viewer', function() {
     const errorSelectors = '.lh-audit-explanation, .tooltip--error';
     const auditErrors = await viewerPage.$$eval(errorSelectors, getErrors, selectors);
     const errors = auditErrors.filter(item => item.explanation.includes('Audit error:'));
-    const unexpectedErrrors = errors.filter(item => {
-      return !item.explanation.includes('Required RobotsTxt gatherer did not run') &&
-        !item.explanation.includes('Required TapTargets gatherer did not run');
-    });
-    assert.deepStrictEqual(unexpectedErrrors, [], 'Audit errors found within the report');
+    assert.deepStrictEqual(errors, [], 'Audit errors found within the report');
   });
 });

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -517,17 +517,19 @@
                     }, 
                     {
                         "element": {
-                            "type": "code"
+                            "type": "code", 
+                            "value": "<h2>"
                         }, 
                         "statistic": "Maximum DOM Depth", 
-                        "value": "4"
+                        "value": "3"
                     }, 
                     {
                         "element": {
-                            "type": "code"
+                            "type": "code", 
+                            "value": "<body>"
                         }, 
                         "statistic": "Maximum Child Elements", 
-                        "value": "22"
+                        "value": "29"
                     }
                 ], 
                 "type": "table"
@@ -1030,11 +1032,15 @@
         }, 
         "is-crawlable": {
             "description": "Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/indexing).", 
-            "errorMessage": "Required RobotsTxt gatherer did not run.", 
+            "details": {
+                "headings": [], 
+                "items": [], 
+                "type": "table"
+            }, 
             "id": "is-crawlable", 
-            "score": null, 
-            "scoreDisplayMode": "error", 
-            "title": "Page is blocked from indexing"
+            "score": 1.0, 
+            "scoreDisplayMode": "binary", 
+            "title": "Page isn\u2019t blocked from indexing"
         }, 
         "is-on-https": {
             "description": "All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/https).", 
@@ -1943,6 +1949,7 @@
         }, 
         "offline-start-url": {
             "description": "A service worker enables your web app to be reliable in unpredictable network conditions. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).", 
+            "explanation": "No usable web app manifest found on page.", 
             "id": "offline-start-url", 
             "score": 0.0, 
             "scoreDisplayMode": "binary", 
@@ -2113,11 +2120,10 @@
         }, 
         "robots-txt": {
             "description": "If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed.", 
-            "errorMessage": "Required RobotsTxt gatherer did not run.", 
             "id": "robots-txt", 
             "score": null, 
-            "scoreDisplayMode": "error", 
-            "title": "robots.txt is not valid"
+            "scoreDisplayMode": "notApplicable", 
+            "title": "robots.txt is valid"
         }, 
         "screenshot-thumbnails": {
             "description": "This is what the load of your site looked like.", 
@@ -2233,11 +2239,16 @@
         }, 
         "tap-targets": {
             "description": "Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design).", 
-            "errorMessage": "Required TapTargets gatherer did not run.", 
+            "details": {
+                "headings": [], 
+                "items": [], 
+                "type": "table"
+            }, 
+            "displayValue": "100% appropriately sized tap targets", 
             "id": "tap-targets", 
-            "score": null, 
-            "scoreDisplayMode": "error", 
-            "title": "Tap targets are not sized appropriately"
+            "score": 1.0, 
+            "scoreDisplayMode": "binary", 
+            "title": "Tap targets are sized appropriately"
         }, 
         "td-headers-attr": {
             "description": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse).", 
@@ -2800,17 +2811,17 @@
                 "items": [
                     {
                         "fromProtocol": true, 
-                        "isCrossOrigin": false, 
+                        "isCrossOrigin": true, 
                         "totalBytes": 24620.0, 
-                        "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg", 
-                        "wastedBytes": 8526.0
+                        "url": "http://localhost:54819/dobetterweb/lighthouse-480x318.jpg", 
+                        "wastedBytes": 9028.0
                     }
                 ], 
-                "overallSavingsBytes": 8526.0, 
+                "overallSavingsBytes": 9028.0, 
                 "overallSavingsMs": 0.0, 
                 "type": "opportunity"
             }, 
-            "displayValue": "Potential savings of 8\u00a0KB", 
+            "displayValue": "Potential savings of 9\u00a0KB", 
             "id": "uses-webp-images", 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
@@ -3464,7 +3475,7 @@
                 {
                     "group": "seo-crawl", 
                     "id": "robots-txt", 
-                    "weight": 1.0
+                    "weight": 0.0
                 }, 
                 {
                     "group": "seo-content", 
@@ -3499,7 +3510,7 @@
             "description": "These checks ensure that your page is optimized for search engine results ranking. There are additional factors Lighthouse does not check that may affect your search ranking. [Learn more](https://support.google.com/webmasters/answer/35769).", 
             "id": "seo", 
             "manualDescription": "Run these additional validators on your site to check additional SEO best practices.", 
-            "score": null, 
+            "score": 0.9, 
             "title": "SEO"
         }
     }, 
@@ -3602,7 +3613,7 @@
             "warningAuditsGroupTitle": "Passed audits but with warnings", 
             "warningHeader": "Warnings: "
         }
-    },
+    }, 
     "stackPacks": [],
     "lighthouseVersion": "4.3.0", 
     "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html", 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -369,7 +369,12 @@ declare global {
         }[];
       }
 
-      export interface MeasureEntry extends PerformanceEntry {
+      export interface MeasureEntry {
+        // From PerformanceEntry
+        readonly duration: number;
+        readonly entryType: string;
+        readonly name: string;
+        readonly startTime: number;
         /** Whether timing entry was collected during artifact gathering. */
         gather?: boolean;
       }


### PR DESCRIPTION
I started writing a test that needed the `settings` on the artifacts that generate `sample_v2.json` and I noticed they weren't there. Did a little housecleaning on the easy to update artifacts (deleting `EventListeners` and `WebSQL`, finally adding `RobotsTxt` and `TapTargets`), though at some point (maybe for v5) we should still do a whole-hog update of the artifacts, trace, and devtools log.

At that point, surprisingly `sample_v2.json` still wasn't a valid `LH.Result`, which isn't super important but is kind of annoying. To fix we just had to
- not delete `lhr.configSettings.auditMode` in the cleanup script (just hardcoded to `true` to sidestep the travis issue mentioned in the comment in that file) and
- `Artifacts.MeasureEntry` (which makes up the `Timing` artifact) needed to not inherit from `PerformanceEntry`. `PerformanceEntry` has a [`toJSON` method](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry#Methods), but when we save artifacts as JSON methods aren't preserved, so the resulting object is no longer a `PerformanceEntry`. I just copied the properties over to the type definition rather than inherit now.