### PR TITLE
tests(i18n): update canonical locale test for node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 matrix:
   include:
     - node_js: "10"
-    - node_js: "11"
+    - node_js: "12"
       if: head_branch IS blank AND branch = master
 dist: trusty
 cache:

--- a/lighthouse-core/test/lib/i18n/locales-test.js
+++ b/lighthouse-core/test/lib/i18n/locales-test.js
@@ -18,13 +18,14 @@ describe('locales', () => {
     const deprecatedCodes = {
       in: 'id',
       iw: 'he',
+      mo: 'ro',
     };
 
     for (const locale of Object.keys(locales)) {
       const canonicalLocale = Intl.getCanonicalLocales(locale)[0];
       const substitute = deprecatedCodes[locale];
       assert.ok(locale === canonicalLocale || substitute === canonicalLocale,
-          `locale code '${locale}' not canonical`);
+        `locale code '${locale}' not canonical ('${canonicalLocale}' found instead)`);
     }
 
     // Deprecation subsitutes should be removed from the test if no longer used.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4280,6 +4280,11 @@ is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
 is-wsl@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.0.tgz#94369bbeb2249ef07b831b1b08590e686330ccbb"


### PR DESCRIPTION
Node 12.6 is now calling `'mo'` deprecated and gives `'ro'` as the canonical version for me. `mo` is already an alias of `ro`, so that seems fine, but the canonical locale test needs to account for this or it will fail.

Also:
- adds Node 12 to travis testing
- updates yarn.lock to account for `is-wsl` change, missed due to a combo of #9267 and #9339 (chrome-launcher moved to `2.1.0` but `open` still requires `1.1.0`)