### PR TITLE
misc(proto): use python3 shebang for roundtrip script

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mixed-content": "./lighthouse-cli/index.js --chrome-flags='--headless' --preset=mixed-content",
     "minify-latest-run": "./lighthouse-core/scripts/lantern/minify-trace.js ./latest-run/defaultPass.trace.json ./latest-run/defaultPass.trace.min.json && ./lighthouse-core/scripts/lantern/minify-devtoolslog.js ./latest-run/defaultPass.devtoolslog.json ./latest-run/defaultPass.devtoolslog.min.json",
     "compile-proto": "protoc --python_out=./ ./proto/lighthouse-result.proto && mv ./proto/*_pb2.py ./proto/scripts || (echo \"❌ Install protobuf ≥ 3.7.1 to compile the proto file.\" && false)",
-    "build-proto-roundtrip": "cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 python json_roundtrip_via_proto.py",
+    "build-proto-roundtrip": "cd proto/scripts && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=cpp PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2 json_roundtrip_via_proto.py",
     "static-server": "node lighthouse-cli/test/fixtures/static-server.js"
   },
   "devDependencies": {

--- a/proto/scripts/json_roundtrip_via_proto.py
+++ b/proto/scripts/json_roundtrip_via_proto.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 import json


### PR DESCRIPTION
Use shebang in the script b/c tying the major version of python needed for a script to the file itself is helpful.

Without this change, `yarn build-proto-roundtrip` uses python2 on my Linux machine.
