### PR TITLE
report: show metric descriptions by default when errors exist

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -119,7 +119,9 @@ class ReportUIFeatures {
     }
 
     // Show the metric descriptions by default when there is an error.
-    if (report.audits.metrics.errorMessage) {
+    const hasMetricError = report.categories.performance.auditRefs
+      .some(audit => Boolean(audit.group === 'metrics' && report.audits[audit.id].errorMessage));
+    if (hasMetricError) {
       const toggleInputEl = /** @type {HTMLInputElement} */ (
         this._dom.find('.lh-metrics-toggle__input', this._document));
       toggleInputEl.checked = true;

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -119,7 +119,7 @@ class ReportUIFeatures {
     }
 
     // Show the metric descriptions by default when there is an error.
-    const hasMetricError = report.categories.performance.auditRefs
+    const hasMetricError = report.categories.performance && report.categories.performance.auditRefs
       .some(audit => Boolean(audit.group === 'metrics' && report.audits[audit.id].errorMessage));
     if (hasMetricError) {
       const toggleInputEl = /** @type {HTMLInputElement} */ (

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -117,6 +117,13 @@ class ReportUIFeatures {
       this._document.addEventListener('scroll', this._updateStickyHeaderOnScroll);
       window.addEventListener('resize', this._updateStickyHeaderOnScroll);
     }
+
+    // Show the metric descriptions by default when there is an error.
+    if (report.audits.metrics.errorMessage) {
+      const toggleInputEl = /** @type {HTMLInputElement} */ (
+        this._dom.find('.lh-metrics-toggle__input', this._document));
+      toggleInputEl.checked = true;
+    }
   }
 
   /**

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -239,4 +239,19 @@ describe('ReportUIFeatures', () => {
       assert.ok(container.querySelector('.score100'), 'has fireworks treatment');
     });
   });
+
+  describe('metric descriptions', () => {
+    it('with no errors, hide by default', () => {
+      const lhr = JSON.parse(JSON.stringify(sampleResults));
+      const container = render(lhr);
+      assert.ok(!container.querySelector('.lh-metrics-toggle__input').checked);
+    });
+
+    it('with error, show by default', () => {
+      const lhr = JSON.parse(JSON.stringify(sampleResults));
+      lhr.audits.metrics.errorMessage = 'Error.';
+      const container = render(lhr);
+      assert.ok(container.querySelector('.lh-metrics-toggle__input').checked);
+    });
+  });
 });

--- a/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
+++ b/lighthouse-core/test/report/html/renderer/report-ui-features-test.js
@@ -249,7 +249,7 @@ describe('ReportUIFeatures', () => {
 
     it('with error, show by default', () => {
       const lhr = JSON.parse(JSON.stringify(sampleResults));
-      lhr.audits.metrics.errorMessage = 'Error.';
+      lhr.audits['first-contentful-paint'].errorMessage = 'Error.';
       const container = render(lhr);
       assert.ok(container.querySelector('.lh-metrics-toggle__input').checked);
     });


### PR DESCRIPTION
See https://github.com/GoogleChrome/lighthouse/issues/9019#issuecomment-494961806