### PR TITLE
clients(devtools): audits2 -> audits1 and defer reading resources

### DIFF
--- a/clients/devtools-report-assets.js
+++ b/clients/devtools-report-assets.js
@@ -16,9 +16,21 @@
 // @ts-ignore: Runtime exists in Devtools.
 const cachedResources = Runtime.cachedResources;
 
+// Getters are necessary because the DevTools bundling processes
+// resources after this module is resolved. These properties are not
+// read from immeditely, so we can defer reading with getters and everything
+// is going to be OK.
 module.exports = {
-  REPORT_CSS: cachedResources['audits/lighthouse/report.css'],
-  REPORT_JAVASCRIPT: cachedResources['audits/lighthouse/report.js'],
-  REPORT_TEMPLATE: cachedResources['audits/lighthouse/template.html'],
-  REPORT_TEMPLATES: cachedResources['audits/lighthouse/templates.html'],
+  get REPORT_CSS() {
+    return cachedResources['audits/lighthouse/report.css'];
+  },
+  get REPORT_JAVASCRIPT() {
+    return cachedResources['audits/lighthouse/report.js'];
+  },
+  get REPORT_TEMPLATE() {
+    return cachedResources['audits/lighthouse/template.html'];
+  },
+  get REPORT_TEMPLATES() {
+    return cachedResources['audits/lighthouse/templates.html'];
+  },
 };

--- a/clients/devtools-report-assets.js
+++ b/clients/devtools-report-assets.js
@@ -18,7 +18,7 @@ const cachedResources = Runtime.cachedResources;
 
 // Getters are necessary because the DevTools bundling processes
 // resources after this module is resolved. These properties are not
-// read from immeditely, so we can defer reading with getters and everything
+// read from immediately, so we can defer reading with getters and everything
 // is going to be OK.
 module.exports = {
   get REPORT_CSS() {

--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -43,6 +43,8 @@ cp -pPR "$lh_bg_js" "$lh_worker_dir/lighthouse-dt-bundle.js"
 echo -e "\033[96m ✓\033[39m (Potentially stale) lighthouse-dt-bundle copied."
 
 # copy report generator + cached resources into $fe_lh_dir
+# use dir/* format to copy over all files in dt-report-resources directly to $fe_lh_dir 
+# dir/ format behavior changes based on if their exists a folder named dir, which can get weird
 cp -r dist/dt-report-resources/* $fe_lh_dir
 
 # update expected version string in tests

--- a/lighthouse-core/scripts/roll-to-devtools.sh
+++ b/lighthouse-core/scripts/roll-to-devtools.sh
@@ -21,7 +21,7 @@ else
   frontend_dir="$chromium_dir/third_party/blink/renderer/devtools/front_end"
 fi
 
-tests_dir="$frontend_dir/../../../web_tests/http/tests/devtools/audits2"
+tests_dir="$frontend_dir/../../../web_tests/http/tests/devtools/audits"
 
 if [[ ! -d "$frontend_dir" || ! -a "$frontend_dir/Runtime.js" ]]; then
   echo -e "\033[31m✖ Error!\033[39m"
@@ -43,10 +43,10 @@ cp -pPR "$lh_bg_js" "$lh_worker_dir/lighthouse-dt-bundle.js"
 echo -e "\033[96m ✓\033[39m (Potentially stale) lighthouse-dt-bundle copied."
 
 # copy report generator + cached resources into $fe_lh_dir
-cp -r dist/dt-report-resources/ $fe_lh_dir
+cp -r dist/dt-report-resources/* $fe_lh_dir
 
 # update expected version string in tests
 VERSION=$(node -e "console.log(require('./package.json').version)")
 sed -i '' -e "s/Version:.*/Version: $VERSION/g" "$tests_dir"/*-expected.txt
 
-echo "Done. To rebase the test expectations, run: yarn --cwd ~/chromium/src/third_party/blink/renderer/devtools test 'http/tests/devtools/audits2/*' --reset-results"
+echo "Done. To rebase the test expectations, run: yarn --cwd ~/chromium/src/third_party/blink/renderer/devtools test 'http/tests/devtools/audits/*' --reset-results"


### PR DESCRIPTION
Current canary errors when saving as HTML. Issue is with how DevTools is bundled. Read comments for more.

Associated chromium change: https://chromium-review.googlesource.com/c/chromium/src/+/1696348

Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=979131