### PR TITLE
tests: run CI with a frozen yarn.lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   # with the latest puppeteer api so we probably need to run on chromimum
   # @see https://github.com/GoogleChrome/lighthouse/pull/4640/files#r171425004
   - export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-  - yarn
+  - yarn --frozen-lockfile
 before_script:
   - export DISPLAY=:99.0
   # see comment above about puppeteer

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "speedline-core": "1.4.2",
     "third-party-web": "^0.8.2",
     "update-notifier": "^2.5.0",
-    "ws": "3.3.2",
+    "ws": "3.3.3",
     "yargs": "3.32.0",
     "yargs-parser": "7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "speedline-core": "1.4.2",
     "third-party-web": "^0.8.2",
     "update-notifier": "^2.5.0",
-    "ws": "3.3.3",
+    "ws": "3.3.2",
     "yargs": "3.32.0",
     "yargs-parser": "7.0.0"
   },


### PR DESCRIPTION
thanks to @wardpeet and @patrickhulce for telling me about this flag :)

Trivial change to give a CI failure if any `yarn.lock` changes weren't committed (happened in #9267 but tests were green)