### PR TITLE
docs: rename Google AdSpeed Insights to Publisher Ads Audits

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -350,5 +350,5 @@ Most artifacts will try to represent as truthfully as possible what was observed
 
 ## Examples
 
-- [Google AdSpeed Insights](https://github.com/googleads/ad-speed-insights) - a well-written, but complex, plugin
+- [Publisher Ads Audits](https://github.com/googleads/pub-ads-lighthouse-plugin) - a well-written, but complex, plugin
 - [Lighthouse Plugin Recipe](./recipes/lighthouse-plugin-example)


### PR DESCRIPTION
Full name is currently "Publisher Ads Audits for Lighthouse", but the "for Lighthouse" bit seems redundant here. Also changed repository name.