### PR TITLE
report: position sticky-header highlighter with css grid

### DIFF
--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -314,9 +314,8 @@ class ReportUIFeatures {
     this.scoreScaleEl = this._dom.find('.lh-scorescale', this._document);
     this.stickyHeaderEl = this._dom.find('.lh-sticky-header', this._document);
 
-    // Position highlighter at first gauge; will be transformed on scroll.
-    const firstGauge = this._dom.find('.lh-gauge__wrapper', this.stickyHeaderEl);
-    this.highlightEl = this._dom.createChildOf(firstGauge, 'div', 'lh-highlighter');
+    // Highlighter will be absolutely positioned at first gauge, then transformed on scroll.
+    this.highlightEl = this._dom.createChildOf(this.stickyHeaderEl, 'div', 'lh-highlighter');
   }
 
   /**

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -186,7 +186,8 @@ limitations under the License.
     }
 
     .lh-sticky-header--visible {
-      display: flex;
+      display: grid;
+      grid-auto-flow: column;
       pointer-events: auto;
     }
 
@@ -204,8 +205,10 @@ limitations under the License.
       width: var(--score-container-width);
       height: 1px;
       background: var(--color-highlighter-bg);
+      /* Position at bottom of first gauge in sticky header. */
       position: absolute;
-      bottom: -5px;
+      grid-column: 1;
+      bottom: 0;
     }
 
     .lh-gauge__wrapper:first-of-type {

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -208,7 +208,7 @@ limitations under the License.
       /* Position at bottom of first gauge in sticky header. */
       position: absolute;
       grid-column: 1;
-      bottom: 0;
+      bottom: -1px;
     }
 
     .lh-gauge__wrapper:first-of-type {


### PR DESCRIPTION
alternative fix to #9167

Putting the sticky-header highlighter in the first gauge was a nice way to get it positioned correctly on load and a good transform origin to translate from on scroll, but it ends up a little weird since it's fundamentally part of the sticky header, not a single gauge.

Moving it out of the gauge, though, I couldn't find a way to get an absolutely positioned element to be aligned with the first gauge using flexbox. CSS grid makes this really easy, though, so switched the sticky header to using that.