### PR TITLE
misc: simplify LH.Config settings types

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -495,7 +495,7 @@ class Config {
   }
 
   /**
-   * @param {LH.Config.SettingsJson=} settingsJson
+   * @param {LH.SharedFlagsSettings=} settingsJson
    * @param {LH.Flags=} flags
    * @return {LH.Config.Settings}
    */

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -15,16 +15,12 @@ declare global {
        */
       export interface Json {
         extends?: 'lighthouse:default' | 'lighthouse:full' | string | boolean;
-        settings?: SettingsJson;
+        settings?: SharedFlagsSettings;
         passes?: PassJson[] | null;
         audits?: Config.AuditJson[] | null;
         categories?: Record<string, CategoryJson> | null;
         groups?: Record<string, Config.GroupJson> | null;
         plugins?: Array<string>,
-      }
-
-      export interface SettingsJson extends SharedFlagsSettings {
-        extraHeaders?: Crdp.Network.Headers | null;
       }
 
       export interface PassJson {
@@ -80,7 +76,7 @@ declare global {
         group?: string;
       }
 
-      export interface Settings extends Required<SettingsJson> {
+      export interface Settings extends Required<SharedFlagsSettings> {
         throttling: Required<ThrottlingSettings>;
       }
 


### PR DESCRIPTION
We missed this simplification while doing the flags/settings unification stuff.

We needed `extraHeaders` to be a more specific type for configJson settings at some point, but it's now the same type as on the base `SharedFlagsSettings`, so `LH.Config.Json['settings']` can just be `SharedFlagsSettings`, as you'd pretty much expect.