### PR TITLE
cli: Allow ignoring default chrome flags

### DIFF
--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -61,10 +61,13 @@ function parseChromeFlags(flags = '') {
 
   if (ignoreDefaultFlags) {
     chromeFlags = chromeFlags
-      .filter(flag => (
-        !flag.endsWith('=false') ||
-        !defaultFlags.includes(flag.substring(0, flag.length - 6))
-      ))
+      .filter(flag => {
+        // The flag wasn't an ignored default, let it through.
+        if (!flag.endsWith('=false')) return true;
+        // Keep the flag if it's not a negated default.
+        const flagWithoutNegation = flag.replace(/=false$/, '');
+        return !defaultFlags.includes(flagWithoutNegation);
+      })
       .concat(includedDefaultFlags);
   }
 

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -26,7 +26,12 @@ const _RUNTIME_ERROR_CODE = 1;
 const _PROTOCOL_TIMEOUT_EXIT_CODE = 67;
 
 /**
- * exported for testing
+ * Parse Chrome Flags string using yargs into individual arguments, so they can be passed to
+ * chrome-launcher.
+ * The flags are scanned for any disabled default flags (specified as `${flag}=false`). If any
+ * default flags are disabled, we ignore all default flags then add back any default flags that
+ * were not disabled.
+ * This function is exported for testing.
  * @param {string} flags
  * @return {{chromeFlags: Array<string>, ignoreDefaultFlags: boolean}}
  */

--- a/lighthouse-cli/run.js
+++ b/lighthouse-cli/run.js
@@ -67,8 +67,9 @@ function parseChromeFlags(flags = '') {
         // Keep the flag if it's not a negated default.
         const flagWithoutNegation = flag.replace(/=false$/, '');
         return !defaultFlags.includes(flagWithoutNegation);
-      })
-      .concat(includedDefaultFlags);
+      });
+    // Add non-disabled defaults first to prevent them from being overridden
+    chromeFlags = [...includedDefaultFlags, ...chromeFlags];
   }
 
   return {

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -135,7 +135,7 @@ describe('Parsing --chrome-flags', () => {
     );
   });
 
-  it('handles ignoring single default flag', () => {
+  it('handles ignoring a default flag', () => {
     const defaultFlags = Launcher.defaultFlags().slice();
     const firstDefaultFlag = defaultFlags[0];
     const remainingDefaultFlags = defaultFlags.slice(1);
@@ -143,6 +143,20 @@ describe('Parsing --chrome-flags', () => {
     assert.deepStrictEqual(
       parseChromeFlags(`${firstDefaultFlag}=false`),
       {chromeFlags: remainingDefaultFlags, ignoreDefaultFlags: true}
+    );
+  });
+
+  it('handles ignoring a default flag while passing additional flags', () => {
+    const defaultFlags = Launcher.defaultFlags().slice();
+    const firstDefaultFlag = defaultFlags[0];
+    const remainingDefaultFlags = defaultFlags.slice(1);
+
+    assert.deepStrictEqual(
+      parseChromeFlags(`${firstDefaultFlag}=false --spaces="1 2 3 4" --debug=false --verbose`),
+      {
+        chromeFlags: [...remainingDefaultFlags, '--spaces=1 2 3 4', '--debug=false', '--verbose'],
+        ignoreDefaultFlags: true,
+      }
     );
   });
 

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -9,7 +9,7 @@
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const defaultFlags = require('chrome-launcher').Launcher.defaultFlags;
+const Launcher = require('chrome-launcher').Launcher;
 const run = require('../../run.js');
 const parseChromeFlags = require('../../run.js').parseChromeFlags;
 const fastConfig = {
@@ -136,8 +136,9 @@ describe('Parsing --chrome-flags', () => {
   });
 
   it('handles ignoring single default flag', () => {
-    const firstDefaultFlag = defaultFlags()[0];
-    const remainingDefaultFlags = defaultFlags().slice(1);
+    const defaultFlags = Launcher.defaultFlags().slice();
+    const firstDefaultFlag = defaultFlags[0];
+    const remainingDefaultFlags = defaultFlags.slice(1);
 
     assert.deepStrictEqual(
       parseChromeFlags(`${firstDefaultFlag}=false`).chromeFlags,
@@ -146,7 +147,7 @@ describe('Parsing --chrome-flags', () => {
   });
 
   it('handles ignoring all default flags', () => {
-    const excludeAllFlags = defaultFlags()
+    const excludeAllFlags = Launcher.defaultFlags()
       .map(flag => `${flag}=false`)
       .join(' ');
 

--- a/lighthouse-cli/test/cli/run-test.js
+++ b/lighthouse-cli/test/cli/run-test.js
@@ -124,8 +124,8 @@ describe('Parsing --chrome-flags', () => {
 
   it('handles flag values with spaces in them (#2817)', () => {
     assert.deepStrictEqual(
-      parseChromeFlags('--user-agent="iPhone UA Test"').chromeFlags,
-      ['--user-agent=iPhone UA Test']
+      parseChromeFlags('--user-agent="iPhone UA Test"'),
+      {chromeFlags: ['--user-agent=iPhone UA Test'], ignoreDefaultFlags: false}
     );
 
     assert.deepStrictEqual(
@@ -141,8 +141,8 @@ describe('Parsing --chrome-flags', () => {
     const remainingDefaultFlags = defaultFlags.slice(1);
 
     assert.deepStrictEqual(
-      parseChromeFlags(`${firstDefaultFlag}=false`).chromeFlags,
-      remainingDefaultFlags
+      parseChromeFlags(`${firstDefaultFlag}=false`),
+      {chromeFlags: remainingDefaultFlags, ignoreDefaultFlags: true}
     );
   });
 
@@ -152,16 +152,18 @@ describe('Parsing --chrome-flags', () => {
       .join(' ');
 
     assert.deepStrictEqual(
-      parseChromeFlags(excludeAllFlags).chromeFlags,
-      []
+      parseChromeFlags(excludeAllFlags),
+      {chromeFlags: [], ignoreDefaultFlags: true}
     );
   });
 
   it('returns all flags as provided', () => {
     assert.deepStrictEqual(
-      parseChromeFlags('--spaces="1 2 3 4" --debug=false --verbose --more-spaces="9 9 9"')
-        .chromeFlags,
-      ['--spaces=1 2 3 4', '--debug=false', '--verbose', '--more-spaces=9 9 9']
+      parseChromeFlags('--spaces="1 2 3 4" --debug=false --verbose --more-spaces="9 9 9"'),
+      {
+        chromeFlags: ['--spaces=1 2 3 4', '--debug=false', '--verbose', '--more-spaces=9 9 9'],
+        ignoreDefaultFlags: false,
+      }
     );
   });
 });


### PR DESCRIPTION
Chrome flags set by default by Chrome Launcher were previously impossible to unset - the existing `--chrome-flags` configuration would only allow adding additional Chrome flags.

Default flags can now be disabled by passing in the flag set to the value "false". For example, the `--disable-extensions` Chrome flag can be disabled by passing in `--disable-extensions=false`.

Only default flags are affected; any other flags are passed through unaffected. The default flags are only removed if set to the value "false"; if they are set to any other value, they are passed through unaffected.

This change was adapted from a proposal made in this issue: https://github.com/GoogleChrome/chrome-launcher/issues/65

This PR closes #9390

~This PR has been set as a draft initially, because it doesn't work due to a bug in Chrome Launcher. This bug has been fixed in this PR: https://github.com/GoogleChrome/chrome-launcher/pull/162
I'll update this PR once Chrome Launcher has been released with that bugfix. Or I could workaround the issue, if that would be preferred.~

~Edit: That bug was avoided by ensuring the `defaultFlags()` method was only called once per test.~

Edit: Ah, that update was premature - the tests are still failing.