### PR TITLE
report(redesign): fix word breaking in audit display text

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -470,11 +470,8 @@
   margin: 0 var(--audit-item-gap);
 }
 .lh-chevron-container {
+  margin-left: auto;
   margin-right: 0;
-}
-
-.lh-audit__display-text {
-  flex: 1;
 }
 
 /* Prepend display text with em dash separator. But not in Opportunities. */


### PR DESCRIPTION
Issue:

![image](https://user-images.githubusercontent.com/4071474/57335939-13911480-70d9-11e9-934d-57e093b3d10a.png)

now

![image](https://user-images.githubusercontent.com/4071474/57336002-44714980-70d9-11e9-906a-64c9453a4be2.png)

![image](https://user-images.githubusercontent.com/4071474/57336233-07f21d80-70da-11e9-8322-2fe43fc1e737.png)


Better but the em dash does get its own line on some viewports. may need to rethink where we put the warnings/errors text.

