### PR TITLE
audits(font-size): calculate accurate line/column for inline styles

### DIFF
--- a/lighthouse-cli/test/fixtures/seo/seo-tester-styles.css
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester-styles.css
@@ -1,0 +1,7 @@
+/** some filler */
+
+.small-4 {
+    font-size: 6px;
+}
+
+/*# sourceURL=seo-tester-styles-magic.css */

--- a/lighthouse-cli/test/fixtures/seo/seo-tester.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester.html
@@ -25,6 +25,7 @@
       font-size: 11px;
     }
   </style>
+  <style> /* some filler to offset things */ .small-2 { font-size: 11px; }</style>
 </head>
 <body>
   <!-- PASS(hreflang): should ignore links in the body -->
@@ -43,6 +44,7 @@
   <h2>Small text</h2>
   <!-- PASS(font-size): amount of illegible text is below the 60% threshold -->
   <p class='small'> 1 </p>
+  <p class='small-2'> 2 </p>
   <h6>2</h6>
   <font size="1">3<b>4</b></font>
   <p style='font-size:10px'>5        </p>

--- a/lighthouse-cli/test/fixtures/seo/seo-tester.html
+++ b/lighthouse-cli/test/fixtures/seo/seo-tester.html
@@ -24,8 +24,16 @@
     .small {
       font-size: 11px;
     }
-  </style>
+    </style>
   <style> /* some filler to offset things */ .small-2 { font-size: 11px; }</style>
+  <style>
+    /* some filler to offset things */
+    .small-3 {
+      font-size: 6px;
+    }
+    /*# sourceURL=seo-tester-inline-magic.css */
+  </style>
+  <link rel="stylesheet" href="seo-tester-styles.css">
 </head>
 <body>
   <!-- PASS(hreflang): should ignore links in the body -->
@@ -43,11 +51,14 @@
 
   <h2>Small text</h2>
   <!-- PASS(font-size): amount of illegible text is below the 60% threshold -->
-  <p class='small'> 1 </p>
-  <p class='small-2'> 2 </p>
+  <!-- font-size items are ordered by text length, so force an order with filler for stable expectations. -->
+  <p class='small'> 1.... </p>
+  <p class='small-2'> 2... </p>
+  <p class='small-3'> 3.. </p>
+  <p class='small-4'> 4. </p>
   <h6>2</h6>
   <font size="1">3<b>4</b></font>
-  <p style='font-size:10px'>5        </p>
+  <p style='font-size:10px'> 5 </p>
   <script class='small'>
     // text from SCRIPT tags should be ignored by the font-size audit
   </script>

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -117,9 +117,62 @@ module.exports = [
         'font-size': {
           score: 1,
           details: {
-            items: {
-              length: 6,
-            },
+            items: [
+              {
+                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522:24:12',
+                selector: '.small',
+                coverage: '1.32%',
+                fontSize: '11px',
+              },
+              {
+                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522:28:55',
+                selector: '.small-2',
+                coverage: '1.32%',
+                fontSize: '11px',
+              },
+              {
+                source: 'User Agent Stylesheet',
+                selector: 'h6',
+                coverage: '1.32%',
+                fontSize: '10px',
+              },
+              {
+                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522',
+                selector: {
+                  type: 'node',
+                  selector: 'body',
+                  snippet: '<font size="1">',
+                },
+                coverage: '1.32%',
+                fontSize: '10px',
+              },
+              {
+                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522',
+                selector: {
+                  type: 'node',
+                  selector: 'font',
+                  snippet: '<b>',
+                },
+                coverage: '1.32%',
+                fontSize: '10px',
+              },
+              {
+                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522',
+                selector: {
+                  type: 'node',
+                  selector: 'body',
+                  snippet: '<p style="font-size:10px">',
+                },
+                coverage: '1.32%',
+                fontSize: '10px',
+              },
+              {
+                source: 'Legible text',
+                selector: '',
+                coverage: '92.11%',
+                fontSize: '≥ 12px',
+              },
+            ],
           },
         },
         'link-text': {

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -119,57 +119,50 @@ module.exports = [
           details: {
             items: [
               {
-                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522:24:12',
+                source: /seo-tester\.html.+:24:12$/,
                 selector: '.small',
-                coverage: '1.32%',
                 fontSize: '11px',
               },
               {
-                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522:28:55',
+                source: /seo-tester\.html.+:28:55$/,
                 selector: '.small-2',
-                coverage: '1.32%',
                 fontSize: '11px',
               },
               {
                 source: 'User Agent Stylesheet',
                 selector: 'h6',
-                coverage: '1.32%',
                 fontSize: '10px',
               },
               {
-                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522',
+                source: /seo-tester\.html.+$/,
                 selector: {
                   type: 'node',
                   selector: 'body',
                   snippet: '<font size="1">',
                 },
-                coverage: '1.32%',
                 fontSize: '10px',
               },
               {
-                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522',
+                source: /seo-tester\.html.+$/,
                 selector: {
                   type: 'node',
                   selector: 'font',
                   snippet: '<b>',
                 },
-                coverage: '1.32%',
                 fontSize: '10px',
               },
               {
-                source: 'http://localhost:10200/seo/seo-tester.html?extra_header=link%3D%253Chttp%253A%252F%252Flocalhost%253A10200%252Fseo%252F%253E%253B%2Brel%253D%2522canonical%2522',
+                source: /seo-tester\.html.+$/,
                 selector: {
                   type: 'node',
                   selector: 'body',
                   snippet: '<p style="font-size:10px">',
                 },
-                coverage: '1.32%',
                 fontSize: '10px',
               },
               {
                 source: 'Legible text',
                 selector: '',
-                coverage: '92.11%',
                 fontSize: '≥ 12px',
               },
             ],

--- a/lighthouse-cli/test/smokehouse/seo/expectations.js
+++ b/lighthouse-cli/test/smokehouse/seo/expectations.js
@@ -129,6 +129,16 @@ module.exports = [
                 fontSize: '11px',
               },
               {
+                source: /seo-tester-inline-magic\.css:3:14$/,
+                selector: '.small-3',
+                fontSize: '6px',
+              },
+              {
+                source: /seo-tester-styles-magic\.css:3:10$/,
+                selector: '.small-4',
+                fontSize: '6px',
+              },
+              {
                 source: 'User Agent Stylesheet',
                 selector: 'h6',
                 fontSize: '10px',

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -157,8 +157,8 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
         source = `${url.href}`;
 
         if (range) {
-          let line = stylesheet.startLine + 1;
-          let column = stylesheet.startColumn;
+          let line = range.startLine + 1;
+          let column = range.startColumn;
 
           // Add the startLine/startColumn of the <style> element to the range, if stylesheet
           // is inline.
@@ -168,7 +168,7 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
           // Sources panel.
           const addHtmlLocationOffset = stylesheet.isInline && !stylesheet.hasSourceURL;
           if (addHtmlLocationOffset) {
-            line += range.startLine;
+            line += stylesheet.startLine;
             // The column the stylesheet begins on is only relevant if the rule is declared on the same line.
             if (range.startLine === 0) {
               column += stylesheet.startColumn;

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -157,10 +157,17 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
         source = `${url.href}`;
 
         if (range) {
-          // `stylesheet` can be either an external file (stylesheet.startLine will always be 0),
-          // or a <style> block (stylesheet.startLine will vary)
-          const absoluteStartLine = range.startLine + stylesheet.startLine + 1;
-          const absoluteStartColumn = range.startColumn + stylesheet.startColumn + 1;
+          // Add the startLine/startColumn of the <style> element to the range, if stylesheet is inline.
+          // Just use the rule's location if a sourceURL magic comment is present (`hasSourceURL` is true).
+          const addHtmlLocationOffset = stylesheet.isInline && !stylesheet.hasSourceURL;
+
+          const absoluteStartLine = addHtmlLocationOffset ?
+            range.startLine + stylesheet.startLine + 1 :
+            range.startLine + 1;
+          // The column the stylesheet begins on is only relevant if the rule is declared on the same line.
+          const absoluteStartColumn = addHtmlLocationOffset && range.startLine === 0 ?
+            range.startColumn + stylesheet.startColumn :
+            range.startColumn;
 
           source += `:${absoluteStartLine}:${absoluteStartColumn}`;
         }

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -157,17 +157,23 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
         source = `${url.href}`;
 
         if (range) {
-          // Add the startLine/startColumn of the <style> element to the range, if stylesheet is inline.
-          // Just use the rule's location if a sourceURL magic comment is present (`hasSourceURL` is true).
-          const addHtmlLocationOffset = stylesheet.isInline && !stylesheet.hasSourceURL;
+          let line = stylesheet.startLine + 1;
+          let column = stylesheet.startColumn;
 
-          const line = addHtmlLocationOffset ?
-            range.startLine + stylesheet.startLine + 1 :
-            range.startLine + 1;
-          // The column the stylesheet begins on is only relevant if the rule is declared on the same line.
-          const column = addHtmlLocationOffset && range.startLine === 0 ?
-            range.startColumn + stylesheet.startColumn :
-            range.startColumn;
+          // Add the startLine/startColumn of the <style> element to the range, if stylesheet
+          // is inline.
+          // Always use the rule's location if a sourceURL magic comment is
+          // present (`hasSourceURL` is true) - this makes the line/col relative to the start
+          // of the style tag, which makes them relevant when the "file" is open in DevTool's
+          // Sources panel.
+          const addHtmlLocationOffset = stylesheet.isInline && !stylesheet.hasSourceURL;
+          if (addHtmlLocationOffset) {
+            line += range.startLine;
+            // The column the stylesheet begins on is only relevant if the rule is declared on the same line.
+            if (range.startLine === 0) {
+              column += stylesheet.startColumn;
+            }
+          }
 
           source += `:${line}:${column}`;
         }

--- a/lighthouse-core/audits/seo/font-size.js
+++ b/lighthouse-core/audits/seo/font-size.js
@@ -161,15 +161,15 @@ function findStyleRuleSource(baseURL, styleDeclaration, node) {
           // Just use the rule's location if a sourceURL magic comment is present (`hasSourceURL` is true).
           const addHtmlLocationOffset = stylesheet.isInline && !stylesheet.hasSourceURL;
 
-          const absoluteStartLine = addHtmlLocationOffset ?
+          const line = addHtmlLocationOffset ?
             range.startLine + stylesheet.startLine + 1 :
             range.startLine + 1;
           // The column the stylesheet begins on is only relevant if the rule is declared on the same line.
-          const absoluteStartColumn = addHtmlLocationOffset && range.startLine === 0 ?
+          const column = addHtmlLocationOffset && range.startLine === 0 ?
             range.startColumn + stylesheet.startColumn :
             range.startColumn;
 
-          source += `:${absoluteStartLine}:${absoluteStartColumn}`;
+          source += `:${line}:${column}`;
         }
       } else {
         // dynamically injected to page


### PR DESCRIPTION
split off of #9354

1) For inline styles, the stylesheet's startColumn was always being added to the rule's column. However, this is only valid if the stylesheet and the rule begin on the same line in the HTML.
2) For inline styles with a sourceURL magic comment, the line/column was relative to the HTML file. I've changed it to be relative to the beginning of the style tag, as if it were its own file.
3) Lines are 1-indexed, but columns are 0-indexed. All columns were off by one.

before:

![image](https://user-images.githubusercontent.com/4071474/61092962-461efc80-a3fd-11e9-8dc5-33b0e418f904.png)

after:

![image](https://user-images.githubusercontent.com/4071474/61092968-4fa86480-a3fd-11e9-99ee-25f9ef38c309.png)

```
node lighthouse-cli/ http://misc-hoten.surge.sh/lh-ui-location-font-size/ --only-audits=font-size --view
```