### PR TITLE
core: fix serverResponseTime typo in network-server-latency

### DIFF
--- a/lighthouse-core/audits/network-server-latency.js
+++ b/lighthouse-core/audits/network-server-latency.js
@@ -45,22 +45,22 @@ class NetworkServerLatency extends Audit {
 
     /** @type {number} */
     let maxLatency = 0;
-    /** @type {Array<{origin: string, serverReponseTime: number}>} */
+    /** @type {Array<{origin: string, serverResponseTime: number}>} */
     const results = [];
-    for (const [origin, serverReponseTime] of analysis.serverResponseTimeByOrigin.entries()) {
+    for (const [origin, serverResponseTime] of analysis.serverResponseTimeByOrigin.entries()) {
       // Ignore entries that don't look like real origins, like the __SUMMARY__ entry.
       if (!origin.startsWith('http')) continue;
 
-      maxLatency = Math.max(serverReponseTime, maxLatency);
-      results.push({origin, serverReponseTime});
+      maxLatency = Math.max(serverResponseTime, maxLatency);
+      results.push({origin, serverResponseTime});
     }
 
-    results.sort((a, b) => b.serverReponseTime - a.serverReponseTime);
+    results.sort((a, b) => b.serverResponseTime - a.serverResponseTime);
 
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [
       {key: 'origin', itemType: 'text', text: str_(i18n.UIStrings.columnURL)},
-      {key: 'serverReponseTime', itemType: 'ms', granularity: 1,
+      {key: 'serverResponseTime', itemType: 'ms', granularity: 1,
         text: str_(i18n.UIStrings.columnTimeSpent)},
     ];
 

--- a/lighthouse-core/test/audits/network-server-latency-test.js
+++ b/lighthouse-core/test/audits/network-server-latency-test.js
@@ -16,7 +16,7 @@ describe('Network Server Latency audit', () => {
     const artifacts = {devtoolsLogs: {defaultPass: acceptableDevToolsLog}};
     const result = await ServerLatency.audit(artifacts, {computedCache: new Map()});
     result.details.items.forEach(
-      item => (item.serverReponseTime = Math.round(item.serverReponseTime * 100) / 100)
+      item => (item.serverResponseTime = Math.round(item.serverResponseTime * 100) / 100)
     );
 
     // These were all from a trace that used our ancient 150ms devtools throttling which appears as
@@ -24,15 +24,15 @@ describe('Network Server Latency audit', () => {
     expect(result.details.items).toEqual([
       {
         origin: 'https://www.google-analytics.com',
-        serverReponseTime: 159.55,
+        serverResponseTime: 159.55,
       },
       {
         origin: 'https://pwa.rocks',
-        serverReponseTime: 159.42,
+        serverResponseTime: 159.42,
       },
       {
         origin: 'https://www.googletagmanager.com',
-        serverReponseTime: 153.03,
+        serverResponseTime: 153.03,
       },
     ]);
   });

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -1127,7 +1127,7 @@
             "text": "URL"
           },
           {
-            "key": "serverReponseTime",
+            "key": "serverResponseTime",
             "itemType": "ms",
             "granularity": 1,
             "text": "Time Spent"
@@ -1136,11 +1136,11 @@
         "items": [
           {
             "origin": "http://localhost:10200",
-            "serverReponseTime": 572.829
+            "serverResponseTime": 572.829
           },
           {
             "origin": "http://ajax.googleapis.com",
-            "serverReponseTime": 562.398
+            "serverResponseTime": 562.398
           }
         ]
       }

--- a/proto/sample_v2_round_trip.json
+++ b/proto/sample_v2_round_trip.json
@@ -1824,18 +1824,18 @@
                     {
                         "granularity": 1.0,
                         "itemType": "ms",
-                        "key": "serverReponseTime",
+                        "key": "serverResponseTime",
                         "text": "Time Spent"
                     }
                 ],
                 "items": [
                     {
                         "origin": "http://localhost:10200",
-                        "serverReponseTime": 572.829
+                        "serverResponseTime": 572.829
                     },
                     {
                         "origin": "http://ajax.googleapis.com",
-                        "serverReponseTime": 562.398
+                        "serverResponseTime": 562.398
                     }
                 ],
                 "type": "table"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
This fixes a typo for `network-server-latency`, which has currently `serverReponseTime` instead of `serverResponseTime` (and maybe cause bugs when trying to get some values out of the JSON).
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->