### PR TITLE
devtools: do not query system preferences for dark mode

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -92,7 +92,9 @@ class ReportUIFeatures {
     topbarLogo.addEventListener('click', () => this._toggleDarkTheme());
 
     let turnOffTheLights = false;
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    // Do not query the system preferences for DevTools - DevTools should only apply dark theme
+    // if dark is selected in the settings panel.
+    if (!this._dom.isDevTools() && window.matchMedia('(prefers-color-scheme: dark)').matches) {
       turnOffTheLights = true;
     }
 


### PR DESCRIPTION
Currently, if DevTools is using the light theme and the OS is configured to use dark, our media query check causes the report to be dark. Nothing else in DevTools uses a similar media query, so perhaps we should skip this feature for consistency.