### PR TITLE
core(lightwallet): stricter verification of budget types

### DIFF
--- a/lighthouse-core/test/config/budget-test.js
+++ b/lighthouse-core/test/config/budget-test.js
@@ -43,7 +43,7 @@ describe('Budget', () => {
           {
             metric: 'first-contentful-paint',
             budget: 1000,
-            tolerance: 500,
+            // tolerance is optional, so not defined here.
           },
         ],
       },
@@ -74,55 +74,103 @@ describe('Budget', () => {
 
     // Sets timings correctly
     assert.equal(budgets[0].timings.length, 2);
+    assert.deepStrictEqual(budgets[0].timings[0], {
+      metric: 'interactive',
+      budget: 2000,
+      tolerance: 1000,
+    });
     assert.equal(budgets[0].timings[1].metric, 'first-contentful-paint');
     assert.equal(budgets[0].timings[1].budget, 1000);
-    assert.equal(budgets[0].timings[1].tolerance, 500);
 
     // Does not set unsupplied budgets
     assert.equal(budgets[1].timings, null);
   });
 
+  it('accepts an empty array', () => {
+    const budgets = Budget.initializeBudget([]);
+    assert.deepStrictEqual(budgets, []);
+  });
+
   it('throws error if an unsupported budget property is used', () => {
     budget[0].sizes = [];
-    assert.throws(_ => Budget.initializeBudget(budget), /[sizes]/);
+    assert.throws(_ => Budget.initializeBudget(budget),
+      /Budget has unrecognized properties: \[sizes\]/);
+  });
+
+  describe('top-level validation', () => {
+    it('throws when provided an invalid budget array', () => {
+      assert.throws(_ => Budget.initializeBudget(55),
+        /Budget file is not defined as an array of budgets/);
+
+      assert.throws(_ => Budget.initializeBudget(['invalid123']),
+        /Budget file is not defined as an array of budgets/);
+
+      assert.throws(_ => Budget.initializeBudget([null]),
+        /Budget file is not defined as an array of budgets/);
+    });
+
+    it('throws when budget contains invalid resourceSizes entry', () => {
+      budget[0].resourceSizes = 55;
+      assert.throws(_ => Budget.initializeBudget(budget),
+        /^Error: Invalid resourceSizes entry in budget at index 0$/);
+    });
+
+    it('throws when budget contains invalid resourceCounts entry', () => {
+      budget[0].resourceCounts = 'A string';
+      assert.throws(_ => Budget.initializeBudget(budget),
+        /^Error: Invalid resourceCounts entry in budget at index 0$/);
+    });
+
+    it('throws when budget contains invalid timings entry', () => {
+      budget[1].timings = false;
+      assert.throws(_ => Budget.initializeBudget(budget),
+        /^Error: Invalid timings entry in budget at index 1$/);
+    });
   });
 
   describe('resource budget validation', () => {
     it('throws when an invalid resource type is supplied', () => {
       budget[0].resourceSizes[0].resourceType = 'movies';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid resource type/);
+      assert.throws(_ => Budget.initializeBudget(budget),
+        // eslint-disable-next-line max-len
+        /Invalid resource type: movies. \nValid resource types are: total, document,/);
     });
 
     it('throws when an invalid budget is supplied', () => {
       budget[0].resourceSizes[0].budget = '100 MB';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid budget/);
+      assert.throws(_ => Budget.initializeBudget(budget), /Invalid budget: 100 MB/);
     });
 
     it('throws when an invalid property is supplied', () => {
       budget[0].resourceSizes[0].browser = 'Chrome';
-      assert.throws(_ => Budget.initializeBudget(budget), /[browser]/);
+      assert.throws(_ => Budget.initializeBudget(budget),
+        /Resource Budget has unrecognized properties: \[browser\]/);
     });
   });
 
   describe('timing budget validation', () => {
     it('throws when an invalid metric is supplied', () => {
-      budget[0].timings[0].metric = 'lastMeaningfulPaint';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid timing metric/);
+      budget[0].timings[0].metric = 'medianMeaningfulPaint';
+      assert.throws(_ => Budget.initializeBudget(budget),
+        // eslint-disable-next-line max-len
+        /Invalid timing metric: medianMeaningfulPaint. \nValid timing metrics are: first-contentful-paint, /);
     });
 
     it('throws when an invalid budget is supplied', () => {
       budget[0].timings[0].budget = '100KB';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid budget/);
+      assert.throws(_ => Budget.initializeBudget(budget), /Invalid budget: 100KB/);
     });
 
     it('throws when an invalid tolerance is supplied', () => {
       budget[0].timings[0].tolerance = '100ms';
-      assert.throws(_ => Budget.initializeBudget(budget), /Invalid tolerance/);
+      assert.throws(_ => Budget.initializeBudget(budget), /Invalid tolerance: 100ms/);
     });
 
     it('throws when an invalid property is supplied', () => {
       budget[0].timings[0].device = 'Phone';
-      assert.throws(_ => Budget.initializeBudget(budget), /[device]/);
+      budget[0].timings[0].location = 'The middle somewhere, I don\'t know';
+      assert.throws(_ => Budget.initializeBudget(budget),
+        /Timing Budget has unrecognized properties: \[device, location\]/);
     });
   });
 });

--- a/lighthouse-core/test/config/config-test.js
+++ b/lighthouse-core/test/config/config-test.js
@@ -761,7 +761,7 @@ describe('Config', () => {
 
       it('should throw when provided an invalid budget', () => {
         assert.throws(() => new Config({settings: {budgets: ['invalid123']}}),
-          /Budget has unrecognized properties/);
+          /Budget file is not defined as an array of budgets/);
       });
     });
 


### PR DESCRIPTION
@khempenius @patrickhulce 

This is my proposal for slightly stricter checking of the budgets file, primarily by assuming nothing about the type when it comes into `budget.js` so that we can get a little more verification by the compiler that we're checking the types well.

There are also a few places where the type checks have been tightened and some more tests have been added.

Even though this now returns a totally new budget object instead of just validating in place, it does have the same issue as in #8675 where *in practice* it's just validating in place because it throws on any input that isn't valid. Renaming to reflect that as suggested in https://github.com/GoogleChrome/lighthouse/pull/8675#discussion_r279401765 makes a lot of sense to me, though not creating the object on the fly may reduce tsc's ability to verify the type. We could always create but not return? Or maybe it doesn't matter.