### PR TITLE
core(url): consider mailto: and javascript: urls as non-network

### DIFF
--- a/lighthouse-core/lib/url-shim.js
+++ b/lighthouse-core/lib/url-shim.js
@@ -175,7 +175,7 @@ class URLShim extends URL {
 
 URLShim.URL = URL;
 
-URLShim.NON_NETWORK_PROTOCOLS = ['blob', 'data', 'intent'];
+URLShim.NON_NETWORK_PROTOCOLS = ['blob', 'data', 'intent', 'mailto', 'javascript'];
 
 URLShim.INVALID_URL_DEBUG_STRING =
     'Lighthouse was unable to determine the URL of some script executions. ' +


### PR DESCRIPTION
inspired by paul lewis's patch here https://chromium-review.googlesource.com/c/chromium/src/+/1674157/5/third_party/blink/renderer/devtools/front_end/common/ParsedURL.js