### PR TITLE
misc: remove unneeded reportCategories from LH.ReportResult

### DIFF
--- a/lighthouse-core/report/html/renderer/psi.js
+++ b/lighthouse-core/report/html/renderer/psi.js
@@ -43,7 +43,7 @@ function prepareLabData(LHResult, document) {
   dom.resetTemplates();
 
   const reportLHR = Util.prepareReportResult(lhResult);
-  const perfCategory = reportLHR.reportCategories.find(cat => cat.id === 'performance');
+  const perfCategory = reportLHR.categories.performance;
   if (!perfCategory) throw new Error(`No performance category. Can't make lab data section`);
   if (!reportLHR.categoryGroups) throw new Error(`No category groups found.`);
 

--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -169,7 +169,7 @@ class ReportRenderer {
     const customGauges = []; // PWA.
     const pluginGauges = [];
 
-    for (const category of report.reportCategories) {
+    for (const category of Object.values(report.categories)) {
       const renderer = specificCategoryRenderers[category.id] || categoryRenderer;
       const categoryGauge = renderer.renderScoreGauge(category, report.categoryGroups || {});
 
@@ -212,7 +212,7 @@ class ReportRenderer {
     reportSection.appendChild(this._renderReportWarnings(report));
 
     let scoreHeader;
-    const isSoloCategory = report.reportCategories.length === 1;
+    const isSoloCategory = Object.keys(report.categories).length === 1;
     if (!isSoloCategory) {
       scoreHeader = this._dom.createElement('div', 'lh-scores-header');
     } else {
@@ -234,7 +234,7 @@ class ReportRenderer {
 
     const categories = reportSection.appendChild(this._dom.createElement('div', 'lh-categories'));
 
-    for (const category of report.reportCategories) {
+    for (const category of Object.values(report.categories)) {
       const renderer = specificCategoryRenderers[category.id] || categoryRenderer;
       // .lh-category-wrapper is full-width and provides horizontal rules between categories.
       // .lh-category within has the max-width: var(--report-width);

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -99,12 +99,9 @@ class Util {
       Util.updateAllUIStrings(clone.i18n.rendererFormattedStrings);
     }
 
-    // Transform object of categories into array of categories.
-    if (typeof clone.categories !== 'object') throw new Error('No categories provided.');
-    clone.reportCategories = Object.values(clone.categories);
-
     // For convenience, smoosh all AuditResults into their auditRef (which has just weight & group)
-    for (const category of clone.reportCategories) {
+    if (typeof clone.categories !== 'object') throw new Error('No categories provided.');
+    for (const category of Object.values(clone.categories)) {
       category.auditRefs.forEach(auditRef => {
         const result = clone.audits[auditRef.id];
         auditRef.result = result;

--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -46,8 +46,7 @@ describe('CategoryRenderer', () => {
   });
 
   it('renders an audit', () => {
-    const auditRef = sampleResults.reportCategories
-      .find(c => c.id === 'pwa').auditRefs
+    const auditRef = sampleResults.categories.pwa.auditRefs
       .find(a => a.id === 'works-offline');
 
     const auditDOM = renderer.renderAudit(auditRef);
@@ -157,7 +156,7 @@ describe('CategoryRenderer', () => {
   });
 
   it('renders a category', () => {
-    const category = sampleResults.reportCategories.find(c => c.id === 'pwa');
+    const category = sampleResults.categories.pwa;
     const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
 
     const categoryEl = categoryDOM.querySelector('.lh-category-header');
@@ -179,7 +178,7 @@ describe('CategoryRenderer', () => {
 
   it('plugin category has plugin badge', () => {
     const category = JSON.parse(
-      JSON.stringify(sampleResults.reportCategories.find(c => c.id === 'seo')));
+      JSON.stringify(sampleResults.categories.seo));
     category.id = 'lighthouse-plugin-someplugin';
     category.title = 'Some Plugin';
     const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
@@ -189,7 +188,7 @@ describe('CategoryRenderer', () => {
   });
 
   it('handles markdown in category descriptions a category', () => {
-    const category = sampleResults.reportCategories.find(c => c.id === 'pwa');
+    const category = sampleResults.categories.pwa;
     const prevDesc = category.description;
     category.description += ' [link text](http://example.com).';
     const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
@@ -199,7 +198,7 @@ describe('CategoryRenderer', () => {
   });
 
   it('renders manual audits if the category contains them', () => {
-    const pwaCategory = sampleResults.reportCategories.find(cat => cat.id === 'pwa');
+    const pwaCategory = sampleResults.categories.pwa;
     const categoryDOM = renderer.render(pwaCategory, sampleResults.categoryGroups);
     assert.ok(categoryDOM.querySelector('.lh-clump--manual .lh-audit-group__summary'));
     assert.equal(categoryDOM.querySelectorAll('.lh-audit--manual').length, 3,
@@ -214,7 +213,7 @@ describe('CategoryRenderer', () => {
   });
 
   it('renders not applicable audits if the category contains them', () => {
-    const a11yCategory = sampleResults.reportCategories.find(cat => cat.id === 'accessibility');
+    const a11yCategory = sampleResults.categories.accessibility;
     const categoryDOM = renderer.render(a11yCategory, sampleResults.categoryGroups);
     assert.ok(categoryDOM.querySelector(
         '.lh-clump--notapplicable .lh-audit-group__summary'));
@@ -227,7 +226,7 @@ describe('CategoryRenderer', () => {
       'score shows informative and dash icon'
     );
 
-    const bestPracticeCat = sampleResults.reportCategories.find(cat => cat.id === 'best-practices');
+    const bestPracticeCat = sampleResults.categories['best-practices'];
     const categoryDOM2 = renderer.render(bestPracticeCat, sampleResults.categoryGroups);
     assert.ok(!categoryDOM2.querySelector('.lh-clump--notapplicable'));
   });
@@ -236,7 +235,7 @@ describe('CategoryRenderer', () => {
     let category;
 
     beforeEach(() => {
-      category = sampleResults.reportCategories.find(cat => cat.id === 'accessibility');
+      category = sampleResults.categories.accessibility;
     });
 
     it('renders the category header', () => {
@@ -352,7 +351,7 @@ describe('CategoryRenderer', () => {
 
   describe('clumping passed/failed/warning/manual', () => {
     it('separates audits in the DOM', () => {
-      const category = sampleResults.reportCategories.find(c => c.id === 'pwa');
+      const category = sampleResults.categories.pwa;
       const categoryClone = JSON.parse(JSON.stringify(category));
       // Give the first two passing grades warnings
       const passingRefs = categoryClone.auditRefs.filter(ref => ref.result.score === 1);
@@ -372,7 +371,7 @@ describe('CategoryRenderer', () => {
     });
 
     it('doesnt create a passed section if there were 0 passed', () => {
-      const origCategory = sampleResults.reportCategories.find(c => c.id === 'pwa');
+      const origCategory = sampleResults.categories.pwa;
       const category = JSON.parse(JSON.stringify(origCategory));
       category.auditRefs.forEach(audit => audit.result.score = 0);
       const elem = renderer.render(category, sampleResults.categoryGroups);
@@ -384,7 +383,7 @@ describe('CategoryRenderer', () => {
     });
 
     it('expands warning audit group', () => {
-      const category = sampleResults.reportCategories.find(c => c.id === 'pwa');
+      const category = sampleResults.categories.pwa;
       const categoryClone = JSON.parse(JSON.stringify(category));
       categoryClone.auditRefs[0].result.warnings = ['Some warning'];
 

--- a/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
@@ -43,7 +43,7 @@ describe('PerfCategoryRenderer', () => {
 
     // TODO: don't call a LH.ReportResult `sampleResults`, which is typically always LH.Result
     sampleResults = Util.prepareReportResult(sampleResultsOrig);
-    category = sampleResults.reportCategories.find(cat => cat.id === 'performance');
+    category = sampleResults.categories.performance;
   });
 
   afterAll(() => {

--- a/lighthouse-core/test/report/html/renderer/pwa-category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/pwa-category-renderer-test.js
@@ -43,7 +43,7 @@ describe('PwaCategoryRenderer', () => {
 
   beforeEach(() => {
     // Clone category to allow modifications.
-    const pwaCategory = sampleResults.reportCategories.find(cat => cat.id === 'pwa');
+    const pwaCategory = sampleResults.categories.pwa;
     category = JSON.parse(JSON.stringify(pwaCategory));
   });
 

--- a/lighthouse-core/test/report/html/renderer/report-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-renderer-test.js
@@ -81,7 +81,7 @@ describe('ReportRenderer', () => {
       assert.ok(output.querySelector('.lh-report'), 'has report body');
       // 3 sets of gauges - one in sticky header, one in scores header, and one in each section.
       assert.equal(output.querySelectorAll('.lh-gauge__wrapper, .lh-gauge--pwa__wrapper').length,
-          sampleResults.reportCategories.length * 3, 'renders category gauges');
+          Object.keys(sampleResults.categories).length * 3, 'renders category gauges');
     });
 
     it('renders additional reports by replacing the existing one', () => {

--- a/types/html-renderer.d.ts
+++ b/types/html-renderer.d.ts
@@ -47,11 +47,9 @@ declare global {
 
   module LH {
     // During report generation, the LHR object is transformed a bit for convenience
-    // Primarily, the auditResult is added as .result onto the auditRef.
-    // Also: a reportCategories property is added. We're lazy sometimes. It'll be removed in due time.
+    // Primarily, the auditResult is added as .result onto the auditRef. We're lazy sometimes. It'll be removed in due time.
     export interface ReportResult extends Result {
       categories: Record<string, ReportResult.Category>;
-      reportCategories: Array<ReportResult.Category>;
     }
     export module ReportResult {
       export interface Category extends Result.Category {


### PR DESCRIPTION
`Util.prepareReportResult` smooshes audit results onto audit refs, but it also creates a bonus array of the report categories via `Object.values()`. We barely use these and [we all agree they're technical debt](https://github.com/GoogleChrome/lighthouse/blob/0b96e7af1a73e34e84b6a17e5a69f1d77a12698a/lighthouse-core/report/html/renderer/util.js#L55), so this is an easy removal.

As a bonus, this PR clears up all the many places we're calling `.find()` on that array to find a particular category, when the original `categories` is already indexed by category id :)

(noticed while cleaning up `prepareReportResult` in #8822, but punted until after I/O)