### PR TITLE
core(manifest-parser): handle blob manifests

### DIFF
--- a/lighthouse-core/lib/manifest-parser.js
+++ b/lighthouse-core/lib/manifest-parser.js
@@ -332,7 +332,7 @@ function parseIcons(jsonInput, manifestUrl) {
     raw,
     value,
     warning: ignoredIconsWithWarnings.length ?
-      'WARNING: Some icons were ignored due to warnings.' : '',
+      'WARNING: Some icons were ignored due to warnings.' : undefined,
   };
 }
 

--- a/lighthouse-core/lib/manifest-parser.js
+++ b/lighthouse-core/lib/manifest-parser.js
@@ -321,7 +321,7 @@ function parseIcons(jsonInput, manifestUrl) {
       const possibleWarnings = [icon.warning, icon.value.type.warning, icon.value.src.warning,
         icon.value.sizes.warning, icon.value.density.warning].filter(Boolean);
       const hasSrc = !!icon.value.src.value;
-        return !!possibleWarnings.length && !hasSrc;
+      return !!possibleWarnings.length && !hasSrc;
     });
 
   const value = parsedIcons

--- a/lighthouse-core/lib/manifest-parser.js
+++ b/lighthouse-core/lib/manifest-parser.js
@@ -470,8 +470,8 @@ function parse(string, manifestUrl, documentUrl) {
   let manifestUrlWarning;
   try {
     const manifestUrlParsed = new URL(manifestUrl);
-    if (manifestUrlParsed.protocol !== 'https:') {
-      manifestUrlWarning = `ERROR: manifest URL not available over https`;
+    if (!manifestUrlParsed.protocol.startsWith('http')) {
+      manifestUrlWarning = `WARNING: manifest URL not available over a valid network protocol`;
     }
   } catch (_) {
     manifestUrlWarning = `ERROR: invalid manifest URL ${manifestUrl}`;

--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -11,6 +11,7 @@ const manifestStub = require('../fixtures/manifest.json');
 
 const EXAMPLE_MANIFEST_URL = 'https://example.com/manifest.json';
 const EXAMPLE_DOC_URL = 'https://example.com/index.html';
+const EXAMPLE_MANIFEST_BLOB_URL = 'blob:https://example.com/manifest.json';
 
 /**
  * Simple manifest parsing helper when the manifest URLs aren't material to the
@@ -45,6 +46,16 @@ describe('Manifest Parser', function() {
     // TODO:
     // related_applications
     // prefer_related_applications
+  });
+
+  it('should warn on invalid manifest parser URL', function() {
+    const parsedManifest = manifestParser('{}', 'not a URL', EXAMPLE_DOC_URL);
+    assert.ok(parsedManifest.warning);
+  });
+
+  it('should warn on valid but non-HTTPS manifest parser URL', function() {
+    const parsedManifest = manifestParser('{}', EXAMPLE_MANIFEST_BLOB_URL, EXAMPLE_DOC_URL);
+    assert.ok(parsedManifest.warning);
   });
 
   describe('icon parsing', function() {
@@ -106,6 +117,18 @@ describe('Manifest Parser', function() {
         }],
       });
       const parsedManifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
+      const icons = parsedManifest.value.icons;
+      assert.equal(icons.value.length, 0);
+    });
+
+    it('parses icons and discards any with invalid base URL values', () => {
+      const manifestSrc = JSON.stringify({
+        icons: [{
+          src: '/valid/path',
+        }],
+      });
+      const parsedManifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_BLOB_URL,
+        EXAMPLE_DOC_URL);
       const icons = parsedManifest.value.icons;
       assert.equal(icons.value.length, 0);
     });

--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -54,7 +54,7 @@ describe('Manifest Parser', function() {
       .toEqual('ERROR: invalid manifest URL: \'not a URL\'');
   });
 
-  it('should warn on valid but non-HTTPS manifest parser URL', function() {
+  it('should warn on valid but non-(HTTP|HTTPS) manifest parser URL', function() {
     const parsedManifest = manifestParser('{}', EXAMPLE_MANIFEST_BLOB_URL, EXAMPLE_DOC_URL);
     expect(parsedManifest.warning)
       .toEqual('WARNING: manifest URL not available over a valid network protocol');

--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -28,21 +28,21 @@ function noUrlManifestParser(manifestSrc) {
 describe('Manifest Parser', function() {
   it('should not parse empty string input', function() {
     const parsedManifest = noUrlManifestParser('');
-    assert.ok(parsedManifest.warning);
+    expect(parsedManifest.warning)
+      .toEqual('ERROR: file isn\'t valid JSON: SyntaxError: Unexpected end of JSON input');
   });
 
   it('accepts empty dictionary', function() {
     const parsedManifest = noUrlManifestParser('{}');
-    assert(!parsedManifest.warning);
-    assert.equal(parsedManifest.value.name.value, undefined);
-    assert.equal(parsedManifest.value.short_name.value, undefined);
-    assert.equal(parsedManifest.value.start_url.value, EXAMPLE_DOC_URL);
-    assert.equal(parsedManifest.value.display.value, 'browser');
-    assert.equal(parsedManifest.value.orientation.value, undefined);
-    assert.equal(parsedManifest.value.theme_color.value, undefined);
-    assert.equal(parsedManifest.value.background_color.value, undefined);
-    assert.ok(Array.isArray(parsedManifest.value.icons.value));
-    assert.ok(parsedManifest.value.icons.value.length === 0);
+    expect(parsedManifest.warning).toBeUndefined();
+    expect(parsedManifest.value.name.value).toBe(undefined);
+    expect(parsedManifest.value.short_name.value).toBe(undefined);
+    expect(parsedManifest.value.start_url.value).toBe(EXAMPLE_DOC_URL);
+    expect(parsedManifest.value.display.value).toBe('browser');
+    expect(parsedManifest.value.orientation.value).toBe(undefined);
+    expect(parsedManifest.value.theme_color.value).toBe(undefined);
+    expect(parsedManifest.value.background_color.value).toBe(undefined);
+    expect(parsedManifest.value.icons.value).toHaveLength(0);
     // TODO:
     // related_applications
     // prefer_related_applications
@@ -50,20 +50,26 @@ describe('Manifest Parser', function() {
 
   it('should warn on invalid manifest parser URL', function() {
     const parsedManifest = manifestParser('{}', 'not a URL', EXAMPLE_DOC_URL);
-    assert.ok(parsedManifest.warning);
+    expect(parsedManifest.warning)
+      .toEqual('ERROR: invalid manifest URL: \'not a URL\'');
   });
 
   it('should warn on valid but non-HTTPS manifest parser URL', function() {
     const parsedManifest = manifestParser('{}', EXAMPLE_MANIFEST_BLOB_URL, EXAMPLE_DOC_URL);
-    assert.ok(parsedManifest.warning);
+    expect(parsedManifest.warning)
+      .toEqual('WARNING: manifest URL not available over a valid network protocol');
   });
 
   describe('icon parsing', function() {
     // 9.7
     it('gives an empty array and an error for erroneous icons entry', () => {
-      const parsedManifest = manifestParser('{"icons": {"16": "img/icons/icon16.png"}}',
-          EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-      assert.ok(!parsedManifest.warning);
+      const parsedManifest = manifestParser(
+        '{"icons": {"16": "img/icons/icon16.png"}}',
+        EXAMPLE_MANIFEST_URL,
+        EXAMPLE_DOC_URL
+      );
+
+      expect(parsedManifest.warning).toBeUndefined();
       const icons = parsedManifest.value.icons;
       assert.ok(Array.isArray(icons.value));
       assert.equal(icons.value.length, 0);
@@ -71,9 +77,8 @@ describe('Manifest Parser', function() {
     });
 
     it('gives an empty array and no error for missing icons entry', () => {
-      const parsedManifest = manifestParser('{}',
-          EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-      assert.ok(!parsedManifest.warning);
+      const parsedManifest = manifestParser('{}', EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
+      expect(parsedManifest.warning).toBeUndefined();
       const icons = parsedManifest.value.icons;
       assert.ok(Array.isArray(icons.value));
       assert.equal(icons.value.length, 0);
@@ -81,9 +86,12 @@ describe('Manifest Parser', function() {
     });
 
     it('parses basic string', function() {
-      const parsedManifest = manifestParser('{"icons": [{"src": "192.png", "sizes": "192x192"}]}',
-          EXAMPLE_MANIFEST_URL, EXAMPLE_DOC_URL);
-      assert(!parsedManifest.warning);
+      const parsedManifest = manifestParser(
+        '{"icons": [{"src": "192.png", "sizes": "192x192"}]}',
+        EXAMPLE_MANIFEST_URL,
+        EXAMPLE_DOC_URL
+      );
+      expect(parsedManifest.warning).toBeUndefined();
       const icons = parsedManifest.value.icons;
       assert(!icons.warning);
       const icon192 = icons.value[0];
@@ -92,9 +100,12 @@ describe('Manifest Parser', function() {
     });
 
     it('finds four icons in the stub manifest', function() {
-      const parsedManifest = manifestParser(JSON.stringify(manifestStub), EXAMPLE_MANIFEST_URL,
-          EXAMPLE_DOC_URL);
-      assert(!parsedManifest.warning);
+      const parsedManifest = manifestParser(
+        JSON.stringify(manifestStub),
+        EXAMPLE_MANIFEST_URL,
+        EXAMPLE_DOC_URL
+      );
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.icons.value.length, 4);
     });
 
@@ -130,7 +141,8 @@ describe('Manifest Parser', function() {
       const parsedManifest = manifestParser(manifestSrc, EXAMPLE_MANIFEST_BLOB_URL,
         EXAMPLE_DOC_URL);
       const icons = parsedManifest.value.icons;
-      assert.equal(icons.value.length, 0);
+      expect(icons.value).toHaveLength(0);
+      expect(icons.warning).toEqual('WARNING: Some icons were ignored due to warnings.');
     });
 
     it('parses icons and discards any with undefined or empty string src values', () => {
@@ -162,23 +174,23 @@ describe('Manifest Parser', function() {
   describe('name parsing', function() {
     it('parses basic string', function() {
       const parsedManifest = noUrlManifestParser('{"name":"foo"}');
-      assert(!parsedManifest.warning);
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.name.value, 'foo');
     });
 
     it('trims whitespaces', function() {
       const parsedManifest = noUrlManifestParser('{"name":" foo "}');
-      assert(!parsedManifest.warning);
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.name.value, 'foo');
     });
 
-    it('doesn\'t parse non-string', function() {
+    it("doesn't parse non-string", function() {
       let parsedManifest = noUrlManifestParser('{"name": {} }');
-      assert(!parsedManifest.warning);
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.name.value, undefined);
 
       parsedManifest = noUrlManifestParser('{"name": 42 }');
-      assert(!parsedManifest.warning);
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.name.value, undefined);
     });
   });
@@ -186,23 +198,23 @@ describe('Manifest Parser', function() {
   describe('short_name parsing', function() {
     it('parses basic string', function() {
       const parsedManifest = noUrlManifestParser('{"short_name":"foo"}');
-      assert(!parsedManifest.warning);
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.short_name.value, 'foo');
     });
 
     it('trims whitespaces', function() {
       const parsedManifest = noUrlManifestParser('{"short_name":" foo "}');
-      assert(!parsedManifest.warning);
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.short_name.value, 'foo');
     });
 
-    it('doesn\'t parse non-string', function() {
+    it("doesn't parse non-string", function() {
       let parsedManifest = noUrlManifestParser('{"short_name": {} }');
-      assert(!parsedManifest.warning);
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.short_name.value, undefined);
 
       parsedManifest = noUrlManifestParser('{"short_name": 42 }');
-      assert(!parsedManifest.warning);
+      expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.short_name.value, undefined);
     });
   });

--- a/lighthouse-core/test/lib/manifest-parser-test.js
+++ b/lighthouse-core/test/lib/manifest-parser-test.js
@@ -184,7 +184,7 @@ describe('Manifest Parser', function() {
       assert.equal(parsedManifest.value.name.value, 'foo');
     });
 
-    it("doesn't parse non-string", function() {
+    it('doesn\'t parse non-string', function() {
       let parsedManifest = noUrlManifestParser('{"name": {} }');
       expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.name.value, undefined);
@@ -208,7 +208,7 @@ describe('Manifest Parser', function() {
       assert.equal(parsedManifest.value.short_name.value, 'foo');
     });
 
-    it("doesn't parse non-string", function() {
+    it('doesn\'t parse non-string', function() {
       let parsedManifest = noUrlManifestParser('{"short_name": {} }');
       expect(parsedManifest.warning).toBeUndefined();
       assert.equal(parsedManifest.value.short_name.value, undefined);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
A manifest can be fetched over a `blob:` URL but all of its URLs will be invalid. Handle the case where we have invalid URLs and add a toplevel manifest warning when it's bloby

**Related Issues/PRs**
closes #9087
