### PR TITLE
clients(devtools): escape assets based on filetype

### DIFF
--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -23,8 +23,20 @@ const htmlReportAssets = require('../lighthouse-core/report/html/html-report-ass
  */
 function convertToAsciiAndWriteFile(name, content) {
   assert(content);
+
+  /** @type {string} */
+  let prefix;
+  if (name.endsWith('.html')) {
+    // This will not support unicode characters in inline stylesheets or js.
+    prefix = '&#x';
+  } else if (name.endsWith('.css')) {
+    prefix = '\\';
+  } else {
+    prefix = '\\\\u';
+  }
+
   // eslint-disable-next-line no-control-regex
-  const escaped = content.replace(/[^\x00-\x7F]/g, c => '\\\\u' + c.charCodeAt(0).toString(16));
+  const escaped = content.replace(/[^\x00-\x7F]/g, c => prefix + c.charCodeAt(0).toString(16));
   fs.writeFileSync(`${distDir}/${name}`, escaped);
 }
 

--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -18,21 +18,22 @@ const htmlReportAssets = require('../lighthouse-core/report/html/html-report-ass
 
 /**
  * Used to save cached resources (Runtime.cachedResources). Content must be converted to ascii.
+ * TODO(#8525): potentially remove this.
  * @param {string} name
  * @param {string} content
  */
 function convertToAsciiAndWriteFile(name, content) {
   assert(content);
 
-  /** @type {string} */
-  let unicodeEscapePrefix;
+  let unicodeEscapePrefix = '\\\\u'; // js
   if (name.endsWith('.html')) {
-    // This will not support unicode characters in inline stylesheets or js.
-    unicodeEscapePrefix = '&#x';
+    // Can't support unicode characters in inline stylesheets or js, would have to parse
+    // and apply context-specific escapes. Instead, since no ascii is used in html yet,
+    // punt and throw if any ascii is found.
+    // eslint-disable-next-line no-control-regex
+    assert(!content.match(/[^\x00-\x7F]/));
   } else if (name.endsWith('.css')) {
     unicodeEscapePrefix = '\\';
-  } else {
-    unicodeEscapePrefix = '\\\\u';
   }
 
   const escaped =

--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -25,18 +25,19 @@ function convertToAsciiAndWriteFile(name, content) {
   assert(content);
 
   /** @type {string} */
-  let prefix;
+  let unicodeEscapePrefix;
   if (name.endsWith('.html')) {
     // This will not support unicode characters in inline stylesheets or js.
-    prefix = '&#x';
+    unicodeEscapePrefix = '&#x';
   } else if (name.endsWith('.css')) {
-    prefix = '\\';
+    unicodeEscapePrefix = '\\';
   } else {
-    prefix = '\\\\u';
+    unicodeEscapePrefix = '\\\\u';
   }
 
-  // eslint-disable-next-line no-control-regex
-  const escaped = content.replace(/[^\x00-\x7F]/g, c => prefix + c.charCodeAt(0).toString(16));
+  const escaped =
+    // eslint-disable-next-line no-control-regex
+    content.replace(/[^\x00-\x7F]/g, c => unicodeEscapePrefix + c.charCodeAt(0).toString(16));
   fs.writeFileSync(`${distDir}/${name}`, escaped);
 }
 

--- a/build/build-dt-report-resources.js
+++ b/build/build-dt-report-resources.js
@@ -18,7 +18,6 @@ const htmlReportAssets = require('../lighthouse-core/report/html/html-report-ass
 
 /**
  * Used to save cached resources (Runtime.cachedResources). Content must be converted to ascii.
- * TODO(#8525): potentially remove this.
  * @param {string} name
  * @param {string} content
  */


### PR DESCRIPTION
Was tripped up by https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/report/html/report-styles.css#L738