### PR TITLE
core(tracehouse): Use requestedUrl to detect navigationStart

### DIFF
--- a/lighthouse-core/computed/trace-of-tab.js
+++ b/lighthouse-core/computed/trace-of-tab.js
@@ -33,13 +33,14 @@ class TraceOfTab {
    * Finds key trace events, identifies main process/thread, and returns timings of trace events
    * in milliseconds since navigation start in addition to the standard microsecond monotonic timestamps.
    * @param {LH.Trace} trace
+   * @param {LH.Audit.Context} context
    * @return {Promise<LH.Artifacts.TraceOfTab>}
   */
-  static async compute_(trace) {
+  static async compute_(trace, context) {
     // Trace of tab doesn't require FCP to exist, but all of LH requires it.
     // We'll check that we got an FCP here and re-type accordingly so all of our consumers don't
     // have to repeat this check.
-    const traceOfTab = await LHTraceProcessor.computeTraceOfTab(trace);
+    const traceOfTab = await LHTraceProcessor.computeTraceOfTab(trace, context);
     const {timings, timestamps, firstContentfulPaintEvt} = traceOfTab;
     const {firstContentfulPaint: firstContentfulPaintTiming} = timings;
     const {firstContentfulPaint: firstContentfulPaintTs} = timestamps;

--- a/lighthouse-core/runner.js
+++ b/lighthouse-core/runner.js
@@ -250,6 +250,7 @@ class Runner {
       settings,
       LighthouseRunWarnings: runWarnings,
       computedCache: new Map(),
+      URL: artifacts.URL,
     };
 
     // Run each audit sequentially
@@ -268,7 +269,7 @@ class Runner {
    * Otherwise returns error audit result.
    * @param {LH.Config.AuditDefn} auditDefn
    * @param {LH.Artifacts} artifacts
-   * @param {Pick<LH.Audit.Context, 'settings'|'LighthouseRunWarnings'|'computedCache'>} sharedAuditContext
+   * @param {Pick<LH.Audit.Context, 'settings'|'LighthouseRunWarnings'|'computedCache'|'URL'>} sharedAuditContext
    * @return {Promise<LH.Audit.Result>}
    * @private
    */

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -14,6 +14,8 @@ declare global {
       settings: Config.Settings;
       /** Push to this array to add top-level warnings to the LHR. */
       LighthouseRunWarnings: Array<string>;
+      /** The URL initially requested and the post-redirects URL that was actually loaded. */
+      URL: {requestedUrl: string, finalUrl: string};
       /**
        * Nested cache for already-computed computed artifacts. Keyed first on
        * the computed artifact's `name` property, then on input artifact(s).


### PR DESCRIPTION
**Summary**
The TraceProcessor was using a regex to find the first `navigationStart` event "of interest", excluding navigation events that did not represent the page under test (e.g. requests from chrome extensions). It now compares the `documentLoaderURL` of the event directly with the requestedUrl instead.

This should help prevent false positive `navigationStart` events from being incorrectly identified as the start of the navigation of interest. It also prevents a false negative in the case where a chrome-extension
URL is under test, thus fixing #9402

**Related Issues/PRs**
This approach was discussed recently in #9405, which was my first attempt fixing #9402

**PR Status**
This is just a proof of concept. The unit tests aren't working yet, nor have I added any to cover these changes. I also haven't done a lot of digging yet to ensure this covers all of the edge cases that led to the regex this replaces.

The smoke test does appear to be working though.