### PR TITLE
core(driver): only fail security state if scheme is not cryptographic

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -912,8 +912,12 @@ class Driver {
       /**
        * @param {LH.Crdp.Security.SecurityStateChangedEvent} event
        */
-      const securityStateChangedListener = ({securityState, explanations}) => {
-        if (securityState === 'insecure') {
+      const securityStateChangedListener = ({
+        securityState,
+        explanations,
+        schemeIsCryptographic,
+      }) => {
+        if (securityState === 'insecure' && schemeIsCryptographic) {
           cancel();
           const insecureDescriptions = explanations
             .filter(exp => exp.securityState === 'insecure')

--- a/lighthouse-core/test/gather/driver-test.js
+++ b/lighthouse-core/test/gather/driver-test.js
@@ -700,6 +700,31 @@ describe('.gotoURL', () => {
       await loadPromise;
     });
 
+    it('does not reject when page is insecure but http', async () => {
+      const secureSecurityState = {
+        explanations: [],
+        securityState: 'insecure',
+        schemeIsCryptographic: false,
+      };
+
+      driver.on = driver.once = createMockOnceFn()
+        .mockEvent('Security.securityStateChanged', secureSecurityState);
+
+      const startUrl = 'https://www.example.com';
+      const loadOptions = {
+        waitForLoad: true,
+        passContext: {
+          settings: {
+            maxWaitForLoad: 1,
+          },
+        },
+      };
+
+      const loadPromise = driver.gotoURL(startUrl, loadOptions);
+      await flushAllTimersAndMicrotasks();
+      await loadPromise;
+    });
+
     it('rejects when page is insecure', async () => {
       const insecureSecurityState = {
         explanations: [
@@ -717,6 +742,7 @@ describe('.gotoURL', () => {
           },
         ],
         securityState: 'insecure',
+        schemeIsCryptographic: true,
       };
 
       driver.on = driver.once = createMockOnceFn();


### PR DESCRIPTION
**Summary**
Currently no `http` site seems to be auditable by the extension in Canary. AFAICT, Chrome has started to fire security state `insecure` events, but not over the websocket protocol for some reason, just chrome.debugger... 😕 

It *seems* like we should be able to just do the security check if the scheme is cryptographic and ignore it if it wasn't cryptographic? There are some other properties in the object that look promising (`displayedInsecureContentStyle === 'insecure'` maybe?), but want @Hoten 's take since he's our resident security state expert :)


**Event we get for bad ssl site**
![image](https://user-images.githubusercontent.com/2301202/56242496-0ba3fe80-605e-11e9-95f2-d4a0c35415fa.png)



**Event we get for http site**
![image](https://user-images.githubusercontent.com/2301202/56243038-3b9fd180-605f-11e9-85fa-626a2ab0674f.png)




