### PR TITLE
new_audit: add third party entity summary

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -130,6 +130,9 @@ Object {
       "path": "resource-summary",
     },
     Object {
+      "path": "third-party-summary",
+    },
+    Object {
       "path": "manual/pwa-cross-browser",
     },
     Object {
@@ -828,6 +831,11 @@ Object {
         Object {
           "group": "diagnostics",
           "id": "resource-summary",
+          "weight": 0,
+        },
+        Object {
+          "group": "diagnostics",
+          "id": "third-party-summary",
           "weight": 0,
         },
         Object {

--- a/lighthouse-core/audits/bootup-time.js
+++ b/lighthouse-core/audits/bootup-time.js
@@ -78,6 +78,20 @@ class BootupTime extends Audit {
   }
 
   /**
+   * @param {LH.Artifacts.TaskNode} task
+   * @param {Set<string>} jsURLs
+   * @return {string}
+   */
+  static getAttributableURLForTask(task, jsURLs) {
+    const jsURL = task.attributableURLs.find(url => jsURLs.has(url));
+    const fallbackURL = task.attributableURLs[0];
+    let attributableURL = jsURL || fallbackURL;
+    // If we can't find what URL was responsible for this execution, just attribute it to the root page.
+    if (!attributableURL || attributableURL === 'about:blank') attributableURL = 'Other';
+    return attributableURL;
+  }
+
+  /**
    * @param {LH.Artifacts.TaskNode[]} tasks
    * @param {Set<string>} jsURLs
    * @return {Map<string, Object<string, number>>}
@@ -87,12 +101,7 @@ class BootupTime extends Audit {
     const result = new Map();
 
     for (const task of tasks) {
-      const jsURL = task.attributableURLs.find(url => jsURLs.has(url));
-      const fallbackURL = task.attributableURLs[0];
-      let attributableURL = jsURL || fallbackURL;
-      // If we can't find what URL was responsible for this execution, just attribute it to the root page.
-      if (!attributableURL || attributableURL === 'about:blank') attributableURL = 'Other';
-
+      const attributableURL = BootupTime.getAttributableURLForTask(task, jsURLs);
       const timingByGroupId = result.get(attributableURL) || {};
       const originalTime = timingByGroupId[task.group.id] || 0;
       timingByGroupId[task.group.id] = originalTime + task.selfTime;

--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -18,8 +18,10 @@ const UIStrings = {
   title: 'Third-Party Usage',
   /** Description of a Lighthouse audit that identifies the code on the page that the user doesn't control. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
   description: 'Third-party code can significantly impact load performance. ' +
-    'Limit the number of redundant third-party providers and only load third-party code after ' +
+    'Limit the number of redundant third-party providers and try to load third-party code after ' +
     'your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).',
+  /** Label for a table column that displays the name of a third-party provider that potentially links to their website. */
+  columnThirdParty: 'Third-Party',
   /** Label for a table column that displays how much time each row spent executing on the main thread, entries will be the number of milliseconds spent. */
   columnMainThreadTime: 'Main Thread Time',
   /** Summary text for the result of a Lighthouse audit that identifies the code on the page that the user doesn't control. This text summarizes the number of distinct entities that were found on the page. */
@@ -139,7 +141,7 @@ class ThirdPartySummary extends Audit {
 
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [
-      {key: 'entity', itemType: 'link', text: str_(i18n.UIStrings.columnURL)},
+      {key: 'entity', itemType: 'link', text: str_(UIStrings.columnThirdParty)},
       {key: 'transferSize', granularity: 1, itemType: 'bytes',
         text: str_(i18n.UIStrings.columnSize)},
       {key: 'mainThreadTime', granularity: 1, itemType: 'ms',

--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -1,0 +1,150 @@
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const thirdPartyWeb = require('third-party-web/httparchive-nostats-subset');
+
+const Audit = require('./audit.js');
+const BootupTime = require('./bootup-time.js');
+const i18n = require('../lib/i18n/i18n.js');
+const NetworkRecords = require('../computed/network-records.js');
+const MainThreadTasks = require('../computed/main-thread-tasks.js');
+
+const UIStrings = {
+  /** Title of a Lighthouse audit that identifies the code on the page that the user doesn't control. This is shown in a list of audits that Lighthouse generates. */
+  title: 'Third-Party Usage',
+  /** Description of a Lighthouse audit that identifies the code on the page that the user doesn't control. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation. */
+  description: 'Third-party code can significantly impact load performance. ' +
+    'Limit the number of redundant third-party providers and only load third-party code after ' +
+    'your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).',
+  /** Label for a table column that displays how much time each row spent executing on the main thread, entries will be the number of milliseconds spent. */
+  columnMainThreadTime: 'Main Thread Time',
+};
+
+const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+/** @typedef {import("third-party-web").IEntity} ThirdPartyEntity */
+
+class ThirdPartySummary extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'third-party-summary',
+      title: str_(UIStrings.title),
+      description: str_(UIStrings.description),
+      scoreDisplayMode: Audit.SCORING_MODES.INFORMATIVE,
+      requiredArtifacts: ['traces', 'devtoolsLogs'],
+    };
+  }
+
+  /**
+   * `third-party-web` throws when the passed in string doesn't appear to have any domain whatsoever.
+   * We pass in some not-so-url-like things, so make the dependent-code simpler by making this call safe.
+   * @param {string} url
+   * @return {ThirdPartyEntity|undefined}
+   */
+  static getEntitySafe(url) {
+    try {
+      return thirdPartyWeb.getEntity(url);
+    } catch (_) {
+      return undefined;
+    }
+  }
+
+
+  /**
+   *
+   * @param {Array<LH.Artifacts.NetworkRequest>} networkRecords
+   * @param {Array<LH.Artifacts.TaskNode>} mainThreadTasks
+   * @param {number} cpuMultiplier
+   * @return {Map<ThirdPartyEntity, {mainThreadTime: number, transferSize: number}>}
+   */
+  static getSummaryByEntity(networkRecords, mainThreadTasks, cpuMultiplier) {
+    /** @type {Map<ThirdPartyEntity, {mainThreadTime: number, transferSize: number}>} */
+    const entities = new Map();
+
+    for (const request of networkRecords) {
+      const entity = ThirdPartySummary.getEntitySafe(request.url);
+      if (!entity) continue;
+
+      const entityStats = entities.get(entity) || {mainThreadTime: 0, transferSize: 0}
+      entityStats.transferSize += request.transferSize;
+      entities.set(entity, entityStats);
+    }
+
+    const jsURLs = BootupTime.getJavaScriptURLs(networkRecords);
+
+    for (const task of mainThreadTasks) {
+      const attributeableURL = BootupTime.getAttributableURLForTask(task, jsURLs);
+      const entity = ThirdPartySummary.getEntitySafe(attributeableURL);
+      if (!entity) continue;
+
+      const entityStats = entities.get(entity) || {mainThreadTime: 0, transferSize: 0}
+      entityStats.mainThreadTime += task.selfTime * cpuMultiplier;
+      entities.set(entity, entityStats);
+    }
+
+    return entities;
+
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @param {LH.Audit.Context} context
+   * @return {Promise<LH.Audit.Product>}
+   */
+  static async audit(artifacts, context) {
+    const settings = context.settings || {};
+    const trace = artifacts.traces[Audit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const networkRecords = await NetworkRecords.request(devtoolsLog, context);
+    const tasks = await MainThreadTasks.request(trace, context);
+    const multiplier = settings.throttlingMethod === 'simulate' ?
+      settings.throttling.cpuSlowdownMultiplier : 1;
+
+    const summaryByEntity = ThirdPartySummary.getSummaryByEntity(networkRecords, tasks, multiplier);
+
+    const summary = {wastedBytes: 0, wastedMs: 0};
+
+    // Sort by a combined measure of bytes + main thread time.
+    // 1KB ~= 1 ms
+    /** @param {{transferSize: number, mainThreadTime: number}} stats */
+    const computeSortValue = stats => stats.transferSize / 1024 + stats.mainThreadTime;
+
+    const results = Array.from(summaryByEntity.entries())
+      .map(([entity, stats]) => {
+        summary.wastedBytes += stats.transferSize;
+        summary.wastedMs += stats.mainThreadTime;
+
+        return {
+          entity: /** @type {LH.Audit.Details.LinkValue} */ ({
+            type: 'link',
+            text: entity.name,
+            url: entity.homepage || '',
+          }),
+          transferSize: stats.transferSize,
+          mainThreadTime: stats.mainThreadTime,
+        }
+      })
+      .sort((a, b) => computeSortValue(b) - computeSortValue(a));
+
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const headings = [
+      {key: 'entity', itemType: 'link', text: str_(i18n.UIStrings.columnURL)},
+      {key: 'transferSize', granularity: 1, itemType: 'bytes', text: str_(i18n.UIStrings.columnSize)},
+      {key: 'mainThreadTime', granularity: 1, itemType: 'ms', text: str_(UIStrings.columnMainThreadTime)},
+    ];
+
+    return {
+      score: Number(results.length === 0),
+      details: Audit.makeTableDetails(headings, results, summary),
+    };
+  }
+}
+
+module.exports = ThirdPartySummary;

--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -149,3 +149,4 @@ class ThirdPartySummary extends Audit {
 }
 
 module.exports = ThirdPartySummary;
+module.exports.UIStrings = UIStrings;

--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -72,7 +72,7 @@ class ThirdPartySummary extends Audit {
       const entity = ThirdPartySummary.getEntitySafe(request.url);
       if (!entity) continue;
 
-      const entityStats = entities.get(entity) || {mainThreadTime: 0, transferSize: 0}
+      const entityStats = entities.get(entity) || {mainThreadTime: 0, transferSize: 0};
       entityStats.transferSize += request.transferSize;
       entities.set(entity, entityStats);
     }
@@ -84,13 +84,12 @@ class ThirdPartySummary extends Audit {
       const entity = ThirdPartySummary.getEntitySafe(attributeableURL);
       if (!entity) continue;
 
-      const entityStats = entities.get(entity) || {mainThreadTime: 0, transferSize: 0}
+      const entityStats = entities.get(entity) || {mainThreadTime: 0, transferSize: 0};
       entityStats.mainThreadTime += task.selfTime * cpuMultiplier;
       entities.set(entity, entityStats);
     }
 
     return entities;
-
   }
 
   /**
@@ -129,15 +128,17 @@ class ThirdPartySummary extends Audit {
           }),
           transferSize: stats.transferSize,
           mainThreadTime: stats.mainThreadTime,
-        }
+        };
       })
       .sort((a, b) => computeSortValue(b) - computeSortValue(a));
 
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [
       {key: 'entity', itemType: 'link', text: str_(i18n.UIStrings.columnURL)},
-      {key: 'transferSize', granularity: 1, itemType: 'bytes', text: str_(i18n.UIStrings.columnSize)},
-      {key: 'mainThreadTime', granularity: 1, itemType: 'ms', text: str_(UIStrings.columnMainThreadTime)},
+      {key: 'transferSize', granularity: 1, itemType: 'bytes',
+        text: str_(i18n.UIStrings.columnSize)},
+      {key: 'mainThreadTime', granularity: 1, itemType: 'ms',
+        text: str_(UIStrings.columnMainThreadTime)},
     ];
 
     return {

--- a/lighthouse-core/audits/third-party-summary.js
+++ b/lighthouse-core/audits/third-party-summary.js
@@ -22,6 +22,11 @@ const UIStrings = {
     'your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).',
   /** Label for a table column that displays how much time each row spent executing on the main thread, entries will be the number of milliseconds spent. */
   columnMainThreadTime: 'Main Thread Time',
+  /** Summary text for the result of a Lighthouse audit that identifies the code on the page that the user doesn't control. This text summarizes the number of distinct entities that were found on the page. */
+  displayValue: `{itemCount, plural,
+    =1 {1 Third-Party Found}
+    other {# Third-Parties Found}
+  }`,
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -141,8 +146,16 @@ class ThirdPartySummary extends Audit {
         text: str_(UIStrings.columnMainThreadTime)},
     ];
 
+    if (!results.length) {
+      return {
+        score: 1,
+        notApplicable: true,
+      };
+    }
+
     return {
       score: Number(results.length === 0),
+      displayValue: str_(UIStrings.displayValue, {itemCount: results.length}),
       details: Audit.makeTableDetails(headings, results, summary),
     };
   }

--- a/lighthouse-core/config/default-config.js
+++ b/lighthouse-core/config/default-config.js
@@ -199,6 +199,7 @@ const defaultConfig = {
     'offline-start-url',
     'performance-budget',
     'resource-summary',
+    'third-party-summary',
     'manual/pwa-cross-browser',
     'manual/pwa-page-transitions',
     'manual/pwa-each-page-has-url',
@@ -391,6 +392,7 @@ const defaultConfig = {
         {id: 'font-display', weight: 0, group: 'diagnostics'},
         {id: 'performance-budget', weight: 0, group: 'budgets'},
         {id: 'resource-summary', weight: 0, group: 'diagnostics'},
+        {id: 'third-party-summary', weight: 0, group: 'diagnostics'},
         // Audits past this point don't belong to a group and will not be shown automatically
         {id: 'network-requests', weight: 0},
         {id: 'network-rtt', weight: 0},

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -1003,8 +1003,12 @@
     "message": "Main Thread Time",
     "description": "Label for a table column that displays how much time each row spent executing on the main thread, entries will be the number of milliseconds spent."
   },
+  "lighthouse-core/audits/third-party-summary.js | columnThirdParty": {
+    "message": "Third-Party",
+    "description": "Label for a table column that displays the name of a third-party provider that potentially links to their website."
+  },
   "lighthouse-core/audits/third-party-summary.js | description": {
-    "message": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and only load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
+    "message": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
     "description": "Description of a Lighthouse audit that identifies the code on the page that the user doesn't control. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
   },
   "lighthouse-core/audits/third-party-summary.js | displayValue": {

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -999,6 +999,22 @@
     "message": "Tap targets are sized appropriately",
     "description": "Title of a Lighthouse audit that provides detail on whether tap targets (like buttons and links) on a page are big enough so they can easily be tapped on a mobile device. This descriptive title is shown when tap targets are easy to tap on."
   },
+  "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": {
+    "message": "Main Thread Time",
+    "description": "Label for a table column that displays how much time each row spent executing on the main thread, entries will be the number of milliseconds spent."
+  },
+  "lighthouse-core/audits/third-party-summary.js | description": {
+    "message": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and only load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
+    "description": "Description of a Lighthouse audit that identifies the code on the page that the user doesn't control. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation."
+  },
+  "lighthouse-core/audits/third-party-summary.js | displayValue": {
+    "message": "{itemCount, plural,\n    =1 {1 Third-Party Found}\n    other {# Third-Parties Found}\n  }",
+    "description": "Summary text for the result of a Lighthouse audit that identifies the code on the page that the user doesn't control. This text summarizes the number of distinct entities that were found on the page."
+  },
+  "lighthouse-core/audits/third-party-summary.js | title": {
+    "message": "Third-Party Usage",
+    "description": "Title of a Lighthouse audit that identifies the code on the page that the user doesn't control. This is shown in a list of audits that Lighthouse generates."
+  },
   "lighthouse-core/audits/time-to-first-byte.js | description": {
     "message": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).",
     "description": "Description of a Lighthouse audit that tells the user *why* they should reduce the amount of time it takes their server to start responding to requests. This is displayed after a user expands the section to see more. No character length limits. 'Learn More' becomes link text to additional documentation."

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -134,20 +134,31 @@ class DetailsRenderer {
    * @return {Element}
    */
   _renderLink(details) {
-    const allowedProtocols = ['https:', 'http:'];
-    const url = new URL(details.url);
-    if (!allowedProtocols.includes(url.protocol)) {
-      // Fall back to just the link text if protocol not allowed.
-      return this._renderText(details.text);
+    try {
+      const allowedProtocols = ['https:', 'http:'];
+      const url = new URL(details.url);
+      if (!allowedProtocols.includes(url.protocol)) {
+        // Fall back to just the link text if protocol not allowed.
+        return this._renderText(details.text);
+      }
+
+      const a = this._dom.createElement('a');
+      a.rel = 'noopener';
+      a.target = '_blank';
+      a.textContent = details.text;
+      a.href = url.href;
+
+      return a;
+    } catch (err) {
+      if (err.message.startsWith(`Failed to construct 'URL'`) ||
+          err.message.includes('Invalid URL')) {
+        // Fall back to text if URL was invalid.
+        console.warn(`Link details URL "${details.url}" was invalid.`);
+        return this._renderText(details.text);
+      }
+
+      throw err;
     }
-
-    const a = this._dom.createElement('a');
-    a.rel = 'noopener';
-    a.target = '_blank';
-    a.textContent = details.text;
-    a.href = url.href;
-
-    return a;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -134,31 +134,24 @@ class DetailsRenderer {
    * @return {Element}
    */
   _renderLink(details) {
+    const allowedProtocols = ['https:', 'http:'];
+    let url;
     try {
-      const allowedProtocols = ['https:', 'http:'];
-      const url = new URL(details.url);
-      if (!allowedProtocols.includes(url.protocol)) {
-        // Fall back to just the link text if protocol not allowed.
-        return this._renderText(details.text);
-      }
+      url = new URL(details.url);
+    } catch (_) {}
 
-      const a = this._dom.createElement('a');
-      a.rel = 'noopener';
-      a.target = '_blank';
-      a.textContent = details.text;
-      a.href = url.href;
-
-      return a;
-    } catch (err) {
-      if (err.message.startsWith(`Failed to construct 'URL'`) ||
-          err.message.includes('Invalid URL')) {
-        // Fall back to text if URL was invalid.
-        console.warn(`Link details URL "${details.url}" was invalid.`); // eslint-disable-line no-console
-        return this._renderText(details.text);
-      }
-
-      throw err;
+    if (!url || !allowedProtocols.includes(url.protocol)) {
+      // Fall back to just the link text if invalid or protocol not allowed.
+      return this._renderText(details.text);
     }
+
+    const a = this._dom.createElement('a');
+    a.rel = 'noopener';
+    a.target = '_blank';
+    a.textContent = details.text;
+    a.href = url.href;
+
+    return a;
   }
 
   /**

--- a/lighthouse-core/report/html/renderer/details-renderer.js
+++ b/lighthouse-core/report/html/renderer/details-renderer.js
@@ -153,7 +153,7 @@ class DetailsRenderer {
       if (err.message.startsWith(`Failed to construct 'URL'`) ||
           err.message.includes('Invalid URL')) {
         // Fall back to text if URL was invalid.
-        console.warn(`Link details URL "${details.url}" was invalid.`);
+        console.warn(`Link details URL "${details.url}" was invalid.`); // eslint-disable-line no-console
         return this._renderText(details.text);
       }
 

--- a/lighthouse-core/test/audits/third-party-summary-test.js
+++ b/lighthouse-core/test/audits/third-party-summary-test.js
@@ -1,0 +1,58 @@
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+const ThirdPartySummary = require('../../audits/third-party-summary.js');
+
+const pwaTrace = require('../fixtures/traces/progressive-app-m60.json');
+const pwaDevtoolsLog = require('../fixtures/traces/progressive-app-m60.devtools.log.json');
+
+/* eslint-env jest */
+describe('Third party summary', () => {
+  it('surface the discovered third parties', async () => {
+    const artifacts = {
+      devtoolsLogs: {defaultPass: pwaDevtoolsLog},
+      traces: {defaultPass: pwaTrace},
+    };
+
+    const results = await ThirdPartySummary.audit(artifacts, {computedCache: new Map()});
+
+    expect(results.details.items).toEqual([
+      {
+        entity: {
+          text: 'Google Tag Manager',
+          type: 'link',
+          url: 'https://marketingplatform.google.com/about/tag-manager/',
+        },
+        mainThreadTime: 104.70300000000002,
+        transferSize: 30827,
+      },
+      {
+        entity: {
+          text: 'Google Analytics',
+          type: 'link',
+          url: 'https://www.google.com/analytics/analytics/',
+        },
+        mainThreadTime: 87.576,
+        transferSize: 20913,
+      },
+    ]);
+  });
+
+  it('account for simulated throttling', async () => {
+    const artifacts = {
+      devtoolsLogs: {defaultPass: pwaDevtoolsLog},
+      traces: {defaultPass: pwaTrace},
+    };
+
+    const settings = {throttlingMethod: 'simulate', throttling: {cpuSlowdownMultiplier: 4}};
+    const results = await ThirdPartySummary.audit(artifacts, {computedCache: new Map(), settings});
+
+    expect(results.details.items).toHaveLength(2);
+    expect(Math.round(results.details.items[0].mainThreadTime)).toEqual(419);
+    expect(Math.round(results.details.items[1].mainThreadTime)).toEqual(350);
+  });
+});

--- a/lighthouse-core/test/report/html/renderer/details-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/details-renderer-test.js
@@ -346,6 +346,26 @@ describe('DetailsRenderer', () => {
       assert.equal(linkEl.textContent, linkText);
     });
 
+    it('renders link value as text if URL is invalid', () => {
+      const linkText = 'Invalid Link';
+      const linkUrl = 'link nonsense';
+      const link = {
+        type: 'link',
+        text: linkText,
+        url: linkUrl,
+      };
+      const details = {
+        type: 'table',
+        headings: [{key: 'content', itemType: 'link', text: 'Heading'}],
+        items: [{content: link}],
+      };
+
+      const el = renderer.render(details);
+      const linkEl = el.querySelector('td.lh-table-column--link > .lh-text');
+      assert.equal(linkEl.localName, 'div');
+      assert.equal(linkEl.textContent, linkText);
+    });
+
     it('renders node values', () => {
       const node = {
         type: 'node',

--- a/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
+++ b/lighthouse-core/test/report/html/renderer/performance-category-renderer-test.js
@@ -138,7 +138,7 @@ describe('PerfCategoryRenderer', () => {
 
   it('renders the failing diagnostics', () => {
     const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
-    const diagnosticSection = categoryDOM.querySelectorAll('.lh-category > .lh-audit-group')[2];
+    const diagnosticSection = categoryDOM.querySelectorAll('.lh-category > .lh-audit-group')[3];
 
     const diagnosticAudits = category.auditRefs.filter(audit => audit.group === 'diagnostics' &&
         !Util.showAsPassed(audit.result));

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1471,7 +1471,7 @@
     "third-party-summary": {
       "id": "third-party-summary",
       "title": "Third-Party Usage",
-      "description": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and only load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
+      "description": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
       "score": null,
       "scoreDisplayMode": "informative",
       "displayValue": "1 Third-Party Found",
@@ -1481,7 +1481,7 @@
           {
             "key": "entity",
             "itemType": "link",
-            "text": "URL"
+            "text": "Third-Party"
           },
           {
             "key": "transferSize",
@@ -5272,7 +5272,6 @@
         "audits[bootup-time].details.headings[0].text",
         "audits[network-rtt].details.headings[0].text",
         "audits[network-server-latency].details.headings[0].text",
-        "audits[third-party-summary].details.headings[0].text",
         "audits[uses-long-cache-ttl].details.headings[0].text",
         "audits[total-byte-weight].details.headings[0].text",
         "audits[render-blocking-resources].details.headings[0].label",
@@ -5421,6 +5420,9 @@
           },
           "path": "audits[third-party-summary].displayValue"
         }
+      ],
+      "lighthouse-core/audits/third-party-summary.js | columnThirdParty": [
+        "audits[third-party-summary].details.headings[0].text"
       ],
       "lighthouse-core/lib/i18n/i18n.js | columnSize": [
         "audits[third-party-summary].details.headings[1].text",

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1468,6 +1468,51 @@
         ]
       }
     },
+    "third-party-summary": {
+      "id": "third-party-summary",
+      "title": "Third-Party Usage",
+      "description": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and only load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
+      "score": null,
+      "scoreDisplayMode": "informative",
+      "displayValue": "1 Third-Party Found",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "entity",
+            "itemType": "link",
+            "text": "URL"
+          },
+          {
+            "key": "transferSize",
+            "granularity": 1,
+            "itemType": "bytes",
+            "text": "Size"
+          },
+          {
+            "key": "mainThreadTime",
+            "granularity": 1,
+            "itemType": "ms",
+            "text": "Main Thread Time"
+          }
+        ],
+        "items": [
+          {
+            "entity": {
+              "type": "link",
+              "text": "Google CDN",
+              "url": "https://developers.google.com/speed/libraries/"
+            },
+            "transferSize": 30174,
+            "mainThreadTime": 82.74100000000001
+          }
+        ],
+        "summary": {
+          "wastedBytes": 30174,
+          "wastedMs": 82.74100000000001
+        }
+      }
+    },
     "pwa-cross-browser": {
       "id": "pwa-cross-browser",
       "title": "Site works cross-browser",
@@ -3481,6 +3526,11 @@
           "group": "diagnostics"
         },
         {
+          "id": "third-party-summary",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
           "id": "network-requests",
           "weight": 0
         },
@@ -4482,6 +4532,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:audit:third-party-summary",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:pwa-cross-browser",
         "duration": 100,
         "entryType": "measure"
@@ -5216,6 +5272,7 @@
         "audits[bootup-time].details.headings[0].text",
         "audits[network-rtt].details.headings[0].text",
         "audits[network-server-latency].details.headings[0].text",
+        "audits[third-party-summary].details.headings[0].text",
         "audits[uses-long-cache-ttl].details.headings[0].text",
         "audits[total-byte-weight].details.headings[0].text",
         "audits[render-blocking-resources].details.headings[0].label",
@@ -5350,6 +5407,33 @@
           },
           "path": "audits[resource-summary].displayValue"
         }
+      ],
+      "lighthouse-core/audits/third-party-summary.js | title": [
+        "audits[third-party-summary].title"
+      ],
+      "lighthouse-core/audits/third-party-summary.js | description": [
+        "audits[third-party-summary].description"
+      ],
+      "lighthouse-core/audits/third-party-summary.js | displayValue": [
+        {
+          "values": {
+            "itemCount": 1
+          },
+          "path": "audits[third-party-summary].displayValue"
+        }
+      ],
+      "lighthouse-core/lib/i18n/i18n.js | columnSize": [
+        "audits[third-party-summary].details.headings[1].text",
+        "audits[uses-long-cache-ttl].details.headings[2].text",
+        "audits[total-byte-weight].details.headings[1].text",
+        "audits[render-blocking-resources].details.headings[1].label",
+        "audits[unminified-javascript].details.headings[1].label",
+        "audits[uses-webp-images].details.headings[2].label",
+        "audits[uses-text-compression].details.headings[1].label",
+        "audits[tap-targets].details.headings[1].text"
+      ],
+      "lighthouse-core/audits/third-party-summary.js | columnMainThreadTime": [
+        "audits[third-party-summary].details.headings[2].text"
       ],
       "lighthouse-core/audits/accessibility/accesskeys.js | title": [
         "audits.accesskeys.title"
@@ -5585,15 +5669,6 @@
       ],
       "lighthouse-core/lib/i18n/i18n.js | columnCacheTTL": [
         "audits[uses-long-cache-ttl].details.headings[1].text"
-      ],
-      "lighthouse-core/lib/i18n/i18n.js | columnSize": [
-        "audits[uses-long-cache-ttl].details.headings[2].text",
-        "audits[total-byte-weight].details.headings[1].text",
-        "audits[render-blocking-resources].details.headings[1].label",
-        "audits[unminified-javascript].details.headings[1].label",
-        "audits[uses-webp-images].details.headings[2].label",
-        "audits[uses-text-compression].details.headings[1].label",
-        "audits[tap-targets].details.headings[1].text"
       ],
       "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | title": [
         "audits[total-byte-weight].title"

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "robots-parser": "^2.0.1",
     "semver": "^5.3.0",
     "speedline-core": "1.4.2",
+    "third-party-web": "^0.8.2",
     "update-notifier": "^2.5.0",
     "ws": "3.3.2",
     "yargs": "3.32.0",

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -2558,6 +2558,51 @@
             "scoreDisplayMode": "binary",
             "title": "Does not set an address-bar theme color"
         },
+        "third-party-summary": {
+            "description": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and only load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
+            "details": {
+                "headings": [
+                    {
+                        "itemType": "link",
+                        "key": "entity",
+                        "text": "URL"
+                    },
+                    {
+                        "granularity": 1.0,
+                        "itemType": "bytes",
+                        "key": "transferSize",
+                        "text": "Size"
+                    },
+                    {
+                        "granularity": 1.0,
+                        "itemType": "ms",
+                        "key": "mainThreadTime",
+                        "text": "Main Thread Time"
+                    }
+                ],
+                "items": [
+                    {
+                        "entity": {
+                            "text": "Google CDN",
+                            "type": "link",
+                            "url": "https://developers.google.com/speed/libraries/"
+                        },
+                        "mainThreadTime": 82.74100000000001,
+                        "transferSize": 30174.0
+                    }
+                ],
+                "summary": {
+                    "wastedBytes": 30174.0,
+                    "wastedMs": 82.74100000000001
+                },
+                "type": "table"
+            },
+            "displayValue": "1 Third-Party Found",
+            "id": "third-party-summary",
+            "score": null,
+            "scoreDisplayMode": "informative",
+            "title": "Third-Party Usage"
+        },
         "time-to-first-byte": {
             "description": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/ttfb).",
             "details": {
@@ -3610,6 +3655,11 @@
                     "weight": 0.0
                 },
                 {
+                    "group": "diagnostics",
+                    "id": "third-party-summary",
+                    "weight": 0.0
+                },
+                {
                     "id": "network-requests",
                     "weight": 0.0
                 },
@@ -4374,6 +4424,12 @@
                 "duration": 100.0,
                 "entryType": "measure",
                 "name": "lh:audit:resource-summary",
+                "startTime": 0.0
+            },
+            {
+                "duration": 100.0,
+                "entryType": "measure",
+                "name": "lh:audit:third-party-summary",
                 "startTime": 0.0
             },
             {

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -2559,13 +2559,13 @@
             "title": "Does not set an address-bar theme color"
         },
         "third-party-summary": {
-            "description": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and only load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
+            "description": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
             "details": {
                 "headings": [
                     {
                         "itemType": "link",
                         "key": "entity",
-                        "text": "URL"
+                        "text": "Third-Party"
                     },
                     {
                         "granularity": 1.0,

--- a/types/audit-details.d.ts
+++ b/types/audit-details.d.ts
@@ -145,6 +145,7 @@ declare global {
       /**
        * A value used within a details object, intended to be displayed as a
        * link with text, regardless of the controlling heading's valueType.
+       * If URL is the empty string, fallsback to a basic `TextValue`.
        */
       export interface LinkValue {
         type: 'link',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8063,6 +8063,11 @@ text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+third-party-web@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.8.2.tgz#9a13841174a2b2333a15233cb6dbf6553c03a7be"
+  integrity sha512-HVsNbtlvshQ7X+HwiMvVbes+aH5KwvfncUcUR1EaJ9qENZO/I3fNysunKBUtJZeVoIYq3HHKqeDayarTmBtdPw==
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"


### PR DESCRIPTION
**Summary**
Shines the light on third party impact!! Starting small with just a diagnostic audit that says "here are the ones you're using." I'd love to get more aggressive and in the users' face about alternatives/rankings/stats etc at some point, but this seems pretty decent start.

I'm using the `httparchive-no-stats` subset of the `third-party-web` dataset. It only includes the origins we actually observed in `HTTPArchive` and deletes the stats to cut down on bundle size impact (weighs in at 65KB compared to 202KB).

This is what it looks like for The Verge 😮 
![image](https://user-images.githubusercontent.com/2301202/58433295-2bc2d680-807c-11e9-922d-f97e08ad7ef6.png)

(and another 10 more got cutoff)

