### PR TITLE
report: remove unused css vars

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -22,59 +22,31 @@
   --body-text-color: var(--color-black-900);
   --body-font-size: 16px;
   --body-line-height: 24px;
-  --subheader-font-size: 14px;
-  --subheader-line-height: 20px;
   --subheader-color: hsl(206, 6%, 25%);
-  --header-bg-color: #f1f3f4;
   --header-font-size: 20px;
   --header-line-height: 24px;
-  --title-font-size: 24px;
-  --title-line-height: 28px;
-  --caption-font-size: 12px;
   --caption-line-height: 16px;
   --default-padding: 12px;
   --section-padding: 16px;
   --section-indent: 16px;
-  --audit-group-indent: 16px;
   --audit-item-gap: 5px;
-  --audit-indent: 16px;
   --text-indent: 8px;
-  --expandable-indent: 20px;
   --secondary-text-color: var(--color-black-800);
   /*--accent-color: #3879d9;*/
   --informative-color: var(--color-blue-900);
   --medium-75-gray: #757575;
   --medium-50-gray: hsl(210, 17%, 98%);
-  --medium-100-gray: hsl(200, 12%, 95%);
-  --warning-color: #ffab00; /* md amber a700 */
   --report-secondary-border-color: #ebebeb;
-  --metric-timeline-rule-color: #b3b3b3;
   --display-value-gray: hsl(216, 5%, 39%);
   --report-width: calc(60 * var(--body-font-size));
   --report-min-width: 400px;
-  /* Edge doesn't support calc(var(calc())) */
-  --report-width-half: calc(30 * var(--body-font-size));
   --report-header-height: 161px;
-  --report-header-color: #202124;
-  --navitem-font-size: var(--body-font-size);
-  --navitem-line-height: var(--body-line-height);
-  --navitem-hpadding: var(--body-font-size);
-  --navitem-vpadding: calc(var(--navitem-line-height) / 2);
-  --lh-score-highlight-bg: hsla(0, 0%, 90%, 0.2);
   --lh-score-icon-background-size: 24px;
-  --lh-group-icon-background-size: var(--lh-score-icon-background-size);
   --lh-export-icon-size: var(--lh-score-icon-background-size);
   --lh-export-icon-color: var(--medium-75-gray);
-  --lh-score-margin: 12px;
-  --lh-table-header-bg: #f8f9fa;
   --lh-table-higlight-bg: hsla(0, 0%, 75%, 0.1);
   --lh-sparkline-height: 5px;
-  --lh-sparkline-thin-height: 3px;
-  --lh-filmstrip-thumbnail-width: 60px;
-  --lh-category-score-width: calc(5 * var(--body-font-size));
   --lh-audit-vpadding: 8px;
-  --lh-audit-index-width: 18px;
-  --lh-audit-hgap: 12px;
   --lh-audit-group-vpadding: 8px;
   --lh-section-vpadding: 12px;
   --chevron-size: 12px;
@@ -89,7 +61,6 @@
   --color-black-600: #757575;
   --color-black-800: #424242;
   --color-black-900: #212121;
-  --off-black: #111111;
   --color-black: #000000;
   --color-blue: #2962FF;
   --color-green-700: #018642;
@@ -114,7 +85,6 @@
   --gauge-circle-size-big: 112px;
   --gauge-circle-size: 80px;
   --header-padding: 20px 0 20px 0;
-  --highlighter-bg: var(--color-black-400);
   --icon-square-size: calc(var(--score-shape-size) * 0.88);
   --plugin-badge-bg: var(--color-white);
   --plugin-badge-size-big: calc(var(--gauge-circle-size-big) / 2.7);
@@ -187,7 +157,6 @@
 
   --topbar-bg: var(--color-black);
   --plugin-badge-bg: var(--color-black-800);
-  --header-bg-color: var(--color-black-900);
   --env-item-bg: var(--color-black);
   --report-secondary-border-color: var(--color-black-200);
 
@@ -195,7 +164,6 @@
   --body-text-color: var(--color-black-100);
   --secondary-text-color: var(--color-black-400);
 
-  --highlighter-bg: var(--color-black-200);
   --plugin-icon-url: var(--plugin-icon-url-dark);
 
   --informative-color: var(--color-blue-200);
@@ -246,20 +214,12 @@
   --monospace-font-family: 'Menlo', 'dejavu sans mono', 'Consolas', 'Lucida Console', monospace;
   --body-font-size: 12px;
   --body-line-height: 20px;
-  --subheader-font-size: 14px;
-  --subheader-line-height: 18px;
   --header-font-size: 16px;
   --header-line-height: 20px;
-  --title-font-size: 20px;
-  --title-line-height: 24px;
-  --caption-font-size: 11px;
   --caption-line-height: 14px;
   --default-padding: 12px;
   --section-padding: 12px;
   --section-indent: 8px;
-  --audit-group-indent: 16px;
-  --audit-indent: 16px;
-  --expandable-indent: 16px;
 
   --gauge-circle-size-big: 72px;
   --gauge-circle-size: 64px;
@@ -280,7 +240,6 @@
   --score-title-line-height: 20px;
 
   --lh-audit-vpadding: 4px;
-  --lh-audit-hgap: 12px;
   --lh-audit-group-vpadding: 12px;
   --lh-section-vpadding: 8px;
 }

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -32,7 +32,6 @@
   --audit-item-gap: 5px;
   --text-indent: 8px;
   --secondary-text-color: var(--color-black-800);
-  /*--accent-color: #3879d9;*/
   --informative-color: var(--color-blue-900);
   --medium-75-gray: #757575;
   --medium-50-gray: hsl(210, 17%, 98%);


### PR DESCRIPTION
I ran this to determine what variables are unused (I verified each):

```
echo 'text-font-family
monospace-font-family
body-background-color
body-text-color
body-font-size
body-line-height
subheader-font-size
subheader-line-height
subheader-color
header-bg-color
header-font-size
header-line-height
title-font-size
title-line-height
caption-font-size
caption-line-height
default-padding
section-padding
section-indent
audit-group-indent
audit-item-gap
audit-indent
text-indent
expandable-indent
secondary-text-color
informative-color
medium-75-gray
medium-50-gray
medium-100-gray
warning-color
report-secondary-border-color
metric-timeline-rule-color
display-value-gray
report-width
report-min-width
report-width-half
report-header-height
report-header-color
navitem-font-size
navitem-line-height
navitem-hpadding
navitem-vpadding
lh-score-highlight-bg
lh-score-icon-background-size
lh-group-icon-background-size
lh-export-icon-size
lh-export-icon-color
lh-score-margin
lh-table-header-bg
lh-table-higlight-bg
lh-sparkline-height
lh-sparkline-thin-height
lh-filmstrip-thumbnail-width
lh-category-score-width
lh-audit-vpadding
lh-audit-index-width
lh-audit-hgap
lh-audit-group-vpadding
lh-section-vpadding
chevron-size
inner-audit-left-padding
color-black-100
color-black-200
color-black-400
color-black-500
color-black-600
color-black-800
color-black-900
off-black
color-black
color-blue
color-green-700
color-green
color-orange-700
color-orange
color-red-700
color-red
color-white
color-blue-200
color-blue-900
color-cyan-500
color-teal-600
audits-margin-bottom
env-item-bg
env-name-min-width
env-tem-padding
expandable-padding
gauge-circle-size-big
gauge-circle-size
header-padding
highlighter-bg
icon-square-size
plugin-badge-bg
plugin-badge-size-big
plugin-badge-size
plugin-icon-size
pwa-icon-margin
pwa-icon-size
score-container-padding
score-container-width
score-number-font-size-big
score-number-font-size
score-shape-margin-left
score-shape-margin-right
score-shape-margin
score-shape-size
score-title-font-size-big
score-title-font-size
score-title-line-height-big
score-title-line-height
scorescale-height
scorescale-width
section-padding
topbar-bg
topbar-height
topbar-icon-size
topbar-padding
metrics-toggle-color
color-average-secondary
color-average
color-fail-secondary
color-fail
color-pass-secondary
color-pass
color-sticky-header-bg
color-highlighter-bg
color-hover
color-metric-toggle-lines' | xargs -I {} bash -c "grep -q '.*:.*\-\-{}' ./lighthouse-core/report/html/templates.html ./lighthouse-core/report/html/report-styles.css || echo {}" | sort
```

Result:
```
audit-group-indent
audit-indent
caption-font-size
expandable-indent
header-bg-color
highlighter-bg
lh-audit-hgap
lh-audit-index-width
lh-category-score-width
lh-filmstrip-thumbnail-width
lh-group-icon-background-size
lh-score-highlight-bg
lh-score-margin
lh-sparkline-thin-height
lh-table-header-bg
medium-100-gray
metric-timeline-rule-color
navitem-font-size
navitem-hpadding
navitem-vpadding
off-black
report-header-color
report-width-half
subheader-font-size
subheader-line-height
title-font-size
title-line-height
warning-color
```

Noticed this one too, which wasn't caught by the simple command above:
```
navitem-line-height
```