### PR TITLE
core: replace EIL with MP-FID

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -694,11 +694,11 @@ Object {
         },
         Object {
           "group": "metrics",
-          "id": "estimated-input-latency",
+          "id": "max-potential-fid",
           "weight": 0,
         },
         Object {
-          "id": "max-potential-fid",
+          "id": "estimated-input-latency",
           "weight": 0,
         },
         Object {

--- a/lighthouse-core/audits/metrics/max-potential-fid.js
+++ b/lighthouse-core/audits/metrics/max-potential-fid.js
@@ -13,8 +13,8 @@ const UIStrings = {
   /** The name of the metric "Maximum Potential First Input Delay" that marks the maximum estimated time between the page receiving input (a user clicking, tapping, or typing) and the page responding. Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit. */
   title: 'Max Potential FID',
   /** Description of the Maximum Potential First Input Delay metric that marks the maximum estimated time between the page receiving input (a user clicking, tapping, or typing) and the page responding. This description is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
-  description: 'The potential First Input Delay that your users could experience is the ' +
-      'duration, in milliseconds, of the longest task.',
+  description: 'The maximum potential First Input Delay that your users could experience is the ' +
+      'duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay).',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -353,8 +353,8 @@ const defaultConfig = {
         {id: 'speed-index', weight: 4, group: 'metrics'},
         {id: 'interactive', weight: 5, group: 'metrics'},
         {id: 'first-cpu-idle', weight: 2, group: 'metrics'},
-        {id: 'estimated-input-latency', weight: 0, group: 'metrics'},
-        {id: 'max-potential-fid', weight: 0}, // intentionally left out of metrics so it won't be displayed yet
+        {id: 'max-potential-fid', weight: 0, group: 'metrics'},
+        {id: 'estimated-input-latency', weight: 0}, // intentionally left out of metrics so it won't be displayed
 
         {id: 'render-blocking-resources', weight: 0, group: 'load-opportunities'},
         {id: 'uses-responsive-images', weight: 0, group: 'load-opportunities'},

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -712,7 +712,7 @@
     "description": "The name of the metric that marks the time at which the page is fully loaded and is able to quickly respond to user input (clicks, taps, and keypresses feel responsive). Shown to users as the label for the numeric metric value. Ideally fits within a ~40 character limit."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | description": {
-    "message": "The potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task.",
+    "message": "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay).",
     "description": "Description of the Maximum Potential First Input Delay metric that marks the maximum estimated time between the page receiving input (a user clicking, tapping, or typing) and the page responding. This description is displayed within a tooltip when the user hovers on the metric name to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
   },
   "lighthouse-core/audits/metrics/max-potential-fid.js | title": {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -194,7 +194,7 @@
     "max-potential-fid": {
       "id": "max-potential-fid",
       "title": "Max Potential FID",
-      "description": "The potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task.",
+      "description": "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay).",
       "score": 0.92,
       "scoreDisplayMode": "numeric",
       "numericValue": 122.537,
@@ -3005,12 +3005,12 @@
           "group": "metrics"
         },
         {
-          "id": "estimated-input-latency",
+          "id": "max-potential-fid",
           "weight": 0,
           "group": "metrics"
         },
         {
-          "id": "max-potential-fid",
+          "id": "estimated-input-latency",
           "weight": 0
         },
         {

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -1425,7 +1425,7 @@
             "title": "The user's focus is directed to new content added to the page"
         }, 
         "max-potential-fid": {
-            "description": "The potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task.", 
+            "description": "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay).", 
             "displayValue": "120\u00a0ms", 
             "id": "max-potential-fid", 
             "numericValue": 122.537, 
@@ -3242,11 +3242,11 @@
                 }, 
                 {
                     "group": "metrics", 
-                    "id": "estimated-input-latency", 
+                    "id": "max-potential-fid", 
                     "weight": 0.0
                 }, 
                 {
-                    "id": "max-potential-fid", 
+                    "id": "estimated-input-latency", 
                     "weight": 0.0
                 }, 
                 {


### PR DESCRIPTION
**Summary**
Promotes Max Potential FID to the spot of EIL, moves EIL to JSON only.

> @patrickhulce: oh we're def making that happen for v5? 😀
> @paulirish: ya


It's difficult to analyze our thresholds because the HTTPArchive data we have on max potential FID will all by impacted by the missing microtask data bug (see #8379), but MPFID differentiates **MUCH* better than than EIL, they feel about right, and its still not a scored metric anyway...


**Ventiles**
```sql
SELECT
  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.max-potential-fid.rawValue') as FLOAT64),
    20) as mpfid,
  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.estimated-input-latency.rawValue') as FLOAT64),
    20) as eil
FROM
  httparchive.lighthouse.2019_03_01_mobile
```
![image](https://user-images.githubusercontent.com/2301202/56939028-5e080500-6acb-11e9-87b4-37e6d8faebb7.png)


**Related Issues/PRs**
picks up the mantle of #5842 and raises it to glory.
