### PR TITLE
misc(proto): remove trailing whitespace; add contributing messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
     "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --preset=mixed-content",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
-    "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts",
+    "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf to compile the proto file.\" && false)",
     "build-proto-roundtrip": "cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py"
   },
   "devDependencies": {

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -1,4716 +1,4716 @@
 {
     "audits": {
         "accesskeys": {
-            "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).", 
+            "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "accesskeys", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "accesskeys",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "`[accesskey]` values are unique"
-        }, 
+        },
         "appcache-manifest": {
-            "description": "Application Cache is deprecated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/appcache).", 
-            "displayValue": "Found \"clock.appcache\"", 
-            "id": "appcache-manifest", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "Application Cache is deprecated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/appcache).",
+            "displayValue": "Found \"clock.appcache\"",
+            "id": "appcache-manifest",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Uses Application Cache"
-        }, 
+        },
         "aria-allowed-attr": {
-            "description": "Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse).", 
-            "id": "aria-allowed-attr", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=lighthouse).",
+            "id": "aria-allowed-attr",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`[aria-*]` attributes match their roles"
-        }, 
+        },
         "aria-required-attr": {
-            "description": "Some ARIA roles have required attributes that describe the state of the element to screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse).", 
-            "id": "aria-required-attr", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Some ARIA roles have required attributes that describe the state of the element to screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-attr?application=lighthouse).",
+            "id": "aria-required-attr",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`[role]`s have all required `[aria-*]` attributes"
-        }, 
+        },
         "aria-required-children": {
-            "description": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse).", 
-            "id": "aria-required-children", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-children?application=lighthouse).",
+            "id": "aria-required-children",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "Elements with `[role]` that require specific children `[role]`s, are present"
-        }, 
+        },
         "aria-required-parent": {
-            "description": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse).", 
-            "id": "aria-required-parent", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-required-parent?application=lighthouse).",
+            "id": "aria-required-parent",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`[role]`s are contained by their required parent element"
-        }, 
+        },
         "aria-roles": {
-            "description": "ARIA roles must have valid values in order to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse).", 
-            "id": "aria-roles", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "ARIA roles must have valid values in order to perform their intended accessibility functions. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-roles?application=lighthouse).",
+            "id": "aria-roles",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`[role]` values are valid"
-        }, 
+        },
         "aria-valid-attr": {
-            "description": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid names. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse).", 
-            "id": "aria-valid-attr", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid names. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr?application=lighthouse).",
+            "id": "aria-valid-attr",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`[aria-*]` attributes are valid and not misspelled"
-        }, 
+        },
         "aria-valid-attr-value": {
-            "description": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid values. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse).", 
-            "id": "aria-valid-attr-value", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid values. [Learn more](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=lighthouse).",
+            "id": "aria-valid-attr-value",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`[aria-*]` attributes have valid values"
-        }, 
+        },
         "audio-caption": {
-            "description": "Captions make audio elements usable for deaf or hearing-impaired users, providing critical information such as who is talking, what they're saying, and other non-speech information. [Learn more](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse).", 
-            "id": "audio-caption", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Captions make audio elements usable for deaf or hearing-impaired users, providing critical information such as who is talking, what they're saying, and other non-speech information. [Learn more](https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=lighthouse).",
+            "id": "audio-caption",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`<audio>` elements contain a `<track>` element with `[kind=\"captions\"]`"
-        }, 
+        },
         "bootup-time": {
-            "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/bootup).", 
+            "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/bootup).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "total", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "total",
                         "text": "Total CPU Time"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "scripting", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "scripting",
                         "text": "Script Evaluation"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "scriptParseCompile", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "scriptParseCompile",
                         "text": "Script Parse"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "scriptParseCompile": 2.777, 
-                        "scripting": 957.494, 
-                        "total": 966.9800000000001, 
+                        "scriptParseCompile": 2.777,
+                        "scripting": 957.494,
+                        "total": 966.9800000000001,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "scriptParseCompile": 0.092, 
-                        "scripting": 17.790999999999997, 
-                        "total": 391.76699999999977, 
+                        "scriptParseCompile": 0.092,
+                        "scripting": 17.790999999999997,
+                        "total": 391.76699999999977,
                         "url": "Other"
-                    }, 
+                    },
                     {
-                        "scriptParseCompile": 1.674, 
-                        "scripting": 89.50799999999998, 
-                        "total": 101.21099999999998, 
+                        "scriptParseCompile": 1.674,
+                        "scripting": 89.50799999999998,
+                        "total": 101.21099999999998,
                         "url": "http://localhost:10200/zone.js"
-                    }, 
+                    },
                     {
-                        "scriptParseCompile": 1.205, 
-                        "scripting": 80.032, 
-                        "total": 82.741, 
+                        "scriptParseCompile": 1.205,
+                        "scripting": 80.032,
+                        "total": 82.741,
                         "url": "http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"
                     }
-                ], 
+                ],
                 "summary": {
                     "wastedMs": 1150.573
-                }, 
+                },
                 "type": "table"
-            }, 
-            "displayValue": "1.2\u00a0s", 
-            "id": "bootup-time", 
-            "numericValue": 1150.573, 
-            "score": 0.92, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "displayValue": "1.2\u00a0s",
+            "id": "bootup-time",
+            "numericValue": 1150.573,
+            "score": 0.92,
+            "scoreDisplayMode": "numeric",
             "title": "JavaScript execution time"
-        }, 
+        },
         "button-name": {
-            "description": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse).", 
-            "id": "button-name", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse).",
+            "id": "button-name",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "Buttons have an accessible name"
-        }, 
+        },
         "bypass": {
-            "description": "Adding ways to bypass repetitive content lets keyboard users navigate the page more efficiently. [Learn more](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse).", 
+            "description": "Adding ways to bypass repetitive content lets keyboard users navigate the page more efficiently. [Learn more](https://dequeuniversity.com/rules/axe/3.1/bypass?application=lighthouse).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "bypass", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "bypass",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "The page contains a heading, skip link, or landmark region"
-        }, 
+        },
         "canonical": {
-            "description": "Canonical links suggest which URL to show in search results. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/canonical).", 
-            "id": "canonical", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Canonical links suggest which URL to show in search results. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/canonical).",
+            "id": "canonical",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "Document has a valid `rel=canonical`"
-        }, 
+        },
         "color-contrast": {
-            "description": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse).", 
+            "description": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://dequeuniversity.com/rules/axe/3.1/color-contrast?application=lighthouse).",
             "details": {
                 "debugData": {
-                    "impact": "serious", 
+                    "impact": "serious",
                     "tags": [
-                        "cat.color", 
-                        "wcag2aa", 
+                        "cat.color",
+                        "wcag2aa",
                         "wcag143"
-                    ], 
+                    ],
                     "type": "debugdata"
-                }, 
+                },
                 "headings": [
                     {
-                        "itemType": "node", 
-                        "key": "node", 
+                        "itemType": "node",
+                        "key": "node",
                         "text": "Failing Elements"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  Element has insufficient color contrast of 1.32 (foreground color: #ffc0cb, background color: #eeeeee, font size: 18.0pt, font weight: bold). Expected contrast ratio of 3:1", 
-                            "path": "3,HTML,1,BODY,5,DIV,0,H2", 
-                            "selector": "h2", 
-                            "snippet": "<h2>Do better web tester page</h2>", 
+                            "explanation": "Fix any of the following:\n  Element has insufficient color contrast of 1.32 (foreground color: #ffc0cb, background color: #eeeeee, font size: 18.0pt, font weight: bold). Expected contrast ratio of 3:1",
+                            "path": "3,HTML,1,BODY,5,DIV,0,H2",
+                            "selector": "h2",
+                            "snippet": "<h2>Do better web tester page</h2>",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  Element has insufficient color contrast of 1.32 (foreground color: #ffc0cb, background color: #eeeeee, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1", 
-                            "path": "3,HTML,1,BODY,5,DIV,1,SPAN", 
-                            "selector": "span", 
-                            "snippet": "<span>Hi there!</span>", 
+                            "explanation": "Fix any of the following:\n  Element has insufficient color contrast of 1.32 (foreground color: #ffc0cb, background color: #eeeeee, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1",
+                            "path": "3,HTML,1,BODY,5,DIV,1,SPAN",
+                            "selector": "span",
+                            "snippet": "<span>Hi there!</span>",
                             "type": "node"
                         }
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "color-contrast", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "color-contrast",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Background and foreground colors do not have a sufficient contrast ratio."
-        }, 
+        },
         "content-width": {
-            "description": "If the width of your app's content doesn't match the width of the viewport, your app might not be optimized for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport).", 
-            "id": "content-width", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "If the width of your app's content doesn't match the width of the viewport, your app might not be optimized for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/content-sized-correctly-for-viewport).",
+            "id": "content-width",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Content is sized correctly for the viewport"
-        }, 
+        },
         "critical-request-chains": {
-            "description": "The Critical Request Chains below show you what resources are loaded with a high priority. Consider reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains).", 
+            "description": "The Critical Request Chains below show you what resources are loaded with a high priority. Consider reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/critical-request-chains).",
             "details": {
                 "chains": {
                     "75994.33": {
                         "request": {
-                            "endTime": 185608.857719, 
-                            "responseReceivedTime": 185608.85586200003, 
-                            "startTime": 185608.288594, 
-                            "transferSize": 221.0, 
+                            "endTime": 185608.857719,
+                            "responseReceivedTime": 185608.85586200003,
+                            "startTime": 185608.288594,
+                            "transferSize": 221.0,
                             "url": "http://localhost:10200/favicon.ico"
                         }
-                    }, 
+                    },
                     "F3B687683512E0F003DD41EB23E2091A": {
                         "children": {
                             "75994.10": {
                                 "request": {
-                                    "endTime": 185605.113307, 
-                                    "responseReceivedTime": 185605.104776, 
-                                    "startTime": 185603.965303, 
-                                    "transferSize": 1703.0, 
+                                    "endTime": 185605.113307,
+                                    "responseReceivedTime": 185605.104776,
+                                    "startTime": 185603.965303,
+                                    "transferSize": 1703.0,
                                     "url": "http://localhost:10200/dobetterweb/dbw_tester.js"
                                 }
-                            }, 
+                            },
                             "75994.11": {
                                 "request": {
-                                    "endTime": 185604.557407, 
-                                    "responseReceivedTime": 185604.556719, 
-                                    "startTime": 185603.96675, 
-                                    "transferSize": 144.0, 
+                                    "endTime": 185604.557407,
+                                    "responseReceivedTime": 185604.556719,
+                                    "startTime": 185603.96675,
+                                    "transferSize": 144.0,
                                     "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500"
                                 }
-                            }, 
+                            },
                             "75994.21": {
                                 "request": {
-                                    "endTime": 185607.28227, 
-                                    "responseReceivedTime": 185606.742005, 
-                                    "startTime": 185606.170955, 
-                                    "transferSize": 71654.0, 
+                                    "endTime": 185607.28227,
+                                    "responseReceivedTime": 185606.742005,
+                                    "startTime": 185606.170955,
+                                    "transferSize": 71654.0,
                                     "url": "http://localhost:10200/zone.js"
                                 }
-                            }, 
+                            },
                             "75994.22": {
                                 "request": {
-                                    "endTime": 185608.117509, 
-                                    "responseReceivedTime": 185607.822806, 
-                                    "startTime": 185607.195975, 
-                                    "transferSize": 30174.0, 
+                                    "endTime": 185608.117509,
+                                    "responseReceivedTime": 185607.822806,
+                                    "startTime": 185607.195975,
+                                    "transferSize": 30174.0,
                                     "url": "http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"
                                 }
-                            }, 
+                            },
                             "75994.28": {
                                 "request": {
-                                    "endTime": 185607.285454, 
-                                    "responseReceivedTime": 185606.82147599998, 
-                                    "startTime": 185606.245562, 
-                                    "transferSize": 821.0, 
+                                    "endTime": 185607.285454,
+                                    "responseReceivedTime": 185606.82147599998,
+                                    "startTime": 185606.245562,
+                                    "transferSize": 821.0,
                                     "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
                                 }
-                            }, 
+                            },
                             "75994.3": {
                                 "request": {
-                                    "endTime": 185604.52588, 
-                                    "responseReceivedTime": 185604.52470399998, 
-                                    "startTime": 185603.956717, 
-                                    "transferSize": 821.0, 
+                                    "endTime": 185604.52588,
+                                    "responseReceivedTime": 185604.52470399998,
+                                    "startTime": 185603.956717,
+                                    "transferSize": 821.0,
                                     "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100"
                                 }
-                            }, 
+                            },
                             "75994.4": {
                                 "request": {
-                                    "endTime": 185604.534512, 
-                                    "responseReceivedTime": 185604.532778, 
-                                    "startTime": 185603.957861, 
-                                    "transferSize": 139.0, 
+                                    "endTime": 185604.534512,
+                                    "responseReceivedTime": 185604.532778,
+                                    "startTime": 185603.957861,
+                                    "transferSize": 139.0,
                                     "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200"
                                 }
-                            }, 
+                            },
                             "75994.5": {
                                 "request": {
-                                    "endTime": 185606.170588, 
-                                    "responseReceivedTime": 185606.169761, 
-                                    "startTime": 185603.959225, 
-                                    "transferSize": 821.0, 
+                                    "endTime": 185606.170588,
+                                    "responseReceivedTime": 185606.169761,
+                                    "startTime": 185603.959225,
+                                    "transferSize": 821.0,
                                     "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200"
                                 }
-                            }, 
+                            },
                             "75994.6": {
                                 "request": {
-                                    "endTime": 185604.541262, 
-                                    "responseReceivedTime": 185604.54052399998, 
-                                    "startTime": 185603.960011, 
-                                    "transferSize": 1108.0, 
+                                    "endTime": 185604.541262,
+                                    "responseReceivedTime": 185604.54052399998,
+                                    "startTime": 185603.960011,
+                                    "transferSize": 1108.0,
                                     "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
                                 }
-                            }, 
+                            },
                             "75994.7": {
                                 "request": {
-                                    "endTime": 185604.549739, 
-                                    "responseReceivedTime": 185604.54903999998, 
-                                    "startTime": 185603.961819, 
-                                    "transferSize": 736.0, 
+                                    "endTime": 185604.549739,
+                                    "responseReceivedTime": 185604.54903999998,
+                                    "startTime": 185603.961819,
+                                    "transferSize": 736.0,
                                     "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200"
                                 }
-                            }, 
+                            },
                             "75994.8": {
                                 "request": {
-                                    "endTime": 185605.097653, 
-                                    "responseReceivedTime": 185605.096858, 
-                                    "startTime": 185603.962566, 
-                                    "transferSize": 733.0, 
+                                    "endTime": 185605.097653,
+                                    "responseReceivedTime": 185605.096858,
+                                    "startTime": 185603.962566,
+                                    "transferSize": 733.0,
                                     "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200&isasync"
                                 }
-                            }, 
+                            },
                             "75994.9": {
                                 "request": {
-                                    "endTime": 185607.537382, 
-                                    "responseReceivedTime": 185607.53660999998, 
-                                    "startTime": 185603.964089, 
-                                    "transferSize": 821.0, 
+                                    "endTime": 185607.537382,
+                                    "responseReceivedTime": 185607.53660999998,
+                                    "startTime": 185603.964089,
+                                    "transferSize": 821.0,
                                     "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true"
                                 }
                             }
-                        }, 
+                        },
                         "request": {
-                            "endTime": 185603.961376, 
-                            "responseReceivedTime": 185603.89718499998, 
-                            "startTime": 185603.321221, 
-                            "transferSize": 12640.0, 
+                            "endTime": 185603.961376,
+                            "responseReceivedTime": 185603.89718499998,
+                            "startTime": 185603.321221,
+                            "transferSize": 12640.0,
                             "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
                         }
                     }
-                }, 
+                },
                 "longestChain": {
-                    "duration": 5536.498000001302, 
-                    "length": 1.0, 
+                    "duration": 5536.498000001302,
+                    "length": 1.0,
                     "transferSize": 221.0
-                }, 
+                },
                 "type": "criticalrequestchain"
-            }, 
-            "displayValue": "12 chains found", 
-            "id": "critical-request-chains", 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "displayValue": "12 chains found",
+            "id": "critical-request-chains",
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Minimize Critical Requests Depth"
-        }, 
+        },
         "custom-controls-labels": {
-            "description": "Custom interactive controls have associated labels, provided by aria-label or aria-labelledby. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).", 
-            "id": "custom-controls-labels", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Custom interactive controls have associated labels, provided by aria-label or aria-labelledby. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).",
+            "id": "custom-controls-labels",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Custom controls have associated labels"
-        }, 
+        },
         "custom-controls-roles": {
-            "description": "Custom interactive controls have appropriate ARIA roles. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).", 
-            "id": "custom-controls-roles", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Custom interactive controls have appropriate ARIA roles. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).",
+            "id": "custom-controls-roles",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Custom controls have ARIA roles"
-        }, 
+        },
         "definition-list": {
-            "description": "When definition lists are not properly marked up, screen readers may produce confusing or inaccurate output. [Learn more](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse).", 
-            "id": "definition-list", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "When definition lists are not properly marked up, screen readers may produce confusing or inaccurate output. [Learn more](https://dequeuniversity.com/rules/axe/3.1/definition-list?application=lighthouse).",
+            "id": "definition-list",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`<dl>`'s contain only properly-ordered `<dt>` and `<dd>` groups, `<script>` or `<template>` elements."
-        }, 
+        },
         "deprecations": {
-            "description": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated).", 
+            "description": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://www.chromestatus.com/features#deprecated).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "code", 
-                        "key": "value", 
+                        "itemType": "code",
+                        "key": "value",
                         "text": "Deprecation / Warning"
-                    }, 
+                    },
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "lineNumber", 
+                        "itemType": "text",
+                        "key": "lineNumber",
                         "text": "Line"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "lineNumber": 322.0, 
-                        "source": "deprecation", 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html", 
+                        "lineNumber": 322.0,
+                        "source": "deprecation",
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
                         "value": "Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/."
-                    }, 
+                    },
                     {
-                        "lineNumber": 325.0, 
-                        "source": "deprecation", 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html", 
+                        "lineNumber": 325.0,
+                        "source": "deprecation",
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
                         "value": "'window.webkitStorageInfo' is deprecated. Please use 'navigator.webkitTemporaryStorage' or 'navigator.webkitPersistentStorage' instead."
-                    }, 
+                    },
                     {
-                        "source": "deprecation", 
+                        "source": "deprecation",
                         "value": "/deep/ combinator is no longer supported in CSS dynamic profile.It is now effectively no-op, acting as if it were a descendant combinator. /deep/ combinator will be removed, and will be invalid at M65. You should remove it. See https://www.chromestatus.com/features/4964279606312960 for more details."
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "3 warnings found", 
-            "id": "deprecations", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "displayValue": "3 warnings found",
+            "id": "deprecations",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Uses deprecated APIs"
-        }, 
+        },
         "diagnostics": {
-            "description": "Collection of useful page vitals.", 
+            "description": "Collection of useful page vitals.",
             "details": {
                 "items": [
                     {
-                        "mainDocumentTransferSize": 12640.0, 
-                        "maxRtt": 1.7249999999999943, 
-                        "maxServerLatency": 572.829, 
-                        "numFonts": 0.0, 
-                        "numRequests": 18.0, 
-                        "numScripts": 4.0, 
-                        "numStylesheets": 7.0, 
-                        "numTasks": 107.0, 
-                        "numTasksOver100ms": 3.0, 
-                        "numTasksOver10ms": 7.0, 
-                        "numTasksOver25ms": 5.0, 
-                        "numTasksOver500ms": 1.0, 
-                        "numTasksOver50ms": 4.0, 
-                        "rtt": 0.8639999999999999, 
-                        "throughput": 1398339.461891128, 
-                        "totalByteWeight": 160738.0, 
+                        "mainDocumentTransferSize": 12640.0,
+                        "maxRtt": 1.7249999999999943,
+                        "maxServerLatency": 572.829,
+                        "numFonts": 0.0,
+                        "numRequests": 18.0,
+                        "numScripts": 4.0,
+                        "numStylesheets": 7.0,
+                        "numTasks": 107.0,
+                        "numTasksOver100ms": 3.0,
+                        "numTasksOver10ms": 7.0,
+                        "numTasksOver25ms": 5.0,
+                        "numTasksOver500ms": 1.0,
+                        "numTasksOver50ms": 4.0,
+                        "rtt": 0.8639999999999999,
+                        "throughput": 1398339.461891128,
+                        "totalByteWeight": 160738.0,
                         "totalTaskTime": 1548.5690000000002
                     }
-                ], 
+                ],
                 "type": "debugdata"
-            }, 
-            "id": "diagnostics", 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "id": "diagnostics",
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Diagnostics"
-        }, 
+        },
         "dlitem": {
-            "description": "Definition list items (`<dt>` and `<dd>`) must be wrapped in a parent `<dl>` element to ensure that screen readers can properly announce them. [Learn more](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse).", 
-            "id": "dlitem", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Definition list items (`<dt>` and `<dd>`) must be wrapped in a parent `<dl>` element to ensure that screen readers can properly announce them. [Learn more](https://dequeuniversity.com/rules/axe/3.1/dlitem?application=lighthouse).",
+            "id": "dlitem",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "Definition list items are wrapped in `<dl>` elements"
-        }, 
+        },
         "doctype": {
-            "description": "Specifying a doctype prevents the browser from switching to quirks-mode.Read more on the [MDN Web Docs page](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)", 
-            "id": "doctype", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "Specifying a doctype prevents the browser from switching to quirks-mode.Read more on the [MDN Web Docs page](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)",
+            "id": "doctype",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Page has the HTML doctype"
-        }, 
+        },
         "document-title": {
-            "description": "The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/title).", 
+            "description": "The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/title).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "document-title", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "document-title",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Document has a `<title>` element"
-        }, 
+        },
         "dom-size": {
-            "description": "Browser engineers recommend pages contain fewer than ~1,500 DOM elements. The sweet spot is a tree depth < 32 elements and fewer than 60 children/parent element. A large DOM can increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size).", 
+            "description": "Browser engineers recommend pages contain fewer than ~1,500 DOM elements. The sweet spot is a tree depth < 32 elements and fewer than 60 children/parent element. A large DOM can increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://developers.google.com/web/tools/lighthouse/audits/dom-size).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "text", 
-                        "key": "statistic", 
+                        "itemType": "text",
+                        "key": "statistic",
                         "text": "Statistic"
-                    }, 
+                    },
                     {
-                        "itemType": "code", 
-                        "key": "element", 
+                        "itemType": "code",
+                        "key": "element",
                         "text": "Element"
-                    }, 
+                    },
                     {
-                        "itemType": "numeric", 
-                        "key": "value", 
+                        "itemType": "numeric",
+                        "key": "value",
                         "text": "Value"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "statistic": "Total DOM Elements", 
+                        "statistic": "Total DOM Elements",
                         "value": "31"
-                    }, 
+                    },
                     {
                         "element": {
-                            "type": "code", 
+                            "type": "code",
                             "value": "<h2>"
-                        }, 
-                        "statistic": "Maximum DOM Depth", 
+                        },
+                        "statistic": "Maximum DOM Depth",
                         "value": "3"
-                    }, 
+                    },
                     {
                         "element": {
-                            "type": "code", 
+                            "type": "code",
                             "value": "<body>"
-                        }, 
-                        "statistic": "Maximum Child Elements", 
+                        },
+                        "statistic": "Maximum Child Elements",
                         "value": "29"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "31 elements", 
-            "id": "dom-size", 
-            "numericValue": 31.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "displayValue": "31 elements",
+            "id": "dom-size",
+            "numericValue": 31.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
             "title": "Avoids an excessive DOM size"
-        }, 
+        },
         "duplicate-id": {
-            "description": "The value of an id attribute must be unique to prevent other instances from being overlooked by assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse).", 
+            "description": "The value of an id attribute must be unique to prevent other instances from being overlooked by assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/3.1/duplicate-id?application=lighthouse).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "duplicate-id", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "duplicate-id",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "`[id]` attributes on the page are unique"
-        }, 
+        },
         "efficient-animated-content": {
-            "description": "Large GIFs are inefficient for delivering animated content. Consider using MPEG4/WebM videos for animations and PNG/WebP for static images instead of GIF to save network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)", 
+            "description": "Large GIFs are inefficient for delivering animated content. Consider using MPEG4/WebM videos for animations and PNG/WebP for static images instead of GIF to save network bytes. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/)",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsBytes": 0.0, 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsBytes": 0.0,
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "efficient-animated-content", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "id": "efficient-animated-content",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
             "title": "Use video formats for animated content"
-        }, 
+        },
         "errors-in-console": {
-            "description": "Errors logged to the console indicate unresolved problems. They can come from network request failures and other browser concerns.", 
+            "description": "Errors logged to the console indicate unresolved problems. They can come from network request failures and other browser concerns.",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "code", 
-                        "key": "description", 
+                        "itemType": "code",
+                        "key": "description",
                         "text": "Description"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "description": "Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache", 
-                        "source": "other", 
+                        "description": "Application Cache Error event: Manifest fetch failed (404) http://localhost:10200/dobetterweb/clock.appcache",
+                        "source": "other",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "description": "Failed to load resource: the server responded with a status of 404 (Not Found)", 
-                        "source": "network", 
+                        "description": "Failed to load resource: the server responded with a status of 404 (Not Found)",
+                        "source": "network",
                         "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200"
-                    }, 
+                    },
                     {
-                        "description": "Failed to load resource: the server responded with a status of 404 (Not Found)", 
-                        "source": "network", 
+                        "description": "Failed to load resource: the server responded with a status of 404 (Not Found)",
+                        "source": "network",
                         "url": "http://localhost:10200/favicon.ico"
-                    }, 
+                    },
                     {
-                        "description": "Failed to load resource: the server responded with a status of 404 (Not Found)", 
-                        "source": "network", 
+                        "description": "Failed to load resource: the server responded with a status of 404 (Not Found)",
+                        "source": "network",
                         "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200"
-                    }, 
+                    },
                     {
-                        "description": "Error: An error\n    at http://localhost:10200/dobetterweb/dbw_tester.html:42:38", 
-                        "source": "Runtime.exception", 
+                        "description": "Error: An error\n    at http://localhost:10200/dobetterweb/dbw_tester.html:42:38",
+                        "source": "Runtime.exception",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "errors-in-console", 
-            "numericValue": 5.0, 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "errors-in-console",
+            "numericValue": 5.0,
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Browser errors were logged to the console"
-        }, 
+        },
         "estimated-input-latency": {
-            "description": "Estimated Input Latency is an estimate of how long your app takes to respond to user input, in milliseconds, during the busiest 5s window of page load. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency).", 
-            "displayValue": "20\u00a0ms", 
-            "id": "estimated-input-latency", 
-            "numericValue": 16.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
+            "description": "Estimated Input Latency is an estimate of how long your app takes to respond to user input, in milliseconds, during the busiest 5s window of page load. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency).",
+            "displayValue": "20\u00a0ms",
+            "id": "estimated-input-latency",
+            "numericValue": 16.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
             "title": "Estimated Input Latency"
-        }, 
+        },
         "external-anchors-use-rel-noopener": {
-            "description": "Add `rel=\"noopener\"` or `rel=\"noreferrer\"` to any external links to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).", 
+            "description": "Add `rel=\"noopener\"` or `rel=\"noreferrer\"` to any external links to improve performance and prevent security vulnerabilities. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/noopener).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "href", 
+                        "itemType": "url",
+                        "key": "href",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "target", 
+                        "itemType": "text",
+                        "key": "target",
                         "text": "Target"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "rel", 
+                        "itemType": "text",
+                        "key": "rel",
                         "text": "Rel"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "href": "https://www.google.com/", 
-                        "outerHTML": "<a href=\"https://www.google.com/\" target=\"blank\">Hello</a>", 
+                        "href": "https://www.google.com/",
+                        "outerHTML": "<a href=\"https://www.google.com/\" target=\"blank\">Hello</a>",
                         "target": "_blank"
-                    }, 
+                    },
                     {
-                        "href": "Unknown", 
-                        "outerHTML": "<a target=\"blank\">Hello</a>", 
+                        "href": "Unknown",
+                        "outerHTML": "<a target=\"blank\">Hello</a>",
                         "target": "_blank"
-                    }, 
+                    },
                     {
-                        "href": "https://www.google.com/", 
-                        "outerHTML": "<a rel=\"nofollow\" href=\"https://www.google.com/\" target=\"blank\">Hello</a>", 
-                        "rel": "nofollow", 
+                        "href": "https://www.google.com/",
+                        "outerHTML": "<a rel=\"nofollow\" href=\"https://www.google.com/\" target=\"blank\">Hello</a>",
+                        "rel": "nofollow",
                         "target": "_blank"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "external-anchors-use-rel-noopener", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
-            "title": "Links to cross-origin destinations are unsafe", 
+            },
+            "id": "external-anchors-use-rel-noopener",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
+            "title": "Links to cross-origin destinations are unsafe",
             "warnings": [
                 "Unable to determine the destination for anchor (<a target=\"blank\">Hello</a>). If not used as a hyperlink, consider removing target=_blank."
             ]
-        }, 
+        },
         "final-screenshot": {
-            "description": "The last screenshot captured of the pageload.", 
+            "description": "The last screenshot captured of the pageload.",
             "details": {
-                "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAECAJEDASIAAhEBAxEB/8QAHQAAAgEFAQEAAAAAAAAAAAAAAAIBAwQFBwgGCf/EAEwQAAEDAgQBBQoKBggHAAAAAAEAAgMEEQUSITEGExRBUXEiMjZUYXSBkrLRBwgjM1ORk6GxwRUYQ1JilBYkY3Jzs+HwFyY1VVZkov/EABsBAQEBAQEBAQEAAAAAAAAAAAABAgMEBQYH/8QALBEAAgECBAUCBwEBAAAAAAAAAAECAxEEE0FREhQhMWFSoQUGIiNCcYHwMv/aAAwDAQACEQMRAD8A6TQhCAEIQgBCEIAQhCAEIQgBCEIAQhCAEIQgBCEIDUCEIQG30nKM/fb9adYuna04pKC0W10so2dIQUk29DJggi41ClYwHm2IhjNI327no1Vc1t2yPZHmjYbE3sT2JcrpPQvErXtcbNcCfIURvbIxr2m4IuFjYXOZX1BjZmNjpe3SlyRhxX8GUQrMV0ZpjKQb3tl8qY1TgXsLAJA3MBfQpcmXLYukLG0tRLzWaTKHG5NyfyT0tQWURkmBIubG+pN0uadFov0K1ZUkyNY5ga57czdd/IqTa9z2ksgcbGxsUuRUpPQv0JXuLYy5rcxAvZWYr705lEegdlIza/grckYSl2L5Ctm1N9XNAZkzkg3slZWX5MuZlZIbNN/xUuMuWxcte13euB7CmWKp3OjrKkxszWvpe3Sr+lnbURZ2i3QR1ImWdNx6rsamQhCpzNvLHQteyvklMT8hvbRZJCjRuM+G63LBlO+arM8rcjR3rTuqTIpIqaeAscXOPckC4PpWUQljSrP/AHgo0kZhp2MO4GqtY2virJ5HRvLXXAsL3WQQljKm7u+piOZS8zOnd5s2XyK5haHtOWm5N2UglwtrboV8hLG5VnLuYylZKKSaIxOBIOp06ErYZZKDkuTc1zDfutLrKoSwzne9vJYUoFmE0xa9o7pxFvqRhjHxiRsjHNJNxcK/QljLqXTW4LGtoyZp2nSMi7eq59yySEsSM3G9ixgpncwcx2kjx09HUFTpI7Nax9MTID3xGn1rJISxrNfXyY6Jr4qmokdG8tdfLYXvqq2GwOhhOcWc43t1K7QliSqNqxqBCEKnM2+hCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQGoEIQgNvKwEpFNNd0heCbGx0t5VfqgKe0MkefR5JJt1qM6QaXcInfKtaS8nk76nQpKiZ952NFg1mYOB1VVkJbI15dezctrKJafO95Dy0PblIshU43uxRUhrSHtcHAD03RzrQWjcSXZbabofS5iSXkGwAIG1timMLiWF0hJab7J1H0ENqg57W5XanLfqKanzfKZyT3Zt2KGQFryWyODCc2Xy9qqsaW5ruvc322QzJx0GQhCpgEIQgBCEIAQhCAEIQgNQIQhAbdccrSbE2F7Dcrx3D3HtLi+D4fVmhrIqrEJJ20tEA10kjYnEOdvYAAC5JAubC9xf2RNhc7LWmB8FV2CvwKogxWgmqMHfVxxMc0sbPTzvzua83OV4IaQQCO5Isb6AejouOcGr3UzaJ1RM6ppp6mMCKxtC4NlYQbFr2ucAQbbqHcdYQcLhxCnbWVNO+jjxB/IQFzoad/eve3fWx7kXd3J00XnY+BqqiqqCtw3F6BtaDXmrM0Jcxxq3te4sAcCMpYAATqN1HD3BeM8NvoDg/EWHgfo2nw6tE1KXB3I5gyWMZ9HZXEEG4O/kQF3hXHHNeIsdoMafVSwR4vFQ0s7KU8nEJYojGx7gNy95F9TqL2uFkZfhDwSOpMRZiRArXYfygoZcvOAL8nte5tposTW8IYhOcXyYjh/9dxqkxVpeXXa2Dku4Nty7kW6jbMdNEO4RryQefYd4Q/pzvnd7b5rt/i+5F5/3YM9BS8a4XVwQGmZVyVc9RNSsouSyz8pF84C0kABvSSbajXUIoON8Hr6nCYaV07jiT5ooXOjyhssV+Ujfexa8WOhGttLrztFwbW0eORY1DiFCa6DEayrZESeTkhqQ3PE47hwLGkOAO22qr1XAcFVwvJQOxQQYlJijsWNZBYclM+QueGC+gyFzNeu5QGSr/hDwLD6BlZVvqI4eQbVSfJ3MULnFrZHAHvTYkWubAm1lncXxqjwulpZ53F4qpmQU7Y7Xle/vQCSBqATqRsvL4lwxVxcTnE+Hq/Cqenno4qOop6ym5YMEZdkfHZwsQHkWOh0WX4qweHHMEhw2bmVZTB7ecRVg0nYGkbt7x18rg4DQhAUMX48wTCKYT17542tgbUztMfdU8TnFoc9u41DtBc9yTawV1LxbhzaxkMTKqojdUto+cQRZ4mzFuYMJGu1tbZQTYkFeSwzgjFsGq6efDceoKl0lFHR1ZxKAzn5Nzyx8Zzg3AkLbOJuACVluH+HsVwPGK5tLj1I/A6urNc6OSC9S17rF7A8ODcrnC98txcgdBACYTxozG6Ph6t/rmFNr8QmpmQPpxKKgMEoDS8XDO8zXve7SBcarKU/G2Dz1FGxjqgQ1zpI6OpMJ5Kpey5c1hGpNmutcDNY5brzuHcHYjRUOAURxLDZafCcUlrmHK5rpI38r3J1IzWmOu3cjr0qYTwXNQ4fgOFS4hSTYbgNW6ro3aiWSweImP6AG5zdwvmsNBqgM3w3x1g/ENXR09AK1prKd9TTPnpnRNmYxwa/KTuQXNv2r1S11wlwfWYJUcKmfEKCWLBqOppX5MwMvKua7ML7WyDTXcrYPLRfSs9YICohU+Wi+kZ6wRy0X0rPWCA1IhJyjP32/WhAbN4s14WxnzKb2CuBWRjqXfXFfgvjHmc3sFcGNXswqumcK2hDYwqgaAFHQm6F7UcBhZTfqUAadKkKoyMAmGigFMEBI7AmAUCyYehaISG3UhtkAjZMHBUAG69CnKi6kFLgkN61OXyKpT081S4tp4ZZX72jYXH7lUkoa+MaYfWOd0DkXD8QuU8RSg7Skl/TcaU5dYplANJ6FORXEOH17wCaCrBPRyLj+SmooqmmIFRBLCTqBIwtv9aQxNKbtGSb/AGJUZx6yTPPZUJshQsXRo7v4r8FsY8zm9grguxIuBfsC704r8FsZtvzKb2CuCLzNZoy57AvHQk4pneorlQZuokpnODe+BHaCljgmnbfm5ud/93CZzDA20kUw7W/6rvmSMcCAPGW42UCeL9/7lD6prWi0buwsIVHnbY3fMg36wf8AVHWaJll617SNDoqnRfZWUU0Mr/lGRsJ23H32srl1OHaske3yNc0j71pVX+zLporNN9jdPbrKsCyaMi0unlY33quI+Ub8o/uvI234FXNewy1uXFwBcuFu1UxUQE2EzCeq6tpKEgEsncD/AAtP+qo8hI1pPLuNt75vcsOtNaFVOO5mY4S9ocHtsfSryGizC5qqdo/icR+S80xhcNahgPU4kJslQwHk5m262lxHsrLrTZrLge3wYVlDVienqYTl70wTtufQV6mn4tx5jWllRLaxAvyRWnBNVDephP8AeJCZlVWXs3knn+F4K8lbD0K7vVpqT8pHWMpRVoysbpZxVjszQyapeGbWvGLK1xGmGINjdiFeyRzT3GaYEDtFlqmOuxFhvzZrrdbQ5VDjFSHAyYewddg5v4Fc6eCoUnxUoKL8I26smrSdzPfo+m8YpfrQvH/pF3i3/wBlC7Wl6jN47HfHF+nCeNH/ANKf/LcvnrHVhvc6AdQ0X0K4w8Esb8xn/wAty+dgjd0WKxFtdisvGVrmvuZLt6rK4ZiXdGztO1Y1jCc3dNFvInbGzTPbtXRSkZaRkXYgNXCME/3il52ya2djx2PVq0tYfkzayh+WR3dAOPWQreRLIvOUa0EQyvaTvmcPzCpxz5CeUeD2gFUHNaDZrfSCpIJ71pt2q/UOhe87hPeyAu/u7fepZWkuy8qLdRbb81aCC/7IuHlCrtp2CO3Iv9BsPwWryJZF1ztsbgHyAA9IBUTVLW5XtmJB8tlZOpGA3fE2w6CqeSlJtZgH1q8TXclkXs1bcaSFxHQSD+SRlQ62ZryDe1tFbO5s2xGUnqCjlo2/Nxu9AWePdlstjJ85cxhdI5xHVYK3fXRkmzI3g9bLH7lbsnDwbteO0FVGOGU2bp/vyKcSepUt0BrKZmroA4+SRzbKqa+neBlfUR9khNvrVAh5HcxOIU8o4acg63aFOIv8KPKR+NTf79CFS5T+zchZuU+iuN0bsRwavomPDHVNPJCHEXDS5pF/vXM4+LHiw24jof5d/vXR/FhtwrjJG/MpvYK4EZNN9LJ6xVpQctSTlwm7T8WTFejiKg9NO/3qf1ZsXt4RYf8Ayz/etMMmm+kk9Yqs2aX6R/rFd+Xk/wAjnmrY3B+rLjP/AJNQjspne9S74s2MOIvxLRfy7vetRCWU2+Uf6xTiWUH5x/rFVYZv8iZ3g21+rPjAsRxLRAj+wf71V/Vuxy1v6T0X8u73rUIml25R/rFMJpbfOP8AWK1yj9Qz1sbZ/VqxzX/mml+wf70w+LZjdwf6UUn8u/3rUollv84/1imEst/nH+sU5R+oZ62NuO+LVibx8rxLTyHywO96VvxZKod9jdIT/hP961MZZbG0j/WKlk0tvnH+sU5R+r2Gf4NvRfFsq4zduM0HpgcfzV1H8XesYf8Aq2G+ilcPzWmWSyt/aP8AWKkzS3+cf6xTlGvy9iZy2N3H4AK3KAzGaRvZAVB+L/iGWwx+mHWRAb/itKGWT6R/rFAmlP7R/rFa5WXq9iZy2N1s+ADEmCzeI4gBtaEqoPgExA/OY7TP7YnD8CtI8rLb5x/rFHKSkj5R+v8AEU5aXq9hnLY9t/wnn/7hB9m73oWs87/33fWhcsmW/sazFsd38WeCuM+ZTewVwIwLvzizwVxnzKb2CuBWhZw2pqroVGjRVG7BK3ZVG7L3JHnZUGylKFJRIyNa6YDo6FANtUNJJvZaBUb12JUjc6Jc1lIN2hVAYbWOyZo8iiw0U3KpCQNQmGg1SNvfdODbfVAySmAsErSLEHpTXGwVIQR1qTaw6UXCkC42RAwunUhPlQvPY6nePFngtjPmU3sFcDtC744r8FsZ8ym9grgloXmwq6M7VtCowJ9lDNlJ2XsRwYwKm4JUDZT0qmRwApGigJiNEQAC5T20shveqQ03utEGaddBdMCSNlDRcqW9SoBoCY2Jv5EBljdMNkBDT0KSANVKDfoQhAsSnBHQpaOvdSQ3TRVAwt0KcoQvOdTu/ivwWxjzOb2CuCmgjoXevFfgvjHmc3sFcGAmy82E7M7VtB2oIuhuymy9hwJaEwFkrEw3VIxwmG26gItrui7kHB8qZpSehO0LYHabNU7i4UNBITAdCEJvrZTa40QLdSkbIQBtZPfUW0VMGyZvdGyoHvY3Ug31SAG5CDcWsgMShRfyoXn6HU7w4r8FsY8zm9grg1oXeXFfgvjHmc3sFcGNK82E7M7VtBimGygDTVT0L2JHAm1gmAJ26FAFwpVRkYGwT9qTYJ2i4RdwO3UJthdK3ZS3dbIOy9k6QO12TXPUgJ3Q297KBe6a9ihAtoVI01RsEr3tZG4v0t0qXsUdpN1N1EeV4BabghMQOtLh9DDWQpQvOdTvDirwXxjzOb2CuDG2C7z4q8F8Y8zm9grg0AXXDCdmda2hNzZN0apT1pxY2XrOAMOhumGqLDKgDqKqMjNTgXSj0KQTfdUDi46NFUba+ypg30T6HW60iDXAPQpBtuFTtqdUwc46FUDE9SAT1I26EwN9bWUuCWkEd1orPE52S07oWAknpWbwfB5cZqX09PIxkgYXDOTZ2oG47VcVHBOLwHSjebjN3Dg4EL5mK+IUaU8qUkmfQw2E445hgcNkbHCyOQWIG991f5Q7UHRZSm4MxKfKOacmLZrySAJsZwQ4M6FjpmzGRmYll7DyarGG+JUqk1RUk34LiMJwRzEeQyhCawQvZc8ljuvivwWxjzOb2CuCgb2C714q8F8Y8zm9grgtccL2Z0raDlTfRINE4XsOAw71AUDfVTbXRVOxLFRm2yYdiRjes2TAa7oQqDdNbdJ6VIsRY3VTsCo3Syg7qGjQ62QEINfqVZgv9SoNd9arxuJ6UB7P4NYWP4hha6QR8o0sZY7nM3cLdtNgEkwgBET8rHNuOndc6cP4lHhmK09TMHOiBs4NF7DpW4sD4wos0LoMTLY8p7kuzHp61/PPmfD1pYlVIp2tsfewL+zZM9bNgojoWksjBLL7/wAC1J8J9C2KTD3Qua5xjOYAbAL2NdxDRvpY3vxINma0MsX2GxGw8q1djFe/EaymhgEs0MRN5niw1Oq5fL1KpDE5jTsXGL7fCzw9vIULMchH1tQv3fGfJ4TBVHHPFstPLHLxRjr43tLXNdiExDgRqCM2oXj+dVH08vrlCFxo9mdJk86qPp5fXKBV1HjE3rlCF2ME87qfGJvXKOd1PjE3rlCEITzyp8Ym9co55VeMzeuUIVAc9qvGZ/tCp57V+Mz/AGhQhAHPavxmf7Qo57VeMz/aFCEIHParxmf7QqRXVY2qp/tChCAdmI1odcVlSD5JXe9Jz+szX53UX6+UPvQhefEf8nekOzEq4OuK2pB/xXe9XJxnFMjW/pKtyjYcu7T70IXCidKha/pGt8cqftXe9CELoYP/2Q==", 
-                "timestamp": 185608111383.0, 
-                "timing": 4791.0, 
+                "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAECAJEDASIAAhEBAxEB/8QAHQAAAgEFAQEAAAAAAAAAAAAAAAIBAwQFBwgGCf/EAEwQAAEDAgQBBQoKBggHAAAAAAEAAgMEEQUSITEGExRBUXEiMjZUYXSBkrLRBwgjM1ORk6GxwRUYQ1JilBYkY3Jzs+HwFyY1VVZkov/EABsBAQEBAQEBAQEAAAAAAAAAAAABAgMEBQYH/8QALBEAAgECBAUCBwEBAAAAAAAAAAECAxEEE0FREhQhMWFSoQUGIiNCcYHwMv/aAAwDAQACEQMRAD8A6TQhCAEIQgBCEIAQhCAEIQgBCEIAQhCAEIQgBCEIDUCEIQG30nKM/fb9adYuna04pKC0W10so2dIQUk29DJggi41ClYwHm2IhjNI327no1Vc1t2yPZHmjYbE3sT2JcrpPQvErXtcbNcCfIURvbIxr2m4IuFjYXOZX1BjZmNjpe3SlyRhxX8GUQrMV0ZpjKQb3tl8qY1TgXsLAJA3MBfQpcmXLYukLG0tRLzWaTKHG5NyfyT0tQWURkmBIubG+pN0uadFov0K1ZUkyNY5ga57czdd/IqTa9z2ksgcbGxsUuRUpPQv0JXuLYy5rcxAvZWYr705lEegdlIza/grckYSl2L5Ctm1N9XNAZkzkg3slZWX5MuZlZIbNN/xUuMuWxcte13euB7CmWKp3OjrKkxszWvpe3Sr+lnbURZ2i3QR1ImWdNx6rsamQhCpzNvLHQteyvklMT8hvbRZJCjRuM+G63LBlO+arM8rcjR3rTuqTIpIqaeAscXOPckC4PpWUQljSrP/AHgo0kZhp2MO4GqtY2virJ5HRvLXXAsL3WQQljKm7u+piOZS8zOnd5s2XyK5haHtOWm5N2UglwtrboV8hLG5VnLuYylZKKSaIxOBIOp06ErYZZKDkuTc1zDfutLrKoSwzne9vJYUoFmE0xa9o7pxFvqRhjHxiRsjHNJNxcK/QljLqXTW4LGtoyZp2nSMi7eq59yySEsSM3G9ixgpncwcx2kjx09HUFTpI7Nax9MTID3xGn1rJISxrNfXyY6Jr4qmokdG8tdfLYXvqq2GwOhhOcWc43t1K7QliSqNqxqBCEKnM2+hCEAIQhACEIQAhCEAIQhACEIQAhCEAIQhACEIQGoEIQgNvKwEpFNNd0heCbGx0t5VfqgKe0MkefR5JJt1qM6QaXcInfKtaS8nk76nQpKiZ952NFg1mYOB1VVkJbI15dezctrKJafO95Dy0PblIshU43uxRUhrSHtcHAD03RzrQWjcSXZbabofS5iSXkGwAIG1timMLiWF0hJab7J1H0ENqg57W5XanLfqKanzfKZyT3Zt2KGQFryWyODCc2Xy9qqsaW5ruvc322QzJx0GQhCpgEIQgBCEIAQhCAEIQgNQIQhAbdccrSbE2F7Dcrx3D3HtLi+D4fVmhrIqrEJJ20tEA10kjYnEOdvYAAC5JAubC9xf2RNhc7LWmB8FV2CvwKogxWgmqMHfVxxMc0sbPTzvzua83OV4IaQQCO5Isb6AejouOcGr3UzaJ1RM6ppp6mMCKxtC4NlYQbFr2ucAQbbqHcdYQcLhxCnbWVNO+jjxB/IQFzoad/eve3fWx7kXd3J00XnY+BqqiqqCtw3F6BtaDXmrM0Jcxxq3te4sAcCMpYAATqN1HD3BeM8NvoDg/EWHgfo2nw6tE1KXB3I5gyWMZ9HZXEEG4O/kQF3hXHHNeIsdoMafVSwR4vFQ0s7KU8nEJYojGx7gNy95F9TqL2uFkZfhDwSOpMRZiRArXYfygoZcvOAL8nte5tposTW8IYhOcXyYjh/9dxqkxVpeXXa2Dku4Nty7kW6jbMdNEO4RryQefYd4Q/pzvnd7b5rt/i+5F5/3YM9BS8a4XVwQGmZVyVc9RNSsouSyz8pF84C0kABvSSbajXUIoON8Hr6nCYaV07jiT5ooXOjyhssV+Ujfexa8WOhGttLrztFwbW0eORY1DiFCa6DEayrZESeTkhqQ3PE47hwLGkOAO22qr1XAcFVwvJQOxQQYlJijsWNZBYclM+QueGC+gyFzNeu5QGSr/hDwLD6BlZVvqI4eQbVSfJ3MULnFrZHAHvTYkWubAm1lncXxqjwulpZ53F4qpmQU7Y7Xle/vQCSBqATqRsvL4lwxVxcTnE+Hq/Cqenno4qOop6ym5YMEZdkfHZwsQHkWOh0WX4qweHHMEhw2bmVZTB7ecRVg0nYGkbt7x18rg4DQhAUMX48wTCKYT17542tgbUztMfdU8TnFoc9u41DtBc9yTawV1LxbhzaxkMTKqojdUto+cQRZ4mzFuYMJGu1tbZQTYkFeSwzgjFsGq6efDceoKl0lFHR1ZxKAzn5Nzyx8Zzg3AkLbOJuACVluH+HsVwPGK5tLj1I/A6urNc6OSC9S17rF7A8ODcrnC98txcgdBACYTxozG6Ph6t/rmFNr8QmpmQPpxKKgMEoDS8XDO8zXve7SBcarKU/G2Dz1FGxjqgQ1zpI6OpMJ5Kpey5c1hGpNmutcDNY5brzuHcHYjRUOAURxLDZafCcUlrmHK5rpI38r3J1IzWmOu3cjr0qYTwXNQ4fgOFS4hSTYbgNW6ro3aiWSweImP6AG5zdwvmsNBqgM3w3x1g/ENXR09AK1prKd9TTPnpnRNmYxwa/KTuQXNv2r1S11wlwfWYJUcKmfEKCWLBqOppX5MwMvKua7ML7WyDTXcrYPLRfSs9YICohU+Wi+kZ6wRy0X0rPWCA1IhJyjP32/WhAbN4s14WxnzKb2CuBWRjqXfXFfgvjHmc3sFcGNXswqumcK2hDYwqgaAFHQm6F7UcBhZTfqUAadKkKoyMAmGigFMEBI7AmAUCyYehaISG3UhtkAjZMHBUAG69CnKi6kFLgkN61OXyKpT081S4tp4ZZX72jYXH7lUkoa+MaYfWOd0DkXD8QuU8RSg7Skl/TcaU5dYplANJ6FORXEOH17wCaCrBPRyLj+SmooqmmIFRBLCTqBIwtv9aQxNKbtGSb/AGJUZx6yTPPZUJshQsXRo7v4r8FsY8zm9grguxIuBfsC704r8FsZtvzKb2CuCLzNZoy57AvHQk4pneorlQZuokpnODe+BHaCljgmnbfm5ud/93CZzDA20kUw7W/6rvmSMcCAPGW42UCeL9/7lD6prWi0buwsIVHnbY3fMg36wf8AVHWaJll617SNDoqnRfZWUU0Mr/lGRsJ23H32srl1OHaske3yNc0j71pVX+zLporNN9jdPbrKsCyaMi0unlY33quI+Ub8o/uvI234FXNewy1uXFwBcuFu1UxUQE2EzCeq6tpKEgEsncD/AAtP+qo8hI1pPLuNt75vcsOtNaFVOO5mY4S9ocHtsfSryGizC5qqdo/icR+S80xhcNahgPU4kJslQwHk5m262lxHsrLrTZrLge3wYVlDVienqYTl70wTtufQV6mn4tx5jWllRLaxAvyRWnBNVDephP8AeJCZlVWXs3knn+F4K8lbD0K7vVpqT8pHWMpRVoysbpZxVjszQyapeGbWvGLK1xGmGINjdiFeyRzT3GaYEDtFlqmOuxFhvzZrrdbQ5VDjFSHAyYewddg5v4Fc6eCoUnxUoKL8I26smrSdzPfo+m8YpfrQvH/pF3i3/wBlC7Wl6jN47HfHF+nCeNH/ANKf/LcvnrHVhvc6AdQ0X0K4w8Esb8xn/wAty+dgjd0WKxFtdisvGVrmvuZLt6rK4ZiXdGztO1Y1jCc3dNFvInbGzTPbtXRSkZaRkXYgNXCME/3il52ya2djx2PVq0tYfkzayh+WR3dAOPWQreRLIvOUa0EQyvaTvmcPzCpxz5CeUeD2gFUHNaDZrfSCpIJ71pt2q/UOhe87hPeyAu/u7fepZWkuy8qLdRbb81aCC/7IuHlCrtp2CO3Iv9BsPwWryJZF1ztsbgHyAA9IBUTVLW5XtmJB8tlZOpGA3fE2w6CqeSlJtZgH1q8TXclkXs1bcaSFxHQSD+SRlQ62ZryDe1tFbO5s2xGUnqCjlo2/Nxu9AWePdlstjJ85cxhdI5xHVYK3fXRkmzI3g9bLH7lbsnDwbteO0FVGOGU2bp/vyKcSepUt0BrKZmroA4+SRzbKqa+neBlfUR9khNvrVAh5HcxOIU8o4acg63aFOIv8KPKR+NTf79CFS5T+zchZuU+iuN0bsRwavomPDHVNPJCHEXDS5pF/vXM4+LHiw24jof5d/vXR/FhtwrjJG/MpvYK4EZNN9LJ6xVpQctSTlwm7T8WTFejiKg9NO/3qf1ZsXt4RYf8Ayz/etMMmm+kk9Yqs2aX6R/rFd+Xk/wAjnmrY3B+rLjP/AJNQjspne9S74s2MOIvxLRfy7vetRCWU2+Uf6xTiWUH5x/rFVYZv8iZ3g21+rPjAsRxLRAj+wf71V/Vuxy1v6T0X8u73rUIml25R/rFMJpbfOP8AWK1yj9Qz1sbZ/VqxzX/mml+wf70w+LZjdwf6UUn8u/3rUollv84/1imEst/nH+sU5R+oZ62NuO+LVibx8rxLTyHywO96VvxZKod9jdIT/hP961MZZbG0j/WKlk0tvnH+sU5R+r2Gf4NvRfFsq4zduM0HpgcfzV1H8XesYf8Aq2G+ilcPzWmWSyt/aP8AWKkzS3+cf6xTlGvy9iZy2N3H4AK3KAzGaRvZAVB+L/iGWwx+mHWRAb/itKGWT6R/rFAmlP7R/rFa5WXq9iZy2N1s+ADEmCzeI4gBtaEqoPgExA/OY7TP7YnD8CtI8rLb5x/rFHKSkj5R+v8AEU5aXq9hnLY9t/wnn/7hB9m73oWs87/33fWhcsmW/sazFsd38WeCuM+ZTewVwIwLvzizwVxnzKb2CuBWhZw2pqroVGjRVG7BK3ZVG7L3JHnZUGylKFJRIyNa6YDo6FANtUNJJvZaBUb12JUjc6Jc1lIN2hVAYbWOyZo8iiw0U3KpCQNQmGg1SNvfdODbfVAySmAsErSLEHpTXGwVIQR1qTaw6UXCkC42RAwunUhPlQvPY6nePFngtjPmU3sFcDtC744r8FsZ8ym9grgloXmwq6M7VtCowJ9lDNlJ2XsRwYwKm4JUDZT0qmRwApGigJiNEQAC5T20shveqQ03utEGaddBdMCSNlDRcqW9SoBoCY2Jv5EBljdMNkBDT0KSANVKDfoQhAsSnBHQpaOvdSQ3TRVAwt0KcoQvOdTu/ivwWxjzOb2CuCmgjoXevFfgvjHmc3sFcGAmy82E7M7VtB2oIuhuymy9hwJaEwFkrEw3VIxwmG26gItrui7kHB8qZpSehO0LYHabNU7i4UNBITAdCEJvrZTa40QLdSkbIQBtZPfUW0VMGyZvdGyoHvY3Ug31SAG5CDcWsgMShRfyoXn6HU7w4r8FsY8zm9grg1oXeXFfgvjHmc3sFcGNK82E7M7VtBimGygDTVT0L2JHAm1gmAJ26FAFwpVRkYGwT9qTYJ2i4RdwO3UJthdK3ZS3dbIOy9k6QO12TXPUgJ3Q297KBe6a9ihAtoVI01RsEr3tZG4v0t0qXsUdpN1N1EeV4BabghMQOtLh9DDWQpQvOdTvDirwXxjzOb2CuDG2C7z4q8F8Y8zm9grg0AXXDCdmda2hNzZN0apT1pxY2XrOAMOhumGqLDKgDqKqMjNTgXSj0KQTfdUDi46NFUba+ypg30T6HW60iDXAPQpBtuFTtqdUwc46FUDE9SAT1I26EwN9bWUuCWkEd1orPE52S07oWAknpWbwfB5cZqX09PIxkgYXDOTZ2oG47VcVHBOLwHSjebjN3Dg4EL5mK+IUaU8qUkmfQw2E445hgcNkbHCyOQWIG991f5Q7UHRZSm4MxKfKOacmLZrySAJsZwQ4M6FjpmzGRmYll7DyarGG+JUqk1RUk34LiMJwRzEeQyhCawQvZc8ljuvivwWxjzOb2CuCgb2C714q8F8Y8zm9grgtccL2Z0raDlTfRINE4XsOAw71AUDfVTbXRVOxLFRm2yYdiRjes2TAa7oQqDdNbdJ6VIsRY3VTsCo3Syg7qGjQ62QEINfqVZgv9SoNd9arxuJ6UB7P4NYWP4hha6QR8o0sZY7nM3cLdtNgEkwgBET8rHNuOndc6cP4lHhmK09TMHOiBs4NF7DpW4sD4wos0LoMTLY8p7kuzHp61/PPmfD1pYlVIp2tsfewL+zZM9bNgojoWksjBLL7/wAC1J8J9C2KTD3Qua5xjOYAbAL2NdxDRvpY3vxINma0MsX2GxGw8q1djFe/EaymhgEs0MRN5niw1Oq5fL1KpDE5jTsXGL7fCzw9vIULMchH1tQv3fGfJ4TBVHHPFstPLHLxRjr43tLXNdiExDgRqCM2oXj+dVH08vrlCFxo9mdJk86qPp5fXKBV1HjE3rlCF2ME87qfGJvXKOd1PjE3rlCEITzyp8Ym9co55VeMzeuUIVAc9qvGZ/tCp57V+Mz/AGhQhAHPavxmf7Qo57VeMz/aFCEIHParxmf7QqRXVY2qp/tChCAdmI1odcVlSD5JXe9Jz+szX53UX6+UPvQhefEf8nekOzEq4OuK2pB/xXe9XJxnFMjW/pKtyjYcu7T70IXCidKha/pGt8cqftXe9CELoYP/2Q==",
+                "timestamp": 185608111383.0,
+                "timing": 4791.0,
                 "type": "screenshot"
-            }, 
-            "id": "final-screenshot", 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "id": "final-screenshot",
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Final Screenshot"
-        }, 
+        },
         "first-contentful-paint": {
-            "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).", 
-            "displayValue": "4.0\u00a0s", 
-            "id": "first-contentful-paint", 
-            "numericValue": 3969.135, 
-            "score": 0.51, 
-            "scoreDisplayMode": "numeric", 
+            "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).",
+            "displayValue": "4.0\u00a0s",
+            "id": "first-contentful-paint",
+            "numericValue": 3969.135,
+            "score": 0.51,
+            "scoreDisplayMode": "numeric",
             "title": "First Contentful Paint"
-        }, 
+        },
         "first-cpu-idle": {
-            "description": "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-interactive).", 
-            "displayValue": "4.9\u00a0s", 
-            "id": "first-cpu-idle", 
-            "numericValue": 4927.278, 
-            "score": 0.72, 
-            "scoreDisplayMode": "numeric", 
+            "description": "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-interactive).",
+            "displayValue": "4.9\u00a0s",
+            "id": "first-cpu-idle",
+            "numericValue": 4927.278,
+            "score": 0.72,
+            "scoreDisplayMode": "numeric",
             "title": "First CPU Idle"
-        }, 
+        },
         "first-meaningful-paint": {
-            "description": "First Meaningful Paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint).", 
-            "displayValue": "4.0\u00a0s", 
-            "id": "first-meaningful-paint", 
-            "numericValue": 3969.136, 
-            "score": 0.51, 
-            "scoreDisplayMode": "numeric", 
+            "description": "First Meaningful Paint measures when the primary content of a page is visible. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint).",
+            "displayValue": "4.0\u00a0s",
+            "id": "first-meaningful-paint",
+            "numericValue": 3969.136,
+            "score": 0.51,
+            "scoreDisplayMode": "numeric",
             "title": "First Meaningful Paint"
-        }, 
+        },
         "focus-traps": {
-            "description": "A user can tab into and out of any control or region without accidentally trapping their focus. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).", 
-            "id": "focus-traps", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "A user can tab into and out of any control or region without accidentally trapping their focus. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).",
+            "id": "focus-traps",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "User focus is not accidentally trapped in a region"
-        }, 
+        },
         "focusable-controls": {
-            "description": "Custom interactive controls are keyboard focusable and display a focus indicator. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).", 
-            "id": "focusable-controls", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Custom interactive controls are keyboard focusable and display a focus indicator. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).",
+            "id": "focusable-controls",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Interactive controls are keyboard focusable"
-        }, 
+        },
         "font-display": {
-            "description": "Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading. [Learn more](https://developers.google.com/web/updates/2016/02/font-display).", 
+            "description": "Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading. [Learn more](https://developers.google.com/web/updates/2016/02/font-display).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "font-display", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "font-display",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "All text remains visible during webfont loads"
-        }, 
+        },
         "font-size": {
-            "description": "Font sizes less than 12px are too small to be legible and require mobile visitors to \u201cpinch to zoom\u201d in order to read. Strive to have >60% of page text \u226512px. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/font-sizes).", 
+            "description": "Font sizes less than 12px are too small to be legible and require mobile visitors to \u201cpinch to zoom\u201d in order to read. Strive to have >60% of page text \u226512px. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/font-sizes).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "source", 
+                        "itemType": "url",
+                        "key": "source",
                         "text": "Source"
-                    }, 
+                    },
                     {
-                        "itemType": "code", 
-                        "key": "selector", 
+                        "itemType": "code",
+                        "key": "selector",
                         "text": "Selector"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "coverage", 
+                        "itemType": "text",
+                        "key": "coverage",
                         "text": "% of Page Text"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "fontSize", 
+                        "itemType": "text",
+                        "key": "fontSize",
                         "text": "Font Size"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "coverage": "100.00%", 
-                        "fontSize": "\u2265 12px", 
+                        "coverage": "100.00%",
+                        "fontSize": "\u2265 12px",
                         "source": "Legible text"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "100% legible text", 
-            "id": "font-size", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "displayValue": "100% legible text",
+            "id": "font-size",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Document uses legible font sizes"
-        }, 
+        },
         "frame-title": {
-            "description": "Screen reader users rely on frame titles to describe the contents of frames. [Learn more](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse).", 
-            "id": "frame-title", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Screen reader users rely on frame titles to describe the contents of frames. [Learn more](https://dequeuniversity.com/rules/axe/3.1/frame-title?application=lighthouse).",
+            "id": "frame-title",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`<frame>` or `<iframe>` elements have a title"
-        }, 
+        },
         "geolocation-on-start": {
-            "description": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).", 
+            "description": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/geolocation-on-load).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "label", 
+                        "itemType": "text",
+                        "key": "label",
                         "text": "Location"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "label": "line: 277", 
+                        "label": "line: 277",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "label": "line: 281", 
+                        "label": "line: 281",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "geolocation-on-start", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "geolocation-on-start",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Requests the geolocation permission on page load"
-        }, 
+        },
         "heading-levels": {
-            "description": "Headings are used to create an outline for the page and heading levels are not skipped. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#take_advantage_of_headings_and_landmarks).", 
-            "id": "heading-levels", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Headings are used to create an outline for the page and heading levels are not skipped. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#take_advantage_of_headings_and_landmarks).",
+            "id": "heading-levels",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Headings don't skip levels"
-        }, 
+        },
         "hreflang": {
-            "description": "hreflang links tell search engines what version of a page they should list in search results for a given language or region. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/hreflang).", 
+            "description": "hreflang links tell search engines what version of a page they should list in search results for a given language or region. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/hreflang).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "hreflang", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "hreflang",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Document has a valid `hreflang`"
-        }, 
+        },
         "html-has-lang": {
-            "description": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse).", 
+            "description": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/html-has-lang?application=lighthouse).",
             "details": {
                 "debugData": {
-                    "impact": "serious", 
+                    "impact": "serious",
                     "tags": [
-                        "cat.language", 
-                        "wcag2a", 
+                        "cat.language",
+                        "wcag2a",
                         "wcag311"
-                    ], 
+                    ],
                     "type": "debugdata"
-                }, 
+                },
                 "headings": [
                     {
-                        "itemType": "node", 
-                        "key": "node", 
+                        "itemType": "node",
+                        "key": "node",
                         "text": "Failing Elements"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  The <html> element does not have a lang attribute", 
-                            "path": "3,HTML", 
-                            "selector": "html", 
-                            "snippet": "<html manifest=\"clock.appcache\">", 
+                            "explanation": "Fix any of the following:\n  The <html> element does not have a lang attribute",
+                            "path": "3,HTML",
+                            "selector": "html",
+                            "snippet": "<html manifest=\"clock.appcache\">",
                             "type": "node"
                         }
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "html-has-lang", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "html-has-lang",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "`<html>` element does not have a `[lang]` attribute"
-        }, 
+        },
         "html-lang-valid": {
-            "description": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) helps screen readers announce text properly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse).", 
-            "id": "html-lang-valid", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) helps screen readers announce text properly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse).",
+            "id": "html-lang-valid",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`<html>` element has a valid value for its `[lang]` attribute"
-        }, 
+        },
         "http-status-code": {
-            "description": "Pages with unsuccessful HTTP status codes may not be indexed properly. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code).", 
-            "id": "http-status-code", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "Pages with unsuccessful HTTP status codes may not be indexed properly. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/successful-http-code).",
+            "id": "http-status-code",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Page has successful HTTP status code"
-        }, 
+        },
         "image-alt": {
-            "description": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse).", 
+            "description": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://dequeuniversity.com/rules/axe/3.1/image-alt?application=lighthouse).",
             "details": {
                 "debugData": {
-                    "impact": "critical", 
+                    "impact": "critical",
                     "tags": [
-                        "cat.text-alternatives", 
-                        "wcag2a", 
-                        "wcag111", 
-                        "section508", 
+                        "cat.text-alternatives",
+                        "wcag2a",
+                        "wcag111",
+                        "section508",
                         "section508.22.a"
-                    ], 
+                    ],
                     "type": "debugdata"
-                }, 
+                },
                 "headings": [
                     {
-                        "itemType": "node", 
-                        "key": "node", 
+                        "itemType": "node",
+                        "key": "node",
                         "text": "Failing Elements"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"", 
-                            "path": "3,HTML,1,BODY,10,IMG", 
-                            "selector": "img[height=\"\\35 7\"]", 
-                            "snippet": "<img src=\"lighthouse-480x318.jpg\" width=\"480\" height=\"57\">", 
+                            "explanation": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"",
+                            "path": "3,HTML,1,BODY,10,IMG",
+                            "selector": "img[height=\"\\35 7\"]",
+                            "snippet": "<img src=\"lighthouse-480x318.jpg\" width=\"480\" height=\"57\">",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"", 
-                            "path": "3,HTML,1,BODY,12,IMG", 
-                            "selector": "img[height=\"\\33 18\"]", 
-                            "snippet": "<img src=\"lighthouse-480x318.jpg\" width=\"480\" height=\"318\">", 
+                            "explanation": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"",
+                            "path": "3,HTML,1,BODY,12,IMG",
+                            "selector": "img[height=\"\\33 18\"]",
+                            "snippet": "<img src=\"lighthouse-480x318.jpg\" width=\"480\" height=\"318\">",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"", 
-                            "path": "3,HTML,1,BODY,14,IMG", 
-                            "selector": "img[src$=\"lighthouse-rotating.gif\"]", 
-                            "snippet": "<img src=\"lighthouse-rotating.gif\" width=\"811\" height=\"462\">", 
+                            "explanation": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"",
+                            "path": "3,HTML,1,BODY,14,IMG",
+                            "selector": "img[src$=\"lighthouse-rotating.gif\"]",
+                            "snippet": "<img src=\"lighthouse-rotating.gif\" width=\"811\" height=\"462\">",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"", 
-                            "path": "3,HTML,1,BODY,49,IMG", 
-                            "selector": "img:nth-child(27)", 
-                            "snippet": "<img src=\"blob:http://localhost:62824/289254fd-ef1d-4c1a-96a8-ba291caa2140\">", 
+                            "explanation": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"",
+                            "path": "3,HTML,1,BODY,49,IMG",
+                            "selector": "img:nth-child(27)",
+                            "snippet": "<img src=\"blob:http://localhost:62824/289254fd-ef1d-4c1a-96a8-ba291caa2140\">",
                             "type": "node"
                         }
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "image-alt", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "image-alt",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Image elements do not have `[alt]` attributes"
-        }, 
+        },
         "image-aspect-ratio": {
-            "description": "Image display dimensions should match natural aspect ratio. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio).", 
+            "description": "Image display dimensions should match natural aspect ratio. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/aspect-ratio).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "thumbnail", 
+                        "itemType": "thumbnail",
                         "key": "url"
-                    }, 
+                    },
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "displayedAspectRatio", 
+                        "itemType": "text",
+                        "key": "displayedAspectRatio",
                         "text": "Aspect Ratio (Displayed)"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "actualAspectRatio", 
+                        "itemType": "text",
+                        "key": "actualAspectRatio",
                         "text": "Aspect Ratio (Actual)"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "actualAspectRatio": "480 x 318\n        (1.51)", 
-                        "displayedAspectRatio": "480 x 57\n        (8.42)", 
-                        "doRatiosMatch": false, 
+                        "actualAspectRatio": "480 x 318\n        (1.51)",
+                        "displayedAspectRatio": "480 x 57\n        (8.42)",
+                        "doRatiosMatch": false,
                         "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "image-aspect-ratio", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
-            "title": "Displays images with incorrect aspect ratio", 
+            },
+            "id": "image-aspect-ratio",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
+            "title": "Displays images with incorrect aspect ratio",
             "warnings": []
-        }, 
+        },
         "input-image-alt": {
-            "description": "When an image is being used as an `<input>` button, providing alternative text can help screen reader users understand the purpose of the button. [Learn more](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse).", 
-            "id": "input-image-alt", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "When an image is being used as an `<input>` button, providing alternative text can help screen reader users understand the purpose of the button. [Learn more](https://dequeuniversity.com/rules/axe/3.1/input-image-alt?application=lighthouse).",
+            "id": "input-image-alt",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`<input type=\"image\">` elements have `[alt]` text"
-        }, 
+        },
         "installable-manifest": {
-            "description": "Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/install-prompt).", 
+            "description": "Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/install-prompt).",
             "details": {
                 "items": [
                     {
                         "failures": [
                             "No manifest was fetched"
-                        ], 
-                        "isParseFailure": true, 
+                        ],
+                        "isParseFailure": true,
                         "parseFailureReason": "No manifest was fetched"
                     }
-                ], 
+                ],
                 "type": "debugdata"
-            }, 
-            "explanation": "Failures: No manifest was fetched.", 
-            "id": "installable-manifest", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "explanation": "Failures: No manifest was fetched.",
+            "id": "installable-manifest",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Web app manifest does not meet the installability requirements"
-        }, 
+        },
         "interactive": {
-            "description": "Time to interactive is the amount of time it takes for the page to become fully interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive).", 
-            "displayValue": "4.9\u00a0s", 
-            "id": "interactive", 
-            "numericValue": 4927.278, 
-            "score": 0.78, 
-            "scoreDisplayMode": "numeric", 
+            "description": "Time to interactive is the amount of time it takes for the page to become fully interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/consistently-interactive).",
+            "displayValue": "4.9\u00a0s",
+            "id": "interactive",
+            "numericValue": 4927.278,
+            "score": 0.78,
+            "scoreDisplayMode": "numeric",
             "title": "Time to Interactive"
-        }, 
+        },
         "interactive-element-affordance": {
-            "description": "Interactive elements, such as links and buttons, should indicate their state and be distinguishable from non-interactive elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#interactive_elements_like_links_and_buttons_should_indicate_their_purpose_and_state).", 
-            "id": "interactive-element-affordance", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Interactive elements, such as links and buttons, should indicate their state and be distinguishable from non-interactive elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#interactive_elements_like_links_and_buttons_should_indicate_their_purpose_and_state).",
+            "id": "interactive-element-affordance",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Interactive elements indicate their purpose and state"
-        }, 
+        },
         "is-crawlable": {
-            "description": "Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/indexing).", 
+            "description": "Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/indexing).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "is-crawlable", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "is-crawlable",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Page isn\u2019t blocked from indexing"
-        }, 
+        },
         "is-on-https": {
-            "description": "All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/https).", 
+            "description": "All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/https).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "Insecure URL"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "url": "http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "1 insecure request found", 
-            "id": "is-on-https", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "displayValue": "1 insecure request found",
+            "id": "is-on-https",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Does not use HTTPS"
-        }, 
+        },
         "js-libraries": {
-            "description": "All front-end JavaScript libraries detected on the page.", 
+            "description": "All front-end JavaScript libraries detected on the page.",
             "details": {
                 "headings": [
                     {
-                        "itemType": "text", 
-                        "key": "name", 
+                        "itemType": "text",
+                        "key": "name",
                         "text": "Name"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "version", 
+                        "itemType": "text",
+                        "key": "version",
                         "text": "Version"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "name": "jQuery", 
-                        "npm": "jquery", 
+                        "name": "jQuery",
+                        "npm": "jquery",
                         "version": "2.1.1"
-                    }, 
+                    },
                     {
                         "name": "WordPress"
                     }
-                ], 
-                "summary": null, 
+                ],
+                "summary": null,
                 "type": "table"
-            }, 
-            "id": "js-libraries", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "js-libraries",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Detected JavaScript libraries"
-        }, 
+        },
         "label": {
-            "description": "Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse).", 
+            "description": "Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/label?application=lighthouse).",
             "details": {
                 "debugData": {
-                    "impact": "critical", 
+                    "impact": "critical",
                     "tags": [
-                        "cat.forms", 
-                        "wcag2a", 
-                        "wcag332", 
-                        "wcag131", 
-                        "section508", 
+                        "cat.forms",
+                        "wcag2a",
+                        "wcag332",
+                        "wcag131",
+                        "section508",
                         "section508.22.n"
-                    ], 
+                    ],
                     "type": "debugdata"
-                }, 
+                },
                 "headings": [
                     {
-                        "itemType": "node", 
-                        "key": "node", 
+                        "itemType": "node",
+                        "key": "node",
                         "text": "Failing Elements"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty", 
-                            "path": "3,HTML,1,BODY,44,INPUT", 
-                            "selector": "input[onpaste=\"event\\.preventDefault\\(\\)\\;\"]", 
-                            "snippet": "<input type=\"password\" onpaste=\"event.preventDefault();\">", 
+                            "explanation": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty",
+                            "path": "3,HTML,1,BODY,44,INPUT",
+                            "selector": "input[onpaste=\"event\\.preventDefault\\(\\)\\;\"]",
+                            "snippet": "<input type=\"password\" onpaste=\"event.preventDefault();\">",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty", 
-                            "path": "3,HTML,1,BODY,46,INPUT", 
-                            "selector": "input:nth-child(25)", 
-                            "snippet": "<input type=\"password\">", 
+                            "explanation": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty",
+                            "path": "3,HTML,1,BODY,46,INPUT",
+                            "selector": "input:nth-child(25)",
+                            "snippet": "<input type=\"password\">",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty", 
-                            "path": "3,HTML,1,BODY,48,INPUT", 
-                            "selector": "input[onpaste=\"return\\ false\\;\"]", 
-                            "snippet": "<input type=\"password\" onpaste=\"return false;\">", 
+                            "explanation": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty",
+                            "path": "3,HTML,1,BODY,48,INPUT",
+                            "selector": "input[onpaste=\"return\\ false\\;\"]",
+                            "snippet": "<input type=\"password\" onpaste=\"return false;\">",
                             "type": "node"
                         }
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "label", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "label",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Form elements do not have associated labels"
-        }, 
+        },
         "layout-table": {
-            "description": "A table being used for layout purposes should not include data elements, such as the th or caption elements or the summary attribute, because this can create a confusing experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse).", 
-            "id": "layout-table", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "A table being used for layout purposes should not include data elements, such as the th or caption elements or the summary attribute, because this can create a confusing experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/layout-table?application=lighthouse).",
+            "id": "layout-table",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "Presentational `<table>` elements avoid using `<th>`, `<caption>` or the `[summary]` attribute."
-        }, 
+        },
         "link-name": {
-            "description": "Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse).", 
+            "description": "Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/link-name?application=lighthouse).",
             "details": {
                 "debugData": {
-                    "impact": "serious", 
+                    "impact": "serious",
                     "tags": [
-                        "cat.name-role-value", 
-                        "wcag2a", 
-                        "wcag412", 
-                        "wcag244", 
-                        "section508", 
+                        "cat.name-role-value",
+                        "wcag2a",
+                        "wcag412",
+                        "wcag244",
+                        "section508",
                         "section508.22.a"
-                    ], 
+                    ],
                     "type": "debugdata"
-                }, 
+                },
                 "headings": [
                     {
-                        "itemType": "node", 
-                        "key": "node", 
+                        "itemType": "node",
+                        "key": "node",
                         "text": "Failing Elements"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "node": {
-                            "explanation": "Fix all of the following:\n  Element is in tab order and does not have accessible text\n\nFix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"", 
-                            "path": "3,HTML,1,BODY,40,A", 
-                            "selector": "a[href=\"javascript:void(0)\"]", 
-                            "snippet": "<a href=\"javascript:void(0)\" target=\"_blank\"></a>", 
+                            "explanation": "Fix all of the following:\n  Element is in tab order and does not have accessible text\n\nFix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"",
+                            "path": "3,HTML,1,BODY,40,A",
+                            "selector": "a[href=\"javascript:void(0)\"]",
+                            "snippet": "<a href=\"javascript:void(0)\" target=\"_blank\"></a>",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "explanation": "Fix all of the following:\n  Element is in tab order and does not have accessible text\n\nFix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"", 
-                            "path": "3,HTML,1,BODY,42,A", 
-                            "selector": "a[href$=\"mailto:inbox@email.com\"]", 
-                            "snippet": "<a href=\"mailto:inbox@email.com\" target=\"_blank\"></a>", 
+                            "explanation": "Fix all of the following:\n  Element is in tab order and does not have accessible text\n\nFix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"",
+                            "path": "3,HTML,1,BODY,42,A",
+                            "selector": "a[href$=\"mailto:inbox@email.com\"]",
+                            "snippet": "<a href=\"mailto:inbox@email.com\" target=\"_blank\"></a>",
                             "type": "node"
                         }
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "link-name", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "link-name",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Links do not have a discernible name"
-        }, 
+        },
         "link-text": {
-            "description": "Descriptive link text helps search engines understand your content. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text).", 
+            "description": "Descriptive link text helps search engines understand your content. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "summary": null, 
+                "headings": [],
+                "items": [],
+                "summary": null,
                 "type": "table"
-            }, 
-            "id": "link-text", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "link-text",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Links have descriptive text"
-        }, 
+        },
         "list": {
-            "description": "Screen readers have a specific way of announcing lists. Ensuring proper list structure aids screen reader output. [Learn more](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse).", 
-            "id": "list", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Screen readers have a specific way of announcing lists. Ensuring proper list structure aids screen reader output. [Learn more](https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse).",
+            "id": "list",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "Lists contain only `<li>` elements and script supporting elements (`<script>` and `<template>`)."
-        }, 
+        },
         "listitem": {
-            "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse).", 
-            "id": "listitem", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://dequeuniversity.com/rules/axe/3.1/listitem?application=lighthouse).",
+            "id": "listitem",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements"
-        }, 
+        },
         "load-fast-enough-for-pwa": {
-            "description": "A fast page load over a cellular network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g).", 
-            "id": "load-fast-enough-for-pwa", 
-            "numericValue": 4927.278, 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "A fast page load over a cellular network ensures a good mobile user experience. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/fast-3g).",
+            "id": "load-fast-enough-for-pwa",
+            "numericValue": 4927.278,
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Page load is fast enough on mobile networks"
-        }, 
+        },
         "logical-tab-order": {
-            "description": "Tabbing through the page follows the visual layout. Users cannot focus elements that are offscreen. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).", 
-            "id": "logical-tab-order", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Tabbing through the page follows the visual layout. Users cannot focus elements that are offscreen. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).",
+            "id": "logical-tab-order",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "The page has a logical tab order"
-        }, 
+        },
         "main-thread-tasks": {
-            "description": "Lists the toplevel main thread tasks that executed during page load.", 
+            "description": "Lists the toplevel main thread tasks that executed during page load.",
             "details": {
                 "headings": [
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "startTime", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "startTime",
                         "text": "Start Time"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "duration", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "duration",
                         "text": "End Time"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "duration": 5.272, 
+                        "duration": 5.272,
                         "startTime": 598.738
-                    }, 
+                    },
                     {
-                        "duration": 26.926, 
+                        "duration": 26.926,
                         "startTime": 604.035
-                    }, 
+                    },
                     {
-                        "duration": 6.681, 
+                        "duration": 6.681,
                         "startTime": 630.994
-                    }, 
+                    },
                     {
-                        "duration": 19.718, 
+                        "duration": 19.718,
                         "startTime": 637.706
-                    }, 
+                    },
                     {
-                        "duration": 7.812, 
+                        "duration": 7.812,
                         "startTime": 666.147
-                    }, 
+                    },
                     {
-                        "duration": 10.087, 
+                        "duration": 10.087,
                         "startTime": 2639.59
-                    }, 
+                    },
                     {
-                        "duration": 983.081, 
+                        "duration": 983.081,
                         "startTime": 2854.095
-                    }, 
+                    },
                     {
-                        "duration": 123.752, 
+                        "duration": 123.752,
                         "startTime": 3839.839
-                    }, 
+                    },
                     {
-                        "duration": 5.338, 
+                        "duration": 5.338,
                         "startTime": 3980.383
-                    }, 
+                    },
                     {
-                        "duration": 6.574, 
+                        "duration": 6.574,
                         "startTime": 3986.1
-                    }, 
+                    },
                     {
-                        "duration": 96.198, 
+                        "duration": 96.198,
                         "startTime": 3996.134
-                    }, 
+                    },
                     {
-                        "duration": 9.23, 
+                        "duration": 9.23,
                         "startTime": 4098.379
-                    }, 
+                    },
                     {
-                        "duration": 5.463, 
+                        "duration": 5.463,
                         "startTime": 4784.783
-                    }, 
+                    },
                     {
-                        "duration": 127.282, 
+                        "duration": 127.282,
                         "startTime": 4808.602
-                    }, 
+                    },
                     {
-                        "duration": 6.885, 
+                        "duration": 6.885,
                         "startTime": 8603.411
-                    }, 
+                    },
                     {
-                        "duration": 7.258, 
+                        "duration": 7.258,
                         "startTime": 10219.292
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "main-thread-tasks", 
-            "numericValue": 16.0, 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "id": "main-thread-tasks",
+            "numericValue": 16.0,
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Tasks"
-        }, 
+        },
         "mainthread-work-breakdown": {
-            "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this.", 
+            "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this.",
             "details": {
                 "headings": [
                     {
-                        "itemType": "text", 
-                        "key": "groupLabel", 
+                        "itemType": "text",
+                        "key": "groupLabel",
                         "text": "Category"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "duration", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "duration",
                         "text": "Time Spent"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "duration": 1148.6240000000003, 
-                        "group": "scriptEvaluation", 
+                        "duration": 1148.6240000000003,
+                        "group": "scriptEvaluation",
                         "groupLabel": "Script Evaluation"
-                    }, 
+                    },
                     {
-                        "duration": 177.20099999999977, 
-                        "group": "other", 
+                        "duration": 177.20099999999977,
+                        "group": "other",
                         "groupLabel": "Other"
-                    }, 
+                    },
                     {
-                        "duration": 121.584, 
-                        "group": "styleLayout", 
+                        "duration": 121.584,
+                        "group": "styleLayout",
                         "groupLabel": "Style & Layout"
-                    }, 
+                    },
                     {
-                        "duration": 53.65500000000001, 
-                        "group": "parseHTML", 
+                        "duration": 53.65500000000001,
+                        "group": "parseHTML",
                         "groupLabel": "Parse HTML & CSS"
-                    }, 
+                    },
                     {
-                        "duration": 26.198999999999998, 
-                        "group": "garbageCollection", 
+                        "duration": 26.198999999999998,
+                        "group": "garbageCollection",
                         "groupLabel": "Garbage Collection"
-                    }, 
+                    },
                     {
-                        "duration": 13.486999999999998, 
-                        "group": "paintCompositeRender", 
+                        "duration": 13.486999999999998,
+                        "group": "paintCompositeRender",
                         "groupLabel": "Rendering"
-                    }, 
+                    },
                     {
-                        "duration": 7.818999999999999, 
-                        "group": "scriptParseCompile", 
+                        "duration": 7.818999999999999,
+                        "group": "scriptParseCompile",
                         "groupLabel": "Script Parsing & Compilation"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "1.5\u00a0s", 
-            "id": "mainthread-work-breakdown", 
-            "numericValue": 1548.5690000000002, 
-            "score": 0.96, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "displayValue": "1.5\u00a0s",
+            "id": "mainthread-work-breakdown",
+            "numericValue": 1548.5690000000002,
+            "score": 0.96,
+            "scoreDisplayMode": "numeric",
             "title": "Minimizes main-thread work"
-        }, 
+        },
         "managed-focus": {
-            "description": "If new content, such as a dialog, is added to the page, the user's focus is directed to it. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).", 
-            "id": "managed-focus", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "If new content, such as a dialog, is added to the page, the user's focus is directed to it. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#start_with_the_keyboard).",
+            "id": "managed-focus",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "The user's focus is directed to new content added to the page"
-        }, 
+        },
         "max-potential-fid": {
-            "description": "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay).", 
-            "displayValue": "120\u00a0ms", 
-            "id": "max-potential-fid", 
-            "numericValue": 122.537, 
-            "score": 0.92, 
-            "scoreDisplayMode": "numeric", 
+            "description": "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay).",
+            "displayValue": "120\u00a0ms",
+            "id": "max-potential-fid",
+            "numericValue": 122.537,
+            "score": 0.92,
+            "scoreDisplayMode": "numeric",
             "title": "Max Potential FID"
-        }, 
+        },
         "meta-description": {
-            "description": "Meta descriptions may be included in search results to concisely summarize page content. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/description).", 
-            "id": "meta-description", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "Meta descriptions may be included in search results to concisely summarize page content. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/description).",
+            "id": "meta-description",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Document does not have a meta description"
-        }, 
+        },
         "meta-refresh": {
-            "description": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse).", 
-            "id": "meta-refresh", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-refresh?application=lighthouse).",
+            "id": "meta-refresh",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "The document does not use `<meta http-equiv=\"refresh\">`"
-        }, 
+        },
         "meta-viewport": {
-            "description": "Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse).", 
+            "description": "Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page. [Learn more](https://dequeuniversity.com/rules/axe/3.1/meta-viewport?application=lighthouse).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "meta-viewport", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "meta-viewport",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "`[user-scalable=\"no\"]` is not used in the `<meta name=\"viewport\">` element and the `[maximum-scale]` attribute is not less than 5."
-        }, 
+        },
         "metrics": {
-            "description": "Collects all available metrics.", 
+            "description": "Collects all available metrics.",
             "details": {
                 "items": [
                     {
-                        "estimatedInputLatency": 16.0, 
-                        "firstCPUIdle": 4927.0, 
-                        "firstCPUIdleTs": 185608247190.0, 
-                        "firstContentfulPaint": 3969.0, 
-                        "firstContentfulPaintTs": 185607289047.0, 
-                        "firstMeaningfulPaint": 3969.0, 
-                        "firstMeaningfulPaintTs": 185607289048.0, 
-                        "interactive": 4927.0, 
-                        "interactiveTs": 185608247190.0, 
-                        "observedDomContentLoaded": 4901.0, 
-                        "observedDomContentLoadedTs": 185608220734.0, 
-                        "observedFirstContentfulPaint": 3969.0, 
-                        "observedFirstContentfulPaintTs": 185607289047.0, 
-                        "observedFirstMeaningfulPaint": 3969.0, 
-                        "observedFirstMeaningfulPaintTs": 185607289048.0, 
-                        "observedFirstPaint": 3969.0, 
-                        "observedFirstPaintTs": 185607289043.0, 
-                        "observedFirstVisualChange": 3969.0, 
-                        "observedFirstVisualChangeTs": 185607288912.0, 
-                        "observedLastVisualChange": 4791.0, 
-                        "observedLastVisualChangeTs": 185608110912.0, 
-                        "observedLoad": 4924.0, 
-                        "observedLoadTs": 185608244374.0, 
-                        "observedNavigationStart": 0.0, 
-                        "observedNavigationStartTs": 185603319912.0, 
-                        "observedSpeedIndex": 4417.0, 
-                        "observedSpeedIndexTs": 185607736763.0, 
-                        "observedTraceEnd": 10281.0, 
-                        "observedTraceEndTs": 185613601189.0, 
-                        "speedIndex": 4417.0, 
+                        "estimatedInputLatency": 16.0,
+                        "firstCPUIdle": 4927.0,
+                        "firstCPUIdleTs": 185608247190.0,
+                        "firstContentfulPaint": 3969.0,
+                        "firstContentfulPaintTs": 185607289047.0,
+                        "firstMeaningfulPaint": 3969.0,
+                        "firstMeaningfulPaintTs": 185607289048.0,
+                        "interactive": 4927.0,
+                        "interactiveTs": 185608247190.0,
+                        "observedDomContentLoaded": 4901.0,
+                        "observedDomContentLoadedTs": 185608220734.0,
+                        "observedFirstContentfulPaint": 3969.0,
+                        "observedFirstContentfulPaintTs": 185607289047.0,
+                        "observedFirstMeaningfulPaint": 3969.0,
+                        "observedFirstMeaningfulPaintTs": 185607289048.0,
+                        "observedFirstPaint": 3969.0,
+                        "observedFirstPaintTs": 185607289043.0,
+                        "observedFirstVisualChange": 3969.0,
+                        "observedFirstVisualChangeTs": 185607288912.0,
+                        "observedLastVisualChange": 4791.0,
+                        "observedLastVisualChangeTs": 185608110912.0,
+                        "observedLoad": 4924.0,
+                        "observedLoadTs": 185608244374.0,
+                        "observedNavigationStart": 0.0,
+                        "observedNavigationStartTs": 185603319912.0,
+                        "observedSpeedIndex": 4417.0,
+                        "observedSpeedIndexTs": 185607736763.0,
+                        "observedTraceEnd": 10281.0,
+                        "observedTraceEndTs": 185613601189.0,
+                        "speedIndex": 4417.0,
                         "speedIndexTs": 185607736912.0
                     }
-                ], 
+                ],
                 "type": "debugdata"
-            }, 
-            "id": "metrics", 
-            "numericValue": 4927.278, 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "id": "metrics",
+            "numericValue": 4927.278,
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Metrics"
-        }, 
+        },
         "network-requests": {
-            "description": "Lists the network requests that were made during page load.", 
+            "description": "Lists the network requests that were made during page load.",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "startTime", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "startTime",
                         "text": "Start Time"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "endTime", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "endTime",
                         "text": "End Time"
-                    }, 
+                    },
                     {
-                        "displayUnit": "kb", 
-                        "granularity": 1.0, 
-                        "itemType": "bytes", 
-                        "key": "transferSize", 
+                        "displayUnit": "kb",
+                        "granularity": 1.0,
+                        "itemType": "bytes",
+                        "key": "transferSize",
                         "text": "Transfer Size"
-                    }, 
+                    },
                     {
-                        "displayUnit": "kb", 
-                        "granularity": 1.0, 
-                        "itemType": "bytes", 
-                        "key": "resourceSize", 
+                        "displayUnit": "kb",
+                        "granularity": 1.0,
+                        "itemType": "bytes",
+                        "key": "resourceSize",
                         "text": "Resource Size"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "statusCode", 
+                        "itemType": "text",
+                        "key": "statusCode",
                         "text": "Status Code"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "mimeType", 
+                        "itemType": "text",
+                        "key": "mimeType",
                         "text": "MIME Type"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "resourceType", 
+                        "itemType": "text",
+                        "key": "resourceType",
                         "text": "Resource Type"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "endTime": 640.1550000009593, 
-                        "mimeType": "text/html", 
-                        "resourceSize": 12519.0, 
-                        "resourceType": "Document", 
-                        "startTime": 0.0, 
-                        "statusCode": 200.0, 
-                        "transferSize": 12640.0, 
+                        "endTime": 640.1550000009593,
+                        "mimeType": "text/html",
+                        "resourceSize": 12519.0,
+                        "resourceType": "Document",
+                        "startTime": 0.0,
+                        "statusCode": 200.0,
+                        "transferSize": 12640.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "endTime": 2635.035000013886, 
-                        "mimeType": "text/css", 
-                        "resourceSize": 677.0, 
-                        "resourceType": "Stylesheet", 
-                        "startTime": 630.2950000099372, 
-                        "statusCode": 200.0, 
-                        "transferSize": 821.0, 
+                        "endTime": 2635.035000013886,
+                        "mimeType": "text/css",
+                        "resourceSize": 677.0,
+                        "resourceType": "Stylesheet",
+                        "startTime": 630.2950000099372,
+                        "statusCode": 200.0,
+                        "transferSize": 821.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true"
-                    }, 
+                    },
                     {
-                        "endTime": 1204.6590000099968, 
-                        "mimeType": "text/css", 
-                        "resourceSize": 677.0, 
-                        "resourceType": "Stylesheet", 
-                        "startTime": 635.496000002604, 
-                        "statusCode": 200.0, 
-                        "transferSize": 821.0, 
+                        "endTime": 1204.6590000099968,
+                        "mimeType": "text/css",
+                        "resourceSize": 677.0,
+                        "resourceType": "Stylesheet",
+                        "startTime": 635.496000002604,
+                        "statusCode": 200.0,
+                        "transferSize": 821.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100"
-                    }, 
+                    },
                     {
-                        "endTime": 1213.2910000218544, 
-                        "mimeType": "text/css", 
-                        "resourceSize": 0.0, 
-                        "resourceType": "Stylesheet", 
-                        "startTime": 636.6400000115391, 
-                        "statusCode": 404.0, 
-                        "transferSize": 139.0, 
+                        "endTime": 1213.2910000218544,
+                        "mimeType": "text/css",
+                        "resourceSize": 0.0,
+                        "resourceType": "Stylesheet",
+                        "startTime": 636.6400000115391,
+                        "statusCode": 404.0,
+                        "transferSize": 139.0,
                         "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200"
-                    }, 
+                    },
                     {
-                        "endTime": 2849.3670000170823, 
-                        "mimeType": "text/css", 
-                        "resourceSize": 677.0, 
-                        "resourceType": "Stylesheet", 
-                        "startTime": 638.0040000076406, 
-                        "statusCode": 200.0, 
-                        "transferSize": 821.0, 
+                        "endTime": 2849.3670000170823,
+                        "mimeType": "text/css",
+                        "resourceSize": 677.0,
+                        "resourceType": "Stylesheet",
+                        "startTime": 638.0040000076406,
+                        "statusCode": 200.0,
+                        "transferSize": 821.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200"
-                    }, 
+                    },
                     {
-                        "endTime": 1220.04100002232, 
-                        "mimeType": "text/css", 
-                        "resourceSize": 964.0, 
-                        "resourceType": "Stylesheet", 
-                        "startTime": 638.7899999972433, 
-                        "statusCode": 200.0, 
-                        "transferSize": 1108.0, 
+                        "endTime": 1220.04100002232,
+                        "mimeType": "text/css",
+                        "resourceSize": 964.0,
+                        "resourceType": "Stylesheet",
+                        "startTime": 638.7899999972433,
+                        "statusCode": 200.0,
+                        "transferSize": 1108.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
-                    }, 
+                    },
                     {
-                        "endTime": 1228.5180000180844, 
-                        "mimeType": "text/html", 
-                        "resourceSize": 616.0, 
-                        "resourceType": "Document", 
-                        "startTime": 640.5979999981355, 
-                        "statusCode": 200.0, 
-                        "transferSize": 736.0, 
+                        "endTime": 1228.5180000180844,
+                        "mimeType": "text/html",
+                        "resourceSize": 616.0,
+                        "resourceType": "Document",
+                        "startTime": 640.5979999981355,
+                        "statusCode": 200.0,
+                        "transferSize": 736.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200"
-                    }, 
+                    },
                     {
-                        "endTime": 1776.4320000133011, 
-                        "mimeType": "text/html", 
-                        "resourceSize": 613.0, 
-                        "resourceType": "Document", 
-                        "startTime": 641.3450000109151, 
-                        "statusCode": 200.0, 
-                        "transferSize": 733.0, 
+                        "endTime": 1776.4320000133011,
+                        "mimeType": "text/html",
+                        "resourceSize": 613.0,
+                        "resourceType": "Document",
+                        "startTime": 641.3450000109151,
+                        "statusCode": 200.0,
+                        "transferSize": 733.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200&isasync"
-                    }, 
+                    },
                     {
-                        "endTime": 4216.161000018474, 
-                        "mimeType": "text/css", 
-                        "resourceSize": 677.0, 
-                        "resourceType": "Stylesheet", 
-                        "startTime": 642.8679999953602, 
-                        "statusCode": 200.0, 
-                        "transferSize": 821.0, 
+                        "endTime": 4216.161000018474,
+                        "mimeType": "text/css",
+                        "resourceSize": 677.0,
+                        "resourceType": "Stylesheet",
+                        "startTime": 642.8679999953602,
+                        "statusCode": 200.0,
+                        "transferSize": 821.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true"
-                    }, 
+                    },
                     {
-                        "endTime": 1792.0860000012908, 
-                        "mimeType": "text/javascript", 
-                        "resourceSize": 1552.0, 
-                        "resourceType": "Script", 
-                        "startTime": 644.0820000134408, 
-                        "statusCode": 200.0, 
-                        "transferSize": 1703.0, 
+                        "endTime": 1792.0860000012908,
+                        "mimeType": "text/javascript",
+                        "resourceSize": 1552.0,
+                        "resourceType": "Script",
+                        "startTime": 644.0820000134408,
+                        "statusCode": 200.0,
+                        "transferSize": 1703.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.js"
-                    }, 
+                    },
                     {
-                        "endTime": 1236.1859999946319, 
-                        "mimeType": "text/javascript", 
-                        "resourceSize": 0.0, 
-                        "resourceType": "Script", 
-                        "startTime": 645.529000001261, 
-                        "statusCode": 200.0, 
-                        "transferSize": 144.0, 
+                        "endTime": 1236.1859999946319,
+                        "mimeType": "text/javascript",
+                        "resourceSize": 0.0,
+                        "resourceType": "Script",
+                        "startTime": 645.529000001261,
+                        "statusCode": 200.0,
+                        "transferSize": 144.0,
                         "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500"
-                    }, 
+                    },
                     {
-                        "endTime": 4779.641000000993, 
-                        "mimeType": "image/jpeg", 
-                        "resourceSize": 24620.0, 
-                        "resourceType": "Image", 
-                        "startTime": 3951.6250000160653, 
-                        "statusCode": 200.0, 
-                        "transferSize": 24741.0, 
+                        "endTime": 4779.641000000993,
+                        "mimeType": "image/jpeg",
+                        "resourceSize": 24620.0,
+                        "resourceType": "Image",
+                        "startTime": 3951.6250000160653,
+                        "statusCode": 200.0,
+                        "transferSize": 24741.0,
                         "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg"
-                    }, 
+                    },
                     {
-                        "endTime": 3961.049000005005, 
-                        "mimeType": "text/javascript", 
-                        "resourceSize": 71501.0, 
-                        "resourceType": "Script", 
-                        "startTime": 2849.7340000176337, 
-                        "statusCode": 200.0, 
-                        "transferSize": 71654.0, 
+                        "endTime": 3961.049000005005,
+                        "mimeType": "text/javascript",
+                        "resourceSize": 71501.0,
+                        "resourceType": "Script",
+                        "startTime": 2849.7340000176337,
+                        "statusCode": 200.0,
+                        "transferSize": 71654.0,
                         "url": "http://localhost:10200/zone.js"
-                    }, 
+                    },
                     {
-                        "endTime": 4796.288000012282, 
-                        "mimeType": "text/javascript", 
-                        "resourceSize": 84245.0, 
-                        "resourceType": "Script", 
-                        "startTime": 3874.7540000185836, 
-                        "statusCode": 200.0, 
-                        "transferSize": 30174.0, 
+                        "endTime": 4796.288000012282,
+                        "mimeType": "text/javascript",
+                        "resourceSize": 84245.0,
+                        "resourceType": "Script",
+                        "startTime": 3874.7540000185836,
+                        "statusCode": 200.0,
+                        "transferSize": 30174.0,
                         "url": "http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"
-                    }, 
+                    },
                     {
-                        "endTime": 3964.233000006061, 
-                        "mimeType": "text/css", 
-                        "resourceSize": 677.0, 
-                        "resourceType": "Stylesheet", 
-                        "startTime": 2924.34100000537, 
-                        "statusCode": 200.0, 
-                        "transferSize": 821.0, 
+                        "endTime": 3964.233000006061,
+                        "mimeType": "text/css",
+                        "resourceSize": 677.0,
+                        "resourceType": "Stylesheet",
+                        "startTime": 2924.34100000537,
+                        "statusCode": 200.0,
+                        "transferSize": 821.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
-                    }, 
+                    },
                     {
-                        "endTime": 3772.7560000203084, 
-                        "mimeType": "text/html", 
-                        "resourceSize": 12519.0, 
-                        "resourceType": "XHR", 
-                        "startTime": 3066.252999997232, 
-                        "statusCode": 200.0, 
-                        "transferSize": 12640.0, 
+                        "endTime": 3772.7560000203084,
+                        "mimeType": "text/html",
+                        "resourceSize": 12519.0,
+                        "resourceType": "XHR",
+                        "startTime": 3066.252999997232,
+                        "statusCode": 200.0,
+                        "transferSize": 12640.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "endTime": 3968.59800000675, 
-                        "mimeType": "text/plain", 
-                        "resourceSize": 4.0, 
-                        "resourceType": "Image", 
-                        "startTime": 3829.6360000094865, 
-                        "statusCode": 200.0, 
-                        "transferSize": 0.0, 
+                        "endTime": 3968.59800000675,
+                        "mimeType": "text/plain",
+                        "resourceSize": 4.0,
+                        "resourceType": "Image",
+                        "startTime": 3829.6360000094865,
+                        "statusCode": 200.0,
+                        "transferSize": 0.0,
                         "url": "blob:http://localhost:10200/ae0eac03-ab9b-4a6a-b299-f5212153e277"
-                    }, 
+                    },
                     {
-                        "endTime": 5536.498000001302, 
-                        "mimeType": "text/plain", 
-                        "resourceSize": 95.0, 
-                        "resourceType": "Other", 
-                        "startTime": 4967.373000021325, 
-                        "statusCode": 404.0, 
-                        "transferSize": 221.0, 
+                        "endTime": 5536.498000001302,
+                        "mimeType": "text/plain",
+                        "resourceSize": 95.0,
+                        "resourceType": "Other",
+                        "startTime": 4967.373000021325,
+                        "statusCode": 404.0,
+                        "transferSize": 221.0,
                         "url": "http://localhost:10200/favicon.ico"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "network-requests", 
-            "numericValue": 18.0, 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "id": "network-requests",
+            "numericValue": 18.0,
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Network Requests"
-        }, 
+        },
         "network-rtt": {
-            "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more](https://hpbn.co/primer-on-latency-and-bandwidth/).", 
+            "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more](https://hpbn.co/primer-on-latency-and-bandwidth/).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "text", 
-                        "key": "origin", 
+                        "itemType": "text",
+                        "key": "origin",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "rtt", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "rtt",
                         "text": "Time Spent"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "origin": "http://ajax.googleapis.com", 
+                        "origin": "http://ajax.googleapis.com",
                         "rtt": 1.7249999999999943
-                    }, 
+                    },
                     {
-                        "origin": "http://localhost:10200", 
+                        "origin": "http://localhost:10200",
                         "rtt": 0.8639999999999999
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "0\u00a0ms", 
-            "id": "network-rtt", 
-            "numericValue": 1.7249999999999943, 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "displayValue": "0\u00a0ms",
+            "id": "network-rtt",
+            "numericValue": 1.7249999999999943,
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Network Round Trip Times"
-        }, 
+        },
         "network-server-latency": {
-            "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).", 
+            "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "text", 
-                        "key": "origin", 
+                        "itemType": "text",
+                        "key": "origin",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "granularity": 1.0, 
-                        "itemType": "ms", 
-                        "key": "serverReponseTime", 
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "serverReponseTime",
                         "text": "Time Spent"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "origin": "http://localhost:10200", 
+                        "origin": "http://localhost:10200",
                         "serverReponseTime": 572.829
-                    }, 
+                    },
                     {
-                        "origin": "http://ajax.googleapis.com", 
+                        "origin": "http://ajax.googleapis.com",
                         "serverReponseTime": 562.398
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "570\u00a0ms", 
-            "id": "network-server-latency", 
-            "numericValue": 572.829, 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "displayValue": "570\u00a0ms",
+            "id": "network-server-latency",
+            "numericValue": 572.829,
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Server Backend Latencies"
-        }, 
+        },
         "no-document-write": {
-            "description": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).", 
+            "description": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/document-write).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "label", 
+                        "itemType": "text",
+                        "key": "label",
                         "text": "Location"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "label": "line: 178", 
+                        "label": "line: 178",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "label": "line: 179", 
+                        "label": "line: 179",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "label": "line: 180", 
+                        "label": "line: 180",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "no-document-write", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "no-document-write",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Uses `document.write()`"
-        }, 
+        },
         "no-vulnerable-libraries": {
-            "description": "Some third-party scripts may contain known security vulnerabilities that are easily identified and exploited by attackers. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities).", 
+            "description": "Some third-party scripts may contain known security vulnerabilities that are easily identified and exploited by attackers. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/vulnerabilities).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "link", 
-                        "key": "detectedLib", 
+                        "itemType": "link",
+                        "key": "detectedLib",
                         "text": "Library Version"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "vulnCount", 
+                        "itemType": "text",
+                        "key": "vulnCount",
                         "text": "Vulnerability Count"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "highestSeverity", 
+                        "itemType": "text",
+                        "key": "highestSeverity",
                         "text": "Highest Severity"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "detectedLib": {
-                            "text": "jQuery@2.1.1", 
-                            "type": "link", 
+                            "text": "jQuery@2.1.1",
+                            "type": "link",
                             "url": "https://snyk.io/vuln/npm:jquery?lh=2.1.1&utm_source=lighthouse&utm_medium=ref&utm_campaign=audit"
-                        }, 
-                        "highestSeverity": "Medium", 
+                        },
+                        "highestSeverity": "Medium",
                         "vulnCount": 2.0
                     }
-                ], 
-                "summary": null, 
+                ],
+                "summary": null,
                 "type": "table"
-            }, 
-            "displayValue": "2 vulnerabilities detected", 
-            "id": "no-vulnerable-libraries", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "displayValue": "2 vulnerabilities detected",
+            "id": "no-vulnerable-libraries",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Includes front-end JavaScript libraries with known security vulnerabilities"
-        }, 
+        },
         "notification-on-start": {
-            "description": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).", 
+            "description": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/notifications-on-load).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "label", 
+                        "itemType": "text",
+                        "key": "label",
                         "text": "Location"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "label": "line: 287", 
+                        "label": "line: 287",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "notification-on-start", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "notification-on-start",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Requests the notification permission on page load"
-        }, 
+        },
         "object-alt": {
-            "description": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse).", 
+            "description": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/object-alt?application=lighthouse).",
             "details": {
                 "debugData": {
-                    "impact": "serious", 
+                    "impact": "serious",
                     "tags": [
-                        "cat.text-alternatives", 
-                        "wcag2a", 
-                        "wcag111", 
-                        "section508", 
+                        "cat.text-alternatives",
+                        "wcag2a",
+                        "wcag111",
+                        "section508",
                         "section508.22.a"
-                    ], 
+                    ],
                     "type": "debugdata"
-                }, 
+                },
                 "headings": [
                     {
-                        "itemType": "node", 
-                        "key": "node", 
+                        "itemType": "node",
+                        "key": "node",
                         "text": "Failing Elements"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty", 
-                            "path": "3,HTML,1,BODY,2,OBJECT", 
-                            "selector": "#\\35 934a", 
-                            "snippet": "<object id=\"5934a\"></object>", 
+                            "explanation": "Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty",
+                            "path": "3,HTML,1,BODY,2,OBJECT",
+                            "selector": "#\\35 934a",
+                            "snippet": "<object id=\"5934a\"></object>",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "explanation": "Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty", 
-                            "path": "3,HTML,1,BODY,3,OBJECT", 
-                            "selector": "#\\35 934b", 
-                            "snippet": "<object id=\"5934b\"></object>", 
+                            "explanation": "Fix any of the following:\n  Element does not have text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty",
+                            "path": "3,HTML,1,BODY,3,OBJECT",
+                            "selector": "#\\35 934b",
+                            "snippet": "<object id=\"5934b\"></object>",
                             "type": "node"
                         }
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "object-alt", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "object-alt",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "`<object>` elements do not have `[alt]` text"
-        }, 
+        },
         "offline-start-url": {
-            "description": "A service worker enables your web app to be reliable in unpredictable network conditions. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).", 
-            "explanation": "No usable web app manifest found on page.", 
-            "id": "offline-start-url", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
-            "title": "start_url does not respond with a 200 when offline", 
+            "description": "A service worker enables your web app to be reliable in unpredictable network conditions. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).",
+            "explanation": "No usable web app manifest found on page.",
+            "id": "offline-start-url",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
+            "title": "start_url does not respond with a 200 when offline",
             "warnings": []
-        }, 
+        },
         "offscreen-content-hidden": {
-            "description": "Offscreen content is hidden with display: none or aria-hidden=true. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).", 
-            "id": "offscreen-content-hidden", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Offscreen content is hidden with display: none or aria-hidden=true. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).",
+            "id": "offscreen-content-hidden",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Offscreen content is hidden from assistive technology"
-        }, 
+        },
         "offscreen-images": {
-            "description": "Consider lazy-loading offscreen and hidden images after all critical resources have finished loading to lower time to interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images).", 
+            "description": "Consider lazy-loading offscreen and hidden images after all critical resources have finished loading to lower time to interactive. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/offscreen-images).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsBytes": 0.0, 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsBytes": 0.0,
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "offscreen-images", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
-            "title": "Defer offscreen images", 
+            },
+            "id": "offscreen-images",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
+            "title": "Defer offscreen images",
             "warnings": []
-        }, 
+        },
         "password-inputs-can-be-pasted-into": {
-            "description": "Preventing password pasting undermines good security policy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/password-pasting).", 
+            "description": "Preventing password pasting undermines good security policy. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/password-pasting).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "node", 
-                        "key": "node", 
+                        "itemType": "node",
+                        "key": "node",
                         "text": "Failing Elements"
                     }
-                ], 
+                ],
                 "items": [
                     {
                         "node": {
-                            "snippet": "<input type=\"password\" onpaste=\"event.preventDefault();\">", 
+                            "snippet": "<input type=\"password\" onpaste=\"event.preventDefault();\">",
                             "type": "node"
                         }
-                    }, 
+                    },
                     {
                         "node": {
-                            "snippet": "<input type=\"password\" onpaste=\"return false;\">", 
+                            "snippet": "<input type=\"password\" onpaste=\"return false;\">",
                             "type": "node"
                         }
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "password-inputs-can-be-pasted-into", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "password-inputs-can-be-pasted-into",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Prevents users to paste into password fields"
-        }, 
+        },
         "plugins": {
-            "description": "Search engines can't index plugin content, and many devices restrict plugins or don't support them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/plugins).", 
+            "description": "Search engines can't index plugin content, and many devices restrict plugins or don't support them. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/plugins).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "plugins", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "plugins",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Document avoids plugins"
-        }, 
+        },
         "pwa-cross-browser": {
-            "description": "To reach the most number of users, sites should work across every major browser. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#site-works-cross-browser).", 
-            "id": "pwa-cross-browser", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "To reach the most number of users, sites should work across every major browser. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#site-works-cross-browser).",
+            "id": "pwa-cross-browser",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Site works cross-browser"
-        }, 
+        },
         "pwa-each-page-has-url": {
-            "description": "Ensure individual pages are deep linkable via the URLs and that URLs are unique for the purpose of shareability on social media. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#each-page-has-a-url).", 
-            "id": "pwa-each-page-has-url", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Ensure individual pages are deep linkable via the URLs and that URLs are unique for the purpose of shareability on social media. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#each-page-has-a-url).",
+            "id": "pwa-each-page-has-url",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Each page has a URL"
-        }, 
+        },
         "pwa-page-transitions": {
-            "description": "Transitions should feel snappy as you tap around, even on a slow network, a key to perceived performance. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#page-transitions-dont-feel-like-they-block-on-the-network).", 
-            "id": "pwa-page-transitions", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Transitions should feel snappy as you tap around, even on a slow network, a key to perceived performance. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist#page-transitions-dont-feel-like-they-block-on-the-network).",
+            "id": "pwa-page-transitions",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Page transitions don't feel like they block on the network"
-        }, 
+        },
         "redirects": {
-            "description": "Redirects introduce additional delays before the page can be loaded. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/redirects).", 
+            "description": "Redirects introduce additional delays before the page can be loaded. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/redirects).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "redirects", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "id": "redirects",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
             "title": "Avoid multiple page redirects"
-        }, 
+        },
         "redirects-http": {
-            "description": "If you've already set up HTTPS, make sure that you redirect all HTTP traffic to HTTPS. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-redirects-to-https).", 
-            "id": "redirects-http", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "If you've already set up HTTPS, make sure that you redirect all HTTP traffic to HTTPS. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-redirects-to-https).",
+            "id": "redirects-http",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Does not redirect HTTP traffic to HTTPS"
-        }, 
+        },
         "render-blocking-resources": {
-            "description": "Resources are blocking the first paint of your page. Consider delivering critical JS/CSS inline and deferring all non-critical JS/styles. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).", 
+            "description": "Resources are blocking the first paint of your page. Consider delivering critical JS/CSS inline and deferring all non-critical JS/styles. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources).",
             "details": {
                 "headings": [
                     {
-                        "key": "url", 
-                        "label": "URL", 
+                        "key": "url",
+                        "label": "URL",
                         "valueType": "url"
-                    }, 
+                    },
                     {
-                        "key": "totalBytes", 
-                        "label": "Size", 
+                        "key": "totalBytes",
+                        "label": "Size",
                         "valueType": "bytes"
-                    }, 
+                    },
                     {
-                        "key": "wastedMs", 
-                        "label": "Potential Savings", 
+                        "key": "wastedMs",
+                        "label": "Potential Savings",
                         "valueType": "timespanMs"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "totalBytes": 821.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100", 
+                        "totalBytes": 821.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
                         "wastedMs": 873.0
-                    }, 
+                    },
                     {
-                        "totalBytes": 139.0, 
-                        "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200", 
+                        "totalBytes": 139.0,
+                        "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200",
                         "wastedMs": 873.0
-                    }, 
+                    },
                     {
-                        "totalBytes": 821.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200", 
+                        "totalBytes": 821.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
                         "wastedMs": 873.0
-                    }, 
+                    },
                     {
-                        "totalBytes": 736.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200", 
+                        "totalBytes": 736.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200",
                         "wastedMs": 873.0
-                    }, 
+                    },
                     {
-                        "totalBytes": 1703.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.js", 
+                        "totalBytes": 1703.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
                         "wastedMs": 723.0
                     }
-                ], 
-                "overallSavingsMs": 1129.0, 
+                ],
+                "overallSavingsMs": 1129.0,
                 "type": "opportunity"
-            }, 
-            "displayValue": "Potential savings of 1,130\u00a0ms", 
-            "id": "render-blocking-resources", 
-            "numericValue": 1129.0, 
-            "score": 0.46, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "displayValue": "Potential savings of 1,130\u00a0ms",
+            "id": "render-blocking-resources",
+            "numericValue": 1129.0,
+            "score": 0.46,
+            "scoreDisplayMode": "numeric",
             "title": "Eliminate render-blocking resources"
-        }, 
+        },
         "resource-summary": {
-            "description": "To set budgets for the quantity and size of page resources, add a budget.json file.", 
+            "description": "To set budgets for the quantity and size of page resources, add a budget.json file.",
             "details": {
                 "headings": [
                     {
-                        "itemType": "text", 
-                        "key": "label", 
+                        "itemType": "text",
+                        "key": "label",
                         "text": "Resource Type"
-                    }, 
+                    },
                     {
-                        "itemType": "numeric", 
-                        "key": "requestCount", 
+                        "itemType": "numeric",
+                        "key": "requestCount",
                         "text": "Requests"
-                    }, 
+                    },
                     {
-                        "itemType": "bytes", 
-                        "key": "size", 
+                        "itemType": "bytes",
+                        "key": "size",
                         "text": "Transfer Size"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "label": "Total", 
-                        "requestCount": 18.0, 
-                        "resourceType": "total", 
+                        "label": "Total",
+                        "requestCount": 18.0,
+                        "resourceType": "total",
                         "size": 160738.0
-                    }, 
+                    },
                     {
-                        "label": "Script", 
-                        "requestCount": 4.0, 
-                        "resourceType": "script", 
+                        "label": "Script",
+                        "requestCount": 4.0,
+                        "resourceType": "script",
                         "size": 103675.0
-                    }, 
+                    },
                     {
-                        "label": "Image", 
-                        "requestCount": 2.0, 
-                        "resourceType": "image", 
+                        "label": "Image",
+                        "requestCount": 2.0,
+                        "resourceType": "image",
                         "size": 24741.0
-                    }, 
+                    },
                     {
-                        "label": "Document", 
-                        "requestCount": 3.0, 
-                        "resourceType": "document", 
+                        "label": "Document",
+                        "requestCount": 3.0,
+                        "resourceType": "document",
                         "size": 14109.0
-                    }, 
+                    },
                     {
-                        "label": "Other", 
-                        "requestCount": 2.0, 
-                        "resourceType": "other", 
+                        "label": "Other",
+                        "requestCount": 2.0,
+                        "resourceType": "other",
                         "size": 12861.0
-                    }, 
+                    },
                     {
-                        "label": "Stylesheet", 
-                        "requestCount": 7.0, 
-                        "resourceType": "stylesheet", 
+                        "label": "Stylesheet",
+                        "requestCount": 7.0,
+                        "resourceType": "stylesheet",
                         "size": 5352.0
-                    }, 
+                    },
                     {
-                        "label": "Media", 
-                        "requestCount": 0.0, 
-                        "resourceType": "media", 
+                        "label": "Media",
+                        "requestCount": 0.0,
+                        "resourceType": "media",
                         "size": 0.0
-                    }, 
+                    },
                     {
-                        "label": "Font", 
-                        "requestCount": 0.0, 
-                        "resourceType": "font", 
+                        "label": "Font",
+                        "requestCount": 0.0,
+                        "resourceType": "font",
                         "size": 0.0
-                    }, 
+                    },
                     {
-                        "label": "Third-party", 
-                        "requestCount": 2.0, 
-                        "resourceType": "third-party", 
+                        "label": "Third-party",
+                        "requestCount": 2.0,
+                        "resourceType": "third-party",
                         "size": 30174.0
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "18 requests \u2022 157 KB", 
-            "id": "resource-summary", 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "displayValue": "18 requests \u2022 157 KB",
+            "id": "resource-summary",
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Keep request counts low and transfer sizes small"
-        }, 
+        },
         "robots-txt": {
-            "description": "If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed.", 
-            "id": "robots-txt", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed.",
+            "id": "robots-txt",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "robots.txt is valid"
-        }, 
+        },
         "screenshot-thumbnails": {
-            "description": "This is what the load of your site looked like.", 
+            "description": "This is what the load of your site looked like.",
             "details": {
                 "items": [
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z", 
-                        "timestamp": 185603812639.80002, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z",
+                        "timestamp": 185603812639.80002,
                         "timing": 493.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z", 
-                        "timestamp": 185604305367.6, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z",
+                        "timestamp": 185604305367.6,
                         "timing": 985.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z", 
-                        "timestamp": 185604798095.4, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z",
+                        "timestamp": 185604798095.4,
                         "timing": 1478.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z", 
-                        "timestamp": 185605290823.19998, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z",
+                        "timestamp": 185605290823.19998,
                         "timing": 1971.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z", 
-                        "timestamp": 185605783551.0, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z",
+                        "timestamp": 185605783551.0,
                         "timing": 2464.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z", 
-                        "timestamp": 185606276278.80002, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z",
+                        "timestamp": 185606276278.80002,
                         "timing": 2956.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z", 
-                        "timestamp": 185606769006.6, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z",
+                        "timestamp": 185606769006.6,
                         "timing": 3449.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z", 
-                        "timestamp": 185607261734.4, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP1ToAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgD//Z",
+                        "timestamp": 185607261734.4,
                         "timing": 3942.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP0loAKACgAoAKACgAoAKACgAoAKACgAoAKACgAp2DpcKQk7hQMKBpXAc0C62CgAoFcMigLhmgYUCuGadirBSBqwUCFoFcTNOxVhDnBx1pNl01zT5GZVtrM11a3E0dsn7gkMPNJyB17VnfU7p0Iwsi5p+oRalbCaIkDoVbgiquc0qT6Fk/d4Gc9PQ/Si5i4unHmZnHV9msCxMWFxkyBvbPSi50xo80PaGhuHXd8v94njFFzlu+xBf30VhbiVznJCqPU0XLhF1HYbNqMMF1Bbkgyy9v7oxnmi5botFpgUba3ykZyCeaLmTTg7CEgfxA/Q0XKSb6DseuBVXM0mwYbfY/lSbK5ZR1Y3cvXcMHoc9aVxXfYz7rWDa6pDaeVlZcYk3YIyfSpvqdfsuajzLc0QNwJyDxnrmtEzhUZReojEAMSQBjqahm8dK6/rsc3o9zFDp+oF5APnOFz146D61n1PUrOLrQf9dDMSwuLSC1edGS3llBKnjAHTP5nvVG0XTbkuxt6KGXWdRC5EG7OVxy1Bw4z2bop9dCveCI+KG8zbsEZJ39OVoNKdT/ZrLzMmMzQWVq7bhbrOSCwyOMdR6UHfNUUvdLd/AsOnE+es0f2gNlF+QZBPB7jigxpSTctNkya5eD/hILNxt8sxjBxjLcjpQJybhzdf+CVoEa4e7WWZbedZlfLKS56420E1mqUYtLVotadYW9/rGopKquqsSoB9+1AV63saPPBK+m50GpWgu9OngC7nZCE9c44p3PMpy5Z2ZzcU11KNNuVj3AE2y57kcc/r+RpXPZ5qbTRZv4jBq6Qlo4rdrfZG0oJX3PUc0GFCcKibktinJbpDfaXE0iyqEwXPQjc1IIVI3NPwumHv9vNv537vA9znFO5y4uUZG4eRgjI9DWzR57dnzES2kCkbYYxzn7orO2o5VnKLl2JXQSKUcB1PVW5H5VViPbSSi+4kUSRKFRFRR2UYosVO9RuPYa9tFJnfEj5OTuUGixVObXuDmhRo9jIpT+6VGKLD9pIabaAw+V5SeVxhNowPwosJ1ZJpR66A1vE7IWjjOz7uVHy9+PSiwuep7XkBreJ5RK0aGQdHIGaLD9rKTcZdAW2hjbcsaK3qFGTRYbqOouRkme/Q0WM5P3xqxIoACqADkADofWixpKcoyElgiuP9bGsgznDqCAfxosJTdPRdQa2hdcNEjDAGCo6CixXM0OjjWJQqKqKOyjFFjOTch1MQUAFABQAUAFABQAUAFABQAUAFABQAUAFACO4jRmY4VRkn2oGlcg/tC3xE3mfLKcIcHB5xU3NfZS3JYZknjDodyk46EU7mTTTsJHcRyu6q4JQ7WHof8mmtRuLjuSAgkjI49+tMVmBIAyTx61Nx8rGxyLKispypGRRckdTAKACgAoAKACgAoAKAGSjMTA55UjjrSZrT0ephWsE6W2mM/mlllyU2AbBg+g+nWo6nc5x5C2RPP4fkVg7SfNxghuvtTMY8l7sjzNDdXEkKSqWmG3Knldh55HTOPzod+hvJ02x9vJcNBH5jzlmdFZTGVK8/NzS1I/djrKS4+1ETNNsDMu0x/KV/hOaYTdO2hoWyCO3iABChAACMEU0cMmnsSVRAUAFABQAUAFABQAUAUtZ1mx8P6Teanql5Dp+nWcL3Fxd3DbI4Y1BZmZuwABJPtQO5laN8R/DPiHS9D1Ky1uye11uFZ9PV7hVkuFIzhVPO4ZAIGcHg4PSbBdmpp+uadqhi+x6hZ3zTFjF9mnVxIFIDbcHJwTgnHBOPq7BdmNd/EXRIBY3K6jp82h3Kz51YX8f2eNkZAELZAOdx5yMFcHqKd0gRqXXibRrGaOG61WyikfbsR7lFZ9wyuATk5GCOORT1Ym2Rv4w8P22lwX82u6bHZXMnl29y15GIpjxwrZwx56Ln8TxU2FbzHf8ACWaJ9qe2Ot6d9pjnW2kjN2mUlPRGGchj/dxnqOaLBYuwanZ3wnWzuY55LeTyJlRlcxS4yUYA/K2P4Tz9eDTGUz4r0QxX8ia1ppTT22Xjfa0It2yRhyM7ORj5sfQ0AWLnWbCxura1ub+2hubgMYYnlCvKFwSVU4JAU5J6d+xoA5Xw78UbHxtc6Rd+Gfsus+Fr+G+b+247xFAltplhKJGeZFLeYfMU7QEH99TQB0Ft4t0K808Xtvrmm3FqZjALiK8iaIuOSofdgnGePYntigDUhniuYY5oZUmikUMkkbBldT0YEdiORQA6gAoAwfH/AIfn8WeBfEeiWzxx3Wpabc2UTy52K0kTIpbHOASOlAHiHwf+APi/wPpfinS9Zk0O6ttf0/RYGktb2Yvaz2tlDZSspaBdy7LcTRv8uJCykKMSUAcnq/7Knj7V7XX9KGo6DY6dcweMEtL+K9uGmB1e7gu7dnhNvgBTAY5B5hBEhK+hAPdLfw74p1H7Rd6npHhzTru4F0Xh0y8kkVmaBY42eV4UMjMVALbAFVR941Ljd3KR5R8IP2avFvw/8NTWGq3OiXExg8Hwq9pcTOpGlGD7TndApAbySYxjn5d23rWilymbOs8AfCTxf4L8X67fvFoGpaZqeo+IL1rdrqcSbb2a1ltlx5JHWCQSjkAOrAt2kosw/s6Q2fxG0TxHBqDeRa+GDo12TlZZrqJfJtbvgFdwhmvlbLfxx4yASACL9m34O618KNFsrbXNL8K2up2ek2+kSaxoMk011qIgYiJ5mkjj8sBMfIPMG6RyCBjIB58f2UvFeg6joGpaDd6TPZadqUGqP4O1PVbr+zIpXhvYLxbWXyDJbxsLmKRFKsqsHGFBBcA634e/BXxh8PvH95cW2neCm8I6rFpcr2kQmSTRJbRDGYbOIxFJE2BQjl4yrMzFDnZQBy2jfs1ePdG8N6Bp4n8OvPpGh+KNNjLXc5jlfUbhZrVyBbj5RtAkGeAfl30AdX47+Bvijxl8XtE8YIuhWUNrqeg3lygupWldbFdSMuP3OC2+/UKDjKxkkqTtoA7/AOAHgTUvhf8ABXwb4S1h7STU9G06OymewkaSBig27kJVTg46FQR0oA7+gAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA//9k=", 
-                        "timestamp": 185607754462.19998, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP0loAKACgAoAKACgAoAKACgAoAKACgAoAKACgAp2DpcKQk7hQMKBpXAc0C62CgAoFcMigLhmgYUCuGadirBSBqwUCFoFcTNOxVhDnBx1pNl01zT5GZVtrM11a3E0dsn7gkMPNJyB17VnfU7p0Iwsi5p+oRalbCaIkDoVbgiquc0qT6Fk/d4Gc9PQ/Si5i4unHmZnHV9msCxMWFxkyBvbPSi50xo80PaGhuHXd8v94njFFzlu+xBf30VhbiVznJCqPU0XLhF1HYbNqMMF1Bbkgyy9v7oxnmi5botFpgUba3ykZyCeaLmTTg7CEgfxA/Q0XKSb6DseuBVXM0mwYbfY/lSbK5ZR1Y3cvXcMHoc9aVxXfYz7rWDa6pDaeVlZcYk3YIyfSpvqdfsuajzLc0QNwJyDxnrmtEzhUZReojEAMSQBjqahm8dK6/rsc3o9zFDp+oF5APnOFz146D61n1PUrOLrQf9dDMSwuLSC1edGS3llBKnjAHTP5nvVG0XTbkuxt6KGXWdRC5EG7OVxy1Bw4z2bop9dCveCI+KG8zbsEZJ39OVoNKdT/ZrLzMmMzQWVq7bhbrOSCwyOMdR6UHfNUUvdLd/AsOnE+es0f2gNlF+QZBPB7jigxpSTctNkya5eD/hILNxt8sxjBxjLcjpQJybhzdf+CVoEa4e7WWZbedZlfLKS56420E1mqUYtLVotadYW9/rGopKquqsSoB9+1AV63saPPBK+m50GpWgu9OngC7nZCE9c44p3PMpy5Z2ZzcU11KNNuVj3AE2y57kcc/r+RpXPZ5qbTRZv4jBq6Qlo4rdrfZG0oJX3PUc0GFCcKibktinJbpDfaXE0iyqEwXPQjc1IIVI3NPwumHv9vNv537vA9znFO5y4uUZG4eRgjI9DWzR57dnzES2kCkbYYxzn7orO2o5VnKLl2JXQSKUcB1PVW5H5VViPbSSi+4kUSRKFRFRR2UYosVO9RuPYa9tFJnfEj5OTuUGixVObXuDmhRo9jIpT+6VGKLD9pIabaAw+V5SeVxhNowPwosJ1ZJpR66A1vE7IWjjOz7uVHy9+PSiwuep7XkBreJ5RK0aGQdHIGaLD9rKTcZdAW2hjbcsaK3qFGTRYbqOouRkme/Q0WM5P3xqxIoACqADkADofWixpKcoyElgiuP9bGsgznDqCAfxosJTdPRdQa2hdcNEjDAGCo6CixXM0OjjWJQqKqKOyjFFjOTch1MQUAFABQAUAFABQAUAFABQAUAFABQAUAFACO4jRmY4VRkn2oGlcg/tC3xE3mfLKcIcHB5xU3NfZS3JYZknjDodyk46EU7mTTTsJHcRyu6q4JQ7WHof8mmtRuLjuSAgkjI49+tMVmBIAyTx61Nx8rGxyLKispypGRRckdTAKACgAoAKACgAoAKAGSjMTA55UjjrSZrT0ephWsE6W2mM/mlllyU2AbBg+g+nWo6nc5x5C2RPP4fkVg7SfNxghuvtTMY8l7sjzNDdXEkKSqWmG3Knldh55HTOPzod+hvJ02x9vJcNBH5jzlmdFZTGVK8/NzS1I/djrKS4+1ETNNsDMu0x/KV/hOaYTdO2hoWyCO3iABChAACMEU0cMmnsSVRAUAFABQAUAFABQAUAUtZ1mx8P6Teanql5Dp+nWcL3Fxd3DbI4Y1BZmZuwABJPtQO5laN8R/DPiHS9D1Ky1uye11uFZ9PV7hVkuFIzhVPO4ZAIGcHg4PSbBdmpp+uadqhi+x6hZ3zTFjF9mnVxIFIDbcHJwTgnHBOPq7BdmNd/EXRIBY3K6jp82h3Kz51YX8f2eNkZAELZAOdx5yMFcHqKd0gRqXXibRrGaOG61WyikfbsR7lFZ9wyuATk5GCOORT1Ym2Rv4w8P22lwX82u6bHZXMnl29y15GIpjxwrZwx56Ln8TxU2FbzHf8ACWaJ9qe2Ot6d9pjnW2kjN2mUlPRGGchj/dxnqOaLBYuwanZ3wnWzuY55LeTyJlRlcxS4yUYA/K2P4Tz9eDTGUz4r0QxX8ia1ppTT22Xjfa0It2yRhyM7ORj5sfQ0AWLnWbCxura1ub+2hubgMYYnlCvKFwSVU4JAU5J6d+xoA5Xw78UbHxtc6Rd+Gfsus+Fr+G+b+247xFAltplhKJGeZFLeYfMU7QEH99TQB0Ft4t0K808Xtvrmm3FqZjALiK8iaIuOSofdgnGePYntigDUhniuYY5oZUmikUMkkbBldT0YEdiORQA6gAoAwfH/AIfn8WeBfEeiWzxx3Wpabc2UTy52K0kTIpbHOASOlAHiHwf+APi/wPpfinS9Zk0O6ttf0/RYGktb2Yvaz2tlDZSspaBdy7LcTRv8uJCykKMSUAcnq/7Knj7V7XX9KGo6DY6dcweMEtL+K9uGmB1e7gu7dnhNvgBTAY5B5hBEhK+hAPdLfw74p1H7Rd6npHhzTru4F0Xh0y8kkVmaBY42eV4UMjMVALbAFVR941Ljd3KR5R8IP2avFvw/8NTWGq3OiXExg8Hwq9pcTOpGlGD7TndApAbySYxjn5d23rWilymbOs8AfCTxf4L8X67fvFoGpaZqeo+IL1rdrqcSbb2a1ltlx5JHWCQSjkAOrAt2kosw/s6Q2fxG0TxHBqDeRa+GDo12TlZZrqJfJtbvgFdwhmvlbLfxx4yASACL9m34O618KNFsrbXNL8K2up2ek2+kSaxoMk011qIgYiJ5mkjj8sBMfIPMG6RyCBjIB58f2UvFeg6joGpaDd6TPZadqUGqP4O1PVbr+zIpXhvYLxbWXyDJbxsLmKRFKsqsHGFBBcA634e/BXxh8PvH95cW2neCm8I6rFpcr2kQmSTRJbRDGYbOIxFJE2BQjl4yrMzFDnZQBy2jfs1ePdG8N6Bp4n8OvPpGh+KNNjLXc5jlfUbhZrVyBbj5RtAkGeAfl30AdX47+Bvijxl8XtE8YIuhWUNrqeg3lygupWldbFdSMuP3OC2+/UKDjKxkkqTtoA7/AOAHgTUvhf8ABXwb4S1h7STU9G06OymewkaSBig27kJVTg46FQR0oA7+gAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA//9k=",
+                        "timestamp": 185607754462.19998,
                         "timing": 4435.0
-                    }, 
+                    },
                     {
-                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP0loAKACgAoAKACgAoAKACgAoAKACgAoAKACgAp2DpcKQk7hQMKBpXAc0C62CgAoFcMigLhmgYUCuGadirBSBqwUCFoFcTNOxVhDnBx1pNl01zT5GZVtrM11a3E0dsn7gkMPNJyB17VnfU7p0Iwsi5p+oRalbCaIkDoVbgiquc0qT6Fk/d4Gc9PQ/Si5i4unHmZnHV9msCxMWFxkyBvbPSi50xo80PaGhuHXd8v94njFFzlu+xBf30VhbiVznJCqPU0XLhF1HYbNqMMF1Bbkgyy9v7oxnmi5botFpgUba3ykZyCeaLmTTg7CEgfxA/Q0XKSb6DseuBVXM0mwYbfY/lSbK5ZR1Y3cvXcMHoc9aVxXfYz7rWDa6pDaeVlZcYk3YIyfSpvqdfsuajzLc0QNwJyDxnrmtEzhUZReojEAMSQBjqahm8dK6/rsc3o9zFDp+oF5APnOFz146D61n1PUrOLrQf9dDMSwuLSC1edGS3llBKnjAHTP5nvVG0XTbkuxt6KGXWdRC5EG7OVxy1Bw4z2bop9dCveCI+KG8zbsEZJ39OVoNKdT/ZrLzMmMzQWVq7bhbrOSCwyOMdR6UHfNUUvdLd/AsOnE+es0f2gNlF+QZBPB7jigxpSTctNkya5eD/hILNxt8sxjBxjLcjpQJybhzdf+CVoEa4e7WWZbedZlfLKS56420E1mqUYtLVotadYW9/rGopKquqsSoB9+1AV63saPPBK+m50GpWgu9OngC7nZCE9c44p3PMpy5Z2ZzcU11KNNuVj3AE2y57kcc/r+RpXPZ5qbTRZv4jBq6Qlo4rdrfZG0oJX3PUc0GFCcKibktinJbpDfaXE0iyqEwXPQjc1IIVI3NPwumHv9vNv537vA9znFO5y4uUZG4eRgjI9DWzR57dnzES2kCkbYYxzn7orO2o5VnKLl2JXQSKUcB1PVW5H5VViPbSSi+4kUSRKFRFRR2UYosVO9RuPYa9tFJnfEj5OTuUGixVObXuDmhRo9jIpT+6VGKLD9pIabaAw+V5SeVxhNowPwosJ1ZJpR66A1vE7IWjjOz7uVHy9+PSiwuep7XkBreJ5RK0aGQdHIGaLD9rKTcZdAW2hjbcsaK3qFGTRYbqOouRkme/Q0WM5P3xqxIoACqADkADofWixpKcoyElgiuP9bGsgznDqCAfxosJTdPRdQa2hdcNEjDAGCo6CixXM0OjjWJQqKqKOyjFFjOTch1MQUAFABQAUAFABQAUAFABQAUAFABQAUAFACO4jRmY4VRkn2oGlcg/tC3xE3mfLKcIcHB5xU3NfZS3JYZknjDodyk46EU7mTTTsJHcRyu6q4JQ7WHof8mmtRuLjuSAgkjI49+tMVmBIAyTx61Nx8rGxyLKispypGRRckdTAKACgAoAKACgAoAKAGSjMTA55UjjrSZrT0ephWsE6W2mM/mlllyU2AbBg+g+nWo6nc5x5C2RPP4fkVg7SfNxghuvtTMY8l7sjzNDdXEkKSqWmG3Knldh55HTOPzod+hvJ02x9vJcNBH5jzlmdFZTGVK8/NzS1I/djrKS4+1ETNNsDMu0x/KV/hOaYTdO2hoWyCO3iABChAACMEU0cMmnsSVRAUAFABQAUAFABQAUAUtZ1mx8P6Teanql5Dp+nWcL3Fxd3DbI4Y1BZmZuwABJPtQO5laN8R/DPiHS9D1Ky1uye11uFZ9PV7hVkuFIzhVPO4ZAIGcHg4PSbBdmpp+uadqhi+x6hZ3zTFjF9mnVxIFIDbcHJwTgnHBOPq7BdmNd/EXRIBY3K6jp82h3Kz51YX8f2eNkZAELZwc7jzkYK4PUVMpcqYI1LrxNo1lNHDdatZQyPt2I9ygZywyoAJycjBHHIraStt3t+Am2Rv4w8P22lwX82u6bHZXMnl29y15GIpjxwrZwx56Ln8TxWdhW8x3/CWaJ9qe2Ot6d9pjnW2kjN2mUlPRGGchj/AHcZ6jmiwWLsGp2d8J1s7mOeS3k8iZUZXMUuMlGAPytj+E8/Xg0xlM+K9EMV/ImtaaU09tl432tCLdskYcjOzkY+bH0NAFi51mwsbq2tbm/tobm4DGGJ5QryhcElVOCQFOSenfsaAOV8O/FGx8bXOkXfhn7LrPha/hvm/tuO8RQJbaZYSiRnmRS3mHzFO0BB/fU0AdBbeLdCvNPF7b65ptxamYwC4ivImiLjkqH3YJxnj2J7YoA1IZ4rmGOaGVJopFDJJGwZXU9GBHYjkUAOoAKAOf8AiFokvifwF4j0eGSKGfUtNubKKWbIRWkiZFLY52gkE4oA8J+EHwT8SeCNL8VaXrN94cubbX9P0WBpbXUJS9rPa2UFlKVLQruXZbiaN/lxIWQhRiSgDk9X/Zm8Z6vba/pS634astOubfxelpfxahM0wbV7uC7t2eEwYAUwmOQeYQRISvoQD3a10zX9SNxd6nZ+FtOu7j7UXh0y/eRWZoFjjZ5XhQyMxUAttAVVH3jWNSN03/W5SPJvhD+z14j+H3hubT9U1Lw7cymDwfCr2l9IykaUYPtOd8CkBvKYxjHPy7tvWuycrX9V+SM2dZ4A+G/ifwX4v12/d/DOpaZqeo+IL1rdr+USbb2a1ltlx5JHWCQSjkAMrAt2xKLMHwGsLT4j6J4ji1iMQWvhg6NdkygSzXUS+Ta3fy/LuEM18rZb+OPGQCQARfs2/C3UPhRotla63ZeEbfU7PSbfSJNY0G4kludREDERPM0iJ5YCY+QeYN0jkEDGQDz0/sxeI9B1HQNS0HUtEnstO1GDVJPB2qa1cf2ZFK8N7BeLay+QZLdGFzFIilWRWDjCgguAdd8PPhL4n+H3j+9uLa38CnwjqsWlyvaRSyJJoktohjMNnEYmSRNgUI5eMqzMxQ52UAcxo37PPjLRvDegWA1Dwu8+kaH4o02MtfzGOV9RuFmtXIEA+UbQJBngH5fMoA6zx18Hdd8Z/F7RPGCXHhyyitdT0G8uUF7I0rrYrqRlx+4wW336hQcZWMklSdtAHf8AwB8JXHwv+Cvg3wlq99p0mp6Np0dlO9hOZIGKDbuQsqnBx0KgjpQB33261/5+Yf8Avsf40AH2+1/5+of++x/jQB4t+2yPN/Zb+IY6/wDEvHH/AG1jrqw2tQyqfwz8VoLReMpivqFHVM8Tqy2lugPSuhAWItoyMVTIluSFuPlqkSTKlICQDt/SqjuJkqJn0/AVoSTLHk4oAesIU8UAOWEZP+FXcCRIefSmuV/G7FJN7Ow4IpJAIz35pc0fsy/Ijlqxd0yRYvmxkD2zTU2/cctPkOUq0tLjvJXJGQTntV3pU95fkEadTrL+vuP1v/bSB/4Ze+IJ9bEf+jY6+Awi/eH0dTSFj8XFcKeeK+t0sjxmrNkqNuOQD+VUnYkliOCcqR9RTvclocGBPpVpomzLCPQ7LqTclRwPb60lLUV7kocY6/kavmQWJFmx0/WjmQiQTnOAM07odhRNnof1oenUnXsWIommOAykepqfbumm4x5vIap+1fK9D1fwt8F9I8UaUl4njvSrCZlyYLxCpUj6tz19K/PMw4uxOBlaGCqy/wAMb/ofRYfKqU1dzS/r1N2D9l63jEsk/wATfDUmMFUjBz0zxg814j8QcU9Hl9Zesf8AgHb/AGLQa0qL+vmcb44+G1p4X+yLYa/Br0szMjLBEyCIjHOSxGD+HSvs8o4kePjeph5R9dOnoeRisqjTfuy/r7z9MP22G8v9ln4gk9BYA/8AkWOuGheNQ7KmqPxX+0wEJvJRzwMtgZr25VXojg5PeLMKbzhFck9WTOB+a8/hS52aciHi1kQsZZflx3Qj+lWqrSIlTuV2eSJ8LqEUcfYuCB+ZFQ67RPsizbTvKSqXFvKAcMRJj+laL3NUwdNE09zdQYxYT7f7yhWB/I5rX63Laxn7FSH2mpmY7RaXAc/3oj/hR9al2H9Wj3JLjULi3JxZPIMdQh4/EgCsp4mbeiKWHj3MtfEVzuy3yR/3WhXI/HfXM8XNdDVYeHc17fxnFawJuswdo5ZhgH8waTrzZryQNFfi1YRxiOTRrGeNhhl+zK+R9VYEVhKd/jvbyE4R6GhD8ZdCBAGmeUApXZFcyxqPTAzWscRGHwRY3Q9orKVi/a/GXQ43VvsLF+PvXchH14Oaf1mtU92Tsv68hQwzpO/MdfZ/tA6X5cUaw6TBnGWlWVmb2bK81xVaMZO/P/X3nS6ttD9KP2438n9k74kyE426euDwcfvo/WuenJp3Y2rn4fLq8LxBysbunZgAT+I4r0FWi9W9TFwXQuwa/bTQ5lggRgegVcn8RVqtEhxZM11pjDIYwk9Qhcgj/vqm6sRJSIHNhdKBbzLGc9W3g/zqHKDHaRNa31xpqO1u8V0W7RyOVX/gJBFNVEg5Szb649wv74RB/RvLH8wK0jWXUhwHrq6Wr5EcUh9VeMflg1p7WJPIy3/wkJQAuzRKeeWA/UGmqsSXBjZ9RMYDCUNE3ykid2/k1P3JByyIZPEJswFidY16AJKxwf8AgQrPnpdEX7OfcbHq0rn96rSk/MP37YqeaPYahKO7Jr3UrQRbZyvHVVdGI/BhWV4rZFcknszKabS53yLyOFPV7RWI/wC+aL825pyStqyTydNZVNtc6bO3+2JIT+PzUe72QezZ+1P7doLfsjfEwZx/xLl/9Hx15aVzdn4RC2KgsVUjGS2a1UGQtGT/AGJWCE7GBGcDrWigwcixDBDDgpIWY9jyBWns7kcw+UxzsBt2n1jO3+VHsw5hzwhZeCz+rbs5rT2RPMBsjOcNCdvsoOaapBzFiDRSSP3Mqj0ySD+HSq9mHMStojuhVvNRCf75UflVKmS5FU2tiR5TXEirn7plJwaly5RcwjpYQsMSNJu6qrZrLniiveHx6mlvxHDNjGMhc0niIroHJKehZLRXMysYt7Hr5in/AApqtF9C1CURJbXzGYJZ+Z2wF4/Wk53d0NqTIxCIlCf2Z2xn5anmYuWR+9H7TWi+GvEvwI8Yad4v1qfw74cubNUvtSt4mlaBPMQ7gihiecdAfyrjpuo2bPQ/M2P9nf8AZNPT9oDWiPT+xZf/AIxXeoVbXRj7SN7MmT9nT9lXd8v7QGtAe2iSf/GKTp4l/wDDj56Yr/s3fsrv1/aB17H+zo8o/wDaFCo4j+mS6tOIo/Zq/ZWZVUfH3XmAPfSZs/8Aoiq+r4h/8OL21MUfs1fssjay/HzWwR3XRpR/7Qp/VcT/AEy/a0iST9m39l2dcSfH7XSOozpMp/8AaFH1XE/0w9rSGp+zN+yyucfH3XcEf9AiX/4xR9VxP9MPa0i3B+zb+ytGPn+OuuTntu0qYD8vIq1hcV0in8/+CL21NE8H7On7KS5P/C59Qc+raLL/APGKr6ri/wDn2vw/zD29Mv2XwM/Zeg+aD42apF/u6NJ/8YpLCYv/AJ9r8P8AMj2lM1Lb4U/szWzZ/wCF2apL/vaRKP5QCrWHxa/5dr8P8xOpTF/4VT+zIXLf8Lp1bd040yfj84av2GM/59r8P8yfaUyIfBv9l7du/wCF06zk/e/4l9wM/lDT9ji1/wAu1+H+Ye0pk0Xwq/Zih4Pxm1SQdvO0uaT+cNHssX/z7X4f5h7SmfZn7bmT+yr8Qx/1Dx/6NjrzKDfPZnVUd43R+J1vHjHT8q+lpppI8eV5NmhCvbj8q6E5GRdhG4dsUSlK+hLsTqQOg4+lbRnIXujg+D0yPYVtzyIJlbd6dPSjnkBIqnYOP0p88mBKFyccDAp8z6sNOokKMOMUcz7/AJC0JUAXheKpy83+AWJEByehqU3ff8iboUIzNjirv5v8AuP2heDgn2pX8/yC4oQfKSueecCnr3/ILn64/ttL/wAYr/EP/sHj/wBGx18DQ/iI+ln/AAz8UoV5Ar6iOyPI7l5B8wroSMmWogVBFElqZslztFUkIkTHJPbvWgD4iGzg4+lICZdpOOcn3q0BKBuBIHSqZLJFwp5yTSELG4JPB9KCmSqcDP6U0ZE6x7GPcetMBMAn39aXUBSCygZ6VoB+t/7bAP8Awy18Qx/1Dx/6Njr4HDa1NT6af8M/FWNCMV9Ulax4ybuy6iYwe9bpksnjYVW5myQ4bApiJBFkcnNJNgSLxxVrUTHxRYIY1Qrk6YAOehPamInBRs4U0ALCnIyeO9AClApJ680CZJsDL8pwKLkgFBYc80wLMYCjGc1oB+tf7a5z+y58Qv8ArwX/ANGx18Lhbe0Ppqn8M/FmIcivqraI8VbsucYH0qkJhCRzyKszaJhgkYxmgROtSgJAn7zpWqEywVJ4HAqySREOR6igCVchiM/jQA5YwmTnP40ASEKcdKBMUA4IA5oJHwxfMN6genFNATmNAR8pznnFWB+s/wC2mM/su/EEf9OA/wDRsdfB4P8AiH01T+Gfi4qFMcjFfXdEeJ1ZP2FUARqAetNAWEAH1pmbJscVEhEqsMnGTW8dgJFbkf1qgLMbHJPtQSxwO9Tng0CHAnJ44oIJNoBBz+FNATqcBvemA5X4HqKAHpJv5PWgD9aP20v+TXviCf8ApwH/AKNjr4XB/wAQ+mqfwz8XQvINfXbJHidWTKQaL3Acq/NxVpibsShguCfWqM2WAwPNZyAkQcnt7it47CJkTB65qguTpt38+lAmTgAEelAhNxA6k0EC7wRxRewxdxBxVLULExZC69Qe9MLCsqvjB6Uh2P1u/bSP/GL3xB/68B/6Njr4XB/xD6Sp/DPxeVuK+t6I8TqyQDmqSAlTuKpqxEtx6jC8jP1qkSP6AE1nICwoO72reOwmWN2MVRJLGFU5J5PrQBNuUdxQA1WBOKCB6KMEDrmkND8hnAyBn16Ur2KFVTnIAPzYovcq2lx5DYGQc+1FzNux+t37aAz+y98Qv+vAf+jY6+Jwf8Q+lqfwz8Xo8KfU19d0R4nVkytlulF2A5H2y49aLtkS3Js7jitESSKA/XnFFgJvmAz29KpMTJY2DjnIIq0SWNowD1psB6uM85AoAQsUPHNPQVhUl2nODzxUtX62GkSzTQWcZkmfjsBXLWnGmr8x0UcPUnLXYx/D16WvJ/NdvLeXMZxxivPoYuE6vLKp8tP8z0KmDkoe6dM0Ak5Vsj1r1FKLfu6nl+ycH+8P1n/bP4/Zf+IOeB9gH/o2OvjsJ/EPfqfwz8Xk2huOpr62+iPE6smiwrEHn6UASKEB/CgiW45QOzYrVJkkyNxxj8KAHo7Dqc0XEyxG2VOcjdWkSRQASMMeKpgSrI4+QkYpXQDlO0jCg1FwJVAJweMnpnAJ9KmUoxi3JXKj8SPRdP8A2bde8QaLa6rb3VlLDJbpOFklkjkUEAngqV6uO9fjOP4yoYTEeynTf3ry/wAz9NwmCTpX/rqWbL9l/wATyZjkWzLFgpla4YjHBzhUPYiuKtxrl0Y86pPm9V/mbU8OnNxZQ8WfDSX4f21gbi7iuXuvMBEO7auwgYG7rnPpX2XDGdPNeaUItLzt2bPls6oRpNWf9XP04/bU5/Zd+IQHX7AP/Rsdd2F/iHNU/hn4tREhgW49K+qXQ8TqydTzkVoBInU54oJauCnDc8VtGVibFmF/lxuH5VAiZDu7g0gJkK4Azz6VpF2AcGXccHmnJ3JYrMGbI5qRD48s47DNAGlZqquCTjn7wwcD19PzrGq7R3sXCLlJWPvH9nQ+HdU+GtitxN/Z0qW4hbzHwhUCMdTxnI7V/GnFscSsxunp8u0T9WwbmqNk/wCtT2KPTvC9hBI39pwP8youxlbrFGe3418m+eUFeev/AATSHMpNs+QP2lrjRtSg0C3024V7i3mu0lZGyC3yELx75r+hvD6Xs6T9pO2q/wDST5fOIqq1/XU+2P20W/4xj+IKeth1+kiH+lfoWHly1DzZr3bH4tbsdq+h+sWtoeZ7LV6kkb5zxVfWfIPZeZOo3c0fWfIXsvMeeetL6z5B7LzJYpRHxsBz61f1nyI9j5k0TjONoo+s+Qex8yVSScj5cUfWfIPY+ZIrYYE/NTWJt0JdHzG7sHpT+tf3Rex8xVcrgdRR9a/uh7HzNKyff2xgZ+tY1asayUZJ/J/8AqNJxaaZ6Z4K+MOtfDjRvsxWLVLGZiVgf93sOQeoznp6V+YZ3wphMfP2rk19z6Ly8j7HC5jKnHl5b/M9CsP2sNRaFkXQYFFwoUj7RwPkCZwEHYCvi6fBOHjUv7VtX/lR6X9oe58H4/8AAOM12O48X31lqtzOsFtHMxjsYI9qjkHls5PSv0fKspoZfDlg7/cunofP4qr7Z3tY/wD/2Q==", 
-                        "timestamp": 185608247190.0, 
+                        "data": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRQBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIANUAeAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AP0loAKACgAoAKACgAoAKACgAoAKACgAoAKACgAp2DpcKQk7hQMKBpXAc0C62CgAoFcMigLhmgYUCuGadirBSBqwUCFoFcTNOxVhDnBx1pNl01zT5GZVtrM11a3E0dsn7gkMPNJyB17VnfU7p0Iwsi5p+oRalbCaIkDoVbgiquc0qT6Fk/d4Gc9PQ/Si5i4unHmZnHV9msCxMWFxkyBvbPSi50xo80PaGhuHXd8v94njFFzlu+xBf30VhbiVznJCqPU0XLhF1HYbNqMMF1Bbkgyy9v7oxnmi5botFpgUba3ykZyCeaLmTTg7CEgfxA/Q0XKSb6DseuBVXM0mwYbfY/lSbK5ZR1Y3cvXcMHoc9aVxXfYz7rWDa6pDaeVlZcYk3YIyfSpvqdfsuajzLc0QNwJyDxnrmtEzhUZReojEAMSQBjqahm8dK6/rsc3o9zFDp+oF5APnOFz146D61n1PUrOLrQf9dDMSwuLSC1edGS3llBKnjAHTP5nvVG0XTbkuxt6KGXWdRC5EG7OVxy1Bw4z2bop9dCveCI+KG8zbsEZJ39OVoNKdT/ZrLzMmMzQWVq7bhbrOSCwyOMdR6UHfNUUvdLd/AsOnE+es0f2gNlF+QZBPB7jigxpSTctNkya5eD/hILNxt8sxjBxjLcjpQJybhzdf+CVoEa4e7WWZbedZlfLKS56420E1mqUYtLVotadYW9/rGopKquqsSoB9+1AV63saPPBK+m50GpWgu9OngC7nZCE9c44p3PMpy5Z2ZzcU11KNNuVj3AE2y57kcc/r+RpXPZ5qbTRZv4jBq6Qlo4rdrfZG0oJX3PUc0GFCcKibktinJbpDfaXE0iyqEwXPQjc1IIVI3NPwumHv9vNv537vA9znFO5y4uUZG4eRgjI9DWzR57dnzES2kCkbYYxzn7orO2o5VnKLl2JXQSKUcB1PVW5H5VViPbSSi+4kUSRKFRFRR2UYosVO9RuPYa9tFJnfEj5OTuUGixVObXuDmhRo9jIpT+6VGKLD9pIabaAw+V5SeVxhNowPwosJ1ZJpR66A1vE7IWjjOz7uVHy9+PSiwuep7XkBreJ5RK0aGQdHIGaLD9rKTcZdAW2hjbcsaK3qFGTRYbqOouRkme/Q0WM5P3xqxIoACqADkADofWixpKcoyElgiuP9bGsgznDqCAfxosJTdPRdQa2hdcNEjDAGCo6CixXM0OjjWJQqKqKOyjFFjOTch1MQUAFABQAUAFABQAUAFABQAUAFABQAUAFACO4jRmY4VRkn2oGlcg/tC3xE3mfLKcIcHB5xU3NfZS3JYZknjDodyk46EU7mTTTsJHcRyu6q4JQ7WHof8mmtRuLjuSAgkjI49+tMVmBIAyTx61Nx8rGxyLKispypGRRckdTAKACgAoAKACgAoAKAGSjMTA55UjjrSZrT0ephWsE6W2mM/mlllyU2AbBg+g+nWo6nc5x5C2RPP4fkVg7SfNxghuvtTMY8l7sjzNDdXEkKSqWmG3Knldh55HTOPzod+hvJ02x9vJcNBH5jzlmdFZTGVK8/NzS1I/djrKS4+1ETNNsDMu0x/KV/hOaYTdO2hoWyCO3iABChAACMEU0cMmnsSVRAUAFABQAUAFABQAUAUtZ1mx8P6Teanql5Dp+nWcL3Fxd3DbI4Y1BZmZuwABJPtQO5laN8R/DPiHS9D1Ky1uye11uFZ9PV7hVkuFIzhVPO4ZAIGcHg4PSbBdmpp+uadqhi+x6hZ3zTFjF9mnVxIFIDbcHJwTgnHBOPq7BdmNd/EXRIBY3K6jp82h3Kz51YX8f2eNkZAELZwc7jzkYK4PUVMpcqYI1LrxNo1lNHDdatZQyPt2I9ygZywyoAJycjBHHIraStt3t+Am2Rv4w8P22lwX82u6bHZXMnl29y15GIpjxwrZwx56Ln8TxWdhW8x3/CWaJ9qe2Ot6d9pjnW2kjN2mUlPRGGchj/AHcZ6jmiwWLsGp2d8J1s7mOeS3k8iZUZXMUuMlGAPytj+E8/Xg0xlM+K9EMV/ImtaaU09tl432tCLdskYcjOzkY+bH0NAFi51mwsbq2tbm/tobm4DGGJ5QryhcElVOCQFOSenfsaAOV8O/FGx8bXOkXfhn7LrPha/hvm/tuO8RQJbaZYSiRnmRS3mHzFO0BB/fU0AdBbeLdCvNPF7b65ptxamYwC4ivImiLjkqH3YJxnj2J7YoA1IZ4rmGOaGVJopFDJJGwZXU9GBHYjkUAOoAKAOf8AiFokvifwF4j0eGSKGfUtNubKKWbIRWkiZFLY52gkE4oA8J+EHwT8SeCNL8VaXrN94cubbX9P0WBpbXUJS9rPa2UFlKVLQruXZbiaN/lxIWQhRiSgDk9X/Zm8Z6vba/pS634astOubfxelpfxahM0wbV7uC7t2eEwYAUwmOQeYQRISvoQD3a10zX9SNxd6nZ+FtOu7j7UXh0y/eRWZoFjjZ5XhQyMxUAttAVVH3jWNSN03/W5SPJvhD+z14j+H3hubT9U1Lw7cymDwfCr2l9IykaUYPtOd8CkBvKYxjHPy7tvWuycrX9V+SM2dZ4A+G/ifwX4v12/d/DOpaZqeo+IL1rdr+USbb2a1ltlx5JHWCQSjkAMrAt2xKLMHwGsLT4j6J4ji1iMQWvhg6NdkygSzXUS+Ta3fy/LuEM18rZb+OPGQCQARfs2/C3UPhRotla63ZeEbfU7PSbfSJNY0G4kludREDERPM0iJ5YCY+QeYN0jkEDGQDz0/sxeI9B1HQNS0HUtEnstO1GDVJPB2qa1cf2ZFK8N7BeLay+QZLdGFzFIilWRWDjCgguAdd8PPhL4n+H3j+9uLa38CnwjqsWlyvaRSyJJoktohjMNnEYmSRNgUI5eMqzMxQ52UAcxo37PPjLRvDegWA1Dwu8+kaH4o02MtfzGOV9RuFmtXIEA+UbQJBngH5fMoA6zx18Hdd8Z/F7RPGCXHhyyitdT0G8uUF7I0rrYrqRlx+4wW336hQcZWMklSdtAHf8AwB8JXHwv+Cvg3wlq99p0mp6Np0dlO9hOZIGKDbuQsqnBx0KgjpQB33261/5+Yf8Avsf40AH2+1/5+of++x/jQB4t+2yPN/Zb+IY6/wDEvHH/AG1jrqw2tQyqfwz8VoLReMpivqFHVM8Tqy2lugPSuhAWItoyMVTIluSFuPlqkSTKlICQDt/SqjuJkqJn0/AVoSTLHk4oAesIU8UAOWEZP+FXcCRIefSmuV/G7FJN7Ow4IpJAIz35pc0fsy/Ijlqxd0yRYvmxkD2zTU2/cctPkOUq0tLjvJXJGQTntV3pU95fkEadTrL+vuP1v/bSB/4Ze+IJ9bEf+jY6+Awi/eH0dTSFj8XFcKeeK+t0sjxmrNkqNuOQD+VUnYkliOCcqR9RTvclocGBPpVpomzLCPQ7LqTclRwPb60lLUV7kocY6/kavmQWJFmx0/WjmQiQTnOAM07odhRNnof1oenUnXsWIommOAykepqfbumm4x5vIap+1fK9D1fwt8F9I8UaUl4njvSrCZlyYLxCpUj6tz19K/PMw4uxOBlaGCqy/wAMb/ofRYfKqU1dzS/r1N2D9l63jEsk/wATfDUmMFUjBz0zxg814j8QcU9Hl9Zesf8AgHb/AGLQa0qL+vmcb44+G1p4X+yLYa/Br0szMjLBEyCIjHOSxGD+HSvs8o4kePjeph5R9dOnoeRisqjTfuy/r7z9MP22G8v9ln4gk9BYA/8AkWOuGheNQ7KmqPxX+0wEJvJRzwMtgZr25VXojg5PeLMKbzhFck9WTOB+a8/hS52aciHi1kQsZZflx3Qj+lWqrSIlTuV2eSJ8LqEUcfYuCB+ZFQ67RPsizbTvKSqXFvKAcMRJj+laL3NUwdNE09zdQYxYT7f7yhWB/I5rX63Laxn7FSH2mpmY7RaXAc/3oj/hR9al2H9Wj3JLjULi3JxZPIMdQh4/EgCsp4mbeiKWHj3MtfEVzuy3yR/3WhXI/HfXM8XNdDVYeHc17fxnFawJuswdo5ZhgH8waTrzZryQNFfi1YRxiOTRrGeNhhl+zK+R9VYEVhKd/jvbyE4R6GhD8ZdCBAGmeUApXZFcyxqPTAzWscRGHwRY3Q9orKVi/a/GXQ43VvsLF+PvXchH14Oaf1mtU92Tsv68hQwzpO/MdfZ/tA6X5cUaw6TBnGWlWVmb2bK81xVaMZO/P/X3nS6ttD9KP2438n9k74kyE426euDwcfvo/WuenJp3Y2rn4fLq8LxBysbunZgAT+I4r0FWi9W9TFwXQuwa/bTQ5lggRgegVcn8RVqtEhxZM11pjDIYwk9Qhcgj/vqm6sRJSIHNhdKBbzLGc9W3g/zqHKDHaRNa31xpqO1u8V0W7RyOVX/gJBFNVEg5Szb649wv74RB/RvLH8wK0jWXUhwHrq6Wr5EcUh9VeMflg1p7WJPIy3/wkJQAuzRKeeWA/UGmqsSXBjZ9RMYDCUNE3ykid2/k1P3JByyIZPEJswFidY16AJKxwf8AgQrPnpdEX7OfcbHq0rn96rSk/MP37YqeaPYahKO7Jr3UrQRbZyvHVVdGI/BhWV4rZFcknszKabS53yLyOFPV7RWI/wC+aL825pyStqyTydNZVNtc6bO3+2JIT+PzUe72QezZ+1P7doLfsjfEwZx/xLl/9Hx15aVzdn4RC2KgsVUjGS2a1UGQtGT/AGJWCE7GBGcDrWigwcixDBDDgpIWY9jyBWns7kcw+UxzsBt2n1jO3+VHsw5hzwhZeCz+rbs5rT2RPMBsjOcNCdvsoOaapBzFiDRSSP3Mqj0ySD+HSq9mHMStojuhVvNRCf75UflVKmS5FU2tiR5TXEirn7plJwaly5RcwjpYQsMSNJu6qrZrLniiveHx6mlvxHDNjGMhc0niIroHJKehZLRXMysYt7Hr5in/AApqtF9C1CURJbXzGYJZ+Z2wF4/Wk53d0NqTIxCIlCf2Z2xn5anmYuWR+9H7TWi+GvEvwI8Yad4v1qfw74cubNUvtSt4mlaBPMQ7gihiecdAfyrjpuo2bPQ/M2P9nf8AZNPT9oDWiPT+xZf/AIxXeoVbXRj7SN7MmT9nT9lXd8v7QGtAe2iSf/GKTp4l/wDDj56Yr/s3fsrv1/aB17H+zo8o/wDaFCo4j+mS6tOIo/Zq/ZWZVUfH3XmAPfSZs/8Aoiq+r4h/8OL21MUfs1fssjay/HzWwR3XRpR/7Qp/VcT/AEy/a0iST9m39l2dcSfH7XSOozpMp/8AaFH1XE/0w9rSGp+zN+yyucfH3XcEf9AiX/4xR9VxP9MPa0i3B+zb+ytGPn+OuuTntu0qYD8vIq1hcV0in8/+CL21NE8H7On7KS5P/C59Qc+raLL/APGKr6ri/wDn2vw/zD29Mv2XwM/Zeg+aD42apF/u6NJ/8YpLCYv/AJ9r8P8AMj2lM1Lb4U/szWzZ/wCF2apL/vaRKP5QCrWHxa/5dr8P8xOpTF/4VT+zIXLf8Lp1bd040yfj84av2GM/59r8P8yfaUyIfBv9l7du/wCF06zk/e/4l9wM/lDT9ji1/wAu1+H+Ye0pk0Xwq/Zih4Pxm1SQdvO0uaT+cNHssX/z7X4f5h7SmfZn7bmT+yr8Qx/1Dx/6NjrzKDfPZnVUd43R+J1vHjHT8q+lpppI8eV5NmhCvbj8q6E5GRdhG4dsUSlK+hLsTqQOg4+lbRnIXujg+D0yPYVtzyIJlbd6dPSjnkBIqnYOP0p88mBKFyccDAp8z6sNOokKMOMUcz7/AJC0JUAXheKpy83+AWJEByehqU3ff8iboUIzNjirv5v8AuP2heDgn2pX8/yC4oQfKSueecCnr3/ILn64/ttL/wAYr/EP/sHj/wBGx18DQ/iI+ln/AAz8UoV5Ar6iOyPI7l5B8wroSMmWogVBFElqZslztFUkIkTHJPbvWgD4iGzg4+lICZdpOOcn3q0BKBuBIHSqZLJFwp5yTSELG4JPB9KCmSqcDP6U0ZE6x7GPcetMBMAn39aXUBSCygZ6VoB+t/7bAP8Awy18Qx/1Dx/6Njr4HDa1NT6af8M/FWNCMV9Ulax4ybuy6iYwe9bpksnjYVW5myQ4bApiJBFkcnNJNgSLxxVrUTHxRYIY1Qrk6YAOehPamInBRs4U0ALCnIyeO9AClApJ680CZJsDL8pwKLkgFBYc80wLMYCjGc1oB+tf7a5z+y58Qv8ArwX/ANGx18Lhbe0Ppqn8M/FmIcivqraI8VbsucYH0qkJhCRzyKszaJhgkYxmgROtSgJAn7zpWqEywVJ4HAqySREOR6igCVchiM/jQA5YwmTnP40ASEKcdKBMUA4IA5oJHwxfMN6genFNATmNAR8pznnFWB+s/wC2mM/su/EEf9OA/wDRsdfB4P8AiH01T+Gfi4qFMcjFfXdEeJ1ZP2FUARqAetNAWEAH1pmbJscVEhEqsMnGTW8dgJFbkf1qgLMbHJPtQSxwO9Tng0CHAnJ44oIJNoBBz+FNATqcBvemA5X4HqKAHpJv5PWgD9aP20v+TXviCf8ApwH/AKNjr4XB/wAQ+mqfwz8XQvINfXbJHidWTKQaL3Acq/NxVpibsShguCfWqM2WAwPNZyAkQcnt7it47CJkTB65qguTpt38+lAmTgAEelAhNxA6k0EC7wRxRewxdxBxVLULExZC69Qe9MLCsqvjB6Uh2P1u/bSP/GL3xB/68B/6Njr4XB/xD6Sp/DPxeVuK+t6I8TqyQDmqSAlTuKpqxEtx6jC8jP1qkSP6AE1nICwoO72reOwmWN2MVRJLGFU5J5PrQBNuUdxQA1WBOKCB6KMEDrmkND8hnAyBn16Ur2KFVTnIAPzYovcq2lx5DYGQc+1FzNux+t37aAz+y98Qv+vAf+jY6+Jwf8Q+lqfwz8Xo8KfU19d0R4nVkytlulF2A5H2y49aLtkS3Js7jitESSKA/XnFFgJvmAz29KpMTJY2DjnIIq0SWNowD1psB6uM85AoAQsUPHNPQVhUl2nODzxUtX62GkSzTQWcZkmfjsBXLWnGmr8x0UcPUnLXYx/D16WvJ/NdvLeXMZxxivPoYuE6vLKp8tP8z0KmDkoe6dM0Ak5Vsj1r1FKLfu6nl+ycH+8P1n/bP4/Zf+IOeB9gH/o2OvjsJ/EPfqfwz8Xk2huOpr62+iPE6smiwrEHn6UASKEB/CgiW45QOzYrVJkkyNxxj8KAHo7Dqc0XEyxG2VOcjdWkSRQASMMeKpgSrI4+QkYpXQDlO0jCg1FwJVAJweMnpnAJ9KmUoxi3JXKj8SPRdP8A2bde8QaLa6rb3VlLDJbpOFklkjkUEAngqV6uO9fjOP4yoYTEeynTf3ry/wAz9NwmCTpX/rqWbL9l/wATyZjkWzLFgpla4YjHBzhUPYiuKtxrl0Y86pPm9V/mbU8OnNxZQ8WfDSX4f21gbi7iuXuvMBEO7auwgYG7rnPpX2XDGdPNeaUItLzt2bPls6oRpNWf9XP04/bU5/Zd+IQHX7AP/Rsdd2F/iHNU/hn4tREhgW49K+qXQ8TqydTzkVoBInU54oJauCnDc8VtGVibFmF/lxuH5VAiZDu7g0gJkK4Azz6VpF2AcGXccHmnJ3JYrMGbI5qRD48s47DNAGlZqquCTjn7wwcD19PzrGq7R3sXCLlJWPvH9nQ+HdU+GtitxN/Z0qW4hbzHwhUCMdTxnI7V/GnFscSsxunp8u0T9WwbmqNk/wCtT2KPTvC9hBI39pwP8youxlbrFGe3418m+eUFeev/AATSHMpNs+QP2lrjRtSg0C3024V7i3mu0lZGyC3yELx75r+hvD6Xs6T9pO2q/wDST5fOIqq1/XU+2P20W/4xj+IKeth1+kiH+lfoWHly1DzZr3bH4tbsdq+h+sWtoeZ7LV6kkb5zxVfWfIPZeZOo3c0fWfIXsvMeeetL6z5B7LzJYpRHxsBz61f1nyI9j5k0TjONoo+s+Qex8yVSScj5cUfWfIPY+ZIrYYE/NTWJt0JdHzG7sHpT+tf3Rex8xVcrgdRR9a/uh7HzNKyff2xgZ+tY1asayUZJ/J/8AqNJxaaZ6Z4K+MOtfDjRvsxWLVLGZiVgf93sOQeoznp6V+YZ3wphMfP2rk19z6Ly8j7HC5jKnHl5b/M9CsP2sNRaFkXQYFFwoUj7RwPkCZwEHYCvi6fBOHjUv7VtX/lR6X9oe58H4/8AAOM12O48X31lqtzOsFtHMxjsYI9qjkHls5PSv0fKspoZfDlg7/cunofP4qr7Z3tY/wD/2Q==",
+                        "timestamp": 185608247190.0,
                         "timing": 4927.0
                     }
-                ], 
-                "scale": 4927.278, 
+                ],
+                "scale": 4927.278,
                 "type": "filmstrip"
-            }, 
-            "id": "screenshot-thumbnails", 
-            "score": null, 
-            "scoreDisplayMode": "informative", 
+            },
+            "id": "screenshot-thumbnails",
+            "score": null,
+            "scoreDisplayMode": "informative",
             "title": "Screenshot Thumbnails"
-        }, 
+        },
         "service-worker": {
-            "description": "The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker).", 
-            "id": "service-worker", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/registered-service-worker).",
+            "id": "service-worker",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Does not register a service worker that controls page and start_url"
-        }, 
+        },
         "speed-index": {
-            "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index).", 
-            "displayValue": "4.4\u00a0s", 
-            "id": "speed-index", 
-            "numericValue": 4417.0, 
-            "score": 0.74, 
-            "scoreDisplayMode": "numeric", 
+            "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/speed-index).",
+            "displayValue": "4.4\u00a0s",
+            "id": "speed-index",
+            "numericValue": 4417.0,
+            "score": 0.74,
+            "scoreDisplayMode": "numeric",
             "title": "Speed Index"
-        }, 
+        },
         "splash-screen": {
-            "description": "A themed splash screen ensures a high-quality experience when users launch your app from their homescreens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/custom-splash-screen).", 
+            "description": "A themed splash screen ensures a high-quality experience when users launch your app from their homescreens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/custom-splash-screen).",
             "details": {
                 "items": [
                     {
                         "failures": [
                             "No manifest was fetched"
-                        ], 
-                        "isParseFailure": true, 
+                        ],
+                        "isParseFailure": true,
                         "parseFailureReason": "No manifest was fetched"
                     }
-                ], 
+                ],
                 "type": "debugdata"
-            }, 
-            "explanation": "Failures: No manifest was fetched.", 
-            "id": "splash-screen", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "explanation": "Failures: No manifest was fetched.",
+            "id": "splash-screen",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Is not configured for a custom splash screen"
-        }, 
+        },
         "structured-data": {
-            "description": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more](https://developers.google.com/search/docs/guides/mark-up-content).", 
-            "id": "structured-data", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more](https://developers.google.com/search/docs/guides/mark-up-content).",
+            "id": "structured-data",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Structured data is valid"
-        }, 
+        },
         "tabindex": {
-            "description": "A value greater than 0 implies an explicit navigation ordering. Although technically valid, this often creates frustrating experiences for users who rely on assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse).", 
-            "id": "tabindex", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "A value greater than 0 implies an explicit navigation ordering. Although technically valid, this often creates frustrating experiences for users who rely on assistive technologies. [Learn more](https://dequeuniversity.com/rules/axe/3.1/tabindex?application=lighthouse).",
+            "id": "tabindex",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "No element has a `[tabindex]` value greater than 0"
-        }, 
+        },
         "tap-targets": {
-            "description": "Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design).", 
+            "description": "Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#multi-device_responsive_design).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "displayValue": "100% appropriately sized tap targets", 
-            "id": "tap-targets", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "displayValue": "100% appropriately sized tap targets",
+            "id": "tap-targets",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Tap targets are sized appropriately"
-        }, 
+        },
         "td-headers-attr": {
-            "description": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse).", 
-            "id": "td-headers-attr", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/td-headers-attr?application=lighthouse).",
+            "id": "td-headers-attr",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "Cells in a `<table>` element that use the `[headers]` attribute only refer to other cells of that same table."
-        }, 
+        },
         "th-has-data-cells": {
-            "description": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse).", 
-            "id": "th-has-data-cells", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://dequeuniversity.com/rules/axe/3.1/th-has-data-cells?application=lighthouse).",
+            "id": "th-has-data-cells",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`<th>` elements and elements with `[role=\"columnheader\"/\"rowheader\"]` have data cells they describe."
-        }, 
+        },
         "themed-omnibox": {
-            "description": "The browser address bar can be themed to match your site. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/address-bar).", 
+            "description": "The browser address bar can be themed to match your site. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/address-bar).",
             "details": {
                 "items": [
                     {
                         "failures": [
-                            "No manifest was fetched", 
+                            "No manifest was fetched",
                             "No `<meta name=\"theme-color\">` tag found"
-                        ], 
-                        "isParseFailure": true, 
-                        "parseFailureReason": "No manifest was fetched", 
+                        ],
+                        "isParseFailure": true,
+                        "parseFailureReason": "No manifest was fetched",
                         "themeColor": null
                     }
-                ], 
+                ],
                 "type": "debugdata"
-            }, 
-            "explanation": "Failures: No manifest was fetched,\nNo `<meta name=\"theme-color\">` tag found.", 
-            "id": "themed-omnibox", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "explanation": "Failures: No manifest was fetched,\nNo `<meta name=\"theme-color\">` tag found.",
+            "id": "themed-omnibox",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Does not set an address-bar theme color"
-        }, 
+        },
         "time-to-first-byte": {
-            "description": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).", 
+            "description": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsMs": -29.436999999999898, 
+                "headings": [],
+                "items": [],
+                "overallSavingsMs": -29.436999999999898,
                 "type": "opportunity"
-            }, 
-            "displayValue": "Root document took 570\u00a0ms", 
-            "id": "time-to-first-byte", 
-            "numericValue": 570.5630000000001, 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "displayValue": "Root document took 570\u00a0ms",
+            "id": "time-to-first-byte",
+            "numericValue": 570.5630000000001,
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Server response times are low (TTFB)"
-        }, 
+        },
         "total-byte-weight": {
-            "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/network-payloads).", 
+            "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/network-payloads).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "bytes", 
-                        "key": "totalBytes", 
+                        "itemType": "bytes",
+                        "key": "totalBytes",
                         "text": "Size"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "totalBytes": 71654.0, 
+                        "totalBytes": 71654.0,
                         "url": "http://localhost:10200/zone.js"
-                    }, 
+                    },
                     {
-                        "totalBytes": 30174.0, 
+                        "totalBytes": 30174.0,
                         "url": "http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"
-                    }, 
+                    },
                     {
-                        "totalBytes": 24741.0, 
+                        "totalBytes": 24741.0,
                         "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg"
-                    }, 
+                    },
                     {
-                        "totalBytes": 12640.0, 
+                        "totalBytes": 12640.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "totalBytes": 12640.0, 
+                        "totalBytes": 12640.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "totalBytes": 1703.0, 
+                        "totalBytes": 1703.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.js"
-                    }, 
+                    },
                     {
-                        "totalBytes": 1108.0, 
+                        "totalBytes": 1108.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
-                    }, 
+                    },
                     {
-                        "totalBytes": 821.0, 
+                        "totalBytes": 821.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100"
-                    }, 
+                    },
                     {
-                        "totalBytes": 821.0, 
+                        "totalBytes": 821.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true"
-                    }, 
+                    },
                     {
-                        "totalBytes": 821.0, 
+                        "totalBytes": 821.0,
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "Total size was 157\u00a0KB", 
-            "id": "total-byte-weight", 
-            "numericValue": 160738.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "displayValue": "Total size was 157\u00a0KB",
+            "id": "total-byte-weight",
+            "numericValue": 160738.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
             "title": "Avoids enormous network payloads"
-        }, 
+        },
         "unminified-css": {
-            "description": "Minifying CSS files can reduce network payload sizes. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/minify-css).", 
+            "description": "Minifying CSS files can reduce network payload sizes. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/minify-css).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsBytes": 0.0, 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsBytes": 0.0,
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "unminified-css", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "id": "unminified-css",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
             "title": "Minify CSS"
-        }, 
+        },
         "unminified-javascript": {
-            "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn more](https://developers.google.com/speed/docs/insights/MinifyResources).", 
+            "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn more](https://developers.google.com/speed/docs/insights/MinifyResources).",
             "details": {
                 "headings": [
                     {
-                        "key": "url", 
-                        "label": "URL", 
+                        "key": "url",
+                        "label": "URL",
                         "valueType": "url"
-                    }, 
+                    },
                     {
-                        "key": "totalBytes", 
-                        "label": "Size", 
+                        "key": "totalBytes",
+                        "label": "Size",
                         "valueType": "bytes"
-                    }, 
+                    },
                     {
-                        "key": "wastedBytes", 
-                        "label": "Potential Savings", 
+                        "key": "wastedBytes",
+                        "label": "Potential Savings",
                         "valueType": "bytes"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "totalBytes": 71654.0, 
-                        "url": "http://localhost:10200/zone.js", 
-                        "wastedBytes": 30470.0, 
+                        "totalBytes": 71654.0,
+                        "url": "http://localhost:10200/zone.js",
+                        "wastedBytes": 30470.0,
                         "wastedPercent": 42.52388078488413
                     }
-                ], 
-                "overallSavingsBytes": 30470.0, 
-                "overallSavingsMs": 150.0, 
+                ],
+                "overallSavingsBytes": 30470.0,
+                "overallSavingsMs": 150.0,
                 "type": "opportunity"
-            }, 
-            "displayValue": "Potential savings of 30\u00a0KB", 
-            "id": "unminified-javascript", 
-            "numericValue": 150.0, 
-            "score": 0.88, 
-            "scoreDisplayMode": "numeric", 
-            "title": "Minify JavaScript", 
+            },
+            "displayValue": "Potential savings of 30\u00a0KB",
+            "id": "unminified-javascript",
+            "numericValue": 150.0,
+            "score": 0.88,
+            "scoreDisplayMode": "numeric",
+            "title": "Minify JavaScript",
             "warnings": []
-        }, 
+        },
         "unused-css-rules": {
-            "description": "Remove dead rules from stylesheets and defer the loading of CSS not used for above-the-fold content to reduce unnecessary bytes consumed by network activity. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/unused-css).", 
+            "description": "Remove dead rules from stylesheets and defer the loading of CSS not used for above-the-fold content to reduce unnecessary bytes consumed by network activity. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/unused-css).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsBytes": 0.0, 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsBytes": 0.0,
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "unused-css-rules", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "id": "unused-css-rules",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
             "title": "Remove unused CSS"
-        }, 
+        },
         "use-landmarks": {
-            "description": "Landmark elements (<main>, <nav>, etc.) are used to improve the keyboard navigation of the page for assistive technology. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#take_advantage_of_headings_and_landmarks).", 
-            "id": "use-landmarks", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "Landmark elements (<main>, <nav>, etc.) are used to improve the keyboard navigation of the page for assistive technology. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#take_advantage_of_headings_and_landmarks).",
+            "id": "use-landmarks",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "HTML5 landmark elements are used to improve navigation"
-        }, 
+        },
         "user-timings": {
-            "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing).", 
+            "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/user-timing).",
             "details": {
-                "headings": [], 
-                "items": [], 
+                "headings": [],
+                "items": [],
                 "type": "table"
-            }, 
-            "id": "user-timings", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            },
+            "id": "user-timings",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "User Timing marks and measures"
-        }, 
+        },
         "uses-http2": {
-            "description": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).", 
+            "description": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http2).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "protocol", 
+                        "itemType": "text",
+                        "key": "protocol",
                         "text": "Protocol"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/unknown404.css?delay=200"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_partial_a.html?delay=200"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_partial_b.html?delay=200&isasync"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.js"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/zone.js"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200"
-                    }, 
+                    },
                     {
-                        "protocol": "http/1.1", 
+                        "protocol": "http/1.1",
                         "url": "http://localhost:10200/favicon.ico"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "displayValue": "15 requests not served via HTTP/2", 
-            "id": "uses-http2", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "displayValue": "15 requests not served via HTTP/2",
+            "id": "uses-http2",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Does not use HTTP/2 for all of its resources"
-        }, 
+        },
         "uses-long-cache-ttl": {
-            "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/cache-policy).", 
+            "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/cache-policy).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "displayUnit": "duration", 
-                        "itemType": "ms", 
-                        "key": "cacheLifetimeMs", 
+                        "displayUnit": "duration",
+                        "itemType": "ms",
+                        "key": "cacheLifetimeMs",
                         "text": "Cache TTL"
-                    }, 
+                    },
                     {
-                        "displayUnit": "kb", 
-                        "granularity": 1.0, 
-                        "itemType": "bytes", 
-                        "key": "totalBytes", 
+                        "displayUnit": "kb",
+                        "granularity": 1.0,
+                        "itemType": "bytes",
+                        "key": "totalBytes",
                         "text": "Size"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 71654.0, 
-                        "url": "http://localhost:10200/zone.js", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 71654.0,
+                        "url": "http://localhost:10200/zone.js",
                         "wastedBytes": 71654.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 24741.0, 
-                        "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 24741.0,
+                        "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg",
                         "wastedBytes": 24741.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 1703.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.js", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 1703.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
                         "wastedBytes": 1703.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 1108.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 1108.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
                         "wastedBytes": 1108.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 821.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 821.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
                         "wastedBytes": 821.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 821.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 821.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true",
                         "wastedBytes": 821.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 821.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 821.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
                         "wastedBytes": 821.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 821.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 821.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true",
                         "wastedBytes": 821.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 821.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 821.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
                         "wastedBytes": 821.0
-                    }, 
+                    },
                     {
-                        "cacheHitProbability": 0.0, 
-                        "cacheLifetimeMs": 0.0, 
-                        "totalBytes": 144.0, 
-                        "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500", 
+                        "cacheHitProbability": 0.0,
+                        "cacheLifetimeMs": 0.0,
+                        "totalBytes": 144.0,
+                        "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500",
                         "wastedBytes": 144.0
                     }
-                ], 
+                ],
                 "summary": {
                     "wastedBytes": 103455.0
-                }, 
+                },
                 "type": "table"
-            }, 
-            "displayValue": "10 resources found", 
-            "id": "uses-long-cache-ttl", 
-            "numericValue": 103455.0, 
-            "score": 0.58, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "displayValue": "10 resources found",
+            "id": "uses-long-cache-ttl",
+            "numericValue": 103455.0,
+            "score": 0.58,
+            "scoreDisplayMode": "numeric",
             "title": "Serve static assets with an efficient cache policy"
-        }, 
+        },
         "uses-optimized-images": {
-            "description": "Optimized images load faster and consume less cellular data. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/optimize-images).", 
+            "description": "Optimized images load faster and consume less cellular data. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/optimize-images).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsBytes": 0.0, 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsBytes": 0.0,
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "uses-optimized-images", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
-            "title": "Efficiently encode images", 
+            },
+            "id": "uses-optimized-images",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
+            "title": "Efficiently encode images",
             "warnings": []
-        }, 
+        },
         "uses-passive-event-listeners": {
-            "description": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).", 
+            "description": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners).",
             "details": {
                 "headings": [
                     {
-                        "itemType": "url", 
-                        "key": "url", 
+                        "itemType": "url",
+                        "key": "url",
                         "text": "URL"
-                    }, 
+                    },
                     {
-                        "itemType": "text", 
-                        "key": "label", 
+                        "itemType": "text",
+                        "key": "label",
                         "text": "Location"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "label": "line: 26", 
+                        "label": "line: 26",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.js"
-                    }, 
+                    },
                     {
-                        "label": "line: 222", 
+                        "label": "line: 222",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
-                    }, 
+                    },
                     {
-                        "label": "line: 248", 
+                        "label": "line: 248",
                         "url": "http://localhost:10200/dobetterweb/dbw_tester.html"
                     }
-                ], 
+                ],
                 "type": "table"
-            }, 
-            "id": "uses-passive-event-listeners", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
+            },
+            "id": "uses-passive-event-listeners",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
             "title": "Does not use passive listeners to improve scrolling performance"
-        }, 
+        },
         "uses-rel-preconnect": {
-            "description": "Consider adding preconnect or dns-prefetch resource hints to establish early connections to important third-party origins. [Learn more](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect).", 
+            "description": "Consider adding preconnect or dns-prefetch resource hints to establish early connections to important third-party origins. [Learn more](https://developers.google.com/web/fundamentals/performance/resource-prioritization#preconnect).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "uses-rel-preconnect", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
-            "title": "Preconnect to required origins", 
+            },
+            "id": "uses-rel-preconnect",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
+            "title": "Preconnect to required origins",
             "warnings": []
-        }, 
+        },
         "uses-rel-preload": {
-            "description": "Consider using <link rel=preload> to prioritize fetching resources that are currently requested later in page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/preload).", 
+            "description": "Consider using <link rel=preload> to prioritize fetching resources that are currently requested later in page load. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/preload).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "uses-rel-preload", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "id": "uses-rel-preload",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
             "title": "Preload key requests"
-        }, 
+        },
         "uses-responsive-images": {
-            "description": "Serve images that are appropriately-sized to save cellular data and improve load time. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/oversized-images).", 
+            "description": "Serve images that are appropriately-sized to save cellular data and improve load time. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/oversized-images).",
             "details": {
-                "headings": [], 
-                "items": [], 
-                "overallSavingsBytes": 0.0, 
-                "overallSavingsMs": 0.0, 
+                "headings": [],
+                "items": [],
+                "overallSavingsBytes": 0.0,
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "id": "uses-responsive-images", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
-            "title": "Properly size images", 
+            },
+            "id": "uses-responsive-images",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
+            "title": "Properly size images",
             "warnings": []
-        }, 
+        },
         "uses-text-compression": {
-            "description": "Text-based resources should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/text-compression).", 
+            "description": "Text-based resources should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/text-compression).",
             "details": {
                 "headings": [
                     {
-                        "key": "url", 
-                        "label": "URL", 
+                        "key": "url",
+                        "label": "URL",
                         "valueType": "url"
-                    }, 
+                    },
                     {
-                        "key": "totalBytes", 
-                        "label": "Size", 
+                        "key": "totalBytes",
+                        "label": "Size",
                         "valueType": "bytes"
-                    }, 
+                    },
                     {
-                        "key": "wastedBytes", 
-                        "label": "Potential Savings", 
+                        "key": "wastedBytes",
+                        "label": "Potential Savings",
                         "valueType": "bytes"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "totalBytes": 71501.0, 
-                        "url": "http://localhost:10200/zone.js", 
+                        "totalBytes": 71501.0,
+                        "url": "http://localhost:10200/zone.js",
                         "wastedBytes": 56204.0
-                    }, 
+                    },
                     {
-                        "totalBytes": 12519.0, 
-                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html", 
+                        "totalBytes": 12519.0,
+                        "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
                         "wastedBytes": 8442.0
                     }
-                ], 
-                "overallSavingsBytes": 64646.0, 
-                "overallSavingsMs": 300.0, 
+                ],
+                "overallSavingsBytes": 64646.0,
+                "overallSavingsMs": 300.0,
                 "type": "opportunity"
-            }, 
-            "displayValue": "Potential savings of 63\u00a0KB", 
-            "id": "uses-text-compression", 
-            "numericValue": 300.0, 
-            "score": 0.75, 
-            "scoreDisplayMode": "numeric", 
+            },
+            "displayValue": "Potential savings of 63\u00a0KB",
+            "id": "uses-text-compression",
+            "numericValue": 300.0,
+            "score": 0.75,
+            "scoreDisplayMode": "numeric",
             "title": "Enable text compression"
-        }, 
+        },
         "uses-webp-images": {
-            "description": "Image formats like JPEG 2000, JPEG XR, and WebP often provide better compression than PNG or JPEG, which means faster downloads and less data consumption. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/webp).", 
+            "description": "Image formats like JPEG 2000, JPEG XR, and WebP often provide better compression than PNG or JPEG, which means faster downloads and less data consumption. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/webp).",
             "details": {
                 "headings": [
                     {
-                        "key": "url", 
+                        "key": "url",
                         "valueType": "thumbnail"
-                    }, 
+                    },
                     {
-                        "key": "url", 
-                        "label": "URL", 
+                        "key": "url",
+                        "label": "URL",
                         "valueType": "url"
-                    }, 
+                    },
                     {
-                        "key": "totalBytes", 
-                        "label": "Size", 
+                        "key": "totalBytes",
+                        "label": "Size",
                         "valueType": "bytes"
-                    }, 
+                    },
                     {
-                        "key": "wastedBytes", 
-                        "label": "Potential Savings", 
+                        "key": "wastedBytes",
+                        "label": "Potential Savings",
                         "valueType": "bytes"
                     }
-                ], 
+                ],
                 "items": [
                     {
-                        "fromProtocol": true, 
-                        "isCrossOrigin": true, 
-                        "totalBytes": 24620.0, 
-                        "url": "http://localhost:54819/dobetterweb/lighthouse-480x318.jpg", 
+                        "fromProtocol": true,
+                        "isCrossOrigin": true,
+                        "totalBytes": 24620.0,
+                        "url": "http://localhost:54819/dobetterweb/lighthouse-480x318.jpg",
                         "wastedBytes": 9028.0
                     }
-                ], 
-                "overallSavingsBytes": 9028.0, 
-                "overallSavingsMs": 0.0, 
+                ],
+                "overallSavingsBytes": 9028.0,
+                "overallSavingsMs": 0.0,
                 "type": "opportunity"
-            }, 
-            "displayValue": "Potential savings of 9\u00a0KB", 
-            "id": "uses-webp-images", 
-            "numericValue": 0.0, 
-            "score": 1.0, 
-            "scoreDisplayMode": "numeric", 
-            "title": "Serve images in next-gen formats", 
+            },
+            "displayValue": "Potential savings of 9\u00a0KB",
+            "id": "uses-webp-images",
+            "numericValue": 0.0,
+            "score": 1.0,
+            "scoreDisplayMode": "numeric",
+            "title": "Serve images in next-gen formats",
             "warnings": []
-        }, 
+        },
         "valid-lang": {
-            "description": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) on elements helps ensure that text is pronounced correctly by a screen reader. [Learn more](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse).", 
-            "id": "valid-lang", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) on elements helps ensure that text is pronounced correctly by a screen reader. [Learn more](https://dequeuniversity.com/rules/axe/3.1/valid-lang?application=lighthouse).",
+            "id": "valid-lang",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`[lang]` attributes have a valid value"
-        }, 
+        },
         "video-caption": {
-            "description": "When a video provides a caption it is easier for deaf and hearing impaired users to access its information. [Learn more](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse).", 
-            "id": "video-caption", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "When a video provides a caption it is easier for deaf and hearing impaired users to access its information. [Learn more](https://dequeuniversity.com/rules/axe/3.1/video-caption?application=lighthouse).",
+            "id": "video-caption",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`<video>` elements contain a `<track>` element with `[kind=\"captions\"]`"
-        }, 
+        },
         "video-description": {
-            "description": "Audio descriptions provide relevant information for videos that dialogue cannot, such as facial expressions and scenes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse).", 
-            "id": "video-description", 
-            "score": null, 
-            "scoreDisplayMode": "notApplicable", 
+            "description": "Audio descriptions provide relevant information for videos that dialogue cannot, such as facial expressions and scenes. [Learn more](https://dequeuniversity.com/rules/axe/3.1/video-description?application=lighthouse).",
+            "id": "video-description",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`<video>` elements contain a `<track>` element with `[kind=\"description\"]`"
-        }, 
+        },
         "viewport": {
-            "description": "Add a viewport meta tag to optimize your app for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag).", 
-            "id": "viewport", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
-            "title": "Has a `<meta name=\"viewport\">` tag with `width` or `initial-scale`", 
+            "description": "Add a viewport meta tag to optimize your app for mobile screens. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/has-viewport-meta-tag).",
+            "id": "viewport",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
+            "title": "Has a `<meta name=\"viewport\">` tag with `width` or `initial-scale`",
             "warnings": []
-        }, 
+        },
         "visual-order-follows-dom": {
-            "description": "DOM order matches the visual order, improving navigation for assistive technology. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).", 
-            "id": "visual-order-follows-dom", 
-            "score": null, 
-            "scoreDisplayMode": "manual", 
+            "description": "DOM order matches the visual order, improving navigation for assistive technology. [Learn more](https://developers.google.com/web/fundamentals/accessibility/how-to-review#try_it_with_a_screen_reader).",
+            "id": "visual-order-follows-dom",
+            "score": null,
+            "scoreDisplayMode": "manual",
             "title": "Visual order on the page follows DOM order"
-        }, 
+        },
         "without-javascript": {
-            "description": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/no-js).", 
-            "id": "without-javascript", 
-            "score": 1.0, 
-            "scoreDisplayMode": "binary", 
+            "description": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/no-js).",
+            "id": "without-javascript",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Contains some content when JavaScript is not available"
-        }, 
+        },
         "works-offline": {
-            "description": "If you're building a Progressive Web App, consider using a service worker so that your app can work offline. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).", 
-            "id": "works-offline", 
-            "score": 0.0, 
-            "scoreDisplayMode": "binary", 
-            "title": "Current page does not respond with a 200 when offline", 
+            "description": "If you're building a Progressive Web App, consider using a service worker so that your app can work offline. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/http-200-when-offline).",
+            "id": "works-offline",
+            "score": 0.0,
+            "scoreDisplayMode": "binary",
+            "title": "Current page does not respond with a 200 when offline",
             "warnings": []
         }
-    }, 
+    },
     "categories": {
         "accessibility": {
             "auditRefs": [
                 {
-                    "group": "a11y-navigation", 
-                    "id": "accesskeys", 
+                    "group": "a11y-navigation",
+                    "id": "accesskeys",
                     "weight": 3.0
-                }, 
+                },
                 {
-                    "group": "a11y-aria", 
-                    "id": "aria-allowed-attr", 
+                    "group": "a11y-aria",
+                    "id": "aria-allowed-attr",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-aria", 
-                    "id": "aria-required-attr", 
+                    "group": "a11y-aria",
+                    "id": "aria-required-attr",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-aria", 
-                    "id": "aria-required-children", 
+                    "group": "a11y-aria",
+                    "id": "aria-required-children",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-aria", 
-                    "id": "aria-required-parent", 
+                    "group": "a11y-aria",
+                    "id": "aria-required-parent",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-aria", 
-                    "id": "aria-roles", 
+                    "group": "a11y-aria",
+                    "id": "aria-roles",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-aria", 
-                    "id": "aria-valid-attr-value", 
+                    "group": "a11y-aria",
+                    "id": "aria-valid-attr-value",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-aria", 
-                    "id": "aria-valid-attr", 
+                    "group": "a11y-aria",
+                    "id": "aria-valid-attr",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-audio-video", 
-                    "id": "audio-caption", 
+                    "group": "a11y-audio-video",
+                    "id": "audio-caption",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-names-labels", 
-                    "id": "button-name", 
+                    "group": "a11y-names-labels",
+                    "id": "button-name",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-navigation", 
-                    "id": "bypass", 
+                    "group": "a11y-navigation",
+                    "id": "bypass",
                     "weight": 10.0
-                }, 
+                },
                 {
-                    "group": "a11y-color-contrast", 
-                    "id": "color-contrast", 
+                    "group": "a11y-color-contrast",
+                    "id": "color-contrast",
                     "weight": 6.0
-                }, 
+                },
                 {
-                    "group": "a11y-tables-lists", 
-                    "id": "definition-list", 
+                    "group": "a11y-tables-lists",
+                    "id": "definition-list",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-tables-lists", 
-                    "id": "dlitem", 
+                    "group": "a11y-tables-lists",
+                    "id": "dlitem",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-names-labels", 
-                    "id": "document-title", 
+                    "group": "a11y-names-labels",
+                    "id": "document-title",
                     "weight": 2.0
-                }, 
+                },
                 {
-                    "group": "a11y-best-practices", 
-                    "id": "duplicate-id", 
+                    "group": "a11y-best-practices",
+                    "id": "duplicate-id",
                     "weight": 5.0
-                }, 
+                },
                 {
-                    "group": "a11y-names-labels", 
-                    "id": "frame-title", 
+                    "group": "a11y-names-labels",
+                    "id": "frame-title",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-language", 
-                    "id": "html-has-lang", 
+                    "group": "a11y-language",
+                    "id": "html-has-lang",
                     "weight": 4.0
-                }, 
+                },
                 {
-                    "group": "a11y-language", 
-                    "id": "html-lang-valid", 
+                    "group": "a11y-language",
+                    "id": "html-lang-valid",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-names-labels", 
-                    "id": "image-alt", 
+                    "group": "a11y-names-labels",
+                    "id": "image-alt",
                     "weight": 8.0
-                }, 
+                },
                 {
-                    "group": "a11y-names-labels", 
-                    "id": "input-image-alt", 
+                    "group": "a11y-names-labels",
+                    "id": "input-image-alt",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-names-labels", 
-                    "id": "label", 
+                    "group": "a11y-names-labels",
+                    "id": "label",
                     "weight": 10.0
-                }, 
+                },
                 {
-                    "group": "a11y-tables-lists", 
-                    "id": "layout-table", 
+                    "group": "a11y-tables-lists",
+                    "id": "layout-table",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-names-labels", 
-                    "id": "link-name", 
+                    "group": "a11y-names-labels",
+                    "id": "link-name",
                     "weight": 9.0
-                }, 
+                },
                 {
-                    "group": "a11y-tables-lists", 
-                    "id": "list", 
+                    "group": "a11y-tables-lists",
+                    "id": "list",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-tables-lists", 
-                    "id": "listitem", 
+                    "group": "a11y-tables-lists",
+                    "id": "listitem",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-best-practices", 
-                    "id": "meta-refresh", 
+                    "group": "a11y-best-practices",
+                    "id": "meta-refresh",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-best-practices", 
-                    "id": "meta-viewport", 
+                    "group": "a11y-best-practices",
+                    "id": "meta-viewport",
                     "weight": 3.0
-                }, 
+                },
                 {
-                    "group": "a11y-names-labels", 
-                    "id": "object-alt", 
+                    "group": "a11y-names-labels",
+                    "id": "object-alt",
                     "weight": 4.0
-                }, 
+                },
                 {
-                    "group": "a11y-navigation", 
-                    "id": "tabindex", 
+                    "group": "a11y-navigation",
+                    "id": "tabindex",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-tables-lists", 
-                    "id": "td-headers-attr", 
+                    "group": "a11y-tables-lists",
+                    "id": "td-headers-attr",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-tables-lists", 
-                    "id": "th-has-data-cells", 
+                    "group": "a11y-tables-lists",
+                    "id": "th-has-data-cells",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-language", 
-                    "id": "valid-lang", 
+                    "group": "a11y-language",
+                    "id": "valid-lang",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-audio-video", 
-                    "id": "video-caption", 
+                    "group": "a11y-audio-video",
+                    "id": "video-caption",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "a11y-audio-video", 
-                    "id": "video-description", 
+                    "group": "a11y-audio-video",
+                    "id": "video-description",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "logical-tab-order", 
+                    "id": "logical-tab-order",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "focusable-controls", 
+                    "id": "focusable-controls",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "interactive-element-affordance", 
+                    "id": "interactive-element-affordance",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "managed-focus", 
+                    "id": "managed-focus",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "focus-traps", 
+                    "id": "focus-traps",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "custom-controls-labels", 
+                    "id": "custom-controls-labels",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "custom-controls-roles", 
+                    "id": "custom-controls-roles",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "visual-order-follows-dom", 
+                    "id": "visual-order-follows-dom",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "offscreen-content-hidden", 
+                    "id": "offscreen-content-hidden",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "heading-levels", 
+                    "id": "heading-levels",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "use-landmarks", 
+                    "id": "use-landmarks",
                     "weight": 0.0
                 }
-            ], 
-            "description": "These checks highlight opportunities to [improve the accessibility of your web app](https://developers.google.com/web/fundamentals/accessibility). Only a subset of accessibility issues can be automatically detected so manual testing is also encouraged.", 
-            "id": "accessibility", 
-            "manualDescription": "These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).", 
-            "score": 0.36, 
+            ],
+            "description": "These checks highlight opportunities to [improve the accessibility of your web app](https://developers.google.com/web/fundamentals/accessibility). Only a subset of accessibility issues can be automatically detected so manual testing is also encouraged.",
+            "id": "accessibility",
+            "manualDescription": "These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).",
+            "score": 0.36,
             "title": "Accessibility"
-        }, 
+        },
         "best-practices": {
             "auditRefs": [
                 {
-                    "id": "appcache-manifest", 
+                    "id": "appcache-manifest",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "is-on-https", 
+                    "id": "is-on-https",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "uses-http2", 
+                    "id": "uses-http2",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "uses-passive-event-listeners", 
+                    "id": "uses-passive-event-listeners",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "no-document-write", 
+                    "id": "no-document-write",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "external-anchors-use-rel-noopener", 
+                    "id": "external-anchors-use-rel-noopener",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "geolocation-on-start", 
+                    "id": "geolocation-on-start",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "doctype", 
+                    "id": "doctype",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "no-vulnerable-libraries", 
+                    "id": "no-vulnerable-libraries",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "js-libraries", 
+                    "id": "js-libraries",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "notification-on-start", 
+                    "id": "notification-on-start",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "deprecations", 
+                    "id": "deprecations",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "password-inputs-can-be-pasted-into", 
+                    "id": "password-inputs-can-be-pasted-into",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "errors-in-console", 
+                    "id": "errors-in-console",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "image-aspect-ratio", 
+                    "id": "image-aspect-ratio",
                     "weight": 1.0
                 }
-            ], 
-            "id": "best-practices", 
-            "score": 0.07, 
+            ],
+            "id": "best-practices",
+            "score": 0.07,
             "title": "Best Practices"
-        }, 
+        },
         "performance": {
             "auditRefs": [
                 {
-                    "group": "metrics", 
-                    "id": "first-contentful-paint", 
+                    "group": "metrics",
+                    "id": "first-contentful-paint",
                     "weight": 3.0
-                }, 
+                },
                 {
-                    "group": "metrics", 
-                    "id": "first-meaningful-paint", 
+                    "group": "metrics",
+                    "id": "first-meaningful-paint",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "metrics", 
-                    "id": "speed-index", 
+                    "group": "metrics",
+                    "id": "speed-index",
                     "weight": 4.0
-                }, 
+                },
                 {
-                    "group": "metrics", 
-                    "id": "interactive", 
+                    "group": "metrics",
+                    "id": "interactive",
                     "weight": 5.0
-                }, 
+                },
                 {
-                    "group": "metrics", 
-                    "id": "first-cpu-idle", 
+                    "group": "metrics",
+                    "id": "first-cpu-idle",
                     "weight": 2.0
-                }, 
+                },
                 {
-                    "group": "metrics", 
-                    "id": "max-potential-fid", 
+                    "group": "metrics",
+                    "id": "max-potential-fid",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "estimated-input-latency", 
+                    "id": "estimated-input-latency",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "render-blocking-resources", 
+                    "group": "load-opportunities",
+                    "id": "render-blocking-resources",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "uses-responsive-images", 
+                    "group": "load-opportunities",
+                    "id": "uses-responsive-images",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "offscreen-images", 
+                    "group": "load-opportunities",
+                    "id": "offscreen-images",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "unminified-css", 
+                    "group": "load-opportunities",
+                    "id": "unminified-css",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "unminified-javascript", 
+                    "group": "load-opportunities",
+                    "id": "unminified-javascript",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "unused-css-rules", 
+                    "group": "load-opportunities",
+                    "id": "unused-css-rules",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "uses-optimized-images", 
+                    "group": "load-opportunities",
+                    "id": "uses-optimized-images",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "uses-webp-images", 
+                    "group": "load-opportunities",
+                    "id": "uses-webp-images",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "uses-text-compression", 
+                    "group": "load-opportunities",
+                    "id": "uses-text-compression",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "uses-rel-preconnect", 
+                    "group": "load-opportunities",
+                    "id": "uses-rel-preconnect",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "time-to-first-byte", 
+                    "group": "load-opportunities",
+                    "id": "time-to-first-byte",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "redirects", 
+                    "group": "load-opportunities",
+                    "id": "redirects",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "uses-rel-preload", 
+                    "group": "load-opportunities",
+                    "id": "uses-rel-preload",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "load-opportunities", 
-                    "id": "efficient-animated-content", 
+                    "group": "load-opportunities",
+                    "id": "efficient-animated-content",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "total-byte-weight", 
+                    "group": "diagnostics",
+                    "id": "total-byte-weight",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "uses-long-cache-ttl", 
+                    "group": "diagnostics",
+                    "id": "uses-long-cache-ttl",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "dom-size", 
+                    "group": "diagnostics",
+                    "id": "dom-size",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "critical-request-chains", 
+                    "group": "diagnostics",
+                    "id": "critical-request-chains",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "user-timings", 
+                    "group": "diagnostics",
+                    "id": "user-timings",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "bootup-time", 
+                    "group": "diagnostics",
+                    "id": "bootup-time",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "mainthread-work-breakdown", 
+                    "group": "diagnostics",
+                    "id": "mainthread-work-breakdown",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "font-display", 
+                    "group": "diagnostics",
+                    "id": "font-display",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "diagnostics", 
-                    "id": "resource-summary", 
+                    "group": "diagnostics",
+                    "id": "resource-summary",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "network-requests", 
+                    "id": "network-requests",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "network-rtt", 
+                    "id": "network-rtt",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "network-server-latency", 
+                    "id": "network-server-latency",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "main-thread-tasks", 
+                    "id": "main-thread-tasks",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "diagnostics", 
+                    "id": "diagnostics",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "metrics", 
+                    "id": "metrics",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "screenshot-thumbnails", 
+                    "id": "screenshot-thumbnails",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "final-screenshot", 
+                    "id": "final-screenshot",
                     "weight": 0.0
                 }
-            ], 
-            "id": "performance", 
-            "score": 0.69, 
+            ],
+            "id": "performance",
+            "score": 0.69,
             "title": "Performance"
-        }, 
+        },
         "pwa": {
             "auditRefs": [
                 {
-                    "group": "pwa-fast-reliable", 
-                    "id": "load-fast-enough-for-pwa", 
+                    "group": "pwa-fast-reliable",
+                    "id": "load-fast-enough-for-pwa",
                     "weight": 7.0
-                }, 
+                },
                 {
-                    "group": "pwa-fast-reliable", 
-                    "id": "works-offline", 
+                    "group": "pwa-fast-reliable",
+                    "id": "works-offline",
                     "weight": 5.0
-                }, 
+                },
                 {
-                    "group": "pwa-fast-reliable", 
-                    "id": "offline-start-url", 
+                    "group": "pwa-fast-reliable",
+                    "id": "offline-start-url",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "pwa-installable", 
-                    "id": "is-on-https", 
+                    "group": "pwa-installable",
+                    "id": "is-on-https",
                     "weight": 2.0
-                }, 
+                },
                 {
-                    "group": "pwa-installable", 
-                    "id": "service-worker", 
+                    "group": "pwa-installable",
+                    "id": "service-worker",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "pwa-installable", 
-                    "id": "installable-manifest", 
+                    "group": "pwa-installable",
+                    "id": "installable-manifest",
                     "weight": 2.0
-                }, 
+                },
                 {
-                    "group": "pwa-optimized", 
-                    "id": "redirects-http", 
+                    "group": "pwa-optimized",
+                    "id": "redirects-http",
                     "weight": 2.0
-                }, 
+                },
                 {
-                    "group": "pwa-optimized", 
-                    "id": "splash-screen", 
+                    "group": "pwa-optimized",
+                    "id": "splash-screen",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "pwa-optimized", 
-                    "id": "themed-omnibox", 
+                    "group": "pwa-optimized",
+                    "id": "themed-omnibox",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "pwa-optimized", 
-                    "id": "content-width", 
+                    "group": "pwa-optimized",
+                    "id": "content-width",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "pwa-optimized", 
-                    "id": "viewport", 
+                    "group": "pwa-optimized",
+                    "id": "viewport",
                     "weight": 2.0
-                }, 
+                },
                 {
-                    "group": "pwa-optimized", 
-                    "id": "without-javascript", 
+                    "group": "pwa-optimized",
+                    "id": "without-javascript",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "pwa-cross-browser", 
+                    "id": "pwa-cross-browser",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "pwa-page-transitions", 
+                    "id": "pwa-page-transitions",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "id": "pwa-each-page-has-url", 
+                    "id": "pwa-each-page-has-url",
                     "weight": 0.0
                 }
-            ], 
-            "description": "These checks validate the aspects of a Progressive Web App. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist).", 
-            "id": "pwa", 
-            "manualDescription": "These checks are required by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are not automatically checked by Lighthouse. They do not affect your score but it's important that you verify them manually.", 
-            "score": 0.42, 
+            ],
+            "description": "These checks validate the aspects of a Progressive Web App. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist).",
+            "id": "pwa",
+            "manualDescription": "These checks are required by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are not automatically checked by Lighthouse. They do not affect your score but it's important that you verify them manually.",
+            "score": 0.42,
             "title": "Progressive Web App"
-        }, 
+        },
         "seo": {
             "auditRefs": [
                 {
-                    "group": "seo-mobile", 
-                    "id": "viewport", 
+                    "group": "seo-mobile",
+                    "id": "viewport",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-content", 
-                    "id": "document-title", 
+                    "group": "seo-content",
+                    "id": "document-title",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-content", 
-                    "id": "meta-description", 
+                    "group": "seo-content",
+                    "id": "meta-description",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-crawl", 
-                    "id": "http-status-code", 
+                    "group": "seo-crawl",
+                    "id": "http-status-code",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-content", 
-                    "id": "link-text", 
+                    "group": "seo-content",
+                    "id": "link-text",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-crawl", 
-                    "id": "is-crawlable", 
+                    "group": "seo-crawl",
+                    "id": "is-crawlable",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-crawl", 
-                    "id": "robots-txt", 
+                    "group": "seo-crawl",
+                    "id": "robots-txt",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "seo-content", 
-                    "id": "image-alt", 
+                    "group": "seo-content",
+                    "id": "image-alt",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-content", 
-                    "id": "hreflang", 
+                    "group": "seo-content",
+                    "id": "hreflang",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-content", 
-                    "id": "canonical", 
+                    "group": "seo-content",
+                    "id": "canonical",
                     "weight": 0.0
-                }, 
+                },
                 {
-                    "group": "seo-mobile", 
-                    "id": "font-size", 
+                    "group": "seo-mobile",
+                    "id": "font-size",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-content", 
-                    "id": "plugins", 
+                    "group": "seo-content",
+                    "id": "plugins",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "group": "seo-mobile", 
-                    "id": "tap-targets", 
+                    "group": "seo-mobile",
+                    "id": "tap-targets",
                     "weight": 1.0
-                }, 
+                },
                 {
-                    "id": "structured-data", 
+                    "id": "structured-data",
                     "weight": 0.0
                 }
-            ], 
-            "description": "These checks ensure that your page is optimized for search engine results ranking. There are additional factors Lighthouse does not check that may affect your search ranking. [Learn more](https://support.google.com/webmasters/answer/35769).", 
-            "id": "seo", 
-            "manualDescription": "Run these additional validators on your site to check additional SEO best practices.", 
-            "score": 0.82, 
+            ],
+            "description": "These checks ensure that your page is optimized for search engine results ranking. There are additional factors Lighthouse does not check that may affect your search ranking. [Learn more](https://support.google.com/webmasters/answer/35769).",
+            "id": "seo",
+            "manualDescription": "Run these additional validators on your site to check additional SEO best practices.",
+            "score": 0.82,
             "title": "SEO"
         }
-    }, 
+    },
     "categoryGroups": {
         "a11y-aria": {
-            "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader.", 
+            "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader.",
             "title": "ARIA"
-        }, 
+        },
         "a11y-audio-video": {
-            "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments.", 
+            "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments.",
             "title": "Audio and video"
-        }, 
+        },
         "a11y-best-practices": {
-            "description": "These items highlight common accessibility best practices.", 
+            "description": "These items highlight common accessibility best practices.",
             "title": "Best practices"
-        }, 
+        },
         "a11y-color-contrast": {
-            "description": "These are opportunities to improve the legibility of your content.", 
+            "description": "These are opportunities to improve the legibility of your content.",
             "title": "Contrast"
-        }, 
+        },
         "a11y-language": {
-            "description": "These are opportunities to improve the interpretation of your content by users in different locales.", 
+            "description": "These are opportunities to improve the interpretation of your content by users in different locales.",
             "title": "Internationalization and localization"
-        }, 
+        },
         "a11y-names-labels": {
-            "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.", 
+            "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader.",
             "title": "Names and labels"
-        }, 
+        },
         "a11y-navigation": {
-            "description": "These are opportunities to improve keyboard navigation in your application.", 
+            "description": "These are opportunities to improve keyboard navigation in your application.",
             "title": "Navigation"
-        }, 
+        },
         "a11y-tables-lists": {
-            "description": "These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader.", 
+            "description": "These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader.",
             "title": "Tables and lists"
-        }, 
+        },
         "diagnostics": {
-            "description": "More information about the performance of your application.", 
+            "description": "More information about the performance of your application.",
             "title": "Diagnostics"
-        }, 
+        },
         "load-opportunities": {
-            "description": "These optimizations can speed up your page load.", 
+            "description": "These optimizations can speed up your page load.",
             "title": "Opportunities"
-        }, 
+        },
         "metrics": {
             "title": "Metrics"
-        }, 
+        },
         "pwa-fast-reliable": {
             "title": "Fast and reliable"
-        }, 
+        },
         "pwa-installable": {
             "title": "Installable"
-        }, 
+        },
         "pwa-optimized": {
             "title": "PWA Optimized"
-        }, 
+        },
         "seo-content": {
-            "description": "Format your HTML in a way that enables crawlers to better understand your app\u2019s content.", 
+            "description": "Format your HTML in a way that enables crawlers to better understand your app\u2019s content.",
             "title": "Content Best Practices"
-        }, 
+        },
         "seo-crawl": {
-            "description": "To appear in search results, crawlers need access to your app.", 
+            "description": "To appear in search results, crawlers need access to your app.",
             "title": "Crawling and Indexing"
-        }, 
+        },
         "seo-mobile": {
-            "description": "Make sure your pages are mobile friendly so users don\u2019t have to pinch or zoom in order to read the content pages. [Learn more](https://developers.google.com/search/mobile-sites/).", 
+            "description": "Make sure your pages are mobile friendly so users don\u2019t have to pinch or zoom in order to read the content pages. [Learn more](https://developers.google.com/search/mobile-sites/).",
             "title": "Mobile Friendly"
         }
-    }, 
+    },
     "configSettings": {
-        "emulatedFormFactor": "mobile", 
-        "locale": "en-US", 
+        "emulatedFormFactor": "mobile",
+        "locale": "en-US",
         "onlyCategories": null
-    }, 
+    },
     "environment": {
-        "benchmarkIndex": 1000.0, 
-        "hostUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36", 
+        "benchmarkIndex": 1000.0,
+        "hostUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36",
         "networkUserAgent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/66.0.3359.30 Mobile Safari/537.36"
-    }, 
-    "fetchTime": "2018-03-13T00:55:45.840Z", 
-    "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html", 
+    },
+    "fetchTime": "2018-03-13T00:55:45.840Z",
+    "finalUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
     "i18n": {
         "rendererFormattedStrings": {
-            "auditGroupExpandTooltip": "Show audits", 
-            "crcInitialNavigation": "Initial Navigation", 
-            "crcLongestDurationLabel": "Maximum critical path latency:", 
-            "errorLabel": "Error!", 
-            "errorMissingAuditInfo": "Report error: no audit information", 
-            "labDataTitle": "Lab Data", 
-            "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.", 
-            "manualAuditsGroupTitle": "Additional items to manually check", 
-            "notApplicableAuditsGroupTitle": "Not applicable", 
-            "opportunityResourceColumnLabel": "Opportunity", 
-            "opportunitySavingsColumnLabel": "Estimated Savings", 
-            "passedAuditsGroupTitle": "Passed audits", 
-            "snippetCollapseButtonLabel": "Collapse snippet", 
-            "snippetExpandButtonLabel": "Expand snippet", 
-            "thirdPartyResourcesLabel": "Show 3rd-party resources", 
-            "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:", 
-            "varianceDisclaimer": "Values are estimated and may vary.", 
-            "warningAuditsGroupTitle": "Passed audits but with warnings", 
+            "auditGroupExpandTooltip": "Show audits",
+            "crcInitialNavigation": "Initial Navigation",
+            "crcLongestDurationLabel": "Maximum critical path latency:",
+            "errorLabel": "Error!",
+            "errorMissingAuditInfo": "Report error: no audit information",
+            "labDataTitle": "Lab Data",
+            "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+            "manualAuditsGroupTitle": "Additional items to manually check",
+            "notApplicableAuditsGroupTitle": "Not applicable",
+            "opportunityResourceColumnLabel": "Opportunity",
+            "opportunitySavingsColumnLabel": "Estimated Savings",
+            "passedAuditsGroupTitle": "Passed audits",
+            "snippetCollapseButtonLabel": "Collapse snippet",
+            "snippetExpandButtonLabel": "Expand snippet",
+            "thirdPartyResourcesLabel": "Show 3rd-party resources",
+            "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+            "varianceDisclaimer": "Values are estimated and may vary.",
+            "warningAuditsGroupTitle": "Passed audits but with warnings",
             "warningHeader": "Warnings: "
         }
-    }, 
-    "lighthouseVersion": "4.3.0", 
-    "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html", 
-    "runWarnings": [], 
+    },
+    "lighthouseVersion": "4.3.0",
+    "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
+    "runWarnings": [],
     "stackPacks": [
         {
             "descriptions": {
-                "efficient-animated-content": "Consider uploading your GIF to a service which will make it available to embed as an HTML5 video.", 
-                "offscreen-images": "Install a [lazy-load WordPress plugin](https://wordpress.org/plugins/search/lazy+load/) that provides the ability to defer any offscreen images, or switch to a theme that provides that functionality. Also consider using [the AMP plugin](https://wordpress.org/plugins/amp/).", 
-                "render-blocking-resources": "There are a number of WordPress plugins that can help you [inline critical assets](https://wordpress.org/plugins/search/critical+css/) or [defer less important resources](https://wordpress.org/plugins/search/defer+css+javascript/). Beware that optimizations provided by these plugins may break features of your theme or plugins, so you will likely need to make code changes.", 
-                "time-to-first-byte": "Themes, plugins, and server specifications all contribute to server response time. Consider finding a more optimized theme, carefully selecting an optimization plugin, and/or upgrading your server.", 
-                "total-byte-weight": "Consider showing excerpts in your post lists (e.g. via the more tag), reducing the number of posts shown on a given page, breaking your long posts into multiple pages, or using a plugin to lazy-load comments.", 
-                "unminified-css": "A number of [WordPress plugins](https://wordpress.org/plugins/search/minify+css/) can speed up your site by concatenating, minifying, and compressing your styles. You may also want to use a build process to do this minification up-front if possible.", 
-                "unminified-javascript": "A number of [WordPress plugins](https://wordpress.org/plugins/search/minify+javascript/) can speed up your site by concatenating, minifying, and compressing your scripts. You may also want to use a build process to do this minification up front if possible.", 
-                "unused-css-rules": "Consider reducing, or switching, the number of [WordPress plugins](https://wordpress.org/plugins/) loading unused CSS in your page. To identify plugins that are adding extraneous CSS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/plugin responsible from the URL of the stylesheet. Look out for plugins that have many stylesheets in the list which have a lot of red in code coverage. A plugin should only enqueue a stylesheet if it is actually used on the page.", 
-                "unused-javascript": "Consider reducing, or switching, the number of [WordPress plugins](https://wordpress.org/plugins/) loading unused JavaScript in your page. To identify plugins that are adding extraneous JS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/plugin responsible from the URL of the script. Look out for plugins that have many scripts in the list which have a lot of red in code coverage. A plugin should only enqueue a script if it is actually used on the page.", 
-                "uses-long-cache-ttl": "Read about [Browser Caching in WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching).", 
-                "uses-optimized-images": "Consider using an [image optimization WordPress plugin](https://wordpress.org/plugins/search/optimize+images/) that compresses your images while retaining quality.", 
-                "uses-responsive-images": "Upload images directly through the [media library](https://codex.wordpress.org/Media_Library_Screen) to ensure that the required image sizes are available, and then insert them from the media library or use the image widget to ensure the optimal image sizes are used (including those for the responsive breakpoints). Avoid using `Full Size` images unless the dimensions are adequate for their usage. [Learn More](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size).", 
-                "uses-text-compression": "You can enable text compression in your web server configuration.", 
+                "efficient-animated-content": "Consider uploading your GIF to a service which will make it available to embed as an HTML5 video.",
+                "offscreen-images": "Install a [lazy-load WordPress plugin](https://wordpress.org/plugins/search/lazy+load/) that provides the ability to defer any offscreen images, or switch to a theme that provides that functionality. Also consider using [the AMP plugin](https://wordpress.org/plugins/amp/).",
+                "render-blocking-resources": "There are a number of WordPress plugins that can help you [inline critical assets](https://wordpress.org/plugins/search/critical+css/) or [defer less important resources](https://wordpress.org/plugins/search/defer+css+javascript/). Beware that optimizations provided by these plugins may break features of your theme or plugins, so you will likely need to make code changes.",
+                "time-to-first-byte": "Themes, plugins, and server specifications all contribute to server response time. Consider finding a more optimized theme, carefully selecting an optimization plugin, and/or upgrading your server.",
+                "total-byte-weight": "Consider showing excerpts in your post lists (e.g. via the more tag), reducing the number of posts shown on a given page, breaking your long posts into multiple pages, or using a plugin to lazy-load comments.",
+                "unminified-css": "A number of [WordPress plugins](https://wordpress.org/plugins/search/minify+css/) can speed up your site by concatenating, minifying, and compressing your styles. You may also want to use a build process to do this minification up-front if possible.",
+                "unminified-javascript": "A number of [WordPress plugins](https://wordpress.org/plugins/search/minify+javascript/) can speed up your site by concatenating, minifying, and compressing your scripts. You may also want to use a build process to do this minification up front if possible.",
+                "unused-css-rules": "Consider reducing, or switching, the number of [WordPress plugins](https://wordpress.org/plugins/) loading unused CSS in your page. To identify plugins that are adding extraneous CSS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/plugin responsible from the URL of the stylesheet. Look out for plugins that have many stylesheets in the list which have a lot of red in code coverage. A plugin should only enqueue a stylesheet if it is actually used on the page.",
+                "unused-javascript": "Consider reducing, or switching, the number of [WordPress plugins](https://wordpress.org/plugins/) loading unused JavaScript in your page. To identify plugins that are adding extraneous JS, try running [code coverage](https://developers.google.com/web/updates/2017/04/devtools-release-notes#coverage) in Chrome DevTools. You can identify the theme/plugin responsible from the URL of the script. Look out for plugins that have many scripts in the list which have a lot of red in code coverage. A plugin should only enqueue a script if it is actually used on the page.",
+                "uses-long-cache-ttl": "Read about [Browser Caching in WordPress](https://codex.wordpress.org/WordPress_Optimization#Browser_Caching).",
+                "uses-optimized-images": "Consider using an [image optimization WordPress plugin](https://wordpress.org/plugins/search/optimize+images/) that compresses your images while retaining quality.",
+                "uses-responsive-images": "Upload images directly through the [media library](https://codex.wordpress.org/Media_Library_Screen) to ensure that the required image sizes are available, and then insert them from the media library or use the image widget to ensure the optimal image sizes are used (including those for the responsive breakpoints). Avoid using `Full Size` images unless the dimensions are adequate for their usage. [Learn More](https://codex.wordpress.org/Inserting_Images_into_Posts_and_Pages#Image_Size).",
+                "uses-text-compression": "You can enable text compression in your web server configuration.",
                 "uses-webp-images": "Consider using a [plugin](https://wordpress.org/plugins/search/convert+webp/) or service that will automatically convert your uploaded images to the optimal formats."
-            }, 
-            "iconDataURL": "data:image/svg+xml,%3Csvg viewBox='0 0 122.5 122.5' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%232f3439'%3E%3Cpath d='M8.7 61.3c0 20.8 12.1 38.7 29.6 47.3l-25-68.7c-3 6.5-4.6 13.7-4.6 21.4zM96.7 58.6c0-6.5-2.3-11-4.3-14.5-2.7-4.3-5.2-8-5.2-12.3 0-4.8 3.7-9.3 8.9-9.3h.7a52.4 52.4 0 0 0-79.4 9.9h3.3c5.5 0 14-.6 14-.6 2.9-.2 3.2 4 .4 4.3 0 0-2.9.4-6 .5l19.1 57L59.7 59l-8.2-22.5c-2.8-.1-5.5-.5-5.5-.5-2.8-.1-2.5-4.5.3-4.3 0 0 8.7.7 13.9.7 5.5 0 14-.7 14-.7 2.8-.2 3.2 4 .3 4.3 0 0-2.8.4-6 .5l19 56.5 5.2-17.5c2.3-7.3 4-12.5 4-17z'/%3E%3Cpath d='M62.2 65.9l-15.8 45.8a52.6 52.6 0 0 0 32.3-.9l-.4-.7zM107.4 36a49.6 49.6 0 0 1-3.6 24.2l-16.1 46.5A52.5 52.5 0 0 0 107.4 36z'/%3E%3Cpath d='M61.3 0a61.3 61.3 0 1 0 .1 122.7A61.3 61.3 0 0 0 61.3 0zm0 119.7a58.5 58.5 0 1 1 .1-117 58.5 58.5 0 0 1-.1 117z'/%3E%3C/g%3E%3C/svg%3E", 
-            "id": "wordpress", 
+            },
+            "iconDataURL": "data:image/svg+xml,%3Csvg viewBox='0 0 122.5 122.5' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%232f3439'%3E%3Cpath d='M8.7 61.3c0 20.8 12.1 38.7 29.6 47.3l-25-68.7c-3 6.5-4.6 13.7-4.6 21.4zM96.7 58.6c0-6.5-2.3-11-4.3-14.5-2.7-4.3-5.2-8-5.2-12.3 0-4.8 3.7-9.3 8.9-9.3h.7a52.4 52.4 0 0 0-79.4 9.9h3.3c5.5 0 14-.6 14-.6 2.9-.2 3.2 4 .4 4.3 0 0-2.9.4-6 .5l19.1 57L59.7 59l-8.2-22.5c-2.8-.1-5.5-.5-5.5-.5-2.8-.1-2.5-4.5.3-4.3 0 0 8.7.7 13.9.7 5.5 0 14-.7 14-.7 2.8-.2 3.2 4 .3 4.3 0 0-2.8.4-6 .5l19 56.5 5.2-17.5c2.3-7.3 4-12.5 4-17z'/%3E%3Cpath d='M62.2 65.9l-15.8 45.8a52.6 52.6 0 0 0 32.3-.9l-.4-.7zM107.4 36a49.6 49.6 0 0 1-3.6 24.2l-16.1 46.5A52.5 52.5 0 0 0 107.4 36z'/%3E%3Cpath d='M61.3 0a61.3 61.3 0 1 0 .1 122.7A61.3 61.3 0 0 0 61.3 0zm0 119.7a58.5 58.5 0 1 1 .1-117 58.5 58.5 0 0 1-.1 117z'/%3E%3C/g%3E%3C/svg%3E",
+            "id": "wordpress",
             "title": "WordPress"
         }
-    ], 
+    ],
     "timing": {
         "entries": [
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:init:config", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:init:config",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:config:requireGatherers", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:config:requireGatherers",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:config:requireAudits", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:config:requireAudits",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:runner:run", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:runner:run",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:runner:auditing", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:runner:auditing",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:is-on-https", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:is-on-https",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:NetworkRecords", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:NetworkRecords",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:redirects-http", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:redirects-http",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:service-worker", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:service-worker",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:works-offline", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:works-offline",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:viewport", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:viewport",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:ViewportMeta", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:ViewportMeta",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:without-javascript", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:without-javascript",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:first-contentful-paint", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:first-contentful-paint",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:FirstContentfulPaint", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:FirstContentfulPaint",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:TraceOfTab", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:TraceOfTab",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:first-meaningful-paint", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:first-meaningful-paint",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:FirstMeaningfulPaint", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:FirstMeaningfulPaint",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:load-fast-enough-for-pwa", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:load-fast-enough-for-pwa",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:Interactive", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:Interactive",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:speed-index", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:speed-index",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:SpeedIndex", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:SpeedIndex",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:Speedline", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:Speedline",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:screenshot-thumbnails", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:screenshot-thumbnails",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:final-screenshot", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:final-screenshot",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:Screenshots", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:Screenshots",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:estimated-input-latency", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:estimated-input-latency",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:EstimatedInputLatency", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:EstimatedInputLatency",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:max-potential-fid", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:max-potential-fid",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:MaxPotentialFID", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:MaxPotentialFID",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:errors-in-console", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:errors-in-console",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:time-to-first-byte", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:time-to-first-byte",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:MainResource", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:MainResource",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:first-cpu-idle", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:first-cpu-idle",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:FirstCPUIdle", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:FirstCPUIdle",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:interactive", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:interactive",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:user-timings", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:user-timings",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:UserTimings", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:UserTimings",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:critical-request-chains", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:critical-request-chains",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:CriticalRequestChains", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:CriticalRequestChains",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:redirects", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:redirects",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:LanternInteractive", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:LanternInteractive",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:LanternFirstMeaningfulPaint", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:LanternFirstMeaningfulPaint",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:LanternFirstContentfulPaint", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:LanternFirstContentfulPaint",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:PageDependencyGraph", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:PageDependencyGraph",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:LoadSimulator", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:LoadSimulator",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:NetworkAnalysis", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:NetworkAnalysis",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:installable-manifest", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:installable-manifest",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:ManifestValues", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:ManifestValues",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:splash-screen", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:splash-screen",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:themed-omnibox", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:themed-omnibox",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:content-width", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:content-width",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:image-aspect-ratio", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:image-aspect-ratio",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:deprecations", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:deprecations",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:mainthread-work-breakdown", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:mainthread-work-breakdown",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:MainThreadTasks", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:MainThreadTasks",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:bootup-time", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:bootup-time",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-rel-preload", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-rel-preload",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:LoadSimulator", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:LoadSimulator",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-rel-preconnect", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-rel-preconnect",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:font-display", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:font-display",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:diagnostics", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:diagnostics",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:network-requests", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:network-requests",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:network-rtt", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:network-rtt",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:network-server-latency", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:network-server-latency",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:main-thread-tasks", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:main-thread-tasks",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:metrics", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:metrics",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:offline-start-url", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:offline-start-url",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:resource-summary", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:resource-summary",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:ResourceSummary", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:ResourceSummary",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:pwa-cross-browser", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:pwa-cross-browser",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:pwa-page-transitions", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:pwa-page-transitions",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:pwa-each-page-has-url", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:pwa-each-page-has-url",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:accesskeys", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:accesskeys",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:aria-allowed-attr", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:aria-allowed-attr",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:aria-required-attr", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:aria-required-attr",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:aria-required-children", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:aria-required-children",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:aria-required-parent", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:aria-required-parent",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:aria-roles", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:aria-roles",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:aria-valid-attr-value", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:aria-valid-attr-value",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:aria-valid-attr", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:aria-valid-attr",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:audio-caption", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:audio-caption",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:button-name", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:button-name",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:bypass", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:bypass",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:color-contrast", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:color-contrast",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:definition-list", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:definition-list",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:dlitem", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:dlitem",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:document-title", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:document-title",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:duplicate-id", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:duplicate-id",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:frame-title", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:frame-title",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:html-has-lang", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:html-has-lang",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:html-lang-valid", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:html-lang-valid",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:image-alt", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:image-alt",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:input-image-alt", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:input-image-alt",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:label", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:label",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:layout-table", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:layout-table",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:link-name", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:link-name",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:list", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:list",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:listitem", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:listitem",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:meta-refresh", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:meta-refresh",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:meta-viewport", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:meta-viewport",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:object-alt", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:object-alt",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:tabindex", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:tabindex",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:td-headers-attr", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:td-headers-attr",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:th-has-data-cells", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:th-has-data-cells",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:valid-lang", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:valid-lang",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:video-caption", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:video-caption",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:video-description", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:video-description",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:custom-controls-labels", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:custom-controls-labels",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:custom-controls-roles", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:custom-controls-roles",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:focus-traps", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:focus-traps",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:focusable-controls", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:focusable-controls",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:heading-levels", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:heading-levels",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:interactive-element-affordance", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:interactive-element-affordance",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:logical-tab-order", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:logical-tab-order",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:managed-focus", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:managed-focus",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:offscreen-content-hidden", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:offscreen-content-hidden",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:use-landmarks", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:use-landmarks",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:visual-order-follows-dom", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:visual-order-follows-dom",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-long-cache-ttl", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-long-cache-ttl",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:total-byte-weight", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:total-byte-weight",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:offscreen-images", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:offscreen-images",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:render-blocking-resources", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:render-blocking-resources",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:FirstContentfulPaint", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:FirstContentfulPaint",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:computed:LanternFirstContentfulPaint", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:computed:LanternFirstContentfulPaint",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:unminified-css", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:unminified-css",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:unminified-javascript", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:unminified-javascript",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:unused-css-rules", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:unused-css-rules",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-webp-images", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-webp-images",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-optimized-images", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-optimized-images",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-text-compression", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-text-compression",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-responsive-images", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-responsive-images",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:efficient-animated-content", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:efficient-animated-content",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:appcache-manifest", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:appcache-manifest",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:doctype", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:doctype",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:dom-size", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:dom-size",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:external-anchors-use-rel-noopener", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:external-anchors-use-rel-noopener",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:geolocation-on-start", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:geolocation-on-start",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:no-document-write", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:no-document-write",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:no-vulnerable-libraries", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:no-vulnerable-libraries",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:js-libraries", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:js-libraries",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:notification-on-start", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:notification-on-start",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:password-inputs-can-be-pasted-into", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:password-inputs-can-be-pasted-into",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-http2", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-http2",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:uses-passive-event-listeners", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:uses-passive-event-listeners",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:meta-description", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:meta-description",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:http-status-code", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:http-status-code",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:font-size", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:font-size",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:link-text", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:link-text",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:is-crawlable", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:is-crawlable",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:robots-txt", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:robots-txt",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:tap-targets", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:tap-targets",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:hreflang", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:hreflang",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:plugins", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:plugins",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:canonical", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:canonical",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:audit:structured-data", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:structured-data",
                 "startTime": 0.0
-            }, 
+            },
             {
-                "duration": 100.0, 
-                "entryType": "measure", 
-                "name": "lh:runner:generate", 
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:runner:generate",
                 "startTime": 0.0
             }
-        ], 
+        ],
         "total": 12345.6789
-    }, 
+    },
     "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3358.0 Safari/537.36"
 }

--- a/proto/scripts/json_roundtrip_via_proto.py
+++ b/proto/scripts/json_roundtrip_via_proto.py
@@ -40,4 +40,4 @@ round_trip_lhr = json.loads(MessageToJson(proto_lhr, including_default_value_fie
 
 # write the json to disk
 with open(path_round_trip, 'w') as f:
-    json.dump(round_trip_lhr, f, indent=4, sort_keys=True)
+    json.dump(round_trip_lhr, f, indent=4, sort_keys=True, separators=(',', ': '))

--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,8 @@ yarn
 yarn build-all
 ```
 
+If changing audit output, you'll likely also need to have the protocol-buffer compiler installed. See the [official installation instructions](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation) or consult your [favorite package manager](https://formulae.brew.sh/formula/protobuf) for your OS.
+
 ### Run
 
 ```sh


### PR DESCRIPTION
kind of a follow up to #8815

This
- adds a note to our readme that if you're going to be touching audits you'll likely need protobuf installed (so that `yarn update:sample-json` can run successfully)
- adds a more explicit error message if `yarn update:sample-json` fails on the proto step to install protobuf
- trims trailing whitespace from `proto/sample_v2_round_trip.json`. We've had a decent amount of churn from PRs that have needed to manually edit the file and have had whitespace automatically (or manually) trimmed. Hopefully this reduces future noise