### PR TITLE
core(budget): support additional first-party domains

### DIFF
--- a/lighthouse-core/config/budget.js
+++ b/lighthouse-core/config/budget.js
@@ -31,6 +31,22 @@ function isNumber(val) {
   return typeof val === 'number' && !isNaN(val);
 }
 
+/**
+ * @param {unknown} val
+ * @return {val is string}
+ */
+function isString(val) {
+  return typeof val === 'string';
+}
+
+/**
+ * @param {unknown} arr
+ * @return {arr is string[]}
+ */
+function isArrayOfStrings(arr) {
+  return Array.isArray(arr) && arr.every(isString);
+}
+
 class Budget {
   /**
    * Asserts that obj has no own properties, throwing a nice error message if it does.
@@ -147,8 +163,16 @@ class Budget {
       /** @type {LH.Budget} */
       const budget = {};
 
-      const {resourceSizes, resourceCounts, timings, ...invalidRest} = b;
+      const {ownDomains, resourceSizes, resourceCounts, timings, ...invalidRest} = b;
       Budget.assertNoExcessProperties(invalidRest, 'Budget');
+
+      if (isArrayOfStrings(ownDomains)) {
+        budget.ownDomains = ownDomains;
+        Budget.assertNoDuplicateStrings(budget.ownDomains,
+          `budgets[${index}].ownDomains`);
+      } else if (ownDomains !== undefined) {
+        throw new Error(`Invalid ownDomains entry in budget at index ${index}`);
+      }
 
       if (isArrayOfUnknownObjects(resourceSizes)) {
         budget.resourceSizes = resourceSizes.map(Budget.validateResourceBudget);

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -373,6 +373,11 @@ class Util {
       return value;
     }
 
+    // Default protocol to https if missing
+    if (!/:\/\//.test(value)) {
+      value = 'https://' + value;
+    }
+
     return new URL(value);
   }
 

--- a/lighthouse-core/test/audits/resource-summary-test.js
+++ b/lighthouse-core/test/audits/resource-summary-test.js
@@ -14,7 +14,7 @@ describe('Performance: Resource summary audit', () => {
   let artifacts;
   let context;
   beforeEach(() => {
-    context = {computedCache: new Map()};
+    context = {computedCache: new Map(), settings: {}};
 
     artifacts = {
       devtoolsLogs: {

--- a/lighthouse-core/test/computed/resource-summary-test.js
+++ b/lighthouse-core/test/computed/resource-summary-test.js
@@ -28,7 +28,7 @@ describe('Resource summary computed', () => {
       {url: 'http://cdn.example.com/script.js', resourceType: 'Script', transferSize: 50},
       {url: 'http://third-party.com/file.jpg', resourceType: 'Image', transferSize: 70},
     ]);
-    context = {computedCache: new Map()};
+    context = {computedCache: new Map(), settings: {}};
   });
 
   it('includes all resource types, regardless of whether page contains them', async () => {
@@ -55,7 +55,7 @@ describe('Resource summary computed', () => {
       {url: 'http://third-party.com/another-file.html', resourceType: 'manifest', transferSize: 50},
     ];
 
-    const result = ComputedResourceSummary.summarize(networkRecords, networkRecords[0].url);
+    const result = ComputedResourceSummary.summarize(networkRecords, [networkRecords[0].url]);
     assert.equal(result.other.count, 1);
     assert.equal(result.other.size, 50);
   });

--- a/types/budget.d.ts
+++ b/types/budget.d.ts
@@ -11,6 +11,8 @@ declare global {
      * More info: https://github.com/GoogleChrome/lighthouse/issues/6053#issuecomment-428385930
      */
     export interface Budget {
+      /** Own domains, not to count as third-party */
+      ownDomains?: Array<string>;
       /** Budgets based on resource count. */
       resourceCounts?: Array<Budget.ResourceBudget>;
       /** Budgets based on resource size. */


### PR DESCRIPTION
**Summary**

This PR adds a new optional field in `budget.json` named `ownDomains` (open for suggestions) to allow specifying additional first-party domains (that won't be considered third-party while budgeting).

Pages can load their assets from a CDN that has a non-matching domain (not even at the root level). This change will make it possible to use third-party budgets without incorrectly including first-party requests for these pages.

Examples:
* `https://www.vrbo.com/vacation-rentals/usa` -> `https://csvcus.homeaway.com/...`
* `https://www.hotels.com/` -> `https://a.cdn-hotels.com/...`

Open to naming suggestions or moving this elsewhere in `budget.json`. 

Please note I'm raising this PR before adding more tests to get some feedback first.

**Related Issues/PRs**
N/A
