### PR TITLE
misc: nest deployed-report directory

### DIFF
--- a/lighthouse-core/scripts/build-report-for-autodeployment.js
+++ b/lighthouse-core/scripts/build-report-for-autodeployment.js
@@ -19,7 +19,7 @@ const {defaultSettings} = require('../config/constants.js');
 const lighthouse = require('../index.js');
 const lhr = /** @type {LH.Result} */ (require('../../lighthouse-core/test/results/sample_v2.json'));
 
-const DIST = path.join(__dirname, `../../dist`);
+const DIST = path.join(__dirname, `../../dist/now`);
 
 (async function() {
   addPluginCategory(lhr);

--- a/now.json
+++ b/now.json
@@ -3,7 +3,8 @@
   "builds": [
     {
       "src": "package.json",
-      "use": "@now/static-build"
+      "use": "@now/static-build",
+      "config": {"distDir": "dist/now"}
     }
   ],
   "github": {


### PR DESCRIPTION
trying this out to see if now deployment will work with a different directory than default (`dist/`) so they're all nested in `dist/now/`