### PR TITLE
tests(smoke): re-enable dialog prompt

### DIFF
--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -198,7 +198,6 @@
   https://github.com/GoogleChrome/lighthouse/issues/1194 -->
 <script>window.Error = function(error) { this.stack = 'stacktrace'; };</script>
 
-<!--The javascriptDialogOpening test is disabled as we hit a platform bug frequently on travis-->
 <script>window.confirm('Is DBW Mega Tester the best site?')</script>
 
 <script>

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -199,7 +199,7 @@
 <script>window.Error = function(error) { this.stack = 'stacktrace'; };</script>
 
 <!--The javascriptDialogOpening test is disabled as we hit a platform bug frequently on travis-->
-<!--<script>window.confirm('Is DBW Mega Tester the best site?')</script>-->
+<script>window.confirm('Is DBW Mega Tester the best site?')</script>
 
 <script>
 function stampTemplate(id, location) {

--- a/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/lighthouse-cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -198,6 +198,7 @@
   https://github.com/GoogleChrome/lighthouse/issues/1194 -->
 <script>window.Error = function(error) { this.stack = 'stacktrace'; };</script>
 
+<!-- Does the automatic dialog suppression `driver.dismissJavaScriptDialogs()` work? -->
 <script>window.confirm('Is DBW Mega Tester the best site?')</script>
 
 <script>

--- a/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
+++ b/lighthouse-cli/test/smokehouse/dobetterweb/dbw-expectations.js
@@ -155,12 +155,12 @@ module.exports = [
         },
         'dom-size': {
           score: 1,
-          numericValue: 34,
+          numericValue: 35,
           details: {
             items: [
-              {statistic: 'Total DOM Elements', value: '34'},
+              {statistic: 'Total DOM Elements', value: '35'},
               {statistic: 'Maximum DOM Depth', value: '3'},
-              {statistic: 'Maximum Child Elements', value: '32'},
+              {statistic: 'Maximum Child Elements', value: '33'},
             ],
           },
         },


### PR DESCRIPTION
This was disabled here: #2437

![image](https://user-images.githubusercontent.com/4071474/57274061-c49e9d00-704e-11e9-86eb-f0a00aba9ed0.png)

Let's see what happens in Travis these days.

fixes #2423