### PR TITLE
misc: release script should commit with format vx.y.z

### DIFF
--- a/lighthouse-core/scripts/release/prepare-commit.sh
+++ b/lighthouse-core/scripts/release/prepare-commit.sh
@@ -64,7 +64,7 @@ if [[ $(echo "$NEW_CONTRIBUTORS" | wc -l) -gt 1 ]]; then
 fi
 
 git add changelog.md lighthouse-core/test/results/ proto/
-git commit -m "$NEW_VERSION"
+git commit -m "v$NEW_VERSION"
 
 echo "Version bump commit ready on the ${TXT_BOLD}$BRANCH_NAME${TXT_RESET} branch!"
 


### PR DESCRIPTION
This matches expectation in `lighthouse-core/scripts/release/prepare-package.sh`.