### PR TITLE
i18n: align type names with docs

### DIFF
--- a/lighthouse-core/audits/dobetterweb/appcache-manifest.js
+++ b/lighthouse-core/audits/dobetterweb/appcache-manifest.js
@@ -49,13 +49,16 @@ class AppCacheManifestAttr extends Audit {
    * @return {LH.Audit.Product}
    */
   static audit(artifacts) {
-    const usingAppcache = artifacts.AppCacheManifest !== null;
-    const displayValue = usingAppcache ?
-      str_(UIStrings.displayValue, {AppCacheManifest: artifacts.AppCacheManifest}) : '';
+    // Fails if an AppCacheManifest was found.
+    if (artifacts.AppCacheManifest !== null) {
+      return {
+        score: 0,
+        displayValue: str_(UIStrings.displayValue, {AppCacheManifest: artifacts.AppCacheManifest}),
+      };
+    }
 
     return {
-      score: usingAppcache ? 0 : 1,
-      displayValue,
+      score: 1,
     };
   }
 }

--- a/lighthouse-core/audits/seo/canonical.js
+++ b/lighthouse-core/audits/seo/canonical.js
@@ -178,7 +178,7 @@ class Canonical extends Audit {
     if (!URL.rootDomainsMatch(canonicalURL, baseURL)) {
       return {
         score: 0,
-        explanation: str_(UIStrings.explanationDifferentDomain, {url: canonicalURL}),
+        explanation: str_(UIStrings.explanationDifferentDomain, {url: canonicalURL.href}),
       };
     }
 

--- a/lighthouse-core/lib/i18n/i18n.js
+++ b/lighthouse-core/lib/i18n/i18n.js
@@ -127,7 +127,7 @@ function lookupLocale(locale) {
 
 /**
  * @param {string} icuMessage
- * @param {Record<string, *>} [values]
+ * @param {Record<string, string | number>} [values]
  */
 function _preprocessMessageValues(icuMessage, values = {}) {
   const clonedValues = JSON.parse(JSON.stringify(values));
@@ -166,7 +166,7 @@ function _preprocessMessageValues(icuMessage, values = {}) {
  * @typedef IcuMessageInstance
  * @prop {string} icuMessageId
  * @prop {string} icuMessage
- * @prop {*} [values]
+ * @prop {Record<string, string | number>|undefined} [values]
  */
 
 /** @type {Map<string, IcuMessageInstance[]>} */
@@ -178,7 +178,7 @@ const _ICUMsgNotFoundMsg = 'ICU message not found in destination locale';
  * @param {LH.Locale} locale
  * @param {string} icuMessageId
  * @param {string=} uiStringMessage The original string given in 'UIStrings', used as a backup if no locale message can be found
- * @param {*} [values]
+ * @param {Record<string, string | number>} [values]
  * @return {{formattedString: string, icuMessage: string}}
  */
 function _formatIcuMessage(locale, icuMessageId, uiStringMessage, values) {
@@ -266,7 +266,7 @@ function createMessageInstanceIdFn(filename, fileStrings) {
    * indexed id value in the form '{messageid} | # {index}'.
    *
    * @param {string} icuMessage
-   * @param {*} [values]
+   * @param {Record<string, string | number>} [values]
    * */
   const getMessageInstanceIdFn = (icuMessage, values) => {
     const keyname = Object.keys(mergedStrings).find(key => mergedStrings[key] === icuMessage);
@@ -317,7 +317,7 @@ function getFormatted(icuMessageIdOrRawString, locale) {
 /**
  * @param {LH.Locale} locale
  * @param {string} icuMessageId
- * @param {*} [values]
+ * @param {Record<string, string | number>} [values]
  * @return {string}
  */
 function getFormattedFromIdAndValues(locale, icuMessageId, values) {

--- a/lighthouse-core/lib/i18n/locales.js
+++ b/lighthouse-core/lib/i18n/locales.js
@@ -12,10 +12,10 @@
  * CLDR language aliases: https://www.unicode.org/cldr/charts/latest/supplemental/aliases.html
  */
 
-/** @typedef {Record<string, {message: string}>} LocaleMessages */
+/** @typedef {Record<string, {message: string}>} LhlMessages */
 
 // The keys within this const must exactly match the LH.Locale type in externs.d.ts
-/** @type {Record<LH.Locale, LocaleMessages>} */
+/** @type {Record<LH.Locale, LhlMessages>} */
 const locales = {
   'en-US': require('./locales/en-US.json'), // The 'source' strings, with descriptions
   'en': require('./locales/en-US.json'), // According to CLDR/ICU, 'en' == 'en-US' dates/numbers (Why?!)

--- a/lighthouse-core/lib/i18n/swap-locale.js
+++ b/lighthouse-core/lib/i18n/swap-locale.js
@@ -50,7 +50,8 @@ function swapLocale(lhr, requestedLocale) {
 
   const locale = i18n.lookupLocale(requestedLocale);
   const {icuMessagePaths} = lhr.i18n;
-  const missingIcuMessageIds = /** @type {string[]} */([]);
+  /** @type {string[]} */
+  const missingIcuMessageIds = [];
 
   Object.entries(icuMessagePaths).forEach(([icuMessageId, messageInstancesInLHR]) => {
     for (const instance of messageInstancesInLHR) {

--- a/lighthouse-core/test/scripts/i18n/collect-strings-test.js
+++ b/lighthouse-core/test/scripts/i18n/collect-strings-test.js
@@ -172,14 +172,14 @@ describe('Convert Message to Placeholder', () => {
   it('passthroughs a basic message unchanged', () => {
     const message = 'Hello World.';
     const res = collect.convertMessageToPlaceholders(message, undefined);
-    expect(res).toEqual({message, placeholders: undefined});
+    expect(res).toEqual({message, placeholders: {}});
   });
 
   it('passthroughs an ICU plural unchanged', () => {
     const message = '{var, select, male{Hello Mr. Programmer.} ' +
       'female{Hello Ms. Programmer} other{Hello Programmer.}}';
     const res = collect.convertMessageToPlaceholders(message, undefined);
-    expect(res).toEqual({message, placeholders: undefined});
+    expect(res).toEqual({message, placeholders: {}});
   });
 
   // TODO(exterkamp): more strict parsing for this case


### PR DESCRIPTION
Follow up to #9114 
- renaming typedefs to align with CTC and LHL as defined in the [readme](https://github.com/GoogleChrome/lighthouse/blob/0cf90aa34708c539058e68c5692e838020419cd8/lighthouse-core/lib/i18n/README.md#terminology)
- fixing some placeholder `undefined` nonsense by tsc (https://github.com/GoogleChrome/lighthouse/pull/9114#discussion_r306576574)
- finishing up the suggestion from https://github.com/GoogleChrome/lighthouse/pull/8755#discussion_r280968989 and making sure all our instances of icu replacement values are typed as `Record<string, string|number>` since that's all we accept