### PR TITLE
core(lightwallet): add budget to sample artifacts config

### DIFF
--- a/lighthouse-core/scripts/update-report-fixtures.js
+++ b/lighthouse-core/scripts/update-report-fixtures.js
@@ -12,6 +12,25 @@ const {server} = require('../../lighthouse-cli/test/fixtures/static-server.js');
 
 /** @typedef {import('net').AddressInfo} AddressInfo */
 
+/** @type {LH.Config.Json} */
+const budgetedConfig = {
+  extends: 'lighthouse:default',
+  settings: {
+    budgets: [{
+      resourceSizes: [
+        {resourceType: 'script', budget: 125},
+        {resourceType: 'total', budget: 500},
+      ],
+      timings: [
+        {metric: 'interactive', budget: 5000, tolerance: 1000},
+      ],
+      resourceCounts: [
+        {resourceType: 'third-party', budget: 0},
+      ],
+    }],
+  },
+};
+
 /**
  * Update the report artifacts
  */
@@ -31,7 +50,7 @@ async function update() {
     url,
   ].join(' ');
   const flags = cliFlags.getFlags(rawFlags);
-  await cli.runLighthouse(url, flags, undefined);
+  await cli.runLighthouse(url, flags, budgetedConfig);
   await new Promise(res => server.close(res));
 }
 

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -41,17 +41,17 @@
             "budget": 500
           }
         ],
+        "resourceCounts": [
+          {
+            "resourceType": "third-party",
+            "budget": 0
+          }
+        ],
         "timings": [
           {
             "metric": "interactive",
             "budget": 5000,
             "tolerance": 1000
-          }
-        ],
-         "resourceCounts": [
-          {
-           "resourceType": "third-party",
-           "budget": 0
           }
         ]
       }


### PR DESCRIPTION
#8427 manually added a budget to the sample artifacts. This PR changes `update-report-fixtures.js` to add a budget to the run so that it will always be in the sample artifacts when it's updated in the future.

Originally discussed in https://github.com/GoogleChrome/lighthouse/pull/8427#discussion_r277925455.

I just copied the budget added in #8427. The property order changes in the `artifacts.json` file because this is the order that `budget.js` initializes things.

