### PR TITLE
lightwallet: Use gray circles & font for informative audits

### DIFF
--- a/lighthouse-core/report/html/renderer/category-renderer.js
+++ b/lighthouse-core/report/html/renderer/category-renderer.js
@@ -158,7 +158,10 @@ class CategoryRenderer {
    */
   _setRatingClass(element, score, scoreDisplayMode) {
     const rating = Util.calculateRating(score, scoreDisplayMode);
-    element.classList.add(`lh-audit--${rating}`, `lh-audit--${scoreDisplayMode.toLowerCase()}`);
+    element.classList.add(`lh-audit--${scoreDisplayMode.toLowerCase()}`);
+    if (scoreDisplayMode !== 'informative') {
+      element.classList.add(`lh-audit--${rating}`);
+    }
     return element;
   }
 

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -439,6 +439,16 @@
   display: none;
 }
 
+.lh-audit--informative .lh-audit__display-text {
+  color: var(--color-black-600);
+}
+
+.lh-audit--informative .lh-audit__score-icon {
+  border: none;
+  border-radius: 100%;
+  background: var(--color-black-400);
+}
+
 .lh-audit__description,
 .lh-audit__stackpack {
   color: var(--secondary-text-color);

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -96,7 +96,34 @@ describe('CategoryRenderer', () => {
         score: 0,
       },
     });
+    assert.ok(auditDOM.matches('.lh-audit--informative'));
+  });
 
+  it('adds a pass/average/fail class for non-informative audits', () => {
+    const auditDOM = renderer.renderAudit({
+      id: 'not-informative',
+      result: {
+        title: 'Not informative',
+        description: 'help text',
+        scoreDisplayMode: 'numeric',
+        score: 0,
+      },
+    });
+    assert.ok(auditDOM.matches('.lh-audit--fail'));
+  });
+
+  it('does not add a pass/average/fail class for informative audits', () => {
+    const auditDOM = renderer.renderAudit({
+      id: 'informative',
+      result: {
+        title: 'It informs',
+        description: 'help text',
+        scoreDisplayMode: 'informative',
+        score: 0,
+      },
+    });
+    assert.equal(auditDOM.classList.length, 2);
+    assert.ok(auditDOM.matches('.lh-audit'));
     assert.ok(auditDOM.matches('.lh-audit--informative'));
   });
 


### PR DESCRIPTION

<img width="916" alt="Screen Shot 2019-05-01 at 12 44 44 AM" src="https://user-images.githubusercontent.com/6076184/57005951-5c613e80-6baa-11e9-91bf-c186b2f20585.png">


**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
