### PR TITLE
clients(lr): increase Page.getAppManifest timeout to 10s

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -531,6 +531,7 @@ class Driver {
     // return) and when other requests take a long time to finish. We allow 10 seconds
     // for outgoing requests to finish. Anything more, and we continue the run without
     // a manifest.
+    // Googlers, see: http://b/124008171
     this.setNextProtocolTimeout(10000);
     let response;
     try {

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -525,7 +525,13 @@ class Driver {
    * @return {Promise<{url: string, data: string}|null>}
    */
   async getAppManifest() {
-    this.setNextProtocolTimeout(3000);
+    // In all environments but LR, Page.getAppManifest finishes very quickly.
+    // In LR, there is a bug that causes this command to hang until outgoing
+    // requests finish. This has been seen in long polling (where it will never
+    // return) and when other requests take a long time to finish. We allow 10 seconds
+    // for outgoing requests to finish. Anything more, and we continue the run without
+    // a manifest.
+    this.setNextProtocolTimeout(10000);
     let response;
     try {
       response = await this.sendCommand('Page.getAppManifest');


### PR DESCRIPTION
This was the issue behind `/offline-ready?slow` failing in Smokerider with `service-worker.score = 0`.

The smoketest mimics a SW that takes 5s to register by delaying the request for the `.js` by 5s\*. Outgoing connections trip up LR w/ re: to fetching the manifest, as we saw before with long-polling, and this delay was causing the manifest fetch to fail.

By setting this timeout to x seconds, we are effectively saying "in LR, allow requests to take up to x seconds before giving up on the manifest". We don't want x to be too large, or we will get nothing (LR timeout). x shouldn't be too small either, but I'm not sure how to evaluate what it should be. 10 seconds seems closer than 3 seconds for a threshold where we start giving up on things.

It's unclear if any long request can cause this - `GatherRunner.getWebAppManifest` runs after the first pass, so perhaps all requests that the page makes must finish first? Would really like to understand this better.

\* Sidenote: maybe the smoketest should have the SW do something that takes 5s instead? or is it not possible to delay registration like that?

Googlers can see: b/128446845#comment2