### PR TITLE
docs(plugins): add link to field-performance plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -350,5 +350,6 @@ Most artifacts will try to represent as truthfully as possible what was observed
 
 ## Examples
 
+- [Field Performance](https://github.com/treosh/lighthouse-plugin-field-performance) - A plugin to gather and display Chrome UX Report field data
 - [Publisher Ads Audits](https://github.com/googleads/pub-ads-lighthouse-plugin) - a well-written, but complex, plugin
 - [Lighthouse Plugin Recipe](./recipes/lighthouse-plugin-example)


### PR DESCRIPTION
Followup to #9049.. linking here will be useful for prospective plugin authors :)


--------

Also...  

@alekseykulikov @denar90 I was hoping to get some feedback from you guys on writing a plugin.. It looks like there were some rough edges and I think we could improve docs and perhaps some APIs to make it more straightforward for the next plugin :)

What did you notice? What was annoying? What was hard to figure out? What could we document better? :)
