### PR TITLE
docs: change score type from 'string' to 'number'

### DIFF
--- a/docs/understanding-results.md
+++ b/docs/understanding-results.md
@@ -158,7 +158,7 @@ An array containing the different categories, their scores, and the results of t
 | id | `string` | The string identifier of the category. |
 | title | `string` | The human-friendly display name of the category. |
 | description | `string` | A brief description of the purpose of the category, supports markdown links. |
-| score | `string` | The overall score of the category, the weighted average of all its audits. |
+| score | `number` | The overall score of the category, the weighted average of all its audits. |
 | auditRefs | `AuditEntry[]` | An array of all the audit results in the category. |
 
 ### AuditEntry Properties


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
Changes documentation based on issue raised (#8901)

<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
Documentation bug

<!-- Describe the need for this change -->
Updated the type for 'score'

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
fixes https://github.com/GoogleChrome/lighthouse/issues/8901