### PR TITLE
feat(lightwallet): add resource-summary & resource-budget audits

### DIFF
--- a/lighthouse-core/audits/resource-budget.js
+++ b/lighthouse-core/audits/resource-budget.js
@@ -1,0 +1,185 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Audit = require('./audit');
+const NetworkRecords = require('../computed/network-records.js');
+const ComputedResourceSummary = require('../computed/resource-summary.js');
+const i18n = require('../lib/i18n/i18n.js');
+const MainResource = require('../computed/main-resource.js');
+const Budget = require('../config/budget.js');
+
+const UIStrings = {
+  /** Imperative title of a Lighthouse audit that tells the user to minimize the size and quantity of resources used to load the page. */
+  title: 'Keep request counts and file sizes small',
+  /** Description of a Lighthouse audit that tells the user that they can setup a budgets for the quantity and size of page resources. No character length limits. */
+  description: 'To set budgets for the quantity and size of page resources,' +
+    ' add a budget.json file.',
+  /** [ICU Syntax] Label identifying the number of requests*/
+  requestCount: `{count, plural,
+    =1 {1 request}
+    other {# requests}
+   }`,
+  totalResourceType: 'Total',
+  /** Label for the 'Document' resource type. */
+  documentResourceType: 'Document',
+  /** Label for the 'script' resource type. */
+  scriptResourceType: 'Script',
+  /** Label for the 'stylesheet' resource type. */
+  stylesheetResourceType: 'Stylesheet',
+  /** Label for the 'image' resource type. */
+  imageResourceType: 'Image',
+  /** Label for the 'media' resource type. */
+  mediaResourceType: 'Media',
+  /** Label for the 'font' resource type. */
+  fontResourceType: 'Font',
+  /** Label for the 'other' resource type. */
+  otherResourceType: 'Other',
+  /** Label for the 'third-party' resource type. */
+  thirdPartyResourceType: 'Third-party',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+class ResourceBudget extends Audit {
+  /**
+     * @return {LH.Audit.Meta}
+     */
+  static get meta() {
+    return {
+      id: 'resource-budget',
+      title: str_(UIStrings.title),
+      description: str_(UIStrings.description),
+      scoreDisplayMode: Audit.SCORING_MODES.INFORMATIVE,
+      requiredArtifacts: ['devtoolsLogs'],
+    };
+  }
+
+  /**
+ * @param {Array<LH.Budget.ResourceBudget>|undefined} budget
+ * @param {number} measurement
+ * @param {string} resourceType
+ * @return {number|undefined}
+ */
+  static overBudgetAmount(budget, measurement, resourceType) {
+    if (budget === undefined) {
+      return undefined;
+    }
+    const resourceBudget = budget.find((b) => b.resourceType === resourceType);
+    if (resourceBudget === undefined) {
+      return undefined;
+    }
+    const overBudget = measurement - resourceBudget.budget;
+    return overBudget > 0 ? overBudget : undefined;
+  }
+
+  /**
+ * @param {LH.Budget | undefined} budget
+ * @return {LH.Audit.Details.Table['headings']}
+ */
+  static tableHeadings(budget) {
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const headers = [
+      {key: 'label', itemType: 'text', text: 'Resource Type'},
+      {key: 'count', itemType: 'numeric', text: 'Requests'},
+      {key: 'size', itemType: 'bytes', text: 'File Size'},
+    ];
+
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const budgetHeaders = [
+      {key: 'countOverBudget', itemType: 'text', text: ''},
+      {key: 'sizeOverBudget', itemType: 'bytes', text: 'Over Budget'},
+    ];
+    return budget ? headers.concat(budgetHeaders) : headers;
+  }
+
+  /**
+* @param {{resourceType: string, count: number, size: number}} row
+* @param {LH.Budget | undefined} budget
+* @return {boolean}
+*/
+  static shouldIncludeRow(row, budget) {
+    if (budget === undefined) {
+      return true;
+    } else {
+      const budgets = (budget.resourceCounts || []).concat(budget.resourceSizes || []);
+      return !!budgets.find((b) => {
+        return b.resourceType === row.resourceType;
+      });
+    }
+  }
+
+  /**
+* @param {LH.Budget|undefined} budget
+* @param {Object<string,{resourceType: string, count: number, size: number}>} summary
+* @return {Array<{label: string, count: number, size: number, countOverBudget?: string|undefined, sizeOverBudget?: number|undefined}>}
+*/
+  static tableItems(budget, summary) {
+    /** @type {Object<string,string>} */
+    const strMappings = {
+      'total': str_(UIStrings.totalResourceType),
+      'document': str_(UIStrings.documentResourceType),
+      'script': str_(UIStrings.scriptResourceType),
+      'stylesheet': str_(UIStrings.stylesheetResourceType),
+      'image': str_(UIStrings.imageResourceType),
+      'media': str_(UIStrings.mediaResourceType),
+      'font': str_(UIStrings.fontResourceType),
+      'other': str_(UIStrings.otherResourceType),
+      'third-party': str_(UIStrings.thirdPartyResourceType),
+    };
+
+    /** @type {Array<{label: string, count: number, size: number, countOverBudget?: string|undefined, sizeOverBudget?: number|undefined}>}*/
+    return Object.values(summary).filter((row) => {
+      return this.shouldIncludeRow(row, budget);
+    }).map((row) => {
+      const type = row.resourceType;
+
+      const overCount = this.overBudgetAmount(budget && budget.resourceCounts, row.count, type);
+      const overSize = this.overBudgetAmount(budget && budget.resourceSizes, row.size, type);
+
+      return {
+        label: strMappings[type],
+        count: row.count,
+        size: row.size,
+        countOverBudget: overCount !== undefined ?
+          str_(UIStrings.requestCount, {count: overCount}) : undefined,
+        sizeOverBudget: overSize,
+      };
+    }).sort((a, b) => {
+      const overBudgetComparison = (b.sizeOverBudget || 0) - (a.sizeOverBudget || 0);
+      const sizeComparison = b.size - a.size;
+      return budget ? overBudgetComparison : sizeComparison;
+    });
+  }
+
+  /**
+     * @param {LH.Artifacts} artifacts
+     * @param {LH.Audit.Context} context
+     * @return {Promise<LH.Audit.Product>}
+     */
+  static async audit(artifacts, context) {
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
+    const mainResource = await (MainResource.request({devtoolsLog, URL: artifacts.URL}, context));
+
+    /** @type{LH.Budget | undefined} */
+    const budget = (context.settings.budgets || []).reverse().find((budget) => {
+      return Budget.urlMatchesPattern(mainResource.url, budget.path);
+    });
+    const resourceSummary = ComputedResourceSummary.summarize(networkRecords, mainResource.url);
+
+    const headings = ResourceBudget.tableHeadings(budget);
+    const tableItems = ResourceBudget.tableItems(budget, resourceSummary);
+
+    return {
+      details: Audit.makeTableDetails(headings, tableItems),
+      score: 1,
+    };
+  }
+}
+
+module.exports = ResourceBudget;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/audits/resource-summary.js
+++ b/lighthouse-core/audits/resource-summary.js
@@ -1,0 +1,115 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Audit = require('./audit');
+const NetworkRecords = require('../computed/network-records.js');
+const ComputedResourceSummary = require('../computed/resource-summary.js');
+const i18n = require('../lib/i18n/i18n.js');
+const MainResource = require('../computed/main-resource.js');
+
+const UIStrings = {
+  /** Imperative title of a Lighthouse audit that tells the user to minimize the size and quantity of resources used to load the page. */
+  title: 'Keep request counts and file sizes small',
+  /** Description of a Lighthouse audit that tells the user that they can setup a budgets for the quantity and size of page resources. No character length limits. */
+  description: 'To set budgets for the quantity and size of page resources,' +
+    ' add a budget.json file.',
+  /** [ICU Syntax] Label for an audit identifying the number of requests and kilobytes used to load the page. */
+  displayValue: `{requestCount, plural, =1 {1 request} other {# requests}}` +
+    ` • { byteCount, number, bytes } KB`,
+  /** Label for the combination of all resources on the page. */
+  totalResourceType: 'Total',
+  /** Label for the 'Document' resource type. */
+  documentResourceType: 'Document',
+  /** Label for the 'script' resource type. */
+  scriptResourceType: 'Script',
+  /** Label for the 'stylesheet' resource type. */
+  stylesheetResourceType: 'Stylesheet',
+  /** Label for the 'image' resource type. */
+  imageResourceType: 'Image',
+  /** Label for the 'media' resource type. */
+  mediaResourceType: 'Media',
+  /** Label for the 'font' resource type. */
+  fontResourceType: 'Font',
+  /** Label for the 'other' resource type. */
+  otherResourceType: 'Other',
+  /** Label for the 'third-party' resource type. */
+  thirdPartyResourceType: 'Third-party',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+class ResourceSummary extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'resource-summary',
+      title: str_(UIStrings.title),
+      description: str_(UIStrings.description),
+      scoreDisplayMode: Audit.SCORING_MODES.INFORMATIVE,
+      requiredArtifacts: ['devtoolsLogs'],
+    };
+  }
+
+  /**
+    * @param {LH.Artifacts} artifacts
+    * @param {LH.Audit.Context} context
+    * @return {Promise<LH.Audit.Product>}
+    */
+  static async audit(artifacts, context) {
+    /** @type {Object<string,string>} */
+    const strMappings = {
+      'total': str_(UIStrings.totalResourceType),
+      'document': str_(UIStrings.documentResourceType),
+      'script': str_(UIStrings.scriptResourceType),
+      'stylesheet': str_(UIStrings.stylesheetResourceType),
+      'image': str_(UIStrings.imageResourceType),
+      'media': str_(UIStrings.mediaResourceType),
+      'font': str_(UIStrings.fontResourceType),
+      'other': str_(UIStrings.otherResourceType),
+      'third-party': str_(UIStrings.thirdPartyResourceType),
+    };
+
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
+    const mainResource = await (MainResource.request({devtoolsLog, URL: artifacts.URL}, context));
+    const resourceSummary = ComputedResourceSummary.summarize(networkRecords, mainResource.url);
+
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const headings = [
+      {key: 'label', itemType: 'text', text: 'Resource Type'},
+      {key: 'count', itemType: 'numeric', text: 'Requests'},
+      {key: 'size', itemType: 'bytes', text: 'File Size'},
+    ];
+
+    const tableContents = Object.values(resourceSummary).map((resource) => {
+      return {
+        resourceType: resource.resourceType,
+        label: strMappings[resource.resourceType],
+        count: resource.count,
+        size: resource.size,
+      };
+    }).sort((a, b) => {
+      return b.size - a.size;
+    });
+
+    const tableDetails = Audit.makeTableDetails(headings, tableContents);
+
+    return {
+      details: tableDetails,
+      score: 1,
+      displayValue: str_(UIStrings.displayValue, {
+        requestCount: resourceSummary.total.count,
+        byteCount: resourceSummary.total.size,
+      }),
+    };
+  }
+}
+
+module.exports = ResourceSummary;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/computed/resource-summary.js
+++ b/lighthouse-core/computed/resource-summary.js
@@ -1,0 +1,78 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const makeComputedArtifact = require('./computed-artifact.js');
+const NetworkRecords = require('./network-records.js');
+const MainResource = require('./main-resource.js');
+const URL = require('../lib/url-shim');
+const Budget = require('../config/budget.js');
+
+class ResourceSummary {
+  /**
+   * @param {LH.Artifacts.NetworkRequest} record
+   * @return string
+   */
+  static determineResourceType(record) {
+    switch (record.resourceType) {
+      case 'Stylesheet':
+      case 'Image':
+      case 'Media':
+      case 'Font':
+      case 'Script':
+      case 'Document':
+        // budget.json uses lowercase for resource types
+        return record.resourceType.toLowerCase();
+      default:
+        return 'other';
+    }
+  }
+
+  /**
+   * @param {Array<LH.Artifacts.NetworkRequest>} networkRecords
+   * @param {string} mainResourceURL
+   * @return {Object<string,{resourceType: string, count: number, size: number}>}
+   */
+  static summarize(networkRecords, mainResourceURL) {
+    /** @type {Object<string,{resourceType: string, count: number, size: number}>} */
+    const map = {};
+
+    Budget.validResourceTypes().forEach(type => {
+      map[type] = {count: 0, size: 0, resourceType: type};
+    });
+
+    for (const record of networkRecords) {
+      const type = this.determineResourceType(record);
+      map[type].count = map[type].count + 1;
+      map[type].size = map[type].size + record.transferSize;
+
+      map.total.count = map.total.count + 1;
+      map.total.size = map.total.size + record.transferSize;
+
+      if (!URL.rootDomainsMatch(record.url, mainResourceURL)) {
+        map['third-party'].count = map['third-party'].count + 1;
+        map['third-party'].size = map['third-party'].size + record.transferSize;
+      }
+    }
+    return map;
+  }
+
+  /**
+   * @param {{URL: LH.Artifacts['URL'], devtoolsLog: LH.DevtoolsLog}} data
+   * @param {LH.Audit.Context} context
+   * @return {Promise<Object<string,{resourceType: string, count: number, size: number}>>}
+   */
+  static async compute_(data, context) {
+    const [networkRecords, mainResource] = await Promise.all([
+      NetworkRecords.request(data.devtoolsLog, context),
+      MainResource.request(data, context),
+    ]);
+
+    return ResourceSummary.summarize(networkRecords, mainResource.url);
+  }
+}
+
+module.exports = makeComputedArtifact(ResourceSummary);

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -13,6 +13,10 @@ const i18n = require('../lib/i18n/i18n.js');
 const UIStrings = {
   /** Title of the Performance category of audits. Equivalent to 'Web performance', this term is inclusive of all web page speed and loading optimization topics. Also used as a label of a score gauge; try to limit to 20 characters. */
   performanceCategoryTitle: 'Performance',
+  /** Title of the Budgets section of the Performance Category. 'Budgets' refers to a budget (like a financial budget), but applied to the amount of resources on a page, rather than money. */
+  budgetsGroupTitle: 'Budgets',
+  /** Description of the Budgets section of the Performance category. Within this section the budget results are displayed. */
+  budgetsGroupDescription: 'Performance budgets set standards for the performance of your site.',
   /** Title of the speed metrics section of the Performance category. Within this section are various speed metrics which quantify the pageload performance into values presented in seconds and milliseconds. */
   metricGroupTitle: 'Metrics',
   /** Title of the opportunity section of the Performance category. Within this section are audits with imperative titles that suggest actions the user can take to improve the loading performance of their web page. 'Suggestion'/'Optimization'/'Recommendation' are reasonable synonyms for 'opportunity' in this case. */
@@ -192,6 +196,8 @@ const defaultConfig = {
     'main-thread-tasks',
     'metrics',
     'offline-start-url',
+    'resource-summary',
+    'resource-budget',
     'manual/pwa-cross-browser',
     'manual/pwa-page-transitions',
     'manual/pwa-each-page-has-url',
@@ -286,6 +292,10 @@ const defaultConfig = {
       title: str_(UIStrings.loadOpportunitiesGroupTitle),
       description: str_(UIStrings.loadOpportunitiesGroupDescription),
     },
+    'budgets': {
+      title: str_(UIStrings.budgetsGroupTitle),
+      description: str_(UIStrings.budgetsGroupDescription),
+    },
     'diagnostics': {
       title: str_(UIStrings.diagnosticsGroupTitle),
       description: str_(UIStrings.diagnosticsGroupDescription),
@@ -378,6 +388,8 @@ const defaultConfig = {
         {id: 'bootup-time', weight: 0, group: 'diagnostics'},
         {id: 'mainthread-work-breakdown', weight: 0, group: 'diagnostics'},
         {id: 'font-display', weight: 0, group: 'diagnostics'},
+        {id: 'resource-summary', weight: 0, group: 'diagnostics'},
+        {id: 'resource-budget', weight: 0, group: 'budgets'},
         // Audits past this point don't belong to a group and will not be shown automatically
         {id: 'network-requests', weight: 0},
         {id: 'network-rtt', weight: 0},

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -751,6 +751,102 @@
     "message": "Avoid multiple page redirects",
     "description": "Imperative title of a Lighthouse audit that tells the user to eliminate the redirects taken through multiple URLs to load the page. This is shown in a list of audits that Lighthouse generates."
   },
+  "lighthouse-core/audits/resource-budget.js | description": {
+    "message": "To set budgets for the quantity and size of page resources, add a budget.json file.",
+    "description": "Description of a Lighthouse audit that tells the user that they can setup a budgets for the quantity and size of page resources. No character length limits."
+  },
+  "lighthouse-core/audits/resource-budget.js | documentResourceType": {
+    "message": "Document",
+    "description": "Label for the 'Document' resource type."
+  },
+  "lighthouse-core/audits/resource-budget.js | fontResourceType": {
+    "message": "Font",
+    "description": "Label for the 'font' resource type."
+  },
+  "lighthouse-core/audits/resource-budget.js | imageResourceType": {
+    "message": "Image",
+    "description": "Label for the 'image' resource type."
+  },
+  "lighthouse-core/audits/resource-budget.js | mediaResourceType": {
+    "message": "Media",
+    "description": "Label for the 'media' resource type."
+  },
+  "lighthouse-core/audits/resource-budget.js | otherResourceType": {
+    "message": "Other",
+    "description": "Label for the 'other' resource type."
+  },
+  "lighthouse-core/audits/resource-budget.js | requestCount": {
+    "message": "{count, plural,\n    =1 {1 request}\n    other {# requests}\n   }",
+    "description": "[ICU Syntax] Label identifying the number of requests"
+  },
+  "lighthouse-core/audits/resource-budget.js | scriptResourceType": {
+    "message": "Script",
+    "description": "Label for the 'script' resource type."
+  },
+  "lighthouse-core/audits/resource-budget.js | stylesheetResourceType": {
+    "message": "Stylesheet",
+    "description": "Label for the 'stylesheet' resource type."
+  },
+  "lighthouse-core/audits/resource-budget.js | thirdPartyResourceType": {
+    "message": "Third-party",
+    "description": "Label for the 'third-party' resource type."
+  },
+  "lighthouse-core/audits/resource-budget.js | title": {
+    "message": "Keep request counts and file sizes small",
+    "description": "Imperative title of a Lighthouse audit that tells the user to minimize the size and quantity of resources used to load the page."
+  },
+  "lighthouse-core/audits/resource-budget.js | totalResourceType": {
+    "message": "Total",
+    "description": ""
+  },
+  "lighthouse-core/audits/resource-summary.js | description": {
+    "message": "To set budgets for the quantity and size of page resources, add a budget.json file.",
+    "description": "Description of a Lighthouse audit that tells the user that they can setup a budgets for the quantity and size of page resources. No character length limits."
+  },
+  "lighthouse-core/audits/resource-summary.js | displayValue": {
+    "message": "{requestCount, plural, =1 {1 request} other {# requests}} • { byteCount, number, bytes } KB",
+    "description": "[ICU Syntax] Label for an audit identifying the number of requests and kilobytes used to load the page."
+  },
+  "lighthouse-core/audits/resource-summary.js | documentResourceType": {
+    "message": "Document",
+    "description": "Label for the 'Document' resource type."
+  },
+  "lighthouse-core/audits/resource-summary.js | fontResourceType": {
+    "message": "Font",
+    "description": "Label for the 'font' resource type."
+  },
+  "lighthouse-core/audits/resource-summary.js | imageResourceType": {
+    "message": "Image",
+    "description": "Label for the 'image' resource type."
+  },
+  "lighthouse-core/audits/resource-summary.js | mediaResourceType": {
+    "message": "Media",
+    "description": "Label for the 'media' resource type."
+  },
+  "lighthouse-core/audits/resource-summary.js | otherResourceType": {
+    "message": "Other",
+    "description": "Label for the 'other' resource type."
+  },
+  "lighthouse-core/audits/resource-summary.js | scriptResourceType": {
+    "message": "Script",
+    "description": "Label for the 'script' resource type."
+  },
+  "lighthouse-core/audits/resource-summary.js | stylesheetResourceType": {
+    "message": "Stylesheet",
+    "description": "Label for the 'stylesheet' resource type."
+  },
+  "lighthouse-core/audits/resource-summary.js | thirdPartyResourceType": {
+    "message": "Third-party",
+    "description": "Label for the 'third-party' resource type."
+  },
+  "lighthouse-core/audits/resource-summary.js | title": {
+    "message": "Keep request counts and file sizes small",
+    "description": "Imperative title of a Lighthouse audit that tells the user to minimize the size and quantity of resources used to load the page."
+  },
+  "lighthouse-core/audits/resource-summary.js | totalResourceType": {
+    "message": "Total",
+    "description": "Label for the combination of all resources on the page."
+  },
   "lighthouse-core/audits/seo/canonical.js | description": {
     "message": "Canonical links suggest which URL to show in search results. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/canonical).",
     "description": "Description of a Lighthouse audit that tells the user *why* they need to have a valid rel=canonical link. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
@@ -1102,6 +1198,14 @@
   "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": {
     "message": "Tables and lists",
     "description": "Title of the navigation section within the Accessibility category. Within this section are audits with descriptive titles that highlight opportunities to improve the experience of reading tabular or list data using assistive technology."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupDescription": {
+    "message": "Performance budgets set standards for the performance of your site.",
+    "description": "Description of the Budgets section of the Performance category. Within this section the budget results are displayed."
+  },
+  "lighthouse-core/config/default-config.js | budgetsGroupTitle": {
+    "message": "Budgets",
+    "description": "Title of the Budgets section of the Performance Category. 'Budgets' refers to a budget (like a financial budget), but applied to the amount of resources on a page, rather than money."
   },
   "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": {
     "message": "More information about the performance of your application.",

--- a/lighthouse-core/report/html/renderer/performance-category-renderer.js
+++ b/lighthouse-core/report/html/renderer/performance-category-renderer.js
@@ -122,6 +122,23 @@ class PerformanceCategoryRenderer extends CategoryRenderer {
       element.appendChild(this.renderCategoryHeader(category, groups));
     }
 
+    // Budgets
+    const budgetAudits = category.auditRefs.filter(audit => audit.group === 'budgets');
+    if (budgetAudits && budgetAudits[0] && budgetAudits[0].result &&
+      budgetAudits[0].result.details) {
+      const budgetsGroupEl = this.renderAuditGroup(groups['budgets']);
+      const tmpl = this.dom.cloneTemplate('#tmpl-lh-opportunity-header', this.templateContext);
+      budgetsGroupEl.appendChild(this.dom.find('.lh-load-opportunity__header', tmpl));
+
+      const resourceBudgetDetails = budgetAudits[0].result.details;
+      const table = this.detailsRenderer.render(resourceBudgetDetails);
+      if (table) {
+        budgetsGroupEl.appendChild(table);
+        budgetsGroupEl.classList.add('lh-audit-group--budgets');
+        element.appendChild(budgetsGroupEl);
+      }
+    }
+
     // Metrics
     const metricAudits = category.auditRefs.filter(audit => audit.group === 'metrics');
     const metricAuditsEl = this.renderAuditGroup(groups.metrics);

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -679,6 +679,19 @@
   vertical-align: middle;
 }
 
+.lh-audit-group--budgets .lh-table tbody tr td:nth-child(4),
+.lh-audit-group--budgets .lh-table tbody tr td:nth-child(5){
+  color: var(--color-red-700);
+}
+
+.lh-audit-group--budgets .lh-table tbody tr td:nth-child(4){
+  text-align: right;
+}
+
+.lh-audit-group--budgets .lh-table {
+  width: 100%;
+}
+
 .lh-audit-group--pwa-fast-reliable .lh-audit-group__header::before {
   content: '';
   background-image: var(--pwa-fast-reliable-gray-url);
@@ -699,6 +712,11 @@
 }
 .lh-audit-group--pwa-optimized.lh-badged .lh-audit-group__header::before {
   background-image: var(--pwa-optimized-color-url);
+}
+
+.lh-audit-group--metrics {
+  padding-top: calc(var(--circle-size)/2 * -1);
+  border-bottom: none;
 }
 
 .lh-audit-group--metrics .lh-audit-group__summary {

--- a/lighthouse-core/test/audits/resource-budget-test.js
+++ b/lighthouse-core/test/audits/resource-budget-test.js
@@ -1,0 +1,144 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Audit = require('../../audits/resource-budget.js');
+const assert = require('assert');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
+
+/* eslint-env jest */
+
+describe('Performance: Resource budgets audit', () => {
+  let artifacts;
+  let context;
+  beforeEach(() => {
+    artifacts = {
+      devtoolsLogs: {
+        defaultPass: networkRecordsToDevtoolsLog([
+          {url: 'http://example.com/file.html', resourceType: 'Document', transferSize: 30},
+          {url: 'http://example.com/app.js', resourceType: 'Script', transferSize: 10},
+          {url: 'http://third-party.com/script.js', resourceType: 'Script', transferSize: 50},
+          {url: 'http://third-party.com/file.jpg', resourceType: 'Image', transferSize: 70},
+        ]),
+      },
+      URL: {requestedURL: 'http://example.com', finalURL: 'http://example.com'},
+    };
+    context = {computedCache: new Map(), settings: {}};
+  });
+
+  describe('with a budget.json', () => {
+    beforeEach(() => {
+      context.settings.budgets = [{
+        path: '/',
+        resourceSizes: [{
+          resourceType: 'script',
+          budget: 1,
+        }],
+        resourceCounts: [{
+          resourceType: 'script',
+          budget: 10000,
+        }],
+      }];
+    });
+
+    it('includes table columns for request & file size overages', () => {
+      return Audit.audit(artifacts, context).then(result => {
+        assert.equal(result.details.headings.length, 5);
+      });
+    });
+
+    it('displays request & file size overages correctly', () => {
+      return Audit.audit(artifacts, context).then(result => {
+        assert.equal(result.details.items[0].sizeOverBudget, 59);
+        assert.equal(result.details.items[0].countOverBudget, undefined);
+      });
+    });
+
+    it('only includes rows for resource types with budgets', () => {
+      return Audit.audit(artifacts, context).then(result => {
+        assert.equal(result.details.items.length, 1);
+      });
+    });
+
+    it('sorts rows by descending file size overage', () => {
+      context.settings.budgets = [{
+        path: '/',
+        resourceSizes: [
+          {
+            resourceType: 'document',
+            budget: 0,
+          },
+          {
+            resourceType: 'script',
+            budget: 0,
+          },
+          {
+            resourceType: 'image',
+            budget: 0,
+          },
+        ],
+      }];
+      return Audit.audit(artifacts, context).then(result => {
+        const items = result.details.items;
+        assert.ok(items[0].sizeOverBudget >= items[1].sizeOverBudget);
+        assert.ok(items[1].sizeOverBudget >= items[2].sizeOverBudget);
+      });
+    });
+
+    it('uses the last matching budget', () => {
+      context.settings.budgets = [{
+        path: '/',
+        resourceSizes: [
+          {
+            resourceType: 'image',
+            budget: 0,
+          },
+        ],
+      },
+      {
+        path: '/',
+        resourceSizes: [
+          {
+            resourceType: 'script',
+            budget: 0,
+          },
+        ],
+      },
+      ];
+      return Audit.audit(artifacts, context).then(result => {
+        const items = result.details.items;
+        assert.ok(items[0].label.includes('script'));
+      });
+    });
+  });
+
+  describe('without a budget.json', () => {
+    beforeEach(() => {
+      context.settings.budgets = null;
+    });
+
+    it('table only includes resourceType, requests, and file size', () => {
+      return Audit.audit(artifacts, context).then(result => {
+        assert.equal(result.details.headings.length, 3);
+      });
+    });
+
+    it('table includes all resource types', () => {
+      return Audit.audit(artifacts, context).then(result => {
+        assert.equal(result.details.items.length, 9);
+      });
+    });
+
+    it('sorts rows by descending file size', () => {
+      return Audit.audit(artifacts, context).then(result => {
+        const items = result.details.items;
+        assert.ok(items[0].size >= items[1].size);
+        assert.ok(items[1].size >= items[2].size);
+        assert.ok(items[2].size >= items[3].size);
+      });
+    });
+  });
+});

--- a/lighthouse-core/test/audits/resource-summary-test.js
+++ b/lighthouse-core/test/audits/resource-summary-test.js
@@ -1,0 +1,54 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const Audit = require('../../audits/resource-summary.js');
+const assert = require('assert');
+const networkRecordsToDevtoolsLog = require('../network-records-to-devtools-log.js');
+
+/* eslint-env jest */
+
+describe('Performance: Resource summary audit', () => {
+  let artifacts;
+  let context;
+  beforeEach(() => {
+    context = {computedCache: new Map()};
+
+    artifacts = {
+      devtoolsLogs: {
+        defaultPass: networkRecordsToDevtoolsLog([
+          {url: 'http://example.com/file.html', resourceType: 'Document', transferSize: 30},
+          {url: 'http://example.com/app.js', resourceType: 'Script', transferSize: 10},
+          {url: 'http://third-party.com/script.js', resourceType: 'Script', transferSize: 50},
+          {url: 'http://third-party.com/file.jpg', resourceType: 'Image', transferSize: 70},
+        ])},
+      URL: {finalURL: 'https://example.com'},
+    };
+  });
+
+  it('includes all resource types, regardless of whether page contains them', () => {
+    return Audit.audit(artifacts, context).then(result => {
+      assert.equal(Object.keys(result.details.items).length, 9);
+    });
+  });
+
+  it('it displays "0" if there are no resources of that type', () => {
+    return Audit.audit(artifacts, context).then(result => {
+      const fontItem = result.details.items.find(item => item.resourceType === 'font');
+      assert.equal(fontItem.count, 0);
+      assert.equal(fontItem.size, 0);
+    });
+  });
+
+  it('it sorts items by size (descending)', () => {
+    return Audit.audit(artifacts, context).then(result => {
+      const items = result.details.items;
+      assert.ok(items[0].size >= items[1].size);
+      assert.ok(items[1].size >= items[2].size);
+      assert.ok(items[2].size >= items[3].size);
+    });
+  });
+});

--- a/lighthouse-core/test/computed/resource-summary-test.js
+++ b/lighthouse-core/test/computed/resource-summary-test.js
@@ -1,0 +1,68 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const ComputedResourceSummary = require('../../computed/resource-summary.js');
+const assert = require('assert');
+
+/* eslint-env jest */
+
+function mockTracingData(recordInfo) {
+  const networkRecords = recordInfo.map((info, index) => ({
+    requestId: index.toString(),
+    resourceType: info.resourceType,
+    frameId: 1,
+    finished: true,
+    priority: 'HIGH',
+    initiatorRequest: null,
+    statusCode: 200,
+    transferSize: info.transferSize,
+    url: info.url,
+  }));
+
+  return networkRecords;
+}
+
+describe('Resource summary computed', () => {
+  let networkRecords;
+  let mainResource;
+  beforeEach(() => {
+    const networkRecordInfo = [
+      {url: 'http://example.com/file.html', resourceType: 'Document', transferSize: 30},
+      {url: 'http://example.com/app.js', resourceType: 'Script', transferSize: 10},
+      {url: 'http://third-party.com/script.js', resourceType: 'Script', transferSize: 50},
+      {url: 'http://third-party.com/file.jpg', resourceType: 'Image', transferSize: 70},
+    ];
+    networkRecords = mockTracingData(networkRecordInfo);
+    mainResource = networkRecords[0];
+  });
+
+  it('includes all resource types, regardless of whether page contains them', () => {
+    const result = ComputedResourceSummary.summarize(networkRecords, mainResource.url);
+    assert.equal(Object.keys(result).length, 9);
+  });
+
+  it('sets size and count correctly', async () => {
+    const result = ComputedResourceSummary.summarize(networkRecords, mainResource.url);
+    const scriptItem = Object.values(result).find(item => item.resourceType === 'script');
+    assert.equal(scriptItem.count, 2);
+    assert.equal(scriptItem.size, 10 + 50);
+  });
+
+  it('sets "total" resource metrics correctly', async () => {
+    const result = ComputedResourceSummary.summarize(networkRecords, mainResource.url);
+    const totalItem = Object.values(result).find(item => item.resourceType === 'total');
+    assert.equal(totalItem.count, 4);
+    assert.equal(totalItem.size, 30 + 10 + 50 + 70);
+  });
+
+  it('sets "third-party" resource metrics correctly', async () => {
+    const result = ComputedResourceSummary.summarize(networkRecords, mainResource.url);
+    const thirdPartyItem = Object.values(result).find(item => item.resourceType === 'third-party');
+    assert.equal(thirdPartyItem.count, 2);
+    assert.equal(thirdPartyItem.size, 70 + 50);
+  });
+});

--- a/lighthouse-core/test/config/budget-test.js
+++ b/lighthouse-core/test/config/budget-test.js
@@ -10,10 +10,11 @@ const assert = require('assert');
 /* eslint-env jest */
 
 describe('Budget', () => {
-  let budget;
+  let budgetJson;
   beforeEach(() => {
-    budget = [
+    budgetJson = [
       {
+        path: '/',
         resourceSizes: [
           {
             resourceType: 'script',
@@ -48,6 +49,7 @@ describe('Budget', () => {
         ],
       },
       {
+        path: '/',
         resourceSizes: [
           {
             resourceType: 'script',
@@ -59,70 +61,153 @@ describe('Budget', () => {
   });
 
   it('initializes correctly', () => {
-    const budgets = Budget.initializeBudget(budget);
-    assert.equal(budgets.length, 2);
+    const budget = Budget.initializeBudget(budgetJson);
+    assert.equal(budget.length, 2);
+
+    assert.equal(budget[0].path, '/');
 
     // Sets resources sizes correctly
-    assert.equal(budgets[0].resourceSizes.length, 2);
-    assert.equal(budgets[0].resourceSizes[0].resourceType, 'script');
-    assert.equal(budgets[0].resourceSizes[0].budget, 123);
+    assert.equal(budget[0].resourceSizes.length, 2);
+    assert.equal(budget[0].resourceSizes[0].resourceType, 'script');
+    assert.equal(budget[0].resourceSizes[0].budget, 123 * 1024);
 
     // Sets resource counts correctly
-    assert.equal(budgets[0].resourceCounts.length, 2);
-    assert.equal(budgets[0].resourceCounts[0].resourceType, 'total');
-    assert.equal(budgets[0].resourceCounts[0].budget, 100);
+    assert.equal(budget[0].resourceCounts.length, 2);
+    assert.equal(budget[0].resourceCounts[0].resourceType, 'total');
+    assert.equal(budget[0].resourceCounts[0].budget, 100);
 
     // Sets timings correctly
-    assert.equal(budgets[0].timings.length, 2);
-    assert.equal(budgets[0].timings[1].metric, 'first-contentful-paint');
-    assert.equal(budgets[0].timings[1].budget, 1000);
-    assert.equal(budgets[0].timings[1].tolerance, 500);
+    assert.equal(budget[0].timings.length, 2);
+    assert.equal(budget[0].timings[1].metric, 'first-contentful-paint');
+    assert.equal(budget[0].timings[1].budget, 1000);
+    assert.equal(budget[0].timings[1].tolerance, 500);
 
-    // Does not set unsupplied budgets
-    assert.equal(budgets[1].timings, null);
+    // Does not set unsupplied budget
+    assert.equal(budget[1].timings, null);
   });
 
   it('throws error if an unsupported budget property is used', () => {
-    budget[0].sizes = [];
-    assert.throws(_ => Budget.initializeBudget(budget), /[sizes]/);
+    budgetJson[0].sizes = [];
+    assert.throws(_ => Budget.initializeBudget(budgetJson), /[sizes]/);
   });
 
   describe('resource budget validation', () => {
     it('throws when an invalid resource type is supplied', () => {
-      budget[0].resourceSizes[0].resourceType = 'movies';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid resource type/);
+      budgetJson[0].resourceSizes[0].resourceType = 'movies';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /Invalid resource type/);
     });
 
     it('throws when an invalid budget is supplied', () => {
-      budget[0].resourceSizes[0].budget = '100 MB';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid budget/);
+      budgetJson[0].resourceSizes[0].budget = '100 MB';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /Invalid budget/);
     });
 
     it('throws when an invalid property is supplied', () => {
-      budget[0].resourceSizes[0].browser = 'Chrome';
-      assert.throws(_ => Budget.initializeBudget(budget), /[browser]/);
+      budgetJson[0].resourceSizes[0].browser = 'Chrome';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /[browser]/);
+    })
+    ;
+    it('throws when snake case is not used', () => {
+      budgetJson[0].resourceSizes[0].resourceType = 'thirdParty';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /Invalid resource type/);
     });
   });
 
   describe('timing budget validation', () => {
     it('throws when an invalid metric is supplied', () => {
-      budget[0].timings[0].metric = 'lastMeaningfulPaint';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid timing metric/);
+      budgetJson[0].timings[0].metric = 'lastMeaningfulPaint';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /Invalid timing metric/);
     });
 
     it('throws when an invalid budget is supplied', () => {
-      budget[0].timings[0].budget = '100KB';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid budget/);
+      budgetJson[0].timings[0].budget = '100KB';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /Invalid budget/);
     });
 
     it('throws when an invalid tolerance is supplied', () => {
-      budget[0].timings[0].tolerance = '100ms';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid tolerance/);
+      budgetJson[0].timings[0].tolerance = '100ms';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /Invalid tolerance/);
     });
 
     it('throws when an invalid property is supplied', () => {
-      budget[0].timings[0].device = 'Phone';
-      assert.throws(_ => Budget.initializeBudget(budget), /[device]/);
+      budgetJson[0].timings[0].device = 'Phone';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /[device]/);
+    });
+
+    it('throws when "time-to-interactive is supplied', () => {
+      budgetJson[0].timings[0].metric = 'time-to-interactive';
+      assert.throws(_ => Budget.initializeBudget(budgetJson), /Invalid timing metric/);
+    });
+  });
+
+  describe('path validation', () => {
+    it('initializes correctly', () => {
+      const budgetArr = [{}];
+
+      budgetArr[0].path = '/';
+      assert.equal(Budget.initializeBudget(budgetArr)[0].path, '/');
+
+      budgetArr[0].path = '/*';
+      assert.equal(Budget.initializeBudget(budgetArr)[0].path, '/*');
+
+      budgetArr[0].path = '/fish*.php';
+      assert.equal(Budget.initializeBudget(budgetArr)[0].path, '/fish*.php');
+
+      budgetArr[0].path = '/*.php$';
+      assert.equal(Budget.initializeBudget(budgetArr)[0].path, '/*.php$');
+    });
+  });
+
+  describe('path validation', () => {
+    it('throws error if an invalid path is used', () => {
+      const budget = {};
+
+      budget.path = '';
+      assert.throws(_ => Budget.initializeBudget(budget), /[A valid path]/);
+
+      budget.path = 'cat';
+      assert.throws(_ => Budget.initializeBudget(budget), /[Invalid path]/);
+
+      budget.path = '/cat*cat*cat';
+      assert.throws(_ => Budget.initializeBudget(budget), /[Invalid path]/);
+
+      budget.path = '/cat$html';
+      assert.throws(_ => Budget.initializeBudget(budget), /[Invalid path]/);
+    });
+
+    it('matches root', () => {
+      assert.ok(Budget.urlMatchesPattern('https://google.com', '/'));
+      assert.ok(Budget.urlMatchesPattern('https://google.com', '*'));
+    });
+
+    it('ignores origin', () => {
+      assert.equal(Budget.urlMatchesPattern('https://yt.com/videos?id=', '/videos'), true);
+      assert.equal(Budget.urlMatchesPattern('https://go.com/dogs', '/go'), false);
+    });
+
+    it('is correct', () => {
+      const pathMatch = (path, pattern) => {
+        const origin = 'https://example.com';
+        return Budget.urlMatchesPattern(origin + path, pattern);
+      };
+
+      assert.equal(pathMatch('/anything', '/'), true);
+      assert.equal(pathMatch('/anything', '/*'), true);
+      assert.equal(pathMatch('/anything', '/any'), true);
+      assert.equal(pathMatch('/anything', '/anything1'), false);
+
+      assert.equal(pathMatch('/fish', '/fish*'), true);
+      assert.equal(pathMatch('/fishfood', '/*food'), true);
+      assert.equal(pathMatch('/fish.php', '/*.php$'), true);
+      assert.equal(pathMatch('/fis/', '/fish*'), false);
+
+      assert.equal(pathMatch('/fish.php?species=', '/*.php$'), false);
+      assert.equal(pathMatch('/Fish.PHP', '/fish.php$'), false);
+
+      assert.equal(pathMatch('/folder/filename.php', '/*.php$'), true);
+      assert.equal(pathMatch('/folder/filename.php', '/folder*.php$'), true);
+      assert.equal(pathMatch('/filename.php/', '/folder*.php$'), false);
+      assert.equal(pathMatch('/filename.php?parameters', '/*.php$'), false);
     });
   });
 });

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -746,6 +746,7 @@ describe('Config', () => {
         const configJson = {
           settings: {
             budgets: [{
+              path: '/',
               resourceCounts: [{
                 resourceType: 'image',
                 budget: 500,

--- a/lighthouse-core/test/fixtures/simple-budget.json
+++ b/lighthouse-core/test/fixtures/simple-budget.json
@@ -1,5 +1,6 @@
 [
     {
+        "path": "/",
         "resourceSizes": [
             {
                 "resourceType": "script",
@@ -18,19 +19,6 @@
                 "budget": 200
             }
         ],
-        "timings": [
-            {
-                "metric": "interactive",
-                "budget": 5000,
-                "tolerance": 1000
-            },
-            {
-                "metric": "first-meaningful-paint",
-                "budget": 2000
-            }
-        ]
-    },
-    {
         "resourceCounts": [
             {
                 "resourceType": "total",

--- a/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
@@ -67,12 +67,12 @@ describe('PerfCategoryRenderer', () => {
   it('renders the sections', () => {
     const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
     const sections = categoryDOM.querySelectorAll('.lh-category > .lh-audit-group');
-    assert.equal(sections.length, 4);
+    assert.equal(sections.length, 5);
   });
 
   it('renders the metrics', () => {
     const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
-    const metricsSection = categoryDOM.querySelectorAll('.lh-category > .lh-audit-group')[0];
+    const metricsSection = categoryDOM.querySelectorAll('.lh-category > .lh-audit-group')[1];
 
     const metricAudits = category.auditRefs.filter(audit => audit.group === 'metrics');
     const timelineElements = metricsSection.querySelectorAll('.lh-metric');

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1273,6 +1273,164 @@
       "explanation": "No usable web app manifest found on page.",
       "warnings": []
     },
+    "resource-summary": {
+      "id": "resource-summary",
+      "title": "Keep request counts and file sizes small",
+      "description": "To set budgets for the quantity and size of page resources, add a budgets.json file.",
+      "score": null,
+      "scoreDisplayMode": "informative",
+      "displayValue": "18 requests • 157 KB",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "label",
+            "itemType": "text",
+            "text": "Resource Type"
+          },
+          {
+            "key": "count",
+            "itemType": "numeric",
+            "text": "Requests"
+          },
+          {
+            "key": "size",
+            "itemType": "bytes",
+            "text": "File Size"
+          }
+        ],
+        "items": [
+          {
+            "resourceType": "total",
+            "label": "Total",
+            "count": 18,
+            "size": 160738
+          },
+          {
+            "resourceType": "script",
+            "label": "Script",
+            "count": 4,
+            "size": 103675
+          },
+          {
+            "resourceType": "third-party",
+            "label": "Third-party",
+            "count": 2,
+            "size": 30174
+          },
+          {
+            "resourceType": "image",
+            "label": "Image",
+            "count": 2,
+            "size": 24741
+          },
+          {
+            "resourceType": "document",
+            "label": "Document",
+            "count": 3,
+            "size": 14109
+          },
+          {
+            "resourceType": "other",
+            "label": "Other",
+            "count": 2,
+            "size": 12861
+          },
+          {
+            "resourceType": "stylesheet",
+            "label": "Stylesheet",
+            "count": 7,
+            "size": 5352
+          },
+          {
+            "resourceType": "media",
+            "label": "Media",
+            "count": 0,
+            "size": 0
+          },
+          {
+            "resourceType": "font",
+            "label": "Font",
+            "count": 0,
+            "size": 0
+          }
+        ]
+      }
+    },
+    "resource-budget": {
+      "id": "resource-budget",
+      "title": "Keep request counts and file sizes small",
+      "description": "To set budgets for the quantity and size of page resources, add a budget.json file.",
+      "score": null,
+      "scoreDisplayMode": "informative",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "label",
+            "itemType": "text",
+            "text": "Resource Type"
+          },
+          {
+            "key": "count",
+            "itemType": "numeric",
+            "text": "Requests"
+          },
+          {
+            "key": "size",
+            "itemType": "bytes",
+            "text": "File Size"
+          }
+        ],
+        "items": [
+          {
+            "label": "Total",
+            "count": 18,
+            "size": 160738
+          },
+          {
+            "label": "Script",
+            "count": 4,
+            "size": 103675
+          },
+          {
+            "label": "Third-party",
+            "count": 2,
+            "size": 30174
+          },
+          {
+            "label": "Image",
+            "count": 2,
+            "size": 24741
+          },
+          {
+            "label": "Document",
+            "count": 3,
+            "size": 14109
+          },
+          {
+            "label": "Other",
+            "count": 2,
+            "size": 12861
+          },
+          {
+            "label": "Stylesheet",
+            "count": 7,
+            "size": 5352
+          },
+          {
+            "label": "Media",
+            "count": 0,
+            "size": 0
+          },
+          {
+            "label": "Font",
+            "count": 0,
+            "size": 0
+          }
+        ]
+      }
+    },
     "pwa-cross-browser": {
       "id": "pwa-cross-browser",
       "title": "Site works cross-browser",
@@ -3121,6 +3279,16 @@
           "group": "diagnostics"
         },
         {
+          "id": "resource-summary",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "resource-budget",
+          "weight": 0,
+          "group": "budgets"
+        },
+        {
           "id": "network-requests",
           "weight": 0
         },
@@ -3619,6 +3787,10 @@
       "title": "Opportunities",
       "description": "These optimizations can speed up your page load."
     },
+    "budgets": {
+      "title": "Budgets",
+      "description": "Performance budgets set standards for the performance of your site."
+    },
     "diagnostics": {
       "title": "Diagnostics",
       "description": "More information about the performance of your application."
@@ -4084,6 +4256,18 @@
       {
         "startTime": 0,
         "name": "lh:audit:offline-start-url",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:audit:resource-summary",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:audit:resource-budget",
         "duration": 100,
         "entryType": "measure"
       },
@@ -4862,6 +5046,81 @@
       "lighthouse-core/audits/network-server-latency.js | description": [
         "audits[network-server-latency].description"
       ],
+      "lighthouse-core/audits/resource-summary.js | title": [
+        "audits[resource-summary].title"
+      ],
+      "lighthouse-core/audits/resource-summary.js | description": [
+        "audits[resource-summary].description"
+      ],
+      "lighthouse-core/audits/resource-summary.js | displayValue": [
+        {
+          "values": {
+            "requestCount": 18,
+            "byteCount": 160738
+          },
+          "path": "audits[resource-summary].displayValue"
+        }
+      ],
+      "lighthouse-core/audits/resource-summary.js | totalResourceType": [
+        "audits[resource-summary].details.items[0].label"
+      ],
+      "lighthouse-core/audits/resource-summary.js | scriptResourceType": [
+        "audits[resource-summary].details.items[1].label"
+      ],
+      "lighthouse-core/audits/resource-summary.js | thirdPartyResourceType": [
+        "audits[resource-summary].details.items[2].label"
+      ],
+      "lighthouse-core/audits/resource-summary.js | imageResourceType": [
+        "audits[resource-summary].details.items[3].label"
+      ],
+      "lighthouse-core/audits/resource-summary.js | documentResourceType": [
+        "audits[resource-summary].details.items[4].label"
+      ],
+      "lighthouse-core/audits/resource-summary.js | otherResourceType": [
+        "audits[resource-summary].details.items[5].label"
+      ],
+      "lighthouse-core/audits/resource-summary.js | stylesheetResourceType": [
+        "audits[resource-summary].details.items[6].label"
+      ],
+      "lighthouse-core/audits/resource-summary.js | mediaResourceType": [
+        "audits[resource-summary].details.items[7].label"
+      ],
+      "lighthouse-core/audits/resource-summary.js | fontResourceType": [
+        "audits[resource-summary].details.items[8].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | title": [
+        "audits[resource-budget].title"
+      ],
+      "lighthouse-core/audits/resource-budget.js | description": [
+        "audits[resource-budget].description"
+      ],
+      "lighthouse-core/audits/resource-budget.js | totalResourceType": [
+        "audits[resource-budget].details.items[0].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | scriptResourceType": [
+        "audits[resource-budget].details.items[1].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | thirdPartyResourceType": [
+        "audits[resource-budget].details.items[2].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | imageResourceType": [
+        "audits[resource-budget].details.items[3].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | documentResourceType": [
+        "audits[resource-budget].details.items[4].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | otherResourceType": [
+        "audits[resource-budget].details.items[5].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | stylesheetResourceType": [
+        "audits[resource-budget].details.items[6].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | mediaResourceType": [
+        "audits[resource-budget].details.items[7].label"
+      ],
+      "lighthouse-core/audits/resource-budget.js | fontResourceType": [
+        "audits[resource-budget].details.items[8].label"
+      ],
       "lighthouse-core/audits/accessibility/accesskeys.js | title": [
         "audits.accesskeys.title"
       ],
@@ -5358,6 +5617,12 @@
       ],
       "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": [
         "categoryGroups[load-opportunities].description"
+      ],
+      "lighthouse-core/config/default-config.js | budgetsGroupTitle": [
+        "categoryGroups.budgets.title"
+      ],
+      "lighthouse-core/config/default-config.js | budgetsGroupDescription": [
+        "categoryGroups.budgets.description"
       ],
       "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": [
         "categoryGroups.diagnostics.title"

--- a/types/budget.d.ts
+++ b/types/budget.d.ts
@@ -11,6 +11,8 @@ declare global {
      * More info: https://github.com/GoogleChrome/lighthouse/issues/6053#issuecomment-428385930
      */
     export interface Budget {
+      /** Indicates which pages a budget applies to. Uses the robots.txt format */
+      path: string;
       /** Budgets based on resource count. */
       resourceCounts?: Array<Budget.ResourceBudget>;
       /** Budgets based on resource size. */


### PR DESCRIPTION
**Summary**
Adds resource-summary and resource-budget audits.

This started out as PRs https://github.com/GoogleChrome/lighthouse/pull/8539 & https://github.com/GoogleChrome/lighthouse/pull/8522, but due to code changes, it seemed like a good idea to replace them with a single PR.

**Screenshots**
*With a budget*
<img width="947" alt="Screen Shot 2019-04-27 at 5 07 33 PM" src="https://user-images.githubusercontent.com/6076184/56855097-176dab80-690f-11e9-920a-0f744a05a0e7.png">

*Without a budget*
<img width="923" alt="Screen Shot 2019-04-27 at 5 07 54 PM" src="https://user-images.githubusercontent.com/6076184/56855099-176dab80-690f-11e9-9c37-f0472c5deabf.png">

*Diagnostic*
<img width="959" alt="Screen Shot 2019-04-27 at 5 07 44 PM" src="https://user-images.githubusercontent.com/6076184/56855098-176dab80-690f-11e9-9ea2-29423256c734.png">

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
LightWallet, pt 1:
https://github.com/GoogleChrome/lighthouse/pull/8427
PRs that this PR replaces:
https://github.com/GoogleChrome/lighthouse/pull/8539
https://github.com/GoogleChrome/lighthouse/pull/8522
