### PR TITLE
core: replace rawValue with numericValue in audit result

### DIFF
--- a/clients/lightrider/lightrider-entry.js
+++ b/clients/lightrider/lightrider-entry.js
@@ -26,11 +26,11 @@ const LR_PRESETS = {
  * @param {Connection} connection
  * @param {string} url
  * @param {LH.Flags} flags Lighthouse flags, including `output`
- * @param {{lrDevice?: 'desktop'|'mobile', categoryIDs?: Array<string>, logAssets: boolean, keepRawValues: boolean, configOverride?: LH.Config.Json}} lrOpts Options coming from Lightrider
+ * @param {{lrDevice?: 'desktop'|'mobile', categoryIDs?: Array<string>, logAssets: boolean, configOverride?: LH.Config.Json}} lrOpts Options coming from Lightrider
  * @return {Promise<string|Array<string>|void>}
  */
 async function runLighthouseInLR(connection, url, flags, lrOpts) {
-  const {lrDevice, categoryIDs, logAssets, keepRawValues, configOverride} = lrOpts;
+  const {lrDevice, categoryIDs, logAssets, configOverride} = lrOpts;
 
   // Certain fixes need to kick in under LR, see https://github.com/GoogleChrome/lighthouse/issues/5839
   global.isLightrider = true;
@@ -61,7 +61,7 @@ async function runLighthouseInLR(connection, url, flags, lrOpts) {
 
     // pre process the LHR for proto
     if (flags.output === 'json' && typeof results.report === 'string') {
-      return preprocessor.processForProto(results.report, {keepRawValues});
+      return preprocessor.processForProto(results.report);
     }
 
     return results.report;

--- a/docs/recipes/gulp/gulpfile.js
+++ b/docs/recipes/gulp/gulpfile.js
@@ -50,7 +50,7 @@ const handleOk = function(results) {
   console.log(results); // eslint-disable-line no-console
   // TODO: use lighthouse results for checking your performance expectations.
   // e.g. process.exit(1) or throw Error if score falls below a certain threshold.
-  // if (results.audits['first-meaningful-paint'].rawValue > 3000) {
+  // if (results.audits['first-meaningful-paint'].numericValue > 3000) {
   //   console.log(`Warning: Time to first meaningful paint ${results.audits['first-meaningful-paint'].displayValue}`);
   //   process.exit(1);
   // }

--- a/docs/understanding-results.md
+++ b/docs/understanding-results.md
@@ -55,7 +55,7 @@ An object containing the results of the audits, keyed by their name.
 | explanation | <code>string&#124;undefined</code> | A string indicating the reason for audit failure. |
 | warnings | <code>string[]&#124;undefined</code> | Messages identifying potentially invalid cases |
 | errorMessage | <code>string&#124;undefined</code> | A message set |
-| rawValue | <code>boolean&#124;number</code> | The unscored value determined by the audit. Typically this will match the score if there's no additional information to impart. For performance audits, this value is typically a number indicating the metric value. |
+| numericValue | <code>number&#124;undefined</code> | The unscored value determined by the audit. Typically this will match the score if there's no additional information to impart. For performance audits, this value is typically a number indicating the metric value. |
 | displayValue | `string` | The string to display in the report alongside audit results. If empty, nothing additional is shown. This is typically used to explain additional information such as the number and nature of failing items. |
 | score | <code>number</code> | The scored value determined by the audit as a number `0-1`, representing displayed scores of 0-100. |
 | scoreDisplayMode | <code>"binary"&#124;"numeric"&#124;"error"&#124;"manual"&#124;"notApplicable"&#124;"informative"</code> | A string identifying how the score should be interpreted for display i.e. is the audit pass/fail (score of 1 or 0), did it fail, should it be ignored, or are there shades of gray (scores between 0-1 inclusive). |

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -65,7 +65,7 @@ describe('CLI run', function() {
       assert.strictEqual(fileResults.fetchTime, lhr.fetchTime);
       assert.strictEqual(fileResults.requestedUrl, lhr.requestedUrl);
       assert.strictEqual(fileResults.finalUrl, lhr.finalUrl);
-      assert.strictEqual(fileResults.audits.viewport.rawValue, lhr.audits.viewport.rawValue);
+      assert.strictEqual(fileResults.audits.viewport.score, lhr.audits.viewport.score);
       assert.strictEqual(
           Object.keys(fileResults.audits).length,
           Object.keys(lhr.audits).length);

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -75,7 +75,7 @@ module.exports = [
         },
         'render-blocking-resources': {
           score: '<1',
-          rawValue: '>100',
+          numericValue: '>100',
           details: {
             items: {
               length: 7,
@@ -145,7 +145,7 @@ module.exports = [
         },
         'dom-size': {
           score: 1,
-          rawValue: 31,
+          numericValue: 31,
           details: {
             items: [
               {statistic: 'Total DOM Elements', value: '31'},

--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -27,8 +27,8 @@ module.exports = [
           score: '>=0.90',
         },
         'time-to-first-byte': {
-        // Can be flaky, so test float rawValue instead of boolean score
-          rawValue: '<1000',
+          // Can be flaky, so test float numericValue instead of boolean score
+          numericValue: '<1000',
         },
         'network-requests': {
           details: {
@@ -39,7 +39,7 @@ module.exports = [
         },
         'uses-rel-preload': {
           score: '<1',
-          rawValue: '>500',
+          numericValue: '>500',
           warnings: {
             0: /level-2.*warning/,
             length: 1,

--- a/lighthouse-cli/test/smokehouse/perf/lantern-expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/lantern-expectations.js
@@ -15,13 +15,13 @@ module.exports = [
       finalUrl: 'http://localhost:10200/online-only.html',
       audits: {
         'first-contentful-paint': {
-          rawValue: '>2000',
+          numericValue: '>2000',
         },
         'first-cpu-idle': {
-          rawValue: '>2000',
+          numericValue: '>2000',
         },
         'interactive': {
-          rawValue: '>2000',
+          numericValue: '>2000',
         },
       },
     },

--- a/lighthouse-cli/test/smokehouse/redirects/expectations.js
+++ b/lighthouse-cli/test/smokehouse/redirects/expectations.js
@@ -18,7 +18,7 @@ module.exports = [
       audits: {
         'redirects': {
           score: '<1',
-          rawValue: '>=500',
+          numericValue: '>=500',
           details: {
             items: {
               length: 3,
@@ -35,7 +35,7 @@ module.exports = [
       audits: {
         'redirects': {
           score: 1,
-          rawValue: '>=250',
+          numericValue: '>=250',
           details: {
             items: {
               length: 2,

--- a/lighthouse-cli/test/smokehouse/tricky-metrics/expectations.js
+++ b/lighthouse-cli/test/smokehouse/tricky-metrics/expectations.js
@@ -16,11 +16,11 @@ module.exports = [
       audits: {
         'first-cpu-idle': {
           score: '<75',
-          rawValue: '>9000',
+          numericValue: '>9000',
         },
         'interactive': {
           score: '<75',
-          rawValue: '>9000',
+          numericValue: '>9000',
         },
       },
     },
@@ -31,7 +31,7 @@ module.exports = [
       finalUrl: 'http://localhost:10200/delayed-fcp.html',
       audits: {
         'first-contentful-paint': {
-          rawValue: '>1', // We just want to check that it doesn't error
+          numericValue: '>1', // We just want to check that it doesn't error
         },
       },
     },

--- a/lighthouse-core/audits/audit.js
+++ b/lighthouse-core/audits/audit.js
@@ -270,7 +270,7 @@ class Audit {
 
       score,
       scoreDisplayMode,
-      rawValue: product.rawValue,
+      numericValue: product.rawValue,
 
       displayValue: product.displayValue,
       explanation: product.explanation,

--- a/lighthouse-core/lib/proto-preprocessor.js
+++ b/lighthouse-core/lib/proto-preprocessor.js
@@ -17,11 +17,8 @@ const fs = require('fs');
 
 /**
   * @param {string} result
-  * @param {{keepRawValues?: boolean}} opts
   */
-function processForProto(result, opts = {}) {
-  const {keepRawValues = false} = opts;
-
+function processForProto(result) {
   /** @type {LH.Result} */
   const reportJson = JSON.parse(result);
 
@@ -56,13 +53,8 @@ function processForProto(result, opts = {}) {
           audit.scoreDisplayMode = 'notApplicable';
         }
       }
-      // Drop numeric values until we decide what to do with the optional type in proto.
-      // https://github.com/GoogleChrome/lighthouse/issues/6199
-      if (!keepRawValues && 'numericValue' in audit) {
-        delete audit.numericValue;
-      }
-      // Normalize displayValue to always be a string, not an array. #6200
 
+      // Normalize displayValue to always be a string, not an array. #6200
       if (Array.isArray(audit.displayValue)) {
         /** @type {Array<any>}*/
         const values = [];

--- a/lighthouse-core/lib/proto-preprocessor.js
+++ b/lighthouse-core/lib/proto-preprocessor.js
@@ -56,9 +56,10 @@ function processForProto(result, opts = {}) {
           audit.scoreDisplayMode = 'notApplicable';
         }
       }
-      // Drop raw values. https://github.com/GoogleChrome/lighthouse/issues/6199
-      if (!keepRawValues && 'rawValue' in audit) {
-        delete audit.rawValue;
+      // Drop numeric values until we decide what to do with the optional type in proto.
+      // https://github.com/GoogleChrome/lighthouse/issues/6199
+      if (!keepRawValues && 'numericValue' in audit) {
+        delete audit.numericValue;
       }
       // Normalize displayValue to always be a string, not an array. #6200
 

--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -347,7 +347,6 @@ describe('Manifest Parser', function() {
       const display = parsedManifest.value.display;
       assert.ok(!display.warning);
       assert.equal(display.value, 'browser');
-      assert.equal(display.rawValue, undefined);
     });
 
     it('trims whitespace', () => {

--- a/lighthouse-core/test/lib/proto-preprocessor-test.js
+++ b/lighthouse-core/test/lib/proto-preprocessor-test.js
@@ -78,7 +78,7 @@ describe('processing for proto', () => {
       'audits': {
         'critical-request-chains': {
           'scoreDisplayMode': 'not-applicable',
-          'rawValue': 14.3,
+          'numericValue': 14.3,
           'displayValue': ['hello %d', 123],
         },
       },

--- a/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
@@ -122,7 +122,7 @@ describe('PerfCategoryRenderer', () => {
       group: 'load-opportunities',
       result: {
         score: 0, scoreDisplayMode: 'numeric',
-        rawValue: 100, explanation: 'Yikes!!', title: 'Bug #2', description: '',
+        numericValue: 100, explanation: 'Yikes!!', title: 'Bug #2', description: '',
       },
     };
 
@@ -166,7 +166,7 @@ describe('PerfCategoryRenderer', () => {
         group: 'load-opportunities',
         result: {
           error: true, score: 0,
-          rawValue: 100, explanation: 'Yikes!!', title: 'Bug #2',
+          numericValue: 100, explanation: 'Yikes!!', title: 'Bug #2',
         },
       };
       const wastedMs = renderer._getWastedMs(auditWithDebug);

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -77,7 +77,7 @@
       "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).",
       "score": 0.51,
       "scoreDisplayMode": "numeric",
-      "rawValue": 3969.135,
+      "numericValue": 3969.135,
       "displayValue": "4.0 s"
     },
     "first-meaningful-paint": {
@@ -86,7 +86,7 @@
       "description": "First Meaningful Paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint).",
       "score": 0.51,
       "scoreDisplayMode": "numeric",
-      "rawValue": 3969.136,
+      "numericValue": 3969.136,
       "displayValue": "4.0 s"
     },
     "load-fast-enough-for-pwa": {
@@ -95,7 +95,7 @@
       "description": "A fast page load over a cellular network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": 4927.278
+      "numericValue": 4927.278
     },
     "speed-index": {
       "id": "speed-index",
@@ -103,7 +103,7 @@
       "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index).",
       "score": 0.74,
       "scoreDisplayMode": "numeric",
-      "rawValue": 4417,
+      "numericValue": 4417,
       "displayValue": "4.4 s"
     },
     "screenshot-thumbnails": {
@@ -188,7 +188,7 @@
       "description": "Estimated Input Latency is an estimate of how long your app takes to respond to user input, in milliseconds, during the busiest 5s window of page load. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 16,
+      "numericValue": 16,
       "displayValue": "20 ms"
     },
     "max-potential-fid": {
@@ -197,7 +197,7 @@
       "description": "The potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task.",
       "score": 0.92,
       "scoreDisplayMode": "numeric",
-      "rawValue": 122.537,
+      "numericValue": 122.537,
       "displayValue": "120 ms"
     },
     "errors-in-console": {
@@ -206,7 +206,7 @@
       "description": "Errors logged to the console indicate unresolved problems. They can come from network request failures and other browser concerns.",
       "score": 0,
       "scoreDisplayMode": "binary",
-      "rawValue": 5,
+      "numericValue": 5,
       "details": {
         "type": "table",
         "headings": [
@@ -256,7 +256,7 @@
       "description": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).",
       "score": 1,
       "scoreDisplayMode": "binary",
-      "rawValue": 570.5630000000001,
+      "numericValue": 570.5630000000001,
       "displayValue": "Root document took 570 ms",
       "details": {
         "type": "opportunity",
@@ -271,7 +271,7 @@
       "description": "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-interactive).",
       "score": 0.72,
       "scoreDisplayMode": "numeric",
-      "rawValue": 4927.278,
+      "numericValue": 4927.278,
       "displayValue": "4.9 s"
     },
     "interactive": {
@@ -280,7 +280,7 @@
       "description": "Time to interactive is the amount of time it takes for the page to become fully interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive).",
       "score": 0.78,
       "scoreDisplayMode": "numeric",
-      "rawValue": 4927.278,
+      "numericValue": 4927.278,
       "displayValue": "4.9 s"
     },
     "user-timings": {
@@ -447,7 +447,7 @@
       "description": "Redirects introduce additional delays before the page can be loaded. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/redirects).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "details": {
         "type": "opportunity",
@@ -620,7 +620,7 @@
       "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this.",
       "score": 0.96,
       "scoreDisplayMode": "numeric",
-      "rawValue": 1548.5690000000002,
+      "numericValue": 1548.5690000000002,
       "displayValue": "1.5 s",
       "details": {
         "type": "table",
@@ -682,7 +682,7 @@
       "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/bootup).",
       "score": 0.92,
       "scoreDisplayMode": "numeric",
-      "rawValue": 1150.573,
+      "numericValue": 1150.573,
       "displayValue": "1.2 s",
       "details": {
         "type": "table",
@@ -748,7 +748,7 @@
       "description": "Consider using <link rel=preload> to prioritize fetching resources that are currently requested later in page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/preload).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "details": {
         "type": "opportunity",
@@ -763,7 +763,7 @@
       "description": "Consider adding preconnect or dns-prefetch resource hints to establish early connections to important third-party origins. [Learn more](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "warnings": [],
       "details": {
@@ -791,7 +791,7 @@
       "description": "Collection of useful page vitals.",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": 1,
+      "numericValue": 1,
       "details": {
         "type": "debugdata",
         "items": [
@@ -823,7 +823,7 @@
       "description": "Lists the network requests that were made during page load.",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": 18,
+      "numericValue": 18,
       "details": {
         "type": "table",
         "headings": [
@@ -1064,7 +1064,7 @@
       "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more](https://hpbn.co/primer-on-latency-and-bandwidth/).",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": 1.7249999999999943,
+      "numericValue": 1.7249999999999943,
       "displayValue": "0 ms",
       "details": {
         "type": "table",
@@ -1099,7 +1099,7 @@
       "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": 572.829,
+      "numericValue": 572.829,
       "displayValue": "570 ms",
       "details": {
         "type": "table",
@@ -1134,7 +1134,7 @@
       "description": "Lists the toplevel main thread tasks that executed during page load.",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": 16,
+      "numericValue": 16,
       "details": {
         "type": "table",
         "headings": [
@@ -1225,7 +1225,7 @@
       "description": "Collects all available metrics.",
       "score": null,
       "scoreDisplayMode": "informative",
-      "rawValue": 4927.278,
+      "numericValue": 4927.278,
       "details": {
         "type": "debugdata",
         "items": [
@@ -1910,7 +1910,7 @@
       "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/cache-policy).",
       "score": 0.58,
       "scoreDisplayMode": "numeric",
-      "rawValue": 103455,
+      "numericValue": 103455,
       "displayValue": "11 resources found",
       "details": {
         "type": "table",
@@ -2024,7 +2024,7 @@
       "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/network-payloads).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 160738,
+      "numericValue": 160738,
       "displayValue": "Total size was 157 KB",
       "details": {
         "type": "table",
@@ -2090,7 +2090,7 @@
       "description": "Consider lazy-loading offscreen and hidden images after all critical resources have finished loading to lower time to interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "warnings": [],
       "details": {
@@ -2107,7 +2107,7 @@
       "description": "Resources are blocking the first paint of your page. Consider delivering critical JS/CSS inline and deferring all non-critical JS/styles. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
       "score": 0.46,
       "scoreDisplayMode": "numeric",
-      "rawValue": 1129,
+      "numericValue": 1129,
       "displayValue": "Potential savings of 1,130 ms",
       "details": {
         "type": "opportunity",
@@ -2164,7 +2164,7 @@
       "description": "Minifying CSS files can reduce network payload sizes. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/minify-css).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "details": {
         "type": "opportunity",
@@ -2180,7 +2180,7 @@
       "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn more](https://developers.google.com/speed/docs/insights/MinifyResources).",
       "score": 0.88,
       "scoreDisplayMode": "numeric",
-      "rawValue": 150,
+      "numericValue": 150,
       "displayValue": "Potential savings of 30 KB",
       "warnings": [],
       "details": {
@@ -2220,7 +2220,7 @@
       "description": "Remove dead rules from stylesheets and defer the loading of CSS not used for above-the-fold content to reduce unnecessary bytes consumed by network activity. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/unused-css).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "details": {
         "type": "opportunity",
@@ -2236,7 +2236,7 @@
       "description": "Image formats like JPEG 2000, JPEG XR, and WebP often provide better compression than PNG or JPEG, which means faster downloads and less data consumption. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/webp).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "Potential savings of 9 KB",
       "warnings": [],
       "details": {
@@ -2282,7 +2282,7 @@
       "description": "Optimized images load faster and consume less cellular data. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/optimize-images).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "warnings": [],
       "details": {
@@ -2299,7 +2299,7 @@
       "description": "Text-based resources should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/text-compression).",
       "score": 0.75,
       "scoreDisplayMode": "numeric",
-      "rawValue": 300,
+      "numericValue": 300,
       "displayValue": "Potential savings of 63 KB",
       "details": {
         "type": "opportunity",
@@ -2342,7 +2342,7 @@
       "description": "Serve images that are appropriately-sized to save cellular data and improve load time. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/oversized-images).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "warnings": [],
       "details": {
@@ -2359,7 +2359,7 @@
       "description": "Large GIFs are inefficient for delivering animated content. Consider using MPEG4/WebM videos for animations and PNG/WebP for static images instead of GIF to save network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 0,
+      "numericValue": 0,
       "displayValue": "",
       "details": {
         "type": "opportunity",
@@ -2390,7 +2390,7 @@
       "description": "Browser engineers recommend pages contain fewer than ~1,500 DOM elements. The sweet spot is a tree depth < 32 elements and fewer than 60 children/parent element. A large DOM can increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size).",
       "score": 1,
       "scoreDisplayMode": "numeric",
-      "rawValue": 31,
+      "numericValue": 31,
       "displayValue": "31 elements",
       "details": {
         "type": "table",

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -561,7 +561,8 @@ describe('Runner', () => {
           static audit(artifacts, context) {
             context.LighthouseRunWarnings.push(warningString);
             return {
-              rawValue: 5,
+              numericValue: 5,
+              score: 1,
             };
           }
         },

--- a/lighthouse-core/test/scoring-test.js
+++ b/lighthouse-core/test/scoring-test.js
@@ -35,7 +35,7 @@ describe('ReportScoring', () => {
   describe('#scoreAllCategories', () => {
     it('should score the categories', () => {
       const resultsByAuditId = {
-        'my-audit': {rawValue: 'you passed', score: 0},
+        'my-audit': {score: 0},
         'my-boolean-audit': {score: 1, extendedInfo: {}},
         'my-scored-audit': {score: 1},
         'my-failed-audit': {score: 0.2},

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -283,6 +283,11 @@ message AuditResult {
   // List of warnings associated with this audit
   // type of `Value` since this can be null
   google.protobuf.Value warnings = 10;
+
+  // A numeric value that has a meaning specific to the audit, e.g. the number
+  // of nodes in the DOM or the timestamp of a specific load event. More
+  // information can be found in the audit details, if present.
+  google.protobuf.DoubleValue numeric_value = 11;
 }
 
 // Message containing the i18n data for the LHR - Version 1

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -137,6 +137,7 @@
             }, 
             "displayValue": "1.2\u00a0s", 
             "id": "bootup-time", 
+            "numericValue": 1150.573, 
             "score": 0.92, 
             "scoreDisplayMode": "numeric", 
             "title": "JavaScript execution time"
@@ -460,6 +461,7 @@
                 "type": "debugdata"
             }, 
             "id": "diagnostics", 
+            "numericValue": 1.0, 
             "score": null, 
             "scoreDisplayMode": "informative", 
             "title": "Diagnostics"
@@ -536,6 +538,7 @@
             }, 
             "displayValue": "31 elements", 
             "id": "dom-size", 
+            "numericValue": 31.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Avoids an excessive DOM size"
@@ -562,6 +565,7 @@
                 "type": "opportunity"
             }, 
             "id": "efficient-animated-content", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Use video formats for animated content"
@@ -611,6 +615,7 @@
                 "type": "table"
             }, 
             "id": "errors-in-console", 
+            "numericValue": 5.0, 
             "score": 0.0, 
             "scoreDisplayMode": "binary", 
             "title": "Browser errors were logged to the console"
@@ -619,6 +624,7 @@
             "description": "Estimated Input Latency is an estimate of how long your app takes to respond to user input, in milliseconds, during the busiest 5s window of page load. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency).", 
             "displayValue": "20\u00a0ms", 
             "id": "estimated-input-latency", 
+            "numericValue": 16.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Estimated Input Latency"
@@ -688,6 +694,7 @@
             "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).", 
             "displayValue": "4.0\u00a0s", 
             "id": "first-contentful-paint", 
+            "numericValue": 3969.135, 
             "score": 0.51, 
             "scoreDisplayMode": "numeric", 
             "title": "First Contentful Paint"
@@ -696,6 +703,7 @@
             "description": "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-interactive).", 
             "displayValue": "4.9\u00a0s", 
             "id": "first-cpu-idle", 
+            "numericValue": 4927.278, 
             "score": 0.72, 
             "scoreDisplayMode": "numeric", 
             "title": "First CPU Idle"
@@ -704,6 +712,7 @@
             "description": "First Meaningful Paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint).", 
             "displayValue": "4.0\u00a0s", 
             "id": "first-meaningful-paint", 
+            "numericValue": 3969.136, 
             "score": 0.51, 
             "scoreDisplayMode": "numeric", 
             "title": "First Meaningful Paint"
@@ -1020,6 +1029,7 @@
             "description": "Time to interactive is the amount of time it takes for the page to become fully interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive).", 
             "displayValue": "4.9\u00a0s", 
             "id": "interactive", 
+            "numericValue": 4927.278, 
             "score": 0.78, 
             "scoreDisplayMode": "numeric", 
             "title": "Time to Interactive"
@@ -1240,6 +1250,7 @@
         "load-fast-enough-for-pwa": {
             "description": "A fast page load over a cellular network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g).", 
             "id": "load-fast-enough-for-pwa", 
+            "numericValue": 4927.278, 
             "score": 1.0, 
             "scoreDisplayMode": "binary", 
             "title": "Page load is fast enough on mobile networks"
@@ -1337,6 +1348,7 @@
                 "type": "table"
             }, 
             "id": "main-thread-tasks", 
+            "numericValue": 16.0, 
             "score": null, 
             "scoreDisplayMode": "informative", 
             "title": "Tasks"
@@ -1398,6 +1410,7 @@
             }, 
             "displayValue": "1.5\u00a0s", 
             "id": "mainthread-work-breakdown", 
+            "numericValue": 1548.5690000000002, 
             "score": 0.96, 
             "scoreDisplayMode": "numeric", 
             "title": "Minimizes main-thread work"
@@ -1413,6 +1426,7 @@
             "description": "The potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task.", 
             "displayValue": "120\u00a0ms", 
             "id": "max-potential-fid", 
+            "numericValue": 122.537, 
             "score": 0.92, 
             "scoreDisplayMode": "numeric", 
             "title": "Max Potential FID"
@@ -1484,6 +1498,7 @@
                 "type": "debugdata"
             }, 
             "id": "metrics", 
+            "numericValue": 4927.278, 
             "score": null, 
             "scoreDisplayMode": "informative", 
             "title": "Metrics"
@@ -1724,6 +1739,7 @@
                 "type": "table"
             }, 
             "id": "network-requests", 
+            "numericValue": 18.0, 
             "score": null, 
             "scoreDisplayMode": "informative", 
             "title": "Network Requests"
@@ -1758,6 +1774,7 @@
             }, 
             "displayValue": "0\u00a0ms", 
             "id": "network-rtt", 
+            "numericValue": 1.7249999999999943, 
             "score": null, 
             "scoreDisplayMode": "informative", 
             "title": "Network Round Trip Times"
@@ -1792,6 +1809,7 @@
             }, 
             "displayValue": "570\u00a0ms", 
             "id": "network-server-latency", 
+            "numericValue": 572.829, 
             "score": null, 
             "scoreDisplayMode": "informative", 
             "title": "Server Backend Latencies"
@@ -1974,6 +1992,7 @@
                 "type": "opportunity"
             }, 
             "id": "offscreen-images", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Defer offscreen images", 
@@ -2052,6 +2071,7 @@
                 "type": "opportunity"
             }, 
             "id": "redirects", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Avoid multiple page redirects"
@@ -2115,6 +2135,7 @@
             }, 
             "displayValue": "Potential savings of 1,130\u00a0ms", 
             "id": "render-blocking-resources", 
+            "numericValue": 1129.0, 
             "score": 0.46, 
             "scoreDisplayMode": "numeric", 
             "title": "Eliminate render-blocking resources"
@@ -2200,6 +2221,7 @@
             "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index).", 
             "displayValue": "4.4\u00a0s", 
             "id": "speed-index", 
+            "numericValue": 4417.0, 
             "score": 0.74, 
             "scoreDisplayMode": "numeric", 
             "title": "Speed Index"
@@ -2297,6 +2319,7 @@
             }, 
             "displayValue": "Root document took 570\u00a0ms", 
             "id": "time-to-first-byte", 
+            "numericValue": 570.5630000000001, 
             "score": 1.0, 
             "scoreDisplayMode": "binary", 
             "title": "Server response times are low (TTFB)"
@@ -2362,6 +2385,7 @@
             }, 
             "displayValue": "Total size was 157\u00a0KB", 
             "id": "total-byte-weight", 
+            "numericValue": 160738.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Avoids enormous network payloads"
@@ -2376,6 +2400,7 @@
                 "type": "opportunity"
             }, 
             "id": "unminified-css", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Minify CSS"
@@ -2414,6 +2439,7 @@
             }, 
             "displayValue": "Potential savings of 30\u00a0KB", 
             "id": "unminified-javascript", 
+            "numericValue": 150.0, 
             "score": 0.88, 
             "scoreDisplayMode": "numeric", 
             "title": "Minify JavaScript", 
@@ -2429,6 +2455,7 @@
                 "type": "opportunity"
             }, 
             "id": "unused-css-rules", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Remove unused CSS"
@@ -2646,6 +2673,7 @@
             }, 
             "displayValue": "11 resources found", 
             "id": "uses-long-cache-ttl", 
+            "numericValue": 103455.0, 
             "score": 0.58, 
             "scoreDisplayMode": "numeric", 
             "title": "Serve static assets with an efficient cache policy"
@@ -2660,6 +2688,7 @@
                 "type": "opportunity"
             }, 
             "id": "uses-optimized-images", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Efficiently encode images", 
@@ -2710,6 +2739,7 @@
                 "type": "opportunity"
             }, 
             "id": "uses-rel-preconnect", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Preconnect to required origins", 
@@ -2724,6 +2754,7 @@
                 "type": "opportunity"
             }, 
             "id": "uses-rel-preload", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Preload key requests"
@@ -2738,6 +2769,7 @@
                 "type": "opportunity"
             }, 
             "id": "uses-responsive-images", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Properly size images", 
@@ -2781,6 +2813,7 @@
             }, 
             "displayValue": "Potential savings of 63\u00a0KB", 
             "id": "uses-text-compression", 
+            "numericValue": 300.0, 
             "score": 0.75, 
             "scoreDisplayMode": "numeric", 
             "title": "Enable text compression"
@@ -2824,6 +2857,7 @@
             }, 
             "displayValue": "Potential savings of 9\u00a0KB", 
             "id": "uses-webp-images", 
+            "numericValue": 0.0, 
             "score": 1.0, 
             "scoreDisplayMode": "numeric", 
             "title": "Serve images in next-gen formats", 

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -113,7 +113,7 @@ declare global {
       /** A more detailed description that describes why the audit is important and links to Lighthouse documentation on the audit; markdown links supported. */
       description: string;
       /** A numeric value that has a meaning specific to the audit, e.g. the number of nodes in the DOM or the timestamp of a specific load event. More information can be found in the audit details, if present. */
-      rawValue?: number;
+      numericValue?: number;
       /** Extra information about the page provided by some types of audits, in one of several possible forms that can be rendered in the HTML report. */
       details?: Audit.Details;
     }


### PR DESCRIPTION
part 2 of apparently 3 for #6199

Following #8343, this now renames the public `rawValue` on `LH.Audit.Result` to `numericValue`. We have very few places we rely on this except the smoke tests, so it's an easy change and a better place to bikeshed on `numericValue` and the public interface than the next PR :)

The last PR will be renaming the variable internal to audits/audit tests.