### PR TITLE
tests: update a11y artifacts

### DIFF
--- a/lighthouse-core/test/report/html/renderer/category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/category-renderer-test.js
@@ -242,7 +242,7 @@ describe('CategoryRenderer', () => {
       const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
 
       const gauge = categoryDOM.querySelector('.lh-gauge__percentage');
-      assert.equal(gauge.textContent.trim(), '38', 'score is 0-100');
+      assert.equal(gauge.textContent.trim(), '46', 'score is 0-100');
 
       const score = categoryDOM.querySelector('.lh-category-header');
       const value = categoryDOM.querySelector('.lh-gauge__percentage');

--- a/lighthouse-core/test/report/proto-test.js
+++ b/lighthouse-core/test/report/proto-test.js
@@ -14,8 +14,49 @@ const preprocessor = require('../../lib/proto-preprocessor.js');
 
 /* eslint-env jest */
 
-describe('proto test', () => {
+describe('round trip JSON comparison subsets', () => {
   let sampleJson;
+
+  beforeEach(() => {
+    sampleJson = JSON.parse(preprocessor.processForProto(sample));
+  });
+
+  it('has the same audit results and details (if applicable)', () => {
+    for (const auditId of Object.keys(sampleJson.audits)) {
+      expect(roundTripJson.audits[auditId]).toEqual(sampleJson.audits[auditId]);
+    }
+  });
+
+  it('has the same i18n rendererFormattedStrings', () => {
+    expect(roundTripJson.i18n).toMatchObject(sampleJson.i18n);
+  });
+
+  it('has the same top level values', () => {
+    // Don't test all top level properties that are objects.
+    Object.keys(sampleJson).forEach(audit => {
+      if (typeof sampleJson[audit] === 'object' && !Array.isArray(sampleJson[audit])) {
+        delete sampleJson[audit];
+      }
+    });
+
+    // Properties set to their type's default value will be omitted in the roundTripJson.
+    // For an explicit list of properties, remove sampleJson values if set to a default.
+    if (Array.isArray(sampleJson.stackPacks) && sampleJson.stackPacks.length === 0) {
+      delete sampleJson.stackPacks;
+    }
+
+    expect(roundTripJson).toMatchObject(sampleJson);
+  });
+
+  it('has the same config values', () => {
+    // Config settings from proto round trip should be a subset of the actual settings.
+    expect(sampleJson.configSettings).toMatchObject(roundTripJson.configSettings);
+  });
+});
+
+describe('round trip JSON comparison to everything', () => {
+  let sampleJson;
+
   beforeEach(() => {
     sampleJson = JSON.parse(preprocessor.processForProto(sample));
 
@@ -29,43 +70,7 @@ describe('proto test', () => {
     }
   });
 
-  describe('round trip JSON comparison subsets', () => {
-    it('has the same audit results and details (if applicable)', () => {
-      for (const auditId of Object.keys(sampleJson.audits)) {
-        expect(roundTripJson.audits[auditId]).toEqual(sampleJson.audits[auditId]);
-      }
-    });
-
-    it('has the same i18n rendererFormattedStrings', () => {
-      expect(roundTripJson.i18n).toMatchObject(sampleJson.i18n);
-    });
-
-    it('has the same top level values', () => {
-      // Don't test all top level properties that are objects.
-      Object.keys(sampleJson).forEach(audit => {
-        if (typeof sampleJson[audit] === 'object' && !Array.isArray(sampleJson[audit])) {
-          delete sampleJson[audit];
-        }
-      });
-
-      // Properties set to their type's default value will be omitted in the roundTripJson.
-      // For an explicit list of properties, remove sampleJson values if set to a default.
-      if (Array.isArray(sampleJson.stackPacks) && sampleJson.stackPacks.length === 0) {
-        delete sampleJson.stackPacks;
-      }
-
-      expect(roundTripJson).toMatchObject(sampleJson);
-    });
-
-    it('has the same config values', () => {
-      // Config settings from proto round trip should be a subset of the actual settings.
-      expect(sampleJson.configSettings).toMatchObject(roundTripJson.configSettings);
-    });
-  });
-
-  describe('round trip JSON comparison to everything', () => {
-    it('has the same JSON overall', () => {
-      expect(sampleJson).toMatchObject(roundTripJson);
-    });
+  it('has the same JSON overall', () => {
+    expect(sampleJson).toMatchObject(roundTripJson);
   });
 });

--- a/lighthouse-core/test/report/proto-test.js
+++ b/lighthouse-core/test/report/proto-test.js
@@ -14,49 +14,8 @@ const preprocessor = require('../../lib/proto-preprocessor.js');
 
 /* eslint-env jest */
 
-describe('round trip JSON comparison subsets', () => {
+describe('proto test', () => {
   let sampleJson;
-
-  beforeEach(() => {
-    sampleJson = JSON.parse(preprocessor.processForProto(sample));
-  });
-
-  it('has the same audit results and details (if applicable)', () => {
-    for (const auditId of Object.keys(sampleJson.audits)) {
-      expect(roundTripJson.audits[auditId]).toEqual(sampleJson.audits[auditId]);
-    }
-  });
-
-  it('has the same i18n rendererFormattedStrings', () => {
-    expect(roundTripJson.i18n).toMatchObject(sampleJson.i18n);
-  });
-
-  it('has the same top level values', () => {
-    // Don't test all top level properties that are objects.
-    Object.keys(sampleJson).forEach(audit => {
-      if (typeof sampleJson[audit] === 'object' && !Array.isArray(sampleJson[audit])) {
-        delete sampleJson[audit];
-      }
-    });
-
-    // Properties set to their type's default value will be omitted in the roundTripJson.
-    // For an explicit list of properties, remove sampleJson values if set to a default.
-    if (Array.isArray(sampleJson.stackPacks) && sampleJson.stackPacks.length === 0) {
-      delete sampleJson.stackPacks;
-    }
-
-    expect(roundTripJson).toMatchObject(sampleJson);
-  });
-
-  it('has the same config values', () => {
-    // Config settings from proto round trip should be a subset of the actual settings.
-    expect(sampleJson.configSettings).toMatchObject(roundTripJson.configSettings);
-  });
-});
-
-describe('round trip JSON comparison to everything', () => {
-  let sampleJson;
-
   beforeEach(() => {
     sampleJson = JSON.parse(preprocessor.processForProto(sample));
 
@@ -70,7 +29,43 @@ describe('round trip JSON comparison to everything', () => {
     }
   });
 
-  it('has the same JSON overall', () => {
-    expect(sampleJson).toMatchObject(roundTripJson);
+  describe('round trip JSON comparison subsets', () => {
+    it('has the same audit results and details (if applicable)', () => {
+      for (const auditId of Object.keys(sampleJson.audits)) {
+        expect(roundTripJson.audits[auditId]).toEqual(sampleJson.audits[auditId]);
+      }
+    });
+
+    it('has the same i18n rendererFormattedStrings', () => {
+      expect(roundTripJson.i18n).toMatchObject(sampleJson.i18n);
+    });
+
+    it('has the same top level values', () => {
+      // Don't test all top level properties that are objects.
+      Object.keys(sampleJson).forEach(audit => {
+        if (typeof sampleJson[audit] === 'object' && !Array.isArray(sampleJson[audit])) {
+          delete sampleJson[audit];
+        }
+      });
+
+      // Properties set to their type's default value will be omitted in the roundTripJson.
+      // For an explicit list of properties, remove sampleJson values if set to a default.
+      if (Array.isArray(sampleJson.stackPacks) && sampleJson.stackPacks.length === 0) {
+        delete sampleJson.stackPacks;
+      }
+
+      expect(roundTripJson).toMatchObject(sampleJson);
+    });
+
+    it('has the same config values', () => {
+      // Config settings from proto round trip should be a subset of the actual settings.
+      expect(sampleJson.configSettings).toMatchObject(roundTripJson.configSettings);
+    });
+  });
+
+  describe('round trip JSON comparison to everything', () => {
+    it('has the same JSON overall', () => {
+      expect(sampleJson).toMatchObject(roundTripJson);
+    });
   });
 });

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -1337,6 +1337,18 @@
     ],
     "notApplicable": [
       {
+        "id": "accesskeys",
+        "impact": null,
+        "tags": [
+          "best-practice",
+          "cat.keyboard"
+        ],
+        "description": "Ensures every accesskey attribute value is unique",
+        "help": "accesskey attribute value must be unique",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/accesskeys?application=axeAPI",
+        "nodes": []
+      },
+      {
         "id": "aria-allowed-attr",
         "impact": null,
         "tags": [
@@ -1346,20 +1358,7 @@
         ],
         "description": "Ensures ARIA attributes are allowed for an element's role",
         "help": "Elements must only use allowed ARIA attributes",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/aria-allowed-attr?application=axeAPI",
-        "nodes": []
-      },
-      {
-        "id": "aria-dpub-role-fallback",
-        "impact": null,
-        "tags": [
-          "cat.aria",
-          "wcag2a",
-          "wcag131"
-        ],
-        "description": "Ensures unsupported DPUB roles are only used on elements with implicit fallback roles",
-        "help": "Unsupported DPUB ARIA roles should be used on elements with implicit fallback roles",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/aria-dpub-role-fallback?application=axeAPI",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/aria-allowed-attr?application=axeAPI",
         "nodes": []
       },
       {
@@ -1452,22 +1451,7 @@
         ],
         "description": "Ensures <audio> elements have captions",
         "help": "<audio> elements must have a captions track",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/audio-caption?application=axeAPI",
-        "nodes": []
-      },
-      {
-        "id": "button-name",
-        "impact": null,
-        "tags": [
-          "cat.name-role-value",
-          "wcag2a",
-          "wcag412",
-          "section508",
-          "section508.22.a"
-        ],
-        "description": "Ensures buttons have discernible text",
-        "help": "Buttons must have discernible text",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/button-name?application=axeAPI",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/audio-caption?application=axeAPI",
         "nodes": []
       },
       {
@@ -1493,33 +1477,7 @@
         ],
         "description": "Ensures <dt> and <dd> elements are contained by a <dl>",
         "help": "<dt> and <dd> elements must be contained by a <dl>",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/dlitem?application=axeAPI",
-        "nodes": []
-      },
-      {
-        "id": "duplicate-id-active",
-        "impact": null,
-        "tags": [
-          "cat.parsing",
-          "wcag2a",
-          "wcag411"
-        ],
-        "description": "Ensures every id attribute value of active elements is unique",
-        "help": "IDs of active elements must be unique",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/duplicate-id-active?application=axeAPI",
-        "nodes": []
-      },
-      {
-        "id": "duplicate-id-aria",
-        "impact": null,
-        "tags": [
-          "cat.parsing",
-          "wcag2a",
-          "wcag411"
-        ],
-        "description": "Ensures every id attribute value used in ARIA and in labels is unique",
-        "help": "IDs used in ARIA and labels must be unique",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/duplicate-id-aria?application=axeAPI",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/dlitem?application=axeAPI",
         "nodes": []
       },
       {
@@ -1548,20 +1506,7 @@
         ],
         "description": "Ensures the lang attribute of the <html> element has a valid value",
         "help": "<html> element must have a valid value for the lang attribute",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/html-lang-valid?application=axeAPI",
-        "nodes": []
-      },
-      {
-        "id": "html-xml-lang-mismatch",
-        "impact": null,
-        "tags": [
-          "cat.language",
-          "wcag2a",
-          "wcag311"
-        ],
-        "description": "Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page",
-        "help": "HTML elements with lang and xml:lang must have the same base language",
-        "helpUrl": "https://dequeuniversity.com/rules/axe/3.1/html-xml-lang-mismatch?application=axeAPI",
+        "helpUrl": "https://dequeuniversity.com/rules/axe/3.2/html-lang-valid?application=axeAPI",
         "nodes": []
       },
       {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1493,13 +1493,8 @@
       "id": "accesskeys",
       "title": "`[accesskey]` values are unique",
       "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).",
-      "score": 1,
-      "scoreDisplayMode": "binary",
-      "details": {
-        "type": "table",
-        "headings": [],
-        "items": []
-      }
+      "score": null,
+      "scoreDisplayMode": "notApplicable"
     },
     "aria-allowed-attr": {
       "id": "aria-allowed-attr",
@@ -1561,8 +1556,13 @@
       "id": "button-name",
       "title": "Buttons have an accessible name",
       "description": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse).",
-      "score": null,
-      "scoreDisplayMode": "notApplicable"
+      "score": 1,
+      "scoreDisplayMode": "binary",
+      "details": {
+        "type": "table",
+        "headings": [],
+        "items": []
+      }
     },
     "bypass": {
       "id": "bypass",
@@ -3523,7 +3523,7 @@
       "auditRefs": [
         {
           "id": "accesskeys",
-          "weight": 3,
+          "weight": 0,
           "group": "a11y-navigation"
         },
         {
@@ -3568,7 +3568,7 @@
         },
         {
           "id": "button-name",
-          "weight": 0,
+          "weight": 10,
           "group": "a11y-names-labels"
         },
         {
@@ -3742,7 +3742,7 @@
         }
       ],
       "id": "accessibility",
-      "score": 0.38
+      "score": 0.46
     },
     "best-practices": {
       "title": "Best Practices",

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -1115,7 +1115,7 @@
                         "name": "WordPress"
                     }
                 ],
-                "summary": null,
+                "summary": {},
                 "type": "table"
             },
             "id": "js-libraries",
@@ -1247,7 +1247,7 @@
             "details": {
                 "headings": [],
                 "items": [],
-                "summary": null,
+                "summary": {},
                 "type": "table"
             },
             "id": "link-text",
@@ -1903,7 +1903,7 @@
                         "vulnCount": 2.0
                     }
                 ],
-                "summary": null,
+                "summary": {},
                 "type": "table"
             },
             "displayValue": "2 vulnerabilities detected",

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -2,14 +2,9 @@
     "audits": {
         "accesskeys": {
             "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://dequeuniversity.com/rules/axe/3.1/accesskeys?application=lighthouse).",
-            "details": {
-                "headings": [],
-                "items": [],
-                "type": "table"
-            },
             "id": "accesskeys",
-            "score": 1.0,
-            "scoreDisplayMode": "binary",
+            "score": null,
+            "scoreDisplayMode": "notApplicable",
             "title": "`[accesskey]` values are unique"
         },
         "appcache-manifest": {
@@ -152,9 +147,14 @@
         },
         "button-name": {
             "description": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://dequeuniversity.com/rules/axe/3.1/button-name?application=lighthouse).",
+            "details": {
+                "headings": [],
+                "items": [],
+                "type": "table"
+            },
             "id": "button-name",
-            "score": null,
-            "scoreDisplayMode": "notApplicable",
+            "score": 1.0,
+            "scoreDisplayMode": "binary",
             "title": "Buttons have an accessible name"
         },
         "bypass": {
@@ -3163,7 +3163,7 @@
                 {
                     "group": "a11y-navigation",
                     "id": "accesskeys",
-                    "weight": 3.0
+                    "weight": 0.0
                 },
                 {
                     "group": "a11y-aria",
@@ -3208,7 +3208,7 @@
                 {
                     "group": "a11y-names-labels",
                     "id": "button-name",
-                    "weight": 0.0
+                    "weight": 10.0
                 },
                 {
                     "group": "a11y-navigation",
@@ -3383,7 +3383,7 @@
             "description": "These checks highlight opportunities to [improve the accessibility of your web app](https://developers.google.com/web/fundamentals/accessibility). Only a subset of accessibility issues can be automatically detected so manual testing is also encouraged.",
             "id": "accessibility",
             "manualDescription": "These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).",
-            "score": 0.38,
+            "score": 0.46,
             "title": "Accessibility"
         },
         "best-practices": {

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -1115,7 +1115,7 @@
                         "name": "WordPress"
                     }
                 ],
-                "summary": {},
+                "summary": null,
                 "type": "table"
             },
             "id": "js-libraries",
@@ -1247,7 +1247,7 @@
             "details": {
                 "headings": [],
                 "items": [],
-                "summary": {},
+                "summary": null,
                 "type": "table"
             },
             "id": "link-text",
@@ -1903,7 +1903,7 @@
                         "vulnCount": 2.0
                     }
                 ],
-                "summary": {},
+                "summary": null,
                 "type": "table"
             },
             "displayValue": "2 vulnerabilities detected",


### PR DESCRIPTION
**Summary**

Update out of date a11y data. Thought it might be related to https://github.com/GoogleChrome/lighthouse/pull/8823, but that PR did update the the artifacts – not sure what changes these are.

Also, when running `npm run update:sample-json` on master you get the `summary: null` sample change, which broke the proto tests. Some of the tests already had a `beforeAll` that fixed that, so moved that beforeAll to be top-level.
