### PR TITLE
tests(snyk): assert upper bounds

### DIFF
--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -104,6 +104,11 @@ describe('Every snyk vulnerability has an upperbound', () => {
   for (const vulns of Object.values(NoVulnerableLibrariesAudit.snykDB.npm)) {
     for (const vuln of vulns) {
       for (const semver of vuln.semver.vulnerable) {
+        // Examples of what semver can be:
+        // <1.12.2
+        // >=1.12.3 <2.2.2
+        // >=2.2.3 <3.0.0
+        // >=3.0.0 <3.10.1 || =3.10.2
         assert.notEqual(semver, '*', 'invalid semver: * is not allowed');
 
         const clauses = semver.split('||');

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -106,6 +106,7 @@ function hasUpperBound(rangeString) {
   const range = new semver.Range(rangeString);
   if (!range) return false;
 
+  // For every subset ...
   for (const subset of range.set) {
     // Upperbound exists if...
 
@@ -119,6 +120,7 @@ function hasUpperBound(rangeString) {
       continue;
     }
 
+    // No upperbound for this subset.
     return false;
   }
 

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -104,7 +104,14 @@ describe('No glob in snyk', () => {
   for (const vulns of Object.values(NoVulnerableLibrariesAudit.snykDB.npm)) {
     for (const vuln of vulns) {
       for (const semver of vuln.semver.vulnerable) {
-        assert.notEqual(semver, '*');
+        assert.notEqual(semver, '*', 'invalid semver: * is not allowed');
+
+        const clauses = semver.split('||');
+        for (const clause of clauses) {
+          if (!clause.trim().startsWith('=') && !clause.includes('<')) {
+            assert.fail(`invalid semver: ${semver}. Must contain an upper bound`);
+          }
+        }
       }
     }
   }

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -100,7 +100,7 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
   });
 });
 
-describe('No glob in snyk', () => {
+describe('Every snyk vulnerability has an upperbound', () => {
   for (const vulns of Object.values(NoVulnerableLibrariesAudit.snykDB.npm)) {
     for (const vuln of vulns) {
       for (const semver of vuln.semver.vulnerable) {

--- a/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
+++ b/lighthouse-core/test/audits/dobetterweb/no-vulnerable-libraries-test.js
@@ -99,3 +99,13 @@ describe('Avoids front-end JavaScript libraries with known vulnerabilities', () 
     assert.equal(auditResult.score, 1);
   });
 });
+
+describe('No glob in snyk', () => {
+  for (const vulns of Object.values(NoVulnerableLibrariesAudit.snykDB.npm)) {
+    for (const vuln of vulns) {
+      for (const semver of vuln.semver.vulnerable) {
+        assert.notEqual(semver, '*');
+      }
+    }
+  }
+});


### PR DESCRIPTION
see https://github.com/GoogleChrome/lighthouse/issues/8409#issuecomment-485009237

> Since we ship to places we can't necessarily quickly update (e.g. DevTools), I wonder if we should have a LH test that fails if the database has * or >=X, and require it be corrected to <= some hardcoded version (presumably the latest available release), even if that version is still vulnerable.
>
> The theory would be: if a new, still vulnerable version of the library comes out after that LH release, then it's better to have a false negative (given that there's no fix available anyways and there are other sources (github, npm, greenkeeper, etc) that will warn folks) than it is to have up to 12 weeks of a false positive (if a new, non-vulnerable version comes out) which would annoy folks and encourage them to ignore Lighthouse's warnings in the future.

Should `<=X` be added to the end of every `semver.vulnerable`, where X = the latest release within that major version?