### PR TITLE
report: use border-box for psuedoelements

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -202,7 +202,7 @@
   100% { opacity: 0.6;}
 }
 
-.lh-root * {
+.lh-root *, .lh-root *::before, .lh-root *::after {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
**Summary**
Super minor fix for error state icon in metrics. It's not in our fixtures so here's the before/after.

**Before**
![image](https://user-images.githubusercontent.com/2301202/56536358-7902d400-6523-11e9-861b-5b5587fa4101.png)


**After**
![image](https://user-images.githubusercontent.com/2301202/56536340-6d171200-6523-11e9-85cd-2ab4331a4316.png)
