### PR TITLE
doc(cli): list valid categories

### DIFF
--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -60,8 +60,7 @@ function getFlags(manualArgv) {
           'Path to JSON file of HTTP Header key/value pairs to send in requests')
       .example(
           'lighthouse <url> --only-categories=performance,pwa',
-          'Only run specific categories.')
-
+          'Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo')
       /**
        * Also accept a file for all of these flags. Yargs will merge in and override the file-based
        * flags with the command-line flags.

--- a/lighthouse-cli/cli-flags.js
+++ b/lighthouse-cli/cli-flags.js
@@ -129,7 +129,7 @@ function getFlags(manualArgv) {
         'precomputed-lantern-data-path': 'Path to the file where lantern simulation data should be read from, overwriting the lantern observed estimates for RTT and server latency.',
         'lantern-data-output-path': 'Path to the file where lantern simulation data should be written to, can be used in a future run with the `precomputed-lantern-data-path` flag.',
         'only-audits': 'Only run the specified audits',
-        'only-categories': 'Only run the specified categories',
+        'only-categories': 'Only run the specified categories. Available categories: accessibility, best-practices, performance, pwa, seo',
         'skip-audits': 'Run everything except these audits',
         'plugins': 'Run the specified plugins',
         'print-config': 'Print the normalized config for the given config and options, then exit.',

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,8 @@ Examples:
   lighthouse <url> --quiet --chrome-flags="--headless"                      Launch Headless Chrome, turn off logging
   lighthouse <url> --extra-headers "{\"Cookie\":\"monster=blue\"}"          Stringify\'d JSON HTTP Header key/value pairs to send in requests
   lighthouse <url> --extra-headers=./path/to/file.json                      Path to JSON file of HTTP Header key/value pairs to send in requests
+  lighthouse <url> --only-categories=performance,pwa                        Only run the specified categories. Available categories: accessibility,
+                                                                            best-practices, performance, pwa, seo.
 
 For more information on Lighthouse, see https://developers.google.com/web/tools/lighthouse/.
 ```


### PR DESCRIPTION
**Summary**
Small doc tweak to fix #9209 by listing the valid categories in an example