### PR TITLE
report: make v5 renderer compatible with v3 and v4 LHRs

### DIFF
--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -61,9 +61,6 @@ class DetailsRenderer {
       case 'screenshot':
       case 'debugdata':
         return null;
-      // Fallback for old LHRs, where no type meant don't render.
-      case undefined:
-        return null;
 
       default: {
         // @ts-ignore tsc thinks this unreachable, but ts-ignore for error message just in case.

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -203,15 +203,6 @@ describe('DetailsRenderer', () => {
 
       assert.throws(() => renderer.render(details), /^Error: Unknown type: imaginary$/);
     });
-
-    it('supports old LHRs by not rendering when type is missing', () => {
-      // Disallowed by type system of current LH, but possible if trying to render an old LHR.
-      const details = {
-        timestamp: 15,
-      };
-
-      assert.strictEqual(renderer.render(details), null);
-    });
   });
 
   describe('Table rendering', () => {

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -138,23 +138,84 @@ describe('util helpers', () => {
   });
 
   describe('#prepareReportResult', () => {
-    it('corrects underscored `notApplicable` scoreDisplayMode', () => {
-      const clonedSampleResult = JSON.parse(JSON.stringify(sampleResult));
+    describe('backward compatibility', () => {
+      it('corrects underscored `notApplicable` scoreDisplayMode', () => {
+        const clonedSampleResult = JSON.parse(JSON.stringify(sampleResult));
 
-      let notApplicableCount = 0;
-      Object.values(clonedSampleResult.audits).forEach(audit => {
-        if (audit.scoreDisplayMode === 'notApplicable') {
-          notApplicableCount++;
-          audit.scoreDisplayMode = 'not_applicable';
-        }
+        let notApplicableCount = 0;
+        Object.values(clonedSampleResult.audits).forEach(audit => {
+          if (audit.scoreDisplayMode === 'notApplicable') {
+            notApplicableCount++;
+            audit.scoreDisplayMode = 'not_applicable';
+          }
+        });
+
+        assert.ok(notApplicableCount > 20); // Make sure something's being tested.
+
+        // Original audit results should be restored.
+        const preparedResult = Util.prepareReportResult(clonedSampleResult);
+
+        assert.deepStrictEqual(preparedResult.audits, sampleResult.audits);
       });
 
-      assert.ok(notApplicableCount > 20); // Make sure something's being tested.
+      it('corrects undefined auditDetails.type to `debugdata`', () => {
+        const clonedSampleResult = JSON.parse(JSON.stringify(sampleResult));
 
-      // Original audit results should be restored.
-      const preparedResult = Util.prepareReportResult(clonedSampleResult);
+        // Delete debugdata details types.
+        let undefinedCount = 0;
+        for (const audit of Object.values(clonedSampleResult.audits)) {
+          if (audit.details && audit.details.type === 'debugdata') {
+            undefinedCount++;
+            delete audit.details.type;
+          }
+        }
+        assert.ok(undefinedCount > 4); // Make sure something's being tested.
+        assert.notDeepStrictEqual(clonedSampleResult.audits, sampleResult.audits);
 
-      assert.deepStrictEqual(preparedResult.audits, sampleResult.audits);
+        // Original audit results should be restored.
+        const preparedResult = Util.prepareReportResult(clonedSampleResult);
+        assert.deepStrictEqual(preparedResult.audits, sampleResult.audits);
+      });
+
+      it('corrects `diagnostic` auditDetails.type to `debugdata`', () => {
+        const clonedSampleResult = JSON.parse(JSON.stringify(sampleResult));
+
+        // Change debugdata details types.
+        let diagnosticCount = 0;
+        for (const audit of Object.values(clonedSampleResult.audits)) {
+          if (audit.details && audit.details.type === 'debugdata') {
+            diagnosticCount++;
+            audit.details.type = 'diagnostic';
+          }
+        }
+        assert.ok(diagnosticCount > 4); // Make sure something's being tested.
+        assert.notDeepStrictEqual(clonedSampleResult.audits, sampleResult.audits);
+
+        // Original audit results should be restored.
+        const preparedResult = Util.prepareReportResult(clonedSampleResult);
+        assert.deepStrictEqual(preparedResult.audits, sampleResult.audits);
+      });
+
+      it('corrects screenshots in the `filmstrip` auditDetails.type', () => {
+        const clonedSampleResult = JSON.parse(JSON.stringify(sampleResult));
+
+        // Strip filmstrip screenshots of data URL prefix.
+        let filmstripCount = 0;
+        for (const audit of Object.values(clonedSampleResult.audits)) {
+          if (audit.details && audit.details.type === 'filmstrip') {
+            filmstripCount++;
+            for (const screenshot of audit.details.items) {
+              screenshot.data = screenshot.data.slice('data:image/jpeg;base64,'.length);
+            }
+          }
+        }
+        assert.ok(filmstripCount > 0); // Make sure something's being tested.
+        assert.notDeepStrictEqual(clonedSampleResult.audits, sampleResult.audits);
+
+        // Original audit results should be restored.
+        const preparedResult = Util.prepareReportResult(clonedSampleResult);
+        assert.deepStrictEqual(preparedResult.audits, sampleResult.audits);
+      });
     });
 
     it('appends stack pack descriptions to auditRefs', () => {

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -145,7 +145,7 @@ class LighthouseReportViewer {
 
     this._validateReportJson(json);
 
-    // Redirect to old viewer if a v2 report. v3 and v4 both handled by v4 viewer.
+    // Redirect to old viewer if a v2 report. v3, v4, v5 handled by v5 viewer.
     if (json.lighthouseVersion.startsWith('2')) {
       this._loadInLegacyViewerVersion(json);
       return;
@@ -216,7 +216,6 @@ class LighthouseReportViewer {
     const warnMsg = `Version mismatch between viewer and JSON. Opening compatible viewer...`;
     logger.log(warnMsg, false);
 
-    // TODO: Handle 4x reports if we break viewer compat moving to v5.
     // Place report in IDB, then navigate current tab to the legacy viewer
     const viewerPath = new URL('../viewer2x/', location.href);
     idbKeyval.set('2xreport', reportJson).then(_ => {


### PR DESCRIPTION
fixes #8598

In addition to the `diagnostic` -> `debug` update that needed to be done, #8299 also meant we needed to update the <5.0 filmstrip screenshots to be able to render in the report.

Tested LHRs back to 3.1, everything is 👍 .

*However*: turns out even the 3.1 viewer isn't compatible with 3.0 LHRs because of the i18n switch. Not sure what we want to do about that, though at least 5.0 isn't a regression on this front :)

<img width="812" alt="metrics screenshot" src="https://user-images.githubusercontent.com/316891/57114259-4748f480-6cfd-11e9-87bd-47f1a1ee9211.png">

https://googlechrome.github.io/lighthouse/viewer/?gist=86d005fa4297bdefacd01b7228ab47fa
