### PR TITLE
deps: details-element-polyfill@2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "chrome-launcher": "^0.11.2",
     "configstore": "^3.1.1",
     "cssstyle": "1.2.1",
-    "details-element-polyfill": "2.2.0",
+    "details-element-polyfill": "^2.4.0",
     "http-link-header": "^0.8.0",
     "inquirer": "^3.3.0",
     "intl": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,10 +2565,10 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
-details-element-polyfill@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/details-element-polyfill/-/details-element-polyfill-2.2.0.tgz#1c0bb65372c20f622e90974b9694ae204d4c8d8c"
-  integrity sha512-Sjg+A4q3Mrn2JKQu58zsreuHqAb4M0qe4eK5ZQAIBuch9i8nx6MlKWCxx0z8s59MMen9I4WXavzW5z+BnkIC0A==
+details-element-polyfill@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/details-element-polyfill/-/details-element-polyfill-2.4.0.tgz#e0622adef7902662faf27b4ab8acba5dc4e3a6e6"
+  integrity sha512-jnZ/m0+b1gz3EcooitqL7oDEkKHEro659dt8bWB/T/HjiILucoQhHvvi5MEOAIFJXxxO+rIYJ/t3qCgfUOSU5g==
 
 detect-indent@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
[changelog](https://github.com/javan/details-element-polyfill/releases):

* Fix testing for support in hidden documents  (from adspeed team)
* Fix typo-induced error in Safari 9
* Fix that the toggle event incorrectly bubbled 
* Lower specificity of `<summary>` styles 