### PR TITLE
core(gather-runner): don't save trace on pass with pageLoadError

### DIFF
--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -216,8 +216,7 @@ module.exports = [
       },
       audits: {
         'http-status-code': {
-          score: 0,
-          displayValue: '403',
+          score: null,
         },
         'viewport': {
           score: null,

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -648,11 +648,6 @@ class GatherRunner {
     // Disable throttling so the afterPass analysis isn't throttled
     await driver.setThrottling(passContext.settings, {useThrottling: false});
 
-    // Save devtoolsLog and trace.
-    const baseArtifacts = passContext.baseArtifacts;
-    baseArtifacts.devtoolsLogs[passConfig.passName] = loadData.devtoolsLog;
-    if (loadData.trace) baseArtifacts.traces[passConfig.passName] = loadData.trace;
-
     // If there were any load errors, treat all gatherers as if they errored.
     const pageLoadError = GatherRunner.getPageLoadError(passContext, loadData, possibleNavError);
     if (pageLoadError) {
@@ -661,7 +656,12 @@ class GatherRunner {
       return GatherRunner.generatePageLoadErrorArtifacts(passContext, pageLoadError);
     }
 
-    // If no error, run `afterPass()` on gatherers and return collected artifacts.
+    // If no error, save devtoolsLog and trace.
+    const baseArtifacts = passContext.baseArtifacts;
+    baseArtifacts.devtoolsLogs[passConfig.passName] = loadData.devtoolsLog;
+    if (loadData.trace) baseArtifacts.traces[passConfig.passName] = loadData.trace;
+
+    // Run `afterPass()` on gatherers and return collected artifacts.
     await GatherRunner.afterPass(passContext, loadData, gathererResults);
     return GatherRunner.collectArtifacts(gathererResults);
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -628,7 +628,7 @@ class GatherRunner {
    * @param {LH.Gatherer.LoadData} loadData
    * @param {string} passName
    */
-  static _saveLoadData(passContext, loadData, passName) {
+  static _addLoadDataToBaseArtifacts(passContext, loadData, passName) {
     const baseArtifacts = passContext.baseArtifacts;
     baseArtifacts.devtoolsLogs[passName] = loadData.devtoolsLog;
     if (loadData.trace) baseArtifacts.traces[passName] = loadData.trace;
@@ -665,12 +665,13 @@ class GatherRunner {
     if (pageLoadError) {
       log.error('GatherRunner', pageLoadError.friendlyMessage, passContext.url);
       passContext.LighthouseRunWarnings.push(pageLoadError.friendlyMessage);
-      GatherRunner._saveLoadData(passContext, loadData, `pageLoadError-${passConfig.passName}`);
+      GatherRunner._addLoadDataToBaseArtifacts(passContext, loadData,
+          `pageLoadError-${passConfig.passName}`);
       return GatherRunner.generatePageLoadErrorArtifacts(passContext, pageLoadError);
     }
 
     // If no error, save devtoolsLog and trace.
-    GatherRunner._saveLoadData(passContext, loadData, passConfig.passName);
+    GatherRunner._addLoadDataToBaseArtifacts(passContext, loadData, passConfig.passName);
 
     // Run `afterPass()` on gatherers and return collected artifacts.
     await GatherRunner.afterPass(passContext, loadData, gathererResults);

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -623,6 +623,18 @@ class GatherRunner {
   }
 
   /**
+   * Save the devtoolsLog and trace (if applicable) to baseArtifacts.
+   * @param {LH.Gatherer.PassContext} passContext
+   * @param {LH.Gatherer.LoadData} loadData
+   * @param {string} passName
+   */
+  static _saveLoadData(passContext, loadData, passName) {
+    const baseArtifacts = passContext.baseArtifacts;
+    baseArtifacts.devtoolsLogs[passName] = loadData.devtoolsLog;
+    if (loadData.trace) baseArtifacts.traces[passName] = loadData.trace;
+  }
+
+  /**
    * Starting from about:blank, load the page and run gatherers for this pass.
    * @param {LH.Gatherer.PassContext} passContext
    * @return {Promise<{artifacts: Partial<LH.GathererArtifacts>, pageLoadError?: LHError}>}
@@ -653,13 +665,12 @@ class GatherRunner {
     if (pageLoadError) {
       log.error('GatherRunner', pageLoadError.friendlyMessage, passContext.url);
       passContext.LighthouseRunWarnings.push(pageLoadError.friendlyMessage);
+      GatherRunner._saveLoadData(passContext, loadData, `pageLoadError-${passConfig.passName}`);
       return GatherRunner.generatePageLoadErrorArtifacts(passContext, pageLoadError);
     }
 
     // If no error, save devtoolsLog and trace.
-    const baseArtifacts = passContext.baseArtifacts;
-    baseArtifacts.devtoolsLogs[passConfig.passName] = loadData.devtoolsLog;
-    if (loadData.trace) baseArtifacts.traces[passConfig.passName] = loadData.trace;
+    GatherRunner._saveLoadData(passContext, loadData, passConfig.passName);
 
     // Run `afterPass()` on gatherers and return collected artifacts.
     await GatherRunner.afterPass(passContext, loadData, gathererResults);

--- a/lighthouse-core/test/gather/gather-runner-test.js
+++ b/lighthouse-core/test/gather/gather-runner-test.js
@@ -776,6 +776,81 @@ describe('GatherRunner', function() {
       });
   });
 
+  it('does not return a trace or devtoolsLog when there was a runtime error', async () => {
+    const requestedUrl = 'https://example.com';
+    const passes = [{
+      passName: 'firstPass',
+      recordTrace: true,
+      gatherers: [{instance: new TestGatherer()}],
+    }];
+    const driver = Object.assign({}, fakeDriver, {
+      // resolved URL here does not match any request in the network records, causing a runtime error.
+      gotoURL: async _ => requestedUrl,
+      online: true,
+    });
+
+    const config = new Config({});
+    const options = {driver, requestedUrl, settings: config.settings, config};
+    const artifacts = await GatherRunner.run(passes, options);
+
+    expect(artifacts.TestGatherer.code).toEqual('NO_DOCUMENT_REQUEST');
+    expect(Object.keys(artifacts.traces)).toHaveLength(0);
+    expect(Object.keys(artifacts.devtoolsLogs)).toHaveLength(0);
+  });
+
+  it('does not run additional passes after a runtime error', async () => {
+    const t1 = new (class Test1 extends TestGatherer {})();
+    const t2 = new (class Test2 extends TestGatherer {})();
+    const t3 = new (class Test3 extends TestGatherer {})();
+    const passes = [{
+      passName: 'firstPass',
+      recordTrace: true,
+      gatherers: [{instance: t1}],
+    }, {
+      passName: 'secondPass',
+      recordTrace: true,
+      gatherers: [{instance: t2}],
+    }, {
+      passName: 'thirdPass',
+      recordTrace: true,
+      gatherers: [{instance: t3}],
+    }];
+
+    const requestedUrl = 'https://www.reddit.com/r/nba';
+    let firstLoad = true;
+    const driver = Object.assign({}, fakeDriver, {
+      // Loads the page successfully in the first pass, fails with NO_FCP in the second.
+      async gotoURL(url) {
+        if (url.includes('blank')) return null;
+        if (firstLoad) {
+          firstLoad = false;
+          return requestedUrl;
+        } else {
+          throw new LHError(LHError.errors.NO_FCP);
+        }
+      },
+      online: true,
+    });
+    const config = new Config({});
+    const options = {driver, requestedUrl, settings: config.settings, config};
+    const artifacts = await GatherRunner.run(passes, options);
+
+    // t1.pass() and t2.pass() called, t3.pass(), after the error, was not.
+    expect(t1.called).toBe(true);
+    expect(t2.called).toBe(true);
+    expect(t3.called).toBe(false);
+
+    // But only t1 has a valid artifact, t2 has an error artifact, and t3 never ran.
+    expect(artifacts.Test1).toBe('MyArtifact');
+    expect(artifacts.Test2).toBeInstanceOf(LHError);
+    expect(artifacts.Test2.code).toEqual('NO_FCP');
+    expect(artifacts.Test3).toBeUndefined();
+
+    // Only the firstPass has a saved trace and devtoolsLog.
+    expect(Object.keys(artifacts.traces)).toEqual(['firstPass']);
+    expect(Object.keys(artifacts.devtoolsLogs)).toEqual(['firstPass']);
+  });
+
   describe('#getNetworkError', () => {
     it('passes when the page is loaded', () => {
       const url = 'http://the-page.com';


### PR DESCRIPTION
part of https://github.com/GoogleChrome/lighthouse/pull/8865#issuecomment-497507618

#9176 turned a load that ends up on a Chrome interstitial (e.g. `INSECURE_DOCUMENT_REQUEST`) into a runtime error to let the user know that the page they were testing had a major problem and was never actually loaded for the test. Currently, however, all the artifacts in that errored pass are returned as errors *except* the devtoolsLog and trace, which end up in a kind of weird state where they're actually tracing the load of the interstitial, not any useful page.

If the load ends up just going to the interstitial, the metrics all end up as `NO_NAVSTART` errors, but if there was somehow a navigation (e.g. a URL redirects to a page with a bad cert), you'll end up with some nice metrics for the interstitial page.

Example report:

[<img width="962" alt="report with valid metrics for error interstitial" src="https://user-images.githubusercontent.com/316891/59466133-5ed9c980-8de1-11e9-8e5b-a6b5e30df376.png">](https://googlechrome.github.io/lighthouse/viewer/?gist=91d3c00c1186fdac9cc64f348dd14274)

https://googlechrome.github.io/lighthouse/viewer/?gist=91d3c00c1186fdac9cc64f348dd14274

Regardless of seeing an audit error, in a pass with a `pageLoadError`, we shouldn't save the trace or devtoolsLog, just like we don't save the rest of the artifacts in that pass.

After this PR:

<img width="985" alt="report with errored metrics for error interstitial" src="https://user-images.githubusercontent.com/316891/59466521-6057c180-8de2-11e9-8d79-eec548952b4a.png">

(also adds a test for the if-pageLoadError-stop-reloading behavior added in #8866/#9121)