### PR TITLE
deps: chrome-launcher@0.11.1

### DIFF
--- a/lighthouse-core/scripts/manual-chrome-launcher.js
+++ b/lighthouse-core/scripts/manual-chrome-launcher.js
@@ -19,7 +19,6 @@ const args = process.argv.slice(2);
 const chromeFlags = [];
 let startingUrl;
 let port;
-let shouldEnableExtensions;
 let ignoreDefaultFlags;
 
 if (args.length) {
@@ -28,9 +27,9 @@ if (args.length) {
   const portFlag = providedFlags.find(flag => flag.startsWith('--port='));
   if (portFlag) port = parseInt(portFlag.replace('--port=', ''), 10);
 
-  shouldEnableExtensions = !!providedFlags.find(flag => flag === '--enable-extensions');
+  const enableExtensions = !!providedFlags.find(flag => flag === '--enable-extensions');
   // The basic pattern for enabling Chrome extensions
-  if (shouldEnableExtensions) {
+  if (enableExtensions) {
     ignoreDefaultFlags = true;
     chromeFlags.push(...Launcher.defaultFlags().filter(flag => flag !== '--disable-extensions'));
   }

--- a/lighthouse-core/scripts/manual-chrome-launcher.js
+++ b/lighthouse-core/scripts/manual-chrome-launcher.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 'use strict';
-
 /**
  * @fileoverview Script to launch a clean Chrome instance on-demand.
  *
@@ -14,29 +13,36 @@
  *     chrome-debug --enable-extensions
  */
 
-const {launch} = require('chrome-launcher');
+const {Launcher, launch} = require('chrome-launcher');
 
 const args = process.argv.slice(2);
-let chromeFlags;
+const chromeFlags = [];
 let startingUrl;
 let port;
-let enableExtensions;
+let shouldEnableExtensions;
+let ignoreDefaultFlags;
 
 if (args.length) {
-  chromeFlags = args.filter(flag => flag.startsWith('--'));
+  const providedFlags = args.filter(flag => flag.startsWith('--'));
 
-  const portFlag = chromeFlags.find(flag => flag.startsWith('--port='));
+  const portFlag = providedFlags.find(flag => flag.startsWith('--port='));
   if (portFlag) port = parseInt(portFlag.replace('--port=', ''), 10);
 
-  enableExtensions = !!chromeFlags.find(flag => flag === '--enable-extensions');
+  shouldEnableExtensions = !!providedFlags.find(flag => flag === '--enable-extensions');
+  // The basic pattern for enabling Chrome extensions
+  if (shouldEnableExtensions) {
+    ignoreDefaultFlags = true;
+    chromeFlags.push(...Launcher.defaultFlags().filter(flag => flag !== '--disable-extensions'));
+  }
 
+  chromeFlags.push(...providedFlags);
   startingUrl = args.find(flag => !flag.startsWith('--'));
 }
 
 launch({
   startingUrl,
   port,
-  enableExtensions,
+  ignoreDefaultFlags,
   chromeFlags,
 })
 // eslint-disable-next-line no-console

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "dependencies": {
     "axe-core": "3.2.2",
-    "chrome-launcher": "^0.10.7",
+    "chrome-launcher": "^0.11.1",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",
     "details-element-polyfill": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,13 +1788,13 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
-chrome-launcher@^0.10.7:
-  version "0.10.7"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.10.7.tgz#5e2a9e99f212e0501d9c7024802acd01a812f5d5"
-  integrity sha512-IoQLp64s2n8OQuvKZwt77CscVj3UlV2Dj7yZtd1EBMld9mSdGcsGy9fN5hd/r4vJuWZR09it78n1+A17gB+AIQ==
+chrome-launcher@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.11.1.tgz#ccc5bd971c76cdd263d17acacaeb762454c1af92"
+  integrity sha512-Om9LtiJ+FIh8sfhx8HaN4Petj75dIVeTBNUbXIXPIS5W3y9dyNRGmChcl0Z5trQkcy+8XDJA3NWicYdpZeF+DA==
   dependencies:
     "@types/node" "*"
-    is-wsl "^1.1.0"
+    is-wsl "^2.1.0"
     lighthouse-logger "^1.0.0"
     mkdirp "0.5.1"
     rimraf "^2.6.1"
@@ -4288,10 +4288,10 @@ is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+is-wsl@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.0.tgz#94369bbeb2249ef07b831b1b08590e686330ccbb"
+  integrity sha512-pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ==
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
notable commits:

* `448a1d48` chrome-finder: Add support for MacOS Catalina (https://github.com/GoogleChrome/chrome-launcher/pull/149)
* `55b891bb` deps(is-wsl): add support for WSL 2; drop Node 6 (https://github.com/GoogleChrome/chrome-launcher/pull/152/)

fixes #9279