### PR TITLE
core: refactor gather-runner

### DIFF
--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1479,12 +1479,12 @@ class Driver {
    * Clear the network cache on disk and in memory.
    * @return {Promise<void>}
    */
-  async cleanBrowserCaches() {
+  cleanBrowserCaches() {
     // Wipe entire disk cache
-    await this.sendCommand('Network.clearBrowserCache');
-    // Toggle 'Disable Cache' to evict the memory cache
-    await this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true});
-    await this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false});
+    return this.sendCommand('Network.clearBrowserCache')
+      // Toggle 'Disable Cache' to evict the memory cache
+      .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true}))
+      .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false}));
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1479,12 +1479,17 @@ class Driver {
    * Clear the network cache on disk and in memory.
    * @return {Promise<void>}
    */
-  cleanBrowserCaches() {
+  async cleanBrowserCaches() {
+    const status = {msg: 'Cleaning browser cache', id: 'lh:driver:cleanBrowserCaches'};
+    log.time(status);
+
     // Wipe entire disk cache
-    return this.sendCommand('Network.clearBrowserCache')
-      // Toggle 'Disable Cache' to evict the memory cache
-      .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true}))
-      .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false}));
+    await this.sendCommand('Network.clearBrowserCache');
+    // Toggle 'Disable Cache' to evict the memory cache
+    await this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true});
+    await this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false});
+
+    log.timeEnd(status);
   }
 
   /**

--- a/lighthouse-core/gather/driver.js
+++ b/lighthouse-core/gather/driver.js
@@ -1476,15 +1476,15 @@ class Driver {
   }
 
   /**
-   * Emulate internet disconnection.
+   * Clear the network cache on disk and in memory.
    * @return {Promise<void>}
    */
-  cleanBrowserCaches() {
+  async cleanBrowserCaches() {
     // Wipe entire disk cache
-    return this.sendCommand('Network.clearBrowserCache')
-      // Toggle 'Disable Cache' to evict the memory cache
-      .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true}))
-      .then(_ => this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false}));
+    await this.sendCommand('Network.clearBrowserCache');
+    // Toggle 'Disable Cache' to evict the memory cache
+    await this.sendCommand('Network.setCacheDisabled', {cacheDisabled: true});
+    await this.sendCommand('Network.setCacheDisabled', {cacheDisabled: false});
   }
 
   /**

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -178,6 +178,9 @@ class GatherRunner {
    * @return {Promise<void>}
    */
   static async setupPassNetwork(passContext) {
+    const status = {msg: 'Setting up network for the pass trace', id: `lh:gather:setupPassNetwork`};
+    log.time(status);
+
     const passConfig = passContext.passConfig;
     await passContext.driver.setThrottling(passContext.settings, passConfig);
 
@@ -189,6 +192,8 @@ class GatherRunner {
     // neccessary at the beginning of the next pass.
     await passContext.driver.blockUrlPatterns(blockedUrls);
     await passContext.driver.setExtraHTTPHeaders(passContext.settings.extraHeaders);
+
+    log.timeEnd(status);
   }
 
   /**
@@ -197,6 +202,9 @@ class GatherRunner {
    * @return {Promise<void>}
    */
   static async beginRecording(passContext) {
+    const status = {msg: 'Beginning devtoolsLog and trace', id: 'lh:gather:beginRecording'};
+    log.time(status);
+
     const {driver, passConfig, settings} = passContext;
 
     // Always record devtoolsLog
@@ -205,6 +213,8 @@ class GatherRunner {
     if (passConfig.recordTrace) {
       await driver.beginTrace(settings);
     }
+
+    log.timeEnd(status);
   }
 
   /**
@@ -400,7 +410,7 @@ class GatherRunner {
    * @param {{driver: Driver, requestedUrl: string, settings: LH.Config.Settings}} options
    * @return {Promise<LH.BaseArtifacts>}
    */
-  static async getBaseArtifacts(options) {
+  static async initializeBaseArtifacts(options) {
     const hostUserAgent = (await options.driver.getBrowserVersion()).userAgent;
 
     const {emulatedFormFactor} = options.settings;
@@ -502,7 +512,7 @@ class GatherRunner {
       // So we first navigate to about:blank, then apply our emulation & setup
       await GatherRunner.loadBlank(driver);
 
-      const baseArtifacts = await GatherRunner.getBaseArtifacts(options);
+      const baseArtifacts = await GatherRunner.initializeBaseArtifacts(options);
       baseArtifacts.BenchmarkIndex = await options.driver.getBenchmarkIndex();
 
       await GatherRunner.setupDriver(driver, options);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -429,6 +429,8 @@ class GatherRunner {
 
   /**
    * Populates the important base artifacts from a fully loaded test page.
+   * Currently must be run before `start-url` gatherer so that `WebAppManifest`
+   * is populated for it.
    * @param {LH.Gatherer.PassContext} passContext
    */
   static async collectBaseArtifacts(passContext) {
@@ -437,11 +439,10 @@ class GatherRunner {
     // Copy redirected URL to artifact in the first pass only.
     baseArtifacts.URL.finalUrl = passContext.url;
 
-    // Fetch the manifest, if it exists. Currently must be fetched before `start-url` gatherer.
+    // Fetch the manifest, if it exists.
     baseArtifacts.WebAppManifest = await GatherRunner.getWebAppManifest(passContext);
 
-    // TODO(bckenny): move back to passContext
-    baseArtifacts.Stacks = await stacksGatherer(passContext.driver);
+    baseArtifacts.Stacks = await stacksGatherer(passContext);
 
     const devtoolsLog = baseArtifacts.devtoolsLogs[passContext.passConfig.passName];
     const userAgentEntry = devtoolsLog.find(entry =>

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -93,14 +93,18 @@ class GatherRunner {
   }
 
   /**
+   * Reset browser state where needed and release the connection.
    * @param {Driver} driver
+   * @param {{requestedUrl: string, settings: LH.Config.Settings}} options
    * @return {Promise<void>}
    */
-  static async disposeDriver(driver) {
+  static async disposeDriver(driver, options) {
     const status = {msg: 'Disconnecting from browser...', id: 'lh:gather:disconnect'};
 
     log.time(status);
     try {
+      const resetStorage = !options.settings.disableStorageReset;
+      if (resetStorage) await driver.clearDataForOrigin(options.requestedUrl);
       await driver.disconnect();
     } catch (err) {
       // Ignore disconnecting error if browser was already closed.
@@ -187,7 +191,8 @@ class GatherRunner {
   }
 
   /**
-   * End recording devtoolsLog and trace (if requested).
+   * End recording devtoolsLog and trace (if requested), returning an
+   * `LH.Gatherer.LoadData` with the recorded data.
    * @param {LH.Gatherer.PassContext} passContext
    * @return {Promise<LH.Gatherer.LoadData>}
    */
@@ -219,8 +224,7 @@ class GatherRunner {
   }
 
   /**
-   * Calls beforePass() on gatherers before tracing
-   * has started and before navigation to the target page.
+   * Run beforePass() on gatherers.
    * @param {LH.Gatherer.PassContext} passContext
    * @param {Partial<GathererResults>} gathererResults
    * @return {Promise<void>}
@@ -280,9 +284,7 @@ class GatherRunner {
   }
 
   /**
-   * Ends tracing and collects trace data (if requested for this pass), and runs
-   * afterPass() on gatherers with trace data passed in. Promise resolves with
-   * object containing trace and network data.
+   * Run afterPass() on gatherers.
    * @param {LH.Gatherer.PassContext} passContext
    * @param {LH.Gatherer.LoadData} loadData
    * @param {Partial<GathererResults>} gathererResults
@@ -318,21 +320,22 @@ class GatherRunner {
   }
 
   /**
+   * Generate a set of artfiacts for the given pass as if all the gatherers
+   * failed with the given pageLoadError.
    * @param {LH.Gatherer.PassContext} passContext
    * @param {LHError} pageLoadError
-   * @param {Partial<GathererResults>} gathererResults
-   * @return {Promise<void>}
+   * @return {Partial<LH.GathererArtifacts>}
    */
-  static async fillWithPageLoadErrors(passContext, pageLoadError, gathererResults) {
-    // Fail every gatherer's afterPass with the pageLoadError.
+  static generatePageLoadErrorArtifacts(passContext, pageLoadError) {
+    /** @type {Partial<Record<keyof LH.GathererArtifacts, LHError>>} */
+    const errorArtifacts = {};
     for (const gathererDefn of passContext.passConfig.gatherers) {
       const gatherer = gathererDefn.instance;
-      const artifactPromise = Promise.reject(pageLoadError);
-      const gathererResult = gathererResults[gatherer.name] || [];
-      gathererResult.push(artifactPromise);
-      gathererResults[gatherer.name] = gathererResult;
-      await artifactPromise.catch(() => {});
+      errorArtifacts[gatherer.name] = pageLoadError;
     }
+
+    // @ts-ignore - TODO(bckenny): figure out how to usefully type errored artifacts.
+    return errorArtifacts;
   }
 
   /**
@@ -341,17 +344,14 @@ class GatherRunner {
    * gatherer. If an error was rejected from a gatherer phase,
    * uses that error object as the artifact instead.
    * @param {Partial<GathererResults>} gathererResults
-   * @param {LH.BaseArtifacts} baseArtifacts
-   * @return {Promise<LH.Artifacts>}
+   * @return {Promise<Partial<LH.GathererArtifacts>>}
    */
-  static async collectArtifacts(gathererResults, baseArtifacts) {
+  static async collectArtifacts(gathererResults) {
     /** @type {Partial<LH.GathererArtifacts>} */
     const gathererArtifacts = {};
 
     const resultsEntries = /** @type {GathererResultsEntries} */ (Object.entries(gathererResults));
     for (const [gathererName, phaseResultsPromises] of resultsEntries) {
-      if (gathererArtifacts[gathererName] !== undefined) continue;
-
       try {
         const phaseResults = await Promise.all(phaseResultsPromises);
         // Take last defined pass result as artifact.
@@ -369,17 +369,12 @@ class GatherRunner {
       }
     }
 
-    // Take only unique LighthouseRunWarnings.
-    baseArtifacts.LighthouseRunWarnings = Array.from(new Set(baseArtifacts.LighthouseRunWarnings));
-
-    // Take the timing entries we've gathered so far.
-    baseArtifacts.Timing = log.getTimeEntries();
-
-    // TODO(bckenny): correct Partial<LH.GathererArtifacts> at this point to drop cast.
-    return /** @type {LH.Artifacts} */ ({...baseArtifacts, ...gathererArtifacts});
+    return gathererArtifacts;
   }
 
   /**
+   * Return an initialized but mostly empty set of base artifacts, to be
+   * populated as the run continues.
    * @param {{driver: Driver, requestedUrl: string, settings: LH.Config.Settings}} options
    * @return {Promise<LH.BaseArtifacts>}
    */
@@ -410,6 +405,47 @@ class GatherRunner {
   }
 
   /**
+   * Populates the important base artifacts from a fully loaded test page.
+   * Currently must be run before `start-url` gatherer so that `WebAppManifest`
+   * will be available to it.
+   * @param {LH.Gatherer.PassContext} passContext
+   */
+  static async populateBaseArtifacts(passContext) {
+    const baseArtifacts = passContext.baseArtifacts;
+
+    // Copy redirected URL to artifact.
+    baseArtifacts.URL.finalUrl = passContext.url;
+
+    // Fetch the manifest, if it exists.
+    baseArtifacts.WebAppManifest = await GatherRunner.getWebAppManifest(passContext);
+
+    baseArtifacts.Stacks = await stacksGatherer(passContext);
+
+    // Find the NetworkUserAgent actually used in the devtoolsLogs.
+    const devtoolsLog = baseArtifacts.devtoolsLogs[passContext.passConfig.passName];
+    const userAgentEntry = devtoolsLog.find(entry =>
+      entry.method === 'Network.requestWillBeSent' &&
+      !!entry.params.request.headers['User-Agent']
+    );
+    if (userAgentEntry) {
+      // @ts-ignore - guaranteed to exist by the find above
+      baseArtifacts.NetworkUserAgent = userAgentEntry.params.request.headers['User-Agent'];
+    }
+  }
+
+  /**
+   * Finalize baseArtifacts after gathering is fully complete.
+   * @param {LH.BaseArtifacts} baseArtifacts
+   */
+  static finalizeBaseArtifacts(baseArtifacts) {
+    // Take only unique LighthouseRunWarnings.
+    baseArtifacts.LighthouseRunWarnings = Array.from(new Set(baseArtifacts.LighthouseRunWarnings));
+
+    // Take the timing entries we've gathered so far.
+    baseArtifacts.Timing = log.getTimeEntries();
+  }
+
+  /**
    * Uses the debugger protocol to fetch the manifest from within the context of
    * the target page, reusing any credentials, emulation, etc, already established
    * there.
@@ -428,82 +464,53 @@ class GatherRunner {
   }
 
   /**
-   * Populates the important base artifacts from a fully loaded test page.
-   * Currently must be run before `start-url` gatherer so that `WebAppManifest`
-   * is populated for it.
-   * @param {LH.Gatherer.PassContext} passContext
-   */
-  static async collectBaseArtifacts(passContext) {
-    const baseArtifacts = passContext.baseArtifacts;
-
-    // Copy redirected URL to artifact in the first pass only.
-    baseArtifacts.URL.finalUrl = passContext.url;
-
-    // Fetch the manifest, if it exists.
-    baseArtifacts.WebAppManifest = await GatherRunner.getWebAppManifest(passContext);
-
-    baseArtifacts.Stacks = await stacksGatherer(passContext);
-
-    const devtoolsLog = baseArtifacts.devtoolsLogs[passContext.passConfig.passName];
-    const userAgentEntry = devtoolsLog.find(entry =>
-      entry.method === 'Network.requestWillBeSent' &&
-      !!entry.params.request.headers['User-Agent']
-    );
-    if (userAgentEntry) {
-      // @ts-ignore - guaranteed to exist by the find above
-      baseArtifacts.NetworkUserAgent = userAgentEntry.params.request.headers['User-Agent'];
-    }
-  }
-
-  /**
-   * @param {Array<LH.Config.Pass>} passes
+   * @param {Array<LH.Config.Pass>} passConfigs
    * @param {{driver: Driver, requestedUrl: string, settings: LH.Config.Settings}} options
    * @return {Promise<LH.Artifacts>}
    */
-  static async run(passes, options) {
+  static async run(passConfigs, options) {
     const driver = options.driver;
 
-    /** @type {Partial<GathererResults>} */
-    const gathererResults = {};
+    /** @type {Partial<LH.GathererArtifacts>} */
+    const artifacts = {};
 
     try {
       await driver.connect();
-      const baseArtifacts = await GatherRunner.getBaseArtifacts(options);
       // In the devtools/extension case, we can't still be on the site while trying to clear state
       // So we first navigate to about:blank, then apply our emulation & setup
       await GatherRunner.loadBlank(driver);
+
+      const baseArtifacts = await GatherRunner.getBaseArtifacts(options);
       baseArtifacts.BenchmarkIndex = await options.driver.getBenchmarkIndex();
+
       await GatherRunner.setupDriver(driver, options);
 
       let isFirstPass = true;
-      for (const passConfig of passes) {
+      for (const passConfig of passConfigs) {
+        /** @type {LH.Gatherer.PassContext} */
         const passContext = {
           driver,
-          // If the main document redirects, we'll update this to keep track
           url: options.requestedUrl,
           settings: options.settings,
           passConfig,
           baseArtifacts,
-          // *pass() functions and gatherers can push to this warnings array.
           LighthouseRunWarnings: baseArtifacts.LighthouseRunWarnings,
         };
-
-        const passResults = await GatherRunner.runPass(passContext);
-        Object.assign(gathererResults, passResults);
+        const passArtifacts = await GatherRunner.runPass(passContext);
+        Object.assign(artifacts, passArtifacts);
 
         if (isFirstPass) {
-          await GatherRunner.collectBaseArtifacts(passContext);
+          await GatherRunner.populateBaseArtifacts(passContext);
           isFirstPass = false;
         }
       }
 
-      const resetStorage = !options.settings.disableStorageReset;
-      if (resetStorage) await driver.clearDataForOrigin(options.requestedUrl);
-      await GatherRunner.disposeDriver(driver);
-      return GatherRunner.collectArtifacts(gathererResults, baseArtifacts);
+      await GatherRunner.disposeDriver(driver, options);
+      GatherRunner.finalizeBaseArtifacts(baseArtifacts);
+      return /** @type {LH.Artifacts} */ ({...baseArtifacts, ...artifacts}); // Cast to drop Partial<>.
     } catch (err) {
       // cleanup on error
-      GatherRunner.disposeDriver(driver);
+      GatherRunner.disposeDriver(driver, options);
       throw err;
     }
   }
@@ -521,21 +528,21 @@ class GatherRunner {
   /**
    * Starting from about:blank, load the page and run gatherers for this pass.
    * @param {LH.Gatherer.PassContext} passContext
-   * @return {Promise<Partial<GathererResults>>}
+   * @return {Promise<Partial<LH.GathererArtifacts>>}
    */
   static async runPass(passContext) {
     /** @type {Partial<GathererResults>} */
     const gathererResults = {};
     const {driver, passConfig} = passContext;
 
-    // Setup on about:blank.
+    // Go to about:blank, set up, and run `beforePass()` on gatherers.
     await GatherRunner.loadBlank(driver, passConfig.blankPage);
     await GatherRunner.setupPassNetwork(passContext);
     const isPerfPass = GatherRunner.isPerfPass(passContext);
     if (isPerfPass) await driver.cleanBrowserCaches(); // Clear disk & memory cache if it's a perf run
     await GatherRunner.beforePass(passContext, gathererResults);
 
-    // Navigate.
+    // Navigate, start recording, and run `pass()` on gatherers.
     await GatherRunner.beginRecording(passContext);
     await GatherRunner.loadPage(driver, passContext);
     await GatherRunner.pass(passContext, gathererResults);
@@ -544,28 +551,23 @@ class GatherRunner {
     // Disable throttling so the afterPass analysis isn't throttled
     await driver.setThrottling(passContext.settings, {useThrottling: false});
 
-    // Save devtoolsLog and trace (if requested by passConfig).
+    // Save devtoolsLog and trace.
     const baseArtifacts = passContext.baseArtifacts;
     baseArtifacts.devtoolsLogs[passConfig.passName] = loadData.devtoolsLog;
     if (loadData.trace) baseArtifacts.traces[passConfig.passName] = loadData.trace;
 
-    // Check for any load errors (but if the driver was offline, ignore the expected error).
+    // If there were any load errors, treat all gatherers as if they errored.
     let pageLoadError = GatherRunner.getPageLoadError(passContext.url, loadData.networkRecords);
-    if (!driver.online) pageLoadError = undefined;
-
-    // If no error, finish the afterPass and return.
-    if (!pageLoadError) {
-      await GatherRunner.afterPass(passContext, loadData, gathererResults);
-      // TODO(bckenny): actually collect here
-      return gathererResults;
+    if (!driver.online) pageLoadError = undefined; //  If the driver was offline, ignore the expected load error.
+    if (pageLoadError) {
+      log.error('GatherRunner', pageLoadError.message, passContext.url);
+      passContext.LighthouseRunWarnings.push(pageLoadError.friendlyMessage);
+      return GatherRunner.generatePageLoadErrorArtifacts(passContext, pageLoadError);
     }
 
-    // Move out of here?
-    log.error('GatherRunner', pageLoadError.message, passContext.url);
-    passContext.LighthouseRunWarnings.push(pageLoadError.friendlyMessage);
-    await GatherRunner.fillWithPageLoadErrors(passContext, pageLoadError, gathererResults);
-    // TODO(bckenny): actually collect here
-    return gathererResults;
+    // If no error, run `afterPass()` on gatherers and return collected artifacts.
+    await GatherRunner.afterPass(passContext, loadData, gathererResults);
+    return GatherRunner.collectArtifacts(gathererResults);
   }
 }
 

--- a/lighthouse-core/lib/stack-collector.js
+++ b/lighthouse-core/lib/stack-collector.js
@@ -17,8 +17,6 @@ const fs = require('fs');
 const libDetectorSource = fs.readFileSync(
   require.resolve('js-library-detector/library/libraries.js'), 'utf8');
 
-/** @typedef {import('./../gather/driver.js')} Driver */
-
 /** @typedef {false | {version: string|null}} JSLibraryDetectorTestResult */
 /**
  * @typedef JSLibraryDetectorTest
@@ -68,17 +66,17 @@ async function detectLibraries() {
 }
 
 /**
- * @param {Driver} driver
+ * @param {LH.Gatherer.PassContext} passContext
  * @return {Promise<LH.Artifacts['Stacks']>}
  */
-async function collectStacks(driver) {
+async function collectStacks(passContext) {
   const expression = `(function () {
     ${libDetectorSource};
     return (${detectLibraries.toString()}());
   })()`;
 
   /** @type {JSLibrary[]} */
-  const jsLibraries = await driver.evaluateAsync(expression);
+  const jsLibraries = await passContext.driver.evaluateAsync(expression);
 
   return jsLibraries.map(lib => ({
     detector: /** @type {'js'} */ ('js'),

--- a/lighthouse-core/lib/stack-collector.js
+++ b/lighthouse-core/lib/stack-collector.js
@@ -17,6 +17,8 @@ const fs = require('fs');
 const libDetectorSource = fs.readFileSync(
   require.resolve('js-library-detector/library/libraries.js'), 'utf8');
 
+/** @typedef {import('./../gather/driver.js')} Driver */
+
 /** @typedef {false | {version: string|null}} JSLibraryDetectorTestResult */
 /**
  * @typedef JSLibraryDetectorTest
@@ -66,17 +68,17 @@ async function detectLibraries() {
 }
 
 /**
- * @param {LH.Gatherer.PassContext} passContext
+ * @param {Driver} driver
  * @return {Promise<LH.Artifacts['Stacks']>}
  */
-async function collectStacks(passContext) {
+async function collectStacks(driver) {
   const expression = `(function () {
     ${libDetectorSource};
     return (${detectLibraries.toString()}());
   })()`;
 
   /** @type {JSLibrary[]} */
-  const jsLibraries = await passContext.driver.evaluateAsync(expression);
+  const jsLibraries = await driver.evaluateAsync(expression);
 
   return jsLibraries.map(lib => ({
     detector: /** @type {'js'} */ ('js'),

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -102,7 +102,9 @@ describe('GatherRunner', function() {
     const passContext = {
       requestedUrl: url1,
       settings: {},
-      passConfig: {},
+      passConfig: {
+        gatherers: [],
+      },
     };
 
     return GatherRunner.loadPage(driver, passContext).then(_ => {
@@ -420,7 +422,7 @@ describe('GatherRunner', function() {
       receivedUrlPatterns = params.urls;
     });
 
-    return GatherRunner.beforePass({
+    return GatherRunner.setupPassNetwork({
       driver,
       settings: {
         blockedUrlPatterns: ['http://*.evil.com', '.jpg', '.woff2'],
@@ -441,7 +443,7 @@ describe('GatherRunner', function() {
       receivedUrlPatterns = params.urls;
     });
 
-    return GatherRunner.beforePass({
+    return GatherRunner.setupPassNetwork({
       driver,
       settings: {},
       passConfig: {gatherers: []},
@@ -459,7 +461,7 @@ describe('GatherRunner', function() {
       'x-men': 'wolverine',
     };
 
-    return GatherRunner.beforePass({
+    return GatherRunner.setupPassNetwork({
       driver,
       settings: {
         extraHeaders: headers,
@@ -471,7 +473,7 @@ describe('GatherRunner', function() {
       ));
   });
 
-  it('tells the driver to begin tracing', () => {
+  it('tells the driver to begin tracing', async () => {
     let calledTrace = false;
     const driver = {
       beginTrace() {
@@ -494,9 +496,8 @@ describe('GatherRunner', function() {
     };
     const settings = {};
 
-    return GatherRunner.pass({driver, passConfig, settings}, {TestGatherer: []}).then(_ => {
-      assert.equal(calledTrace, true);
-    });
+    await GatherRunner.beginRecording({driver, passConfig, settings}, {TestGatherer: []});
+    assert.equal(calledTrace, true);
   });
 
   it('tells the driver to end tracing', () => {
@@ -524,7 +525,7 @@ describe('GatherRunner', function() {
     });
   });
 
-  it('tells the driver to begin devtoolsLog collection', () => {
+  it('tells the driver to begin devtoolsLog collection', async () => {
     let calledDevtoolsLogCollect = false;
     const driver = {
       beginDevtoolsLog() {
@@ -543,9 +544,8 @@ describe('GatherRunner', function() {
     };
     const settings = {};
 
-    return GatherRunner.pass({driver, passConfig, settings}, {TestGatherer: []}).then(_ => {
-      assert.equal(calledDevtoolsLogCollect, true);
-    });
+    await GatherRunner.beginRecording({driver, passConfig, settings}, {TestGatherer: []});
+    assert.equal(calledDevtoolsLogCollect, true);
   });
 
   it('tells the driver to end devtoolsLog collection', () => {

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -389,7 +389,7 @@ describe('GatherRunner', function() {
       driver,
       passConfig,
       settings,
-      baseArtifacts: await GatherRunner.getBaseArtifacts({driver, settings, requestedUrl}),
+      baseArtifacts: await GatherRunner.initializeBaseArtifacts({driver, settings, requestedUrl}),
     };
 
     await GatherRunner.runPass(passContext, {TestGatherer: []});

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -519,7 +519,7 @@ describe('GatherRunner', function() {
       ],
     };
 
-    return GatherRunner.afterPass({url, driver, passConfig}, {TestGatherer: []}).then(passData => {
+    return GatherRunner.endRecording({url, driver, passConfig}).then(passData => {
       assert.equal(calledTrace, true);
       assert.equal(passData.trace, fakeTraceData);
     });
@@ -568,7 +568,7 @@ describe('GatherRunner', function() {
       ],
     };
 
-    return GatherRunner.afterPass({url, driver, passConfig}, {TestGatherer: []}).then(passData => {
+    return GatherRunner.endRecording({url, driver, passConfig}).then(passData => {
       assert.equal(calledDevtoolsLogCollect, true);
       assert.strictEqual(passData.devtoolsLog[0], fakeDevtoolsMessage);
     });

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -657,19 +657,19 @@ describe('GatherRunner', function() {
       });
   });
 
-  describe('#getPageLoadError', () => {
+  describe('#getNetworkError', () => {
     it('passes when the page is loaded', () => {
       const url = 'http://the-page.com';
       const mainRecord = new NetworkRequest();
       mainRecord.url = url;
-      assert.ok(!GatherRunner.getPageLoadError(url, [mainRecord]));
+      assert.ok(!GatherRunner.getNetworkError(url, [mainRecord]));
     });
 
     it('passes when the page is loaded, ignoring any fragment', () => {
       const url = 'http://example.com/#/page/list';
       const mainRecord = new NetworkRequest();
       mainRecord.url = 'http://example.com';
-      assert.ok(!GatherRunner.getPageLoadError(url, [mainRecord]));
+      assert.ok(!GatherRunner.getNetworkError(url, [mainRecord]));
     });
 
     it('fails when page fails to load', () => {
@@ -678,7 +678,7 @@ describe('GatherRunner', function() {
       mainRecord.url = url;
       mainRecord.failed = true;
       mainRecord.localizedFailDescription = 'foobar';
-      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
+      const error = GatherRunner.getNetworkError(url, [mainRecord]);
       assert.equal(error.message, 'FAILED_DOCUMENT_REQUEST');
       assert.equal(error.code, 'FAILED_DOCUMENT_REQUEST');
       expect(error.friendlyMessage)
@@ -688,7 +688,7 @@ describe('GatherRunner', function() {
     it('fails when page times out', () => {
       const url = 'http://the-page.com';
       const records = [];
-      const error = GatherRunner.getPageLoadError(url, records);
+      const error = GatherRunner.getNetworkError(url, records);
       assert.equal(error.message, 'NO_DOCUMENT_REQUEST');
       assert.equal(error.code, 'NO_DOCUMENT_REQUEST');
       expect(error.friendlyMessage).toBeDisplayString(/^Lighthouse was unable to reliably load/);
@@ -699,7 +699,7 @@ describe('GatherRunner', function() {
       const mainRecord = new NetworkRequest();
       mainRecord.url = url;
       mainRecord.statusCode = 404;
-      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
+      const error = GatherRunner.getNetworkError(url, [mainRecord]);
       assert.equal(error.message, 'ERRORED_DOCUMENT_REQUEST');
       assert.equal(error.code, 'ERRORED_DOCUMENT_REQUEST');
       expect(error.friendlyMessage)
@@ -711,7 +711,7 @@ describe('GatherRunner', function() {
       const mainRecord = new NetworkRequest();
       mainRecord.url = url;
       mainRecord.statusCode = 500;
-      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
+      const error = GatherRunner.getNetworkError(url, [mainRecord]);
       assert.equal(error.message, 'ERRORED_DOCUMENT_REQUEST');
       assert.equal(error.code, 'ERRORED_DOCUMENT_REQUEST');
       expect(error.friendlyMessage)
@@ -724,7 +724,7 @@ describe('GatherRunner', function() {
       mainRecord.url = url;
       mainRecord.failed = true;
       mainRecord.localizedFailDescription = 'net::ERR_NAME_NOT_RESOLVED';
-      const error = GatherRunner.getPageLoadError(url, [mainRecord]);
+      const error = GatherRunner.getNetworkError(url, [mainRecord]);
       assert.equal(error.message, 'DNS_FAILURE');
       assert.equal(error.code, 'DNS_FAILURE');
       expect(error.friendlyMessage).toBeDisplayString(/^DNS servers could not resolve/);
@@ -943,7 +943,7 @@ describe('GatherRunner', function() {
         ],
       };
 
-      return GatherRunner.collectArtifacts(gathererResults, {}).then(artifacts => {
+      return GatherRunner.collectArtifacts(gathererResults, {}).then(({artifacts}) => {
         assert.strictEqual(artifacts.AfterGatherer, 97);
         assert.strictEqual(artifacts.PassGatherer, 284);
         assert.strictEqual(artifacts.SingleErrorGatherer, recoverableError);

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -12,13 +12,14 @@ import Driver = require('../lighthouse-core/gather/driver');
 declare global {
   module LH.Gatherer {
     export interface PassContext {
+      /** The url of the currently loaded page. If the main document redirects, this will be updated to keep track. */
       url: string;
       driver: Driver;
       disableJavaScript?: boolean;
       passConfig: Config.Pass
       settings: Config.Settings;
       options?: object;
-      /** Push to this array to add top-level warnings to the LHR. */
+      /** Gatherers can push to this array to add top-level warnings to the LHR. */
       LighthouseRunWarnings: Array<string>;
       baseArtifacts: BaseArtifacts;
     }


### PR DESCRIPTION
This is a refactor of `gather-runner.js` to
1) more clearly say what it's doing. The big outline at the top shouldn't be necessary; you should be able to just read `run()` (and now `runPass()`) to get an overview. `GatherRunner.beforePass`, `pass`, and `afterPass` now *only* call those methods on gatherers and it's a lot easier to see where things like recording a trace starts and stops.
2) make it easier to handle error cases. The code should be able to express what we're trying to do: at certain points (as the page is loading, after the page is done, between passes, etc) we need to check for errors, and then depending on the type of error take one of several actions (continue (allowing what gatherers can run to run), return error artifacts, don't run any more passes, cancel the entire LH run, etc). I've tried to add natural spots for these checks and more explicit error handling rather than trying to cram more things into the array-of-resolved-or-rejected-beforepass-pass-afterpass-promises model :) I believe #8340 and #8866 (and future error handling beyond those) should integrate well with these changes.

`Driver` commands and input/output should be *exactly* the same except:
* we go back to loading `about:blank` twice on the first pass
* some `log.time` groups have different `Driver` functions in them so the timing might change slightly
The first is not a big deal since after #6446 the second `about:blank` load is like 10ms, and the `timing` changes seem unavoidable since it's an explicit externalizing of internal implementation details.

This is a big PR touching a lot of stuff, so if reviewers prefer this PR can just show the motivating goal and be closed and I can split into a couple of PRs.