### PR TITLE
core(font-size): gather style declaration of type Attributes

### DIFF
--- a/lighthouse-core/gather/gatherers/seo/font-size.js
+++ b/lighthouse-core/gather/gatherers/seo/font-size.js
@@ -162,13 +162,16 @@ function findInheritedCSSRule(inheritedEntries = []) {
  * @param {LH.Crdp.CSS.GetMatchedStylesForNodeResponse} matched CSS rules
  * @returns {NodeFontData['cssRule']|undefined}
  */
-function getEffectiveFontRule({inlineStyle, matchedCSSRules, inherited}) {
+function getEffectiveFontRule({attributesStyle, inlineStyle, matchedCSSRules, inherited}) {
   // Inline styles have highest priority
   if (hasFontSizeDeclaration(inlineStyle)) return {type: 'Inline', ...inlineStyle};
 
   // Rules directly referencing the node come next
   const matchedRule = findMostSpecificMatchedCSSRule(matchedCSSRules);
   if (matchedRule) return matchedRule;
+
+  // Then comes attributes styles (<font size="1">)
+  if (hasFontSizeDeclaration(attributesStyle)) return {type: 'Attributes', ...attributesStyle};
 
   // Finally, find an inherited property if there is one
   const inheritedRule = findInheritedCSSRule(inherited);

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -254,7 +254,7 @@ describe('Font size gatherer', () => {
       result = FontSizeGather.getEffectiveFontRule({attributesStyle, inherited});
       expect(result).toMatchObject({type: 'Attributes'});
 
-      result = FontSizeGather.getEffectiveFontRule({matchedCSSRules, inherited});
+      result = FontSizeGather.getEffectiveFontRule({attributesStyle, matchedCSSRules, inherited});
       expect(result.parentRule).toMatchObject({origin: 'regular'});
 
       result = FontSizeGather.getEffectiveFontRule({inherited});

--- a/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
+++ b/lighthouse-core/test/gather/gatherers/seo/font-size-test.js
@@ -151,6 +151,7 @@ describe('Font size gatherer', () => {
 
     let inlineStyle;
     let matchedCSSRules;
+    let attributesStyle;
     let inherited;
 
     beforeEach(() => {
@@ -167,6 +168,7 @@ describe('Font size gatherer', () => {
 
       inlineStyle = createStyle({id: 1, properties: {'font-size': '1em'}});
       matchedCSSRules = [{matchingSelectors: [1], rule: fontRule}];
+      attributesStyle = {cssProperties: createProps({'font-size': '10px'})};
       inherited = [{matchedCSSRules: [{matchingSelectors: [0], rule: userAgentRule}]}];
     });
 
@@ -181,6 +183,19 @@ describe('Font size gatherer', () => {
         ],
         styleSheetId: 1,
         type: 'Inline',
+      });
+    });
+
+    it('should identify attributes styles', () => {
+      const result = FontSizeGather.getEffectiveFontRule({attributesStyle});
+      expect(result).toEqual({
+        cssProperties: [
+          {
+            name: 'font-size',
+            value: '10px',
+          },
+        ],
+        type: 'Attributes',
       });
     });
 
@@ -232,12 +247,19 @@ describe('Font size gatherer', () => {
     });
 
     it('should respect precendence', () => {
-      let result = FontSizeGather.getEffectiveFontRule({inlineStyle, matchedCSSRules, inherited});
+      let result = FontSizeGather.getEffectiveFontRule(
+        {attributesStyle, inlineStyle, matchedCSSRules, inherited});
       expect(result).toMatchObject({type: 'Inline'});
+
+      result = FontSizeGather.getEffectiveFontRule({attributesStyle, inherited});
+      expect(result).toMatchObject({type: 'Attributes'});
+
       result = FontSizeGather.getEffectiveFontRule({matchedCSSRules, inherited});
       expect(result.parentRule).toMatchObject({origin: 'regular'});
+
       result = FontSizeGather.getEffectiveFontRule({inherited});
       expect(result.parentRule).toMatchObject({origin: 'user-agent'});
+
       result = FontSizeGather.getEffectiveFontRule({});
       expect(result).toBe(undefined);
     });


### PR DESCRIPTION
`Attributes` is a [type](https://github.com/GoogleChrome/lighthouse/blob/f968ee94ed539da4046c4e26e65fe3d2990a5554/types/artifacts.d.ts#L250) for `cssRule` in the `font-size` artifact.

The audit checks for it [here](https://github.com/GoogleChrome/lighthouse/blob/f968ee94ed539da4046c4e26e65fe3d2990a5554/lighthouse-core/audits/seo/font-size.js#L129).

However, the gatherer never returned a rule of type `Attributes`. Instead, it was returning no `cssRule` (that property is optional) - which was fine because the audit handles it in the same way.

First thought was to just remove `Attributes` from the type property. But then I saw it was pretty simple to change the gatherer to be correct.

But ... it doesn't really convey much more information - just makes it more explicit - so I could go either way with this. The style declaration will look like this:
```js
{ type: 'Attributes',
  range: undefined,
  styleSheetId: undefined,
  parentRule: undefined }
```

Also: I think this was the only reason `cssRule` was made optional - or is there another valid reason that it would not exist?