### PR TITLE
deps(chrome-launcher): update to 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "dependencies": {
     "axe-core": "3.3.0",
-    "chrome-launcher": "^0.11.1",
+    "chrome-launcher": "^0.11.2",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",
     "details-element-polyfill": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,10 +1761,10 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
-chrome-launcher@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.11.1.tgz#ccc5bd971c76cdd263d17acacaeb762454c1af92"
-  integrity sha512-Om9LtiJ+FIh8sfhx8HaN4Petj75dIVeTBNUbXIXPIS5W3y9dyNRGmChcl0Z5trQkcy+8XDJA3NWicYdpZeF+DA==
+chrome-launcher@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.11.2.tgz#c9a248dbccd3a08565553acf61adff879bcc982c"
+  integrity sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==
   dependencies:
     "@types/node" "*"
     is-wsl "^2.1.0"


### PR DESCRIPTION
0.11.1 was opening an extra tab. Bump minimum required version to 0.11.2.

related: https://github.com/GoogleChrome/chrome-launcher/pull/162
