### PR TITLE
core(gather-runner): add PageLoadError base artifact

### DIFF
--- a/lighthouse-cli/test/smokehouse/error-config.js
+++ b/lighthouse-cli/test/smokehouse/error-config.js
@@ -14,8 +14,6 @@ module.exports = {
     maxWaitForLoad: 5000,
     onlyAudits: [
       'first-contentful-paint',
-      // TODO: this audit collects a non-base artifact, allowing the runtimeError to be collected.
-      'content-width',
     ],
   },
 };

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -13,8 +13,13 @@ module.exports = [
     lhr: {
       requestedUrl: 'http://localhost:10200/infinite-loop.html',
       finalUrl: 'http://localhost:10200/infinite-loop.html',
-      audits: {},
       runtimeError: {code: 'PAGE_HUNG'},
+      audits: {
+        'first-contentful-paint': {
+          scoreDisplayMode: 'error',
+          errorMessage: 'Required traces gatherer did not run.',
+        },
+      },
     },
     artifacts: {
       PageLoadError: {code: 'PAGE_HUNG'},
@@ -30,8 +35,13 @@ module.exports = [
     lhr: {
       requestedUrl: 'https://expired.badssl.com',
       finalUrl: 'https://expired.badssl.com/',
-      audits: {},
       runtimeError: {code: 'INSECURE_DOCUMENT_REQUEST'},
+      audits: {
+        'first-contentful-paint': {
+          scoreDisplayMode: 'error',
+          errorMessage: 'Required traces gatherer did not run.',
+        },
+      },
     },
     artifacts: {
       PageLoadError: {code: 'INSECURE_DOCUMENT_REQUEST'},

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -17,8 +17,13 @@ module.exports = [
       runtimeError: {code: 'PAGE_HUNG'},
     },
     artifacts: {
-      // Assert undefined because pageLoadError prevented gatherer from running.
-      ViewportDimensions: undefined,
+      PageLoadError: {code: 'PAGE_HUNG'},
+      devtoolsLogs: {
+        'pageLoadError-defaultPass': [/* ... */],
+      },
+      traces: {
+        'pageLoadError-defaultPass': {traceEvents: [/* ... */]},
+      },
     },
   },
   {
@@ -29,8 +34,13 @@ module.exports = [
       runtimeError: {code: 'INSECURE_DOCUMENT_REQUEST'},
     },
     artifacts: {
-      // Assert undefined because pageLoadError prevented gatherer from running.
-      ViewportDimensions: undefined,
+      PageLoadError: {code: 'INSECURE_DOCUMENT_REQUEST'},
+      devtoolsLogs: {
+        'pageLoadError-defaultPass': [/* ... */],
+      },
+      traces: {
+        'pageLoadError-defaultPass': {traceEvents: [/* ... */]},
+      },
     },
   },
 ];

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -14,11 +14,11 @@ module.exports = [
       requestedUrl: 'http://localhost:10200/infinite-loop.html',
       finalUrl: 'http://localhost:10200/infinite-loop.html',
       audits: {},
-      // TODO: runtimeError only exists because of selection of audits.
       runtimeError: {code: 'PAGE_HUNG'},
     },
     artifacts: {
-      ViewportDimensions: {code: 'PAGE_HUNG'},
+      // Assert undefined because pageLoadError prevented gatherer from running.
+      ViewportDimensions: undefined,
     },
   },
   {
@@ -26,11 +26,11 @@ module.exports = [
       requestedUrl: 'https://expired.badssl.com',
       finalUrl: 'https://expired.badssl.com/',
       audits: {},
-      // TODO: runtimeError only exists because of selection of audits.
       runtimeError: {code: 'INSECURE_DOCUMENT_REQUEST'},
     },
     artifacts: {
-      ViewportDimensions: {code: 'INSECURE_DOCUMENT_REQUEST'},
+      // Assert undefined because pageLoadError prevented gatherer from running.
+      ViewportDimensions: undefined,
     },
   },
 ];

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -138,13 +138,11 @@ function collateResults(actual, expected) {
     const artifactNames = /** @type {(keyof LH.Artifacts)[]} */ (Object.keys(expectedArtifacts));
     artifactAssertions = artifactNames.map(artifactName => {
       const actualResult = (actual.artifacts || {})[artifactName];
-      const expectedResult = expectedArtifacts[artifactName];
-
-      // Actual artifact *must* exist unless expected is explicitly set to `undefined`.
-      if (!actualResult && expectedResult !== undefined) {
+      if (!actualResult) {
         throw new Error(`Config run did not generate artifact ${artifactName}`);
       }
 
+      const expectedResult = expectedArtifacts[artifactName];
       return makeComparison(artifactName + ' artifact', actualResult, expectedResult);
     });
   }

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -138,11 +138,13 @@ function collateResults(actual, expected) {
     const artifactNames = /** @type {(keyof LH.Artifacts)[]} */ (Object.keys(expectedArtifacts));
     artifactAssertions = artifactNames.map(artifactName => {
       const actualResult = (actual.artifacts || {})[artifactName];
-      if (!actualResult) {
+      const expectedResult = expectedArtifacts[artifactName];
+
+      // Actual artifact *must* exist unless expected is explicitly set to `undefined`.
+      if (!actualResult && expectedResult !== undefined) {
         throw new Error(`Config run did not generate artifact ${artifactName}`);
       }
 
-      const expectedResult = expectedArtifacts[artifactName];
       return makeComparison(artifactName + ' artifact', actualResult, expectedResult);
     });
   }

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -584,11 +584,14 @@ class GatherRunner {
         }
       }
 
+      await GatherRunner.disposeDriver(driver, options);
       GatherRunner.finalizeBaseArtifacts(baseArtifacts);
       return /** @type {LH.Artifacts} */ ({...baseArtifacts, ...artifacts}); // Cast to drop Partial<>.
-    } finally {
-      // Clean up regardless of error.
+    } catch (err) {
+      // Clean up on error. Don't await so that the root error, not a disposal error, is shown.
       GatherRunner.disposeDriver(driver, options);
+
+      throw err;
     }
   }
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -409,28 +409,6 @@ class GatherRunner {
   }
 
   /**
-   * Generate a set of artfiacts for the given pass as if all the gatherers
-   * failed with the given pageLoadError.
-   * @param {LH.Gatherer.PassContext} passContext
-   * @param {LHError} pageLoadError
-   * @return {{pageLoadError: LHError, artifacts: Partial<LH.GathererArtifacts>}}
-   */
-  static generatePageLoadErrorArtifacts(passContext, pageLoadError) {
-    /** @type {Partial<Record<keyof LH.GathererArtifacts, LHError>>} */
-    const errorArtifacts = {};
-    for (const gathererDefn of passContext.passConfig.gatherers) {
-      const gatherer = gathererDefn.instance;
-      errorArtifacts[gatherer.name] = pageLoadError;
-    }
-
-    return {
-      pageLoadError,
-      // @ts-ignore - TODO(bckenny): figure out how to usefully type errored artifacts.
-      artifacts: errorArtifacts,
-    };
-  }
-
-  /**
    * Takes the results of each gatherer phase for each gatherer and uses the
    * last produced value (that's not undefined) as the artifact for that
    * gatherer. If an error was rejected from a gatherer phase,
@@ -495,6 +473,7 @@ class GatherRunner {
       settings: options.settings,
       URL: {requestedUrl: options.requestedUrl, finalUrl: options.requestedUrl},
       Timing: [],
+      PageLoadError: null,
     };
   }
 
@@ -594,7 +573,10 @@ class GatherRunner {
         Object.assign(artifacts, passResults.artifacts);
 
         // If we encountered a pageLoadError, don't try to keep loading the page in future passes.
-        if (passResults.pageLoadError) break;
+        if (passResults.pageLoadError) {
+          baseArtifacts.PageLoadError = passResults.pageLoadError;
+          break;
+        }
 
         if (isFirstPass) {
           await GatherRunner.populateBaseArtifacts(passContext);
@@ -602,13 +584,11 @@ class GatherRunner {
         }
       }
 
-      await GatherRunner.disposeDriver(driver, options);
       GatherRunner.finalizeBaseArtifacts(baseArtifacts);
       return /** @type {LH.Artifacts} */ ({...baseArtifacts, ...artifacts}); // Cast to drop Partial<>.
-    } catch (err) {
-      // cleanup on error
+    } finally {
+      // Clean up regardless of error.
       GatherRunner.disposeDriver(driver, options);
-      throw err;
     }
   }
 
@@ -660,14 +640,15 @@ class GatherRunner {
     // Disable throttling so the afterPass analysis isn't throttled
     await driver.setThrottling(passContext.settings, {useThrottling: false});
 
-    // If there were any load errors, treat all gatherers as if they errored.
+    // In case of load error, save log and trace with an error prefix, return no artifacts for this pass.
     const pageLoadError = GatherRunner.getPageLoadError(passContext, loadData, possibleNavError);
     if (pageLoadError) {
       log.error('GatherRunner', pageLoadError.friendlyMessage, passContext.url);
       passContext.LighthouseRunWarnings.push(pageLoadError.friendlyMessage);
       GatherRunner._addLoadDataToBaseArtifacts(passContext, loadData,
           `pageLoadError-${passConfig.passName}`);
-      return GatherRunner.generatePageLoadErrorArtifacts(passContext, pageLoadError);
+
+      return {artifacts: {}, pageLoadError};
     }
 
     // If no error, save devtoolsLog and trace.

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -352,12 +352,18 @@ class Runner {
   }
 
   /**
-   * Returns first runtimeError found in artifacts.
+   * Searches a pass's artifacts for any `lhrRuntimeError` error artifacts.
+   * Returns the first one found or `null` if none found.
    * @param {LH.Artifacts} artifacts
    * @return {LH.Result['runtimeError']|undefined}
    */
   static getArtifactRuntimeError(artifacts) {
-    for (const possibleErrorArtifact of Object.values(artifacts)) {
+    const possibleErrorArtifacts = [
+      artifacts.PageLoadError, // Preferentially use `PageLoadError`, if it exists.
+      ...Object.values(artifacts), // Otherwise check amongst all artifacts.
+    ];
+
+    for (const possibleErrorArtifact of possibleErrorArtifacts) {
       if (possibleErrorArtifact instanceof LHError && possibleErrorArtifact.lhrRuntimeError) {
         const errorMessage = possibleErrorArtifact.friendlyMessage || possibleErrorArtifact.message;
 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -49,6 +49,8 @@ declare global {
       URL: {requestedUrl: string, finalUrl: string};
       /** The timing instrumentation of the gather portion of a run. */
       Timing: Artifacts.MeasureEntry[];
+      /** If loading the page failed, value is the error that caused it. Otherwise null. */
+      PageLoadError: LighthouseError | null;
     }
 
     /**


### PR DESCRIPTION
*for some background, see conversation (and all the links from it) starting in https://github.com/GoogleChrome/lighthouse/pull/8865#issuecomment-497481383*

## In this PR
This proposal is to disconnect `pageLoadError` from artifact errors:
  - add `PageLoadError` as a base artifact, populated if there was an error for that gathering run, otherwise null
  - artifacts will be `undefined` in the pass that had the pageLoadError (just like all the artifacts from passes after that one, since we bail on gathering after a pageLoadError after #8866/#9121).
  - as a result, audits that depend on those artifacts will move from `"Required x gatherer encountered an error"` errors to `"Required x gatherer did not run"` errors, which is arguably more correct (for artifacts collected in `afterPass`) and doesn't suggest to the user that the issue lies in the gatherer when there was really a runtimeError they should look into 

This gives us a clear and unambiguous place to mark that there was an error in the page load, which makes artifacts easier to understand as well (no more combing *all* artifacts to be sure there wasn't a pageLoadError in some pass).

## Current behavior
When a `pageLoadError` occurs, it's communicated back to `Runner` as a bunch of artifacts from that bad pass set to that page load error. This shows up in the LHR at the audit level (`"Required x gatherer encountered an error"`) and then runner loops over all the artifacts, and if it finds one marked as a runtime error it puts it in the `lhr.runtimeError` slot.

In the HTML report, the errors are displayed in similar positions (in each audit and at the top).

So, `pageLoadError` -> error artifact(s) -> `lhr.runtimeError`/errors audit result(s)

As a result, whether or not a runtime error is visible in the end LHR--even fundamental page load issues--is a function of which gatherers are run. Even more weirdly, if filtering using `--only-audits`, runtime error visibility is a function of which *audits* are run, since the gatherers that might have passed on the pageLoadError could get filtered out. This is why we had to have [an audit that uses a non-trace artifact in the `errors` smoke test](https://github.com/GoogleChrome/lighthouse/blob/016085cf5eed36c89e4e828563a341036b992eb3/lighthouse-cli/test/smokehouse/error-config.js#L17-L18) so that the runtimeError is actually seen and can be tested against.