### PR TITLE
misc(proto): require protobuf 3.7.1, add stricter audit details test

### DIFF
--- a/lighthouse-core/test/report/proto-test.js
+++ b/lighthouse-core/test/report/proto-test.js
@@ -21,23 +21,10 @@ describe('round trip JSON comparison subsets', () => {
     sampleJson = JSON.parse(preprocessor.processForProto(sample));
   });
 
-  it('has the same audit results sans details', () => {
-    Object.keys(sampleJson.audits).forEach(audit => {
-      delete sampleJson.audits[audit].details;
-    });
-
-    expect(roundTripJson.audits).toMatchObject(sampleJson.audits);
-  });
-
-  it('has the same audit results & details if applicable', () => {
-    Object.keys(sampleJson.audits).forEach(auditId => {
-      expect(roundTripJson.audits[auditId]).toMatchObject(sampleJson.audits[auditId]);
-
-      if ('details' in sampleJson.audits[auditId]) {
-        expect(roundTripJson.audits[auditId].details)
-          .toMatchObject(sampleJson.audits[auditId].details);
-      }
-    });
+  it('has the same audit results and details (if applicable)', () => {
+    for (const auditId of Object.keys(sampleJson.audits)) {
+      expect(roundTripJson.audits[auditId]).toEqual(sampleJson.audits[auditId]);
+    }
   });
 
   it('has the same i18n rendererFormattedStrings', () => {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
     "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --preset=mixed-content",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
-    "compile-proto": "[ \"$(protoc --version)\" == 'libprotoc 3.6.1' ] && protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf to compile the proto file.\" && false)",
+    "compile-proto": "[ \"$(protoc --version)\" == 'libprotoc 3.7.1' ] && protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf to compile the proto file.\" && false)",
     "build-proto-roundtrip": "cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ultradumbBenchmark": "./lighthouse-core/scripts/benchmark.js",
     "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --preset=mixed-content",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
-    "compile-proto": "[ \"$(protoc --version)\" == 'libprotoc 3.7.1' ] && protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf to compile the proto file.\" && false)",
+    "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf ≥ 3.7.1 to compile the proto file.\" && false)",
     "build-proto-roundtrip": "cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py"
   },
   "devDependencies": {


### PR DESCRIPTION
follow up to #8863 and https://github.com/GoogleChrome/lighthouse/pull/8857#discussion_r281034929

Something was fixed between protobuf 3.6.1 and 3.7.1 that handled the `details.summary` type when the value was just an empty `{}`. 3.6.1 round tripped it as `null`, 3.7.1 correctly round trips it as `{}`.

The round trip test wasn't catching the issue because `{}` was the `summary` expectation and `{}` matches basically everything with `toMatchObject`. The round trip is good enough for audit results now that we can just do the deep, strict `toEqual` instead.