### PR TITLE
misc: localize logged GatherRunner error

### DIFF
--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -12,6 +12,7 @@ const LHError = require('../lib/lh-error.js');
 const URL = require('../lib/url-shim.js');
 const NetworkRecorder = require('../lib/network-recorder.js');
 const constants = require('../config/constants.js');
+const i18n = require('../lib/i18n/i18n.js');
 
 /** @typedef {import('../gather/driver.js')} Driver */
 
@@ -646,7 +647,10 @@ class GatherRunner {
     // In case of load error, save log and trace with an error prefix, return no artifacts for this pass.
     const pageLoadError = GatherRunner.getPageLoadError(passContext, loadData, possibleNavError);
     if (pageLoadError) {
-      log.error('GatherRunner', pageLoadError.friendlyMessage, passContext.url);
+      const localizedMessage = i18n.getFormatted(pageLoadError.friendlyMessage,
+          passContext.settings.locale);
+      log.error('GatherRunner', localizedMessage, passContext.url);
+
       passContext.LighthouseRunWarnings.push(pageLoadError.friendlyMessage);
       GatherRunner._addLoadDataToBaseArtifacts(passContext, loadData,
           `pageLoadError-${passConfig.passName}`);

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -183,6 +183,8 @@ const _ICUMsgNotFoundMsg = 'ICU message not found in destination locale';
  */
 function _formatIcuMessage(locale, icuMessageId, fallbackMessage, values) {
   const localeMessages = LOCALES[locale];
+  if (!localeMessages) throw new Error(`Unsupported locale '${locale}'`);
+
   const localeMessage = localeMessages[icuMessageId] && localeMessages[icuMessageId].message;
   // fallback to the original english message if we couldn't find a message in the specified locale
   // better to have an english message than no message at all, in some number cases it won't even matter
@@ -220,13 +222,16 @@ function _formatPathAsString(pathInLHR) {
  * @return {LH.I18NRendererStrings}
  */
 function getRendererFormattedStrings(locale) {
-  const icuMessageIds = Object.keys(LOCALES[locale]).filter(f => f.includes('core/report/html/'));
+  const localeMessages = LOCALES[locale];
+  if (!localeMessages) throw new Error(`Unsupported locale '${locale}'`);
+
+  const icuMessageIds = Object.keys(localeMessages).filter(f => f.includes('core/report/html/'));
   /** @type {LH.I18NRendererStrings} */
   const strings = {};
   for (const icuMessageId of icuMessageIds) {
     const [filename, varName] = icuMessageId.split(' | ');
     if (!filename.endsWith('util.js')) throw new Error(`Unexpected message: ${icuMessageId}`);
-    strings[varName] = LOCALES[locale][icuMessageId].message;
+    strings[varName] = localeMessages[icuMessageId].message;
   }
 
   return strings;

--- a/lighthouse-core/test/lib/i18n/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n/i18n-test.js
@@ -61,6 +61,22 @@ describe('i18n', () => {
       expect(strings.passedAuditsGroupTitle).toEqual('[Þåššéð åûðîţš one two]');
       expect(strings.snippetCollapseButtonLabel).toEqual('[Çöļļåþšé šñîþþéţ one two]');
     });
+
+    it('throws an error for invalid locales', () => {
+      expect(_ => i18n.getRendererFormattedStrings('not-a-locale'))
+        .toThrow(`Unsupported locale 'not-a-locale'`);
+    });
+  });
+
+  describe('#getFormatted', () => {
+    it('throws an error for invalid locales', () => {
+      // Populate a string to try to localize to a bad locale.
+      const UIStrings = {testMessage: 'testy test'};
+      const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
+
+      expect(_ => i18n.getFormatted(str_(UIStrings.testMessage), 'still-not-a-locale'))
+        .toThrow(`Unsupported locale 'still-not-a-locale'`);
+    });
   });
 
   describe('#lookupLocale', () => {


### PR DESCRIPTION
another tiny one, apologies for the spam :)

Right now when you hit a pageLoadError you get a logged message like
`GatherRunner:error lighthouse-core/lib/lh-error.js | pageLoadFailedInsecure # 0 https://expired.badssl.com/ +3ms`

This gets the full string for it.

fixes #8944