### PR TITLE
core: fix sample_v2 generation, proto errors

### DIFF
--- a/lighthouse-core/scripts/update-report-fixtures.js
+++ b/lighthouse-core/scripts/update-report-fixtures.js
@@ -25,7 +25,12 @@ async function update() {
   }));
 
   const url = `http://localhost:${port}/dobetterweb/dbw_tester.html`;
-  const flags = cliFlags.getFlags(`--gather-mode=lighthouse-core/test/results/artifacts ${url}`);
+  const rawFlags = [
+    '--gather-mode=lighthouse-core/test/results/artifacts',
+    '--throttling-method=devtools',
+    url,
+  ].join(' ');
+  const flags = cliFlags.getFlags(rawFlags);
   await cli.runLighthouse(url, flags, undefined);
   await new Promise(res => server.close(res));
 }

--- a/lighthouse-core/test/report/proto-test.js
+++ b/lighthouse-core/test/report/proto-test.js
@@ -45,11 +45,18 @@ describe('round trip JSON comparison subsets', () => {
   });
 
   it('has the same top level values', () => {
+    // Don't test all top level properties that are objects.
     Object.keys(sampleJson).forEach(audit => {
       if (typeof sampleJson[audit] === 'object' && !Array.isArray(sampleJson[audit])) {
         delete sampleJson[audit];
       }
     });
+
+    // Properties set to their type's default value will be omitted in the roundTripJson.
+    // For an explicit list of properties, remove sampleJson values if set to a default.
+    if (Array.isArray(sampleJson.stackPacks) && sampleJson.stackPacks.length === 0) {
+      delete sampleJson.stackPacks;
+    }
 
     expect(roundTripJson).toMatchObject(sampleJson);
   });

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "type-check": "tsc -p . && tsc -p lighthouse-viewer/",
     "i18n:checks": "./lighthouse-core/scripts/i18n/assert-strings-collected.sh",
     "i18n:collect-strings": "node lighthouse-core/scripts/i18n/collect-strings.js",
-    "update:sample-artifacts": "node lighthouse-core/scripts/update-report-fixtures.js -G",
+    "update:sample-artifacts": "node lighthouse-core/scripts/update-report-fixtures.js",
     "update:sample-json": "yarn i18n:collect-strings && node ./lighthouse-cli -A=./lighthouse-core/test/results/artifacts --throttling-method=devtools --output=json --output-path=./lighthouse-core/test/results/sample_v2.json && node lighthouse-core/scripts/cleanup-LHR-for-diff.js ./lighthouse-core/test/results/sample_v2.json --only-remove-timing && yarn compile-proto && yarn build-proto-roundtrip",
     "diff:sample-json": "yarn i18n:checks && bash lighthouse-core/scripts/assert-golden-lhr-unchanged.sh",
     "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -161,6 +161,9 @@ message LighthouseResult {
       string entry_type = 2;
       google.protobuf.DoubleValue start_time = 3;
       google.protobuf.DoubleValue duration = 4;
+
+      // Whether timing entry was collected during artifact gathering.
+      bool gather = 5;
     }
 
     // The total duration of Lighthouse's run

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -3653,11 +3653,10 @@
             "warningAuditsGroupTitle": "Passed audits but with warnings", 
             "warningHeader": "Warnings: "
         }
-    },
+    }, 
     "lighthouseVersion": "4.3.0", 
     "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html", 
-    "runWarnings": [],
-    "stackPacks": [],
+    "runWarnings": [], 
     "timing": {
         "entries": [
             {

--- a/types/lhr.d.ts
+++ b/types/lhr.d.ts
@@ -61,7 +61,7 @@ declare global {
       /** The record of all formatted string locations in the LHR and their corresponding source values. */
       i18n: {rendererFormattedStrings: I18NRendererStrings, icuMessagePaths: I18NMessages};
       /** An array containing the result of all stack packs. */
-      stackPacks: Result.StackPack[];
+      stackPacks?: Result.StackPack[];
     }
 
     // Result namespace


### PR DESCRIPTION
recently we (I) have asked a few PRs to update a subset of example artifacts and then `sample_v2.json`. However if you try to run `yarn update:sample-artifacts` and then `yarn update:sample-json`, you'll notice there are a few errors preventing you from actually doing that :)

This PR
- fixes the `throttling-method` mismatch between the `-G` and the `-A` by switching `-G` to `devtools` to match `-A`
- adds the optional `gather` boolean to the proto `Timing` entry interface so that gatherer entries, when reimported with `-A`, will still result in a proto-able LHR at the end.

  I'm not sure how often that will come up in practice for PSI, but it's possible, and with `false`/`undefined` as the default, it's zero overhead when there are no `gather` props (as there aren't in the current `sample_v2.json` because the source artifacts have `Timing: []`)
- makes `lhr.stackPacks` optional, matching the proto's treatment of them as a `repeated` field. This is probably the easiest resolution to #8245 (and solves #8598 for stack packs automatically :), and now folks won't have to keep manually adding that back.

cc @exterkamp 

fixes #8245