### PR TITLE
core(config): add dedicated ID to audit/gatherer defns

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -4,372 +4,495 @@ exports[`CLI Tests print-config should print the default config and exit immedia
 Object {
   "audits": Array [
     Object {
+      "id": "is-on-https",
       "path": "is-on-https",
     },
     Object {
+      "id": "redirects-http",
       "path": "redirects-http",
     },
     Object {
+      "id": "service-worker",
       "path": "service-worker",
     },
     Object {
+      "id": "works-offline",
       "path": "works-offline",
     },
     Object {
+      "id": "viewport",
       "path": "viewport",
     },
     Object {
+      "id": "without-javascript",
       "path": "without-javascript",
     },
     Object {
+      "id": "first-contentful-paint",
       "path": "metrics/first-contentful-paint",
     },
     Object {
+      "id": "first-meaningful-paint",
       "path": "metrics/first-meaningful-paint",
     },
     Object {
+      "id": "load-fast-enough-for-pwa",
       "path": "load-fast-enough-for-pwa",
     },
     Object {
+      "id": "speed-index",
       "path": "metrics/speed-index",
     },
     Object {
+      "id": "screenshot-thumbnails",
       "path": "screenshot-thumbnails",
     },
     Object {
+      "id": "final-screenshot",
       "path": "final-screenshot",
     },
     Object {
+      "id": "estimated-input-latency",
       "path": "metrics/estimated-input-latency",
     },
     Object {
+      "id": "max-potential-fid",
       "path": "metrics/max-potential-fid",
     },
     Object {
+      "id": "errors-in-console",
       "path": "errors-in-console",
     },
     Object {
+      "id": "time-to-first-byte",
       "path": "time-to-first-byte",
     },
     Object {
+      "id": "first-cpu-idle",
       "path": "metrics/first-cpu-idle",
     },
     Object {
+      "id": "interactive",
       "path": "metrics/interactive",
     },
     Object {
+      "id": "user-timings",
       "path": "user-timings",
     },
     Object {
+      "id": "critical-request-chains",
       "path": "critical-request-chains",
     },
     Object {
+      "id": "redirects",
       "path": "redirects",
     },
     Object {
+      "id": "installable-manifest",
       "path": "installable-manifest",
     },
     Object {
+      "id": "splash-screen",
       "path": "splash-screen",
     },
     Object {
+      "id": "themed-omnibox",
       "path": "themed-omnibox",
     },
     Object {
+      "id": "content-width",
       "path": "content-width",
     },
     Object {
+      "id": "image-aspect-ratio",
       "path": "image-aspect-ratio",
     },
     Object {
+      "id": "deprecations",
       "path": "deprecations",
     },
     Object {
+      "id": "mainthread-work-breakdown",
       "path": "mainthread-work-breakdown",
     },
     Object {
+      "id": "bootup-time",
       "path": "bootup-time",
     },
     Object {
+      "id": "uses-rel-preload",
       "path": "uses-rel-preload",
     },
     Object {
+      "id": "uses-rel-preconnect",
       "path": "uses-rel-preconnect",
     },
     Object {
+      "id": "font-display",
       "path": "font-display",
     },
     Object {
+      "id": "diagnostics",
       "path": "diagnostics",
     },
     Object {
+      "id": "network-requests",
       "path": "network-requests",
     },
     Object {
+      "id": "network-rtt",
       "path": "network-rtt",
     },
     Object {
+      "id": "network-server-latency",
       "path": "network-server-latency",
     },
     Object {
+      "id": "main-thread-tasks",
       "path": "main-thread-tasks",
     },
     Object {
+      "id": "metrics",
       "path": "metrics",
     },
     Object {
+      "id": "offline-start-url",
       "path": "offline-start-url",
     },
     Object {
+      "id": "pwa-cross-browser",
       "path": "manual/pwa-cross-browser",
     },
     Object {
+      "id": "pwa-page-transitions",
       "path": "manual/pwa-page-transitions",
     },
     Object {
+      "id": "pwa-each-page-has-url",
       "path": "manual/pwa-each-page-has-url",
     },
     Object {
+      "id": "accesskeys",
       "path": "accessibility/accesskeys",
     },
     Object {
+      "id": "aria-allowed-attr",
       "path": "accessibility/aria-allowed-attr",
     },
     Object {
+      "id": "aria-required-attr",
       "path": "accessibility/aria-required-attr",
     },
     Object {
+      "id": "aria-required-children",
       "path": "accessibility/aria-required-children",
     },
     Object {
+      "id": "aria-required-parent",
       "path": "accessibility/aria-required-parent",
     },
     Object {
+      "id": "aria-roles",
       "path": "accessibility/aria-roles",
     },
     Object {
+      "id": "aria-valid-attr-value",
       "path": "accessibility/aria-valid-attr-value",
     },
     Object {
+      "id": "aria-valid-attr",
       "path": "accessibility/aria-valid-attr",
     },
     Object {
+      "id": "audio-caption",
       "path": "accessibility/audio-caption",
     },
     Object {
+      "id": "button-name",
       "path": "accessibility/button-name",
     },
     Object {
+      "id": "bypass",
       "path": "accessibility/bypass",
     },
     Object {
+      "id": "color-contrast",
       "path": "accessibility/color-contrast",
     },
     Object {
+      "id": "definition-list",
       "path": "accessibility/definition-list",
     },
     Object {
+      "id": "dlitem",
       "path": "accessibility/dlitem",
     },
     Object {
+      "id": "document-title",
       "path": "accessibility/document-title",
     },
     Object {
+      "id": "duplicate-id",
       "path": "accessibility/duplicate-id",
     },
     Object {
+      "id": "frame-title",
       "path": "accessibility/frame-title",
     },
     Object {
+      "id": "html-has-lang",
       "path": "accessibility/html-has-lang",
     },
     Object {
+      "id": "html-lang-valid",
       "path": "accessibility/html-lang-valid",
     },
     Object {
+      "id": "image-alt",
       "path": "accessibility/image-alt",
     },
     Object {
+      "id": "input-image-alt",
       "path": "accessibility/input-image-alt",
     },
     Object {
+      "id": "label",
       "path": "accessibility/label",
     },
     Object {
+      "id": "layout-table",
       "path": "accessibility/layout-table",
     },
     Object {
+      "id": "link-name",
       "path": "accessibility/link-name",
     },
     Object {
+      "id": "list",
       "path": "accessibility/list",
     },
     Object {
+      "id": "listitem",
       "path": "accessibility/listitem",
     },
     Object {
+      "id": "meta-refresh",
       "path": "accessibility/meta-refresh",
     },
     Object {
+      "id": "meta-viewport",
       "path": "accessibility/meta-viewport",
     },
     Object {
+      "id": "object-alt",
       "path": "accessibility/object-alt",
     },
     Object {
+      "id": "tabindex",
       "path": "accessibility/tabindex",
     },
     Object {
+      "id": "td-headers-attr",
       "path": "accessibility/td-headers-attr",
     },
     Object {
+      "id": "th-has-data-cells",
       "path": "accessibility/th-has-data-cells",
     },
     Object {
+      "id": "valid-lang",
       "path": "accessibility/valid-lang",
     },
     Object {
+      "id": "video-caption",
       "path": "accessibility/video-caption",
     },
     Object {
+      "id": "video-description",
       "path": "accessibility/video-description",
     },
     Object {
+      "id": "custom-controls-labels",
       "path": "accessibility/manual/custom-controls-labels",
     },
     Object {
+      "id": "custom-controls-roles",
       "path": "accessibility/manual/custom-controls-roles",
     },
     Object {
+      "id": "focus-traps",
       "path": "accessibility/manual/focus-traps",
     },
     Object {
+      "id": "focusable-controls",
       "path": "accessibility/manual/focusable-controls",
     },
     Object {
+      "id": "heading-levels",
       "path": "accessibility/manual/heading-levels",
     },
     Object {
+      "id": "interactive-element-affordance",
       "path": "accessibility/manual/interactive-element-affordance",
     },
     Object {
+      "id": "logical-tab-order",
       "path": "accessibility/manual/logical-tab-order",
     },
     Object {
+      "id": "managed-focus",
       "path": "accessibility/manual/managed-focus",
     },
     Object {
+      "id": "offscreen-content-hidden",
       "path": "accessibility/manual/offscreen-content-hidden",
     },
     Object {
+      "id": "use-landmarks",
       "path": "accessibility/manual/use-landmarks",
     },
     Object {
+      "id": "visual-order-follows-dom",
       "path": "accessibility/manual/visual-order-follows-dom",
     },
     Object {
+      "id": "uses-long-cache-ttl",
       "path": "byte-efficiency/uses-long-cache-ttl",
     },
     Object {
+      "id": "total-byte-weight",
       "path": "byte-efficiency/total-byte-weight",
     },
     Object {
+      "id": "offscreen-images",
       "path": "byte-efficiency/offscreen-images",
     },
     Object {
+      "id": "render-blocking-resources",
       "path": "byte-efficiency/render-blocking-resources",
     },
     Object {
+      "id": "unminified-css",
       "path": "byte-efficiency/unminified-css",
     },
     Object {
+      "id": "unminified-javascript",
       "path": "byte-efficiency/unminified-javascript",
     },
     Object {
+      "id": "unused-css-rules",
       "path": "byte-efficiency/unused-css-rules",
     },
     Object {
+      "id": "uses-webp-images",
       "path": "byte-efficiency/uses-webp-images",
     },
     Object {
+      "id": "uses-optimized-images",
       "path": "byte-efficiency/uses-optimized-images",
     },
     Object {
+      "id": "uses-text-compression",
       "path": "byte-efficiency/uses-text-compression",
     },
     Object {
+      "id": "uses-responsive-images",
       "path": "byte-efficiency/uses-responsive-images",
     },
     Object {
+      "id": "efficient-animated-content",
       "path": "byte-efficiency/efficient-animated-content",
     },
     Object {
+      "id": "appcache-manifest",
       "path": "dobetterweb/appcache-manifest",
     },
     Object {
+      "id": "doctype",
       "path": "dobetterweb/doctype",
     },
     Object {
+      "id": "dom-size",
       "path": "dobetterweb/dom-size",
     },
     Object {
+      "id": "external-anchors-use-rel-noopener",
       "path": "dobetterweb/external-anchors-use-rel-noopener",
     },
     Object {
+      "id": "geolocation-on-start",
       "path": "dobetterweb/geolocation-on-start",
     },
     Object {
+      "id": "no-document-write",
       "path": "dobetterweb/no-document-write",
     },
     Object {
+      "id": "no-vulnerable-libraries",
       "path": "dobetterweb/no-vulnerable-libraries",
     },
     Object {
+      "id": "js-libraries",
       "path": "dobetterweb/js-libraries",
     },
     Object {
+      "id": "notification-on-start",
       "path": "dobetterweb/notification-on-start",
     },
     Object {
+      "id": "password-inputs-can-be-pasted-into",
       "path": "dobetterweb/password-inputs-can-be-pasted-into",
     },
     Object {
+      "id": "uses-http2",
       "path": "dobetterweb/uses-http2",
     },
     Object {
+      "id": "uses-passive-event-listeners",
       "path": "dobetterweb/uses-passive-event-listeners",
     },
     Object {
+      "id": "meta-description",
       "path": "seo/meta-description",
     },
     Object {
+      "id": "http-status-code",
       "path": "seo/http-status-code",
     },
     Object {
+      "id": "font-size",
       "path": "seo/font-size",
     },
     Object {
+      "id": "link-text",
       "path": "seo/link-text",
     },
     Object {
+      "id": "is-crawlable",
       "path": "seo/is-crawlable",
     },
     Object {
+      "id": "robots-txt",
       "path": "seo/robots-txt",
     },
     Object {
+      "id": "tap-targets",
       "path": "seo/tap-targets",
     },
     Object {
+      "id": "hreflang",
       "path": "seo/hreflang",
     },
     Object {
+      "id": "plugins",
       "path": "seo/plugins",
     },
     Object {
+      "id": "canonical",
       "path": "seo/canonical",
     },
     Object {
+      "id": "structured-data",
       "path": "seo/manual/structured-data",
     },
   ],
@@ -1070,66 +1193,87 @@ Object {
       "cpuQuietThresholdMs": 1000,
       "gatherers": Array [
         Object {
+          "id": "CSSUsage",
           "path": "css-usage",
         },
         Object {
+          "id": "ViewportDimensions",
           "path": "viewport-dimensions",
         },
         Object {
+          "id": "RuntimeExceptions",
           "path": "runtime-exceptions",
         },
         Object {
+          "id": "ChromeConsoleMessages",
           "path": "chrome-console-messages",
         },
         Object {
+          "id": "AnchorElements",
           "path": "anchor-elements",
         },
         Object {
+          "id": "ImageElements",
           "path": "image-elements",
         },
         Object {
+          "id": "LinkElements",
           "path": "link-elements",
         },
         Object {
+          "id": "MetaElements",
           "path": "meta-elements",
         },
         Object {
+          "id": "ScriptElements",
           "path": "script-elements",
         },
         Object {
+          "id": "AppCacheManifest",
           "path": "dobetterweb/appcache",
         },
         Object {
+          "id": "Doctype",
           "path": "dobetterweb/doctype",
         },
         Object {
+          "id": "DOMStats",
           "path": "dobetterweb/domstats",
         },
         Object {
+          "id": "OptimizedImages",
           "path": "dobetterweb/optimized-images",
         },
         Object {
+          "id": "PasswordInputsWithPreventedPaste",
           "path": "dobetterweb/password-inputs-with-prevented-paste",
         },
         Object {
+          "id": "ResponseCompression",
           "path": "dobetterweb/response-compression",
         },
         Object {
+          "id": "TagsBlockingFirstPaint",
           "path": "dobetterweb/tags-blocking-first-paint",
         },
         Object {
+          "id": "FontSize",
           "path": "seo/font-size",
         },
         Object {
+          "id": "EmbeddedContent",
           "path": "seo/embedded-content",
         },
         Object {
+          "id": "RobotsTxt",
           "path": "seo/robots-txt",
         },
         Object {
+          "id": "TapTargets",
           "path": "seo/tap-targets",
         },
         Object {
+          "id": "Accessibility",
           "path": "accessibility",
         },
       ],
@@ -1145,12 +1289,15 @@ Object {
       "cpuQuietThresholdMs": 0,
       "gatherers": Array [
         Object {
+          "id": "ServiceWorker",
           "path": "service-worker",
         },
         Object {
+          "id": "Offline",
           "path": "offline",
         },
         Object {
+          "id": "StartUrl",
           "path": "start-url",
         },
       ],
@@ -1176,9 +1323,11 @@ Object {
       "cpuQuietThresholdMs": 0,
       "gatherers": Array [
         Object {
+          "id": "HTTPRedirect",
           "path": "http-redirect",
         },
         Object {
+          "id": "HTMLWithoutJavaScript",
           "path": "html-without-javascript",
         },
       ],
@@ -1226,6 +1375,7 @@ exports[`CLI Tests print-config should print the overridden config and exit imme
 Object {
   "audits": Array [
     Object {
+      "id": "metrics",
       "path": "metrics",
     },
   ],

--- a/lighthouse-core/config/config-helpers.js
+++ b/lighthouse-core/config/config-helpers.js
@@ -1,0 +1,211 @@
+/**
+ * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const path = require('path');
+const Audit = require('../audits/audit.js');
+const Runner = require('../runner.js');
+
+/**
+ * If any items with identical `path` properties are found in the input array,
+ * merge their `options` properties into the first instance and then discard any
+ * other instances.
+ * Until support of jsdoc templates with constraints, type in config.d.ts.
+ * See https://github.com/Microsoft/TypeScript/issues/24283
+ * @type {LH.Config.MergeOptionsOfItems}
+ */
+const mergeOptionsOfItems = function(items) {
+  /** @type {Array<{id: string, path?: string, options?: Object<string, any>}>} */
+  const mergedItems = [];
+
+  for (const item of items) {
+    const existingItem = mergedItems.find(candidate => candidate.id === item.id);
+    if (!existingItem) {
+      mergedItems.push(item);
+      continue;
+    }
+
+    existingItem.options = Object.assign({}, existingItem.options, item.options);
+  }
+
+  return mergedItems;
+};
+
+/**
+ * @param {LH.Config.AuditDefn} auditDefinition
+ */
+function assertValidAudit(auditDefinition) {
+  const {id, implementation, path: auditPath} = auditDefinition;
+  const auditName = id || auditPath || 'Unknown audit';
+
+  if (typeof implementation.audit !== 'function' || implementation.audit === Audit.audit) {
+    throw new Error(`${auditName} has no audit() method.`);
+  }
+
+  if (typeof id !== 'string' || !id.trim()) {
+    throw new Error(`${auditName} does not have a valid ID.`);
+  }
+
+  if (typeof implementation.meta.id !== 'string') {
+    throw new Error(`${auditName} has no meta.id property, or the property is not a string.`);
+  }
+
+  if (typeof implementation.meta.title !== 'string') {
+    throw new Error(`${auditName} has no meta.title property, or the property is not a string.`);
+  }
+
+  // If it'll have a ✔ or ✖ displayed alongside the result, it should have failureTitle
+  if (
+    typeof implementation.meta.failureTitle !== 'string' &&
+    implementation.meta.scoreDisplayMode === Audit.SCORING_MODES.BINARY
+  ) {
+    throw new Error(`${auditName} has no failureTitle and should.`);
+  }
+
+  if (typeof implementation.meta.description !== 'string') {
+    throw new Error(
+      `${auditName} has no meta.description property, or the property is not a string.`
+    );
+  } else if (implementation.meta.description === '') {
+    throw new Error(
+      `${auditName} has an empty meta.description string. Please add a description for the UI.`
+    );
+  }
+
+  if (!Array.isArray(implementation.meta.requiredArtifacts)) {
+    throw new Error(
+      `${auditName} has no meta.requiredArtifacts property, or the property is not an array.`
+    );
+  }
+}
+
+/**
+ * Expands the audits from user-specified JSON to an internal audit definition format.
+ * @param {LH.Config.Json['audits']} audits
+ * @return {?Array<{id?: string, path: string, options?: {}} | {id?: string, implementation: typeof Audit, path?: string, options?: {}}>}
+ */
+function expandAuditShorthand(audits) {
+  if (!audits) {
+    return null;
+  }
+
+  const newAudits = audits.map(audit => {
+    if (typeof audit === 'string') {
+      // just 'path/to/audit'
+      return {path: audit, options: {}};
+    } else if ('implementation' in audit && typeof audit.implementation.audit === 'function') {
+      // {implementation: AuditClass, ...}
+      return audit;
+    } else if ('path' in audit && typeof audit.path === 'string') {
+      // {path: 'path/to/audit', ...}
+      return audit;
+    } else if ('audit' in audit && typeof audit.audit === 'function') {
+      // just AuditClass
+      return {implementation: audit, options: {}};
+    } else {
+      throw new Error('Invalid Audit type ' + JSON.stringify(audit));
+    }
+  });
+
+  return newAudits;
+}
+
+/**
+ * Take an array of audits and audit paths and require any paths (possibly
+ * relative to the optional `configDir`) using `resolveModule`,
+ * leaving only an array of AuditDefns.
+ * @param {LH.Config.Json['audits']} audits
+ * @param {string=} configDir
+ * @return {Array<LH.Config.AuditDefn>|null}
+ */
+function requireAudits(audits, configDir) {
+  const expandedAudits = expandAuditShorthand(audits);
+  if (!expandedAudits) {
+    return null;
+  }
+
+  const coreList = Runner.getAuditList();
+  const auditDefns = expandedAudits.map(audit => {
+    let implementation;
+    if ('implementation' in audit) {
+      implementation = audit.implementation;
+    } else {
+      // See if the audit is a Lighthouse core audit.
+      const auditPathJs = `${audit.path}.js`;
+      const coreAudit = coreList.find(a => a === auditPathJs);
+      let requirePath = `../audits/${audit.path}`;
+      if (!coreAudit) {
+        // Otherwise, attempt to find it elsewhere. This throws if not found.
+        requirePath = resolveModule(audit.path, configDir, 'audit');
+      }
+      implementation = /** @type {typeof Audit} */ (require(requirePath));
+    }
+
+    return {
+      id: audit.id || (implementation.meta && implementation.meta.id),
+      implementation,
+      path: audit.path,
+      options: audit.options || {},
+    };
+  });
+
+  const mergedAuditDefns = mergeOptionsOfItems(auditDefns);
+  mergedAuditDefns.forEach(audit => assertValidAudit(audit));
+  return mergedAuditDefns;
+}
+
+/**
+ * Resolves the location of the specified module and returns an absolute
+ * string path to the file. Used for loading custom audits and gatherers.
+ * Throws an error if no module is found.
+ * @param {string} moduleIdentifier
+ * @param {string=} configDir The absolute path to the directory of the config file, if there is one.
+ * @param {string=} category Optional plugin category (e.g. 'audit') for better error messages.
+ * @return {string}
+ * @throws {Error}
+ */
+function resolveModule(moduleIdentifier, configDir, category) {
+  // First try straight `require()`. Unlikely to be specified relative to this
+  // file, but adds support for Lighthouse modules from npm since
+  // `require()` walks up parent directories looking inside any node_modules/
+  // present. Also handles absolute paths.
+  try {
+    return require.resolve(moduleIdentifier);
+  } catch (e) {}
+
+  // See if the module resolves relative to the current working directory.
+  // Most useful to handle the case of invoking Lighthouse as a module, since
+  // then the config is an object and so has no path.
+  const cwdPath = path.resolve(process.cwd(), moduleIdentifier);
+  try {
+    return require.resolve(cwdPath);
+  } catch (e) {}
+
+  const errorString =
+    'Unable to locate ' +
+    (category ? `${category}: ` : '') +
+    `${moduleIdentifier} (tried to require() from '${__dirname}' and load from '${cwdPath}'`;
+
+  if (!configDir) {
+    throw new Error(errorString + ')');
+  }
+
+  // Finally, try looking up relative to the config file path. Just like the
+  // relative path passed to `require()` is found relative to the file it's
+  // in, this allows module paths to be specified relative to the config file.
+  const relativePath = path.resolve(configDir, moduleIdentifier);
+  try {
+    return require.resolve(relativePath);
+  } catch (requireError) {}
+
+  throw new Error(errorString + ` and '${relativePath}')`);
+}
+
+module.exports = {
+  mergeOptionsOfItems,
+  requireAudits,
+  resolveModule,
+};

--- a/lighthouse-core/config/config-helpers.js
+++ b/lighthouse-core/config/config-helpers.js
@@ -10,7 +10,7 @@ const Audit = require('../audits/audit.js');
 const Runner = require('../runner.js');
 
 /**
- * If any items with identical `path` properties are found in the input array,
+ * If any items with identical `id` properties are found in the input array,
  * merge their `options` properties into the first instance and then discard any
  * other instances.
  * Until support of jsdoc templates with constraints, type in config.d.ts.

--- a/lighthouse-core/config/config-helpers.js
+++ b/lighthouse-core/config/config-helpers.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright 2016 Google Inc. All Rights Reserved.
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -271,6 +271,7 @@ class Runner {
    * @private
    */
   static async _runAudit(auditDefn, artifacts, sharedAuditContext) {
+    const auditId = auditDefn.id;
     const audit = auditDefn.implementation;
     const status = {
       msg: `Evaluating: ${i18n.getFormatted(audit.meta.title, 'en-US')}`,
@@ -336,6 +337,7 @@ class Runner {
     }
 
     log.timeEnd(status);
+    auditResult.id = auditId;
     return auditResult;
   }
 

--- a/lighthouse-core/test/fixtures/invalid-gatherers/missing-name.js
+++ b/lighthouse-core/test/fixtures/invalid-gatherers/missing-name.js
@@ -1,0 +1,15 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+class MissingName {
+  beforePass() {}
+  pass() {}
+  afterPass() {}
+}
+
+module.exports = MissingName;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -89,6 +89,7 @@ declare global {
       }
 
       export interface GathererDefn {
+        id: string;
         implementation?: typeof Gatherer;
         instance: InstanceType<typeof Gatherer>;
         path?: string;
@@ -96,6 +97,7 @@ declare global {
       }
 
       export interface AuditDefn {
+        id: string;
         implementation: typeof Audit;
         path?: string;
         options: {};
@@ -117,7 +119,7 @@ declare global {
         groups?: Record<string, LH.Config.GroupJson>;
       }
 
-      export type MergeOptionsOfItems = <T extends {path?: string, options: Record<string, any>}>(items: T[]) => T[];
+      export type MergeOptionsOfItems = <T extends {id: string, path?: string, options: Record<string, any>}>(items: T[]) => T[];
 
       export type Merge = {
         <T extends Record<string, any>, U extends Record<string, any>>(base: T|null|undefined, extension: U, overwriteArrays?: boolean): T & U;


### PR DESCRIPTION
**Summary**
So blessed artifacts turned out to be quite the rabbit hole. This is part 1 of 3 stages.

1. (This PR) Split apart some config logic into a helper file and add a dedicated ID to audit and gatherer definitions so that they are more easily referenceable. This also has the happy side effect of enabling the use of options in plugin audits in step 2 :D
2. Enforce that every plugin audit id is prefixed with `<plugin-id>`. It will still be able to reference our existing core audit implementations. 
3. Load each audit when loading a plugin to check its requiredArtifacts against a set of blessed artifacts

**Related Issues/PRs**
#6747 
