### PR TITLE
tests(smokehouse): assert on expected array length

### DIFF
--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -141,7 +141,7 @@ module.exports = [
                 resourceSize: 52997,
               },
               {
-                url: "http://localhost:10200/favicon.ico",
+                url: 'http://localhost:10200/favicon.ico',
               },
             ],
           },

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -140,6 +140,9 @@ module.exports = [
                 transferSize: 53181,
                 resourceSize: 52997,
               },
+              {
+                url: "http://localhost:10200/favicon.ico",
+              },
             ],
           },
         },

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -5,7 +5,11 @@
  */
 'use strict';
 
-const IS_ARRAY = {};
+// Just using `[]` actually asserts for an empty array.
+// Use this expectation object to assert an array with at least one element.
+const IS_NONEMPTY_ARRAY = {
+  length: '>0',
+};
 
 /**
  * Expected Lighthouse audit values for sites with various errors.
@@ -26,10 +30,10 @@ module.exports = [
     artifacts: {
       PageLoadError: {code: 'PAGE_HUNG'},
       devtoolsLogs: {
-        'pageLoadError-defaultPass': IS_ARRAY,
+        'pageLoadError-defaultPass': IS_NONEMPTY_ARRAY,
       },
       traces: {
-        'pageLoadError-defaultPass': {traceEvents: IS_ARRAY},
+        'pageLoadError-defaultPass': {traceEvents: IS_NONEMPTY_ARRAY},
       },
     },
   },
@@ -48,10 +52,10 @@ module.exports = [
     artifacts: {
       PageLoadError: {code: 'INSECURE_DOCUMENT_REQUEST'},
       devtoolsLogs: {
-        'pageLoadError-defaultPass': IS_ARRAY,
+        'pageLoadError-defaultPass': IS_NONEMPTY_ARRAY,
       },
       traces: {
-        'pageLoadError-defaultPass': {traceEvents: IS_ARRAY},
+        'pageLoadError-defaultPass': {traceEvents: IS_NONEMPTY_ARRAY},
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -7,7 +7,7 @@
 
 // Just using `[]` actually asserts for an empty array.
 // Use this expectation object to assert an array with at least one element.
-const IS_NONEMPTY_ARRAY = {
+const NONEMPTY_ARRAY = {
   length: '>0',
 };
 
@@ -30,10 +30,10 @@ module.exports = [
     artifacts: {
       PageLoadError: {code: 'PAGE_HUNG'},
       devtoolsLogs: {
-        'pageLoadError-defaultPass': IS_NONEMPTY_ARRAY,
+        'pageLoadError-defaultPass': NONEMPTY_ARRAY,
       },
       traces: {
-        'pageLoadError-defaultPass': {traceEvents: IS_NONEMPTY_ARRAY},
+        'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY},
       },
     },
   },
@@ -52,10 +52,10 @@ module.exports = [
     artifacts: {
       PageLoadError: {code: 'INSECURE_DOCUMENT_REQUEST'},
       devtoolsLogs: {
-        'pageLoadError-defaultPass': IS_NONEMPTY_ARRAY,
+        'pageLoadError-defaultPass': NONEMPTY_ARRAY,
       },
       traces: {
-        'pageLoadError-defaultPass': {traceEvents: IS_NONEMPTY_ARRAY},
+        'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY},
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/error-expectations.js
+++ b/lighthouse-cli/test/smokehouse/error-expectations.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const IS_ARRAY = {};
+
 /**
  * Expected Lighthouse audit values for sites with various errors.
  */
@@ -24,10 +26,10 @@ module.exports = [
     artifacts: {
       PageLoadError: {code: 'PAGE_HUNG'},
       devtoolsLogs: {
-        'pageLoadError-defaultPass': [/* ... */],
+        'pageLoadError-defaultPass': IS_ARRAY,
       },
       traces: {
-        'pageLoadError-defaultPass': {traceEvents: [/* ... */]},
+        'pageLoadError-defaultPass': {traceEvents: IS_ARRAY},
       },
     },
   },
@@ -46,10 +48,10 @@ module.exports = [
     artifacts: {
       PageLoadError: {code: 'INSECURE_DOCUMENT_REQUEST'},
       devtoolsLogs: {
-        'pageLoadError-defaultPass': [/* ... */],
+        'pageLoadError-defaultPass': IS_ARRAY,
       },
       traces: {
-        'pageLoadError-defaultPass': {traceEvents: [/* ... */]},
+        'pageLoadError-defaultPass': {traceEvents: IS_ARRAY},
       },
     },
   },

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -98,7 +98,7 @@ function findDifference(path, actual, expected) {
     }
   }
 
-  // If the expected value is an array, assert on the length.
+  // If the expected value is an array, assert the length as well.
   // This still allows for asserting that the first n elements of an array are specified elements,
   // but requires using an object literal (ex: {0: x, 1: y, 2: z} matches [x, y, z, q, w, e] and
   // {0: x, 1: y, 2: z, length: 5} does not match [x, y, z].

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -104,7 +104,7 @@ function findDifference(path, actual, expected) {
   // {0: x, 1: y, 2: z, length: 5} does not match [x, y, z].
   if (Array.isArray(expected) && actual.length !== expected.length) {
     return {
-      path,
+      path: `${path}.length`,
       actual,
       expected,
     };

--- a/lighthouse-cli/test/smokehouse/smokehouse-report.js
+++ b/lighthouse-cli/test/smokehouse/smokehouse-report.js
@@ -98,6 +98,18 @@ function findDifference(path, actual, expected) {
     }
   }
 
+  // If the expected value is an array, assert on the length.
+  // This still allows for asserting that the first n elements of an array are specified elements,
+  // but requires using an object literal (ex: {0: x, 1: y, 2: z} matches [x, y, z, q, w, e] and
+  // {0: x, 1: y, 2: z, length: 5} does not match [x, y, z].
+  if (Array.isArray(expected) && actual.length !== expected.length) {
+    return {
+      path,
+      actual,
+      expected,
+    };
+  }
+
   return null;
 }
 


### PR DESCRIPTION
Extracted from https://github.com/GoogleChrome/lighthouse/pull/9248#discussion_r296821666

Proposal to change arrays in expectations to this behavior:


```
{
	expected: []
}

passes: []
fails: literally anything else

------------------------------

{
	expected: [1, 2, 3]
}

passes: [1, 2, 3]
fails: literally anything else

------------------------------

{
	expected: {length: 2}
}

passes: [1, 2] [1, 3] [x, y] {length: 2}
fails: [] [1] [1, 2, 3]

------------------------------

{
	expected: {0: 'a', 1: 'b'}
}

passes: ['a', 'b'] ['a', 'b', 'blah']
fails: ['b', 'a']

------------------------------

{
	expected: {0: 'a', 1: 'b', length: 3}
}

passes: ['a', 'b', *]
fails: ['a', 'b']

```