### PR TITLE
misc: remove duplicate colon from regex

### DIFF
--- a/lighthouse-core/lib/file-namer.js
+++ b/lighthouse-core/lib/file-namer.js
@@ -33,7 +33,7 @@ function getFilenamePrefix(lhr) {
 
   const filenamePrefix = `${hostname}_${dateStr}_${timeStr}`;
   // replace characters that are unfriendly to filenames
-  return filenamePrefix.replace(/[/?<>\\:*|":]/g, '-');
+  return filenamePrefix.replace(/[/?<>\\:*|"]/g, '-');
 }
 
 // don't attempt to export in the browser.


### PR DESCRIPTION
**Summary**

This fixes a [warning from lgtm](https://lgtm.com/projects/g/GoogleChrome/lighthouse/snapshot/1cdbc90f2af7cdb0c3f0894dac1fccdb44c1b30c/files/lighthouse-core/lib/file-namer.js?sort=name&dir=ASC&mode=heatmap)
