### PR TITLE
report(tables): change table layout to fixed to ensure proper display…

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -987,6 +987,7 @@
 .lh-table {
   --image-preview-size: 24px;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 .lh-table thead {


### PR DESCRIPTION
Change table layout to fixed to ensure proper display of all columns

**Summary**
This is a fix for layout bug in the generated report. Currently when the number of characters in the URLs exceed the allowed space it results in a display that looks like this:

![image](https://user-images.githubusercontent.com/87611/56506402-aef18980-651e-11e9-9441-a4685a1c01e1.png)

As you can see, the information for "Potential Savings (KB)" is pushed and cannot be displayed. Fixing that by changing the table layout to `fixed` fix the issue.

![image](https://user-images.githubusercontent.com/87611/56506485-e6f8cc80-651e-11e9-8903-4ab81438fd0d.png)
