### PR TITLE
tests(i18n): no ICU value given to preprocess

### DIFF
--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -127,9 +127,7 @@ function lookupLocale(locale) {
  * @param {string} icuMessage
  * @param {Record<string, *>} [values]
  */
-function _preprocessMessageValues(icuMessage, values) {
-  if (!values) return;
-
+function _preprocessMessageValues(icuMessage, values = {}) {
   const clonedValues = JSON.parse(JSON.stringify(values));
   const parsed = MessageParser.parse(icuMessage);
   // Throw an error if a message's value isn't provided
@@ -374,6 +372,7 @@ function replaceIcuMessageInstanceIds(inputObject, locale) {
 module.exports = {
   _formatPathAsString,
   _ICUMsgNotFoundMsg,
+  _preprocessMessageValues,
   UIStrings,
   lookupLocale,
   getRendererFormattedStrings,

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -135,7 +135,7 @@ function _preprocessMessageValues(icuMessage, values = {}) {
     .filter(el => el.type === 'argumentElement')
     .forEach(el => {
       if (el.id && (el.id in values) === false) {
-        throw new Error('ICU Message contains a value reference that wasn\'t provided');
+        throw new Error(`ICU Message contains a value reference ("${el.id}") that wasn't provided`);
       }
     });
 

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -372,7 +372,6 @@ function replaceIcuMessageInstanceIds(inputObject, locale) {
 module.exports = {
   _formatPathAsString,
   _ICUMsgNotFoundMsg,
-  _preprocessMessageValues,
   UIStrings,
   lookupLocale,
   getRendererFormattedStrings,

--- a/lighthouse-core/test/lib/i18n/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n/i18n-test.js
@@ -134,5 +134,10 @@ describe('i18n', () => {
       const helloPercentStr = str_(UIStrings.helloPercentWorld, {in: 0.43078});
       expect(helloPercentStr).toBeDisplayString('Hello 43.08% World');
     });
+
+    it('throws an error when a value is not provided', () => {
+      expect(_ => i18n.getFormatted(str_(UIStrings.helloBytesWorld, {}), 'en-US'))
+      .toThrow(`ICU Message contains a value reference that wasn't provided`);
+    });
   });
 });

--- a/lighthouse-core/test/lib/i18n/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n/i18n-test.js
@@ -136,7 +136,7 @@ describe('i18n', () => {
       expect(helloPercentStr).toBeDisplayString('Hello 43.08% World');
     });
 
-    it('throws an error when a value is not provided', () => {
+    it('throws an error when values are needed but not provided', () => {
       expect(_ => i18n.getFormatted(str_(UIStrings.helloBytesWorld), 'en-US'))
       .toThrow(`ICU Message contains a value reference ("in") that wasn't provided`);
     });

--- a/lighthouse-core/test/lib/i18n/i18n-test.js
+++ b/lighthouse-core/test/lib/i18n/i18n-test.js
@@ -102,6 +102,7 @@ describe('i18n', () => {
       helloSecWorld: 'Hello {in, number, seconds} World',
       helloTimeInMsWorld: 'Hello {timeInMs, number, seconds} World',
       helloPercentWorld: 'Hello {in, number, extendedPercent} World',
+      helloWorldMultiReplace: '{hello} {world}',
     };
     const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
@@ -136,8 +137,14 @@ describe('i18n', () => {
     });
 
     it('throws an error when a value is not provided', () => {
-      expect(_ => i18n.getFormatted(str_(UIStrings.helloBytesWorld, {}), 'en-US'))
-      .toThrow(`ICU Message contains a value reference that wasn't provided`);
+      expect(_ => i18n.getFormatted(str_(UIStrings.helloBytesWorld), 'en-US'))
+      .toThrow(`ICU Message contains a value reference ("in") that wasn't provided`);
+    });
+
+    it('throws an error when a value is missing', () => {
+      expect(_ => i18n.getFormatted(str_(UIStrings.helloWorldMultiReplace,
+        {hello: 'hello'}), 'en-US'))
+      .toThrow(`ICU Message contains a value reference ("world") that wasn't provided`);
     });
   });
 });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
Add test for a missing ICU replacement value when gettingFormatted.  Removed early exit from _preprocessMessageValues  and added a default so that when sending no replacement object the function will still fire.

fixes: #9383
