### PR TITLE
report: no na-line with single badge

### DIFF
--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -698,7 +698,7 @@ limitations under the License.
       display: inline;
     }
     /* Just optimized. Same n/a line as no passing groups. */
-    .lh-gauge--pwa__wrapper.lh-badged--pwa-optimized .lh-gauge--pwa__na-line {
+    .lh-gauge--pwa__wrapper.lh-badged--pwa-optimized:not(.lh-badged--pwa-installable):not(.lh-badged--pwa-fast-reliable) .lh-gauge--pwa__na-line {
       display: inline;
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Removes na-line from when gauge has optimized + one other badge.
old | new
![image](https://user-images.githubusercontent.com/6392995/57207522-298cc100-6f83-11e9-9ca3-42909d93e68f.png)

**Related Issues/PRs**
fixes: #8856 
