### PR TITLE
report: augment auditRef, not result, with stackPack ref

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -81,8 +81,8 @@ class CategoryRenderer {
     this.dom.find('.lh-audit__description', auditEl)
         .appendChild(this.dom.convertMarkdownLinkSnippets(audit.result.description));
 
-    if (audit.result.stackPacks) {
-      audit.result.stackPacks.forEach(pack => {
+    if (audit.stackPacks) {
+      audit.stackPacks.forEach(pack => {
         const packElm = this.dom.createElement('div');
         packElm.classList.add('lh-audit__stackpack');
 

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -72,21 +72,21 @@ class Util {
       }
     }
 
-    // For convenience, smoosh all AuditResults into their auditDfn (which has just weight & group)
+    // For convenience, smoosh all AuditResults into their auditRef (which has just weight & group)
     for (const category of clone.reportCategories) {
-      category.auditRefs.forEach(auditMeta => {
-        const result = clone.audits[auditMeta.id];
-        auditMeta.result = result;
+      category.auditRefs.forEach(auditRef => {
+        const result = clone.audits[auditRef.id];
+        auditRef.result = result;
 
         // attach the stackpacks to the auditRef object
         if (clone.stackPacks) {
           clone.stackPacks.forEach(pack => {
-            if (pack.descriptions[auditMeta.id]) {
-              auditMeta.result.stackPacks = auditMeta.result.stackPacks || [];
-              auditMeta.result.stackPacks.push({
+            if (pack.descriptions[auditRef.id]) {
+              auditRef.stackPacks = auditRef.stackPacks || [];
+              auditRef.stackPacks.push({
                 title: pack.title,
                 iconDataURL: pack.iconDataURL,
-                description: pack.descriptions[auditMeta.id],
+                description: pack.descriptions[auditRef.id],
               });
             }
           });

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -154,5 +154,31 @@ describe('util helpers', () => {
       const preparedResult = Util.prepareReportResult(clonedSampleResult);
       assert.deepStrictEqual(preparedResult.audits, sampleResult.audits);
     });
+
+    it('appends stack pack descriptions to auditRefs', () => {
+      const clonedSampleResult = JSON.parse(JSON.stringify(sampleResult));
+      const iconDataURL = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"%3E%3C/svg%3E';
+      clonedSampleResult.stackPacks = [{
+        id: 'snackpack',
+        title: 'SnackPack',
+        iconDataURL,
+        descriptions: {
+          'unused-css-rules': 'Consider using snacks in packs.',
+        },
+      }];
+      const preparedResult = Util.prepareReportResult(clonedSampleResult);
+
+      const perfAuditRefs = preparedResult.categories.performance.auditRefs;
+      const unusedCssRef = perfAuditRefs.find(ref => ref.id === 'unused-css-rules');
+      assert.deepStrictEqual(unusedCssRef.stackPacks, [{
+        title: 'SnackPack',
+        iconDataURL,
+        description: 'Consider using snacks in packs.',
+      }]);
+
+      // No stack pack on audit wth no stack pack.
+      const interactiveRef = perfAuditRefs.find(ref => ref.id === 'interactive');
+      assert.strictEqual(interactiveRef.stackPacks, undefined);
+    });
   });
 });

--- a/types/html-renderer.d.ts
+++ b/types/html-renderer.d.ts
@@ -59,7 +59,8 @@ declare global {
       }
 
       export interface AuditRef extends Result.AuditRef {
-        result: Audit.Result & { stackPacks?: StackPackDescription[] }
+        result: Audit.Result;
+        stackPacks?: StackPackDescription[];
       }
 
       export interface StackPackDescription {


### PR DESCRIPTION
Not sure if I can convince everyone we should make this change :) Note that it's contained entirely within the report renderer, so there will be no effect on core, PSI, etc.

In `prepareReportResult` we smoosh a few things to make report rendering easier, like writing a `LH.Audit.Result` to the relevant `LH.Result.AuditRef` and, most recently, writing `LH.ReportResult.StackPackDescription` to the relevant `LH.Audit.Result`.

This PR makes it so *both* `LH.Audit.Result` and `LH.ReportResult.StackPackDescription` are written to the auditRef.

On the con side: it makes a certain amount of sense to match stack packs to auditResults as they have a 1:1 match, while there may be multiple auditRefs to a single audit (and thus a stack pack).

*However*:
- we should be minimizing and isolating the amount of smooshing we do, both for the sake of "purity" and to reduce confusion in the codebase between almost but not quite identical types like the audit results.
- this comes up in a few places in our tests where we formerly could assume that audit results were audit results, but now we have to add special cases to handle these mutant objects. See for example the deleting [needed to make this PR work](https://github.com/GoogleChrome/lighthouse/pull/8536/files#diff-e5c26900a42826b945adef39d538f9ddR157). Ideally we wouldn't have to do that
- the only place we render these we're looping over auditRefs anyway, so we don't save any ease of use either way :)

The solution in this PR keeps modifications contained within `LH.ReportResult.AuditRef` and makes that deletion in #8536 unnecessary.

(@exterkamp if we land this you won't need any of your changes to `util-test.js`)