### PR TITLE
 tests: convert smoke metric assertions to numericValue

### DIFF
--- a/lighthouse-cli/test/smokehouse/perf/expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/expectations.js
@@ -15,19 +15,19 @@ module.exports = [
       finalUrl: 'http://localhost:10200/preload.html',
       audits: {
         'speed-index': {
-          score: '>=0.80',
+          score: '>=0.80', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
         },
         'first-meaningful-paint': {
-          score: '>=0.90',
+          score: '>=0.90', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
         },
         'first-cpu-idle': {
-          score: '>=0.90',
+          score: '>=0.90', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
         },
         'interactive': {
-          score: '>=0.90',
+          score: '>=0.90', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
         },
         'time-to-first-byte': {
-          // Can be flaky, so test float numericValue instead of boolean score
+          // Can be flaky, so test float numericValue instead of binary score
           numericValue: '<1000',
         },
         'network-requests': {

--- a/lighthouse-cli/test/smokehouse/perf/lantern-expectations.js
+++ b/lighthouse-cli/test/smokehouse/perf/lantern-expectations.js
@@ -33,7 +33,8 @@ module.exports = [
       audits: {
         'interactive': {
           // Make sure all of the CPU time is reflected in the perf metrics as well.
-          score: '<.2',
+          // The scripts stalls for 3 seconds and lantern has a 4x multiplier so 12s minimum.
+          numericValue: '>12000',
         },
         'bootup-time': {
           details: {
@@ -56,7 +57,8 @@ module.exports = [
       audits: {
         'interactive': {
           // Make sure all of the CPU time is reflected in the perf metrics as well.
-          score: '<.2',
+          // The scripts stalls for 3 seconds and lantern has a 4x multiplier so 12s minimum.
+          numericValue: '>12000',
         },
         'bootup-time': {
           details: {

--- a/lighthouse-cli/test/smokehouse/tricky-metrics/expectations.js
+++ b/lighthouse-cli/test/smokehouse/tricky-metrics/expectations.js
@@ -15,11 +15,11 @@ module.exports = [
       finalUrl: 'http://localhost:10200/tricky-tti.html',
       audits: {
         'first-cpu-idle': {
-          score: '<75',
+          // stalls for 5 seconds, 5 seconds out, so should be around 10s
           numericValue: '>9000',
         },
         'interactive': {
-          score: '<75',
+          // stalls for 5 seconds, 5 seconds out, so should be around 10s
           numericValue: '>9000',
         },
       },


### PR DESCRIPTION
**Summary**
Converts some smoke metric assertions to assert on numericValue instead of just score. Some folks find this more readable as to the intention of the smoke test (https://github.com/GoogleChrome/lighthouse/pull/8379#issuecomment-488563344), others feel that there's no harm in including both (https://github.com/GoogleChrome/lighthouse/pull/8805#discussion_r280561086). 