### PR TITLE
core(constants): increase default maxWaitForFcp

### DIFF
--- a/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
+++ b/lighthouse-cli/test/cli/__snapshots__/index-test.js.snap
@@ -1248,7 +1248,7 @@ Object {
     "extraHeaders": null,
     "gatherMode": false,
     "locale": "en-US",
-    "maxWaitForFcp": 15000,
+    "maxWaitForFcp": 30000,
     "maxWaitForLoad": 45000,
     "onlyAudits": null,
     "onlyCategories": null,
@@ -1382,7 +1382,7 @@ Object {
     "extraHeaders": null,
     "gatherMode": false,
     "locale": "en-US",
-    "maxWaitForFcp": 15000,
+    "maxWaitForFcp": 30000,
     "maxWaitForLoad": 45000,
     "onlyAudits": Array [
       "metrics",

--- a/lighthouse-core/config/constants.js
+++ b/lighthouse-core/config/constants.js
@@ -43,7 +43,7 @@ const throttling = {
 /** @type {LH.Config.Settings} */
 const defaultSettings = {
   output: 'json',
-  maxWaitForFcp: 15 * 1000,
+  maxWaitForFcp: 30 * 1000,
   maxWaitForLoad: 45 * 1000,
   throttlingMethod: 'simulate',
   throttling: throttling.mobileSlow4G,

--- a/lighthouse-core/config/lr-desktop-config.js
+++ b/lighthouse-core/config/lr-desktop-config.js
@@ -9,6 +9,7 @@
 const config = {
   extends: 'lighthouse:default',
   settings: {
+    maxWaitForFcp: 15 * 1000,
     maxWaitForLoad: 35 * 1000,
     emulatedFormFactor: 'desktop',
     throttling: {

--- a/lighthouse-core/config/lr-mobile-config.js
+++ b/lighthouse-core/config/lr-mobile-config.js
@@ -9,6 +9,7 @@
 const config = {
   extends: 'lighthouse:default',
   settings: {
+    maxWaitForFcp: 15 * 1000,
     maxWaitForLoad: 35 * 1000,
     // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
     skipAudits: ['uses-http2'],

--- a/lighthouse-core/test/results/artifacts/artifacts.json
+++ b/lighthouse-core/test/results/artifacts/artifacts.json
@@ -13,7 +13,7 @@
     "output": [
       "html"
     ],
-    "maxWaitForFcp": 15000,
+    "maxWaitForFcp": 30000,
     "maxWaitForLoad": 45000,
     "throttlingMethod": "devtools",
     "throttling": {

--- a/lighthouse-core/test/results/sample_v2.json
+++ b/lighthouse-core/test/results/sample_v2.json
@@ -3246,7 +3246,7 @@
     "output": [
       "json"
     ],
-    "maxWaitForFcp": 15000,
+    "maxWaitForFcp": 30000,
     "maxWaitForLoad": 45000,
     "throttlingMethod": "devtools",
     "throttling": {


### PR DESCRIPTION
**Summary**
This PR increases the default maxWaitForFcp to 30s while leaving it 15s in LR configs. The original reason we made the limit so low was to avoid timeouts in LR. My gut says this aggressive value in DevTools/CLI is what is causing such a strong uptick in NO_FCP reports. Anecdotally the last 3 filed issues were all pages that took ~20-25 seconds to first paint for me locally, not ones that didn't paint at all.
