### PR TITLE
report: use css grid for metrics

### DIFF
--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -97,7 +97,6 @@
   --header-line-height: 24px;
   --highlighter-background-color: var(--report-text-color);
   --icon-square-size: calc(var(--score-icon-size) * 0.88);
-  --metric-description-padding: 0 0 2px calc(var(--score-icon-margin-left) + var(--score-icon-size) + var(--score-icon-margin-right));
   --metric-toggle-lines-fill: #7F7F7F;
   --metrics-toggle-background-color: var(--color-gray-200);
   --plugin-badge-background-color: var(--color-white);
@@ -570,10 +569,9 @@
 }
 
 .lh-metric__innerwrap {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 80% 20%;
   align-items: center;
-  flex-wrap: wrap;
-  justify-content: space-between;
   padding: 10px 0;
 }
 
@@ -593,8 +591,9 @@
 
 .lh-metric__description {
   display: none;
+  grid-column-start: 1;
+  grid-column-end: 3;
   color: var(--report-text-color-secondary);
-  padding: var(--metric-description-padding);
 }
 
 .lh-metric__value {

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -567,7 +567,7 @@
 
 .lh-metric__innerwrap {
   display: grid;
-  grid-template-columns: 1fr 80% 20%;
+  grid-template-columns: var(--audit-description-padding-left) 10fr 3fr;
   align-items: center;
   padding: 10px 0;
 }
@@ -596,6 +596,7 @@
 .lh-metric__value {
   white-space: nowrap; /* No wrapping between metric value and the icon */
   font-weight: 500;
+  justify-self: end;
 }
 
 /* No-JS toggle switch */

--- a/lighthouse-core/report/html/report-styles.css
+++ b/lighthouse-core/report/html/report-styles.css
@@ -588,7 +588,7 @@
 
 .lh-metric__description {
   display: none;
-  grid-column-start: 1;
+  grid-column-start: 2;
   grid-column-end: 3;
   color: var(--report-text-color-secondary);
 }


### PR DESCRIPTION
Before:
See #9270

After:

![image](https://user-images.githubusercontent.com/4071474/60047478-af251700-967e-11e9-941b-7c3c65fa2b53.png)
![image](https://user-images.githubusercontent.com/4071474/60047493-b5b38e80-967e-11e9-837e-0814bd59fe1b.png)
![image](https://user-images.githubusercontent.com/4071474/60047504-ba784280-967e-11e9-81ca-0d84fad9b576.png)
![image](https://user-images.githubusercontent.com/4071474/60047556-d5e34d80-967e-11e9-9c75-1390b6ded471.png)

Note, I merged #9272 into this changeset b/c the grid styles here require that the score icon is always present and visible.