### PR TITLE
audits(installable-manifest): defer to Page.getInstallabilityErrors when all of our checks pass

### DIFF
--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -124,6 +124,7 @@ const defaultConfig = {
       'link-elements',
       'meta-elements',
       'script-elements',
+      'installability-errors',
       'dobetterweb/appcache',
       'dobetterweb/doctype',
       'dobetterweb/domstats',

--- a/lighthouse-core/gather/gatherers/installability-errors.js
+++ b/lighthouse-core/gather/gatherers/installability-errors.js
@@ -1,0 +1,25 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+/**
+  * @fileoverview Gathers response of Page.getInstallabilityErrors.
+  */
+'use strict';
+
+const Gatherer = require('./gatherer');
+
+class InstallabilityErrors extends Gatherer {
+  /**
+    * @param {LH.Gatherer.PassContext} passContext
+    * @return {Promise<LH.Artifacts['InstallabilityErrors']>}
+    */
+  afterPass(passContext) {
+    const driver = passContext.driver;
+    // @ts-ignore - types are missing in @types/chrome.
+    return driver.sendCommand('Page.getInstallabilityErrors');
+  }
+}
+
+module.exports = InstallabilityErrors;

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -103,6 +103,8 @@ declare global {
       HTMLWithoutJavaScript: {bodyText: string, hasNoScript: boolean};
       /** Whether the page ended up on an HTTPS page after attempting to load the HTTP version. */
       HTTPRedirect: {value: boolean};
+      /** Response from Page.getInstallabilityErrors. */
+      InstallabilityErrors: {errors: string[]};
       /** JS coverage information for code used during page load. */
       JsUsage: Crdp.Profiler.ScriptCoverage[];
       /** Parsed version of the page's Web App Manifest, or null if none found. */


### PR DESCRIPTION
See #8223

This is just meant to cover any possible gaps between our checks and the checks made via the protocol.

I don't see an obvious way to remove our checks completely (see comment block in the PR). Perhaps we could augment the protocol to give us some error codes. That'd allow us to convert errors (or lack thereof) from the protocol to a particular check, which can be consumed by other audits (like `splash-screen`).