### PR TITLE
cli(help): list valid categories

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -157,6 +157,7 @@ function getFlags(manualArgv) {
       .choices('emulated-form-factor', ['mobile', 'desktop', 'none'])
       .choices('throttling-method', ['devtools', 'provided', 'simulate'])
       .choices('preset', ['full', 'perf', 'mixed-content'])
+      .choices('only-categories', ['accessibility', 'best-practices', 'performance', 'pwa'])
       // force as an array
       // note MUST use camelcase versions or only the kebab-case version will be forced
       .array('blockedUrlPatterns')


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Fixes  #9209 by listing the valid categories when using `--help`

![image](https://user-images.githubusercontent.com/159987/61173005-0d953500-a55b-11e9-9ffe-484acab7a77a.png)
