### PR TITLE
core(cli): accept flags from path

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -89,6 +89,7 @@ function getFlags(manualArgv) {
         ],
         'Configuration:')
       .describe({
+        'cli-flags-path': 'The path to a JSON file that contains the desired CLI flags to apply. Flags specified at the command line will still override the file-based ones.',
         // We don't allowlist specific locales. Why? So we can support the user who requests 'es-MX' (unsupported) and we'll fall back to 'es' (supported)
         'locale': 'The locale/language the report should be formatted in',
         'enable-error-reporting':

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -62,6 +62,9 @@ function getFlags(manualArgv) {
           'lighthouse <url> --only-categories=performance,pwa',
           'Only run specific categories.')
 
+      // Accept a file for all of these flags.
+      .config('cli-settings-path')
+
       // List of options
       .group(['verbose', 'quiet'], 'Logging:')
       .describe({

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -62,8 +62,16 @@ function getFlags(manualArgv) {
           'lighthouse <url> --only-categories=performance,pwa',
           'Only run specific categories.')
 
-      // Accept a file for all of these flags.
-      .config('cli-settings-path')
+      /**
+       * Also accept a file for all of these flags. Yargs will merge in and override the file-based
+       * flags with the command-line flags.
+       *
+       * i.e. when command-line `--throttling-method=provided` and file `throttlingMethod: "devtools"`,
+       * throttlingMethod will be `provided`.
+       *
+       * @see https://github.com/yargs/yargs/blob/a6e67f15a61558d0ba28bfe53385332f0ce5d431/docs/api.md#config
+       */
+      .config('cli-flags-path')
 
       // List of options
       .group(['verbose', 'quiet'], 'Logging:')

--- a/lighthouse-cli/test/cli/cli-flags-test.js
+++ b/lighthouse-cli/test/cli/cli-flags-test.js
@@ -29,6 +29,23 @@ describe('CLI bin', function() {
     });
   });
 
+  it('settings are accepted from a file path', () => {
+    const flags = getFlags([
+      'http://www.example.com',
+      `--cli-settings-path="${__dirname}/../fixtures/cli-settings-path.json"`,
+    ].join(' '));
+
+    expect(flags).toMatchObject({
+      onlyCategories: ['performance', 'seo'],
+      chromeFlags: '--window-size 800,600',
+      throttlingMethod: 'devtools',
+      throttling: {
+        requestLatencyMs: 700,
+        cpuSlowdownMultiplier: 6,
+      },
+    });
+  });
+
   it('array values support csv when appropriate', () => {
     const flags = getFlags([
       'http://www.example.com',

--- a/lighthouse-cli/test/cli/cli-flags-test.js
+++ b/lighthouse-cli/test/cli/cli-flags-test.js
@@ -32,10 +32,12 @@ describe('CLI bin', function() {
   it('settings are accepted from a file path', () => {
     const flags = getFlags([
       'http://www.example.com',
-      `--cli-settings-path="${__dirname}/../fixtures/cli-settings-path.json"`,
+      `--cli-flags-path="${__dirname}/../fixtures/cli-flags-path.json"`,
+      '--budgets-path=path/to/my/budget-from-command-line.json', // this should override the config value
     ].join(' '));
 
     expect(flags).toMatchObject({
+      budgetsPath: 'path/to/my/budget-from-command-line.json',
       onlyCategories: ['performance', 'seo'],
       chromeFlags: '--window-size 800,600',
       throttlingMethod: 'devtools',

--- a/lighthouse-cli/test/fixtures/cli-flags-path.json
+++ b/lighthouse-cli/test/fixtures/cli-flags-path.json
@@ -1,4 +1,5 @@
 {
+  "budgetPath": "path/to/my/budget-from-config.json",
   "onlyCategories": ["performance", "seo"],
   "chromeFlags": "--window-size 800,600",
   "throttling-method": "devtools",

--- a/lighthouse-cli/test/fixtures/cli-settings-path.json
+++ b/lighthouse-cli/test/fixtures/cli-settings-path.json
@@ -1,0 +1,9 @@
+{
+  "onlyCategories": ["performance", "seo"],
+  "chromeFlags": "--window-size 800,600",
+  "throttling-method": "devtools",
+  "throttling": {
+    "requestLatencyMs": 700,
+    "cpuSlowdownMultiplier": 6
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,8 @@ Output:
 Options:
   --help                        Show help                                                                                                  [boolean]
   --version                     Show version number                                                                                        [boolean]
+  --cli-flags-path              The path to a JSON file that contains the desired CLI flags to apply.
+                                Flags specified at the command line will still override the file-based ones.
   --blocked-url-patterns        Block any network requests to the specified URL patterns                                                     [array]
   --disable-storage-reset       Disable clearing the browser cache and other storage APIs before a run                                     [boolean]
   --throttling-method                  Controls throttling method         [choices: "devtools", "provided", "simulate"]


### PR DESCRIPTION
**Summary**
In order to easily accept an LH settings object over in Lighthouse CI, we need a way to easily passthrough the object. This can be done with config today but you miss out on some nice features like being able to use `--budgets-path`, set the `--output-path`, etc. 

This is a low-cost way to enable consumers of the LH CLI that run in a child process programmatic access to all our CLI flags without manually (and error-pronely) constructing an argument list.
