### PR TITLE
report(topbar): fix overflowing url

### DIFF
--- a/lighthouse-core/report/html/renderer/report-renderer.js
+++ b/lighthouse-core/report/html/renderer/report-renderer.js
@@ -77,6 +77,7 @@ class ReportRenderer {
     const el = this._dom.cloneTemplate('#tmpl-lh-topbar', this._templateContext);
     const metadataUrl = /** @type {HTMLAnchorElement} */ (this._dom.find('.lh-topbar__url', el));
     metadataUrl.href = metadataUrl.textContent = report.finalUrl;
+    metadataUrl.title = report.finalUrl;
     return el;
   }
 

--- a/lighthouse-core/report/html/templates.html
+++ b/lighthouse-core/report/html/templates.html
@@ -245,6 +245,7 @@ limitations under the License.
       width: var(--topbar-logo-size);
       height: var(--topbar-logo-size);
       user-select: none;
+      flex: none;
     }
     .lh-topbar__logo .shape {
       fill: var(--report-text-color);
@@ -254,6 +255,9 @@ limitations under the License.
       margin: var(--topbar-padding);
       text-decoration: none;
       color: var(--report-text-color);
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
     }
 
     .lh-tools {


### PR DESCRIPTION
This modifies UI in the topbar to
- Show a tooltip when the URL is hovered
- Truncate the URL from the end via CSS, based on available space
- Round Lighthouse icon in the topbar used to shrink due to flexbox, and disappear.  Now, it doesn't flex so it should maintain its size.

Screenshot: https://imgur.com/a/2DQ5RmV

Issue: https://github.com/GoogleChrome/lighthouse/issues/9142
Associated Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=971585