### PR TITLE
report(accessibility): add heading role to report category gauges

### DIFF
--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -45,7 +45,7 @@ limitations under the License.
 <!-- Lighthouse category header -->
 <template id="tmpl-lh-category-header">
   <div class="lh-category-header">
-    <div class="lh-score__gauge"></div>
+    <div class="lh-score__gauge" role="heading" aria-level="2"></div>
     <div class="lh-category-header__description"></div>
   </div>
 </template>


### PR DESCRIPTION
**Summary**
Add role="heading" with aria-level="2" to the report category gauges so
screen readers can easily identify and navigate the report using headings.

Level 2 was chosen because [Accessibility Insights recommends against
multiple level 1 headings in the same section of a document][1].

***Screenshot of gauges in the devtools accessibility tree***
![h2-accessibility-tree](https://user-images.githubusercontent.com/309310/61573908-36419100-aa6b-11e9-8025-0a51f5f9371d.PNG)

***Screenshot of NVDA Element List***
![h2-nvda-element-list](https://user-images.githubusercontent.com/309310/61573916-51ac9c00-aa6b-11e9-9ac8-9a7031d50d8f.PNG)

This meets the following WCAG 2.1 success criteria
1.3.1 Info and Relationships https://www.w3.org/WAI/WCAG21/quickref/#info-and-relationships
2.4.10 Section Headings https://www.w3.org/WAI/WCAG21/quickref/#section-headings

**Related Issues/PRs**
#7575

[1]: https://github.com/microsoft/accessibility-insights-web/blob/900c301e/src/content/adhoc/headings/guidance.tsx#L45-L54