### PR TITLE
core(unused-css): allow up to 10KB of unused CSS per file

### DIFF
--- a/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
+++ b/lighthouse-cli/test/fixtures/byte-efficiency/tester.html
@@ -158,9 +158,9 @@ setTimeout(() => {
 // PASS: unused but too small savings
 generateInlineStyleWithSize(512, '.too-small { background: none; }\n');
 // PASS: used
-generateInlineStyleWithSize(5000, '.mostly-used { background: none; }\n', true);
+generateInlineStyleWithSize(12000, '.mostly-used { background: none; }\n', true);
 // FAIL: unused and a bit of savings
-generateInlineStyleWithSize(5000, '.kinda-unused { background: none; }\n');
+generateInlineStyleWithSize(12000, '.kinda-unused { background: none; }\n');
 // FAIL: unused and lots of savings
 generateInlineStyleWithSize(30000, '.definitely-unused { background: none; }\n');
 </script>

--- a/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
+++ b/lighthouse-cli/test/smokehouse/byte-efficiency/expectations.js
@@ -48,7 +48,7 @@ module.exports = [
         },
         'unused-css-rules': {
           details: {
-            overallSavingsBytes: '>35000',
+            overallSavingsBytes: '>40000',
             items: {
               length: 2,
             },

--- a/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
+++ b/lighthouse-core/audits/byte-efficiency/unused-css-rules.js
@@ -19,7 +19,9 @@ const UIStrings = {
 
 const str_ = i18n.createMessageInstanceIdFn(__filename, UIStrings);
 
-const IGNORE_THRESHOLD_IN_BYTES = 2048;
+// Allow 10KB of unused CSS to permit `:hover` and other styles not used on a non-interactive load.
+// @see https://github.com/GoogleChrome/lighthouse/issues/9353 for more discussion.
+const IGNORE_THRESHOLD_IN_BYTES = 10 * 1024;
 const PREVIEW_LENGTH = 100;
 
 /** @typedef {LH.Artifacts.CSSStyleSheetInfo & {networkRecord: LH.Artifacts.NetworkRequest, usedRules: Array<LH.Crdp.CSS.RuleUsage>}} StyleSheetInfo */

--- a/lighthouse-core/test/audits/byte-efficiency/unused-css-rules-test.js
+++ b/lighthouse-core/test/audits/byte-efficiency/unused-css-rules-test.js
@@ -121,7 +121,7 @@ describe('Best Practices: unused css rules audit', () => {
     const networkRecords = [
       {
         url: 'file://a.css',
-        transferSize: 10 * 1024,
+        transferSize: 100 * 1024,
         resourceType: 'Stylesheet',
       },
     ];
@@ -184,7 +184,7 @@ describe('Best Practices: unused css rules audit', () => {
         ]},
       }), networkRecords).then(result => {
         assert.equal(result.items.length, 2);
-        assert.equal(result.items[0].totalBytes, 10 * 1024);
+        assert.equal(result.items[0].totalBytes, 100 * 1024);
         assert.equal(result.items[1].totalBytes, 40000 * 3 * 0.2);
         assert.equal(result.items[0].wastedPercent, 75);
         assert.equal(result.items[1].wastedPercent, 50);


### PR DESCRIPTION
**Summary**
Bumping the allowable limit to 10KB of unused CSS per file per discussion in https://github.com/GoogleChrome/lighthouse/issues/9353#issue-466944871. Should have minimal impact on displayed results since the 8KB difference would be unlikely to significantly impact any metrics to appear in the first place.

**Related Issues/PRs**
closes https://github.com/GoogleChrome/lighthouse/issues/9353
