### PR TITLE
deps: update to typescript 3.5.3

### DIFF
--- a/lighthouse-core/computed/network-analysis.js
+++ b/lighthouse-core/computed/network-analysis.js
@@ -12,7 +12,7 @@ const NetworkRecords = require('./network-records.js');
 class NetworkAnalysis {
   /**
    * @param {Array<LH.Artifacts.NetworkRequest>} records
-   * @return {Omit<LH.Artifacts.NetworkAnalysis, 'throughput'>}
+   * @return {StrictOmit<LH.Artifacts.NetworkAnalysis, 'throughput'>}
    */
   static computeRTTAndServerResponseTime(records) {
     // First pass compute the estimated observed RTT to each origin's servers.

--- a/lighthouse-core/config/config.js
+++ b/lighthouse-core/config/config.js
@@ -182,11 +182,9 @@ function cleanFlagsForSettings(flags = {}) {
   const settings = {};
 
   for (const key of Object.keys(flags)) {
-    // @ts-ignore - intentionally testing some keys not on defaultSettings to discard them.
-    if (typeof constants.defaultSettings[key] !== 'undefined') {
-      // Cast since key now must be able to index both Flags and Settings.
-      const safekey = /** @type {Extract<keyof LH.Flags, keyof LH.Config.Settings>} */ (key);
-      settings[safekey] = flags[safekey];
+    if (key in constants.defaultSettings) {
+      // @ts-ignore tsc can't yet express that key is only a single type in each iteration, not a union of types.
+      settings[key] = flags[key];
     }
   }
 

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -425,11 +425,11 @@ class GatherRunner {
     for (const [gathererName, phaseResultsPromises] of resultsEntries) {
       try {
         const phaseResults = await Promise.all(phaseResultsPromises);
-        // Take last defined pass result as artifact.
+        // Take last defined pass result as artifact. If there is none, handled by the undefined check below.
         const definedResults = phaseResults.filter(element => element !== undefined);
         const artifact = definedResults[definedResults.length - 1];
-        // Typecast pretends artifact always provided here, but checked below for top-level `throw`.
-        gathererArtifacts[gathererName] = /** @type {NonVoid<PhaseResult>} */ (artifact);
+        // @ts-ignore tsc can't yet express that gathererName is only a single type in each iteration, not a union of types.
+        gathererArtifacts[gathererName] = artifact;
       } catch (err) {
         // Return error to runner to handle turning it into an error audit.
         gathererArtifacts[gathererName] = err;

--- a/lighthouse-core/gather/gather-runner.js
+++ b/lighthouse-core/gather/gather-runner.js
@@ -425,7 +425,7 @@ class GatherRunner {
     for (const [gathererName, phaseResultsPromises] of resultsEntries) {
       try {
         const phaseResults = await Promise.all(phaseResultsPromises);
-        // Take last defined pass result as artifact. If there is none, handled by the undefined check below.
+        // Take the last defined pass result as artifact. If none are defined, the undefined check below handles it.
         const definedResults = phaseResults.filter(element => element !== undefined);
         const artifact = definedResults[definedResults.length - 1];
         // @ts-ignore tsc can't yet express that gathererName is only a single type in each iteration, not a union of types.

--- a/lighthouse-core/lib/lantern-trace-saver.js
+++ b/lighthouse-core/lib/lantern-trace-saver.js
@@ -133,7 +133,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
     if (startTime === endTime) endTime += 0.3;
 
     const requestData = {requestId: requestId.toString(), frame};
-    /** @type {Omit<LH.TraceEvent, 'name'|'ts'|'args'>} */
+    /** @type {StrictOmit<LH.TraceEvent, 'name'|'ts'|'args'>} */
     const baseRequestEvent = {...baseEvent, ph: 'I', s: 't', dur: 0};
 
     const sendRequestData = {

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -328,8 +328,9 @@ class ReportUIFeatures {
    * @param {ClipboardEvent} e
    */
   onCopy(e) {
-    // Only handle copy button presses (e.g. ignore the user copying page text).
-    if (this._copyAttempt) {
+    // Only handle copy button presses (e.g. ignore the user copying page text) and
+    // when the clipboard is available.
+    if (this._copyAttempt && e.clipboardData) {
       // We want to write our own data to the clipboard, not the user's text selection.
       e.preventDefault();
       e.clipboardData.setData('text/plain', JSON.stringify(this.json, null, 2));

--- a/lighthouse-core/report/html/renderer/report-ui-features.js
+++ b/lighthouse-core/report/html/renderer/report-ui-features.js
@@ -328,8 +328,7 @@ class ReportUIFeatures {
    * @param {ClipboardEvent} e
    */
   onCopy(e) {
-    // Only handle copy button presses (e.g. ignore the user copying page text) and
-    // when the clipboard is available.
+    // Only handle copy button presses (e.g. ignore the user copying page text).
     if (this._copyAttempt && e.clipboardData) {
       // We want to write our own data to the clipboard, not the user's text selection.
       e.preventDefault();

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -333,7 +333,9 @@ class Runner {
       // to prevent consumers from unnecessary type assertions.
       const requiredArtifacts = audit.meta.requiredArtifacts
         .reduce((requiredArtifacts, artifactName) => {
-          requiredArtifacts[artifactName] = artifacts[artifactName];
+          const requiredArtifact = artifacts[artifactName];
+          // @ts-ignore tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.
+          requiredArtifacts[artifactName] = requiredArtifact;
           return requiredArtifacts;
         }, /** @type {LH.Artifacts} */ ({}));
       const product = await audit.audit(requiredArtifacts, auditContext);

--- a/lighthouse-core/scripts/update-report-fixtures.js
+++ b/lighthouse-core/scripts/update-report-fixtures.js
@@ -46,7 +46,9 @@ async function update(artifactName) {
       throw Error('Unknown artifact name: ' + artifactName);
     }
     const finalArtifacts = oldArtifacts;
-    finalArtifacts[artifactName] = newArtifacts[artifactName];
+    const newArtifact = newArtifacts[artifactName];
+    // @ts-ignore tsc can't yet express that artifactName is only a single type in each iteration, not a union of types.
+    finalArtifacts[artifactName] = newArtifact;
     await assetSaver.saveArtifacts(finalArtifacts, artifactPath);
   }
 }

--- a/lighthouse-viewer/app/src/lighthouse-report-viewer.js
+++ b/lighthouse-viewer/app/src/lighthouse-report-viewer.js
@@ -276,6 +276,7 @@ class LighthouseReportViewer {
    * @private
    */
   _onPaste(e) {
+    if (!e.clipboardData) return;
     e.preventDefault();
 
     // Try paste as gist URL.

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "prettier": "^1.14.3",
     "pretty-json-stringify": "^0.0.2",
     "puppeteer": "^1.10.0",
-    "typescript": "3.2.2",
+    "typescript": "3.5.3",
     "uglify-es": "3.0.15",
     "url-search-params": "0.6.1",
     "whatwg-fetch": "2.0.1",

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -39,7 +39,7 @@ declare global {
   type NonVoid<T> = T extends void ? never : T;
 
   /** Remove properties K from T. */
-  type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+  type StrictOmit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
   /** Obtain the type of the first parameter of a function. */
   type FirstParamType<T extends (arg1: any, ...args: any[]) => any> =

--- a/yarn.lock
+++ b/yarn.lock
@@ -7585,10 +7585,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+typescript@3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-es@3.0.15:
   version "3.0.15"


### PR DESCRIPTION
unblocks #9267, maybe others?

3.4 crashed on our code base due to out of control unionings. 3.5 introduced a limit to union construction, but the underlying error just morphed into "Expression produces a union type that is too complex to represent" :)

The main cause was https://github.com/microsoft/TypeScript/pull/30769, improving soundness of assigning to an object with enumerated keys (e.g. our artifacts object, where the error was occurring). 

The problem is that tsc doesn't have a notion of a type being a single member of a union (e.g. when looping over the artifact keys, inside the loop it sees the union of all artifact keys, not a single key within that union). So while that change improved soundness, our unsound (due to tsc's limitations, but, notably, still correct) assignments to `artifacts[keyof artifacts]` caused a new error that had been ignored before. Whatever value was written to that property had to match the constraints of all possible types of `artifacts[keyof artifacts]` simultaneously (it had to be a `ScriptElements` *and* a `Manifest` *and* a `StartUrl` *and* a `ViewportDimensions` *and* a...), which caused tsc to give up while trying to find the intersection of all those constraints (which the RHS wouldn't have matched anyways).

See that PR for a long discussion on the benefits and the ways the downsides could be worked around. I'm excited about the `oneof` proposal.

`@ts-ignore` seemed like the best approach for these, since it leaves us open for removing sometime in the future if there becomes a way to express what we mean.

Compilation time over 3.2 decreases slightly, by about 10% on my machine.