### PR TITLE
core(config): assert all audit requiredArtifacts will be gathered

### DIFF
--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -22,6 +22,24 @@ const {requireAudits, mergeOptionsOfItems, resolveModule} = require('./config-he
 /** @typedef {typeof import('../gather/gatherers/gatherer.js')} GathererConstructor */
 /** @typedef {InstanceType<GathererConstructor>} Gatherer */
 
+/** @type {Array<keyof LH.BaseArtifacts>} */
+const BASE_ARTIFACT_NAMES = [
+  'fetchTime',
+  'LighthouseRunWarnings',
+  'TestedAsMobileDevice',
+  'HostUserAgent',
+  'NetworkUserAgent',
+  'BenchmarkIndex',
+  'WebAppManifest',
+  'Stacks',
+  'traces',
+  'devtoolsLogs',
+  'settings',
+  'URL',
+  'Timing',
+  'PageLoadError',
+];
+
 /**
  * @param {Config['passes']} passes
  * @param {Config['audits']} audits
@@ -32,11 +50,14 @@ function assertValidPasses(passes, audits) {
   }
 
   const requiredGatherers = Config.getGatherersNeededByAudits(audits);
+  /** @type {Set<string>} */
+  const foundGatherers = new Set(BASE_ARTIFACT_NAMES);
 
   // Log if we are running gathers that are not needed by the audits listed in the config
   passes.forEach(pass => {
     pass.gatherers.forEach(gathererDefn => {
       const gatherer = gathererDefn.instance;
+      foundGatherers.add(gatherer.name);
       const isGatherRequiredByAudits = requiredGatherers.has(gatherer.name);
       if (!isGatherRequiredByAudits) {
         const msg = `${gatherer.name} gatherer requested, however no audit requires it.`;
@@ -44,6 +65,17 @@ function assertValidPasses(passes, audits) {
       }
     });
   });
+
+  // All required gatherers must be found in the config. Throw otherwise.
+  for (const auditDefn of audits || []) {
+    const auditMeta = auditDefn.implementation.meta;
+    for (const requiredArtifact of auditMeta.requiredArtifacts) {
+      if (!foundGatherers.has(requiredArtifact)) {
+        throw new Error(`${requiredArtifact} gatherer, required by audit ${auditMeta.id}, ` +
+            'was not found in config.');
+      }
+    }
+  }
 
   // Passes must have unique `passName`s. Throw otherwise.
   const usedNames = new Set();

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -22,23 +22,27 @@ const {requireAudits, mergeOptionsOfItems, resolveModule} = require('./config-he
 /** @typedef {typeof import('../gather/gatherers/gatherer.js')} GathererConstructor */
 /** @typedef {InstanceType<GathererConstructor>} Gatherer */
 
-/** @type {Array<keyof LH.BaseArtifacts>} */
-const BASE_ARTIFACT_NAMES = [
-  'fetchTime',
-  'LighthouseRunWarnings',
-  'TestedAsMobileDevice',
-  'HostUserAgent',
-  'NetworkUserAgent',
-  'BenchmarkIndex',
-  'WebAppManifest',
-  'Stacks',
-  'traces',
-  'devtoolsLogs',
-  'settings',
-  'URL',
-  'Timing',
-  'PageLoadError',
-];
+/**
+ * Define with object literal so that tsc will require it to stay updated.
+ * @type {Record<keyof LH.BaseArtifacts, ''>}
+ */
+const BASE_ARTIFACT_BLANKS = {
+  fetchTime: '',
+  LighthouseRunWarnings: '',
+  TestedAsMobileDevice: '',
+  HostUserAgent: '',
+  NetworkUserAgent: '',
+  BenchmarkIndex: '',
+  WebAppManifest: '',
+  Stacks: '',
+  traces: '',
+  devtoolsLogs: '',
+  settings: '',
+  URL: '',
+  Timing: '',
+  PageLoadError: '',
+};
+const BASE_ARTIFACT_NAMES = Object.keys(BASE_ARTIFACT_BLANKS);
 
 /**
  * @param {Config['passes']} passes
@@ -50,7 +54,7 @@ function assertValidPasses(passes, audits) {
   }
 
   const requiredGatherers = Config.getGatherersNeededByAudits(audits);
-  /** @type {Set<string>} */
+  // Base artifacts are provided by GatherRunner, so start foundGatherers with them.
   const foundGatherers = new Set(BASE_ARTIFACT_NAMES);
 
   // Log if we are running gathers that are not needed by the audits listed in the config

--- a/lighthouse-core/lib/i18n/en-US.json
+++ b/lighthouse-core/lib/i18n/en-US.json
@@ -1671,9 +1671,17 @@
     "message": "DNS servers could not resolve the provided domain.",
     "description": "Error message explaining that the requested page could not be resolved by the DNS server."
   },
+  "lighthouse-core/lib/lh-error.js | erroredRequiredArtifact": {
+    "message": "Required {artifactName} gatherer encountered an error: {errorMessage}",
+    "description": "Error message explaning that there was an error while trying to collect a resource that was required for testing. \"artifactName\" will be replaced with the name of the resource that wasn't collected; \"errorMessage\" will be replaced with a string description of the error that occurred."
+  },
   "lighthouse-core/lib/lh-error.js | internalChromeError": {
     "message": "An internal Chrome error occurred. Please restart Chrome and try re-running Lighthouse.",
     "description": "Error message explaining that Chrome has encountered an error during the Lighthouse run, and that Chrome should be restarted."
+  },
+  "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": {
+    "message": "Required {artifactName} gatherer did not run.",
+    "description": "Error message explaning that a resource that was required for testing was never collected. \"artifactName\" will be replaced with the name of the resource that wasn't collected."
   },
   "lighthouse-core/lib/lh-error.js | pageLoadFailed": {
     "message": "Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests.",

--- a/lighthouse-core/lib/lh-error.js
+++ b/lighthouse-core/lib/lh-error.js
@@ -39,6 +39,10 @@ const UIStrings = {
   pageLoadFailedHung: 'Lighthouse was unable to reliably load the URL you requested because the page stopped responding.',
   /** Error message explaining that Lighthouse timed out while waiting for the initial connection to the Chrome Devtools protocol. */
   criTimeout: 'Timeout waiting for initial Debugger Protocol connection.',
+  /** Error message explaning that a resource that was required for testing was never collected. "artifactName" will be replaced with the name of the resource that wasn't collected. */
+  missingRequiredArtifact: 'Required {artifactName} gatherer did not run.',
+  /** Error message explaning that there was an error while trying to collect a resource that was required for testing. "artifactName" will be replaced with the name of the resource that wasn't collected; "errorMessage" will be replaced with a string description of the error that occurred. */
+  erroredRequiredArtifact: 'Required {artifactName} gatherer encountered an error: {errorMessage}',
 };
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
@@ -243,6 +247,24 @@ const ERRORS = {
     code: 'CRI_TIMEOUT',
     message: UIStrings.criTimeout,
     lhrRuntimeError: true,
+  },
+
+  /**
+   * Error internal to Runner used when an artifact required for an audit is missing.
+   * Requires an additional `artifactName` field for translation.
+  */
+  MISSING_REQUIRED_ARTIFACT: {
+    code: 'MISSING_REQUIRED_ARTIFACT',
+    message: UIStrings.missingRequiredArtifact,
+  },
+
+  /**
+   * Error internal to Runner used when an artifact required for an audit was an error.
+   * Requires additional `artifactName` and `errorMessage` fields for translation.
+  */
+  ERRORED_REQUIRED_ARTIFACT: {
+    code: 'ERRORED_REQUIRED_ARTIFACT',
+    message: UIStrings.erroredRequiredArtifact,
   },
 
   // Hey! When adding a new error type, update lighthouse-result.proto too.


### PR DESCRIPTION
as mentioned in https://github.com/GoogleChrome/lighthouse/pull/8865#pullrequestreview-243000692, when there is a pageLoadError you get a *ton* of logging, 2x every audit. #9236 moved that logging from "Required x gatherer encountered an error" to "Required x gatherer did not run", but you still get a lot of it.

This PR
- halves the logging (in the end, it didn't feel right to completely remove the warnings)
- the easiest way to do that was to i18n the "required x gatherer" error strings
- adds a new validation check to Config to separate the cases of `"a gatherer didn't run due to an error"` and `"a gatherer didn't run due to not being included in the config"`. Currently those cases are logged the exact same way, and not until the whole LH run has completed, which sucks if you just messed up your config.