### PR TITLE
deps: axe-core@3.2.2

### DIFF
--- a/lighthouse-core/audits/seo/hreflang.js
+++ b/lighthouse-core/audits/seo/hreflang.js
@@ -35,7 +35,7 @@ function importValidLangs() {
   // @ts-ignore
   global.axe = {utils: {}};
   // @ts-ignore
-  require('axe-core/lib/commons/utils/valid-langs.js');
+  require('axe-core/lib/core/utils/valid-langs.js');
   // @ts-ignore
   const validLangs = global.axe.utils.validLangs();
   // @ts-ignore

--- a/lighthouse-core/gather/gatherers/accessibility.js
+++ b/lighthouse-core/gather/gatherers/accessibility.js
@@ -40,6 +40,8 @@ function runA11yChecks() {
       'area-alt': {enabled: false},
       'blink': {enabled: false},
       'server-side-image-map': {enabled: false},
+      'aria-hidden-focus': {enabled: false},
+      'form-field-multiple-labels': {enabled: false},
     },
     // @ts-ignore
   }).then(axeResult => {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "zone.js": "^0.7.3"
   },
   "dependencies": {
-    "axe-core": "3.1.2",
+    "axe-core": "3.2.2",
     "chrome-launcher": "^0.10.5",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,10 +1177,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.1.2.tgz#ca0aff897ebefca7552f97859dc1217c06c4f9e6"
-  integrity sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg==
+axe-core@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.2.2.tgz#b06d6e9ae4636d706068843272bfaeed3fe97362"
+  integrity sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA==
 
 axios@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
has two perf boosts: https://github.com/dequelabs/axe-core/releases/tag/v3.2.0

3.2.0 introduced rules [`aria-hidden-focus`](https://dequeuniversity.com/rules/axe/3.2/aria-hidden-focus) and [`form-field-multiple-labels`](https://dequeuniversity.com/rules/axe/3.2/form-field-multiple-labels) which are tagged wcag2a (which means we'll run them now).

The hidden-focus rule scares me a bit, implementation-wise, so I'm hesitant to include that in our results. The multiple-labels rule looks straightfoward.

@robdodson @marcysutton do yall have feelings on this?

fixes #7496
fixes #7355