### PR TITLE
core: require score in audit product; make rawValue numeric only

### DIFF
--- a/docs/understanding-results.md
+++ b/docs/understanding-results.md
@@ -71,7 +71,6 @@ An object containing the results of the audits, keyed by their name.
       "description": "All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/https).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "displayValue": "1 insecure request found",
       "details": {
         "type": "table",

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -59,7 +59,7 @@ describe('CLI run', function() {
 
     it('returns results that match the saved results', () => {
       const {lhr} = passedResults;
-      assert.equal(fileResults.audits.viewport.rawValue, false);
+      assert.equal(fileResults.audits.viewport.score, 0);
 
       // passed results match saved results
       assert.strictEqual(fileResults.fetchTime, lhr.fetchTime);

--- a/lighthouse-core/audits/accessibility/axe-audit.js
+++ b/lighthouse-core/audits/accessibility/axe-audit.js
@@ -34,7 +34,7 @@ class AxeAudit extends Audit {
     const isNotApplicable = notApplicables.find(result => result.id === this.meta.id);
     if (isNotApplicable) {
       return {
-        rawValue: true,
+        score: 1,
         notApplicable: true,
       };
     }
@@ -74,7 +74,7 @@ class AxeAudit extends Audit {
     }
 
     return {
-      rawValue: typeof rule === 'undefined',
+      score: Number(rule === undefined),
       extendedInfo: {
         value: rule,
       },

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -90,18 +90,6 @@ class Audit {
   }
 
   /**
-   * @param {typeof Audit} audit
-   * @param {string} errorMessage
-   * @return {LH.Audit.Result}
-   */
-  static generateErrorAuditResult(audit, errorMessage) {
-    return Audit.generateAuditResult(audit, {
-      rawValue: null,
-      errorMessage,
-    });
-  }
-
-  /**
    * @param {LH.Audit.Details.Table['headings']} headings
    * @param {LH.Audit.Details.Table['items']} results
    * @param {LH.Audit.Details.Table['summary']=} summary
@@ -209,61 +197,70 @@ class Audit {
   }
 
   /**
-   * @param {typeof Audit} audit
-   * @param {LH.Audit.Product} result
-   * @return {{score: number|null, scoreDisplayMode: LH.Audit.ScoreDisplayMode}}
+   * @param {number|null} score
+   * @param {LH.Audit.ScoreDisplayMode} scoreDisplayMode
+   * @param {string} auditId
+   * @return {number|null}
    */
-  static _normalizeAuditScore(audit, result) {
-    // Cast true/false to 1/0
-    let score = result.score === undefined ? Number(result.rawValue) : result.score;
+  static _normalizeAuditScore(score, scoreDisplayMode, auditId) {
+    if (scoreDisplayMode !== Audit.SCORING_MODES.BINARY &&
+        scoreDisplayMode !== Audit.SCORING_MODES.NUMERIC) {
+      return null;
+    }
 
-    if (!Number.isFinite(score)) throw new Error(`Invalid score: ${score}`);
-    if (score > 1) throw new Error(`Audit score for ${audit.meta.id} is > 1`);
-    if (score < 0) throw new Error(`Audit score for ${audit.meta.id} is < 0`);
+    // Otherwise, score must be a number in [0, 1].
+    if (score === null || !Number.isFinite(score)) {
+      throw new Error(`Invalid score for ${auditId}: ${score}`);
+    }
+    if (score > 1) throw new Error(`Audit score for ${auditId} is > 1`);
+    if (score < 0) throw new Error(`Audit score for ${auditId} is < 0`);
 
     score = clampTo2Decimals(score);
 
-    const scoreDisplayMode = audit.meta.scoreDisplayMode || Audit.SCORING_MODES.BINARY;
-
-    return {
-      score,
-      scoreDisplayMode,
-    };
+    return score;
   }
 
   /**
    * @param {typeof Audit} audit
-   * @param {LH.Audit.Product} result
+   * @param {string} errorMessage
    * @return {LH.Audit.Result}
    */
-  static generateAuditResult(audit, result) {
-    if (typeof result.rawValue === 'undefined') {
-      throw new Error('generateAuditResult requires a rawValue');
+  static generateErrorAuditResult(audit, errorMessage) {
+    return Audit.generateAuditResult(audit, {
+      score: null,
+      errorMessage,
+    });
+  }
+
+  /**
+   * @param {typeof Audit} audit
+   * @param {LH.Audit.Product} product
+   * @return {LH.Audit.Result}
+   */
+  static generateAuditResult(audit, product) {
+    if (product.score === undefined) {
+      throw new Error('generateAuditResult requires a score');
     }
 
-    // TODO(bckenny): cleanup the flow of notApplicable/error/binary/numeric
-    let {score, scoreDisplayMode} = Audit._normalizeAuditScore(audit, result);
+    // Default to binary scoring.
+    let scoreDisplayMode = audit.meta.scoreDisplayMode || Audit.SCORING_MODES.BINARY;
 
-    // If the audit was determined to not apply to the page, set score display mode appropriately
-    if (result.notApplicable) {
-      scoreDisplayMode = Audit.SCORING_MODES.NOT_APPLICABLE;
-      result.rawValue = true;
-    }
-
-    if (result.errorMessage) {
+    // But override if product contents require it.
+    if (product.errorMessage) {
+      // Error result.
       scoreDisplayMode = Audit.SCORING_MODES.ERROR;
+    } else if (product.notApplicable) {
+      // Audit was determined to not apply to the page.
+      scoreDisplayMode = Audit.SCORING_MODES.NOT_APPLICABLE;
     }
+
+    const score = Audit._normalizeAuditScore(product.score, scoreDisplayMode, audit.meta.id);
 
     let auditTitle = audit.meta.title;
     if (audit.meta.failureTitle) {
-      if (Number(score) < Util.PASS_THRESHOLD) {
+      if (score !== null && score < Util.PASS_THRESHOLD) {
         auditTitle = audit.meta.failureTitle;
       }
-    }
-
-    if (scoreDisplayMode !== Audit.SCORING_MODES.BINARY &&
-        scoreDisplayMode !== Audit.SCORING_MODES.NUMERIC) {
-      score = null;
     }
 
     return {
@@ -273,14 +270,14 @@ class Audit {
 
       score,
       scoreDisplayMode,
-      rawValue: result.rawValue,
+      rawValue: product.rawValue,
 
-      displayValue: result.displayValue,
-      explanation: result.explanation,
-      errorMessage: result.errorMessage,
-      warnings: result.warnings,
+      displayValue: product.displayValue,
+      explanation: product.explanation,
+      errorMessage: product.errorMessage,
+      warnings: product.warnings,
 
-      details: result.details,
+      details: product.details,
     };
   }
 }

--- a/lighthouse-core/audits/content-width.js
+++ b/lighthouse-core/audits/content-width.js
@@ -35,12 +35,12 @@ class ContentWidth extends Audit {
 
     if (IsMobile) {
       return {
-        rawValue: widthsMatch,
+        score: Number(widthsMatch),
         explanation: this.createExplanation(widthsMatch, artifacts.ViewportDimensions),
       };
     } else {
       return {
-        rawValue: true,
+        score: 1,
         notApplicable: true,
       };
     }

--- a/lighthouse-core/audits/critical-request-chains.js
+++ b/lighthouse-core/audits/critical-request-chains.js
@@ -201,7 +201,7 @@ class CriticalRequestChains extends Audit {
       const longestChain = CriticalRequestChains._getLongestChain(flattenedChains);
 
       return {
-        rawValue: chainCount === 0,
+        score: Number(chainCount === 0),
         notApplicable: chainCount === 0,
         displayValue: chainCount ? str_(UIStrings.displayValue, {itemCount: chainCount}) : '',
         extendedInfo: {

--- a/lighthouse-core/audits/deprecations.js
+++ b/lighthouse-core/audits/deprecations.js
@@ -61,7 +61,7 @@ class Deprecations extends Audit {
     }
 
     return {
-      rawValue: deprecations.length === 0,
+      score: Number(deprecations.length === 0),
       displayValue,
       extendedInfo: {
         value: deprecations,

--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -36,7 +36,7 @@ class AppCacheManifestAttr extends Audit {
     const displayValue = usingAppcache ? `Found "${artifacts.AppCacheManifest}"` : '';
 
     return {
-      rawValue: !usingAppcache,
+      score: usingAppcache ? 0 : 1,
       displayValue,
     };
   }

--- a/lighthouse-core/audits/dobetterweb/doctype.js
+++ b/lighthouse-core/audits/dobetterweb/doctype.js
@@ -30,7 +30,7 @@ class Doctype extends Audit {
   static audit(artifacts) {
     if (!artifacts.Doctype) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: 'Document must contain a doctype',
       };
     }
@@ -42,14 +42,14 @@ class Doctype extends Audit {
 
     if (doctypePublicId !== '') {
       return {
-        rawValue: false,
+        score: 0,
         explanation: 'Expected publicId to be an empty string',
       };
     }
 
     if (doctypeSystemId !== '') {
       return {
-        rawValue: false,
+        score: 0,
         explanation: 'Expected systemId to be an empty string',
       };
     }
@@ -59,11 +59,11 @@ class Doctype extends Audit {
        https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode */
     if (doctypeName === 'html') {
       return {
-        rawValue: true,
+        score: 1,
       };
     } else {
       return {
-        rawValue: false,
+        score: 0,
         explanation: 'Doctype name must be the lowercase string `html`',
       };
     }

--- a/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
+++ b/lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js
@@ -67,7 +67,7 @@ class ExternalAnchorsUseRelNoopenerAudit extends Audit {
     const details = Audit.makeTableDetails(headings, failingAnchors);
 
     return {
-      rawValue: failingAnchors.length === 0,
+      score: Number(failingAnchors.length === 0),
       extendedInfo: {
         value: failingAnchors,
       },

--- a/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/geolocation-on-start.js
@@ -47,7 +47,7 @@ class GeolocationOnStart extends ViolationAudit {
     const details = ViolationAudit.makeTableDetails(headings, results);
 
     return {
-      rawValue: results.length === 0,
+      score: Number(results.length === 0),
       extendedInfo: {
         value: results,
       },

--- a/lighthouse-core/audits/dobetterweb/js-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/js-libraries.js
@@ -46,7 +46,7 @@ class JsLibrariesAudit extends Audit {
     const details = Audit.makeTableDetails(headings, libDetails, {});
 
     return {
-      rawValue: true, // Always pass for now.
+      score: 1, // Always pass for now.
       details,
     };
   }

--- a/lighthouse-core/audits/dobetterweb/no-document-write.js
+++ b/lighthouse-core/audits/dobetterweb/no-document-write.js
@@ -44,7 +44,7 @@ class NoDocWriteAudit extends ViolationAudit {
     const details = ViolationAudit.makeTableDetails(headings, results);
 
     return {
-      rawValue: results.length === 0,
+      score: Number(results.length === 0),
       extendedInfo: {
         value: results,
       },

--- a/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
+++ b/lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js
@@ -140,7 +140,7 @@ class NoVulnerableLibrariesAudit extends Audit {
 
     if (!foundLibraries.length) {
       return {
-        rawValue: true,
+        score: 1,
       };
     }
 
@@ -194,7 +194,7 @@ class NoVulnerableLibrariesAudit extends Audit {
     const details = Audit.makeTableDetails(headings, vulnerabilityResults, {});
 
     return {
-      rawValue: totalVulns === 0,
+      score: Number(totalVulns === 0),
       displayValue,
       extendedInfo: {
         jsLibs: libraryVulns,

--- a/lighthouse-core/audits/dobetterweb/notification-on-start.js
+++ b/lighthouse-core/audits/dobetterweb/notification-on-start.js
@@ -45,7 +45,7 @@ class NotificationOnStart extends ViolationAudit {
     const details = ViolationAudit.makeTableDetails(headings, results);
 
     return {
-      rawValue: results.length === 0,
+      score: Number(results.length === 0),
       extendedInfo: {
         value: results,
       },

--- a/lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
+++ b/lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js
@@ -43,7 +43,7 @@ class PasswordInputsCanBePastedIntoAudit extends Audit {
     ];
 
     return {
-      rawValue: passwordInputsWithPreventedPaste.length === 0,
+      score: Number(passwordInputsWithPreventedPaste.length === 0),
       extendedInfo: {
         value: passwordInputsWithPreventedPaste,
       },

--- a/lighthouse-core/audits/dobetterweb/uses-http2.js
+++ b/lighthouse-core/audits/dobetterweb/uses-http2.js
@@ -79,7 +79,7 @@ class UsesHTTP2Audit extends Audit {
       const details = Audit.makeTableDetails(headings, resources);
 
       return {
-        rawValue: resources.length === 0,
+        score: Number(resources.length === 0),
         displayValue: displayValue,
         extendedInfo: {
           value: {

--- a/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
+++ b/lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js
@@ -45,7 +45,7 @@ class PassiveEventsAudit extends ViolationAudit {
     const details = ViolationAudit.makeTableDetails(headings, results);
 
     return {
-      rawValue: results.length === 0,
+      score: Number(results.length === 0),
       extendedInfo: {
         value: results,
       },

--- a/lighthouse-core/audits/final-screenshot.js
+++ b/lighthouse-core/audits/final-screenshot.js
@@ -38,7 +38,7 @@ class FinalScreenshot extends Audit {
     }
 
     return {
-      rawValue: true,
+      score: 1,
       details: {
         type: 'screenshot',
         timestamp: finalScreenshot.timestamp,

--- a/lighthouse-core/audits/font-display.js
+++ b/lighthouse-core/audits/font-display.js
@@ -137,7 +137,6 @@ class FontDisplay extends Audit {
 
     return {
       score: Number(results.length === 0),
-      rawValue: results.length === 0,
       details,
     };
   }

--- a/lighthouse-core/audits/image-aspect-ratio.js
+++ b/lighthouse-core/audits/image-aspect-ratio.js
@@ -105,7 +105,7 @@ class ImageAspectRatio extends Audit {
     ];
 
     return {
-      rawValue: results.length === 0,
+      score: Number(results.length === 0),
       warnings,
       details: Audit.makeTableDetails(headings, results),
     };

--- a/lighthouse-core/audits/is-on-https.js
+++ b/lighthouse-core/audits/is-on-https.js
@@ -68,7 +68,7 @@ class HTTPS extends Audit {
       ];
 
       return {
-        rawValue: items.length === 0,
+        score: Number(items.length === 0),
         displayValue,
         extendedInfo: {
           value: items,

--- a/lighthouse-core/audits/manual/manual-audit.js
+++ b/lighthouse-core/audits/manual/manual-audit.js
@@ -28,7 +28,7 @@ class ManualAudit extends Audit {
    */
   static audit() {
     return {
-      rawValue: false,
+      score: 0,
       // displayValue: '(needs manual verification)'
     };
   }

--- a/lighthouse-core/audits/mixed-content.js
+++ b/lighthouse-core/audits/mixed-content.js
@@ -139,7 +139,6 @@ class MixedContent extends Audit {
       const score = (secureRecords.length + 0.5 * upgradeableResources.length) / totalRecords;
 
       return {
-        rawValue: upgradeableResources.length === 0,
         score,
         displayValue: displayValue,
         details,

--- a/lighthouse-core/audits/multi-check-audit.js
+++ b/lighthouse-core/audits/multi-check-audit.js
@@ -52,7 +52,7 @@ class MultiCheckAudit extends Audit {
     // If we fail, share the failures
     if (result.failures.length > 0) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: `Failures: ${result.failures.join(',\n')}.`,
         details,
       };
@@ -60,7 +60,7 @@ class MultiCheckAudit extends Audit {
 
     // Otherwise, we pass
     return {
-      rawValue: true,
+      score: 1,
       details,
     };
   }

--- a/lighthouse-core/audits/offline-start-url.js
+++ b/lighthouse-core/audits/offline-start-url.js
@@ -39,7 +39,7 @@ class OfflineStartUrl extends Audit {
     const hasOfflineStartUrl = artifacts.StartUrl.statusCode === 200;
 
     return {
-      rawValue: hasOfflineStartUrl,
+      score: Number(hasOfflineStartUrl),
       explanation: artifacts.StartUrl.explanation,
       warnings,
     };

--- a/lighthouse-core/audits/redirects-http.js
+++ b/lighthouse-core/audits/redirects-http.js
@@ -28,7 +28,7 @@ class RedirectsHTTP extends Audit {
    */
   static audit(artifacts) {
     return {
-      rawValue: artifacts.HTTPRedirect.value,
+      score: Number(artifacts.HTTPRedirect.value),
     };
   }
 }

--- a/lighthouse-core/audits/screenshot-thumbnails.js
+++ b/lighthouse-core/audits/screenshot-thumbnails.js
@@ -135,7 +135,6 @@ class ScreenshotThumbnails extends Audit {
 
     return {
       score: 1,
-      rawValue: thumbnails.length > 0,
       details: {
         type: 'filmstrip',
         scale: timelineEnd,

--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -117,7 +117,7 @@ class Canonical extends Audit {
     // the canonical link is totally invalid
     if (invalidCanonicalLink) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanationInvalid, {url: invalidCanonicalLink.hrefRaw}),
       };
     }
@@ -125,7 +125,7 @@ class Canonical extends Audit {
     // the canonical link is valid, but it's relative which isn't allowed
     if (relativeCanonicallink) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanationRelative, {url: relativeCanonicallink.hrefRaw}),
       };
     }
@@ -136,7 +136,7 @@ class Canonical extends Audit {
     // there's no canonical URL at all, we're done
     if (canonicalURLs.length === 0) {
       return {
-        rawValue: true,
+        score: 1,
         notApplicable: true,
       };
     }
@@ -144,7 +144,7 @@ class Canonical extends Audit {
     // we have multiple conflicting canonical URls, we're done
     if (canonicalURLs.length > 1) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanationConflict, {urlList: canonicalURLs.join(', ')}),
       };
     }
@@ -166,7 +166,7 @@ class Canonical extends Audit {
       baseURL.href !== canonicalURL.href
     ) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanationPointsElsewhere, {url: baseURL.href}),
       };
     }
@@ -175,7 +175,7 @@ class Canonical extends Audit {
     // a common mistake to publish a page with canonical pointing to e.g. a test domain or localhost
     if (getPrimaryDomain(canonicalURL) !== getPrimaryDomain(baseURL)) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanationDifferentDomain, {url: canonicalURL}),
       };
     }
@@ -187,7 +187,7 @@ class Canonical extends Audit {
       baseURL.pathname !== '/'
     ) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanationRoot),
       };
     }
@@ -220,7 +220,7 @@ class Canonical extends Audit {
     if (mistakeAuditProduct) return mistakeAuditProduct;
 
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -220,7 +220,7 @@ class FontSize extends Audit {
     if (!artifacts.TestedAsMobileDevice) {
       // Font size isn't important to desktop SEO
       return {
-        rawValue: true,
+        score: 1,
         notApplicable: true,
       };
     }
@@ -228,7 +228,7 @@ class FontSize extends Audit {
     const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
     if (!viewportMeta.isMobileOptimized) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanationViewport),
       };
     }
@@ -243,7 +243,7 @@ class FontSize extends Audit {
 
     if (totalTextLength === 0) {
       return {
-        rawValue: true,
+        score: 1,
       };
     }
 
@@ -319,7 +319,7 @@ class FontSize extends Audit {
     }
 
     return {
-      rawValue: passed,
+      score: Number(passed),
       details,
       displayValue,
       explanation,

--- a/lighthouse-core/audits/seo/hreflang.js
+++ b/lighthouse-core/audits/seo/hreflang.js
@@ -106,7 +106,7 @@ class Hreflang extends Audit {
     const details = Audit.makeTableDetails(headings, invalidHreflangs);
 
     return {
-      rawValue: invalidHreflangs.length === 0,
+      score: Number(invalidHreflangs.length === 0),
       details,
     };
   }

--- a/lighthouse-core/audits/seo/http-status-code.js
+++ b/lighthouse-core/audits/seo/http-status-code.js
@@ -54,13 +54,13 @@ class HTTPStatusCode extends Audit {
         if (statusCode >= HTTP_UNSUCCESSFUL_CODE_LOW &&
           statusCode <= HTTP_UNSUCCESSFUL_CODE_HIGH) {
           return {
-            rawValue: false,
+            score: 0,
             displayValue: `${statusCode}`,
           };
         }
 
         return {
-          rawValue: true,
+          score: 1,
         };
       });
   }

--- a/lighthouse-core/audits/seo/is-crawlable.js
+++ b/lighthouse-core/audits/seo/is-crawlable.js
@@ -139,7 +139,7 @@ class IsCrawlable extends Audit {
         const details = Audit.makeTableDetails(headings, blockingDirectives);
 
         return {
-          rawValue: blockingDirectives.length === 0,
+          score: Number(blockingDirectives.length === 0),
           details,
         };
       });

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -99,7 +99,7 @@ class LinkText extends Audit {
     }
 
     return {
-      rawValue: failingLinks.length === 0,
+      score: Number(failingLinks.length === 0),
       details,
       displayValue,
     };

--- a/lighthouse-core/audits/seo/meta-description.js
+++ b/lighthouse-core/audits/seo/meta-description.js
@@ -45,20 +45,20 @@ class Description extends Audit {
     const metaDescription = artifacts.MetaElements.find(meta => meta.name === 'description');
     if (!metaDescription) {
       return {
-        rawValue: false,
+        score: 0,
       };
     }
 
     const description = metaDescription.content || '';
     if (description.trim().length === 0) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanation),
       };
     }
 
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/audits/seo/plugins.js
+++ b/lighthouse-core/audits/seo/plugins.js
@@ -160,7 +160,7 @@ class Plugins extends Audit {
     const details = Audit.makeTableDetails(headings, plugins);
 
     return {
-      rawValue: plugins.length === 0,
+      score: Number(plugins.length === 0),
       details,
     };
   }

--- a/lighthouse-core/audits/seo/robots-txt.js
+++ b/lighthouse-core/audits/seo/robots-txt.js
@@ -202,19 +202,19 @@ class RobotsTxt extends Audit {
 
     if (!status) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanation),
       };
     }
 
     if (status >= HTTP_SERVER_ERROR_CODE_LOW) {
       return {
-        rawValue: false,
+        score: 0,
         displayValue: str_(UIStrings.displayValueHttpBadCode, {statusCode: status}),
       };
     } else if (status >= HTTP_CLIENT_ERROR_CODE_LOW || content === '') {
       return {
-        rawValue: true,
+        score: 1,
         notApplicable: true,
       };
     }
@@ -242,7 +242,7 @@ class RobotsTxt extends Audit {
     }
 
     return {
-      rawValue: validationErrors.length === 0,
+      score: Number(validationErrors.length === 0),
       details,
       displayValue,
     };

--- a/lighthouse-core/audits/seo/tap-targets.js
+++ b/lighthouse-core/audits/seo/tap-targets.js
@@ -278,7 +278,7 @@ class TapTargets extends Audit {
       // Tap target sizes aren't important for desktop SEO, so disable the audit there.
       // On desktop people also tend to have more precise pointing devices than fingers.
       return {
-        rawValue: true,
+        score: 1,
         notApplicable: true,
       };
     }
@@ -286,7 +286,7 @@ class TapTargets extends Audit {
     const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
     if (!viewportMeta.isMobileOptimized) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: str_(UIStrings.explanationViewportMetaNotOptimized),
       };
     }
@@ -323,7 +323,6 @@ class TapTargets extends Audit {
     const displayValue = str_(UIStrings.displayValue, {decimalProportion: passingTapTargetRatio});
 
     return {
-      rawValue: tableItems.length === 0,
       score,
       details,
       displayValue,

--- a/lighthouse-core/audits/service-worker.js
+++ b/lighthouse-core/audits/service-worker.js
@@ -94,7 +94,7 @@ class ServiceWorker extends Audit {
     const versionsForOrigin = ServiceWorker.getVersionsForOrigin(versions, pageUrl);
     if (versionsForOrigin.length === 0) {
       return {
-        rawValue: false,
+        score: 0,
       };
     }
 
@@ -102,7 +102,7 @@ class ServiceWorker extends Audit {
         registrations, pageUrl);
     if (!controllingScopeUrl) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: `This origin has one or more service workers, however the page ("${pageUrl.href}") is not in scope.`, // eslint-disable-line max-len
       };
     }
@@ -111,14 +111,14 @@ class ServiceWorker extends Audit {
         controllingScopeUrl);
     if (startUrlFailure) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: `This page is controlled by a service worker, however ${startUrlFailure}.`,
       };
     }
 
     // SW controls both finalUrl and start_url.
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/audits/user-timings.js
+++ b/lighthouse-core/audits/user-timings.js
@@ -113,7 +113,7 @@ class UserTimings extends Audit {
 
       return {
         // mark the audit as notApplicable if there were no user timings
-        rawValue: userTimings.length === 0,
+        score: Number(userTimings.length === 0),
         notApplicable: userTimings.length === 0,
         displayValue,
         extendedInfo: {

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -34,13 +34,13 @@ class Viewport extends Audit {
 
     if (!viewportMeta.hasViewportTag) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: 'No viewport meta tag found',
       };
     }
 
     return {
-      rawValue: viewportMeta.isMobileOptimized,
+      score: Number(viewportMeta.isMobileOptimized),
       warnings: viewportMeta.parserWarnings,
     };
   }

--- a/lighthouse-core/audits/without-javascript.js
+++ b/lighthouse-core/audits/without-javascript.js
@@ -33,13 +33,13 @@ class WithoutJavaScript extends Audit {
     // Fail pages that have empty text and are missing a noscript tag
     if (artifact.bodyText.trim() === '' && !artifact.hasNoScript) {
       return {
-        rawValue: false,
+        score: 0,
         explanation: 'The page body should render some content if its scripts are not available.',
       };
     }
 
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/audits/works-offline.js
+++ b/lighthouse-core/audits/works-offline.js
@@ -39,7 +39,7 @@ class WorksOffline extends Audit {
     }
 
     return {
-      rawValue: passed,
+      score: Number(passed),
       warnings,
     };
   }

--- a/lighthouse-core/test/audits/accessibility/aria-allowed-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-allowed-attr-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: aria-allowed-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: aria-allowed-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/aria-required-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-required-attr-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: aria-required-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: aria-required-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/aria-required-children-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-required-children-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: aria-required-children audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: aria-required-children audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/aria-required-parent-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-required-parent-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: aria-required-parent audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: aria-required-parent audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/aria-roles-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-roles-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: aria-roles audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: aria-roles audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/aria-valid-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-valid-attr-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: aria-valid-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: aria-valid-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/aria-valid-attr-value-test.js
+++ b/lighthouse-core/test/audits/accessibility/aria-valid-attr-value-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: aria-valid-attr-value audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: aria-valid-attr-value audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/audio-caption-test.js
+++ b/lighthouse-core/test/audits/accessibility/audio-caption-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: audio-caption audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: audio-caption audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/axe-audit-test.js
+++ b/lighthouse-core/test/audits/accessibility/axe-audit-test.js
@@ -33,7 +33,7 @@ describe('Accessibility: axe-audit', () => {
       };
 
       const output = FakeA11yAudit.audit(artifacts);
-      assert.equal(output.rawValue, false);
+      assert.equal(output.score, 0);
     });
   });
 });

--- a/lighthouse-core/test/audits/accessibility/button-name-test.js
+++ b/lighthouse-core/test/audits/accessibility/button-name-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: button-name audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: button-name audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/bypass-test.js
+++ b/lighthouse-core/test/audits/accessibility/bypass-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: bypass audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: bypass audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/color-contrast-test.js
+++ b/lighthouse-core/test/audits/accessibility/color-contrast-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: color-contrast audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: color-contrast audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/definition-list-test.js
+++ b/lighthouse-core/test/audits/accessibility/definition-list-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: definition-list audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: definition-list audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/dlitem-test.js
+++ b/lighthouse-core/test/audits/accessibility/dlitem-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: dlitem audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: dlitem audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/document-title-test.js
+++ b/lighthouse-core/test/audits/accessibility/document-title-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: document-title audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: document-title audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/duplicate-id-test.js
+++ b/lighthouse-core/test/audits/accessibility/duplicate-id-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: duplicate-id audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: duplicate-id audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/frame-title-test.js
+++ b/lighthouse-core/test/audits/accessibility/frame-title-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: frame-title audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: frame-title audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/html-has-lang-test.js
+++ b/lighthouse-core/test/audits/accessibility/html-has-lang-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: html-has-lang audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: html-has-lang audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/html-lang-valid-test.js
+++ b/lighthouse-core/test/audits/accessibility/html-lang-valid-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: html-lang-valid audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: html-lang-valid audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/image-alt-test.js
+++ b/lighthouse-core/test/audits/accessibility/image-alt-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: image-alt audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: image-alt audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/input-image-alt-test.js
+++ b/lighthouse-core/test/audits/accessibility/input-image-alt-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: input-image-alt audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: input-image-alt audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/label-test.js
+++ b/lighthouse-core/test/audits/accessibility/label-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: label audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: label audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/layout-table-test.js
+++ b/lighthouse-core/test/audits/accessibility/layout-table-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: layout-table audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: layout-table audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/link-name-test.js
+++ b/lighthouse-core/test/audits/accessibility/link-name-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: link-name audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: link-name audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/list-test.js
+++ b/lighthouse-core/test/audits/accessibility/list-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: list audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: list audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/listitem-test.js
+++ b/lighthouse-core/test/audits/accessibility/listitem-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: listitem audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: listitem audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/meta-refresh-test.js
+++ b/lighthouse-core/test/audits/accessibility/meta-refresh-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: meta-refresh audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: meta-refresh audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/meta-viewport-test.js
+++ b/lighthouse-core/test/audits/accessibility/meta-viewport-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: meta-viewport audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: meta-viewport audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/object-alt-test.js
+++ b/lighthouse-core/test/audits/accessibility/object-alt-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: object-alt audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: object-alt audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/tabindex-test.js
+++ b/lighthouse-core/test/audits/accessibility/tabindex-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: tabindex audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: tabindex audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/td-headers-attr-test.js
+++ b/lighthouse-core/test/audits/accessibility/td-headers-attr-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: td-headers-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: td-headers-attr audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/th-has-data-cells-test.js
+++ b/lighthouse-core/test/audits/accessibility/th-has-data-cells-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: th-has-data-cells audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: th-has-data-cells audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/valid-lang-test.js
+++ b/lighthouse-core/test/audits/accessibility/valid-lang-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: valid-lang audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: valid-lang audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/video-caption-test.js
+++ b/lighthouse-core/test/audits/accessibility/video-caption-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: video-caption audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: video-caption audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/accessibility/video-description-test.js
+++ b/lighthouse-core/test/audits/accessibility/video-description-test.js
@@ -23,7 +23,7 @@ describe('Accessibility: video-description audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 
   it('generates an audit output (single node)', () => {
@@ -38,6 +38,6 @@ describe('Accessibility: video-description audit', () => {
     };
 
     const output = Audit.audit(artifacts);
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
   });
 });

--- a/lighthouse-core/test/audits/content-width-test.js
+++ b/lighthouse-core/test/audits/content-width-test.js
@@ -20,7 +20,7 @@ describe('Mobile-friendly: content-width audit', () => {
       },
     });
 
-    assert.equal(result.rawValue, false);
+    assert.equal(result.score, 0);
     assert.ok(result.explanation);
   });
 
@@ -31,7 +31,7 @@ describe('Mobile-friendly: content-width audit', () => {
         innerWidth: 300,
         outerWidth: 300,
       },
-    }, {settings: {emulatedFormFactor: 'mobile'}}).rawValue, true);
+    }, {settings: {emulatedFormFactor: 'mobile'}}).score, 1);
   });
 
   it('not applicable when run on desktop', () => {

--- a/lighthouse-core/test/audits/critical-request-chains-test.js
+++ b/lighthouse-core/test/audits/critical-request-chains-test.js
@@ -82,7 +82,7 @@ describe('Performance: critical-request-chains audit', () => {
     const context = {computedCache: new Map()};
     return CriticalRequestChains.audit(artifacts, context).then(output => {
       expect(output.displayValue).toBeDisplayString('2 chains found');
-      assert.equal(output.rawValue, false);
+      assert.equal(output.score, 0);
       assert.ok(output.details);
     });
   });
@@ -93,7 +93,7 @@ describe('Performance: critical-request-chains audit', () => {
     return CriticalRequestChains.audit(artifacts, context).then(output => {
       assert.equal(output.details.longestChain.duration, 1000);
       assert.equal(output.displayValue, '');
-      assert.equal(output.rawValue, true);
+      assert.equal(output.score, 1);
     });
   });
 
@@ -102,7 +102,7 @@ describe('Performance: critical-request-chains audit', () => {
     const context = {computedCache: new Map()};
     return CriticalRequestChains.audit(artifacts, context).then(output => {
       assert.equal(output.displayValue, '');
-      assert.equal(output.rawValue, true);
+      assert.equal(output.score, 1);
     });
   });
 

--- a/lighthouse-core/test/audits/deprecations-test.js
+++ b/lighthouse-core/test/audits/deprecations-test.js
@@ -15,7 +15,7 @@ describe('Console deprecations audit', () => {
     const auditResult = DeprecationsAudit.audit({
       ChromeConsoleMessages: [],
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
   });
 
@@ -30,7 +30,7 @@ describe('Console deprecations audit', () => {
         },
       ],
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.displayValue, '1 warning found');
     assert.equal(auditResult.details.items.length, 1);
     assert.equal(auditResult.details.items[0].url, '');
@@ -66,7 +66,7 @@ describe('Console deprecations audit', () => {
         },
       ],
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.displayValue, '2 warnings found');
     assert.equal(auditResult.details.items.length, 2);
     assert.equal(auditResult.details.items[0].url, URL);

--- a/lighthouse-core/test/audits/dobetterweb/appcache-manifest-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/appcache-manifest-test.js
@@ -15,13 +15,13 @@ describe('Appcache manifest audit', () => {
     const auditResult = AppCacheManifestAttrAudit.audit({
       AppCacheManifest: 'manifest-name',
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     expect(auditResult.displayValue).toBeDisplayString(/manifest-name/);
   });
 
   it('passes when <html> does not contain a manifest attribute', () => {
     assert.equal(AppCacheManifestAttrAudit.audit({
       AppCacheManifest: null,
-    }).rawValue, true);
+    }).score, 1);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/doctype-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/doctype-test.js
@@ -15,7 +15,7 @@ describe('DOBETTERWEB: doctype audit', () => {
     const auditResult = Audit.audit({
       Doctype: null,
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.explanation, 'Document must contain a doctype');
   });
 
@@ -27,7 +27,7 @@ describe('DOBETTERWEB: doctype audit', () => {
         systemId: '',
       },
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.explanation, 'Doctype name must be the lowercase string `html`');
   });
 
@@ -39,7 +39,7 @@ describe('DOBETTERWEB: doctype audit', () => {
         systemId: '',
       },
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.explanation, 'Doctype name must be the lowercase string `html`');
   });
 
@@ -51,7 +51,7 @@ describe('DOBETTERWEB: doctype audit', () => {
         systemId: '',
       },
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.explanation, 'Expected publicId to be an empty string');
   });
 
@@ -63,7 +63,7 @@ describe('DOBETTERWEB: doctype audit', () => {
         systemId: '189655',
       },
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.explanation, 'Expected systemId to be an empty string');
   });
 
@@ -75,6 +75,6 @@ describe('DOBETTERWEB: doctype audit', () => {
         systemId: '',
       },
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/external-anchors-use-rel-noopener-test.js
@@ -22,7 +22,7 @@ describe('External anchors use rel="noopener"', () => {
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
     assert.equal(auditResult.details.items.length, 0);
   });
@@ -36,7 +36,7 @@ describe('External anchors use rel="noopener"', () => {
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
     assert.equal(auditResult.details.items.length, 0);
   });
@@ -49,7 +49,7 @@ describe('External anchors use rel="noopener"', () => {
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
     assert.equal(auditResult.details.items.length, 0);
   });
@@ -62,7 +62,7 @@ describe('External anchors use rel="noopener"', () => {
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
   });
 
@@ -74,7 +74,7 @@ describe('External anchors use rel="noopener"', () => {
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
   });
 
@@ -86,7 +86,7 @@ describe('External anchors use rel="noopener"', () => {
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 2);
     assert.equal(auditResult.details.items.length, 2);
   });
@@ -98,7 +98,7 @@ describe('External anchors use rel="noopener"', () => {
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 1);
     assert.equal(auditResult.details.items.length, 1);
     assert.ok(auditResult.warnings.length, 'includes warning');
@@ -114,7 +114,7 @@ describe('External anchors use rel="noopener"', () => {
       ],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 4);
     assert.equal(auditResult.details.items.length, 4);
     assert.equal(auditResult.warnings.length, 4);

--- a/lighthouse-core/test/audits/dobetterweb/geolocation-on-start-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/geolocation-on-start-test.js
@@ -22,7 +22,7 @@ describe('UX: geolocation audit', () => {
         {entry: {source: 'deprecation', url: 'https://example.com/two'}},
       ],
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 2);
   });
 
@@ -30,7 +30,7 @@ describe('UX: geolocation audit', () => {
     const auditResult = GeolocationOnStartAudit.audit({
       ChromeConsoleMessages: [],
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/js-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/js-libraries-test.js
@@ -15,7 +15,7 @@ describe('Returns detected front-end JavaScript libraries', () => {
     const auditResult1 = JsLibrariesAudit.audit({
       Stacks: [],
     });
-    assert.equal(auditResult1.rawValue, true);
+    assert.equal(auditResult1.score, 1);
 
     // duplicates. TODO: consider failing in this case
     const auditResult2 = JsLibrariesAudit.audit({
@@ -24,7 +24,7 @@ describe('Returns detected front-end JavaScript libraries', () => {
         {detector: 'js', name: 'lib2', version: undefined, npm: 'lib2'},
       ],
     });
-    assert.equal(auditResult2.rawValue, true);
+    assert.equal(auditResult2.score, 1);
 
     // LOTS of frontend libs
     const auditResult3 = JsLibrariesAudit.audit({
@@ -36,7 +36,7 @@ describe('Returns detected front-end JavaScript libraries', () => {
         {detector: 'js', name: 'jQuery', version: undefined, npm: 'jquery'},
       ],
     });
-    assert.equal(auditResult3.rawValue, true);
+    assert.equal(auditResult3.score, 1);
   });
 
   it('generates expected details', () => {
@@ -58,7 +58,7 @@ describe('Returns detected front-end JavaScript libraries', () => {
         version: undefined,
       },
     ];
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.deepStrictEqual(auditResult.details.items, expected);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/no-document-write-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-document-write-test.js
@@ -18,7 +18,7 @@ describe('Page does not use document.write()', () => {
       ChromeConsoleMessages: [],
       URL: {finalUrl: URL},
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
   });
 
@@ -33,7 +33,7 @@ describe('Page does not use document.write()', () => {
         {entry: {source: 'deprecation', url: 'https://example.com/two'}},
       ],
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 2);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -34,7 +34,7 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
         {detector: 'js', name: 'lib3', version: undefined, npm: 'lib3'},
       ],
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 1);
     assert.equal(auditResult.extendedInfo.jsLibs.length, 3);
     assert.equal(auditResult.details.items[0].highestSeverity, 'High');
@@ -79,7 +79,7 @@ Array [
       ],
     });
 
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 1);
     assert.equal(auditResult.details.items[0].detectedLib.type, 'link');
     assert.equal(auditResult.details.items[0].detectedLib.text, 'jquery@1.8.0');
@@ -92,7 +92,7 @@ Array [
         {detector: 'js', name: 'lib2', version: undefined, npm: 'lib2'},
       ],
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
     assert.equal(auditResult.extendedInfo.jsLibs.length, 2);
   });
@@ -101,6 +101,6 @@ Array [
     const auditResult = NoVulnerableLibrariesAudit.audit({
       Stacks: [],
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/notification-on-start-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/notification-on-start-test.js
@@ -21,7 +21,7 @@ describe('UX: notification audit', () => {
         {entry: {source: 'deprecation', url: 'https://example.com/two'}},
       ],
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 2);
   });
 
@@ -29,7 +29,7 @@ describe('UX: notification audit', () => {
     const auditResult = NotificationOnStart.audit({
       ChromeConsoleMessages: [],
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.details.items.length, 0);
   });
 });

--- a/lighthouse-core/test/audits/dobetterweb/password-inputs-can-be-pasted-into-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/password-inputs-can-be-pasted-into-test.js
@@ -16,7 +16,7 @@ describe('Password inputs can be pasted into', () => {
     const auditResult = PasswordInputsCanBePastedIntoAudit.audit({
       PasswordInputsWithPreventedPaste: [],
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.extendedInfo.value.length, 0);
     assert.equal(auditResult.details.items.length, 0);
   });
@@ -25,7 +25,7 @@ describe('Password inputs can be pasted into', () => {
     const auditResult = PasswordInputsCanBePastedIntoAudit.audit({
       PasswordInputsWithPreventedPaste: [{snippet: ''}, {snippet: ''}],
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.extendedInfo.value.length, 2);
     assert.equal(auditResult.details.items.length, 2);
   });

--- a/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-http2-test.js
@@ -28,7 +28,7 @@ describe('Resources are fetched over http/2', () => {
   it('fails when some resources were requested via http/1.x', () => {
     return UsesHTTP2Audit.audit(getArtifacts(networkRecords, URL), {computedCache: new Map()}).then(
       auditResult => {
-        assert.equal(auditResult.rawValue, false);
+        assert.equal(auditResult.score, 0);
         assert.ok(auditResult.displayValue.match('3 requests not'));
         assert.equal(auditResult.details.items.length, 3);
         assert.equal(
@@ -59,7 +59,7 @@ describe('Resources are fetched over http/2', () => {
 
     return UsesHTTP2Audit.audit(getArtifacts(h2Records, URL), {computedCache: new Map()}).then(
       auditResult => {
-        assert.equal(auditResult.rawValue, true);
+        assert.equal(auditResult.score, 1);
         assert.ok(auditResult.displayValue === '');
       }
     );
@@ -77,7 +77,7 @@ describe('Resources are fetched over http/2', () => {
     return UsesHTTP2Audit.audit(getArtifacts(clonedNetworkRecords, URL), {
       computedCache: new Map(),
     }).then(auditResult => {
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       assert.ok(auditResult.displayValue.match('1 request not'));
       // Protocol is http/1.0 which we don't mark as fetched fetchedViaServiceWorker on line 73.
       assert.equal(

--- a/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/uses-passive-event-listeners-test.js
@@ -24,7 +24,7 @@ describe('Page uses passive events listeners where applicable', () => {
       ],
     });
 
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.extendedInfo.value.length, 2);
   });
 
@@ -32,7 +32,7 @@ describe('Page uses passive events listeners where applicable', () => {
     const auditResult = PassiveEventsAudit.audit({
       ChromeConsoleMessages: [],
     });
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.extendedInfo.value.length, 0);
   });
 });

--- a/lighthouse-core/test/audits/final-screenshot-test.js
+++ b/lighthouse-core/test/audits/final-screenshot-test.js
@@ -19,7 +19,7 @@ describe('Final screenshot', () => {
     });
     const results = await FinalScreenshotAudit.audit(artifacts, {computedCache: new Map()});
 
-    assert.ok(results.rawValue);
+    assert.equal(results.score, 1);
     assert.equal(results.details.timestamp, 225414990.064);
     assert.ok(results.details.data.startsWith('data:image/jpeg;base64,/9j/4AAQSkZJRgABA'));
   });

--- a/lighthouse-core/test/audits/font-display-test.js
+++ b/lighthouse-core/test/audits/font-display-test.js
@@ -73,7 +73,7 @@ describe('Performance: Font Display audit', () => {
       {url: networkRecords[1].url, wastedMs: 3000},
       {url: networkRecords[2].url, wastedMs: 1000},
     ];
-    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.score, 0);
     expect(result.details.items).toEqual(items);
   });
 
@@ -129,7 +129,7 @@ describe('Performance: Font Display audit', () => {
     ];
 
     const result = await FontDisplayAudit.audit(getArtifacts(), context);
-    assert.strictEqual(result.rawValue, true);
+    assert.strictEqual(result.score, 1);
     expect(result.details.items).toEqual([]);
   });
 
@@ -180,7 +180,7 @@ describe('Performance: Font Display audit', () => {
     ];
 
     const result = await FontDisplayAudit.audit(getArtifacts(), context);
-    assert.strictEqual(result.rawValue, true);
+    assert.strictEqual(result.score, 1);
     expect(result.details.items).toEqual([]);
   });
 
@@ -220,7 +220,7 @@ describe('Performance: Font Display audit', () => {
     ];
 
     const result = await FontDisplayAudit.audit(getArtifacts(), context);
-    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.score, 0);
     expect(result.details.items.map(item => item.url)).toEqual([
       'https://edition.i.cdn.cnn.com/.a/fonts/cnn/3.7.2/cnnclock-black.woff2',
       'https://registry.api.cnn.io/assets/fave/fonts/2.0.15/cnnsans-bold.woff',
@@ -259,6 +259,6 @@ describe('Performance: Font Display audit', () => {
 
     const result = await FontDisplayAudit.audit(getArtifacts(), context);
     expect(result.details.items).toEqual([]);
-    assert.strictEqual(result.rawValue, true);
+    assert.strictEqual(result.score, 1);
   });
 });

--- a/lighthouse-core/test/audits/image-aspect-ratio-test.js
+++ b/lighthouse-core/test/audits/image-aspect-ratio-test.js
@@ -30,7 +30,7 @@ describe('Images: aspect-ratio audit', () => {
         ],
       });
 
-      assert.strictEqual(result.rawValue, data.rawValue, 'rawValue does not match');
+      assert.strictEqual(result.score, data.score, 'score does not match');
       if (data.warning) {
         assert.strictEqual(result.warnings[0], data.warning);
       } else {
@@ -40,7 +40,7 @@ describe('Images: aspect-ratio audit', () => {
   }
 
   testImage('is a css image', {
-    rawValue: true,
+    score: 1,
     clientSize: [1000, 20],
     naturalSize: [5, 5],
     props: {
@@ -49,7 +49,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('is much larger than natural aspect ratio', {
-    rawValue: false,
+    score: 0,
     clientSize: [800, 500],
     naturalSize: [200, 200],
     props: {
@@ -59,7 +59,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('is a css image and much larger than natural aspect ratio', {
-    rawValue: true,
+    score: 1,
     clientSize: [],
     naturalSize: [200, 200],
     props: {
@@ -69,7 +69,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('is larger than natural aspect ratio', {
-    rawValue: false,
+    score: 0,
     clientSize: [400, 300],
     naturalSize: [200, 200],
     props: {
@@ -79,7 +79,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('uses object-fit and is much smaller than natural aspect ratio', {
-    rawValue: true,
+    score: 1,
     clientSize: [200, 200],
     naturalSize: [800, 500],
     props: {
@@ -89,7 +89,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('is much smaller than natural aspect ratio', {
-    rawValue: false,
+    score: 0,
     clientSize: [200, 200],
     naturalSize: [800, 500],
     props: {
@@ -99,7 +99,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('is smaller than natural aspect ratio', {
-    rawValue: false,
+    score: 0,
     clientSize: [200, 200],
     naturalSize: [400, 300],
     props: {
@@ -109,7 +109,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('is almost the right aspect ratio', {
-    rawValue: true,
+    score: 1,
     clientSize: [412, 36],
     naturalSize: [800, 69],
     props: {
@@ -119,7 +119,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('aspect ratios match', {
-    rawValue: true,
+    score: 1,
     clientSize: [100, 100],
     naturalSize: [300, 300],
     props: {
@@ -129,7 +129,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('has no display sizing information', {
-    rawValue: true,
+    score: 1,
     clientSize: [0, 0],
     naturalSize: [100, 100],
     props: {
@@ -139,7 +139,7 @@ describe('Images: aspect-ratio audit', () => {
   });
 
   testImage('is placeholder image', {
-    rawValue: true,
+    score: 1,
     clientSize: [300, 220],
     naturalSize: [1, 1],
     props: {
@@ -163,7 +163,7 @@ describe('Images: aspect-ratio audit', () => {
       ],
     });
 
-    assert.strictEqual(result.rawValue, true, 'rawValue does not match');
+    assert.strictEqual(result.score, 1, 'score does not match');
     assert.equal(result.warnings.length, 0, 'should not have warnings');
   });
 });

--- a/lighthouse-core/test/audits/installable-manifest-test.js
+++ b/lighthouse-core/test/audits/installable-manifest-test.js
@@ -38,7 +38,7 @@ describe('PWA: webapp install banner audit', () => {
       const context = generateMockAuditContext();
 
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('No manifest was fetched'), result.explanation);
       });
     });
@@ -48,7 +48,7 @@ describe('PWA: webapp install banner audit', () => {
       artifacts.WebAppManifest = manifestParser('{,:}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
       const context = generateMockAuditContext();
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('failed to parse as valid JSON'));
       });
     });
@@ -58,7 +58,7 @@ describe('PWA: webapp install banner audit', () => {
       artifacts.WebAppManifest = manifestParser('{}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
       const context = generateMockAuditContext();
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation);
         assert.strictEqual(result.details.items[0].failures.length, 4);
       });
@@ -67,7 +67,7 @@ describe('PWA: webapp install banner audit', () => {
     it('passes with complete manifest and SW', () => {
       const context = generateMockAuditContext();
       return InstallableManifestAudit.audit(generateMockArtifacts(), context).then(result => {
-        assert.strictEqual(result.rawValue, true, result.explanation);
+        assert.strictEqual(result.score, 1, result.explanation);
         assert.strictEqual(result.explanation, undefined, result.explanation);
       });
     });
@@ -80,7 +80,7 @@ describe('PWA: webapp install banner audit', () => {
       const context = generateMockAuditContext();
 
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('start_url'), result.explanation);
 
         const details = result.details.items[0];
@@ -96,7 +96,7 @@ describe('PWA: webapp install banner audit', () => {
       const context = generateMockAuditContext();
 
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('short_name'), result.explanation);
 
         const details = result.details.items[0];
@@ -112,7 +112,7 @@ describe('PWA: webapp install banner audit', () => {
       const context = generateMockAuditContext();
 
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('name'), result.explanation);
 
         const details = result.details.items[0];
@@ -128,7 +128,7 @@ describe('PWA: webapp install banner audit', () => {
       const context = generateMockAuditContext();
 
       return InstallableManifestAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('PNG icon'), result.explanation);
 
         const details = result.details.items[0];
@@ -144,7 +144,7 @@ describe('PWA: webapp install banner audit', () => {
     const context = generateMockAuditContext();
 
     return InstallableManifestAudit.audit(artifacts, context).then(result => {
-      assert.strictEqual(result.rawValue, false);
+      assert.strictEqual(result.score, 0);
       assert.ok(result.explanation.includes('PNG icon'), result.explanation);
 
       const details = result.details.items[0];

--- a/lighthouse-core/test/audits/is-on-https-test.js
+++ b/lighthouse-core/test/audits/is-on-https-test.js
@@ -27,7 +27,7 @@ describe('Security: HTTPS audit', () => {
       {url: 'http://insecure.com/image2.jpeg', parsedURL: {scheme: 'http', host: 'insecure.com'}},
       {url: 'https://google.com/', parsedURL: {scheme: 'https', host: 'google.com'}},
     ]), {computedCache: new Map()}).then(result => {
-      assert.strictEqual(result.rawValue, false);
+      assert.strictEqual(result.score, 0);
       assert.ok(result.displayValue.includes('requests found'));
       assert.strictEqual(result.extendedInfo.value.length, 2);
     });
@@ -39,7 +39,7 @@ describe('Security: HTTPS audit', () => {
       {url: 'http://insecure.com/image.jpeg', parsedURL: {scheme: 'http', host: 'insecure.com'}},
       {url: 'https://google.com/', parsedURL: {scheme: 'https', host: 'google.com'}},
     ]), {computedCache: new Map()}).then(result => {
-      assert.strictEqual(result.rawValue, false);
+      assert.strictEqual(result.score, 0);
       assert.ok(result.displayValue.includes('request found'));
       assert.deepEqual(result.extendedInfo.value[0], {url: 'http://insecure.com/image.jpeg'});
     });
@@ -51,7 +51,7 @@ describe('Security: HTTPS audit', () => {
       {url: 'http://localhost/image.jpeg', parsedURL: {scheme: 'http', host: 'localhost'}},
       {url: 'https://google.com/', parsedURL: {scheme: 'https', host: 'google.com'}},
     ]), {computedCache: new Map()}).then(result => {
-      assert.strictEqual(result.rawValue, true);
+      assert.strictEqual(result.score, 1);
     });
   });
 

--- a/lighthouse-core/test/audits/mixed-content-test.js
+++ b/lighthouse-core/test/audits/mixed-content-test.js
@@ -40,7 +40,6 @@ describe('Mixed Content audit', () => {
     return Audit.audit(
       getArtifacts('https://example.org', defaultRecords, upgradeRecords), context
     ).then(result => {
-      assert.strictEqual(result.rawValue, true);
       assert.strictEqual(result.score, 1);
     });
   });
@@ -63,7 +62,6 @@ describe('Mixed Content audit', () => {
       getArtifacts('http://example.org', defaultRecords, upgradeRecords), context
     ).then(result => {
       // Score for 3 upgradeable out of 4: 100 * (0 + 3*0.5) / 4
-      assert.strictEqual(result.rawValue, false);
       assert.strictEqual(result.score, 0.375);
     });
   });

--- a/lighthouse-core/test/audits/offline-start-url-test.js
+++ b/lighthouse-core/test/audits/offline-start-url-test.js
@@ -36,7 +36,7 @@ describe('Offline start_url audit', () => {
     const context = generateMockAuditContext();
 
     const result = await OfflineStartUrlAudit.audit(artifacts, context);
-    assert.strictEqual(result.rawValue, false);
+    assert.strictEqual(result.score, 0);
     assert.strictEqual(result.explanation, explanation);
     assert.strictEqual(result.warnings.length, 0);
   });
@@ -48,7 +48,7 @@ describe('Offline start_url audit', () => {
     const context = generateMockAuditContext();
 
     const result = await OfflineStartUrlAudit.audit(artifacts, context);
-    assert.strictEqual(result.rawValue, true);
+    assert.strictEqual(result.score, 1);
     assert.strictEqual(result.explanation, undefined);
     assert.strictEqual(result.warnings.length, 0);
   });
@@ -65,7 +65,7 @@ describe('Offline start_url audit', () => {
     const context = generateMockAuditContext();
 
     const result = await OfflineStartUrlAudit.audit(artifacts, context);
-    assert.strictEqual(result.rawValue, true);
+    assert.strictEqual(result.score, 1);
     assert.strictEqual(result.explanation, undefined);
     assert.strictEqual(result.warnings.length, 1);
     assert.ok(result.warnings[0].includes('start_url must be same-origin as document'));

--- a/lighthouse-core/test/audits/redirects-http-test.js
+++ b/lighthouse-core/test/audits/redirects-http-test.js
@@ -16,7 +16,7 @@ describe('Security: HTTP->HTTPS audit', () => {
       HTTPRedirect: {
         value: false,
       },
-    }).rawValue, false);
+    }).score, 0);
   });
 
   it('passes when redirect detected', () => {
@@ -24,6 +24,6 @@ describe('Security: HTTP->HTTPS audit', () => {
       HTTPRedirect: {
         value: true,
       },
-    }).rawValue, true);
+    }).score, 1);
   });
 });

--- a/lighthouse-core/test/audits/screenshot-thumbnails-test.js
+++ b/lighthouse-core/test/audits/screenshot-thumbnails-test.js
@@ -33,7 +33,7 @@ describe('Screenshot thumbnails', () => {
         assert.equal(expectedData.length, result.data.length);
       });
 
-      assert.ok(results.rawValue);
+      assert.equal(results.score, 1);
       assert.equal(results.details.items[0].timing, 82);
       assert.equal(results.details.items[2].timing, 245);
       assert.equal(results.details.items[9].timing, 818);

--- a/lighthouse-core/test/audits/seo/canonical-test.js
+++ b/lighthouse-core/test/audits/seo/canonical-test.js
@@ -40,7 +40,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -59,7 +59,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       expect(auditResult.explanation)
         .toBeDisplayString('Multiple conflicting URLs (https://www.example.com, https://example.com)');
     });
@@ -79,8 +79,8 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      const {rawValue, explanation} = auditResult;
-      assert.equal(rawValue, false);
+      const {score, explanation} = auditResult;
+      assert.equal(score, false);
       expect(explanation).toBeDisplayString('Invalid URL (https:// example.com)');
     });
   });
@@ -99,8 +99,8 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      const {rawValue, explanation} = auditResult;
-      assert.equal(rawValue, false);
+      const {score, explanation} = auditResult;
+      assert.equal(score, 0);
       expect(explanation).toBeDisplayString('Relative URL (/)');
     });
   });
@@ -121,7 +121,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       expect(auditResult.explanation)
         .toBeDisplayString('Points to another `hreflang` location (https://example.com/)');
     });
@@ -141,7 +141,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       expect(auditResult.explanation)
         .toBeDisplayString('Points to a different domain (https://example.com/)');
     });
@@ -164,7 +164,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     const auditResult = await CanonicalAudit.audit(artifacts, context);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('fails when canonical points to the root while current URL is not the root', () => {
@@ -181,7 +181,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       expect(auditResult.explanation).toBeDisplayString('Points to the domain\'s root URL (the ' +
         'homepage), instead of an equivalent page of content');
     });
@@ -202,7 +202,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -220,7 +220,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -238,7 +238,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -256,7 +256,7 @@ describe('SEO: Document has valid canonical link', () => {
 
     const context = {computedCache: new Map()};
     return CanonicalAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 });

--- a/lighthouse-core/test/audits/seo/font-size-test.js
+++ b/lighthouse-core/test/audits/seo/font-size-test.js
@@ -26,7 +26,7 @@ describe('SEO: Font size audit', () => {
     };
 
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     expect(auditResult.explanation)
       .toBeDisplayString('Text is illegible because there\'s ' +
         'no viewport meta tag optimized for mobile screens.');
@@ -50,7 +50,7 @@ describe('SEO: Font size audit', () => {
     };
 
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     expect(auditResult.explanation).toBeDisplayString('41% of text is too small.');
     expect(auditResult.displayValue).toBeDisplayString('59% legible text');
   });
@@ -72,7 +72,7 @@ describe('SEO: Font size audit', () => {
     };
 
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('passes when more than 60% of text is legible', async () => {
@@ -92,7 +92,7 @@ describe('SEO: Font size audit', () => {
       TestedAsMobileDevice: true,
     };
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     expect(auditResult.displayValue).toBeDisplayString('90% legible text');
   });
 
@@ -131,7 +131,7 @@ describe('SEO: Font size audit', () => {
     };
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
 
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 2);
     assert.equal(auditResult.details.items[0].coverage, '57.14%');
     expect(auditResult.displayValue).toBeDisplayString('0% legible text');
@@ -153,7 +153,7 @@ describe('SEO: Font size audit', () => {
       TestedAsMobileDevice: true,
     };
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 3);
     assert.equal(auditResult.details.items[1].source, 'Add\'l illegible text');
     assert.equal(auditResult.details.items[1].coverage, '40.00%');
@@ -176,7 +176,7 @@ describe('SEO: Font size audit', () => {
       TestedAsMobileDevice: true,
     };
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     expect(auditResult.explanation).toBeDisplayString(
       '100% of text is too small (based on 50% sample).'
     );
@@ -231,7 +231,7 @@ describe('SEO: Font size audit', () => {
       TestedAsMobileDevice: false,
     };
     const auditResult = await FontSizeAudit.audit(artifacts, getFakeContext());
-    expect(auditResult.rawValue).toBe(true);
+    expect(auditResult.score).toBe(1);
     expect(auditResult.notApplicable).toBe(true);
   });
 });

--- a/lighthouse-core/test/audits/seo/hreflang-test.js
+++ b/lighthouse-core/test/audits/seo/hreflang-test.js
@@ -23,7 +23,7 @@ describe('SEO: Document has valid hreflang code', () => {
     };
 
     const auditResult = HreflangAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 5);
   });
 
@@ -43,7 +43,7 @@ describe('SEO: Document has valid hreflang code', () => {
       };
 
       const auditResult = HreflangAudit.audit(artifacts);
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     }
   });
 
@@ -64,13 +64,13 @@ describe('SEO: Document has valid hreflang code', () => {
       };
 
       const auditResult = HreflangAudit.audit(artifacts);
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
       inHead = !inHead;
     }
   });
 
   it('succeeds when there are no rel=alternate link elements nor headers', () => {
-    assert.equal(HreflangAudit.audit({LinkElements: []}).rawValue, true);
+    assert.equal(HreflangAudit.audit({LinkElements: []}).score, 1);
   });
 
   it('returns all failing items', () => {
@@ -84,7 +84,7 @@ describe('SEO: Document has valid hreflang code', () => {
     };
 
     const auditResult = HreflangAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 4);
   });
 });

--- a/lighthouse-core/test/audits/seo/http-status-code-test.js
+++ b/lighthouse-core/test/audits/seo/http-status-code-test.js
@@ -29,7 +29,7 @@ describe('SEO: HTTP code audit', () => {
       };
 
       return HTTPStatusCodeAudit.audit(artifacts, {computedCache: new Map()}).then(auditResult => {
-        assert.equal(auditResult.rawValue, false);
+        assert.equal(auditResult.score, 0);
         assert.ok(auditResult.displayValue.includes(statusCode), false);
       });
     });
@@ -51,7 +51,7 @@ describe('SEO: HTTP code audit', () => {
     };
 
     return HTTPStatusCodeAudit.audit(artifacts, {computedCache: new Map()}).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 });

--- a/lighthouse-core/test/audits/seo/is-crawlable-test.js
+++ b/lighthouse-core/test/audits/seo/is-crawlable-test.js
@@ -41,7 +41,7 @@ describe('SEO: Is page crawlable audit', () => {
 
       const context = {computedCache: new Map()};
       return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-        assert.equal(auditResult.rawValue, false);
+        assert.equal(auditResult.score, 0);
         assert.equal(auditResult.details.items.length, 1);
       });
     });
@@ -66,7 +66,7 @@ describe('SEO: Is page crawlable audit', () => {
 
     const context = {computedCache: new Map()};
     return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -86,7 +86,7 @@ describe('SEO: Is page crawlable audit', () => {
 
     const context = {computedCache: new Map()};
     return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -129,7 +129,7 @@ describe('SEO: Is page crawlable audit', () => {
 
       const context = {computedCache: new Map()};
       return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-        assert.equal(auditResult.rawValue, false);
+        assert.equal(auditResult.score, 0);
         assert.equal(auditResult.details.items.length, 1);
       });
     });
@@ -156,7 +156,7 @@ describe('SEO: Is page crawlable audit', () => {
 
     const context = {computedCache: new Map()};
     return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -176,7 +176,7 @@ describe('SEO: Is page crawlable audit', () => {
 
     const context = {computedCache: new Map()};
     return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -199,7 +199,7 @@ describe('SEO: Is page crawlable audit', () => {
 
     const context = {computedCache: new Map()};
     return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 
@@ -247,7 +247,7 @@ describe('SEO: Is page crawlable audit', () => {
 
       const context = {computedCache: new Map()};
       return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-        assert.equal(auditResult.rawValue, false);
+        assert.equal(auditResult.score, 0);
         assert.equal(auditResult.details.items.length, 1);
       });
     });
@@ -286,7 +286,7 @@ describe('SEO: Is page crawlable audit', () => {
 
       const context = {computedCache: new Map()};
       return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-        assert.equal(auditResult.rawValue, true);
+        assert.equal(auditResult.score, 1);
       });
     });
 
@@ -316,7 +316,7 @@ describe('SEO: Is page crawlable audit', () => {
 
     const context = {computedCache: new Map()};
     return IsCrawlableAudit.audit(artifacts, context).then(auditResult => {
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       assert.equal(auditResult.details.items.length, 4);
     });
   });

--- a/lighthouse-core/test/audits/seo/link-text-test.js
+++ b/lighthouse-core/test/audits/seo/link-text-test.js
@@ -25,7 +25,7 @@ describe('SEO: link text audit', () => {
     };
 
     const auditResult = LinkTextAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 1);
     assert.equal(auditResult.details.items[0].href, invalidLink.href);
     assert.equal(auditResult.details.items[0].text, invalidLink.text);
@@ -45,7 +45,7 @@ describe('SEO: link text audit', () => {
     };
 
     const auditResult = LinkTextAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('ignores javascript: links', () => {
@@ -61,7 +61,7 @@ describe('SEO: link text audit', () => {
     };
 
     const auditResult = LinkTextAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('ignores mailto: links', () => {
@@ -76,7 +76,7 @@ describe('SEO: link text audit', () => {
     };
 
     const auditResult = LinkTextAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('ignores links with no href', () => {
@@ -90,7 +90,7 @@ describe('SEO: link text audit', () => {
     };
 
     const auditResult = LinkTextAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('ignores links with nofollow', () => {
@@ -104,7 +104,7 @@ describe('SEO: link text audit', () => {
     };
 
     const auditResult = LinkTextAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('passes when all links have descriptive texts', () => {
@@ -120,6 +120,6 @@ describe('SEO: link text audit', () => {
     };
 
     const auditResult = LinkTextAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 });

--- a/lighthouse-core/test/audits/seo/meta-description-test.js
+++ b/lighthouse-core/test/audits/seo/meta-description-test.js
@@ -17,14 +17,14 @@ describe('SEO: description audit', () => {
     const auditResult = Audit.audit({
       MetaElements: [],
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
   });
 
   it('fails when HTML contains an empty description meta tag', () => {
     const auditResult = Audit.audit({
       MetaElements: makeMetaElements(''),
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     expect(auditResult.explanation).toBeDisplayString('Description text is empty.');
   });
 
@@ -32,13 +32,13 @@ describe('SEO: description audit', () => {
     const auditResult = Audit.audit({
       MetaElements: makeMetaElements('\t\xa0'),
     });
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     expect(auditResult.explanation).toBeDisplayString('Description text is empty.');
   });
 
   it('passes when a description text is provided', () => {
     return assert.equal(Audit.audit({
       MetaElements: makeMetaElements('description text'),
-    }).rawValue, true);
+    }).score, 1);
   });
 });

--- a/lighthouse-core/test/audits/seo/plugins-test.js
+++ b/lighthouse-core/test/audits/seo/plugins-test.js
@@ -63,7 +63,7 @@ describe('SEO: Avoids plugins', () => {
       };
 
       const auditResult = PluginsAudit.audit(artifacts);
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       assert.equal(auditResult.details.items.length, 1);
     });
   });
@@ -89,7 +89,7 @@ describe('SEO: Avoids plugins', () => {
     };
 
     const auditResult = PluginsAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.details.items.length, 3);
   });
 
@@ -99,7 +99,7 @@ describe('SEO: Avoids plugins', () => {
     };
 
     const auditResult = PluginsAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('succeeds when all external content is valid', () => {
@@ -136,6 +136,6 @@ describe('SEO: Avoids plugins', () => {
     };
 
     const auditResult = PluginsAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 });

--- a/lighthouse-core/test/audits/seo/robots-txt-test.js
+++ b/lighthouse-core/test/audits/seo/robots-txt-test.js
@@ -20,7 +20,7 @@ describe('SEO: robots.txt audit', () => {
     };
 
     const auditResult = RobotsTxtAudit.audit(artifacts);
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.ok(auditResult.explanation);
   });
 
@@ -46,7 +46,7 @@ describe('SEO: robots.txt audit', () => {
       };
 
       const auditResult = RobotsTxtAudit.audit(artifacts);
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
     });
   });
 
@@ -157,7 +157,7 @@ wrong
 
       const auditResult = RobotsTxtAudit.audit(artifacts);
 
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       assert.equal(auditResult.details.items.length, expectedErrors);
       expect(auditResult.displayValue).toBeDisplayString(/\d errors? found/);
     });
@@ -185,7 +185,7 @@ wrong
       };
 
       const auditResult = RobotsTxtAudit.audit(artifacts);
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
       assert.equal(auditResult.notApplicable, true);
     });
   });
@@ -236,7 +236,7 @@ Request-rate: 1/30m
       };
 
       const auditResult = RobotsTxtAudit.audit(artifacts);
-      assert.equal(auditResult.rawValue, true);
+      assert.equal(auditResult.score, 1);
     });
   });
 });

--- a/lighthouse-core/test/audits/seo/tap-targets-test.js
+++ b/lighthouse-core/test/audits/seo/tap-targets-test.js
@@ -118,21 +118,21 @@ function getBorderlineTapTargets(options = {}) {
 describe('SEO: Tap targets audit', () => {
   it('passes when there are no tap targets', async () => {
     const auditResult = await auditTapTargets([]);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     expect(auditResult.displayValue).toBeDisplayString('100% appropriately sized tap targets');
     assert.equal(auditResult.score, 1);
   });
 
   it('passes when tap targets don\'t overlap', async () => {
     const auditResult = await auditTapTargets(getBorderlineTapTargets());
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('passes when a target is fully contained in an overlapping target', async () => {
     const auditResult = await auditTapTargets(getBorderlineTapTargets({
       addFullyContainedTapTarget: true,
     }));
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 
   it('fails if two tap targets overlaps each other horizontally', async () => {
@@ -141,7 +141,7 @@ describe('SEO: Tap targets audit', () => {
         overlapRight: true,
       })
     );
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score.toFixed(3), '0.297');
     assert.equal(Math.round(auditResult.score * 100), 30);
     const failure = auditResult.details.items[0];
     assert.equal(failure.tapTarget.snippet, '<main></main>');
@@ -161,7 +161,7 @@ describe('SEO: Tap targets audit', () => {
         overlapBelow: true,
       })
     );
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score.toFixed(3), 0.297);
   });
 
   it('fails when one of the client rects overlaps', async () => {
@@ -170,7 +170,7 @@ describe('SEO: Tap targets audit', () => {
         overlapSecondClientRect: true,
       })
     );
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score.toFixed(3), 0.297);
   });
 
   it('reports 2 items if a target overlapped both vertically and horizontally', async () => {
@@ -205,7 +205,7 @@ describe('SEO: Tap targets audit', () => {
 
   it('fails if no meta viewport tag is provided', async () => {
     const auditResult = await auditTapTargets([], {MetaElements: []});
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
 
     expect(auditResult.explanation).toBeDisplayString(
       /* eslint-disable max-len */
@@ -216,7 +216,7 @@ describe('SEO: Tap targets audit', () => {
     const auditResult = await auditTapTargets(getBorderlineTapTargets({
       overlapSecondClientRect: true,
     }), {TestedAsMobileDevice: false});
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
     assert.equal(auditResult.notApplicable, true);
   });
 });

--- a/lighthouse-core/test/audits/service-worker-test.js
+++ b/lighthouse-core/test/audits/service-worker-test.js
@@ -77,7 +77,7 @@ describe('Offline: service worker audit', () => {
     const manifest = {start_url: finalUrl};
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
-    assert.deepStrictEqual(output, {rawValue: true});
+    assert.deepStrictEqual(output, {score: 1});
   });
 
   it('fails when controlling service worker is not activated', () => {
@@ -89,7 +89,7 @@ describe('Offline: service worker audit', () => {
     const manifest = {start_url: finalUrl};
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
-    assert.deepStrictEqual(output, {rawValue: false});
+    assert.deepStrictEqual(output, {score: 0});
   });
 
   it('discards service worker registrations for other origins', () => {
@@ -101,7 +101,7 @@ describe('Offline: service worker audit', () => {
     const manifest = {start_url: finalUrl};
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
-    assert.deepStrictEqual(output, {rawValue: false});
+    assert.deepStrictEqual(output, {score: 0});
   });
 
   it('fails when page URL is out of scope', () => {
@@ -114,7 +114,7 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     expect(output).toMatchObject({
-      rawValue: false,
+      score: 0,
       explanation: expect.stringMatching(new RegExp(`${finalUrl}.*not in scope`)),
     });
   });
@@ -132,7 +132,7 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     expect(output).toMatchObject({
-      rawValue: false,
+      score: 0,
       explanation: expect.stringMatching(new RegExp(`start_url.*${startUrl}.*${scopeURL}`)),
     });
   });
@@ -148,7 +148,7 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     expect(output).toMatchObject({
-      rawValue: false,
+      score: 0,
       explanation: expect.stringMatching(new RegExp(`${finalUrl}.*not in scope`)),
     });
   });
@@ -166,7 +166,7 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     expect(output).toMatchObject({
-      rawValue: false,
+      score: 0,
       explanation: expect.stringMatching(new RegExp(`start_url.*${startUrl}.*${scopeURL}`)),
     });
   });
@@ -182,7 +182,7 @@ describe('Offline: service worker audit', () => {
     const manifest = {start_url: finalUrl};
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
-    assert.deepStrictEqual(output, {rawValue: true});
+    assert.deepStrictEqual(output, {score: 1});
   });
 
   it('passes when multiple SWs control the scope', () => {
@@ -197,7 +197,7 @@ describe('Offline: service worker audit', () => {
     const manifest = {start_url: finalUrl};
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
-    assert.deepStrictEqual(output, {rawValue: true});
+    assert.deepStrictEqual(output, {score: 1});
   });
 
   it('passes when multiple SWs control the origin but only one is in scope', () => {
@@ -218,7 +218,7 @@ describe('Offline: service worker audit', () => {
     const manifest = {start_url: finalUrl};
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
-    assert.deepStrictEqual(output, {rawValue: true});
+    assert.deepStrictEqual(output, {score: 1});
   });
 
   it('fails when multiple SWs control the origin but are all out of scope', () => {
@@ -240,7 +240,7 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     expect(output).toMatchObject({
-      rawValue: false,
+      score: 0,
       explanation: expect.stringMatching(new RegExp(`${finalUrl}.*not in scope`)),
     });
   });
@@ -262,7 +262,7 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     expect(output).toMatchObject({
-      rawValue: false,
+      score: 0,
       explanation: expect.stringMatching(new RegExp(`start_url.*${startUrl}.*${scopeURL}`)),
     });
   });
@@ -277,7 +277,7 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(createArtifacts(swOpts, finalUrl, manifest));
     expect(output).toMatchObject({
-      rawValue: false,
+      score: 0,
       explanation: expect.stringMatching(/start_url.*no manifest was fetched/),
     });
   });
@@ -294,7 +294,7 @@ describe('Offline: service worker audit', () => {
 
     const output = ServiceWorker.audit(artifacts);
     expect(output).toMatchObject({
-      rawValue: false,
+      score: 0,
       explanation: expect.stringMatching(/start_url.*manifest failed to parse as valid JSON/),
     });
   });

--- a/lighthouse-core/test/audits/splash-screen-test.js
+++ b/lighthouse-core/test/audits/splash-screen-test.js
@@ -39,7 +39,7 @@ describe('PWA: splash screen audit', () => {
       const context = generateMockAuditContext();
 
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('No manifest was fetched'), result.explanation);
       });
     });
@@ -49,7 +49,7 @@ describe('PWA: splash screen audit', () => {
       artifacts.WebAppManifest = manifestParser('{,:}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
       const context = generateMockAuditContext();
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('failed to parse as valid JSON'));
       });
     });
@@ -59,7 +59,7 @@ describe('PWA: splash screen audit', () => {
       artifacts.WebAppManifest = manifestParser('{}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
       const context = generateMockAuditContext();
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation);
         assert.strictEqual(result.details.items[0].failures.length, 4);
       });
@@ -68,7 +68,7 @@ describe('PWA: splash screen audit', () => {
     it('passes with complete manifest and SW', () => {
       const context = generateMockAuditContext();
       return SplashScreenAudit.audit(generateMockArtifacts(), context).then(result => {
-        assert.strictEqual(result.rawValue, true, result.explanation);
+        assert.strictEqual(result.score, 1, result.explanation);
         assert.strictEqual(result.explanation, undefined, result.explanation);
       });
     });
@@ -81,7 +81,7 @@ describe('PWA: splash screen audit', () => {
       const context = generateMockAuditContext();
 
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('name'), result.explanation);
       });
     });
@@ -92,7 +92,7 @@ describe('PWA: splash screen audit', () => {
       const context = generateMockAuditContext();
 
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('background_color'), result.explanation);
       });
     });
@@ -104,7 +104,7 @@ describe('PWA: splash screen audit', () => {
       const context = generateMockAuditContext();
 
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('background_color'), result.explanation);
       });
     });
@@ -115,7 +115,7 @@ describe('PWA: splash screen audit', () => {
       const context = generateMockAuditContext();
 
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('theme_color'), result.explanation);
       });
     });
@@ -126,7 +126,7 @@ describe('PWA: splash screen audit', () => {
       const context = generateMockAuditContext();
 
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('PNG icon'), result.explanation);
       });
     });
@@ -136,7 +136,7 @@ describe('PWA: splash screen audit', () => {
       const context = generateMockAuditContext();
 
       return SplashScreenAudit.audit(artifacts, context).then(result => {
-        assert.strictEqual(result.rawValue, false);
+        assert.strictEqual(result.score, 0);
         assert.ok(result.explanation.includes('PNG icon'), result.explanation);
         const failures = result.details.items[0].failures;
         assert.strictEqual(failures.length, 1, failures);

--- a/lighthouse-core/test/audits/themed-omnibox-test.js
+++ b/lighthouse-core/test/audits/themed-omnibox-test.js
@@ -44,7 +44,7 @@ describe('PWA: themed omnibox audit', () => {
     const context = generateMockAuditContext();
 
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.strictEqual(result.rawValue, false);
+      assert.strictEqual(result.score, 0);
       assert.ok(result.explanation.includes('No manifest was fetched'), result.explanation);
     });
   });
@@ -59,7 +59,7 @@ describe('PWA: themed omnibox audit', () => {
     const context = generateMockAuditContext();
 
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, false);
+      assert.equal(result.score, 0);
       assert.ok(result.explanation);
     });
   });
@@ -71,7 +71,7 @@ describe('PWA: themed omnibox audit', () => {
     }));
     const context = generateMockAuditContext();
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, true);
+      assert.equal(result.score, 1);
       assert.equal(result.explanation, undefined);
     });
   });
@@ -81,7 +81,7 @@ describe('PWA: themed omnibox audit', () => {
     const artifacts = generateMockArtifacts();
     const context = generateMockAuditContext();
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, true);
+      assert.equal(result.score, 1);
       assert.equal(result.explanation, undefined);
     });
   });
@@ -91,7 +91,7 @@ describe('PWA: themed omnibox audit', () => {
     artifacts.MetaElements = [];
     const context = generateMockAuditContext();
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, false);
+      assert.equal(result.score, 0);
       assert.ok(result.explanation);
     });
   });
@@ -101,7 +101,7 @@ describe('PWA: themed omnibox audit', () => {
     artifacts.MetaElements = [{name: 'theme-color', content: '#1234567'}];
     const context = generateMockAuditContext();
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, false);
+      assert.equal(result.score, 0);
       assert.ok(result.explanation.includes('valid CSS color'));
     });
   });
@@ -111,7 +111,7 @@ describe('PWA: themed omnibox audit', () => {
     artifacts.MetaElements = [{name: 'theme-color', content: '#fafa33'}];
     const context = generateMockAuditContext();
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, true);
+      assert.equal(result.score, 1);
       assert.equal(result.explanation, undefined);
     });
   });
@@ -121,7 +121,7 @@ describe('PWA: themed omnibox audit', () => {
     artifacts.MetaElements = [{name: 'theme-color', content: 'red'}];
     const context = generateMockAuditContext();
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, true);
+      assert.equal(result.score, 1);
       assert.equal(result.explanation, undefined);
     });
   });
@@ -132,7 +132,7 @@ describe('PWA: themed omnibox audit', () => {
     const context = generateMockAuditContext();
 
     const result = await ThemedOmniboxAudit.audit(artifacts, context);
-    assert.equal(result.rawValue, true);
+    assert.equal(result.score, 1);
     assert.equal(result.explanation, undefined);
   });
 
@@ -143,7 +143,7 @@ describe('PWA: themed omnibox audit', () => {
     }));
     const context = generateMockAuditContext();
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, false);
+      assert.equal(result.score, 0);
       assert.ok(result.explanation.includes('does not have `theme_color`'), result.explanation);
     });
   });
@@ -153,7 +153,7 @@ describe('PWA: themed omnibox audit', () => {
     artifacts.MetaElements = [{name: 'theme-color'}];
     const context = generateMockAuditContext();
     return ThemedOmniboxAudit.audit(artifacts, context).then(result => {
-      assert.equal(result.rawValue, false);
+      assert.equal(result.score, 0);
       assert.ok(result.explanation.includes('theme-color meta tag'), result.explanation);
     });
   });

--- a/lighthouse-core/test/audits/user-timing-test.js
+++ b/lighthouse-core/test/audits/user-timing-test.js
@@ -27,7 +27,7 @@ describe('Performance: user-timings audit', () => {
       });
       assert.equal(blackListedUTs.length, 0, 'Blacklisted usertimings included in results');
 
-      assert.equal(auditResult.rawValue, false);
+      assert.equal(auditResult.score, 0);
       expect(auditResult.displayValue).toBeDisplayString('2 user timings');
 
       assert.equal(auditResult.details.items[0].name, 'measure_test');

--- a/lighthouse-core/test/audits/viewport-test.js
+++ b/lighthouse-core/test/audits/viewport-test.js
@@ -18,14 +18,14 @@ describe('Mobile-friendly: viewport audit', () => {
     const auditResult = await Audit.audit({
       MetaElements: [],
     }, fakeContext);
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.explanation, 'No viewport meta tag found');
   });
 
   it('fails when HTML contains a non-mobile friendly viewport meta tag', async () => {
     const viewport = 'maximum-scale=1';
     const auditResult = await Audit.audit({MetaElements: makeMetaElements(viewport)}, fakeContext);
-    assert.equal(auditResult.rawValue, false);
+    assert.equal(auditResult.score, 0);
     assert.equal(auditResult.warnings[0], undefined);
   });
 
@@ -34,6 +34,6 @@ describe('Mobile-friendly: viewport audit', () => {
     const auditResult = await Audit.audit({
       MetaElements: makeMetaElements(viewport),
     }, fakeContext);
-    assert.equal(auditResult.rawValue, true);
+    assert.equal(auditResult.score, 1);
   });
 });

--- a/lighthouse-core/test/audits/without-javascript-test.js
+++ b/lighthouse-core/test/audits/without-javascript-test.js
@@ -20,7 +20,7 @@ describe('Progressive Enhancement: without javascript audit', () => {
     };
 
     const result = withoutJsAudit.audit(artifacts);
-    assert.equal(result.rawValue, false);
+    assert.equal(result.score, 0);
     assert.ok(result.explanation);
   });
 
@@ -33,7 +33,7 @@ describe('Progressive Enhancement: without javascript audit', () => {
     };
 
     const result = withoutJsAudit.audit(artifacts);
-    assert.equal(result.rawValue, false);
+    assert.equal(result.score, 0);
     assert.ok(result.explanation);
   });
 
@@ -45,7 +45,7 @@ describe('Progressive Enhancement: without javascript audit', () => {
       },
     };
 
-    assert.equal(withoutJsAudit.audit(artifacts).rawValue, true);
+    assert.equal(withoutJsAudit.audit(artifacts).score, 1);
   });
 
   it('succeeds when the js-less body contains noscript', () => {
@@ -56,6 +56,6 @@ describe('Progressive Enhancement: without javascript audit', () => {
       },
     };
 
-    assert.equal(withoutJsAudit.audit(artifacts).rawValue, true);
+    assert.equal(withoutJsAudit.audit(artifacts).score, 1);
   });
 });

--- a/lighthouse-core/test/audits/works-offline-test.js
+++ b/lighthouse-core/test/audits/works-offline-test.js
@@ -19,7 +19,7 @@ describe('Offline: works-offline audit', () => {
       URL: {requestedUrl: URL, finalUrl: URL},
     });
 
-    assert.equal(output.rawValue, true);
+    assert.equal(output.score, 1);
     assert.ok(!output.explanation);
   });
 
@@ -29,7 +29,7 @@ describe('Offline: works-offline audit', () => {
       URL: {requestedUrl: URL, finalUrl: `${URL}/features`},
     });
 
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
     assert.ok(output.warnings[0]);
   });
 
@@ -39,7 +39,7 @@ describe('Offline: works-offline audit', () => {
       URL: {requestedUrl: URL, finalUrl: URL},
     });
 
-    assert.equal(output.rawValue, false);
+    assert.equal(output.score, 0);
     assert.ok(!output.explanation);
   });
 });

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-description.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-description.js
@@ -20,7 +20,7 @@ class MissingDescription extends LighthouseAudit {
 
   static audit(_) {
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-generate-audit-result.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-generate-audit-result.js
@@ -18,7 +18,7 @@ class MissingGenerateAuditResult {
 
   static audit(_) {
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-id.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-id.js
@@ -19,7 +19,7 @@ class MissingID extends LighthouseAudit {
 
   static audit(_) {
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-meta.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-meta.js
@@ -11,7 +11,7 @@ const LighthouseAudit = require('../../../audits/audit');
 class MissingMeta extends LighthouseAudit {
   static audit(_) {
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-required-artifacts.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-required-artifacts.js
@@ -20,7 +20,7 @@ class MissingRequiredArtifacts extends LighthouseAudit {
 
   static audit(_) {
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/test/fixtures/invalid-audits/missing-title.js
+++ b/lighthouse-core/test/fixtures/invalid-audits/missing-title.js
@@ -19,7 +19,7 @@ class MissingTitle extends LighthouseAudit {
 
   static audit(_) {
     return {
-      rawValue: true,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -17,7 +17,6 @@
       "description": "All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/https).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "displayValue": "1 insecure request found",
       "details": {
         "type": "table",
@@ -40,16 +39,14 @@
       "title": "Does not redirect HTTP traffic to HTTPS",
       "description": "If you've already set up HTTPS, make sure that you redirect all HTTP traffic to HTTPS. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-redirects-to-https).",
       "score": 0,
-      "scoreDisplayMode": "binary",
-      "rawValue": false
+      "scoreDisplayMode": "binary"
     },
     "service-worker": {
       "id": "service-worker",
       "title": "Does not register a service worker that controls page and start_url",
       "description": "The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker).",
       "score": 0,
-      "scoreDisplayMode": "binary",
-      "rawValue": false
+      "scoreDisplayMode": "binary"
     },
     "works-offline": {
       "id": "works-offline",
@@ -57,7 +54,6 @@
       "description": "If you're building a Progressive Web App, consider using a service worker so that your app can work offline. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "warnings": []
     },
     "viewport": {
@@ -66,7 +62,6 @@
       "description": "Add a viewport meta tag to optimize your app for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "warnings": []
     },
     "without-javascript": {
@@ -74,8 +69,7 @@
       "title": "Contains some content when JavaScript is not available",
       "description": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/no-js).",
       "score": 1,
-      "scoreDisplayMode": "binary",
-      "rawValue": true
+      "scoreDisplayMode": "binary"
     },
     "first-contentful-paint": {
       "id": "first-contentful-paint",
@@ -118,7 +112,6 @@
       "description": "This is what the load of your site looked like.",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": true,
       "details": {
         "type": "filmstrip",
         "scale": 4927.278,
@@ -182,7 +175,6 @@
       "description": "The last screenshot captured of the pageload.",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": true,
       "details": {
         "type": "screenshot",
         "timestamp": 185608111.383,
@@ -296,7 +288,6 @@
       "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing).",
       "score": null,
       "scoreDisplayMode": "notApplicable",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -309,7 +300,6 @@
       "description": "The Critical Request Chains below show you what resources are loaded with a high priority. Consider reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains).",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": false,
       "displayValue": "12 chains found",
       "details": {
         "type": "criticalrequestchain",
@@ -471,7 +461,6 @@
       "description": "Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/install-prompt).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "explanation": "Failures: No manifest was fetched.",
       "details": {
         "type": "diagnostic",
@@ -492,7 +481,6 @@
       "description": "A themed splash screen ensures a high-quality experience when users launch your app from their homescreens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/custom-splash-screen).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "explanation": "Failures: No manifest was fetched.",
       "details": {
         "type": "diagnostic",
@@ -513,7 +501,6 @@
       "description": "The browser address bar can be themed to match your site. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/address-bar).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "explanation": "Failures: No manifest was fetched,\nNo `<meta name=\"theme-color\">` tag found.",
       "details": {
         "type": "diagnostic",
@@ -536,7 +523,6 @@
       "description": "If the width of your app's content doesn't match the width of the viewport, your app might not be optimized for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "explanation": ""
     },
     "image-aspect-ratio": {
@@ -545,7 +531,6 @@
       "description": "Image display dimensions should match natural aspect ratio. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "warnings": [],
       "details": {
         "type": "table",
@@ -587,7 +572,6 @@
       "description": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "displayValue": "3 warnings found",
       "details": {
         "type": "table",
@@ -794,7 +778,6 @@
       "description": "Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading. [Learn more](https://developers.google.com/web/updates/2016/02/font-display).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -1287,7 +1270,6 @@
       "description": "A service worker enables your web app to be reliable in unpredictable network conditions. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "explanation": "No usable web app manifest found on page.",
       "warnings": []
     },
@@ -1296,24 +1278,21 @@
       "title": "Site works cross-browser",
       "description": "To reach the most number of users, sites should work across every major browser. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#site-works-cross-browser).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "pwa-page-transitions": {
       "id": "pwa-page-transitions",
       "title": "Page transitions don't feel like they block on the network",
       "description": "Transitions should feel snappy as you tap around, even on a slow network, a key to perceived performance. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#page-transitions-dont-feel-like-they-block-on-the-network).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "pwa-each-page-has-url": {
       "id": "pwa-each-page-has-url",
       "title": "Each page has a URL",
       "description": "Ensure individual pages are deep linkable via the URLs and that URLs are unique for the purpose of shareability on social media. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#each-page-has-a-url).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "accesskeys": {
       "id": "accesskeys",
@@ -1321,7 +1300,6 @@
       "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -1333,72 +1311,63 @@
       "title": "`[aria-*]` attributes match their roles",
       "description": "Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "aria-required-attr": {
       "id": "aria-required-attr",
       "title": "`[role]`s have all required `[aria-*]` attributes",
       "description": "Some ARIA roles have required attributes that describe the state of the element to screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "aria-required-children": {
       "id": "aria-required-children",
       "title": "Elements with `[role]` that require specific children `[role]`s, are present",
       "description": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "aria-required-parent": {
       "id": "aria-required-parent",
       "title": "`[role]`s are contained by their required parent element",
       "description": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "aria-roles": {
       "id": "aria-roles",
       "title": "`[role]` values are valid",
       "description": "ARIA roles must have valid values in order to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "aria-valid-attr-value": {
       "id": "aria-valid-attr-value",
       "title": "`[aria-*]` attributes have valid values",
       "description": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid values. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "aria-valid-attr": {
       "id": "aria-valid-attr",
       "title": "`[aria-*]` attributes are valid and not misspelled",
       "description": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid names. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "audio-caption": {
       "id": "audio-caption",
       "title": "`<audio>` elements contain a `<track>` element with `[kind=\"captions\"]`",
       "description": "Captions make audio elements usable for deaf or hearing-impaired users, providing critical information such as who is talking, what they're saying, and other non-speech information. [Learn more](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "button-name": {
       "id": "button-name",
       "title": "Buttons have an accessible name",
       "description": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "bypass": {
       "id": "bypass",
@@ -1406,7 +1375,6 @@
       "description": "Adding ways to bypass repetitive content lets keyboard users navigate the page more efficiently. [Learn more](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -1419,7 +1387,6 @@
       "description": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -1465,16 +1432,14 @@
       "title": "`<dl>`'s contain only properly-ordered `<dt>` and `<dd>` groups, `<script>` or `<template>` elements.",
       "description": "When definition lists are not properly marked up, screen readers may produce confusing or inaccurate output. [Learn more](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "dlitem": {
       "id": "dlitem",
       "title": "Definition list items are wrapped in `<dl>` elements",
       "description": "Definition list items (`<dt>` and `<dd>`) must be wrapped in a parent `<dl>` element to ensure that screen readers can properly announce them. [Learn more](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "document-title": {
       "id": "document-title",
@@ -1482,7 +1447,6 @@
       "description": "The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/title).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -1495,7 +1459,6 @@
       "description": "The value of an id attribute must be unique to prevent other instances from being overlooked by assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -1507,8 +1470,7 @@
       "title": "`<frame>` or `<iframe>` elements have a title",
       "description": "Screen reader users rely on frame titles to describe the contents of frames. [Learn more](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "html-has-lang": {
       "id": "html-has-lang",
@@ -1516,7 +1478,6 @@
       "description": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -1553,8 +1514,7 @@
       "title": "`<html>` element has a valid value for its `[lang]` attribute",
       "description": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) helps screen readers announce text properly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "image-alt": {
       "id": "image-alt",
@@ -1562,7 +1522,6 @@
       "description": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -1628,8 +1587,7 @@
       "title": "`<input type=\"image\">` elements have `[alt]` text",
       "description": "When an image is being used as an `<input>` button, providing alternative text can help screen reader users understand the purpose of the button. [Learn more](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "label": {
       "id": "label",
@@ -1637,7 +1595,6 @@
       "description": "Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -1695,8 +1652,7 @@
       "title": "Presentational `<table>` elements avoid using `<th>`, `<caption>` or the `[summary]` attribute.",
       "description": "A table being used for layout purposes should not include data elements, such as the th or caption elements or the summary attribute, because this can create a confusing experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "link-name": {
       "id": "link-name",
@@ -1704,7 +1660,6 @@
       "description": "Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -1753,24 +1708,21 @@
       "title": "Lists contain only `<li>` elements and script supporting elements (`<script>` and `<template>`).",
       "description": "Screen readers have a specific way of announcing lists. Ensuring proper list structure aids screen reader output. [Learn more](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "listitem": {
       "id": "listitem",
       "title": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements",
       "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "meta-refresh": {
       "id": "meta-refresh",
       "title": "The document does not use `<meta http-equiv=\"refresh\">`",
       "description": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "meta-viewport": {
       "id": "meta-viewport",
@@ -1778,7 +1730,6 @@
       "description": "Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -1791,7 +1742,6 @@
       "description": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -1839,136 +1789,119 @@
       "title": "No element has a `[tabindex]` value greater than 0",
       "description": "A value greater than 0 implies an explicit navigation ordering. Although technically valid, this often creates frustrating experiences for users who rely on assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "td-headers-attr": {
       "id": "td-headers-attr",
       "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other cells of that same table.",
       "description": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "th-has-data-cells": {
       "id": "th-has-data-cells",
       "title": "`<th>` elements and elements with `[role=\"columnheader\"/\"rowheader\"]` have data cells they describe.",
       "description": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "valid-lang": {
       "id": "valid-lang",
       "title": "`[lang]` attributes have a valid value",
       "description": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) on elements helps ensure that text is pronounced correctly by a screen reader. [Learn more](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "video-caption": {
       "id": "video-caption",
       "title": "`<video>` elements contain a `<track>` element with `[kind=\"captions\"]`",
       "description": "When a video provides a caption it is easier for deaf and hearing impaired users to access its information. [Learn more](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "video-description": {
       "id": "video-description",
       "title": "`<video>` elements contain a `<track>` element with `[kind=\"description\"]`",
       "description": "Audio descriptions provide relevant information for videos that dialogue cannot, such as facial expressions and scenes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "custom-controls-labels": {
       "id": "custom-controls-labels",
       "title": "Custom controls have associated labels",
       "description": "Custom interactive controls have associated labels, provided by aria-label or aria-labelledby. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "custom-controls-roles": {
       "id": "custom-controls-roles",
       "title": "Custom controls have ARIA roles",
       "description": "Custom interactive controls have appropriate ARIA roles. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "focus-traps": {
       "id": "focus-traps",
       "title": "User focus is not accidentally trapped in a region",
       "description": "A user can tab into and out of any control or region without accidentally trapping their focus. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "focusable-controls": {
       "id": "focusable-controls",
       "title": "Interactive controls are keyboard focusable",
       "description": "Custom interactive controls are keyboard focusable and display a focus indicator. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "heading-levels": {
       "id": "heading-levels",
       "title": "Headings don't skip levels",
       "description": "Headings are used to create an outline for the page and heading levels are not skipped. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#take_advantage_of_headings_and_landmarks).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "interactive-element-affordance": {
       "id": "interactive-element-affordance",
       "title": "Interactive elements indicate their purpose and state",
       "description": "Interactive elements, such as links and buttons, should indicate their state and be distinguishable from non-interactive elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#interactive_elements_like_links_and_buttons_should_indicate_their_purpose_and_state).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "logical-tab-order": {
       "id": "logical-tab-order",
       "title": "The page has a logical tab order",
       "description": "Tabbing through the page follows the visual layout. Users cannot focus elements that are offscreen. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "managed-focus": {
       "id": "managed-focus",
       "title": "The user's focus is directed to new content added to the page",
       "description": "If new content, such as a dialog, is added to the page, the user's focus is directed to it. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "offscreen-content-hidden": {
       "id": "offscreen-content-hidden",
       "title": "Offscreen content is hidden from assistive technology",
       "description": "Offscreen content is hidden with display: none or aria-hidden=true. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "use-landmarks": {
       "id": "use-landmarks",
       "title": "HTML5 landmark elements are used to improve navigation",
       "description": "Landmark elements (<main>, <nav>, etc.) are used to improve the keyboard navigation of the page for assistive technology. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#take_advantage_of_headings_and_landmarks).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "visual-order-follows-dom": {
       "id": "visual-order-follows-dom",
       "title": "Visual order on the page follows DOM order",
       "description": "DOM order matches the visual order, improving navigation for assistive technology. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     },
     "uses-long-cache-ttl": {
       "id": "uses-long-cache-ttl",
@@ -2441,7 +2374,6 @@
       "description": "Application Cache is deprecated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/appcache).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "displayValue": "Found \"clock.appcache\""
     },
     "doctype": {
@@ -2449,8 +2381,7 @@
       "title": "Page has the HTML doctype",
       "description": "Specifying a doctype prevents the browser from switching to quirks-mode.Read more on the [MDN Web Docs page](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)",
       "score": 1,
-      "scoreDisplayMode": "binary",
-      "rawValue": true
+      "scoreDisplayMode": "binary"
     },
     "dom-size": {
       "id": "dom-size",
@@ -2510,7 +2441,6 @@
       "description": "Add `rel=\"noopener\"` or `rel=\"noreferrer\"` to any external links to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "warnings": [
         "Unable to determine the destination for anchor (<a target=\"blank\">Hello</a>). If not used as a hyperlink, consider removing target=_blank."
       ],
@@ -2561,7 +2491,6 @@
       "description": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -2594,7 +2523,6 @@
       "description": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -2631,7 +2559,6 @@
       "description": "Some third-party scripts may contain known security vulnerabilities that are easily identified and exploited by attackers. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "displayValue": "2 vulnerabilities detected",
       "details": {
         "type": "table",
@@ -2672,7 +2599,6 @@
       "description": "All front-end JavaScript libraries detected on the page.",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [
@@ -2703,7 +2629,6 @@
       "description": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -2732,7 +2657,6 @@
       "description": "Preventing password pasting undermines good security policy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/password-pasting).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -2764,7 +2688,6 @@
       "description": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "displayValue": "15 requests not served via HTTP/2",
       "details": {
         "type": "table",
@@ -2850,7 +2773,6 @@
       "description": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": false,
       "details": {
         "type": "table",
         "headings": [
@@ -2886,16 +2808,14 @@
       "title": "Document does not have a meta description",
       "description": "Meta descriptions may be included in search results to concisely summarize page content. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/description).",
       "score": 0,
-      "scoreDisplayMode": "binary",
-      "rawValue": false
+      "scoreDisplayMode": "binary"
     },
     "http-status-code": {
       "id": "http-status-code",
       "title": "Page has successful HTTP status code",
       "description": "Pages with unsuccessful HTTP status codes may not be indexed properly. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code).",
       "score": 1,
-      "scoreDisplayMode": "binary",
-      "rawValue": true
+      "scoreDisplayMode": "binary"
     },
     "font-size": {
       "id": "font-size",
@@ -2903,7 +2823,6 @@
       "description": "Font sizes less than 12px are too small to be legible and require mobile visitors to “pinch to zoom” in order to read. Strive to have >60% of page text ≥12px. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/font-sizes).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "displayValue": "100% legible text",
       "details": {
         "type": "table",
@@ -2945,7 +2864,6 @@
       "description": "Descriptive link text helps search engines understand your content. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -2959,7 +2877,6 @@
       "description": "Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/indexing).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -2971,8 +2888,7 @@
       "title": "robots.txt is valid",
       "description": "If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed.",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "tap-targets": {
       "id": "tap-targets",
@@ -2980,7 +2896,6 @@
       "description": "Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "displayValue": "100% appropriately sized tap targets",
       "details": {
         "type": "table",
@@ -2994,7 +2909,6 @@
       "description": "hreflang links tell search engines what version of a page they should list in search results for a given language or region. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/hreflang).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -3007,7 +2921,6 @@
       "description": "Search engines can't index plugin content, and many devices restrict plugins or don't support them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/plugins).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": true,
       "details": {
         "type": "table",
         "headings": [],
@@ -3019,16 +2932,14 @@
       "title": "Document has a valid `rel=canonical`",
       "description": "Canonical links suggest which URL to show in search results. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/canonical).",
       "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "rawValue": true
+      "scoreDisplayMode": "notApplicable"
     },
     "structured-data": {
       "id": "structured-data",
       "title": "Structured data is valid",
       "description": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more](https://developers.google.com/search/docs/guides/mark-up-content).",
       "score": null,
-      "scoreDisplayMode": "manual",
-      "rawValue": false
+      "scoreDisplayMode": "manual"
     }
   },
   "configSettings": {

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -207,7 +207,7 @@ describe('Runner', () => {
       }
       static audit(artifacts, context) {
         calls.push(context.options);
-        return {rawValue: true};
+        return {score: 1};
       }
     }
 
@@ -223,7 +223,7 @@ describe('Runner', () => {
 
     return Runner.run({}, {url, config}).then(results => {
       assert.equal(results.lhr.requestedUrl, url);
-      assert.equal(results.lhr.audits['eavesdrop-audit'].rawValue, true);
+      assert.equal(results.lhr.audits['eavesdrop-audit'].score, 1);
       // assert that the options we received matched expectations
       assert.deepEqual(calls, [{x: 1}, {x: 2}]);
     });
@@ -242,7 +242,8 @@ describe('Runner', () => {
     return Runner.run({}, {config}).then(results => {
       const audits = results.lhr.audits;
       assert.equal(audits['user-timings'].displayValue, '2 user timings');
-      assert.equal(audits['user-timings'].rawValue, false);
+      assert.deepStrictEqual(audits['user-timings'].details.items.map(i => i.startTime),
+        [0.002, 1000.954]);
     });
   });
 
@@ -286,7 +287,7 @@ describe('Runner', () => {
 
       return Runner.run({}, {config}).then(results => {
         const auditResult = results.lhr.audits['user-timings'];
-        assert.strictEqual(auditResult.rawValue, null);
+        assert.strictEqual(auditResult.score, null);
         assert.strictEqual(auditResult.scoreDisplayMode, 'error');
         assert.ok(auditResult.errorMessage.includes('traces'));
       });
@@ -305,7 +306,7 @@ describe('Runner', () => {
 
       return Runner.run({}, {config}).then(results => {
         const auditResult = results.lhr.audits['content-width'];
-        assert.strictEqual(auditResult.rawValue, null);
+        assert.strictEqual(auditResult.score, null);
         assert.strictEqual(auditResult.scoreDisplayMode, 'error');
         assert.ok(auditResult.errorMessage.includes('ViewportDimensions'));
       });
@@ -333,7 +334,7 @@ describe('Runner', () => {
 
       return Runner.run({}, {url, config}).then(results => {
         const auditResult = results.lhr.audits['content-width'];
-        assert.strictEqual(auditResult.rawValue, null);
+        assert.strictEqual(auditResult.score, null);
         assert.strictEqual(auditResult.scoreDisplayMode, 'error');
         assert.ok(auditResult.errorMessage.includes(errorMessage));
       });
@@ -369,7 +370,7 @@ describe('Runner', () => {
 
       return Runner.run({}, {config}).then(results => {
         const auditResult = results.lhr.audits['throwy-audit'];
-        assert.strictEqual(auditResult.rawValue, null);
+        assert.strictEqual(auditResult.score, null);
         assert.strictEqual(auditResult.scoreDisplayMode, 'error');
         assert.ok(auditResult.errorMessage.includes(errorMessage));
       });
@@ -389,7 +390,7 @@ describe('Runner', () => {
     return Runner.run({}, {config}).then(results => {
       const audits = results.lhr.audits;
       assert.equal(audits['critical-request-chains'].displayValue, '5 chains found');
-      assert.equal(audits['critical-request-chains'].rawValue, false);
+      assert.equal(audits['critical-request-chains'].details.longestChain.transferSize, 2468);
     });
   });
 

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -66,28 +66,28 @@ declare global {
       wastedPercent?: number;
     }
 
-    // Type returned by Audit.audit(). Only rawValue is required.
+    /** Type returned by Audit.audit(). Only score is required.  */
     export interface Product {
-      rawValue: boolean | number | null;
+      /** The scored value of the audit, provided in the range `0-1`, or null if `scoreDisplayMode` indicates not scored. */
+      score: number | null;
       displayValue?: string;
       /** An explanation of why the audit failed on the test page. */
       explanation?: string;
       /** Error message from any exception thrown while running this audit. */
       errorMessage?: string;
       warnings?: string[];
-      /** The scored value of the audit, provided in the range `0-1`, or null if `scoreDisplayMode` indicates not scored. */
-      score?: number;
       /** Deprecated and does not make its way into the Lighthouse report. */
       extendedInfo?: {[p: string]: any};
       /** Overrides scoreDisplayMode with notApplicable if set to true */
       notApplicable?: boolean;
+      /** A numeric value that has a meaning specific to the audit, e.g. the number of nodes in the DOM or the timestamp of a specific load event. More information can be found in the audit details, if present. */
+      rawValue?: number;
       /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
       details?: Audit.Details;
     }
 
     /* Audit result returned in Lighthouse report. All audits offer a description and score of 0-1. */
     export interface Result {
-      rawValue: boolean | number | null;
       displayValue?: string;
       /** An explanation of why the audit failed on the test page. */
       explanation?: string;
@@ -112,6 +112,8 @@ declare global {
       id: string;
       /** A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit; markdown links supported. */
       description: string;
+      /** A numeric value that has a meaning specific to the audit, e.g. the number of nodes in the DOM or the timestamp of a specific load event. More information can be found in the audit details, if present. */
+      rawValue?: number;
       /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
       details?: Audit.Details;
     }


### PR DESCRIPTION
The majority of the change in https://github.com/GoogleChrome/lighthouse/issues/6199#issuecomment-477720022.

- makes `score` a required part of `LH.Audit.Product`, either a number or null (in case of ERROR, NOT_APPLICABLE, or INFORMATIVE)
- make all boolean uses of `rawValue` into a `score` of 0 or 1, then drop those `rawValue`s

Mostly string replace, except in `audit.js` and `audit-test.js`

after this I think we want to (at least) rename `rawValue` to finish out #6199 
