### PR TITLE
misc: share markdown parsing in collect-strings and the report

### DIFF
--- a/lighthouse-core/report/html/renderer/dom.js
+++ b/lighthouse-core/report/html/renderer/dom.js
@@ -120,7 +120,7 @@ class DOM {
     for (const segment of Util.splitMarkdownLink(text)) {
       if (!segment.isLink) {
         // Plain text segment.
-        element.appendChild(this._document.createTextNode(segment.plainText));
+        element.appendChild(this._document.createTextNode(segment.text));
         continue;
       }
 
@@ -136,7 +136,7 @@ class DOM {
       const a = this.createElement('a');
       a.rel = 'noopener';
       a.target = '_blank';
-      a.textContent = segment.linkText;
+      a.textContent = segment.text;
       a.href = url.href;
       element.appendChild(a);
     }
@@ -154,10 +154,10 @@ class DOM {
     for (const segment of Util.splitMarkdownCodeSpans(markdownText)) {
       if (segment.isCode) {
         const pre = this.createElement('code');
-        pre.textContent = segment.codeText;
+        pre.textContent = segment.text;
         element.appendChild(pre);
       } else {
-        element.appendChild(this._document.createTextNode(segment.plainText));
+        element.appendChild(this._document.createTextNode(segment.text));
       }
     }
 

--- a/lighthouse-core/report/html/renderer/dom.js
+++ b/lighthouse-core/report/html/renderer/dom.js
@@ -16,7 +16,7 @@
  */
 'use strict';
 
-/* globals URL self */
+/* globals URL self Util */
 
 /** @typedef {HTMLElementTagNameMap & {[id: string]: HTMLElement}} HTMLElementByTagName */
 
@@ -117,12 +117,7 @@ class DOM {
   convertMarkdownLinkSnippets(text) {
     const element = this.createElement('span');
 
-    // Split on markdown links (e.g. [some link](https://...)).
-    const parts = text.split(/\[([^\]]*?)\]\((https?:\/\/.*?)\)/g);
-
-    while (parts.length) {
-      // Pop off the same number of elements as there are capture groups.
-      const [preambleText, linkText, linkHref] = parts.splice(0, 3);
+    for (const {preambleText, linkText, linkHref} of Util.splitMarkdownLink(text)) {
       element.appendChild(this._document.createTextNode(preambleText));
 
       // Append link if there are any.
@@ -154,10 +149,7 @@ class DOM {
   convertMarkdownCodeSnippets(text) {
     const element = this.createElement('span');
 
-    const parts = text.split(/`(.*?)`/g); // Split on markdown code slashes
-    while (parts.length) {
-      // Pop off the same number of elements as there are capture groups.
-      const [preambleText, codeText] = parts.splice(0, 2);
+    for (const {preambleText, codeText} of Util.splitMarkdownCodeSpans(text)) {
       element.appendChild(this._document.createTextNode(preambleText));
       if (codeText) {
         const pre = this.createElement('code');

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -353,47 +353,6 @@ class Util {
     return segments;
   }
 
-
-  /**
-   * Split a string on markdown links (e.g. [some link](https://...)). Text will
-   * be split into segments with a starting `preambleText` that wasn't part of a
-   * link, followed by [`linkText`](`linkHref`) which were part of a link. Both
-   * `linkText` and `linkHref` will be undefined if there was no link in that
-   * segment.
-   * @param {string} text
-   * @return {Array<{isLink: true, linkText: string, linkHref: string}|{isLink: false, plainText: string}>}
-   */
-  static splitMarkdownLink2(text) {
-    /** @type {Array<{isLink: true, linkText: string, linkHref: string}|{isLink: false, plainText: string}>} */
-    const segments = [];
-
-    const parts = text.split(/\[([^\]]*?)\]\((https?:\/\/.*?)\)/g);
-    for (let i = 0; i < parts.length; i++) {
-      const text = parts[i];
-
-      if (i % 3 === 0) {
-        // The first of three is always the plain text before the matched regex.
-        if (!text) continue; // Empty plain text isn't worth saving.
-
-        segments.push({
-          isLink: false,
-          plainText: parts[i],
-        });
-      } else if (i % 3 === 1) {
-        // There will always be a following linkHref if text was matched here.
-        const linkHref = parts[++i];
-
-        segments.push({
-          isLink: true,
-          linkText: text,
-          linkHref,
-        });
-      }
-    }
-
-    return segments;
-  }
-
   /**
    * @param {URL} parsedUrl
    * @param {{numPathParts?: number, preserveQuery?: boolean, preserveHost?: boolean}=} options

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -281,6 +281,55 @@ class Util {
   }
 
   /**
+   * Split a string by markdown code spans (enclosed in backticks), splitting
+   * into segments with a `preambleText` that wasn't enclosed in markdown
+   * backticks and came before the `codeText` which was enclosed. The last
+   * `codeText` in the array will always be `undefined`, while empty
+   * `preambleText` (e.g. between two code spans with no characters between
+   * them) will be an empty string.
+   * @param {string} text
+   * @return {Array<{preambleText: string, codeText?: string}>}
+   */
+  static splitMarkdownCodeSpans(text) {
+    const segments = [];
+
+    // Split on backticked code spans.
+    const parts = text.split(/`(.*?)`/g);
+    for (let i = 0; i < parts.length; i += 2) {
+      segments.push({
+        preambleText: parts[i],
+        codeText: parts[i + 1],
+      });
+    }
+
+    return segments;
+  }
+
+  /**
+   * Split a string on markdown links (e.g. [some link](https://...)). Text will
+   * be split into segments with a starting `preambleText` that wasn't part of a
+   * link, followed by [`linkText`](`linkHref`) which were part of a link. Both
+   * `linkText` and `linkHref` will be undefined if there was no link in that
+   * segment.
+   * @param {string} text
+   * @return {Array<{preambleText: string, linkText?: string, linkHref?: string}>}
+   */
+  static splitMarkdownLink(text) {
+    const segments = [];
+
+    const parts = text.split(/\[([^\]]*?)\]\((https?:\/\/.*?)\)/g);
+    for (let i = 0; i < parts.length; i += 3) {
+      segments.push({
+        preambleText: parts[i],
+        linkText: parts[i + 1],
+        linkHref: parts[i + 2],
+      });
+    }
+
+    return segments;
+  }
+
+  /**
    * @param {URL} parsedUrl
    * @param {{numPathParts?: number, preserveQuery?: boolean, preserveHost?: boolean}=} options
    * @return {string}

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -285,10 +285,10 @@ class Util {
    * into segments that were enclosed in backticks (marked as `isCode === true`)
    * and those that outside the backticks (`isCode === false`).
    * @param {string} text
-   * @return {Array<{isCode: true, codeText: string}|{isCode: false, plainText: string}>}
+   * @return {Array<{isCode: true, text: string}|{isCode: false, text: string}>}
    */
   static splitMarkdownCodeSpans(text) {
-    /** @type {Array<{isCode: true, codeText: string}|{isCode: false, plainText: string}>} */
+    /** @type {Array<{isCode: true, text: string}|{isCode: false, text: string}>} */
     const segments = [];
 
     // Split on backticked code spans.
@@ -300,17 +300,11 @@ class Util {
       if (!text) continue;
 
       // Alternates between plain text and code segments.
-      if (i % 2 === 0) {
-        segments.push({
-          isCode: false,
-          plainText: text,
-        });
-      } else {
-        segments.push({
-          isCode: true,
-          codeText: text,
-        });
-      }
+      const isCode = i % 2 !== 0;
+      segments.push({
+        isCode,
+        text,
+      });
     }
 
     return segments;
@@ -322,21 +316,21 @@ class Util {
    * `isLink === false`), and segments with text content and a URL that did make
    * up a link (marked as `isLink === true`).
    * @param {string} text
-   * @return {Array<{isLink: true, linkText: string, linkHref: string}|{isLink: false, plainText: string}>}
+   * @return {Array<{isLink: true, text: string, linkHref: string}|{isLink: false, text: string}>}
    */
   static splitMarkdownLink(text) {
-    /** @type {Array<{isLink: true, linkText: string, linkHref: string}|{isLink: false, plainText: string}>} */
+    /** @type {Array<{isLink: true, text: string, linkHref: string}|{isLink: false, text: string}>} */
     const segments = [];
 
     const parts = text.split(/\[([^\]]+?)\]\((https?:\/\/.*?)\)/g);
     while (parts.length) {
-      // Pop off the same number of elements as there are capture groups.
+      // Shift off the same number of elements as the pre-split and capture groups.
       const [preambleText, linkText, linkHref] = parts.splice(0, 3);
 
-      if (preambleText) { // Empty plain text is an artifact of splitting, not meaningful.
+      if (preambleText) { // Skip empty text as it's an artifact of splitting, not meaningful.
         segments.push({
           isLink: false,
-          plainText: preambleText,
+          text: preambleText,
         });
       }
 
@@ -344,7 +338,7 @@ class Util {
       if (linkText && linkHref) {
         segments.push({
           isLink: true,
-          linkText,
+          text: linkText,
           linkHref,
         });
       }

--- a/lighthouse-core/report/html/renderer/util.js
+++ b/lighthouse-core/report/html/renderer/util.js
@@ -328,7 +328,7 @@ class Util {
     /** @type {Array<{isLink: true, linkText: string, linkHref: string}|{isLink: false, plainText: string}>} */
     const segments = [];
 
-    const parts = text.split(/\[([^\]]*?)\]\((https?:\/\/.*?)\)/g);
+    const parts = text.split(/\[([^\]]+?)\]\((https?:\/\/.*?)\)/g);
     while (parts.length) {
       // Pop off the same number of elements as there are capture groups.
       const [preambleText, linkText, linkHref] = parts.splice(0, 3);

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -174,11 +174,11 @@ function _processPlaceholderMarkdownCode(icu) {
       // Backtick replacement looks unreadable here, so .join() instead.
       icu.message += '$' + placeholderName + '$';
       icu.placeholders[placeholderName] = {
-        content: '`' + segment.codeText + '`',
-        example: segment.codeText,
+        content: '`' + segment.text + '`',
+        example: segment.text,
       };
     } else {
-      icu.message += segment.plainText;
+      icu.message += segment.text;
     }
   }
 }
@@ -207,14 +207,14 @@ function _processPlaceholderMarkdownLink(icu) {
   for (const segment of Util.splitMarkdownLink(message)) {
     if (!segment.isLink) {
       // Plain text segment.
-      icu.message += segment.plainText;
+      icu.message += segment.text;
       continue;
     }
 
     // Otherwise, append any links found.
     const startPlaceholder = `LINK_START_${idx}`;
     const endPlaceholder = `LINK_END_${idx}`;
-    icu.message += '$' + startPlaceholder + '$' + segment.linkText + '$' + endPlaceholder + '$';
+    icu.message += '$' + startPlaceholder + '$' + segment.text + '$' + endPlaceholder + '$';
     idx++;
     icu.placeholders[startPlaceholder] = {
       content: '[',

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -14,6 +14,7 @@ const path = require('path');
 const assert = require('assert');
 const tsc = require('typescript');
 const collectAndBakeCtcStrings = require('./bake-ctc-to-lhl.js');
+const Util = require('../../report/html/renderer/util.js');
 
 const LH_ROOT = path.join(__dirname, '../../../');
 const UISTRINGS_REGEX = /UIStrings = .*?\};\n/s;
@@ -157,19 +158,17 @@ function convertMessageToCtc(message, examples = {}) {
  * @param {IncrementalCtc} icu
  */
 function _processPlaceholderMarkdownCode(icu) {
+  const message = icu.message;
+
   // Check that number of backticks is even.
-  const match = icu.message.match(/`/g);
+  const match = message.match(/`/g);
   if (match && match.length % 2 !== 0) {
-    throw Error(`Open backtick in message "${icu.message}"`);
+    throw Error(`Open backtick in message "${message}"`);
   }
 
-  // Split on backticked code spans
-  const parts = icu.message.split(/`(.*?)`/g);
   icu.message = '';
   let idx = 0;
-  while (parts.length) {
-    // Pop off the same number of elements as there are capture groups.
-    const [preambleText, codeText] = parts.splice(0, 2);
+  for (const {preambleText, codeText} of Util.splitMarkdownCodeSpans(message)) {
     icu.message += preambleText;
     if (codeText) {
       const placeholderName = `MARKDOWN_SNIPPET_${idx++}`;
@@ -189,20 +188,18 @@ function _processPlaceholderMarkdownCode(icu) {
  * @param {IncrementalCtc} icu
  */
 function _processPlaceholderMarkdownLink(icu) {
+  const message = icu.message;
+
   // Check for markdown link common errors, ex:
   // * [extra] (space between brackets and parens)
-  if (icu.message.match(/\[.*\] \(.*\)/)) {
-    throw Error(`Bad Link syntax in message "${icu.message}"`);
+  if (message.match(/\[.*\] \(.*\)/)) {
+    throw Error(`Bad Link syntax in message "${message}"`);
   }
 
-  // Split on markdown links (e.g. [some link](https://...)).
-  const parts = icu.message.split(/\[([^\]]*?)\]\((https?:\/\/.*?)\)/g);
   icu.message = '';
   let idx = 0;
 
-  while (parts.length) {
-    // Pop off the same number of elements as there are capture groups.
-    const [preambleText, linkText, linkHref] = parts.splice(0, 3);
+  for (const {preambleText, linkText, linkHref} of Util.splitMarkdownLink(message)) {
     icu.message += preambleText;
 
     // Append link if there are any.

--- a/lighthouse-core/scripts/i18n/collect-strings.js
+++ b/lighthouse-core/scripts/i18n/collect-strings.js
@@ -194,7 +194,11 @@ function _processPlaceholderMarkdownLink(icu) {
   // Check for markdown link common errors, ex:
   // * [extra] (space between brackets and parens)
   if (message.match(/\[.*\] \(.*\)/)) {
-    throw Error(`Bad Link syntax in message "${message}"`);
+    throw Error(`Bad Link spacing in message "${message}"`);
+  }
+  // * [](empty link text)
+  if (message.match(/\[\]\(.*\)/)) {
+    throw Error(`markdown link text missing in message "${message}"`);
   }
 
   icu.message = '';

--- a/lighthouse-core/test/report/html/renderer/dom-test.js
+++ b/lighthouse-core/test/report/html/renderer/dom-test.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const jsdom = require('jsdom');
 const URL = require('../../../../lib/url-shim.js');
 const DOM = require('../../../../report/html/renderer/dom.js');
+const Util = require('../../../../report/html/renderer/util.js');
 
 const TEMPLATE_FILE = fs.readFileSync(__dirname +
     '/../../../../report/html/templates.html', 'utf8');
@@ -21,6 +22,7 @@ describe('DOM', () => {
 
   beforeAll(() => {
     global.URL = URL;
+    global.Util = Util;
     const {document} = new jsdom.JSDOM(TEMPLATE_FILE).window;
     dom = new DOM(document);
     dom.setLighthouseChannel('someChannel');
@@ -28,6 +30,7 @@ describe('DOM', () => {
 
   afterAll(() => {
     global.URL = undefined;
+    global.Util = undefined;
   });
 
   describe('createElement', () => {

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -269,69 +269,78 @@ describe('util helpers', () => {
   describe('#splitMarkdownCodeSpans', () => {
     it('handles strings with no backticks in them', () => {
       expect(Util.splitMarkdownCodeSpans('regular text')).toEqual([
-        {isCode: false, plainText: 'regular text'},
+        {isCode: false, text: 'regular text'},
       ]);
     });
 
     it('does not split on a single backtick', () => {
       expect(Util.splitMarkdownCodeSpans('regular `text')).toEqual([
-        {isCode: false, plainText: 'regular `text'},
+        {isCode: false, text: 'regular `text'},
       ]);
     });
 
     it('splits on backticked code', () => {
       expect(Util.splitMarkdownCodeSpans('regular `code` text')).toEqual([
-        {isCode: false, plainText: 'regular '},
-        {isCode: true, codeText: 'code'},
-        {isCode: false, plainText: ' text'},
+        {isCode: false, text: 'regular '},
+        {isCode: true, text: 'code'},
+        {isCode: false, text: ' text'},
       ]);
     });
 
     it('splits on backticked code at the beginning of the string', () => {
       expect(Util.splitMarkdownCodeSpans('`start code` regular text')).toEqual([
-        {isCode: true, codeText: 'start code'},
-        {isCode: false, plainText: ' regular text'},
+        {isCode: true, text: 'start code'},
+        {isCode: false, text: ' regular text'},
       ]);
     });
 
-    it('splits on backticked code at the emd of the string', () => {
+    it('splits on backticked code at the end of the string', () => {
       expect(Util.splitMarkdownCodeSpans('regular text `end code`')).toEqual([
-        {isCode: false, plainText: 'regular text '},
-        {isCode: true, codeText: 'end code'},
+        {isCode: false, text: 'regular text '},
+        {isCode: true, text: 'end code'},
       ]);
     });
 
     it('does not split on a single backtick after split out backticked code', () => {
       expect(Util.splitMarkdownCodeSpans('regular text `code` and more `text')).toEqual([
-        {isCode: false, plainText: 'regular text '},
-        {isCode: true, codeText: 'code'},
-        {isCode: false, plainText: ' and more `text'},
+        {isCode: false, text: 'regular text '},
+        {isCode: true, text: 'code'},
+        {isCode: false, text: ' and more `text'},
       ]);
     });
 
     it('splits on two instances of backticked code', () => {
       expect(Util.splitMarkdownCodeSpans('regular text `code` more text `and more code`')).toEqual([
-        {isCode: false, plainText: 'regular text '},
-        {isCode: true, codeText: 'code'},
-        {isCode: false, plainText: ' more text '},
-        {isCode: true, codeText: 'and more code'},
+        {isCode: false, text: 'regular text '},
+        {isCode: true, text: 'code'},
+        {isCode: false, text: ' more text '},
+        {isCode: true, text: 'and more code'},
       ]);
     });
 
     it('splits on two directly adjacent instances of backticked code', () => {
       // eslint-disable-next-line max-len
       expect(Util.splitMarkdownCodeSpans('regular text `first code``second code` end text')).toEqual([
-        {isCode: false, plainText: 'regular text '},
-        {isCode: true, codeText: 'first code'},
-        {isCode: true, codeText: 'second code'},
-        {isCode: false, plainText: ' end text'},
+        {isCode: false, text: 'regular text '},
+        {isCode: true, text: 'first code'},
+        {isCode: true, text: 'second code'},
+        {isCode: false, text: ' end text'},
       ]);
     });
 
     it('handles text only within backticks', () => {
       expect(Util.splitMarkdownCodeSpans('`first code``second code`')).toEqual([
-        {isCode: true, codeText: 'first code'},
-        {isCode: true, codeText: 'second code'},
+        {isCode: true, text: 'first code'},
+        {isCode: true, text: 'second code'},
+      ]);
+    });
+
+    it('splits on two instances of backticked code separated by only a space', () => {
+      // eslint-disable-next-line max-len
+      expect(Util.splitMarkdownCodeSpans('`first code` `second code`')).toEqual([
+        {isCode: true, text: 'first code'},
+        {isCode: false, text: ' '},
+        {isCode: true, text: 'second code'},
       ]);
     });
   });
@@ -339,88 +348,88 @@ describe('util helpers', () => {
   describe('#splitMarkdownLink', () => {
     it('handles strings with no links in them', () => {
       expect(Util.splitMarkdownLink('some text')).toEqual([
-        {isLink: false, plainText: 'some text'},
+        {isLink: false, text: 'some text'},
       ]);
     });
 
     it('does not split on an incomplete markdown link', () => {
       expect(Util.splitMarkdownLink('some [not link text](text')).toEqual([
-        {isLink: false, plainText: 'some [not link text](text'},
+        {isLink: false, text: 'some [not link text](text'},
       ]);
     });
 
     it('splits on a markdown link', () => {
       expect(Util.splitMarkdownLink('some [link text](https://example.com) text')).toEqual([
-        {isLink: false, plainText: 'some '},
-        {isLink: true, linkText: 'link text', linkHref: 'https://example.com'},
-        {isLink: false, plainText: ' text'},
+        {isLink: false, text: 'some '},
+        {isLink: true, text: 'link text', linkHref: 'https://example.com'},
+        {isLink: false, text: ' text'},
       ]);
     });
 
     it('splits on an http markdown link', () => {
       expect(Util.splitMarkdownLink('you should [totally click here](http://never-mitm.com) now')).toEqual([
-        {isLink: false, plainText: 'you should '},
-        {isLink: true, linkText: 'totally click here', linkHref: 'http://never-mitm.com'},
-        {isLink: false, plainText: ' now'},
+        {isLink: false, text: 'you should '},
+        {isLink: true, text: 'totally click here', linkHref: 'http://never-mitm.com'},
+        {isLink: false, text: ' now'},
       ]);
     });
 
     it('does not split on a non-http/https link', () => {
       expect(Util.splitMarkdownLink('some [link text](ftp://example.com) text')).toEqual([
-        {isLink: false, plainText: 'some [link text](ftp://example.com) text'},
+        {isLink: false, text: 'some [link text](ftp://example.com) text'},
       ]);
     });
 
     it('does not split on a malformed markdown link', () => {
       expect(Util.splitMarkdownLink('some [link ]text](https://example.com')).toEqual([
-        {isLink: false, plainText: 'some [link ]text](https://example.com'},
+        {isLink: false, text: 'some [link ]text](https://example.com'},
       ]);
 
       expect(Util.splitMarkdownLink('some [link text] (https://example.com')).toEqual([
-        {isLink: false, plainText: 'some [link text] (https://example.com'},
+        {isLink: false, text: 'some [link text] (https://example.com'},
       ]);
     });
 
     it('does not split on empty link text', () => {
       expect(Util.splitMarkdownLink('some [](https://example.com) empty link')).toEqual([
-        {isLink: false, plainText: 'some [](https://example.com) empty link'},
+        {isLink: false, text: 'some [](https://example.com) empty link'},
       ]);
     });
 
     it('splits on a markdown link at the beginning of a string', () => {
       expect(Util.splitMarkdownLink('[link text](https://example.com) end text')).toEqual([
-        {isLink: true, linkText: 'link text', linkHref: 'https://example.com'},
-        {isLink: false, plainText: ' end text'},
+        {isLink: true, text: 'link text', linkHref: 'https://example.com'},
+        {isLink: false, text: ' end text'},
       ]);
     });
 
     it('splits on a markdown link at the end of a string', () => {
       expect(Util.splitMarkdownLink('start text [link text](https://example.com)')).toEqual([
-        {isLink: false, plainText: 'start text '},
-        {isLink: true, linkText: 'link text', linkHref: 'https://example.com'},
+        {isLink: false, text: 'start text '},
+        {isLink: true, text: 'link text', linkHref: 'https://example.com'},
       ]);
     });
 
     it('handles a string consisting only of a markdown link', () => {
       expect(Util.splitMarkdownLink(`[I'm only a link](https://example.com)`)).toEqual([
-        {isLink: true, linkText: `I'm only a link`, linkHref: 'https://example.com'},
+        {isLink: true, text: `I'm only a link`, linkHref: 'https://example.com'},
       ]);
     });
 
     it('handles a string starting and ending with a markdown link', () => {
       expect(Util.splitMarkdownLink('[first link](https://first.com) other text [second link](https://second.com)')).toEqual([
-        {isLink: true, linkText: 'first link', linkHref: 'https://first.com'},
-        {isLink: false, plainText: ' other text '},
-        {isLink: true, linkText: 'second link', linkHref: 'https://second.com'},
+        {isLink: true, text: 'first link', linkHref: 'https://first.com'},
+        {isLink: false, text: ' other text '},
+        {isLink: true, text: 'second link', linkHref: 'https://second.com'},
       ]);
     });
 
     it('handles a string with adjacent markdown links', () => {
       expect(Util.splitMarkdownLink('start text [first link](https://first.com)[second link](https://second.com) and scene')).toEqual([
-        {isLink: false, plainText: 'start text '},
-        {isLink: true, linkText: 'first link', linkHref: 'https://first.com'},
-        {isLink: true, linkText: 'second link', linkHref: 'https://second.com'},
-        {isLink: false, plainText: ' and scene'},
+        {isLink: false, text: 'start text '},
+        {isLink: true, text: 'first link', linkHref: 'https://first.com'},
+        {isLink: true, text: 'second link', linkHref: 'https://second.com'},
+        {isLink: false, text: ' and scene'},
       ]);
     });
   });

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -12,23 +12,9 @@ const sampleResult = require('../../../results/sample_v2.json');
 const NBSP = '\xa0';
 
 /* eslint-env jest */
-/* eslint-disable no-console */
 /* global URL */
 
 describe('util helpers', () => {
-  let origConsoleWarn;
-  let consoleWarnCalls;
-
-  beforeEach(() => {
-    origConsoleWarn = console.warn;
-    consoleWarnCalls = [];
-    console.warn = msg => consoleWarnCalls.push(msg);
-  });
-
-  afterEach(() => {
-    console.warn = origConsoleWarn;
-  });
-
   it('formats a number', () => {
     assert.strictEqual(Util.formatNumber(10), '10');
     assert.strictEqual(Util.formatNumber(100.01), '100');
@@ -277,6 +263,154 @@ describe('util helpers', () => {
       assert.equal(Util.getRootDomain(new URL('https://sub.example.tokyo.jp')), 'tokyo.jp');
       assert.equal(Util.getRootDomain(new URL('http://localhost')), 'localhost');
       assert.equal(Util.getRootDomain(new URL('http://localhost:8080')), 'localhost');
+    });
+  });
+
+  describe('#splitMarkdownCodeSpans', () => {
+    it('handles strings with no backticks in them', () => {
+      expect(Util.splitMarkdownCodeSpans('regular text')).toEqual([
+        {preambleText: 'regular text', codeText: undefined},
+      ]);
+    });
+
+    it('does not split on a single backtick', () => {
+      expect(Util.splitMarkdownCodeSpans('regular `text')).toEqual([
+        {preambleText: 'regular `text', codeText: undefined},
+      ]);
+    });
+
+    it('splits on backticked code', () => {
+      expect(Util.splitMarkdownCodeSpans('regular `code` text')).toEqual([
+        {preambleText: 'regular ', codeText: 'code'},
+        {preambleText: ' text', codeText: undefined},
+      ]);
+    });
+
+    it('splits on backticked code at the beginning of the string', () => {
+      expect(Util.splitMarkdownCodeSpans('`start code` regular text')).toEqual([
+        {preambleText: '', codeText: 'start code'},
+        {preambleText: ' regular text', codeText: undefined},
+      ]);
+    });
+
+    it('splits on backticked code at the emd of the string', () => {
+      expect(Util.splitMarkdownCodeSpans('regular text `end code`')).toEqual([
+        {preambleText: 'regular text ', codeText: 'end code'},
+        {preambleText: '', codeText: undefined},
+      ]);
+    });
+
+    it('does not split on a single backtick after split out backticked code', () => {
+      expect(Util.splitMarkdownCodeSpans('regular text `code` and more `text')).toEqual([
+        {preambleText: 'regular text ', codeText: 'code'},
+        {preambleText: ' and more `text', codeText: undefined},
+      ]);
+    });
+
+    it('splits on two instances of backticked code', () => {
+      expect(Util.splitMarkdownCodeSpans('regular text `code` more text `and more code`')).toEqual([
+        {preambleText: 'regular text ', codeText: 'code'},
+        {preambleText: ' more text ', codeText: 'and more code'},
+        {preambleText: '', codeText: undefined},
+      ]);
+    });
+
+    it('splits on two directly adjacent instances of backticked code', () => {
+      // eslint-disable-next-line max-len
+      expect(Util.splitMarkdownCodeSpans('regular text `first code``second code` end text')).toEqual([
+        {preambleText: 'regular text ', codeText: 'first code'},
+        {preambleText: '', codeText: 'second code'},
+        {preambleText: ' end text', codeText: undefined},
+      ]);
+    });
+
+    it('handles text only within backticks', () => {
+      expect(Util.splitMarkdownCodeSpans('`first code``second code`')).toEqual([
+        {preambleText: '', codeText: 'first code'},
+        {preambleText: '', codeText: 'second code'},
+        {preambleText: '', codeText: undefined},
+      ]);
+    });
+  });
+
+  describe('#splitMarkdownLink', () => {
+    it('handles strings with no links in them', () => {
+      expect(Util.splitMarkdownLink('some text')).toEqual([
+        {preambleText: 'some text', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('does not split on an incomplete markdown link', () => {
+      expect(Util.splitMarkdownLink('some [not link text](text')).toEqual([
+        {preambleText: 'some [not link text](text', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('splits on a markdown link', () => {
+      expect(Util.splitMarkdownLink('some [link text](https://example.com) text')).toEqual([
+        {preambleText: 'some ', linkText: 'link text', linkHref: 'https://example.com'},
+        {preambleText: ' text', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('splits on an http markdown link', () => {
+      expect(Util.splitMarkdownLink('you should [totally click here](http://never-mitm.com) now')).toEqual([
+        {preambleText: 'you should ', linkText: 'totally click here', linkHref: 'http://never-mitm.com'},
+        {preambleText: ' now', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('does not split on a non-http/https link', () => {
+      expect(Util.splitMarkdownLink('some [link text](ftp://example.com) text')).toEqual([
+        {preambleText: 'some [link text](ftp://example.com) text', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('does not split on a malformed markdown link', () => {
+      expect(Util.splitMarkdownLink('some [link ]text](https://example.com')).toEqual([
+        {preambleText: 'some [link ]text](https://example.com', linkText: undefined, linkHref: undefined},
+      ]);
+
+      expect(Util.splitMarkdownLink('some [link text] (https://example.com')).toEqual([
+        {preambleText: 'some [link text] (https://example.com', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('splits on a markdown link at the beginning of a string', () => {
+      expect(Util.splitMarkdownLink('[link text](https://example.com) end text')).toEqual([
+        {preambleText: '', linkText: 'link text', linkHref: 'https://example.com'},
+        {preambleText: ' end text', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('splits on a markdown link at the end of a string', () => {
+      expect(Util.splitMarkdownLink('start text [link text](https://example.com)')).toEqual([
+        {preambleText: 'start text ', linkText: 'link text', linkHref: 'https://example.com'},
+        {preambleText: '', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('handles a string consisting only of a markdown link', () => {
+      expect(Util.splitMarkdownLink(`[I'm only a link](https://example.com)`)).toEqual([
+        {preambleText: '', linkText: `I'm only a link`, linkHref: 'https://example.com'},
+        {preambleText: '', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('handles a string starting and ending with a markdown link', () => {
+      expect(Util.splitMarkdownLink('[first link](https://first.com) other text [second link](https://second.com)')).toEqual([
+        {preambleText: '', linkText: 'first link', linkHref: 'https://first.com'},
+        {preambleText: ' other text ', linkText: 'second link', linkHref: 'https://second.com'},
+        {preambleText: '', linkText: undefined, linkHref: undefined},
+      ]);
+    });
+
+    it('handles a string with adjacent markdown links', () => {
+      expect(Util.splitMarkdownLink('start text [first link](https://first.com)[second link](https://second.com) and scene')).toEqual([
+        {preambleText: 'start text ', linkText: 'first link', linkHref: 'https://first.com'},
+        {preambleText: '', linkText: 'second link', linkHref: 'https://second.com'},
+        {preambleText: ' and scene', linkText: undefined, linkHref: undefined},
+      ]);
     });
   });
 });

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -381,6 +381,12 @@ describe('util helpers', () => {
       ]);
     });
 
+    it('does not split on empty link text', () => {
+      expect(Util.splitMarkdownLink('some [](https://example.com) empty link')).toEqual([
+        {isLink: false, plainText: 'some [](https://example.com) empty link'},
+      ]);
+    });
+
     it('splits on a markdown link at the beginning of a string', () => {
       expect(Util.splitMarkdownLink('[link text](https://example.com) end text')).toEqual([
         {isLink: true, linkText: 'link text', linkHref: 'https://example.com'},

--- a/lighthouse-core/test/report/html/renderer/util-test.js
+++ b/lighthouse-core/test/report/html/renderer/util-test.js
@@ -269,66 +269,69 @@ describe('util helpers', () => {
   describe('#splitMarkdownCodeSpans', () => {
     it('handles strings with no backticks in them', () => {
       expect(Util.splitMarkdownCodeSpans('regular text')).toEqual([
-        {preambleText: 'regular text', codeText: undefined},
+        {isCode: false, plainText: 'regular text'},
       ]);
     });
 
     it('does not split on a single backtick', () => {
       expect(Util.splitMarkdownCodeSpans('regular `text')).toEqual([
-        {preambleText: 'regular `text', codeText: undefined},
+        {isCode: false, plainText: 'regular `text'},
       ]);
     });
 
     it('splits on backticked code', () => {
       expect(Util.splitMarkdownCodeSpans('regular `code` text')).toEqual([
-        {preambleText: 'regular ', codeText: 'code'},
-        {preambleText: ' text', codeText: undefined},
+        {isCode: false, plainText: 'regular '},
+        {isCode: true, codeText: 'code'},
+        {isCode: false, plainText: ' text'},
       ]);
     });
 
     it('splits on backticked code at the beginning of the string', () => {
       expect(Util.splitMarkdownCodeSpans('`start code` regular text')).toEqual([
-        {preambleText: '', codeText: 'start code'},
-        {preambleText: ' regular text', codeText: undefined},
+        {isCode: true, codeText: 'start code'},
+        {isCode: false, plainText: ' regular text'},
       ]);
     });
 
     it('splits on backticked code at the emd of the string', () => {
       expect(Util.splitMarkdownCodeSpans('regular text `end code`')).toEqual([
-        {preambleText: 'regular text ', codeText: 'end code'},
-        {preambleText: '', codeText: undefined},
+        {isCode: false, plainText: 'regular text '},
+        {isCode: true, codeText: 'end code'},
       ]);
     });
 
     it('does not split on a single backtick after split out backticked code', () => {
       expect(Util.splitMarkdownCodeSpans('regular text `code` and more `text')).toEqual([
-        {preambleText: 'regular text ', codeText: 'code'},
-        {preambleText: ' and more `text', codeText: undefined},
+        {isCode: false, plainText: 'regular text '},
+        {isCode: true, codeText: 'code'},
+        {isCode: false, plainText: ' and more `text'},
       ]);
     });
 
     it('splits on two instances of backticked code', () => {
       expect(Util.splitMarkdownCodeSpans('regular text `code` more text `and more code`')).toEqual([
-        {preambleText: 'regular text ', codeText: 'code'},
-        {preambleText: ' more text ', codeText: 'and more code'},
-        {preambleText: '', codeText: undefined},
+        {isCode: false, plainText: 'regular text '},
+        {isCode: true, codeText: 'code'},
+        {isCode: false, plainText: ' more text '},
+        {isCode: true, codeText: 'and more code'},
       ]);
     });
 
     it('splits on two directly adjacent instances of backticked code', () => {
       // eslint-disable-next-line max-len
       expect(Util.splitMarkdownCodeSpans('regular text `first code``second code` end text')).toEqual([
-        {preambleText: 'regular text ', codeText: 'first code'},
-        {preambleText: '', codeText: 'second code'},
-        {preambleText: ' end text', codeText: undefined},
+        {isCode: false, plainText: 'regular text '},
+        {isCode: true, codeText: 'first code'},
+        {isCode: true, codeText: 'second code'},
+        {isCode: false, plainText: ' end text'},
       ]);
     });
 
     it('handles text only within backticks', () => {
       expect(Util.splitMarkdownCodeSpans('`first code``second code`')).toEqual([
-        {preambleText: '', codeText: 'first code'},
-        {preambleText: '', codeText: 'second code'},
-        {preambleText: '', codeText: undefined},
+        {isCode: true, codeText: 'first code'},
+        {isCode: true, codeText: 'second code'},
       ]);
     });
   });
@@ -336,80 +339,82 @@ describe('util helpers', () => {
   describe('#splitMarkdownLink', () => {
     it('handles strings with no links in them', () => {
       expect(Util.splitMarkdownLink('some text')).toEqual([
-        {preambleText: 'some text', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'some text'},
       ]);
     });
 
     it('does not split on an incomplete markdown link', () => {
       expect(Util.splitMarkdownLink('some [not link text](text')).toEqual([
-        {preambleText: 'some [not link text](text', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'some [not link text](text'},
       ]);
     });
 
     it('splits on a markdown link', () => {
       expect(Util.splitMarkdownLink('some [link text](https://example.com) text')).toEqual([
-        {preambleText: 'some ', linkText: 'link text', linkHref: 'https://example.com'},
-        {preambleText: ' text', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'some '},
+        {isLink: true, linkText: 'link text', linkHref: 'https://example.com'},
+        {isLink: false, plainText: ' text'},
       ]);
     });
 
     it('splits on an http markdown link', () => {
       expect(Util.splitMarkdownLink('you should [totally click here](http://never-mitm.com) now')).toEqual([
-        {preambleText: 'you should ', linkText: 'totally click here', linkHref: 'http://never-mitm.com'},
-        {preambleText: ' now', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'you should '},
+        {isLink: true, linkText: 'totally click here', linkHref: 'http://never-mitm.com'},
+        {isLink: false, plainText: ' now'},
       ]);
     });
 
     it('does not split on a non-http/https link', () => {
       expect(Util.splitMarkdownLink('some [link text](ftp://example.com) text')).toEqual([
-        {preambleText: 'some [link text](ftp://example.com) text', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'some [link text](ftp://example.com) text'},
       ]);
     });
 
     it('does not split on a malformed markdown link', () => {
       expect(Util.splitMarkdownLink('some [link ]text](https://example.com')).toEqual([
-        {preambleText: 'some [link ]text](https://example.com', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'some [link ]text](https://example.com'},
       ]);
 
       expect(Util.splitMarkdownLink('some [link text] (https://example.com')).toEqual([
-        {preambleText: 'some [link text] (https://example.com', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'some [link text] (https://example.com'},
       ]);
     });
 
     it('splits on a markdown link at the beginning of a string', () => {
       expect(Util.splitMarkdownLink('[link text](https://example.com) end text')).toEqual([
-        {preambleText: '', linkText: 'link text', linkHref: 'https://example.com'},
-        {preambleText: ' end text', linkText: undefined, linkHref: undefined},
+        {isLink: true, linkText: 'link text', linkHref: 'https://example.com'},
+        {isLink: false, plainText: ' end text'},
       ]);
     });
 
     it('splits on a markdown link at the end of a string', () => {
       expect(Util.splitMarkdownLink('start text [link text](https://example.com)')).toEqual([
-        {preambleText: 'start text ', linkText: 'link text', linkHref: 'https://example.com'},
-        {preambleText: '', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'start text '},
+        {isLink: true, linkText: 'link text', linkHref: 'https://example.com'},
       ]);
     });
 
     it('handles a string consisting only of a markdown link', () => {
       expect(Util.splitMarkdownLink(`[I'm only a link](https://example.com)`)).toEqual([
-        {preambleText: '', linkText: `I'm only a link`, linkHref: 'https://example.com'},
-        {preambleText: '', linkText: undefined, linkHref: undefined},
+        {isLink: true, linkText: `I'm only a link`, linkHref: 'https://example.com'},
       ]);
     });
 
     it('handles a string starting and ending with a markdown link', () => {
       expect(Util.splitMarkdownLink('[first link](https://first.com) other text [second link](https://second.com)')).toEqual([
-        {preambleText: '', linkText: 'first link', linkHref: 'https://first.com'},
-        {preambleText: ' other text ', linkText: 'second link', linkHref: 'https://second.com'},
-        {preambleText: '', linkText: undefined, linkHref: undefined},
+        {isLink: true, linkText: 'first link', linkHref: 'https://first.com'},
+        {isLink: false, plainText: ' other text '},
+        {isLink: true, linkText: 'second link', linkHref: 'https://second.com'},
       ]);
     });
 
     it('handles a string with adjacent markdown links', () => {
       expect(Util.splitMarkdownLink('start text [first link](https://first.com)[second link](https://second.com) and scene')).toEqual([
-        {preambleText: 'start text ', linkText: 'first link', linkHref: 'https://first.com'},
-        {preambleText: '', linkText: 'second link', linkHref: 'https://second.com'},
-        {preambleText: ' and scene', linkText: undefined, linkHref: undefined},
+        {isLink: false, plainText: 'start text '},
+        {isLink: true, linkText: 'first link', linkHref: 'https://first.com'},
+        {isLink: true, linkText: 'second link', linkHref: 'https://second.com'},
+        {isLink: false, plainText: ' and scene'},
       ]);
     });
   });

--- a/lighthouse-core/test/scripts/i18n/collect-strings-test.js
+++ b/lighthouse-core/test/scripts/i18n/collect-strings-test.js
@@ -418,10 +418,18 @@ describe('Convert Message to Placeholder', () => {
     });
   });
 
-  it('catches common link markdown mistakes', () => {
-    const message = 'Hello [World] (https://google.com/).';
-    expect(() => collect.convertMessageToCtc(message))
-      .toThrow(/Bad Link syntax in message "Hello \[World\] \(https:\/\/google\.com\/\)\."/);
+  describe('catches common link markdown mistakes', () => {
+    it('throws on spaces between link text and href blocks', () => {
+      const message = 'Hello [World] (https://google.com/).';
+      expect(() => collect.convertMessageToCtc(message))
+        .toThrow(/Bad Link spacing in message "Hello \[World\] \(https:\/\/google\.com\/\)\."/);
+    });
+
+    it('throws on empty link text', () => {
+      const message = '[](https://example.com/).';
+      expect(() => collect.convertMessageToCtc(message))
+        .toThrow(/markdown link text missing in message "\[\]\(https:\/\/example\.com\/\)\."/);
+    });
   });
 
   it('converts custom-formatted ICU to placholders', () => {


### PR DESCRIPTION
duplicated markdown parsing in `dom.js` for the report and `collect-strings.js` for adding placeholders for ctc files (which will eventually be reconstituted and then passed through `dom.js` methods) is a little risky, so the first commit here makes them share a splitting implementation in `util.js`.

There are no changes to the collected locale strings or the existing `dom` and `collect-strings` unit tests.

...but then I couldn't resist making an interface that's easier to understand (no more mysterious empty string for `preambleText` but `undefined` for `linkText` and `linkHref`). This is isolated to the second commit, so if it seems excessive I can drop it :)