### PR TITLE
core(runner): fix missing timing properties in the browser

### DIFF
--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -186,6 +186,8 @@ class Runner {
     // resolution.
     .map(entry => {
       return /** @type {PerformanceEntry} */ ({
+        // Don't spread entry because browser PerformanceEntries can't be spread.
+        // https://github.com/GoogleChrome/lighthouse/issues/8638
         startTime: parseFloat(entry.startTime.toFixed(2)),
         name: entry.name,
         duration: parseFloat(entry.duration.toFixed(2)),

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -186,7 +186,8 @@ class Runner {
     // resolution.
     .map(entry => {
       return /** @type {PerformanceEntry} */ ({
-        ...entry,
+        name: entry.name,
+        entryType: entry.entryType,
         duration: parseFloat(entry.duration.toFixed(2)),
         startTime: parseFloat(entry.startTime.toFixed(2)),
       });

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -186,10 +186,10 @@ class Runner {
     // resolution.
     .map(entry => {
       return /** @type {PerformanceEntry} */ ({
-        name: entry.name,
-        entryType: entry.entryType,
-        duration: parseFloat(entry.duration.toFixed(2)),
         startTime: parseFloat(entry.startTime.toFixed(2)),
+        name: entry.name,
+        duration: parseFloat(entry.duration.toFixed(2)),
+        entryType: entry.entryType,
       });
     });
     const runnerEntry = timingEntries.find(e => e.name === 'lh:runner:run');


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
PerformanceEntries in Lightrider (and the extension) had no names and no entryTypes.  This manifested as a 0 `timing.total` in the API as well.  

@brendankenny found that browser PerformanceEntry objects do not spread, but in Node they do b/c of the marky lib.  So, simple fix to explicitly call out the `name` and `entryType` fields when parsing the entries.  This will also populate the missing `lh:runner:run` entry to fill in `timing.total`.

**Related Issues/PRs**
fixes: #8638 