### PR TITLE
deps: Upgrade debug to 2.6.9

### DIFF
--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.0",
   "license": "Apache-2.0",
   "dependencies": {
-    "debug": "^2.6.8",
+    "debug": "^2.6.9",
     "marky": "^1.2.0"
   }
 }


### PR DESCRIPTION
**Summary**

This fixes a [ReDoS vulnerability in debug 2.6.8](https://snyk.io/test/npm/debug/2.6.8)
