### PR TITLE
core: expose page functions on Gatherer

### DIFF
--- a/lighthouse-core/gather/gatherers/gatherer.js
+++ b/lighthouse-core/gather/gatherers/gatherer.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const pageFunctions = require('../../lib/page-functions.js');
+
 /** @typedef {void|LH.GathererArtifacts[keyof LH.GathererArtifacts]} PhaseResult */
 
 /**
@@ -57,3 +59,8 @@ class Gatherer {
 }
 
 module.exports = Gatherer;
+
+Gatherer.pageFunctions = {
+  getElementsInDocumentString: pageFunctions.getElementsInDocumentString,
+  getNodeSelectorString: pageFunctions.getNodeSelectorString,
+};

--- a/lighthouse-core/test/gather/gatherers/gatherer-test.js
+++ b/lighthouse-core/test/gather/gatherers/gatherer-test.js
@@ -7,12 +7,29 @@
 
 /* eslint-env jest */
 
+const jsdom = require('jsdom');
 const Gatherer = require('../../../gather/gatherers/gatherer');
-const assert = require('assert');
 
 describe('Gatherer', () => {
   it('returns its name', () => {
     const g = new Gatherer();
-    return assert.equal(g.name, 'Gatherer');
+    expect(g.name).toEqual('Gatherer');
+  });
+
+  it('should expose page functions', () => {
+    expect(Gatherer).toHaveProperty('pageFunctions');
+    expect(Gatherer.pageFunctions).toHaveProperty('getNodeSelectorString');
+    expect(Gatherer.pageFunctions).toHaveProperty('getElementsInDocumentString');
+  });
+
+  it('should expose page functions', () => {
+    const {document} = new jsdom.JSDOM().window;
+    const fn = eval(`(() => {
+      ${Gatherer.pageFunctions.getNodeSelectorString}
+      return getNodeSelector
+    })()`);
+    const el = document.createElement('div');
+    el.id = 'test';
+    expect(fn(el)).toEqual('div#test');
   });
 });


### PR DESCRIPTION
**Summary**
People have been reaching into our repo to get page functions, so for v5 we should expose them properly.

Gatherer feels like the right place to expose these since that's the only place you would need to use them when writing a gatherer.

**Related Issues/PRs**
closes #7317