### PR TITLE
core(logging): change log messages for gathering and trace retrieval

### DIFF
--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -53,6 +53,6 @@ comcast --latency=150 --target-bw=1638
 # Run Lighthouse with its own throttling disabled
 lighthouse --throttling.requestLatencyMs=0 --throttling.downloadThroughputKbps=0 --throttling.uploadThroughputKbps=0 # ...
 
-# Disable the traffic throttling once you see "Retrieving trace"
+# Disable the traffic throttling once you see "Gathering trace"
 comcast --stop
 ```

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -228,14 +228,14 @@ class GatherRunner {
 
     let trace;
     if (passConfig.recordTrace) {
-      const status = {msg: 'Retrieving trace', id: `lh:gather:getTrace`};
+      const status = {msg: 'Gathering trace', id: `lh:gather:getTrace`};
       log.time(status);
       trace = await driver.endTrace();
       log.timeEnd(status);
     }
 
     const status = {
-      msg: 'Retrieving devtoolsLog & network records',
+      msg: 'Gathering devtoolsLog & network records',
       id: `lh:gather:getDevtoolsLog`,
     };
     log.time(status);
@@ -265,7 +265,7 @@ class GatherRunner {
       // Abuse the passContext to pass through gatherer options
       passContext.options = gathererDefn.options || {};
       const status = {
-        msg: `Retrieving setup: ${gatherer.name}`,
+        msg: `Gathering setup: ${gatherer.name}`,
         id: `lh:gather:beforePass:${gatherer.name}`,
       };
       log.time(status, 'verbose');
@@ -295,7 +295,7 @@ class GatherRunner {
       // Abuse the passContext to pass through gatherer options
       passContext.options = gathererDefn.options || {};
       const status = {
-        msg: `Retrieving in-page: ${gatherer.name}`,
+        msg: `Gathering in-page: ${gatherer.name}`,
         id: `lh:gather:pass:${gatherer.name}`,
       };
       log.time(status);
@@ -327,7 +327,7 @@ class GatherRunner {
     for (const gathererDefn of gatherers) {
       const gatherer = gathererDefn.instance;
       const status = {
-        msg: `Retrieving: ${gatherer.name}`,
+        msg: `Gathering: ${gatherer.name}`,
         id: `lh:gather:afterPass:${gatherer.name}`,
       };
       log.time(status);

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -274,7 +274,7 @@ class Runner {
   static async _runAudit(auditDefn, artifacts, sharedAuditContext) {
     const audit = auditDefn.implementation;
     const status = {
-      msg: `Evaluating: ${i18n.getFormatted(audit.meta.title, 'en-US')}`,
+      msg: `Auditing: ${i18n.getFormatted(audit.meta.title, 'en-US')}`,
       id: `lh:audit:${audit.meta.id}`,
     };
     log.time(status);


### PR DESCRIPTION
Looked back at the blame, was interested to see if these steps were named differently before.

Evaluating: https://github.com/GoogleChrome/lighthouse/blame/558a26f8661565caebcbba085b26bf028a89c283/lighthouse-core/runner.js#L94

Retrieving: https://github.com/GoogleChrome/lighthouse/blame/2a4d99c93794b883c70acbe24c332aa658e3a455/lighthouse-core/gather/gather-runner.js#L149

The answer is no :)