### PR TITLE
core(runner): audits can only use requiredArtifacts

### DIFF
--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -25,7 +25,7 @@ module.exports = [
           score: 0,
           details: {
             items: {
-              length: 6,
+              length: 8,
             },
           },
         },

--- a/lighthouse-core/audits/bootup-time.js
+++ b/lighthouse-core/audits/bootup-time.js
@@ -45,7 +45,7 @@ class BootupTime extends Audit {
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['traces'],
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
   }
 

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -70,10 +70,9 @@ class RenderBlockingResources extends Audit {
       title: str_(UIStrings.title),
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       description: str_(UIStrings.description),
-      // This audit also looks at CSSUsage but has a graceful fallback if it failed, so do not mark
-      // it as a "requiredArtifact".
-      // TODO: look into adding an `optionalArtifacts` property that captures this
-      requiredArtifacts: ['URL', 'TagsBlockingFirstPaint', 'traces', 'devtoolsLogs'],
+      // TODO: look into adding an `optionalArtifacts` property that captures the non-required nature
+      // of CSSUsage
+      requiredArtifacts: ['URL', 'TagsBlockingFirstPaint', 'traces', 'devtoolsLogs', 'CSSUsage'],
     };
   }
 

--- a/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
+++ b/lighthouse-core/audits/byte-efficiency/render-blocking-resources.js
@@ -73,7 +73,7 @@ class RenderBlockingResources extends Audit {
       // This audit also looks at CSSUsage but has a graceful fallback if it failed, so do not mark
       // it as a "requiredArtifact".
       // TODO: look into adding an `optionalArtifacts` property that captures this
-      requiredArtifacts: ['URL', 'TagsBlockingFirstPaint', 'traces'],
+      requiredArtifacts: ['URL', 'TagsBlockingFirstPaint', 'traces', 'devtoolsLogs'],
     };
   }
 

--- a/lighthouse-core/audits/byte-efficiency/unminified-css.js
+++ b/lighthouse-core/audits/byte-efficiency/unminified-css.js
@@ -36,7 +36,7 @@ class UnminifiedCSS extends ByteEfficiencyAudit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['CSSUsage', 'devtoolsLogs', 'traces'],
+      requiredArtifacts: ['CSSUsage', 'devtoolsLogs', 'traces', 'URL'],
     };
   }
 

--- a/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-optimized-images.js
@@ -35,7 +35,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['OptimizedImages', 'ImageElements', 'devtoolsLogs', 'traces'],
+      requiredArtifacts: ['OptimizedImages', 'ImageElements', 'devtoolsLogs', 'traces', 'URL'],
     };
   }
 

--- a/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
+++ b/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
@@ -35,7 +35,7 @@ class UsesWebPImages extends ByteEfficiencyAudit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       scoreDisplayMode: ByteEfficiencyAudit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['OptimizedImages', 'devtoolsLogs', 'traces'],
+      requiredArtifacts: ['OptimizedImages', 'devtoolsLogs', 'traces', 'URL', 'ImageElements'],
     };
   }
 

--- a/lighthouse-core/audits/metrics/estimated-input-latency.js
+++ b/lighthouse-core/audits/metrics/estimated-input-latency.js
@@ -31,7 +31,7 @@ class EstimatedInputLatency extends Audit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['traces'],
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
   }
 

--- a/lighthouse-core/audits/metrics/first-cpu-idle.js
+++ b/lighthouse-core/audits/metrics/first-cpu-idle.js
@@ -30,7 +30,7 @@ class FirstCPUIdle extends Audit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['traces'],
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
   }
 

--- a/lighthouse-core/audits/metrics/first-meaningful-paint.js
+++ b/lighthouse-core/audits/metrics/first-meaningful-paint.js
@@ -29,7 +29,7 @@ class FirstMeaningfulPaint extends Audit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['traces'],
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
   }
 

--- a/lighthouse-core/audits/metrics/max-potential-fid.js
+++ b/lighthouse-core/audits/metrics/max-potential-fid.js
@@ -34,7 +34,7 @@ class MaxPotentialFID extends Audit {
       title: str_(UIStrings.title),
       description: str_(UIStrings.description),
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
-      requiredArtifacts: ['traces'],
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
     };
   }
 

--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -53,7 +53,7 @@ class Canonical extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['LinkElements', 'URL'],
+      requiredArtifacts: ['LinkElements', 'URL', 'devtoolsLogs'],
     };
   }
 

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -225,7 +225,7 @@ class FontSize extends Audit {
       };
     }
 
-    const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
+    const viewportMeta = await ComputedViewportMeta.request(artifacts.MetaElements, context);
     if (!viewportMeta.isMobileOptimized) {
       return {
         score: 0,

--- a/lighthouse-core/audits/seo/is-crawlable.js
+++ b/lighthouse-core/audits/seo/is-crawlable.js
@@ -81,7 +81,7 @@ class IsCrawlable extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['MetaElements', 'RobotsTxt', 'URL'],
+      requiredArtifacts: ['MetaElements', 'RobotsTxt', 'URL', 'devtoolsLogs'],
     };
   }
 

--- a/lighthouse-core/audits/seo/tap-targets.js
+++ b/lighthouse-core/audits/seo/tap-targets.js
@@ -283,7 +283,7 @@ class TapTargets extends Audit {
       };
     }
 
-    const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
+    const viewportMeta = await ComputedViewportMeta.request(artifacts.MetaElements, context);
     if (!viewportMeta.isMobileOptimized) {
       return {
         score: 0,

--- a/lighthouse-core/audits/viewport.js
+++ b/lighthouse-core/audits/viewport.js
@@ -30,7 +30,7 @@ class Viewport extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit(artifacts, context) {
-    const viewportMeta = await ComputedViewportMeta.request(artifacts, context);
+    const viewportMeta = await ComputedViewportMeta.request(artifacts.MetaElements, context);
 
     if (!viewportMeta.hasViewportTag) {
       return {

--- a/lighthouse-core/computed/viewport-meta.js
+++ b/lighthouse-core/computed/viewport-meta.js
@@ -11,10 +11,10 @@ const makeComputedArtifact = require('./computed-artifact.js');
 
 class ViewportMeta {
   /**
-   * @param {{MetaElements: LH.GathererArtifacts['MetaElements']}} artifacts
+   * @param {LH.GathererArtifacts['MetaElements']} MetaElements
    * @return {Promise<ViewportMetaResult>}
   */
-  static async compute_({MetaElements}) {
+  static async compute_(MetaElements) {
     const viewportMeta = MetaElements.find(meta => meta.name === 'viewport');
 
     if (!viewportMeta) {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -325,7 +325,12 @@ class Runner {
         ...sharedAuditContext,
       };
 
-      const product = await audit.audit(artifacts, auditContext);
+      const requiredArtifacts = audit.meta.requiredArtifacts
+        .reduce((requiredArtifacts, artifactName) => {
+          requiredArtifacts[artifactName] = artifacts[artifactName];
+          return requiredArtifacts;
+        }, /** @type {LH.Artifacts} */ ({}));
+      const product = await audit.audit(requiredArtifacts, auditContext);
       auditResult = Audit.generateAuditResult(audit, product);
     } catch (err) {
       log.warn(audit.meta.id, `Caught exception: ${err.message}`);

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -325,6 +325,9 @@ class Runner {
         ...sharedAuditContext,
       };
 
+      // Only pass the declared `requiredArtifacts` to the audit
+      // The type is masquerading as `LH.Artifacts` but will only contain a subset of the keys
+      // to prevent consumers from unnecessary type assertions.
       const requiredArtifacts = audit.meta.requiredArtifacts
         .reduce((requiredArtifacts, artifactName) => {
           requiredArtifacts[artifactName] = artifacts[artifactName];

--- a/lighthouse-core/test/computed/viewport-meta-test.js
+++ b/lighthouse-core/test/computed/viewport-meta-test.js
@@ -14,7 +14,7 @@ describe('ViewportMeta computed artifact', () => {
   const makeMetaElements = viewport => [{name: 'viewport', content: viewport}];
 
   it('is not mobile optimized when page does not contain a viewport meta tag', async () => {
-    const {hasViewportTag, isMobileOptimized} = await ViewportMeta.compute_({MetaElements: []});
+    const {hasViewportTag, isMobileOptimized} = await ViewportMeta.compute_([]);
     assert.equal(hasViewportTag, false);
     assert.equal(isMobileOptimized, false);
   });
@@ -23,7 +23,7 @@ describe('ViewportMeta computed artifact', () => {
   it('is not mobile optimized when HTML contains a non-mobile friendly viewport meta tag', async () => {
     const viewport = 'maximum-scale=1';
     const {hasViewportTag, isMobileOptimized} =
-      await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+      await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(hasViewportTag, true);
     assert.equal(isMobileOptimized, false);
   });
@@ -31,7 +31,7 @@ describe('ViewportMeta computed artifact', () => {
   it('is not mobile optimized when HTML contains an invalid viewport meta tag key', async () => {
     const viewport = 'nonsense=true';
     const {hasViewportTag, isMobileOptimized} =
-      await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+      await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(hasViewportTag, true);
     assert.equal(isMobileOptimized, false);
   });
@@ -39,7 +39,7 @@ describe('ViewportMeta computed artifact', () => {
   it('is not mobile optimized when HTML contains an invalid viewport meta tag value', async () => {
     const viewport = 'initial-scale=microscopic';
     const {isMobileOptimized, parserWarnings} =
-      await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+      await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(isMobileOptimized, false);
     assert.equal(parserWarnings[0], 'Invalid values found: {"initial-scale":"microscopic"}');
   });
@@ -48,7 +48,7 @@ describe('ViewportMeta computed artifact', () => {
   it('is not mobile optimized when HTML contains an invalid viewport meta tag key and value', async () => {
     const viewport = 'nonsense=true, initial-scale=microscopic';
     const {isMobileOptimized, parserWarnings} =
-      await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+      await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(isMobileOptimized, false);
     assert.equal(parserWarnings[0], 'Invalid properties found: {"nonsense":"true"}');
     assert.equal(parserWarnings[1], 'Invalid values found: {"initial-scale":"microscopic"}');
@@ -64,7 +64,7 @@ describe('ViewportMeta computed artifact', () => {
 
     await Promise.all(viewports.map(async viewport => {
       const {isMobileOptimized} =
-        await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+        await ViewportMeta.compute_(makeMetaElements(viewport));
       assert.equal(isMobileOptimized, true);
     }));
   });
@@ -76,7 +76,7 @@ describe('ViewportMeta computed artifact', () => {
     ];
     await Promise.all(viewports.map(async viewport => {
       const {isMobileOptimized, parserWarnings} =
-        await ViewportMeta.compute_({MetaElements: makeMetaElements(viewport)});
+        await ViewportMeta.compute_(makeMetaElements(viewport));
       assert.equal(isMobileOptimized, true);
       assert.equal(parserWarnings[0], undefined);
     }));

--- a/lighthouse-core/test/fixtures/artifacts/alphabet-artifacts/artifacts.json
+++ b/lighthouse-core/test/fixtures/artifacts/alphabet-artifacts/artifacts.json
@@ -1,0 +1,11 @@
+{
+  "URL": {
+    "requestedUrl": "https://example.com/",
+    "finalUrl": "https://example.com/"
+  },
+  "ArtifactA": "apple",
+  "ArtifactB": "banana",
+  "ArtifactC": "cherry",
+  "ArtifactD": "date",
+  "Stacks": []
+}

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -363,7 +363,7 @@ describe('Runner', () => {
         ],
       });
 
-      const results = await Runner.run({}, {config})
+      const results = await Runner.run({}, {config});
       expect(results.lhr).toMatchObject({audits: {simple: {score: 1}}});
       expect(auditMockFn).toHaveBeenCalled();
       expect(auditMockFn.mock.calls[0][0]).toEqual({

--- a/lighthouse-core/test/runner-test.js
+++ b/lighthouse-core/test/runner-test.js
@@ -339,6 +339,38 @@ describe('Runner', () => {
         assert.ok(auditResult.errorMessage.includes(errorMessage));
       });
     });
+
+    it('only passes the required artifacts to the audit', async () => {
+      class SimpleAudit extends Audit {
+        static get meta() {
+          return {
+            id: 'simple',
+            title: 'Requires some artifacts',
+            failureTitle: 'Artifacts',
+            description: 'Test for always throwing',
+            requiredArtifacts: ['ArtifactA', 'ArtifactC'],
+          };
+        }
+      }
+
+      const auditMockFn = SimpleAudit.audit = jest.fn().mockReturnValue({score: 1});
+      const config = new Config({
+        settings: {
+          auditMode: __dirname + '/fixtures/artifacts/alphabet-artifacts/',
+        },
+        audits: [
+          SimpleAudit,
+        ],
+      });
+
+      const results = await Runner.run({}, {config})
+      expect(results.lhr).toMatchObject({audits: {simple: {score: 1}}});
+      expect(auditMockFn).toHaveBeenCalled();
+      expect(auditMockFn.mock.calls[0][0]).toEqual({
+        ArtifactA: 'apple',
+        ArtifactC: 'cherry',
+      });
+    });
   });
 
   describe('Bad audit behavior handling', () => {


### PR DESCRIPTION
**Summary**
One more breaking change I want to get in we discussed in the meeting that I misunderstood and thought was already on someone's plate :) 

**an audit can only use its `requiredArtifacts`**

With plugins it feels like folks aren't going to remember to use `requiredArtifacts` and if we ever want to enforce it, seems like we need to do it now.

This also fixes the dozen or so audits that were cheating :)
