### PR TITLE
core: rename diagnostics to debugData

### DIFF
--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -63,11 +63,11 @@ class AxeAudit extends Audit {
       {key: 'node', itemType: 'node', text: str_(UIStrings.failingElementsHeader)},
     ];
 
-    /** @type {LH.Audit.Details.Diagnostic|undefined} */
+    /** @type {LH.Audit.Details.DebugData|undefined} */
     let diagnostic;
     if (impact || tags) {
       diagnostic = {
-        type: 'diagnostic',
+        type: 'debug',
         impact,
         tags,
       };
@@ -78,7 +78,7 @@ class AxeAudit extends Audit {
       extendedInfo: {
         value: rule,
       },
-      details: {...Audit.makeTableDetails(headings, items), diagnostic},
+      details: {...Audit.makeTableDetails(headings, items), debug: diagnostic},
     };
   }
 }

--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -64,10 +64,10 @@ class AxeAudit extends Audit {
     ];
 
     /** @type {LH.Audit.Details.DebugData|undefined} */
-    let diagnostic;
+    let debugData;
     if (impact || tags) {
-      diagnostic = {
-        type: 'debug',
+      debugData = {
+        type: 'debugdata',
         impact,
         tags,
       };
@@ -78,7 +78,7 @@ class AxeAudit extends Audit {
       extendedInfo: {
         value: rule,
       },
-      details: {...Audit.makeTableDetails(headings, items), debug: diagnostic},
+      details: {...Audit.makeTableDetails(headings, items), debugData},
     };
   }
 }

--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -242,7 +242,7 @@ class CacheHeaders extends Audit {
         let debugData;
         if (cacheControl) {
           debugData = {
-            type: 'debug',
+            type: 'debugdata',
             ...cacheControl,
           };
         }

--- a/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -238,18 +238,18 @@ class CacheHeaders extends Audit {
         if (url.includes('?')) queryStringCount++;
 
         // Include cacheControl info (if it exists) per url as a diagnostic.
-        /** @type {LH.Audit.Details.Diagnostic|undefined} */
-        let diagnostic;
+        /** @type {LH.Audit.Details.DebugData|undefined} */
+        let debugData;
         if (cacheControl) {
-          diagnostic = {
-            type: 'diagnostic',
+          debugData = {
+            type: 'debug',
             ...cacheControl,
           };
         }
 
         results.push({
           url,
-          diagnostic,
+          debugData,
           cacheLifetimeMs: cacheLifetimeInSeconds * 1000,
           cacheHitProbability,
           totalBytes,

--- a/lighthouse-core/audits/diagnostics.js
+++ b/lighthouse-core/audits/diagnostics.js
@@ -68,7 +68,7 @@ class Diagnostics extends Audit {
       score: 1,
       rawValue: 1,
       details: {
-        type: 'diagnostic',
+        type: 'debug',
         // TODO: Consider not nesting diagnostics under `items`.
         items: [diagnostics],
       },

--- a/lighthouse-core/audits/diagnostics.js
+++ b/lighthouse-core/audits/diagnostics.js
@@ -68,7 +68,7 @@ class Diagnostics extends Audit {
       score: 1,
       rawValue: 1,
       details: {
-        type: 'debug',
+        type: 'debugdata',
         // TODO: Consider not nesting diagnostics under `items`.
         items: [diagnostics],
       },

--- a/lighthouse-core/audits/metrics.js
+++ b/lighthouse-core/audits/metrics.js
@@ -108,9 +108,9 @@ class Metrics extends Audit {
       }
     }
 
-    /** @type {LH.Audit.Details.Diagnostic} */
+    /** @type {LH.Audit.Details.DebugData} */
     const details = {
-      type: 'diagnostic',
+      type: 'debug',
       // TODO: Consider not nesting metrics under `items`.
       items: [metrics],
     };

--- a/lighthouse-core/audits/metrics.js
+++ b/lighthouse-core/audits/metrics.js
@@ -110,7 +110,7 @@ class Metrics extends Audit {
 
     /** @type {LH.Audit.Details.DebugData} */
     const details = {
-      type: 'debug',
+      type: 'debugdata',
       // TODO: Consider not nesting metrics under `items`.
       items: [metrics],
     };

--- a/lighthouse-core/audits/multi-check-audit.js
+++ b/lighthouse-core/audits/multi-check-audit.js
@@ -42,9 +42,9 @@ class MultiCheckAudit extends Audit {
     }
 
     // Include the detailed pass/fail checklist as a diagnostic.
-    /** @type {LH.Audit.Details.Diagnostic} */
+    /** @type {LH.Audit.Details.DebugData} */
     const details = {
-      type: 'diagnostic',
+      type: 'debug',
       // TODO: Consider not nesting detailsItem under `items`.
       items: [detailsItem],
     };

--- a/lighthouse-core/audits/multi-check-audit.js
+++ b/lighthouse-core/audits/multi-check-audit.js
@@ -44,7 +44,7 @@ class MultiCheckAudit extends Audit {
     // Include the detailed pass/fail checklist as a diagnostic.
     /** @type {LH.Audit.Details.DebugData} */
     const details = {
-      type: 'debug',
+      type: 'debugdata',
       // TODO: Consider not nesting detailsItem under `items`.
       items: [detailsItem],
     };

--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -91,7 +91,7 @@ class PredictivePerf extends Audit {
       rawValue: values.roughEstimateOfTTI,
       displayValue: Util.formatMilliseconds(values.roughEstimateOfTTI),
       details: {
-        type: 'debug',
+        type: 'debugdata',
         // TODO: Consider not nesting values under `items`.
         items: [values],
       },

--- a/lighthouse-core/audits/predictive-perf.js
+++ b/lighthouse-core/audits/predictive-perf.js
@@ -91,7 +91,7 @@ class PredictivePerf extends Audit {
       rawValue: values.roughEstimateOfTTI,
       displayValue: Util.formatMilliseconds(values.roughEstimateOfTTI),
       details: {
-        type: 'diagnostic',
+        type: 'debug',
         // TODO: Consider not nesting values under `items`.
         items: [values],
       },

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -59,7 +59,7 @@ class DetailsRenderer {
 
       // Internal-only details, not for rendering.
       case 'screenshot':
-      case 'diagnostic':
+      case 'debug':
         return null;
       // Fallback for old LHRs, where no type meant don't render.
       case undefined:

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -59,7 +59,7 @@ class DetailsRenderer {
 
       // Internal-only details, not for rendering.
       case 'screenshot':
-      case 'debug':
+      case 'debugdata':
         return null;
       // Fallback for old LHRs, where no type meant don't render.
       case undefined:

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -182,7 +182,7 @@ describe('DetailsRenderer', () => {
 
     it('does not render internal-only diagnostic details', () => {
       const details = {
-        type: 'diagnostic',
+        type: 'debug',
         items: [{
           failures: ['No manifest was fetched'],
           isParseFailure: true,

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -182,7 +182,7 @@ describe('DetailsRenderer', () => {
 
     it('does not render internal-only diagnostic details', () => {
       const details = {
-        type: 'debug',
+        type: 'debugdata',
         items: [{
           failures: ['No manifest was fetched'],
           isParseFailure: true,

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -474,7 +474,7 @@
       "rawValue": false,
       "explanation": "Failures: No manifest was fetched.",
       "details": {
-        "type": "debug",
+        "type": "debugdata",
         "items": [
           {
             "failures": [
@@ -495,7 +495,7 @@
       "rawValue": false,
       "explanation": "Failures: No manifest was fetched.",
       "details": {
-        "type": "debug",
+        "type": "debugdata",
         "items": [
           {
             "failures": [
@@ -516,7 +516,7 @@
       "rawValue": false,
       "explanation": "Failures: No manifest was fetched,\nNo `<meta name=\"theme-color\">` tag found.",
       "details": {
-        "type": "debug",
+        "type": "debugdata",
         "items": [
           {
             "failures": [
@@ -809,7 +809,7 @@
       "scoreDisplayMode": "informative",
       "rawValue": 1,
       "details": {
-        "type": "debug",
+        "type": "debugdata",
         "items": [
           {
             "numRequests": 18,
@@ -1243,7 +1243,7 @@
       "scoreDisplayMode": "informative",
       "rawValue": 4927.278,
       "details": {
-        "type": "debug",
+        "type": "debugdata",
         "items": [
           {
             "firstContentfulPaint": 3969,
@@ -1448,8 +1448,8 @@
             }
           }
         ],
-        "debug": {
-          "type": "debug",
+        "debugData": {
+          "type": "debugdata",
           "impact": "serious",
           "tags": [
             "cat.color",
@@ -1536,8 +1536,8 @@
             }
           }
         ],
-        "debug": {
-          "type": "debug",
+        "debugData": {
+          "type": "debugdata",
           "impact": "serious",
           "tags": [
             "cat.language",
@@ -1609,8 +1609,8 @@
             }
           }
         ],
-        "debug": {
-          "type": "debug",
+        "debugData": {
+          "type": "debugdata",
           "impact": "critical",
           "tags": [
             "cat.text-alternatives",
@@ -1675,8 +1675,8 @@
             }
           }
         ],
-        "debug": {
-          "type": "debug",
+        "debugData": {
+          "type": "debugdata",
           "impact": "critical",
           "tags": [
             "cat.forms",
@@ -1733,8 +1733,8 @@
             }
           }
         ],
-        "debug": {
-          "type": "debug",
+        "debugData": {
+          "type": "debugdata",
           "impact": "serious",
           "tags": [
             "cat.name-role-value",
@@ -1820,8 +1820,8 @@
             }
           }
         ],
-        "debug": {
-          "type": "debug",
+        "debugData": {
+          "type": "debugdata",
           "impact": "serious",
           "tags": [
             "cat.text-alternatives",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -474,7 +474,7 @@
       "rawValue": false,
       "explanation": "Failures: No manifest was fetched.",
       "details": {
-        "type": "diagnostic",
+        "type": "debug",
         "items": [
           {
             "failures": [
@@ -495,7 +495,7 @@
       "rawValue": false,
       "explanation": "Failures: No manifest was fetched.",
       "details": {
-        "type": "diagnostic",
+        "type": "debug",
         "items": [
           {
             "failures": [
@@ -516,7 +516,7 @@
       "rawValue": false,
       "explanation": "Failures: No manifest was fetched,\nNo `<meta name=\"theme-color\">` tag found.",
       "details": {
-        "type": "diagnostic",
+        "type": "debug",
         "items": [
           {
             "failures": [
@@ -809,7 +809,7 @@
       "scoreDisplayMode": "informative",
       "rawValue": 1,
       "details": {
-        "type": "diagnostic",
+        "type": "debug",
         "items": [
           {
             "numRequests": 18,
@@ -1243,7 +1243,7 @@
       "scoreDisplayMode": "informative",
       "rawValue": 4927.278,
       "details": {
-        "type": "diagnostic",
+        "type": "debug",
         "items": [
           {
             "firstContentfulPaint": 3969,
@@ -1448,8 +1448,8 @@
             }
           }
         ],
-        "diagnostic": {
-          "type": "diagnostic",
+        "debug": {
+          "type": "debug",
           "impact": "serious",
           "tags": [
             "cat.color",
@@ -1536,8 +1536,8 @@
             }
           }
         ],
-        "diagnostic": {
-          "type": "diagnostic",
+        "debug": {
+          "type": "debug",
           "impact": "serious",
           "tags": [
             "cat.language",
@@ -1609,8 +1609,8 @@
             }
           }
         ],
-        "diagnostic": {
-          "type": "diagnostic",
+        "debug": {
+          "type": "debug",
           "impact": "critical",
           "tags": [
             "cat.text-alternatives",
@@ -1675,8 +1675,8 @@
             }
           }
         ],
-        "diagnostic": {
-          "type": "diagnostic",
+        "debug": {
+          "type": "debug",
           "impact": "critical",
           "tags": [
             "cat.forms",
@@ -1733,8 +1733,8 @@
             }
           }
         ],
-        "diagnostic": {
-          "type": "diagnostic",
+        "debug": {
+          "type": "debug",
           "impact": "serious",
           "tags": [
             "cat.name-role-value",
@@ -1820,8 +1820,8 @@
             }
           }
         ],
-        "diagnostic": {
-          "type": "diagnostic",
+        "debug": {
+          "type": "debug",
           "impact": "serious",
           "tags": [
             "cat.text-alternatives",

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -170,14 +170,14 @@
         "color-contrast": {
             "description": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse).", 
             "details": {
-                "diagnostic": {
+                "debug": {
                     "impact": "serious", 
                     "tags": [
                         "cat.color", 
                         "wcag2aa", 
                         "wcag143"
                     ], 
-                    "type": "diagnostic"
+                    "type": "debug"
                 }, 
                 "headings": [
                     {
@@ -457,7 +457,7 @@
                         "totalTaskTime": 1548.5690000000002
                     }
                 ], 
-                "type": "diagnostic"
+                "type": "debug"
             }, 
             "id": "diagnostics", 
             "score": null, 
@@ -832,14 +832,14 @@
         "html-has-lang": {
             "description": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse).", 
             "details": {
-                "diagnostic": {
+                "debug": {
                     "impact": "serious", 
                     "tags": [
                         "cat.language", 
                         "wcag2a", 
                         "wcag311"
                     ], 
-                    "type": "diagnostic"
+                    "type": "debug"
                 }, 
                 "headings": [
                     {
@@ -883,7 +883,7 @@
         "image-alt": {
             "description": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse).", 
             "details": {
-                "diagnostic": {
+                "debug": {
                     "impact": "critical", 
                     "tags": [
                         "cat.text-alternatives", 
@@ -892,7 +892,7 @@
                         "section508", 
                         "section508.22.a"
                     ], 
-                    "type": "diagnostic"
+                    "type": "debug"
                 }, 
                 "headings": [
                     {
@@ -1005,7 +1005,7 @@
                         "parseFailureReason": "No manifest was fetched"
                     }
                 ], 
-                "type": "diagnostic"
+                "type": "debug"
             }, 
             "explanation": "Failures: No manifest was fetched.", 
             "id": "installable-manifest", 
@@ -1092,7 +1092,7 @@
         "label": {
             "description": "Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse).", 
             "details": {
-                "diagnostic": {
+                "debug": {
                     "impact": "critical", 
                     "tags": [
                         "cat.forms", 
@@ -1102,7 +1102,7 @@
                         "section508", 
                         "section508.22.n"
                     ], 
-                    "type": "diagnostic"
+                    "type": "debug"
                 }, 
                 "headings": [
                     {
@@ -1157,7 +1157,7 @@
         "link-name": {
             "description": "Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse).", 
             "details": {
-                "diagnostic": {
+                "debug": {
                     "impact": "serious", 
                     "tags": [
                         "cat.name-role-value", 
@@ -1167,7 +1167,7 @@
                         "section508", 
                         "section508.22.a"
                     ], 
-                    "type": "diagnostic"
+                    "type": "debug"
                 }, 
                 "headings": [
                     {
@@ -1474,7 +1474,7 @@
                         "speedIndexTs": 185607736912.0
                     }
                 ], 
-                "type": "diagnostic"
+                "type": "debug"
             }, 
             "id": "metrics", 
             "score": null, 
@@ -1896,7 +1896,7 @@
         "object-alt": {
             "description": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse).", 
             "details": {
-                "diagnostic": {
+                "debug": {
                     "impact": "serious", 
                     "tags": [
                         "cat.text-alternatives", 
@@ -1905,7 +1905,7 @@
                         "section508", 
                         "section508.22.a"
                     ], 
-                    "type": "diagnostic"
+                    "type": "debug"
                 }, 
                 "headings": [
                     {
@@ -2209,7 +2209,7 @@
                         "parseFailureReason": "No manifest was fetched"
                     }
                 ], 
-                "type": "diagnostic"
+                "type": "debug"
             }, 
             "explanation": "Failures: No manifest was fetched.", 
             "id": "splash-screen", 
@@ -2267,7 +2267,7 @@
                         "themeColor": null
                     }
                 ], 
-                "type": "diagnostic"
+                "type": "debug"
             }, 
             "explanation": "Failures: No manifest was fetched,\nNo `<meta name=\"theme-color\">` tag found.", 
             "id": "themed-omnibox", 

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -170,14 +170,14 @@
         "color-contrast": {
             "description": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse).", 
             "details": {
-                "debug": {
+                "debugData": {
                     "impact": "serious", 
                     "tags": [
                         "cat.color", 
                         "wcag2aa", 
                         "wcag143"
                     ], 
-                    "type": "debug"
+                    "type": "debugdata"
                 }, 
                 "headings": [
                     {
@@ -457,7 +457,7 @@
                         "totalTaskTime": 1548.5690000000002
                     }
                 ], 
-                "type": "debug"
+                "type": "debugdata"
             }, 
             "id": "diagnostics", 
             "score": null, 
@@ -832,14 +832,14 @@
         "html-has-lang": {
             "description": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse).", 
             "details": {
-                "debug": {
+                "debugData": {
                     "impact": "serious", 
                     "tags": [
                         "cat.language", 
                         "wcag2a", 
                         "wcag311"
                     ], 
-                    "type": "debug"
+                    "type": "debugdata"
                 }, 
                 "headings": [
                     {
@@ -883,7 +883,7 @@
         "image-alt": {
             "description": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse).", 
             "details": {
-                "debug": {
+                "debugData": {
                     "impact": "critical", 
                     "tags": [
                         "cat.text-alternatives", 
@@ -892,7 +892,7 @@
                         "section508", 
                         "section508.22.a"
                     ], 
-                    "type": "debug"
+                    "type": "debugdata"
                 }, 
                 "headings": [
                     {
@@ -1005,7 +1005,7 @@
                         "parseFailureReason": "No manifest was fetched"
                     }
                 ], 
-                "type": "debug"
+                "type": "debugdata"
             }, 
             "explanation": "Failures: No manifest was fetched.", 
             "id": "installable-manifest", 
@@ -1092,7 +1092,7 @@
         "label": {
             "description": "Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse).", 
             "details": {
-                "debug": {
+                "debugData": {
                     "impact": "critical", 
                     "tags": [
                         "cat.forms", 
@@ -1102,7 +1102,7 @@
                         "section508", 
                         "section508.22.n"
                     ], 
-                    "type": "debug"
+                    "type": "debugdata"
                 }, 
                 "headings": [
                     {
@@ -1157,7 +1157,7 @@
         "link-name": {
             "description": "Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse).", 
             "details": {
-                "debug": {
+                "debugData": {
                     "impact": "serious", 
                     "tags": [
                         "cat.name-role-value", 
@@ -1167,7 +1167,7 @@
                         "section508", 
                         "section508.22.a"
                     ], 
-                    "type": "debug"
+                    "type": "debugdata"
                 }, 
                 "headings": [
                     {
@@ -1474,7 +1474,7 @@
                         "speedIndexTs": 185607736912.0
                     }
                 ], 
-                "type": "debug"
+                "type": "debugdata"
             }, 
             "id": "metrics", 
             "score": null, 
@@ -1896,7 +1896,7 @@
         "object-alt": {
             "description": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse).", 
             "details": {
-                "debug": {
+                "debugData": {
                     "impact": "serious", 
                     "tags": [
                         "cat.text-alternatives", 
@@ -1905,7 +1905,7 @@
                         "section508", 
                         "section508.22.a"
                     ], 
-                    "type": "debug"
+                    "type": "debugdata"
                 }, 
                 "headings": [
                     {
@@ -2209,7 +2209,7 @@
                         "parseFailureReason": "No manifest was fetched"
                     }
                 ], 
-                "type": "debug"
+                "type": "debugdata"
             }, 
             "explanation": "Failures: No manifest was fetched.", 
             "id": "splash-screen", 
@@ -2267,7 +2267,7 @@
                         "themeColor": null
                     }
                 ], 
-                "type": "debug"
+                "type": "debugdata"
             }, 
             "explanation": "Failures: No manifest was fetched,\nNo `<meta name=\"theme-color\">` tag found.", 
             "id": "themed-omnibox", 

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -8,7 +8,7 @@ declare global {
   module LH.Audit {
     export type Details =
       Details.CriticalRequestChain |
-      Details.Diagnostic |
+      Details.DebugData |
       Details.Filmstrip |
       Details.List |
       Details.Opportunity |
@@ -51,7 +51,7 @@ declare global {
         overallSavingsBytes?: number;
         headings: OpportunityColumnHeading[];
         items: OpportunityItem[];
-        diagnostic?: Diagnostic;
+        diagnostic?: DebugData;
       }
 
       export interface Screenshot {
@@ -68,15 +68,15 @@ declare global {
           wastedMs?: number;
           wastedBytes?: number;
         };
-        diagnostic?: Diagnostic;
+        debug?: DebugData;
       }
 
       /**
        * A details type that is not rendered in the final report; usually used
-       * for including diagnostic information in the LHR. Can contain anything.
+       * for including debug information in the LHR. Can contain anything.
        */
-      export interface Diagnostic {
-        type: 'diagnostic';
+      export interface DebugData {
+        type: 'debug';
         [p: string]: any;
       }
 
@@ -102,8 +102,8 @@ declare global {
       }
 
       export type TableItem = {
-        diagnostic?: Diagnostic;
-        [p: string]: string | number | boolean | undefined | Diagnostic | NodeValue | LinkValue | UrlValue | CodeValue;
+        diagnostic?: DebugData;
+        [p: string]: string | number | boolean | undefined | DebugData | NodeValue | LinkValue | UrlValue | CodeValue;
       }
 
       export interface OpportunityColumnHeading {
@@ -128,8 +128,8 @@ declare global {
         wastedBytes?: number;
         totalBytes?: number;
         wastedMs?: number;
-        diagnostic?: Diagnostic;
-        [p: string]: number | boolean | string | undefined | Diagnostic;
+        diagnostic?: DebugData;
+        [p: string]: number | boolean | string | undefined | DebugData;
       }
 
       /**

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -51,7 +51,7 @@ declare global {
         overallSavingsBytes?: number;
         headings: OpportunityColumnHeading[];
         items: OpportunityItem[];
-        diagnostic?: DebugData;
+        debugData?: DebugData;
       }
 
       export interface Screenshot {
@@ -68,7 +68,7 @@ declare global {
           wastedMs?: number;
           wastedBytes?: number;
         };
-        debug?: DebugData;
+        debugData?: DebugData;
       }
 
       /**
@@ -76,7 +76,7 @@ declare global {
        * for including debug information in the LHR. Can contain anything.
        */
       export interface DebugData {
-        type: 'debug';
+        type: 'debugdata';
         [p: string]: any;
       }
 
@@ -102,7 +102,7 @@ declare global {
       }
 
       export type TableItem = {
-        diagnostic?: DebugData;
+        debugData?: DebugData;
         [p: string]: string | number | boolean | undefined | DebugData | NodeValue | LinkValue | UrlValue | CodeValue;
       }
 
@@ -128,7 +128,7 @@ declare global {
         wastedBytes?: number;
         totalBytes?: number;
         wastedMs?: number;
-        diagnostic?: DebugData;
+        debugData?: DebugData;
         [p: string]: number | boolean | string | undefined | DebugData;
       }
 


### PR DESCRIPTION
**Summary**
All the data here is essentially used for debugging, so `debugData` seems fair.

`metrics` audit is probably the one exception where I'd expect folks to be explicitly relying on this for presentation, so I'm not sure what to do there. OTOH I also don't feel particularly strongly it needs to be renamed away from `diagnostics` since neither of them describe how it's being used in `metrics` :)

**Related Issues/PRs**
No issue was filed specifically, so it can't be closed yet! ;)
#7752 