### PR TITLE
tests(smokehouse): always assert lhr.runtimeError

### DIFF
--- a/lighthouse-cli/test/smokehouse/error-config.js
+++ b/lighthouse-cli/test/smokehouse/error-config.js
@@ -14,6 +14,8 @@ module.exports = {
     maxWaitForLoad: 5000,
     onlyAudits: [
       'first-contentful-paint',
+      // TODO: this audit collects a non-base artifact, allowing the runtimeError to be collected.
+      'content-width',
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -14,7 +14,8 @@ module.exports = [
       requestedUrl: 'http://localhost:10200/infinite-loop.html',
       finalUrl: 'http://localhost:10200/infinite-loop.html',
       audits: {},
-      runtimeError: {code: 'PAGE_HUNG'},
+      // TODO: runtimeError should always exist for this page
+      // runtimeError: {code: 'PAGE_HUNG'},
     },
   },
   {
@@ -22,7 +23,8 @@ module.exports = [
       requestedUrl: 'https://expired.badssl.com',
       finalUrl: 'https://expired.badssl.com/',
       audits: {},
-      runtimeError: {code: 'FAILED_DOCUMENT_REQUEST'},
+      // TODO: runtimeError should always exist for this page
+      // runtimeError: {code: 'FAILED_DOCUMENT_REQUEST'},
     },
   },
 ];

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -14,8 +14,11 @@ module.exports = [
       requestedUrl: 'http://localhost:10200/infinite-loop.html',
       finalUrl: 'http://localhost:10200/infinite-loop.html',
       audits: {},
-      // TODO: runtimeError should always exist for this page
-      // runtimeError: {code: 'PAGE_HUNG'},
+      // TODO: runtimeError only exists because of selection of audits.
+      runtimeError: {code: 'PAGE_HUNG'},
+    },
+    artifacts: {
+      ViewportDimensions: {code: 'PAGE_HUNG'},
     },
   },
   {
@@ -23,8 +26,11 @@ module.exports = [
       requestedUrl: 'https://expired.badssl.com',
       finalUrl: 'https://expired.badssl.com/',
       audits: {},
-      // TODO: runtimeError should always exist for this page
-      // runtimeError: {code: 'FAILED_DOCUMENT_REQUEST'},
+      // TODO: runtimeError only exists because of selection of audits.
+      runtimeError: {code: 'FAILED_DOCUMENT_REQUEST'},
+    },
+    artifacts: {
+      ViewportDimensions: {code: 'FAILED_DOCUMENT_REQUEST'},
     },
   },
 ];

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -210,6 +210,10 @@ module.exports = [
       // Note: most scores are null (audit error) because the page 403ed.
       requestedUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
       finalUrl: BASE_URL + 'seo-failure-cases.html?status_code=403',
+      runtimeError: {
+        code: 'ERRORED_DOCUMENT_REQUEST',
+        message: /Status code: 403/,
+      },
       audits: {
         'http-status-code': {
           score: 0,

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -127,6 +127,7 @@ function makeComparison(name, actualResult, expectedResult) {
  */
 function collateResults(actual, expected) {
   // If actual run had a runtimeError, expected *must* have a runtimeError.
+  // Relies on the fact that an `undefined` argument to makeComparison() can only match `undefined`.
   const runtimeErrorAssertion = makeComparison('runtimeError', actual.lhr.runtimeError,
       expected.lhr.runtimeError);
 

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -126,6 +126,10 @@ function makeComparison(name, actualResult, expectedResult) {
  * @return {Smokehouse.Comparison[]}
  */
 function collateResults(actual, expected) {
+  // If actual run had a runtimeError, expected *must* have a runtimeError.
+  const runtimeErrorAssertion = makeComparison('runtimeError', actual.lhr.runtimeError,
+      expected.lhr.runtimeError);
+
   /** @type {Smokehouse.Comparison[]} */
   let artifactAssertions = [];
   if (expected.artifacts) {
@@ -161,6 +165,7 @@ function collateResults(actual, expected) {
       expected: expected.lhr.finalUrl,
       equal: actual.lhr.finalUrl === expected.lhr.finalUrl,
     },
+    runtimeErrorAssertion,
     ...artifactAssertions,
     ...auditAssertions,
   ];
@@ -194,7 +199,8 @@ function reportAssertion(assertion) {
   } else {
     if (assertion.diff) {
       const diff = assertion.diff;
-      const fullActual = JSON.stringify(assertion.actual, null, 2).replace(/\n/g, '\n      ');
+      const fullActual = String(JSON.stringify(assertion.actual, null, 2))
+          .replace(/\n/g, '\n      ');
       const msg = `
   ${log.redify(log.cross)} difference at ${log.bold}${diff.path}${log.reset}
               expected: ${JSON.stringify(diff.expected)}

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -114,7 +114,7 @@ function runLighthouse(url, configPath, isDebug) {
   }
 
   // There should either be both an error exitCode and a lhr.runtimeError or neither.
-  if (!exitCode !== !lhr.runtimeError) {
+  if (Boolean(exitCode) !== Boolean(lhr.runtimeError)) {
     const runtimeErrorCode = lhr.runtimeError && lhr.runtimeError.code;
     console.error(`Lighthouse did not exit with an error correctly, exiting with ${exitCode} but with runtimeError '${runtimeErrorCode}'`); // eslint-disable-line max-len
     process.exit(1);

--- a/lighthouse-cli/test/smokehouse/smokehouse.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse.js
@@ -13,7 +13,10 @@ const path = require('path');
 const spawnSync = require('child_process').spawnSync;
 const yargs = require('yargs');
 const log = require('lighthouse-logger');
+const rimraf = require('rimraf');
+
 const {collateResults, report} = require('./smokehouse-report.js');
+const assetSaver = require('../../../lighthouse-core/lib/asset-saver.js');
 
 const PROTOCOL_TIMEOUT_EXIT_CODE = 67;
 const RETRIES = 3;
@@ -88,27 +91,34 @@ function runLighthouse(url, configPath, isDebug) {
     console.error(`STDERR: ${runResults.stderr}`);
   }
 
-  if (runResults.status === PROTOCOL_TIMEOUT_EXIT_CODE) {
+  const exitCode = runResults.status;
+  if (exitCode === PROTOCOL_TIMEOUT_EXIT_CODE) {
     console.error(`Lighthouse debugger connection timed out ${RETRIES} times. Giving up.`);
     process.exit(1);
   } else if (!fs.existsSync(outputPath)) {
-    console.error(`Lighthouse run failed to produce a report and exited with ${runResults.status}. stderr to follow:`); // eslint-disable-line max-len
+    console.error(`Lighthouse run failed to produce a report and exited with ${exitCode}. stderr to follow:`); // eslint-disable-line max-len
     console.error(runResults.stderr);
-    process.exit(runResults.status);
+    process.exit(exitCode);
   }
 
+  /** @type {LH.Result} */
   const lhr = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  const artifacts = assetSaver.loadArtifacts(artifactsDirectory);
+
   if (isDebug) {
     console.log('LHR output available at: ', outputPath);
+    console.log('Artifacts avaiable in: ', artifactsDirectory);
   } else {
     fs.unlinkSync(outputPath);
+    rimraf.sync(artifactsDirectory);
   }
 
-  // Artifacts are undefined if they weren't written to disk (e.g. if there was an error).
-  let artifacts;
-  try {
-    artifacts = JSON.parse(fs.readFileSync(`${artifactsDirectory}/artifacts.json`, 'utf8'));
-  } catch (e) {}
+  // There should either be both an error exitCode and a lhr.runtimeError or neither.
+  if (!exitCode !== !lhr.runtimeError) {
+    const runtimeErrorCode = lhr.runtimeError && lhr.runtimeError.code;
+    console.error(`Lighthouse did not exit with an error correctly, exiting with ${exitCode} but with runtimeError '${runtimeErrorCode}'`); // eslint-disable-line max-len
+    process.exit(1);
+  }
 
   return {
     lhr,

--- a/lighthouse-core/lib/asset-saver.js
+++ b/lighthouse-core/lib/asset-saver.js
@@ -33,9 +33,9 @@ const devtoolsLogSuffix = '.devtoolslog.json';
  * Load artifacts object from files located within basePath
  * Also save the traces to their own files
  * @param {string} basePath
- * @return {Promise<LH.Artifacts>}
+ * @return {LH.Artifacts}
  */
-async function loadArtifacts(basePath) {
+function loadArtifacts(basePath) {
   log.log('Reading artifacts from disk:', basePath);
 
   if (!fs.existsSync(basePath)) {

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -60,7 +60,7 @@ class Runner {
       if (settings.auditMode && !settings.gatherMode) {
         // No browser required, just load the artifacts from disk.
         const path = Runner._getArtifactsPath(settings);
-        artifacts = await assetSaver.loadArtifacts(path);
+        artifacts = assetSaver.loadArtifacts(path);
         requestedUrl = artifacts.URL.requestedUrl;
 
         if (!requestedUrl) {

--- a/lighthouse-core/scripts/update-report-fixtures.js
+++ b/lighthouse-core/scripts/update-report-fixtures.js
@@ -28,7 +28,7 @@ async function update(artifactName) {
     res(address.port);
   }));
 
-  const oldArtifacts = await assetSaver.loadArtifacts(artifactPath);
+  const oldArtifacts = assetSaver.loadArtifacts(artifactPath);
 
   const url = `http://localhost:${port}/dobetterweb/dbw_tester.html`;
   const rawFlags = [
@@ -41,7 +41,7 @@ async function update(artifactName) {
 
   if (artifactName) {
     // Revert everything except the one artifact
-    const newArtifacts = await assetSaver.loadArtifacts(artifactPath);
+    const newArtifacts = assetSaver.loadArtifacts(artifactPath);
     if (!(artifactName in newArtifacts) && !(artifactName in oldArtifacts)) {
       throw Error('Unknown artifact name: ' + artifactName);
     }

--- a/types/smokehouse.d.ts
+++ b/types/smokehouse.d.ts
@@ -19,7 +19,7 @@
     diff?: Difference | null;
   }
 
-  export type ExpectedLHR = Pick<LH.Result, 'audits' | 'finalUrl' | 'requestedUrl'>
+  export type ExpectedLHR = Pick<LH.Result, 'audits' | 'finalUrl' | 'requestedUrl' | 'runtimeError'>
 
   export type ExpectedRunnerResult = {
     lhr: ExpectedLHR,


### PR DESCRIPTION
follow up to #9121 and part of the discussion from #8865. Adds two additional checks to smokehouse:
- if Lighthouse exits with a non-zero exit code the lhr must have a `runtimeError` (or if there's a `runtimeError` it must have had a non-zero exit code). This just double checks the change in https://github.com/GoogleChrome/lighthouse/commit/ff4f486298b5ac1db583a85bfc8a45c9689de5fb#diff-8035764042a5861297234f1e1b922ca7R221 (and should always be 👍)
- if there's a `runtimeError` in the run's LHR there *must* be a `runtimeError` in the expectations (slightly more strict than usual where something left out of the expectations isn't tested). We're asking everyone to keep an eye on `runtimeError` to spot problems, so our tests should be expecting them if one is in there :)

Since we weren't checking `runtimeError` before, it means [`error-expectations.js`](https://github.com/GoogleChrome/lighthouse/blob/9ebae67202a6df281781024ffa911a27643e629d/lighthouse-cli/test/smokehouse/error-expectations.js) needs to be updated because those runs don't actually include a `runtimeError` (because the audit being run is a metric and doesn't need anything but base artifacts -- mentioned in the last bullet point of https://github.com/GoogleChrome/lighthouse/pull/8865#pullrequestreview-243000692).

Also does a drive-by fix to delete the smokehouse test artifact files after use. I was up to several hundred MBs of them in `.tmp/` :)