### PR TITLE
misc: handle connection errors even before the timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
   # see comment above about puppeteer
   - export CHROME_PATH="$(which google-chrome-stable)"
   - sh -e /etc/init.d/xvfb start
+  - google-chrome-stable --version
   - yarn build-all
 script:
   - yarn bundlesize


### PR DESCRIPTION
**Summary**
Should fix travis and give us better error messages when Chrome crashes unexpectedly.

Previously we only handled connection errors after we reached our timeout when we should be handling them as soon as we try to connect in case Chrome crashes unexpectedly.

**Related Issues/PRs**
#7534 
