### PR TITLE
core(seo): support portuguese in link-text audit

### DIFF
--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -46,15 +46,13 @@ const BLOCKLIST = new Set([
   'empezar',
   // Portuguese
   'clique aqui',
-  'ir',
-  'início',
   'inicio',
+  'início',
   'ir',
-  'mais',
   'mais informação',
   'mais informações',
-  'veja mais',
   'mais',
+  'veja mais',
 ]);
 const i18n = require('../../lib/i18n/i18n.js');
 

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -44,6 +44,16 @@ const BLOCKLIST = new Set([
   'enlace',
   'este enlace',
   'empezar',
+  // Portuguese
+  'clique aqui',
+  'ir',
+  'início',
+  'inicio',
+  'ir',
+  'mais',
+  'mais informação',
+  'veja mais',
+  'mais',
 ]);
 const i18n = require('../../lib/i18n/i18n.js');
 

--- a/lighthouse-core/audits/seo/link-text.js
+++ b/lighthouse-core/audits/seo/link-text.js
@@ -52,6 +52,7 @@ const BLOCKLIST = new Set([
   'ir',
   'mais',
   'mais informação',
+  'mais informações',
   'veja mais',
   'mais',
 ]);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->

**Summary**
<!-- What kind of change does this PR introduce? -->
Add Portuguese translations for the [Links Do Not Have Descriptive Text](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text)

Note that in Portuguese there is this symbol: ´. People forget to write it so we may take into account these errors, let me know your opinion.

<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
feature, since adding new words to the test

<!-- Describe the need for this change -->
Portuguese is one of the top 10 languages used on the internet [ref1](https://en.wikipedia.org/wiki/Languages_used_on_the_Internet)

<!-- Link any documentation or information that would help understand this change -->
[translated words for non-portuguese speakers](https://translate.google.com.br/#view=home&op=translate&sl=pt&tl=en&text=clique%20aqui%0Air%0Ain%C3%ADcio%0Ainicio%0Air%0Amais%0Amais%20informa%C3%A7%C3%A3o%0Amais%20informa%C3%A7%C3%B5es%0Aveja%20mais%0Amais)

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
#7547 #5322