### PR TITLE
core(domstats): support an empty html body

### DIFF
--- a/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
+++ b/lighthouse-core/gather/gatherers/dobetterweb/domstats.js
@@ -86,8 +86,8 @@ function elementPathInDOM(element) {
 /* istanbul ignore next */
 function getDOMStats(element, deep = true) {
   let deepestElement = null;
-  let maxDepth = 0;
-  let maxWidth = 0;
+  let maxDepth = -1;
+  let maxWidth = -1;
   let numElements = 0;
   let parentWithMostChildren = null;
 


### PR DESCRIPTION
fixes #8725

The issue was that domstats starts with a 0 as the max number of children seen as the base case, an empty `<body>` has 0 children (which isn't more than 0), and so `parentWithMostChildren` stayed as `null`.

Instead we start with a -1 so that there will always be at least `<body>` in there. Could have also gone with a `>=` check, but that changes it so `parentWithMostChildren` is the last one seen if there are ties, which would sort of be a breaking change. This seemed better (and more the original intent, I guess).